### PR TITLE
[air] Don't set rank-specific local directories for Train workers

### DIFF
--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -338,6 +338,8 @@ class StorageContext:
         >>> storage.trial_dir_name = "trial_dir"
         >>> storage.trial_fs_path
         'bucket/path/exp_name/trial_dir'
+        >>> storage.trial_local_path
+        '/tmp/ray_results/exp_name/trial_dir'
         >>> storage.current_checkpoint_index = 1
         >>> storage.checkpoint_fs_path
         'bucket/path/exp_name/trial_dir/checkpoint_000001'
@@ -357,6 +359,10 @@ class StorageContext:
         >>> storage.storage_local_path
         '/tmp/ray_results'
         >>> storage.experiment_path
+        '/tmp/ray_results/exp_name'
+        >>> storage.experiment_local_path
+        '/tmp/ray_results/exp_name'
+        >>> storage.experiment_fs_path
         '/tmp/ray_results/exp_name'
         >>> storage.syncer is None
         True
@@ -494,6 +500,18 @@ class StorageContext:
         syncing them to the `storage_path` on the `storage_filesystem`.
         """
         return os.path.join(self.storage_local_path, self.experiment_dir_name)
+
+    @property
+    def trial_local_path(self) -> str:
+        """The local filesystem path to the trial directory.
+
+        Raises a ValueError if `trial_dir_name` is not set beforehand.
+        """
+        if self.trial_dir_name is None:
+            raise RuntimeError(
+                "Should not access `trial_local_path` without setting `trial_dir_name`"
+            )
+        return os.path.join(self.experiment_local_path, self.trial_dir_name)
 
     @property
     def trial_fs_path(self) -> str:

--- a/python/ray/train/tests/test_new_persistence.py
+++ b/python/ray/train/tests/test_new_persistence.py
@@ -172,6 +172,8 @@ def test_trainer(tmp_path):
         assert train_session.storage
         assert train_session.storage.checkpoint_fs_path
 
+        assert os.getcwd() == train_session.storage.trial_local_path
+
     trainer = DataParallelTrainer(
         dummy_train_fn,
         scaling_config=train.ScalingConfig(num_workers=2),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is based on the REP here: https://github.com/ray-project/enhancements/pull/35

We don't want to force train workers to have separated working directories (`rank_x`). Instead, this can be configured by the user themselves.

This auto `chdir` behavior led to issues in the past, where certain frameworks expect a common working directory for each worker (https://github.com/ray-project/ray/issues/35894).

```python
# Before
def train_loop_per_worker():
    assert os.getcwd() == "{storage_path}/{exp_name}/{trial_name}/rank_x

# After
def train_loop_per_worker():
    assert os.getcwd() == "{storage_path}/{exp_name}/{trial_name}

    # Write to a unique rank dir yourself if you want to.
    rank_dir = f"rank_{train.get_context().get_world_rank()}"
    os.makedirs(rank_dir, exist_ok=True)
    with open(os.path.join(rank_dir, "artifact.txt")) as f:
        f.write("asdfsadf")
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
