### PR TITLE
[ci] bigger machine to build docker image for release tests

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -12,6 +12,8 @@ from ray_release.util import DeferredEnvVar
 
 DEFAULT_ARTIFACTS_DIR_HOST = "/tmp/ray_release_test_artifacts"
 
+# TODO (can): unify release_queue_small and runner_queue_small_branch queues
+# having too many type of queues make them difficult to maintain
 RELEASE_QUEUE_DEFAULT = DeferredEnvVar("RELEASE_QUEUE_DEFAULT", "release_queue_small")
 RELEASE_QUEUE_CLIENT = DeferredEnvVar("RELEASE_QUEUE_CLIENT", "release_queue_small")
 

--- a/release/ray_release/byod/build_ray.py
+++ b/release/ray_release/byod/build_ray.py
@@ -66,7 +66,7 @@ def _get_build(py_version: str) -> Dict[str, Any]:
     ]
     return {
         "label": py_version,
-        "agents": {"queue": "release_queue_small"},
+        "agents": {"queue": "runner_queue_medium_branch"},
         "commands": cmd,
         "plugins": [
             {


### PR DESCRIPTION
To build the BYOD image for release tests, we currently using a small machine. That OOMs sometimes. Change it to a bigger machine.

Test:
- Release test: https://buildkite.com/ray-project/release-tests-pr/builds/47369#_