### PR TITLE
[civ2][flakiness/9] setup test environment before running tests

### DIFF
--- a/ci/ray_ci/core.tests.env.sh
+++ b/ci/ray_ci/core.tests.env.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# This script is used to setup test environment for running core tests.
+
+set -exo pipefail
+
+DL=1 ./ci/env/install-dependencies.sh

--- a/ci/ray_ci/runner.py
+++ b/ci/ray_ci/runner.py
@@ -69,11 +69,7 @@ def main(
         logging.info("No tests to run")
         return
     logger.info(f"Running tests: {test_targets}")
-    success = run_tests(
-        test_targets,
-        ["DL=1 ./ci/env/install-dependencies.sh"],
-        parallelism_per_worker,
-    )
+    success = run_tests(team, test_targets, parallelism_per_worker)
     sys.exit(0 if success else 1)
 
 

--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -1,0 +1,10 @@
+# syntax=docker/dockerfile:1.3-labs
+# shellcheck disable=SC2148
+
+ARG BASE_IMAGE
+FROM "$BASE_IMAGE"
+
+ARG TEST_ENVIRONMENT_SCRIPT
+
+COPY "$TEST_ENVIRONMENT_SCRIPT" /tmp/post_build_script.sh
+RUN /tmp/post_build_script.sh


### PR DESCRIPTION
Currently, before tests can run on the oss-ci-build image, we need to install the test environment (such as `DL=1 ./ci/env/install-dependencies.sh`). As we move tests in running in parallel, this environment setup step is repetitive in all concurrent processes.

This PR creates a way to setup test environment before spawning concurrent test runs.

Test:
- CI