### PR TITLE
[data] Write each block to a separate file

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -452,6 +452,9 @@ class DatasetStatsSummary:
     def get_max_heap_memory(self) -> float:
         parent_memory = [p.get_max_heap_memory() for p in self.parents]
         parent_max = max(parent_memory) if parent_memory else 0
+        if not self.stages_stats:
+            return parent_max
+
         return max(
             parent_max,
             *[ss.memory.get("max", 0) for ss in self.stages_stats],

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -73,7 +73,7 @@ class BlockWritePathProvider:
         *,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         dataset_uuid: Optional[str] = None,
-        block: Optional[Block] = None,
+        task_index: Optional[int] = None,
         block_index: Optional[int] = None,
         file_format: Optional[str] = None,
     ) -> str:
@@ -91,8 +91,10 @@ class BlockWritePathProvider:
             dataset_uuid: Unique identifier for the dataset that this block
                 belongs to.
             block: The block to write.
-            block_index: Ordered index of the block to write within its parent
+            task_index: Ordered index of the write task within its parent
                 dataset.
+            block_index: Ordered index of the block to write within its parent
+                write task.
             file_format: File format string for the block that can be used as
                 the file extension in the write path returned.
 
@@ -107,7 +109,7 @@ class BlockWritePathProvider:
         *,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         dataset_uuid: Optional[str] = None,
-        block: Optional[Block] = None,
+        task_index: Optional[int] = None,
         block_index: Optional[int] = None,
         file_format: Optional[str] = None,
     ) -> str:
@@ -115,7 +117,7 @@ class BlockWritePathProvider:
             base_path,
             filesystem=filesystem,
             dataset_uuid=dataset_uuid,
-            block=block,
+            task_index=task_index,
             block_index=block_index,
             file_format=file_format,
         )
@@ -125,7 +127,7 @@ class BlockWritePathProvider:
 class DefaultBlockWritePathProvider(BlockWritePathProvider):
     """Default block write path provider implementation that writes each
     dataset block out to a file of the form:
-    {base_path}/{dataset_uuid}_{block_index}.{file_format}
+    {base_path}/{dataset_uuid}_{task_index}_{block_index}.{file_format}
     """
 
     def _get_write_path_for_block(
@@ -134,11 +136,14 @@ class DefaultBlockWritePathProvider(BlockWritePathProvider):
         *,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         dataset_uuid: Optional[str] = None,
-        block: Optional[ObjectRef[Block]] = None,
+        task_index: Optional[int] = None,
         block_index: Optional[int] = None,
         file_format: Optional[str] = None,
     ) -> str:
-        suffix = f"{dataset_uuid}_{block_index:06}.{file_format}"
+        if block_index is not None:
+            suffix = f"{dataset_uuid}_{task_index:06}_{block_index:06}.{file_format}"
+        else:
+            suffix = f"{dataset_uuid}_{task_index:06}.{file_format}"
         # Uses POSIX path for cross-filesystem compatibility, since PyArrow
         # FileSystem paths are always forward slash separated, see:
         # https://arrow.apache.org/docs/python/filesystems.html
@@ -269,18 +274,6 @@ class FileBasedDatasource(Datasource):
         if isinstance(file_format, list):
             file_format = file_format[0]
 
-        builder = DelegatingBlockBuilder()
-        for block in blocks:
-            builder.add_block(block)
-        block = builder.build()
-
-        total_num_rows = BlockAccessor.for_block(block).num_rows()
-        if total_num_rows == 0:
-            logger.get_logger().warning(
-                f"Skipping writing empty dataset with UUID {dataset_uuid} at {path}",
-            )
-            return "skip"
-
         path, filesystem = _resolve_paths_and_filesystem(path, filesystem)
         path = path[0]
         if try_create_dir:
@@ -295,14 +288,30 @@ class FileBasedDatasource(Datasource):
         if open_stream_args is None:
             open_stream_args = {}
 
-        def write_block(write_path: str, block: Block):
+        if not block_path_provider:
+            block_path_provider = DefaultBlockWritePathProvider()
+
+        num_rows_written = 0
+        block_idx = 0
+        for block in blocks:
+            write_path = block_path_provider(
+                path,
+                filesystem=filesystem,
+                dataset_uuid=dataset_uuid,
+                task_index=ctx.task_idx,
+                block_index=block_idx,
+                file_format=file_format,
+            )
+
             logger.get_logger().debug(f"Writing {write_path} file.")
-            fs = _unwrap_s3_serialization_workaround(filesystem)
             if _block_udf is not None:
                 block = _block_udf(block)
 
             block = BlockAccessor.for_block(block)
-            assert block.num_rows() > 0, "Cannot write an empty block."
+            if block.num_rows() == 0:
+                continue
+
+            fs = _unwrap_s3_serialization_workaround(filesystem)
             with fs.open_output_stream(write_path, **open_stream_args) as f:
                 _write_block_to_file(
                     f,
@@ -310,21 +319,19 @@ class FileBasedDatasource(Datasource):
                     writer_args_fn=write_args_fn,
                     **write_args,
                 )
-            # TODO: decide if we want to return richer object when the task
-            # succeeds.
-            return "ok"
 
-        if not block_path_provider:
-            block_path_provider = DefaultBlockWritePathProvider()
-        write_path = block_path_provider(
-            path,
-            filesystem=filesystem,
-            dataset_uuid=dataset_uuid,
-            block=block,
-            block_index=ctx.task_idx,
-            file_format=file_format,
-        )
-        return write_block(write_path, block)
+            num_rows_written += block.num_rows()
+            block_idx += 1
+
+        if num_rows_written == 0:
+            logger.get_logger().warning(
+                f"Skipping writing empty dataset with UUID {dataset_uuid} at {path}",
+            )
+            return "skip"
+
+        # TODO: decide if we want to return richer object when the task
+        # succeeds.
+        return "ok"
 
     def _write_block(
         self,

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -22,7 +22,6 @@ import numpy as np
 from ray._private.utils import _add_creatable_buckets_param_if_s3_uri
 from ray.air._internal.remote_storage import _is_local_windows_path
 from ray.data._internal.dataset_logger import DatasetLogger
-from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.output_buffer import BlockOutputBuffer
 from ray.data._internal.progress_bar import ProgressBar
@@ -40,7 +39,6 @@ from ray.data.datasource.partitioning import (
     PathPartitionFilter,
     PathPartitionParser,
 )
-from ray.types import ObjectRef
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -151,8 +151,8 @@ def local_fs():
 
 
 @pytest.fixture(scope="function")
-def test_block_write_path_provider():
-    class TestBlockWritePathProvider(BlockWritePathProvider):
+def mock_block_write_path_provider():
+    class MockBlockWritePathProvider(BlockWritePathProvider):
         def _get_write_path_for_block(
             self,
             base_path,
@@ -168,7 +168,7 @@ def test_block_write_path_provider():
             )
             return posixpath.join(base_path, suffix)
 
-    yield TestBlockWritePathProvider()
+    yield MockBlockWritePathProvider()
 
 
 @pytest.fixture(scope="function")

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -12,7 +12,7 @@ import ray
 from ray._private.utils import _get_pyarrow_version
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
-from ray.data.block import BlockAccessor, BlockExecStats, BlockMetadata
+from ray.data.block import BlockExecStats, BlockMetadata
 from ray.data.datasource.file_based_datasource import BlockWritePathProvider
 from ray.data.tests.mock_server import *  # noqa
 
@@ -159,13 +159,12 @@ def test_block_write_path_provider():
             *,
             filesystem=None,
             dataset_uuid=None,
-            block=None,
+            task_index=None,
             block_index=None,
             file_format=None,
         ):
-            num_rows = BlockAccessor.for_block(block).num_rows()
             suffix = (
-                f"{block_index:06}_{num_rows:02}_{dataset_uuid}" f".test.{file_format}"
+                f"{task_index:06}_{block_index:06}_{dataset_uuid}.test.{file_format}"
             )
             return posixpath.join(base_path, suffix)
 

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -1561,7 +1561,7 @@ def test_dataset_retry_exceptions(ray_start_regular, local_path):
     ds1 = ray.data.read_datasource(FlakyCSVDatasource(), parallelism=1, paths=path1)
     ds1.write_datasource(FlakyCSVDatasource(), path=local_path, dataset_uuid="data")
     assert df1.equals(
-        pd.read_csv(os.path.join(local_path, "data_000000.csv"), storage_options={})
+        pd.read_csv(os.path.join(local_path, "data_000000_000000.csv"), storage_options={})
     )
 
     counter = Counter.remote()

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -1561,7 +1561,9 @@ def test_dataset_retry_exceptions(ray_start_regular, local_path):
     ds1 = ray.data.read_datasource(FlakyCSVDatasource(), parallelism=1, paths=path1)
     ds1.write_datasource(FlakyCSVDatasource(), path=local_path, dataset_uuid="data")
     assert df1.equals(
-        pd.read_csv(os.path.join(local_path, "data_000000_000000.csv"), storage_options={})
+        pd.read_csv(
+            os.path.join(local_path, "data_000000_000000.csv"), storage_options={}
+        )
     )
 
     counter = Counter.remote()

--- a/python/ray/data/tests/test_csv.py
+++ b/python/ray/data/tests/test_csv.py
@@ -693,7 +693,7 @@ def test_csv_write(ray_start_regular_shared, fs, data_path, endpoint_url):
     ds = ray.data.from_pandas([df1])
     ds._set_uuid("data")
     ds.write_csv(data_path, filesystem=fs)
-    file_path = os.path.join(data_path, "data_000000.csv")
+    file_path = os.path.join(data_path, "data_000000_000000.csv")
     assert df1.equals(pd.read_csv(file_path, storage_options=storage_options))
 
     # Two blocks.
@@ -701,7 +701,7 @@ def test_csv_write(ray_start_regular_shared, fs, data_path, endpoint_url):
     ds = ray.data.from_pandas([df1, df2])
     ds._set_uuid("data")
     ds.write_csv(data_path, filesystem=fs)
-    file_path2 = os.path.join(data_path, "data_000001.csv")
+    file_path2 = os.path.join(data_path, "data_000001_000000.csv")
     df = pd.concat([df1, df2])
     ds_df = pd.concat(
         [
@@ -777,7 +777,7 @@ def test_csv_write_block_path_provider(
     ds.write_csv(
         data_path, filesystem=fs, block_path_provider=test_block_write_path_provider
     )
-    file_path = os.path.join(data_path, "000000_03_data.test.csv")
+    file_path = os.path.join(data_path, "000000_000000_data.test.csv")
     assert df1.equals(pd.read_csv(file_path, storage_options=storage_options))
 
     # Two blocks.
@@ -787,7 +787,7 @@ def test_csv_write_block_path_provider(
     ds.write_csv(
         data_path, filesystem=fs, block_path_provider=test_block_write_path_provider
     )
-    file_path2 = os.path.join(data_path, "000001_03_data.test.csv")
+    file_path2 = os.path.join(data_path, "000001_000000_data.test.csv")
     df = pd.concat([df1, df2])
     ds_df = pd.concat(
         [

--- a/python/ray/data/tests/test_csv.py
+++ b/python/ray/data/tests/test_csv.py
@@ -726,7 +726,7 @@ def test_csv_roundtrip(ray_start_regular_shared, fs, data_path):
     ds = ray.data.from_pandas([df])
     ds._set_uuid("data")
     ds.write_csv(data_path, filesystem=fs)
-    file_path = os.path.join(data_path, "data_000000.csv")
+    file_path = os.path.join(data_path, "data_000000_000000.csv")
     ds2 = ray.data.read_csv([file_path], filesystem=fs)
     ds2df = ds2.to_pandas()
     assert ds2df.equals(df)

--- a/python/ray/data/tests/test_csv.py
+++ b/python/ray/data/tests/test_csv.py
@@ -763,7 +763,7 @@ def test_csv_write_block_path_provider(
     fs,
     data_path,
     endpoint_url,
-    test_block_write_path_provider,
+    mock_block_write_path_provider,
 ):
     if endpoint_url is None:
         storage_options = {}
@@ -775,7 +775,7 @@ def test_csv_write_block_path_provider(
     ds = ray.data.from_pandas([df1])
     ds._set_uuid("data")
     ds.write_csv(
-        data_path, filesystem=fs, block_path_provider=test_block_write_path_provider
+        data_path, filesystem=fs, block_path_provider=mock_block_write_path_provider
     )
     file_path = os.path.join(data_path, "000000_000000_data.test.csv")
     assert df1.equals(pd.read_csv(file_path, storage_options=storage_options))
@@ -785,7 +785,7 @@ def test_csv_write_block_path_provider(
     ds = ray.data.from_pandas([df1, df2])
     ds._set_uuid("data")
     ds.write_csv(
-        data_path, filesystem=fs, block_path_provider=test_block_write_path_provider
+        data_path, filesystem=fs, block_path_provider=mock_block_write_path_provider
     )
     file_path2 = os.path.join(data_path, "000001_000000_data.test.csv")
     df = pd.concat([df1, df2])

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import numpy as np
@@ -6,6 +7,7 @@ import pyarrow as pa
 import pytest
 
 import ray
+from ray.data import Dataset
 from ray.data._internal.lazy_block_list import LazyBlockList
 from ray.data.block import BlockMetadata
 from ray.data.datasource import Datasource
@@ -18,14 +20,17 @@ from ray.tests.conftest import *  # noqa
 class RandomBytesDatasource(Datasource):
     def create_reader(self, **read_args):
         return RandomBytesReader(
-            read_args["num_blocks_per_task"], read_args["block_size"]
+            read_args["num_blocks_per_task"],
+            read_args["block_size"],
+            read_args.get("use_bytes", True),
         )
 
 
 class RandomBytesReader(Reader):
-    def __init__(self, num_blocks_per_task: int, block_size: int):
+    def __init__(self, num_blocks_per_task: int, block_size: int, use_bytes=True):
         self.num_blocks_per_task = num_blocks_per_task
         self.block_size = block_size
+        self.use_bytes = use_bytes
 
     def estimate_inmemory_data_size(self):
         return None
@@ -33,7 +38,12 @@ class RandomBytesReader(Reader):
     def get_read_tasks(self, parallelism: int):
         def _blocks_generator():
             for _ in range(self.num_blocks_per_task):
-                yield pd.DataFrame({"one": [np.random.bytes(self.block_size)]})
+                if self.use_bytes:
+                    yield pd.DataFrame({"one": [np.random.bytes(self.block_size)]})
+                else:
+                    yield pd.DataFrame(
+                        {"one": [np.array2string(np.ones(self.block_size, dtype=int))]}
+                    )
 
         return parallelism * [
             ReadTask(
@@ -367,6 +377,77 @@ def test_read_large_data(ray_start_cluster, enable_dynamic_block_splitting):
 
     ds = ds.map_batches(foo, batch_size=None)
     assert ds.count() == num_blocks_per_task
+
+
+def _test_write_large_data(tmp_path, ext, write_fn, read_fn, use_bytes):
+    # Test 2G input with single task
+    num_blocks_per_task = 200
+    block_size = 10 * 1024 * 1024
+
+    ds = ray.data.read_datasource(
+        RandomBytesDatasource(),
+        parallelism=1,
+        num_blocks_per_task=num_blocks_per_task,
+        block_size=block_size,
+        use_bytes=use_bytes,
+    )
+
+    # This should succeed without OOM.
+    # https://github.com/ray-project/ray/pull/37966.
+    out_dir = os.path.join(tmp_path, ext)
+    write_fn(ds, out_dir)
+
+    max_heap_memory = ds._write_ds._get_stats_summary().get_max_heap_memory()
+    assert max_heap_memory < (num_blocks_per_task * block_size / 2), (
+        max_heap_memory,
+        ext,
+    )
+
+    # Make sure we can read out a record.
+    if read_fn is not None:
+        assert read_fn(out_dir).count() == num_blocks_per_task
+
+
+def test_write_large_data_parquet(shutdown_only, tmp_path):
+    # TODO(swang): Parquet doesn't support streaming read yet.
+    _test_write_large_data(
+        tmp_path,
+        "parquet",
+        Dataset.write_parquet,
+        ray.data.read_parquet,
+        use_bytes=True,
+    )
+
+
+def test_write_large_data_json(shutdown_only, tmp_path):
+    # TODO(swang): JSON doesn't support streaming read yet.
+    _test_write_large_data(tmp_path, "json", Dataset.write_json, None, use_bytes=False)
+
+
+def test_write_large_data_csv(shutdown_only, tmp_path):
+    _test_write_large_data(
+        tmp_path, "csv", Dataset.write_csv, ray.data.read_csv, use_bytes=False
+    )
+
+
+def test_write_large_data_tfrecords(shutdown_only, tmp_path):
+    _test_write_large_data(
+        tmp_path,
+        "tfrecords",
+        Dataset.write_tfrecords,
+        ray.data.read_tfrecords,
+        use_bytes=True,
+    )
+
+
+def test_write_large_data_webdataset(shutdown_only, tmp_path):
+    _test_write_large_data(
+        tmp_path,
+        "webdataset",
+        Dataset.write_webdataset,
+        ray.data.read_webdataset,
+        use_bytes=True,
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -116,8 +116,8 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     ds._set_uuid("data")
     ds.write_parquet(out_path)
 
-    ds_df1 = pd.read_parquet(os.path.join(out_path, "data_000000.parquet"))
-    ds_df2 = pd.read_parquet(os.path.join(out_path, "data_000001.parquet"))
+    ds_df1 = pd.read_parquet(os.path.join(out_path, "data_000000_000000.parquet"))
+    ds_df2 = pd.read_parquet(os.path.join(out_path, "data_000001_000000.parquet"))
     ds_df = pd.concat([ds_df1, ds_df2])
     df = pd.concat([df1, df2])
     assert ds_df.equals(df)

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -568,7 +568,7 @@ def test_json_write_block_path_provider(
     fs,
     data_path,
     endpoint_url,
-    test_block_write_path_provider,
+    mock_block_write_path_provider,
 ):
     if endpoint_url is None:
         storage_options = {}
@@ -580,7 +580,7 @@ def test_json_write_block_path_provider(
     ds = ray.data.from_pandas([df1])
     ds._set_uuid("data")
     ds.write_json(
-        data_path, filesystem=fs, block_path_provider=test_block_write_path_provider
+        data_path, filesystem=fs, block_path_provider=mock_block_write_path_provider
     )
     file_path = os.path.join(data_path, "000000_000000_data.test.json")
     assert df1.equals(
@@ -594,7 +594,7 @@ def test_json_write_block_path_provider(
     ds = ray.data.from_pandas([df1, df2])
     ds._set_uuid("data")
     ds.write_json(
-        data_path, filesystem=fs, block_path_provider=test_block_write_path_provider
+        data_path, filesystem=fs, block_path_provider=mock_block_write_path_provider
     )
     file_path2 = os.path.join(data_path, "000001_000000_data.test.json")
     df = pd.concat([df1, df2])

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -582,7 +582,7 @@ def test_json_write_block_path_provider(
     ds.write_json(
         data_path, filesystem=fs, block_path_provider=test_block_write_path_provider
     )
-    file_path = os.path.join(data_path, "000000_03_data.test.json")
+    file_path = os.path.join(data_path, "000000_000000_data.test.json")
     assert df1.equals(
         pd.read_json(
             file_path, orient="records", lines=True, storage_options=storage_options
@@ -596,7 +596,7 @@ def test_json_write_block_path_provider(
     ds.write_json(
         data_path, filesystem=fs, block_path_provider=test_block_write_path_provider
     )
-    file_path2 = os.path.join(data_path, "000001_03_data.test.json")
+    file_path2 = os.path.join(data_path, "000001_000000_data.test.json")
     df = pd.concat([df1, df2])
     ds_df = pd.concat(
         [

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -471,7 +471,7 @@ def test_json_write(ray_start_regular_shared, fs, data_path, endpoint_url):
     ds = ray.data.from_pandas([df1])
     ds._set_uuid("data")
     ds.write_json(data_path, filesystem=fs)
-    file_path = os.path.join(data_path, "data_000000.json")
+    file_path = os.path.join(data_path, "data_000000_000000.json")
     assert df1.equals(
         pd.read_json(
             file_path, orient="records", lines=True, storage_options=storage_options
@@ -483,7 +483,7 @@ def test_json_write(ray_start_regular_shared, fs, data_path, endpoint_url):
     ds = ray.data.from_pandas([df1, df2])
     ds._set_uuid("data")
     ds.write_json(data_path, filesystem=fs)
-    file_path2 = os.path.join(data_path, "data_000001.json")
+    file_path2 = os.path.join(data_path, "data_000001_000000.json")
     df = pd.concat([df1, df2])
     ds_df = pd.concat(
         [
@@ -519,7 +519,7 @@ def test_json_roundtrip(ray_start_regular_shared, fs, data_path):
     ds = ray.data.from_pandas([df])
     ds._set_uuid("data")
     ds.write_json(data_path, filesystem=fs)
-    file_path = os.path.join(data_path, "data_000000.json")
+    file_path = os.path.join(data_path, "data_000000_000000.json")
     ds2 = ray.data.read_json([file_path], filesystem=fs)
     ds2df = ds2.to_pandas()
     assert ds2df.equals(df)

--- a/python/ray/data/tests/test_numpy.py
+++ b/python/ray/data/tests/test_numpy.py
@@ -276,8 +276,8 @@ def test_numpy_write(ray_start_regular_shared, fs, data_path, endpoint_url):
     ds = ray.data.range_tensor(10, parallelism=2)
     ds._set_uuid("data")
     ds.write_numpy(data_path, filesystem=fs, column="data")
-    file_path1 = os.path.join(data_path, "data_000000.npy")
-    file_path2 = os.path.join(data_path, "data_000001.npy")
+    file_path1 = os.path.join(data_path, "data_000000_000000.npy")
+    file_path2 = os.path.join(data_path, "data_000001_000000.npy")
     if endpoint_url is None:
         arr1 = np.load(file_path1)
         arr2 = np.load(file_path2)

--- a/python/ray/data/tests/test_numpy.py
+++ b/python/ray/data/tests/test_numpy.py
@@ -318,8 +318,8 @@ def test_numpy_write_block_path_provider(
         block_path_provider=test_block_write_path_provider,
         column="data",
     )
-    file_path1 = os.path.join(data_path, "000000_05_data.test.npy")
-    file_path2 = os.path.join(data_path, "000001_05_data.test.npy")
+    file_path1 = os.path.join(data_path, "000000_000000_data.test.npy")
+    file_path2 = os.path.join(data_path, "000001_000000_data.test.npy")
     if endpoint_url is None:
         arr1 = np.load(file_path1)
         arr2 = np.load(file_path2)

--- a/python/ray/data/tests/test_numpy.py
+++ b/python/ray/data/tests/test_numpy.py
@@ -308,14 +308,14 @@ def test_numpy_write_block_path_provider(
     fs,
     data_path,
     endpoint_url,
-    test_block_write_path_provider,
+    mock_block_write_path_provider,
 ):
     ds = ray.data.range_tensor(10, parallelism=2)
     ds._set_uuid("data")
     ds.write_numpy(
         data_path,
         filesystem=fs,
-        block_path_provider=test_block_write_path_provider,
+        block_path_provider=mock_block_write_path_provider,
         column="data",
     )
     file_path1 = os.path.join(data_path, "000000_000000_data.test.npy")

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -741,8 +741,8 @@ def test_parquet_write(ray_start_regular_shared, fs, data_path, endpoint_url):
         fs.create_dir(_unwrap_protocol(path))
     ds._set_uuid("data")
     ds.write_parquet(path, filesystem=fs)
-    path1 = os.path.join(path, "data_000000.parquet")
-    path2 = os.path.join(path, "data_000001.parquet")
+    path1 = os.path.join(path, "data_000000_000000.parquet")
+    path2 = os.path.join(path, "data_000001_000000.parquet")
     dfds = pd.concat(
         [
             pd.read_parquet(path1, storage_options=storage_options),
@@ -788,8 +788,8 @@ def test_parquet_write_create_dir(
         assert fs.get_file_info(_unwrap_protocol(path)).type == pa.fs.FileType.Directory
 
     # Check that data was properly written to the directory.
-    path1 = os.path.join(path, f"{data_key}_000000.parquet")
-    path2 = os.path.join(path, f"{data_key}_000001.parquet")
+    path1 = os.path.join(path, f"{data_key}_000000_000000.parquet")
+    path2 = os.path.join(path, f"{data_key}_000001_000000.parquet")
     dfds = pd.concat(
         [
             pd.read_parquet(path1, storage_options=storage_options),
@@ -800,8 +800,8 @@ def test_parquet_write_create_dir(
 
     # Ensure that directories that already exist are left alone and that the
     # attempted creation still succeeds.
-    path3 = os.path.join(path, f"{data_key}_0000002.parquet")
-    path4 = os.path.join(path, f"{data_key}_0000003.parquet")
+    path3 = os.path.join(path, f"{data_key}_0000002_000000.parquet")
+    path4 = os.path.join(path, f"{data_key}_0000003_000000.parquet")
     if fs is None:
         os.rename(path1, path3)
         os.rename(path2, path4)
@@ -854,7 +854,7 @@ def test_parquet_write_create_dir(
         # Only files for the non-empty blocks should be created.
         file_list = os.listdir(some_empty_path)
         file_list.sort()
-        assert file_list == [f"{some_empty_key}_00000{i}.parquet" for i in range(2)]
+        assert file_list == [f"{some_empty_key}_00000{i}_000000.parquet" for i in range(2)]
     else:
         assert (
             fs.get_file_info(_unwrap_protocol(all_empty_path)).type
@@ -871,7 +871,7 @@ def test_parquet_write_create_dir(
             pd.read_parquet(
                 os.path.join(
                     some_empty_path,
-                    f"{some_empty_key}_00000{i}.parquet",
+                    f"{some_empty_key}_00000{i}_000000.parquet",
                 ),
                 storage_options=storage_options,
             )
@@ -897,8 +897,8 @@ def test_parquet_write_with_udf(ray_start_regular_shared, tmp_path):
     # 2 write tasks
     ds._set_uuid("data")
     ds.write_parquet(data_path, _block_udf=_block_udf)
-    path1 = os.path.join(data_path, "data_000000.parquet")
-    path2 = os.path.join(data_path, "data_000001.parquet")
+    path1 = os.path.join(data_path, "data_000000_000000.parquet")
+    path2 = os.path.join(data_path, "data_000001_000000.parquet")
     dfds = pd.concat([pd.read_parquet(path1), pd.read_parquet(path2)])
     expected_df = df
     expected_df["one"] += 1

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -854,7 +854,9 @@ def test_parquet_write_create_dir(
         # Only files for the non-empty blocks should be created.
         file_list = os.listdir(some_empty_path)
         file_list.sort()
-        assert file_list == [f"{some_empty_key}_00000{i}_000000.parquet" for i in range(2)]
+        assert file_list == [
+            f"{some_empty_key}_00000{i}_000000.parquet" for i in range(2)
+        ]
     else:
         assert (
             fs.get_file_info(_unwrap_protocol(all_empty_path)).type

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -941,8 +941,8 @@ def test_parquet_write_block_path_provider(
     ds.write_parquet(
         path, filesystem=fs, block_path_provider=test_block_write_path_provider
     )
-    path1 = os.path.join(path, "000000_03_data.test.parquet")
-    path2 = os.path.join(path, "000001_03_data.test.parquet")
+    path1 = os.path.join(path, "000000_000000_data.test.parquet")
+    path2 = os.path.join(path, "000001_000000_data.test.parquet")
     dfds = pd.concat(
         [
             pd.read_parquet(path1, storage_options=storage_options),

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -920,7 +920,7 @@ def test_parquet_write_block_path_provider(
     fs,
     data_path,
     endpoint_url,
-    test_block_write_path_provider,
+    mock_block_write_path_provider,
 ):
     if endpoint_url is None:
         storage_options = {}
@@ -939,7 +939,7 @@ def test_parquet_write_block_path_provider(
     ds._set_uuid("data")
 
     ds.write_parquet(
-        path, filesystem=fs, block_path_provider=test_block_write_path_provider
+        path, filesystem=fs, block_path_provider=mock_block_write_path_provider
     )
     path1 = os.path.join(path, "000000_000000_data.test.parquet")
     path2 = os.path.join(path, "000001_000000_data.test.parquet")

--- a/python/ray/data/tests/test_pipeline.py
+++ b/python/ray/data/tests/test_pipeline.py
@@ -582,8 +582,8 @@ def test_json_write(ray_start_regular_shared, tmp_path):
     path = os.path.join(tmp_path, "test_json_dir")
     ds, df = _prepare_dataset_to_write(path)
     ds.write_json(path)
-    path1 = os.path.join(path, "data_000000_000000.json")
-    path2 = os.path.join(path, "data_000001_000000.json")
+    path1 = os.path.join(path, "data_000000_000000_000000.json")
+    path2 = os.path.join(path, "data_000001_000000_000000.json")
     dfds = pd.concat([pd.read_json(path1, lines=True), pd.read_json(path2, lines=True)])
     assert df.equals(dfds)
 
@@ -592,8 +592,8 @@ def test_csv_write(ray_start_regular_shared, tmp_path):
     path = os.path.join(tmp_path, "test_csv_dir")
     ds, df = _prepare_dataset_to_write(path)
     ds.write_csv(path)
-    path1 = os.path.join(path, "data_000000_000000.csv")
-    path2 = os.path.join(path, "data_000001_000000.csv")
+    path1 = os.path.join(path, "data_000000_000000_000000.csv")
+    path2 = os.path.join(path, "data_000001_000000_000000.csv")
     dfds = pd.concat([pd.read_csv(path1), pd.read_csv(path2)])
     assert df.equals(dfds)
 
@@ -602,8 +602,8 @@ def test_parquet_write(ray_start_regular_shared, tmp_path):
     path = os.path.join(tmp_path, "test_parquet_dir")
     ds, df = _prepare_dataset_to_write(path)
     ds.write_parquet(path)
-    path1 = os.path.join(path, "data_000000_000000.parquet")
-    path2 = os.path.join(path, "data_000001_000000.parquet")
+    path1 = os.path.join(path, "data_000000_000000_000000.parquet")
+    path2 = os.path.join(path, "data_000001_000000_000000.parquet")
     dfds = pd.concat([pd.read_parquet(path1), pd.read_parquet(path2)])
     assert df.equals(dfds)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

During file-based write tasks, write each block to a separate file so that we avoid needing to keep all blocks in memory at the same time.

## Related issue number

Closes #37948.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
