### PR TITLE
[Doc] Reposition pydata-sphinx-theme nav bar on mobile

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -288,8 +288,16 @@ pre {
 }
 
 @media (max-width: 900px) {
+  /* If the window is too small, hide the custom sticky navigation bar at the top of the page.
+  Also make the pydata-sphinx-theme nav bar, which usually sits below the top nav bar, stick
+  to the top of the page.
+  */
     .top-nav-content {
         display: none;
+    }
+    div.header-article.row.sticky-top.noprint {
+      position: sticky;
+      top: 0;
     }
 }
 
@@ -391,7 +399,7 @@ pre {
 
 @media (max-width: 1000px) {
   .top-nav-content > button.try-anyscale {
-    display: none;;
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Why are these changes needed?

Currently, the pydata-sphinx-theme nav bar is specially positioned to avoid overlapping with the custom nav bar we have at the top of the docs. On small screens (e.g. mobile) this custom position overlaps with page content. This PR moves the nav bar out of the way. Here's what it currently looks like on `master`:

![image](https://github.com/ray-project/ray/assets/14017872/25140cff-0ab5-47e5-bc87-dcc5a0bbd156)

And here's what it looks like with this branch:

![image](https://github.com/ray-project/ray/assets/14017872/e0a2ef2b-9842-4f56-8a94-ea7aad37b9ca)

## Related issue number

Closes https://github.com/ray-project/ray/issues/34759.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
