### PR TITLE
[core][autoscaler] Fix pending placement group reported when it's committed through autoscaler

### DIFF
--- a/python/ray/autoscaler/v2/BUILD
+++ b/python/ray/autoscaler/v2/BUILD
@@ -93,3 +93,11 @@ py_test(
     tags = ["team:core"],
     deps = ["//:ray_lib", ":conftest"],
 )
+
+py_test(
+    name = "test_e2e",
+    size = "small",
+    srcs = ["tests/test_e2e.py"],
+    tags = ["team:core"],
+    deps = ["//:ray_lib", ":conftest"],
+)

--- a/python/ray/autoscaler/v2/tests/test_e2e.py
+++ b/python/ray/autoscaler/v2/tests/test_e2e.py
@@ -1,11 +1,13 @@
-import pytest
 import os
 import sys
+
+import pytest
+
 import ray
 from ray._private.test_utils import run_string_as_driver_nonblocking, wait_for_condition
 from ray.autoscaler.v2.sdk import get_cluster_status
-from ray.util.state.api import list_placement_groups
 from ray.cluster_utils import AutoscalingCluster
+from ray.util.state.api import list_placement_groups
 
 
 def test_placement_group_consistent(shutdown_only):
@@ -47,7 +49,6 @@ while True:
     time.sleep(0.5)
     remove_placement_group(pg)
     time.sleep(0.5)
-    
 """
     run_string_as_driver_nonblocking(driver_script)
 

--- a/python/ray/autoscaler/v2/tests/test_e2e.py
+++ b/python/ray/autoscaler/v2/tests/test_e2e.py
@@ -59,7 +59,7 @@ while True:
 
     wait_for_condition(pg_created)
 
-    for _ in range(40):
+    for _ in range(30):
         # verify no pending request + resource used.
         status = get_cluster_status()
         has_pg_demand = len(status.resource_demands.placement_group_demand) > 0
@@ -68,7 +68,9 @@ while True:
             has_pg_usage = has_pg_usage or "bundle" in usage.resource_name
         print(has_pg_demand, has_pg_usage)
         assert not (has_pg_demand and has_pg_usage), status
-        time.sleep(0.25)
+        time.sleep(0.1)
+
+    cluster.shutdown()
 
 
 if __name__ == "__main__":

--- a/python/ray/autoscaler/v2/tests/test_e2e.py
+++ b/python/ray/autoscaler/v2/tests/test_e2e.py
@@ -1,0 +1,78 @@
+import pytest
+import os
+import sys
+import ray
+from ray._private.test_utils import run_string_as_driver_nonblocking, wait_for_condition
+from ray.autoscaler.v2.sdk import get_cluster_status
+from ray.util.state.api import list_placement_groups
+from ray.cluster_utils import AutoscalingCluster
+
+
+def test_placement_group_consistent(shutdown_only):
+    # Test that continuously creating and removing placement groups
+    # does not leak pending resource requests.
+    import time
+
+    cluster = AutoscalingCluster(
+        head_resources={"CPU": 0},
+        worker_node_types={
+            "type-1": {
+                "resources": {"CPU": 1},
+                "node_config": {},
+                "min_workers": 0,
+                "max_workers": 2,
+            },
+        },
+    )
+    cluster.start()
+    ray.init("auto")
+
+    driver_script = """
+
+import ray
+import time
+# Import placement group APIs.
+from ray.util.placement_group import (
+    placement_group,
+    placement_group_table,
+    remove_placement_group,
+)
+
+ray.init("auto")
+
+# Reserve all the CPUs of nodes, X= num of cpus, N = num of nodes
+while True:
+    pg = placement_group([{"CPU": 1}])
+    ray.get(pg.ready())
+    time.sleep(0.5)
+    remove_placement_group(pg)
+    time.sleep(0.5)
+    
+"""
+    run_string_as_driver_nonblocking(driver_script)
+
+    def pg_created():
+        pgs = list_placement_groups()
+        assert len(pgs) > 0
+
+        return True
+
+    wait_for_condition(pg_created)
+
+    for _ in range(40):
+        # verify no pending request + resource used.
+        status = get_cluster_status()
+        has_pg_demand = len(status.resource_demands.placement_group_demand) > 0
+        has_pg_usage = False
+        for usage in status.cluster_resource_usage:
+            has_pg_usage = has_pg_usage or "bundle" in usage.resource_name
+        print(has_pg_demand, has_pg_usage)
+        assert not (has_pg_demand and has_pg_usage), status
+        time.sleep(0.25)
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/src/mock/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -72,6 +72,11 @@ class MockGcsPlacementGroupManager : public GcsPlacementGroupManager {
               (const NodeID &node_id),
               (const, override));
 
+  MOCK_METHOD((std::shared_ptr<rpc::PlacementGroupLoad>),
+              GetPlacementGroupLoad,
+              (),
+              (const, override));
+
   instrumented_io_context context_;
 };
 

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -125,8 +125,8 @@ void GcsAutoscalerStateManager::MakeClusterResourceStateInternal(
 void GcsAutoscalerStateManager::GetPendingGangResourceRequests(
     rpc::autoscaler::ClusterResourceState *state) {
   // Get the gang resource requests from the placement group load.
-  auto placement_group_load = gcs_resource_manager_.GetPlacementGroupLoad();
-  if (!placement_group_load) {
+  auto placement_group_load = gcs_placement_group_manager_.GetPlacementGroupLoad();
+  if (!placement_group_load || placement_group_load->placement_group_data_size() == 0) {
     return;
   }
 

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h
@@ -66,6 +66,11 @@ class GcsAutoscalerStateManager : public rpc::autoscaler::AutoscalerStateHandler
   /// \param state The state to be filled.
   void MakeClusterResourceStateInternal(rpc::autoscaler::ClusterResourceState *state);
 
+  /// \brief Get the placement group load from GcsPlacementGroupManager
+  ///
+  /// \return The placement group load, nullptr if there is no placement group load.
+  std::shared_ptr<rpc::PlacementGroupLoad> GetPlacementGroupLoad() const;
+
   /// \brief Increment and get the next cluster resource state version.
   /// \return The incremented cluster resource state version.
   int64_t IncrementAndGetNextClusterResourceStateVersion() {

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -1056,13 +1056,13 @@ bool GcsPlacementGroupManager::RescheduleIfStillHasUnplacedBundles(
 
 const absl::btree_multimap<
     int64_t,
-    std::pair<ExponentialBackOff, std::shared_ptr<GcsPlacementGroup>>> &
-GcsPlacementGroupManager::GetPendingPlacementGroups() const {
+    std::pair<ExponentialBackOff, std::shared_ptr<GcsPlacementGroup>>>
+    &GcsPlacementGroupManager::GetPendingPlacementGroups() const {
   return pending_placement_groups_;
 }
 
-const std::deque<std::shared_ptr<GcsPlacementGroup>> &
-GcsPlacementGroupManager::GetInfeasiblePlacementGroups() const {
+const std::deque<std::shared_ptr<GcsPlacementGroup>>
+    &GcsPlacementGroupManager::GetInfeasiblePlacementGroups() const {
   return infeasible_placement_groups_;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -906,7 +906,7 @@ std::shared_ptr<rpc::PlacementGroupLoad> GcsPlacementGroupManager::GetPlacementG
 void GcsPlacementGroupManager::UpdatePlacementGroupLoad() {
   // TODO(rickyx): We should remove this, no other callers other than autoscaler
   // use this info.
-  gcs_resource_manager_.UpdatePlacementGroupLoad(std::move(GetPlacementGroupLoad()));
+  gcs_resource_manager_.UpdatePlacementGroupLoad(GetPlacementGroupLoad());
 }
 
 void GcsPlacementGroupManager::Initialize(const GcsInitData &gcs_init_data) {
@@ -1056,13 +1056,13 @@ bool GcsPlacementGroupManager::RescheduleIfStillHasUnplacedBundles(
 
 const absl::btree_multimap<
     int64_t,
-    std::pair<ExponentialBackOff, std::shared_ptr<GcsPlacementGroup>>>
-    &GcsPlacementGroupManager::GetPendingPlacementGroups() const {
+    std::pair<ExponentialBackOff, std::shared_ptr<GcsPlacementGroup>>> &
+GcsPlacementGroupManager::GetPendingPlacementGroups() const {
   return pending_placement_groups_;
 }
 
-const std::deque<std::shared_ptr<GcsPlacementGroup>>
-    &GcsPlacementGroupManager::GetInfeasiblePlacementGroups() const {
+const std::deque<std::shared_ptr<GcsPlacementGroup>> &
+GcsPlacementGroupManager::GetInfeasiblePlacementGroups() const {
   return infeasible_placement_groups_;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -873,7 +873,8 @@ void GcsPlacementGroupManager::Tick() {
       std::chrono::milliseconds(1000) /* milliseconds */);
 }
 
-void GcsPlacementGroupManager::UpdatePlacementGroupLoad() {
+std::shared_ptr<rpc::PlacementGroupLoad> GcsPlacementGroupManager::GetPlacementGroupLoad()
+    const {
   std::shared_ptr<rpc::PlacementGroupLoad> placement_group_load =
       std::make_shared<rpc::PlacementGroupLoad>();
   int total_cnt = 0;
@@ -898,7 +899,14 @@ void GcsPlacementGroupManager::UpdatePlacementGroupLoad() {
       break;
     }
   }
-  gcs_resource_manager_.UpdatePlacementGroupLoad(std::move(placement_group_load));
+
+  return placement_group_load;
+}
+
+void GcsPlacementGroupManager::UpdatePlacementGroupLoad() {
+  // TODO(rickyx): We should remove this, no other callers other than autoscaler
+  // use this info.
+  gcs_resource_manager_.UpdatePlacementGroupLoad(std::move(GetPlacementGroupLoad()));
 }
 
 void GcsPlacementGroupManager::Initialize(const GcsInitData &gcs_init_data) {
@@ -1048,13 +1056,13 @@ bool GcsPlacementGroupManager::RescheduleIfStillHasUnplacedBundles(
 
 const absl::btree_multimap<
     int64_t,
-    std::pair<ExponentialBackOff, std::shared_ptr<GcsPlacementGroup>>>
-    &GcsPlacementGroupManager::GetPendingPlacementGroups() const {
+    std::pair<ExponentialBackOff, std::shared_ptr<GcsPlacementGroup>>> &
+GcsPlacementGroupManager::GetPendingPlacementGroups() const {
   return pending_placement_groups_;
 }
 
-const std::deque<std::shared_ptr<GcsPlacementGroup>>
-    &GcsPlacementGroupManager::GetInfeasiblePlacementGroups() const {
+const std::deque<std::shared_ptr<GcsPlacementGroup>> &
+GcsPlacementGroupManager::GetInfeasiblePlacementGroups() const {
   return infeasible_placement_groups_;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -384,8 +384,8 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   /// \return Pending placement groups.
   const absl::btree_multimap<
       int64_t,
-      std::pair<ExponentialBackOff, std::shared_ptr<GcsPlacementGroup>>> &
-  GetPendingPlacementGroups() const;
+      std::pair<ExponentialBackOff, std::shared_ptr<GcsPlacementGroup>>>
+      &GetPendingPlacementGroups() const;
 
   /// Get a read only view of the infeasible placement groups.
   ///

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -384,14 +384,20 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   /// \return Pending placement groups.
   const absl::btree_multimap<
       int64_t,
-      std::pair<ExponentialBackOff, std::shared_ptr<GcsPlacementGroup>>>
-      &GetPendingPlacementGroups() const;
+      std::pair<ExponentialBackOff, std::shared_ptr<GcsPlacementGroup>>> &
+  GetPendingPlacementGroups() const;
 
   /// Get a read only view of the infeasible placement groups.
   ///
   /// \return Infeasible placement groups.
   const std::deque<std::shared_ptr<GcsPlacementGroup>> &GetInfeasiblePlacementGroups()
       const;
+
+  /// Get the placement group load information.
+  ///
+  /// \return Placement group load information. Users should check if
+  /// the returned rpc has any placement_group_data.
+  virtual std::shared_ptr<rpc::PlacementGroupLoad> GetPlacementGroupLoad() const;
 
  protected:
   /// For testing/mocking only.

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -142,8 +142,8 @@ void GcsResourceManager::UpdateResourceLoads(const rpc::ResourcesData &data) {
   }
 }
 
-const absl::flat_hash_map<NodeID, rpc::ResourcesData> &
-GcsResourceManager::NodeResourceReportView() const {
+const absl::flat_hash_map<NodeID, rpc::ResourcesData>
+    &GcsResourceManager::NodeResourceReportView() const {
   return node_resource_usages_;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -142,8 +142,8 @@ void GcsResourceManager::UpdateResourceLoads(const rpc::ResourcesData &data) {
   }
 }
 
-const absl::flat_hash_map<NodeID, rpc::ResourcesData>
-    &GcsResourceManager::NodeResourceReportView() const {
+const absl::flat_hash_map<NodeID, rpc::ResourcesData> &
+GcsResourceManager::NodeResourceReportView() const {
   return node_resource_usages_;
 }
 
@@ -317,6 +317,7 @@ void GcsResourceManager::OnNodeDead(const NodeID &node_id) {
 
 void GcsResourceManager::UpdatePlacementGroupLoad(
     const std::shared_ptr<rpc::PlacementGroupLoad> placement_group_load) {
+  RAY_CHECK(placement_group_load != nullptr);
   placement_group_load_ = absl::make_optional(placement_group_load);
 }
 

--- a/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
@@ -482,13 +482,15 @@ TEST_F(GcsAutoscalerStateManagerTest, TestGangResourceRequestsBasic) {
   // A strict spread pending pg should generate pending gang resource requests.
   {
     auto pg = PlacementGroupID::Of(job_id);
-    UpdatePlacementGroupLoad(
-        {Mocker::GenPlacementGroupTableData(pg,
-                                            job_id,
-                                            {{{"CPU", 1}}, {{"GPU", 1}}},
-                                            {"", ""},
-                                            rpc::PlacementStrategy::STRICT_SPREAD,
-                                            rpc::PlacementGroupTableData::PENDING)});
+    EXPECT_CALL(*gcs_placement_group_manager_, GetPlacementGroupLoad)
+        .WillOnce(
+            Return(Mocker::GenPlacementGroupLoad({Mocker::GenPlacementGroupTableData(
+                pg,
+                job_id,
+                {{{"CPU", 1}}, {{"GPU", 1}}},
+                {"", ""},
+                rpc::PlacementStrategy::STRICT_SPREAD,
+                rpc::PlacementGroupTableData::PENDING)})));
 
     auto state = GetClusterResourceStateSync();
     CheckGangResourceRequests(state,
@@ -501,13 +503,15 @@ TEST_F(GcsAutoscalerStateManagerTest, TestGangResourceRequestsBasic) {
   // A strict pack should also generate constraints.
   {
     auto pg = PlacementGroupID::Of(job_id);
-    UpdatePlacementGroupLoad(
-        {Mocker::GenPlacementGroupTableData(pg,
-                                            job_id,
-                                            {{{"CPU", 1}}, {{"GPU", 1}}},
-                                            {"", ""},
-                                            rpc::PlacementStrategy::STRICT_PACK,
-                                            rpc::PlacementGroupTableData::PENDING)});
+    EXPECT_CALL(*gcs_placement_group_manager_, GetPlacementGroupLoad)
+        .WillOnce(
+            Return(Mocker::GenPlacementGroupLoad({Mocker::GenPlacementGroupTableData(
+                pg,
+                job_id,
+                {{{"CPU", 1}}, {{"GPU", 1}}},
+                {"", ""},
+                rpc::PlacementStrategy::STRICT_PACK,
+                rpc::PlacementGroupTableData::PENDING)})));
 
     auto state = GetClusterResourceStateSync();
     CheckGangResourceRequests(state,
@@ -532,19 +536,21 @@ TEST_F(GcsAutoscalerStateManagerTest, TestGangResourceRequestsNonStrict) {
   {
     auto pg1 = PlacementGroupID::Of(job_id1);
     auto pg2 = PlacementGroupID::Of(job_id2);
-    UpdatePlacementGroupLoad(
-        {Mocker::GenPlacementGroupTableData(pg1,
-                                            job_id1,
-                                            {{{"CPU", 1}, {"GPU", 2}}},
-                                            {""},
-                                            rpc::PlacementStrategy::PACK,
-                                            rpc::PlacementGroupTableData::PENDING),
-         Mocker::GenPlacementGroupTableData(pg2,
-                                            job_id2,
-                                            {{{"TPU", 1}}},
-                                            {""},
-                                            rpc::PlacementStrategy::SPREAD,
-                                            rpc::PlacementGroupTableData::PENDING)});
+    EXPECT_CALL(*gcs_placement_group_manager_, GetPlacementGroupLoad)
+        .WillOnce(Return(Mocker::GenPlacementGroupLoad(
+            {Mocker::GenPlacementGroupTableData(pg1,
+                                                job_id1,
+                                                {{{"CPU", 1}, {"GPU", 2}}},
+                                                {""},
+                                                rpc::PlacementStrategy::PACK,
+                                                rpc::PlacementGroupTableData::PENDING),
+             Mocker::GenPlacementGroupTableData(
+                 pg2,
+                 job_id2,
+                 {{{"TPU", 1}}},
+                 {""},
+                 rpc::PlacementStrategy::SPREAD,
+                 rpc::PlacementGroupTableData::PENDING)})));
 
     const auto &state = GetClusterResourceStateSync();
     CheckGangResourceRequests(state,
@@ -564,13 +570,16 @@ TEST_F(GcsAutoscalerStateManagerTest, TestGangResourceRequestsPartialReschedulin
   // A partially placed PG should not have unplaced bundles requests for strict spread.
   {
     auto pg1 = PlacementGroupID::Of(job_id1);
-    UpdatePlacementGroupLoad({Mocker::GenPlacementGroupTableData(
-        pg1,
-        job_id1,
-        {{{"CPU_failed_1", 1}}, {{"CPU_success_2", 2}}},
-        {"", node->node_id()},
-        rpc::PlacementStrategy::STRICT_SPREAD,
-        rpc::PlacementGroupTableData::RESCHEDULING)});
+
+    EXPECT_CALL(*gcs_placement_group_manager_, GetPlacementGroupLoad)
+        .WillOnce(
+            Return(Mocker::GenPlacementGroupLoad({Mocker::GenPlacementGroupTableData(
+                pg1,
+                job_id1,
+                {{{"CPU_failed_1", 1}}, {{"CPU_success_2", 2}}},
+                {"", node->node_id()},
+                rpc::PlacementStrategy::STRICT_SPREAD,
+                rpc::PlacementGroupTableData::RESCHEDULING)})));
 
     const auto &state = GetClusterResourceStateSync();
 

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -344,6 +344,16 @@ struct Mocker {
     data.set_node_id(node_id);
   }
 
+  static std::shared_ptr<rpc::PlacementGroupLoad> GenPlacementGroupLoad(
+      std::vector<rpc::PlacementGroupTableData> placement_group_table_data_vec) {
+    auto placement_group_load = std::make_shared<rpc::PlacementGroupLoad>();
+    for (auto &placement_group_table_data : placement_group_table_data_vec) {
+      placement_group_load->add_placement_group_data()->CopyFrom(
+          placement_group_table_data);
+    }
+    return placement_group_load;
+  }
+
   static rpc::PlacementGroupTableData GenPlacementGroupTableData(
       const PlacementGroupID &placement_group_id,
       const JobID &job_id,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We get the placement group load directly from PlacementGroupManager instead of the cached data from GcsResourceManager to prevent inconsistent data. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/38006

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
