### PR TITLE
[data] Remove unnecessary and verbose value from error message

### DIFF
--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -691,7 +691,7 @@ class ArrowVariableShapedTensorArray(
                 raise ValueError(
                     "ArrowVariableShapedTensorArray only supports tensor elements that "
                     "all have the same number of dimensions, but got tensor elements "
-                    f"with dimensions: {ndim}, {a.ndim}: {arr}"
+                    f"with dimensions: {ndim}, {a.ndim}"
                 )
             ndim = a.ndim
             shapes.append(a.shape)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Remove an array value from an error message because it is verbose and not useful.
