### PR TITLE
[Data] Allow automatic handling of string features as byte features during TFRecord serialization

### DIFF
--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -231,6 +231,7 @@ def _value_to_feature(
 
     underlying_value_type = {
         "bytes": pa.types.is_binary(value_type),
+        "string": pa.types.is_string(value_type),
         "float": pa.types.is_floating(value_type),
         "int": pa.types.is_integer(value_type),
     }
@@ -246,6 +247,7 @@ def _value_to_feature(
             )
         specified_feature_type = {
             "bytes": schema_feature_type == schema_pb2.FeatureType.BYTES,
+            "string": schema_feature_type == schema_pb2.FeatureType.BYTES,
             "float": schema_feature_type == schema_pb2.FeatureType.FLOAT,
             "int": schema_feature_type == schema_pb2.FeatureType.INT,
         }
@@ -265,6 +267,9 @@ def _value_to_feature(
     if underlying_value_type["float"]:
         return tf.train.Feature(float_list=tf.train.FloatList(value=value))
     if underlying_value_type["bytes"]:
+        return tf.train.Feature(bytes_list=tf.train.BytesList(value=value))
+    if underlying_value_type["string"]:
+        value = [v.encode() for v in value]  # casting to bytes
         return tf.train.Feature(bytes_list=tf.train.BytesList(value=value))
     if pa.types.is_null(value_type):
         raise ValueError(

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -246,8 +246,10 @@ def _value_to_feature(
                 "the tensorflow-metadata package."
             )
         specified_feature_type = {
-            "bytes": schema_feature_type == schema_pb2.FeatureType.BYTES,
-            "string": schema_feature_type == schema_pb2.FeatureType.BYTES,
+            "bytes": schema_feature_type == schema_pb2.FeatureType.BYTES
+            and not underlying_value_type["string"],
+            "string": schema_feature_type == schema_pb2.FeatureType.BYTES
+            and underlying_value_type["string"],
             "float": schema_feature_type == schema_pb2.FeatureType.FLOAT,
             "int": schema_feature_type == schema_pb2.FeatureType.INT,
         }

--- a/python/ray/data/tests/test_tfrecords.py
+++ b/python/ray/data/tests/test_tfrecords.py
@@ -324,6 +324,17 @@ def _features_to_schema(features: "tf.train.Features") -> "schema_pb2.Schema":
 
 
 def _ds_eq_streaming(ds_expected, ds_actual) -> bool:
+    # Casting the strings to bytes for comparing string features
+    def _str2bytes(d):
+        for k, v in d.items():
+            if "string" in k:
+                if isinstance(v, list):
+                    d[k] = [vv.encode() for vv in v]
+                elif isinstance(v, str):
+                    d[k] = v.encode()
+        return d
+
+    ds_expected = ds_expected.map(_str2bytes)
     assert ds_expected.take() == ds_actual.take()
 
 

--- a/python/ray/data/tests/test_tfrecords.py
+++ b/python/ray/data/tests/test_tfrecords.py
@@ -50,6 +50,15 @@ def tf_records_partial():
                     "bytes_partial": tf.train.Feature(
                         bytes_list=tf.train.BytesList(value=[])
                     ),
+                    "string_item": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[b"uvw"])
+                    ),
+                    "string_list": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[b"xyz", b"999"])
+                    ),
+                    "string_partial": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[])
+                    ),
                 }
             )
         ),
@@ -84,6 +93,15 @@ def tf_records_partial():
                     "bytes_partial": tf.train.Feature(
                         bytes_list=tf.train.BytesList(value=[b"hello"])
                     ),
+                    "string_item": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[b"mno"])
+                    ),
+                    "string_list": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[b"pqr", b"111"])
+                    ),
+                    "string_partial": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[b"world"])
+                    ),
                 }
             )
         ),
@@ -104,6 +122,9 @@ def data_partial(with_tf_schema):
             "bytes_item": [b"abc"] if with_tf_schema else b"abc",
             "bytes_list": [b"def", b"1234"],
             "bytes_partial": [] if with_tf_schema else None,
+            "string_item": ["uvw"] if with_tf_schema else "uvw",
+            "string_list": ["xyz", "999"],
+            "string_partial": [] if with_tf_schema else None,
         },
         # Row two.
         {
@@ -116,6 +137,9 @@ def data_partial(with_tf_schema):
             "bytes_item": [b"ghi"] if with_tf_schema else b"ghi",
             "bytes_list": [b"jkl", b"5678"],
             "bytes_partial": [b"hello"] if with_tf_schema else b"hello",
+            "string_item": ["mno"] if with_tf_schema else "mno",
+            "string_list": ["pqr", "111"],
+            "string_partial": ["world"] if with_tf_schema else "world",
         },
     ]
 
@@ -165,6 +189,18 @@ def tf_records_empty():
                     "bytes_empty": tf.train.Feature(
                         bytes_list=tf.train.BytesList(value=[])
                     ),
+                    "string_item": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[b"uvw"])
+                    ),
+                    "string_list": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[b"xyz", b"999"])
+                    ),
+                    "string_partial": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[])
+                    ),
+                    "string_empty": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[])
+                    ),
                 }
             )
         ),
@@ -208,6 +244,18 @@ def tf_records_empty():
                     "bytes_empty": tf.train.Feature(
                         bytes_list=tf.train.BytesList(value=[])
                     ),
+                    "string_item": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[b"mno"])
+                    ),
+                    "string_list": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[b"pqr", b"111"])
+                    ),
+                    "string_partial": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[b"world"])
+                    ),
+                    "string_empty": tf.train.Feature(
+                        bytes_list=tf.train.BytesList(value=[])
+                    ),
                 }
             )
         ),
@@ -232,6 +280,10 @@ def data_empty(with_tf_schema):
             "bytes_list": [b"def", b"1234"],
             "bytes_partial": [],
             "bytes_empty": [],
+            "string_item": ["uvw"] if with_tf_schema else "uvw",
+            "string_list": ["xyz", "999"],
+            "string_partial": [] if with_tf_schema else None,
+            "string_empty": [],
         },
         # Row two.
         {
@@ -247,6 +299,10 @@ def data_empty(with_tf_schema):
             "bytes_list": [b"jkl", b"5678"],
             "bytes_partial": [b"hello"] if with_tf_schema else b"hello",
             "bytes_empty": [],
+            "string_item": ["mno"] if with_tf_schema else "mno",
+            "string_list": ["pqr", "111"],
+            "string_partial": ["world"] if with_tf_schema else "world",
+            "string_empty": [],
         },
     ]
 
@@ -316,6 +372,12 @@ def test_read_tfrecords(
     assert is_object_dtype(dict(df.dtypes)["bytes_list"])
     assert is_object_dtype(dict(df.dtypes)["bytes_empty"])
 
+    # strings are of `object` dtype in pandas
+    assert is_object_dtype(dict(df.dtypes)["string_item"])
+    assert is_object_dtype(dict(df.dtypes)["string_partial"])
+    assert is_object_dtype(dict(df.dtypes)["string_list"])
+    assert is_object_dtype(dict(df.dtypes)["string_empty"])
+
     # If the schema is specified, we should not perform the
     # automatic unwrapping of single-element lists.
     if with_tf_schema:
@@ -339,11 +401,18 @@ def test_read_tfrecords(
     if with_tf_schema:
         assert isinstance(df["bytes_item"], pd.Series)
         assert df["bytes_item"].tolist() == [[b"abc"]]
+        assert isinstance(df["string_item"], pd.Series)
+        assert df["string_item"].tolist() == [[b"uvw"]]  # strings are read as bytes
     else:
         assert list(df["bytes_item"]) == [b"abc"]
+        assert list(df["string_item"]) == [b"uvw"]
     assert np.array_equal(df["bytes_list"][0], np.array([b"def", b"1234"]))
     assert np.array_equal(df["bytes_partial"][0], np.array([], dtype=np.bytes_))
     assert np.array_equal(df["bytes_empty"][0], np.array([], dtype=np.bytes_))
+
+    assert np.array_equal(df["string_list"][0], np.array([b"xyz", b"999"]))
+    assert np.array_equal(df["string_partial"][0], np.array([], dtype=np.bytes_))
+    assert np.array_equal(df["string_empty"][0], np.array([], dtype=np.bytes_))
 
 
 @pytest.mark.parametrize("ignore_missing_paths", [True, False])

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -37,7 +37,7 @@ lxml==4.9.1
 moto[s3,server]==4.0.7
 mypy==0.982
 networkx==2.6.3
-numba==0.56.4
+numba==0.57.1
 openpyxl==3.0.10
 opentelemetry-api==1.1.0
 opentelemetry-sdk==1.1.0

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -37,7 +37,7 @@ lxml==4.9.1
 moto[s3,server]==4.0.7
 mypy==0.982
 networkx==2.6.3
-numba==0.57.1
+numba==0.56.4
 openpyxl==3.0.10
 opentelemetry-api==1.1.0
 opentelemetry-sdk==1.1.0


### PR DESCRIPTION
[Sorry, previous PR was kind of messed up...]

## Why are these changes needed?

I am attempting to use `ray.data.write_tfrecords` to convert my features into TFRecords. Since some of my features are string features, the following error is thrown:

```
ValueError: Value is of type string, which we cannot convert to a supported tf.train.Feature storage type (bytes, float, or int).
```

Naturally, TFRecords serializes string features as bytes feature automatically (as typically done in Tensorflow and Tensorflow-extended (TFX); see for example: https://github.com/tensorflow/tfx/blob/fd070288ffa5dcb28204810d2bed261c7e1df201/tfx/components/example_gen/csv_example_gen/executor.py#L67). Making the TFRecord writer automatically treat strings as bytes would help serialize string features correctly, avoiding the hassle of creating additional map functions to convert string features into bytes.

When reading TFRecords, however, we should still keep the bytes features as bytes, as the program does not necessarily know a byte object represents a string. In [this example](https://www.tensorflow.org/tutorials/load_data/tfrecord#tftrainexample) provided by Tensorflow, tensors are serialized into bytes and stored in tfrecords, using `tf.io.serialize_tensor`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
