### PR TITLE
[Data] Raise error if PIL can't load image

### DIFF
--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -1,7 +1,6 @@
 import io
 import logging
 import time
-import warnings
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import numpy as np

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -3,11 +3,10 @@ import tempfile
 from typing import Dict
 from unittest.mock import ANY, patch
 
+import numpy as np
 import pyarrow as pa
 import pytest
 from fsspec.implementations.local import LocalFileSystem
-
-import numpy as np
 
 import ray
 from ray.data.datasource import Partitioning, PathPartitionFilter

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -2,10 +2,11 @@ import os
 from typing import Dict
 from unittest.mock import ANY, patch
 
-import numpy as np
 import pyarrow as pa
 import pytest
 from fsspec.implementations.local import LocalFileSystem
+
+import numpy as np
 
 import ray
 from ray.data.datasource import Partitioning, PathPartitionFilter
@@ -255,6 +256,11 @@ class TestReadImages:
         kwargs["open_stream_args"] = kwargs.pop("arrow_open_file_args")
         mock.assert_called_once_with(ANY, **kwargs)
         assert isinstance(mock.call_args[0][0], ImageDatasource)
+
+    def test_unidentified_image_error(ray_start_regular_shared):
+        with tempfile.NamedTemporaryFile(suffix=".png") as file:
+            with pytest.raises(ValueError):
+                ray.data.read_images(paths=file.name)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -260,7 +260,7 @@ class TestReadImages:
     def test_unidentified_image_error(ray_start_regular_shared):
         with tempfile.NamedTemporaryFile(suffix=".png") as file:
             with pytest.raises(ValueError):
-                ray.data.read_images(paths=file.name)
+                ray.data.read_images(paths=file.name).materialize()
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from typing import Dict
 from unittest.mock import ANY, patch
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you call `read_images` and PIL can't load a file, you get an unhelpful error message:
> PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x19997c350> 

This PR updates the error message to include the path to the file.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
