### PR TITLE
Revert "[ci] Fix rllib tests"

### DIFF
--- a/release/ray_release/byod/byod_rllib_test.sh
+++ b/release/ray_release/byod/byod_rllib_test.sh
@@ -8,5 +8,12 @@ git clone https://github.com/ray-project/rl-experiments.git
 unzip rl-experiments/halfcheetah-sac/2022-12-17/halfcheetah_1500_mean_reward_sac.zip -d ~/.
 pip3 install torch==2.0.0+cu118 torchvision==0.15.1+cu118 --index-url https://download.pytorch.org/whl/cu118
 
+# TODO(sven): remove once nightly image gets gymnasium and the other new dependencies.
+wget https://mujoco.org/download/mujoco210-linux-x86_64.tar.gz
+mkdir ~/.mujoco
+mv mujoco210-linux-x86_64.tar.gz ~/.mujoco/.
+cd ~/.mujoco
+tar -xf ~/.mujoco/mujoco210-linux-x86_64.tar.gz
+
 # not strictly necessary, but makes debugging easier
 git clone https://github.com/ray-project/ray.git


### PR DESCRIPTION
Reverts ray-project/ray#37975

This was a forward fix of https://github.com/ray-project/ray/pull/38041. But now that original PR gets reverted, this needs to be reverted as well.

Test;
- CI