### PR TITLE
[ci] set RAY_INSTALL_JAVA to 1 by default.

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -461,7 +461,7 @@ build_wheels_and_jars() {
         -e "TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST:-false}"
         -e "TRAVIS_COMMIT=${TRAVIS_COMMIT}"
         -e "CI=${CI}"
-        -e "RAY_INSTALL_JAVA=${RAY_INSTALL_JAVA:-}"
+        -e "RAY_INSTALL_JAVA=${RAY_INSTALL_JAVA:-1}"
         -e "BUILDKITE=${BUILDKITE:-}"
         -e "BUILDKITE_PULL_REQUEST=${BUILDKITE_PULL_REQUEST:-}"
         -e "BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL:-}"


### PR DESCRIPTION
so that by default on ray side we build the java parts by default when building the wheel.

the empty string can be ambiguous and error prone: some code might check if it is "0" or empty, where some code checks if it is "1", and lead to inconsistent results.
