### PR TITLE
Fix bug with multiple gpus per worker

### DIFF
--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -457,6 +457,8 @@ class _TorchAccelerator(Accelerator):
 
         if move_to_device:
             device = get_device()
+            if isinstance(device, list):
+                device = device[0]
             data_loader = _WrappedDataLoader(data_loader, device, auto_transfer)
 
         return data_loader


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Calling ray.torch.train.prepare_data_loader when workers have assigned more than one gpu fails because get_device() returns a list. This change fixes that.

## Related issue number

Issue #38115

## Checks

- [ X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
