### PR TITLE
[CI] Rename `semgrep` step to `untested-code-snippet`

### DIFF
--- a/.buildkite/pipeline.build_lint.yml
+++ b/.buildkite/pipeline.build_lint.yml
@@ -36,7 +36,7 @@
   commands:
     - ./ci/ray_ci/lint.sh copyright
 
-- label: "untested code snippet check"
+- label: "untested code snippet"
   commands:
     - ./ci/ray_ci/lint.sh run_semgrep
 

--- a/.buildkite/pipeline.build_lint.yml
+++ b/.buildkite/pipeline.build_lint.yml
@@ -36,7 +36,7 @@
   commands:
     - ./ci/ray_ci/lint.sh copyright
 
-- label: "untested code snippet"
+- label: "untested code snippet check"
   commands:
     - ./ci/ray_ci/lint.sh run_semgrep
 

--- a/.buildkite/pipeline.build_lint.yml
+++ b/.buildkite/pipeline.build_lint.yml
@@ -36,7 +36,7 @@
   commands:
     - ./ci/ray_ci/lint.sh copyright
 
-- label: ":book: untested-examples-lint"
+- label: ":book: untested examples lint"
   commands:
     - ./ci/ray_ci/lint.sh run_semgrep
 

--- a/.buildkite/pipeline.build_lint.yml
+++ b/.buildkite/pipeline.build_lint.yml
@@ -36,7 +36,7 @@
   commands:
     - ./ci/ray_ci/lint.sh copyright
 
-- label: "semgrep"
+- label: ":book: untested-examples-lint"
   commands:
     - ./ci/ray_ci/lint.sh run_semgrep
 

--- a/.buildkite/pipeline.build_lint.yml
+++ b/.buildkite/pipeline.build_lint.yml
@@ -36,7 +36,7 @@
   commands:
     - ./ci/ray_ci/lint.sh copyright
 
-- label: ":book: untested examples lint"
+- label: "untested code snippet"
   commands:
     - ./ci/ray_ci/lint.sh run_semgrep
 

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -23,8 +23,6 @@ rules:
 
     languages:
       - generic
-    message: > 
-      Don't use 'code-block:: python', it's not tested! Use 'testcode' instead! For more 
-      information, see https://docs.ray.io/en/master/ray-contribute/writing-code-snippets.html.
+    message: Don't use 'code-block:: python', it's not tested! Use 'testcode' instead! For more information, see https://docs.ray.io/en/master/ray-contribute/writing-code-snippets.html.
     pattern: "code-block:: python"
     severity: ERROR


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Despite the doctest ratchet failing in CI, Developers have merged PRs with untested code snippets. This PR renames the doctest ratchet step to make it clearer what the step does.

(Also fixes a typo in the ratchet error message)

![image](https://github.com/ray-project/ray/assets/26107013/d306ab4e-7c43-4393-8dbb-360fc1563b59)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
