### PR TITLE
[Core][Java Label Schedduling 1/n]Java worker add set & get node labels api

### DIFF
--- a/java/api/src/main/java/io/ray/api/runtimecontext/NodeInfo.java
+++ b/java/api/src/main/java/io/ray/api/runtimecontext/NodeInfo.java
@@ -22,6 +22,8 @@ public class NodeInfo {
 
   public final Map<String, Double> resources;
 
+  public final Map<String, String> labels;
+
   public NodeInfo(
       UniqueId nodeId,
       String nodeAddress,
@@ -30,7 +32,8 @@ public class NodeInfo {
       String objectStoreSocketName,
       String rayletSocketName,
       boolean isAlive,
-      Map<String, Double> resources) {
+      Map<String, Double> resources,
+      Map<String, String> labels) {
     this.nodeId = nodeId;
     this.nodeAddress = nodeAddress;
     this.nodeHostname = nodeHostname;
@@ -39,6 +42,7 @@ public class NodeInfo {
     this.rayletSocketName = rayletSocketName;
     this.isAlive = isAlive;
     this.resources = resources;
+    this.labels = labels;
   }
 
   public String toString() {
@@ -56,6 +60,8 @@ public class NodeInfo {
         + isAlive
         + ", resources="
         + resources
+        + ", labels="
+        + labels
         + "}";
   }
 }

--- a/java/runtime/src/main/java/io/ray/runtime/gcs/GcsClient.java
+++ b/java/runtime/src/main/java/io/ray/runtime/gcs/GcsClient.java
@@ -97,7 +97,8 @@ public class GcsClient {
               data.getObjectStoreSocketName(),
               data.getRayletSocketName(),
               data.getState() == GcsNodeInfo.GcsNodeState.ALIVE,
-              new HashMap<>());
+              new HashMap<>(),
+              data.getLabelsMap());
       if (nodeInfo.isAlive) {
         nodeInfo.resources.putAll(data.getResourcesTotalMap());
       }

--- a/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
@@ -37,6 +37,13 @@ public class RunManager {
       command.add(numGpus);
     }
 
+    // Set node labels.
+    String labels = System.getProperty("ray.labels");
+    if (labels != null) {
+      command.add("--labels");
+      command.add(labels);
+    }
+
     String output;
     try {
       output = runCommand(command);

--- a/java/test/src/main/java/io/ray/test/NodeLabelSchedulingTest.java
+++ b/java/test/src/main/java/io/ray/test/NodeLabelSchedulingTest.java
@@ -1,0 +1,42 @@
+package io.ray.test;
+
+import io.ray.api.Ray;
+import io.ray.api.runtimecontext.NodeInfo;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test(groups = "cluster")
+public class NodeLabelSchedulingTest {
+  public void testEmptyNodeLabels() {
+    try {
+      Ray.init();
+      List<NodeInfo> nodeInfos = Ray.getRuntimeContext().getAllNodeInfo();
+      Assert.assertTrue(nodeInfos.size() == 1);
+      Map<String, String> labels = new HashMap<>();
+      labels.put("ray.io/node_id", nodeInfos.get(0).nodeId.toString());
+      Assert.assertEquals(nodeInfos.get(0).labels, labels);
+    } finally {
+      Ray.shutdown();
+    }
+  }
+
+  public void testSetNodeLabels() {
+    System.setProperty("ray.labels", "{\"gpu_type\":\"A100\",\"azone\":\"azone-1\"}");
+    try {
+      Ray.init();
+      List<NodeInfo> nodeInfos = Ray.getRuntimeContext().getAllNodeInfo();
+      Assert.assertTrue(nodeInfos.size() == 1);
+      Map<String, String> labels = new HashMap<>();
+      labels.put("ray.io/node_id", nodeInfos.get(0).nodeId.toString());
+      labels.put("gpu_type", "A100");
+      labels.put("azone", "azone-1");
+      Assert.assertEquals(nodeInfos.get(0).labels, labels);
+    } finally {
+      System.clearProperty("ray.labels");
+      Ray.shutdown();
+    }
+  }
+}


### PR DESCRIPTION
## Why are these changes needed?
Java worker add set & get node labels API.

1. Set node labels for ray.init()
```
    System.setProperty("ray.labels", "{\"gpu_type\":\"A100\",\"azone\":\"azone-1\"}");
    Ray.init();
```

2. Get node labels 
```
    List<NodeInfo> nodeInfos = Ray.getRuntimeContext().getAllNodeInfo();
    Assert.assertTrue(nodeInfos.size() == 1);
    Map<String, String> labels = new HashMap<>();
    labels.put("ray.io/node_id", nodeInfos.get(0).nodeId.toString());
    labels.put("gpu_type", "A100");
    labels.put("azone", "azone-1");
    Assert.assertEquals(nodeInfos.get(0).labels, labels);
```

## Related issue number
#34894
(P3)Implement the node affinity with labels interface in Java and transparently transmit it to the CoreWorker.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
