### PR TITLE
[ci] Fix core tests

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -187,7 +187,7 @@
       --test_tag_filters=client_tests,small_size_python_tests,-team:core 
       -- python/ray/tests/...
     - bazel test --config=ci $(./ci/run/bazel_export_options)
-      --test_tag_filters=ray_ha
+      --test_tag_filters=xcommit
       --test_env=DOCKER_HOST=tcp://docker:2376
       --test_env=DOCKER_TLS_VERIFY=1
       --test_env=DOCKER_CERT_PATH=/certs/client
@@ -195,18 +195,6 @@
       -- python/ray/tests/...
     - bazel test --config=ci $(./ci/run/bazel_export_options)
       -- python/ray/autoscaler/v2/...
-
-- label: ":python: (Large)"
-  conditions: ["RAY_CI_PYTHON_AFFECTED"]
-  instance_size: large
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - DL=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE
-      --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER
-      --test_env=CI --test_tag_filters="large_size_python_tests_shard_0,large_size_python_tests_shard_1,large_size_python_tests_shard_2,-team:core"
-      -- python/ray/tests/...
 
 - label: ":python: (Medium A-J)"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]

--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -1,7 +1,6 @@
 flaky_tests:
   - //python/ray/tests:test_runtime_env_working_dir_3
   - //python/ray/tests:test_placement_group_3
-  - //python/ray/tests:test_memory_pressure
   - //python/ray/tests:test_placement_group_5
   - //python/ray/tests:test_runtime_env_2
   - //python/ray/tests:test_gcs_fault_tolerance

--- a/ci/ray_ci/runner.py
+++ b/ci/ray_ci/runner.py
@@ -110,7 +110,7 @@ def _get_all_test_query(targets: List[str], team: str, size: str) -> str:
     except_query = " union ".join(
         [
             f"attr(tags, {t}, {test_query})"
-            for t in ["debug_tests", "asan_tests", "ray_ha"]
+            for t in ["debug_tests", "asan_tests", "xcommit"]
         ]
     )
 

--- a/ci/ray_ci/test_runner.py
+++ b/ci/ray_ci/test_runner.py
@@ -74,7 +74,7 @@ def test_get_all_test_query() -> None:
         "attr(size, medium, tests(a) union tests(b)))) except "
         "(attr(tags, debug_tests, tests(a) union tests(b)) union "
         "attr(tags, asan_tests, tests(a) union tests(b)) union "
-        "attr(tags, ray_ha, tests(a) union tests(b)))"
+        "attr(tags, xcommit, tests(a) union tests(b)))"
     )
 
 

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -125,7 +125,6 @@ py_test_module_list(
     "test_log_dedup.py",
     "test_logging.py",
     "test_memory_scheduling.py",
-    "test_memory_pressure.py",
     "test_nested_task.py",
     "test_metrics.py",
     "test_task_events.py",
@@ -220,9 +219,10 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_gcs_ha_e2e.py",
+    "test_memory_pressure.py",
   ],
   size = "medium",
-  tags = ["exclusive", "ray_ha", "team:core", "xcommit"],
+  tags = ["exclusive", "team:core", "xcommit"],
   deps = ["//:ray_lib", ":conftest"],
 )
 


### PR DESCRIPTION
Fix a few core test issues that I broke:
- The large buildkite test job no longer has any tests to run, so we can remove it
- The //python/ray/tests:test_memory_pressure fail when moved to a large machine; move it back to a medium machine. Slum together with a ha test and tag both of them as xcommit

Test:
- CI