### PR TITLE
[Core]Add java test dir(test-output/*) to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,7 @@ java/**/.classpath
 java/**/.project
 java/runtime/native_dependencies/
 java/testng_custom.xml
+test-output
 
 dependency-reduced-pom.xml
 


### PR DESCRIPTION
## Why are these changes needed?
Add java test dir(test-output/*) to gitignore。
After test bazel-bin/java/all_tests_shaded.jar, `test-output` dir will be created for test output.  Now add it to gitignore.
```
bazel build //java:all_tests_shaded.jar
java -cp bazel-bin/java/all_tests_shaded.jar org.testng.TestNG -testclass io.ray.test.CrossLanguageInvocationTest
```
![image](https://github.com/ray-project/ray/assets/11072802/0a505902-3e16-46f0-ad94-46afadb0f344)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
