### PR TITLE
Fixed incorrect link for an LLM example

### DIFF
--- a/doc/source/ray-overview/examples.rst
+++ b/doc/source/ray-overview/examples.rst
@@ -50,7 +50,7 @@ Ray Examples
 
     .. grid-item-card:: :bdg-primary:`Blog`
         :class-item: gallery-item training serving huggingface llm
-        :link: https://www.anyscale.com/blog/how-to-fine-tune-and-serve-llms-simply-quickly-and-cost-effectively-using
+        :link: https://www.anyscale.com/blog/how-to-fine-tune-and-serve-llms
 
         How to fine tune and serve LLMs simply, quickly and cost effectively using Ray + DeepSpeed + HuggingFace
 


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The link for "How to fine tune and serve LLMs" was broken in the example gallery. This PR adds a correct link.
