### PR TITLE
[ci] good bye cluster_env

### DIFF
--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -69,9 +69,6 @@
 			"type": "object",
 			"additionalProperties": false,
 			"properties": {
-				"cluster_env": {
-					"type": "string"
-				},
 				"cluster_compute": {
 					"type": "string"
 				},
@@ -90,6 +87,7 @@
 				}
 			},
 			"required": [
+				"byod",
 				"cluster_compute"
 			],
 			"title": "Cluster"

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -24,8 +24,6 @@
 #
 #  # Cluster information
 #  cluster:
-#    # Location of cluster env, relative to working_dir
-#    cluster_env: cluster_env.yaml
 #    # Location of cluster compute, relative to working_dir
 #    cluster_compute: cluster_compute.yaml
 #    # Autosuspend parameter passed to the cluster.
@@ -104,7 +102,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: cpt_autoscaling_1-3_gce.yaml
 
   alert: default
@@ -138,7 +135,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_gpu_1_cpu_16_gce.yaml
 
 # 10 GB image classification parquet with 1 GPU.
@@ -166,7 +162,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_gpu_1_cpu_16_gce.yaml
 
 
@@ -199,7 +194,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_gpu_4x4_gce.yaml
 
 
@@ -232,7 +226,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_gpu_4x4_gce.yaml
 
 # 10 TB image classification parquet data with heterogenous cluster
@@ -287,7 +280,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: frequent_pausing/app_config.yaml
         cluster_compute: frequent_pausing/compute_config_gce.yaml
 
   alert: default
@@ -312,7 +304,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: horovod/app_config_master.yaml
         cluster_compute: horovod/compute_tpl_gce.yaml
 
   run:
@@ -356,7 +347,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_data_20_nodes_gce.yaml
 
   alert: default
@@ -387,7 +377,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: xgboost_app_config.yaml
         cluster_compute: compute_xgboost_gce.yaml
 
   smoke_test:
@@ -424,7 +413,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_cpu_4_gce.yaml
 
   alert: default
@@ -467,7 +455,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_gpu_4x4_gce.yaml
       smoke_test:
         frequency: manual
@@ -497,7 +484,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_cpu_1_gce.yaml
 
   alert: default
@@ -528,7 +514,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_cpu_4_gce.yaml
 
   alert: default
@@ -558,7 +543,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_cpu_8_gce.yaml
 
   alert: default
@@ -588,7 +572,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_gpu_4x4_gce.yaml
 
   alert: default
@@ -619,7 +602,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_cpu_4_gce.yaml
 
   alert: default
@@ -647,7 +629,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_cpu_1_gce.yaml
 
   alert: default
@@ -680,7 +661,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_cpu_4_gce.yaml
 
   alert: default
@@ -725,7 +705,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_gpu_4x4_gce.yaml
       smoke_test:
         frequency: manual
@@ -756,7 +735,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_gpu_1_gce.yaml
 
 
@@ -789,7 +767,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_gpu_4x4_gce.yaml
 
 # Test tiny, and medium input files to check that performance stays about
@@ -821,7 +798,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config_oom.yaml
         cluster_compute: compute_gce_cpu_16.yaml
 
 # Test huge files to check that we do not OOM.
@@ -852,7 +828,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config_oom.yaml
         cluster_compute: compute_gce_cpu_16.yaml
 
 #######################
@@ -910,7 +885,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: gptj_deepspeed_env.yaml
         cluster_compute: gptj_deepspeed_compute_gce.yaml
 
 
@@ -955,7 +929,6 @@
         - myst-parser==0.15.2
         - myst-nb==0.13.1
       post_build_script: byod_vicuna_test.sh
-    cluster_env: vicuna_13b_deepspeed_env.yaml
     cluster_compute: vicuna_13b_deepspeed_compute_aws.yaml
 
   run:
@@ -987,7 +960,6 @@
         env: gce
         frequency: manual
         cluster:
-          cluster_env: ../testing/cluster_envs/default_cluster_env_nightly_ml_py39.yaml
           cluster_compute: ../testing/compute_configs/gpu/gce.yaml
 
 
@@ -1012,7 +984,6 @@
         env: gce
         frequency: manual
         cluster:
-          cluster_env: ../testing/cluster_envs/02_many_model_training.yaml
           cluster_compute: ../testing/compute_configs/cpu/gce.yaml
 
 
@@ -1037,7 +1008,6 @@
         env: gce
         frequency: manual
         cluster:
-          cluster_env: ../testing/cluster_envs/03_serving_stable_diffusion.yaml
           cluster_compute: ../testing/compute_configs/gpu/gce.yaml
 
 - name: workspace_template_finetuning_llms_with_deepspeed_llama_2_7b
@@ -1062,7 +1032,6 @@
       #   env: gce
       #   frequency: manual
       #   cluster:
-      #     cluster_env: ../testing/cluster_envs/04_finetuning_llms_with_deepspeed.yaml
       #     cluster_compute: ../testing/compute_configs/04_finetuning_llms_with_deepspeed/gce_7b_or_13b.yaml
 
 
@@ -1089,7 +1058,6 @@
       #   env: gce
       #   frequency: manual
       #   cluster:
-      #     cluster_env: ../testing/cluster_envs/04_finetuning_llms_with_deepspeed.yaml
       #     cluster_compute: ../testing/compute_configs/04_finetuning_llms_with_deepspeed/gce_7b_or_13b.yaml
 
 #######################
@@ -1107,7 +1075,6 @@
 #   env: staging_v2
 
 #   cluster:
-#     cluster_env: app_config.yaml
 #     cluster_compute: tpl_cpu_small.yaml
 
 #   run:
@@ -1144,7 +1111,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_moderate_gce.yaml
 
   alert: xgboost_tests
@@ -1177,7 +1143,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config_gpu.yaml
         cluster_compute: tpl_gpu_small_gce.yaml
 
   alert: xgboost_tests
@@ -1206,7 +1171,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_small_gce.yaml
 
 
@@ -1237,7 +1201,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_small_gce.yaml
 
   alert: default
@@ -1267,7 +1230,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_small_gce.yaml
 
   alert: default
@@ -1297,7 +1259,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_small_gce.yaml
 
 
@@ -1328,7 +1289,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_moderate_gce.yaml
 
 
@@ -1359,7 +1319,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_moderate_gce.yaml
 
   alert: xgboost_tests
@@ -1379,7 +1338,6 @@
 #   env: staging_v2
 
 #   cluster:
-#     cluster_env: app_config.yaml
 #     cluster_compute: tpl_cpu_small.yaml
 
 #   run:
@@ -1416,7 +1374,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_moderate_gce.yaml
 
 
@@ -1449,7 +1406,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_small_gce.yaml
 
   alert: default
@@ -1481,7 +1437,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_small_gce.yaml
 
   alert: default
@@ -1510,7 +1465,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_small_gce.yaml
 
   alert: default
@@ -1539,7 +1493,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_moderate_gce.yaml
 
   alert: default
@@ -1568,7 +1521,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_moderate_gce.yaml
 
   alert: default
@@ -1603,7 +1555,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce.yaml
 
   alert: default
@@ -1632,7 +1583,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce.yaml
 
   alert: default
@@ -1665,7 +1615,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: horovod/app_config.yaml
         cluster_compute: horovod/compute_tpl_gce.yaml
 
   alert: default
@@ -1695,7 +1644,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: horovod/app_config_master.yaml
         cluster_compute: horovod/compute_tpl_gce.yaml
 
   alert: default
@@ -1726,7 +1674,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: train/app_config.yaml
         cluster_compute: train/compute_tpl_gce.yaml
 
   alert: default
@@ -1757,7 +1704,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: train/app_config.yaml
         cluster_compute: train/compute_tpl_gce.yaml
 
   alert: default
@@ -1787,7 +1733,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: xgboost/app_config_gpu.yaml
         cluster_compute: xgboost/tpl_gpu_small_scaling_gce.yaml
 
   alert: default
@@ -1817,7 +1762,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: xgboost/app_config_gpu_master.yaml
         cluster_compute: xgboost/tpl_gpu_small_scaling_gce.yaml
 
   alert: default
@@ -1850,7 +1794,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: tune_rllib/compute_tpl_gce.yaml
 
   alert: default
@@ -1907,7 +1850,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_gce_4x8.yaml
 
   alert: tune_tests
@@ -1935,7 +1877,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_gce_4x8.yaml
       run:
         timeout: 600
@@ -1974,7 +1915,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config_ml.yaml
         cluster_compute: tpl_gce_4x2.yaml
       run:
         timeout: 600
@@ -2014,7 +1954,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config_ml.yaml
         cluster_compute: tpl_gce_4x2.yaml
       run:
         timeout: 600
@@ -2086,7 +2025,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_gce_1x16.yaml
 
 - name: tune_scalability_durable_trainable
@@ -2117,7 +2055,6 @@
         wait_for_nodes:
           num_nodes: 16
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_gce_16x2.yaml
 
   alert: tune_tests
@@ -2151,7 +2088,6 @@
         wait_for_nodes:
           num_nodes: 16
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_gce_16x2.yaml
 
   alert: tune_tests
@@ -2188,7 +2124,6 @@
       smoke_test:
         frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_gce_1x32_hd.yaml
 
 - name: tune_scalability_network_overhead
@@ -2216,7 +2151,6 @@
     - __suffix__: smoke-test
       frequency: nightly
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_20x2.yaml
       run:
         timeout: 750
@@ -2228,7 +2162,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_gce_100x2.yaml
 
 - name: tune_scalability_result_throughput_cluster
@@ -2257,7 +2190,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_gce_16x64.yaml
 
 - name: tune_scalability_result_throughput_single_node
@@ -2283,7 +2215,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_gce_1x96.yaml
       run:
         timeout: 600
@@ -2317,7 +2248,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config_data.yaml
         cluster_compute: tpl_gce_16x64.yaml
 
 
@@ -2357,7 +2287,6 @@
 #        wait_for_nodes:
 #          num_nodes: 16
 #      cluster:
-#        cluster_env: app_config.yaml
 #        cluster_compute: tpl_gce_16x1.yaml
 
 ########################
@@ -2387,7 +2316,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: torch_tune_serve_app_config.yaml
         cluster_compute: gpu_tpl_gce.yaml
 
   alert: default
@@ -2432,7 +2360,6 @@
       smoke_test:
         frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_apex
@@ -2477,7 +2404,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: tpl_cpu_3_gce.yaml
 
 - name: long_running_impala
@@ -2519,7 +2445,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: tpl_cpu_1_large_gce.yaml
 
 - name: long_running_many_actor_tasks
@@ -2558,7 +2483,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_drivers
@@ -2597,7 +2521,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_ppo
@@ -2644,7 +2567,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: many_ppo_gce.yaml
 
 - name: long_running_many_tasks
@@ -2683,7 +2605,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_tasks_serialized_ids
@@ -2722,7 +2643,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_node_failures
@@ -2761,7 +2681,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_pbt
@@ -2803,7 +2722,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: ../rllib_tests/app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_serve
@@ -2842,7 +2760,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_serve_failure
@@ -2883,7 +2800,6 @@
         run:
           timeout: 86400
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_c5_gce.yaml
 
 - name: long_running_many_jobs
@@ -2924,7 +2840,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_distributed_pytorch_pbt_failure
@@ -2961,7 +2876,6 @@
         run:
           timeout: 3600
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce.yaml
 
 ########################
@@ -2995,7 +2909,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
 - name: jobs_basic_remote_working_dir
@@ -3025,7 +2938,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
 - name: jobs_remote_multi_node
@@ -3050,7 +2962,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
 - name: jobs_check_cuda_available
@@ -3075,7 +2986,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce_gpu_node.yaml
 
 - name: jobs_specify_num_gpus
@@ -3100,7 +3010,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce_gpu_worker.yaml
 
 ########################
@@ -3132,7 +3041,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: rte_gce_small.yaml
 
 - name: runtime_env_wheel_urls
@@ -3161,7 +3069,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: rte_gce_minimal.yaml
 
 # It seems like the consensus is that this should be tested in CI, and not in a nightly test.
@@ -3174,7 +3081,6 @@
 #   team: serve
 
 #   cluster:
-#     cluster_env: app_config.yaml
 #     cluster_compute: rte_minimal.yaml
 
 #   run:
@@ -3214,7 +3120,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_32_cpu_gce.yaml
 
 - name: serve_multi_deployment_1k_noop_replica
@@ -3241,7 +3146,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_32_cpu_gce.yaml
 
 - name: serve_autoscaling_single_deployment
@@ -3268,7 +3172,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_8_cpu_autoscaling_gce.yaml
 
 - name: serve_autoscaling_multi_deployment
@@ -3295,7 +3198,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_32_cpu_autoscaling_gce.yaml
 
 - name: serve_serve_micro_benchmark
@@ -3322,7 +3224,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_single_node_gce.yaml
 
 # - name: serve_serve_micro_benchmark_k8s
@@ -3334,7 +3235,6 @@
 #   team: serve
 
 #   cluster:
-#     cluster_env: app_config.yaml
 #     cluster_compute: compute_tpl_single_node_k8s.yaml
 
 #   run:
@@ -3370,7 +3270,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_single_node_32_cpu_gce.yaml
 
 - name: deployment_graph_wide_ensemble
@@ -3398,7 +3297,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_single_node_32_cpu_gce.yaml
 
 - name: serve_handle_long_chain
@@ -3426,7 +3324,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_single_node_32_cpu_gce.yaml
 
 - name: serve_handle_wide_ensemble
@@ -3454,7 +3351,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_single_node_32_cpu_gce.yaml
 
 
@@ -3482,7 +3378,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_single_node_gce.yaml
 
 - name: serve_micro_protocol_http_benchmark
@@ -3509,7 +3404,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_single_node_gce.yaml
 
 
@@ -3538,7 +3432,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: gpu_app_config.yaml
         cluster_compute: compute_tpl_gpu_node_gce.yaml
 
 ########################
@@ -3571,7 +3464,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: compute_tpl_gce.yaml
 
   alert: default
@@ -3606,7 +3498,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: gpu_2x4_t4_gce.yaml
       run:
         timeout: 3600
@@ -3643,7 +3534,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: gpu_1x8_v100_gce.yaml
       run:
         timeout: 3600
@@ -3689,7 +3579,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: multi_node_checkpointing_compute_config_gce.yaml
 
 - name: rllib_learner_e2e_module_loading
@@ -3723,7 +3612,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: multi_node_checkpointing_compute_config_gce.yaml
 
 - name: rllib_learning_tests_a2c_tf
@@ -3754,7 +3642,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_a2c_torch
@@ -3785,7 +3672,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_a3c_tf
@@ -3816,7 +3702,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 32cpus_gce.yaml
 
 - name: rllib_learning_tests_apex_tf
@@ -3850,7 +3735,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_24cpus_gce.yaml
 
 - name: rllib_learning_tests_apex_torch
@@ -3881,7 +3765,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_24cpus_gce.yaml
 
 - name: rllib_learning_tests_appo_tf
@@ -3912,7 +3795,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 4gpus_64cpus_gce.yaml
 
 - name: rllib_learning_tests_appo_torch
@@ -3946,7 +3828,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 4gpus_64cpus_gce.yaml
 
 # TODO (sven): Remove this test once we are on new stack by default for APPO.
@@ -3978,7 +3859,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 2gpus_32cpus_gce.yaml
 
 # TODO (sven): Remove this test once we are on new stack by default for APPO.
@@ -4013,7 +3893,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 2gpus_32cpus_gce.yaml
 
 - name: rllib_learning_tests_bc_tf
@@ -4044,7 +3923,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_bc_torch
@@ -4075,7 +3953,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_cql_tf
@@ -4109,7 +3986,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_cql_torch
@@ -4143,7 +4019,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_ddpg_tf
@@ -4174,7 +4049,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_ddpg_torch
@@ -4205,7 +4079,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_dqn_tf
@@ -4236,7 +4109,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_dqn_torch
@@ -4270,7 +4142,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_es_tf
@@ -4301,7 +4172,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 2gpus_64cpus_gce.yaml
 
 - name: rllib_learning_tests_es_torch
@@ -4332,7 +4202,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 2gpus_64cpus_gce.yaml
 
 - name: rllib_learning_tests_impala_tf
@@ -4363,7 +4232,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_impala_torch
@@ -4394,7 +4262,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_marwil_tf
@@ -4428,7 +4295,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_marwil_torch
@@ -4462,7 +4328,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_ppo_tf
@@ -4493,7 +4358,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 4gpus_64cpus_gce.yaml
 
 - name: rllib_learning_tests_ppo_torch
@@ -4527,7 +4391,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 4gpus_64cpus_gce.yaml
 
 # TODO (sven): Remove this test once we are on new stack by default for APPO.
@@ -4559,7 +4422,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 2gpus_32cpus_gce.yaml
 
 # TODO (sven): Remove this test once we are on new stack by default for APPO.
@@ -4594,7 +4456,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 2gpus_32cpus_gce.yaml
 
 - name: rllib_learning_tests_sac_tf
@@ -4625,7 +4486,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_sac_torch
@@ -4656,7 +4516,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_slateq_tf
@@ -4687,7 +4546,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_slateq_torch
@@ -4721,7 +4579,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_td3_tf
@@ -4752,7 +4609,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_learning_tests_td3_torch
@@ -4783,7 +4639,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 1gpu_16cpus_gce.yaml
 
 - name: rllib_multi_gpu_learning_tests
@@ -4814,7 +4669,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 8gpus_96cpus_gce.yaml
 
 - name: rllib_multi_gpu_with_lstm_learning_tests
@@ -4845,7 +4699,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 8gpus_96cpus_gce.yaml
 
 - name: rllib_multi_gpu_with_attention_learning_tests
@@ -4878,8 +4731,6 @@
       cluster:
         # TODO(https://github.com/ray-project/ray/issues/34591)
         # Revert to the comment below once ^ closed.
-        # cluster_env: app_config.yaml
-        cluster_env: debug_app_config.yaml
         cluster_compute: 8gpus_96cpus_gce.yaml
 
 - name: rllib_stress_tests
@@ -4923,7 +4774,6 @@
         run:
           timeout: 2000
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: 4gpus_512_cpus_gce.yaml
 
 
@@ -4956,7 +4806,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/shuffle_compute_multi_gce.yaml
 
 
@@ -4981,7 +4830,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: stress_tests/stress_tests_app_config.yaml
         cluster_compute: stress_tests/placement_group_tests_compute_gce.yaml
 
 - name: decision_tree_autoscaling_20_runs
@@ -5005,7 +4853,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: decision_tree/decision_tree_app_config.yaml
         cluster_compute: decision_tree/autoscaling_compute_gce.yaml
 
 - name: autoscaling_shuffle_1tb_1000_partitions
@@ -5032,7 +4879,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/shuffle_compute_autoscaling_gce.yaml
 
 - name: microbenchmark
@@ -5055,7 +4901,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: tpl_64_gce.yaml
 
 
@@ -5087,7 +4932,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config_gpu.yaml
         cluster_compute: only_head_node_1gpu_64cpu_gce.yaml
 
 - name: dask_on_ray_100gb_sort
@@ -5115,7 +4959,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: dask_on_ray/dask_on_ray_app_config.yaml
         cluster_compute: dask_on_ray/dask_on_ray_sort_compute_template_gce.yaml
 
 
@@ -5195,7 +5038,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: stress_tests/state_api_app_config.yaml
         cluster_compute: stress_tests/stress_tests_compute_large_gce.yaml
       smoke_test:
         frequency: manual
@@ -5225,7 +5067,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/shuffle_with_state_api_app_config.yaml
         cluster_compute: shuffle/shuffle_compute_single_gce.yaml
 
 - name: stress_test_many_tasks
@@ -5263,7 +5104,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: stress_tests/stress_tests_app_config.yaml
         cluster_compute: stress_tests/stress_tests_compute_gce.yaml
       smoke_test:
         frequency: manual
@@ -5304,7 +5144,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: stress_tests/stress_tests_app_config.yaml
         cluster_compute: stress_tests/stress_tests_compute_gce.yaml
       smoke_test:
         frequency: manual
@@ -5335,7 +5174,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: stress_tests/stress_tests_app_config.yaml
         cluster_compute: stress_tests/smoke_test_compute_gce.yaml
 
 # - name: threaded_actors_stress_test
@@ -5345,7 +5183,6 @@
 #   frequency: nightly
 #   team: core
 #   cluster:
-#     cluster_env: stress_tests/stress_tests_app_config.yaml
 #     cluster_compute: stress_tests/stress_test_threaded_actor_compute.yaml
 #
 #   run:
@@ -5419,7 +5256,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: stress_tests/stress_tests_single_node_oom_app_config.yaml
         cluster_compute: stress_tests/stress_tests_single_node_oom_compute_gce.yaml
 
 
@@ -5491,7 +5327,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: distributed/many_nodes_tests/app_config.yaml
         cluster_compute: distributed/many_nodes_tests/compute_config_gce.yaml
 
 #- name: many_nodes_multi_master_test
@@ -5501,7 +5336,6 @@
 #  frequency: nightly-3x
 #  team: core
 #  cluster:
-#    cluster_env: many_nodes_tests/app_config.yaml
 #    cluster_compute: many_nodes_tests/compute_config.yaml
 #
 #  run:
@@ -5531,7 +5365,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: placement_group_tests/app_config.yaml
         cluster_compute: placement_group_tests/compute_gce.yaml
 
 - name: placement_group_performance_test
@@ -5556,7 +5389,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: placement_group_tests/app_config.yaml
         cluster_compute: placement_group_tests/pg_perf_test_compute_gce.yaml
 
 
@@ -5588,7 +5420,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: single_node_gce.yaml
 
 - name: object_store
@@ -5616,7 +5447,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: object_store_gce.yaml
 
 - name: many_actors
@@ -5644,7 +5474,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: distributed_gce.yaml
 
 - name: many_actors_smoke_test
@@ -5678,7 +5507,6 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-    cluster_env: app_config.yaml
     cluster_compute: distributed.yaml
 
   run:
@@ -5693,7 +5521,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: distributed_gce.yaml
 
 - name: many_pgs
@@ -5721,7 +5548,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: distributed_gce.yaml
 
 
@@ -5756,7 +5582,6 @@
       type: gpu
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-    cluster_env: app_config.yaml
     cluster_compute: many_nodes.yaml
 
   run:
@@ -5771,7 +5596,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: many_nodes_gce.yaml
 
 - name: scheduling_test_many_0s_tasks_many_nodes
@@ -5804,7 +5628,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: scheduling_gce.yaml
 
 
@@ -5815,7 +5638,6 @@
 #   frequency: nightly
 #   team: core
 #   cluster:
-#     cluster_env: app_config.yaml
 #     cluster_compute: scheduling.yaml
 
 #   run:
@@ -5836,7 +5658,6 @@
 #   frequency: nightly
 #   team: core
 #   cluster:
-#     cluster_env: app_config.yaml
 #     cluster_compute: scheduling.yaml
 
 #   run:
@@ -5878,7 +5699,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: inference_gce.yaml
 
 - name: shuffle_data_loader
@@ -5917,7 +5737,6 @@
   cluster:
     byod:
       type: gpu
-    cluster_env: app_config.yaml
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
@@ -5962,7 +5781,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: pipelined_training_app.yaml
         cluster_compute: pipelined_training_compute_gce.yaml
 
 - name: pipelined_data_ingest_benchmark_1tb
@@ -5989,7 +5807,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: data_ingest_benchmark_compute_gce.yaml
 
 - name: streaming_data_ingest_benchmark_1tb
@@ -6016,7 +5833,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: data_ingest_benchmark_compute_gce.yaml
 
 - name: streaming_data_ingest_benchmark_100gb_gpu
@@ -6043,7 +5859,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: data_ingest_benchmark_compute_gpu_gce.yaml
 
 # This test case will early stop the data ingestion iteration on the GPU actors.
@@ -6075,7 +5890,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: data_ingest_benchmark_compute_gpu_gce.yaml
 
 - name: aggregate_benchmark
@@ -6100,7 +5914,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: read_parquet_benchmark_single_node
@@ -6126,7 +5939,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: read_images_benchmark_single_node
@@ -6151,7 +5963,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: read_images_comparison_microbenchmark_single_node
@@ -6176,7 +5987,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: read_preprocessed_images_comparison_microbenchmark_single_node
@@ -6201,7 +6011,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: read_images_train_4_gpu
@@ -6226,7 +6035,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_2x2_gce.yaml
 
 - name: read_images_train_16_gpu
@@ -6251,7 +6059,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_4x4_gce.yaml
 
 - name: read_images_train_16_gpu_preserve_order
@@ -6276,7 +6083,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_4x4_gce.yaml
 
 - name: read_parquet_train_4_gpu
@@ -6301,7 +6107,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_2x2_gce.yaml
 
 - name: read_parquet_train_16_gpu
@@ -6326,7 +6131,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_4x4_gce.yaml
 
 - name: read_tfrecords_benchmark_single_node
@@ -6352,7 +6156,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: read_tfrecords_benchmark_app.yaml
         cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: map_batches_benchmark_single_node
@@ -6378,7 +6181,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: iter_tensor_batches_benchmark_single_node
@@ -6404,7 +6206,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: iter_tensor_batches_benchmark_multi_node
@@ -6430,7 +6231,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: multi_node_benchmark_compute_gce.yaml
 
 - name: iter_batches_benchmark_single_node
@@ -6456,7 +6256,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: app_config.yaml
         cluster_compute: single_node_benchmark_compute_gce.yaml
 
 - name: pipelined_training_50_gb
@@ -6484,7 +6283,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: pipelined_training_app.yaml
         cluster_compute: pipelined_training_compute_gce.yaml
 
 - name: pipelined_ingestion_1500_gb
@@ -6517,7 +6315,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: pipelined_training_app.yaml
         cluster_compute: pipelined_training_compute_gce.yaml
 
 - name: dataset_shuffle_random_shuffle_1tb
@@ -6547,7 +6344,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 - name: dataset_shuffle_sort_1tb
@@ -6577,7 +6373,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 - name: dataset_shuffle_push_based_random_shuffle_1tb
@@ -6609,7 +6404,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 - name: dataset_shuffle_push_based_sort_1tb
@@ -6639,7 +6433,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 - name: dataset_shuffle_push_based_random_shuffle_100tb
@@ -6670,7 +6463,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/100tb_shuffle_app_config_gce.yaml
         cluster_compute: shuffle/100tb_shuffle_compute_gce.yaml
       run:
         timeout: 28800
@@ -6705,7 +6497,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: chaos_test/app_config.yaml
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_many_actors
@@ -6731,7 +6522,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: chaos_test/app_config.yaml
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 
@@ -6763,7 +6553,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: chaos_test/dask_on_ray_app_config_reconstruction.yaml
         cluster_compute: dask_on_ray/dask_on_ray_stress_compute_gce.yaml
 
 - name: chaos_dask_on_ray_large_scale_test_spilling
@@ -6794,7 +6583,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: chaos_test/dask_on_ray_app_config_reconstruction.yaml
         cluster_compute: dask_on_ray/dask_on_ray_stress_compute_gce.yaml
 
 - name: chaos_pipelined_ingestion_1500_gb_15_windows
@@ -6829,7 +6617,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: dataset/pipelined_ingestion_app.yaml
         cluster_compute: dataset/pipelined_ingestion_compute_gce.yaml
 
 - name: chaos_dataset_shuffle_push_based_sort_1tb
@@ -6862,7 +6649,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/shuffle_app_config.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 - name: chaos_dataset_shuffle_sort_1tb
@@ -6893,7 +6679,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 - name: chaos_dataset_shuffle_random_shuffle_1tb
@@ -6927,7 +6712,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 - name: chaos_dataset_shuffle_push_based_random_shuffle_1tb
@@ -6959,7 +6743,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: shuffle/shuffle_app_config_oom_disabled.yaml
         cluster_compute: shuffle/datasets_large_scale_compute_small_instances_gce.yaml
 
 #####################
@@ -6989,7 +6772,6 @@
       env: gce
       frequency: manual
       cluster:
-        cluster_env: agent_stress_app_config.yaml
         cluster_compute: agent_stress_compute_gce.yaml
 
 - name: k8s_serve_ha_test
@@ -7003,7 +6785,7 @@
   frequency: nightly
   team: serve
   cluster:
-    cluster_env: app_config.yaml
+    byod: {}
     cluster_compute: compute_tpl.yaml
 
   run:
@@ -7036,7 +6818,6 @@
   python: "3.8"
   cluster:
     byod: {}
-    cluster_env: aws/tests/aws_config.yaml
     cluster_compute: aws/tests/aws_compute.yaml
 
   run:
@@ -7069,7 +6850,6 @@
   python: "3.8"
   cluster:
     byod: {}
-    cluster_env: aws/tests/aws_config.yaml
     cluster_compute: aws/tests/aws_compute.yaml
 
   run:
@@ -7100,7 +6880,6 @@
   team: core
   cluster:
     byod: {}
-    cluster_env: aws/tests/aws_config.yaml
     cluster_compute: aws/tests/aws_compute.yaml
 
   run:
@@ -7111,16 +6890,13 @@
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
-  python: "3.7"
-
   stable: true
 
   env: gce
-  python: "3.8"
   frequency: nightly
   team: core
   cluster:
-    cluster_env: gcp/tests/gce_config.yaml
+    byod: {}
     cluster_compute: gcp/tests/single_node_32_cpu_gce.yaml
 
   run:
@@ -7131,16 +6907,13 @@
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
-  python: "3.7"
-
   stable: true
 
   env: gce
-  python: "3.8"
   frequency: nightly
   team: core
   cluster:
-    cluster_env: gcp/tests/gce_config.yaml
+    byod: {}
     cluster_compute: gcp/tests/single_node_32_cpu_gce.yaml
 
   run:
@@ -7158,7 +6931,7 @@
   frequency: nightly
   team: core
   cluster:
-    cluster_env: gcp/tests/gce_config.yaml
+    byod: {}
     cluster_compute: gcp/tests/single_node_32_cpu_gce.yaml
 
   run:
@@ -7176,7 +6949,7 @@
   frequency: nightly
   team: core
   cluster:
-    cluster_env: gcp/tests/gce_config.yaml
+    byod: {}
     cluster_compute: gcp/tests/single_node_32_cpu_gce.yaml
 
   run:
@@ -7195,7 +6968,7 @@
   frequency: manual
   team: core
   cluster:
-    cluster_env: gcp/tests/gce_config.yaml
+    byod: {}
     cluster_compute: gcp/tests/single_node_32_cpu_gce.yaml
 
   run:


### PR DESCRIPTION
Deprecate cluster_env field in release_tests.yaml and move all GCE tests to BYOD

Test:
- Release tests: https://buildkite.com/ray-project/release-tests-pr/builds/47625