### PR TITLE
[autoscaler] Use `bash` instead of `/bin/bash`

### DIFF
--- a/python/ray/autoscaler/_private/cluster_dump.py
+++ b/python/ray/autoscaler/_private/cluster_dump.py
@@ -408,7 +408,7 @@ def create_and_get_archive_from_remote_node(
             else ["--no-proccesses-verbose"]
         )
 
-    cmd += ["/bin/bash", "-c", _wrap(collect_cmd, quotes='"')]
+    cmd += ["bash", "-c", _wrap(collect_cmd, quotes='"')]
 
     cat = "node" if not remote_node.is_head else "head"
 

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -582,7 +582,7 @@ class DockerCommandRunner(CommandRunnerInterface):
             .replace("ssh", "ssh -tt", 1)
             .strip("\n")
         )
-        return inner_str + " {} exec -it {} /bin/bash\n".format(
+        return inner_str + " {} exec -it {} bash\n".format(
             self.docker_cmd, self.container_name
         )
 

--- a/python/ray/autoscaler/_private/docker.py
+++ b/python/ray/autoscaler/_private/docker.py
@@ -54,7 +54,7 @@ def with_docker_exec(
     if env_vars:
         env_str = " ".join(["-e {env}=${env}".format(env=env) for env in env_vars])
     return [
-        "docker exec {interactive} {env} {container} /bin/bash -c {cmd} ".format(
+        "docker exec {interactive} {env} {container} bash -c {cmd} ".format(
             interactive="-it" if with_interactive else "",
             env=env_str,
             container=container_name,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some Docker containers (e.g. from scratch containers, or containers built with nix) may not have `/bin/bash` included. Replacing `/bin/bash` with `bash` allows them to work.

It is already assumed that `bash` will be on the `PATH`, e.g. `docker run` uses `bash` as the cmd:

https://github.com/ray-project/ray/blob/a32d29d8a699cf69ad904dd71c4b3da0bb66fbcc/python/ray/autoscaler/_private/docker.py#L115-L127

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I've run a cluster with this code and the cluster runs successfully.