### PR TITLE
[ci] simplify bazel install script

### DIFF
--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-set -x
-set -euo pipefail
-ROOT_DIR=$(cd "$(dirname "$0")/$(dirname "$(test -L "$0" && readlink "$0" || echo "/")")"; pwd)
+
+set -exuo pipefail
 
 arg1="${1-}"
 
@@ -112,10 +111,6 @@ if [[ "${TRAVIS-}" == true ]]; then
   echo "build --jobs=50" >> ~/.bazelrc
 fi
 
-if [[ "${BUILDKITE-}" == "true" ]]; then
-  cp "${ROOT_DIR}"/../../.bazeliskrc ~/.bazeliskrc
-fi
-
 if [[ "${GITHUB_ACTIONS-}" == "true" ]]; then
   echo "build --config=ci-github" >> ~/.bazelrc
   echo "build --jobs="$(($(nproc)+2)) >> ~/.bazelrc
@@ -137,9 +132,9 @@ if [[ "${CI-}" == "true" ]]; then
     echo "Using local disk cache on mac"
     echo "build --disk_cache=/tmp/bazel-cache" >> ~/.bazelrc
     echo "build --repository_cache=/tmp/bazel-repo-cache" >> ~/.bazelrc
-  else
+  elif [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
     echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> ~/.bazelrc
-    if [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then
+    if [[ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ]]; then
       echo "build --remote_upload_local_results=false" >> ~/.bazelrc
     fi
   fi


### PR DESCRIPTION
- remove the copying of bazeliskrc file. bazelisk always respects the bazeliskrc file in the workspace.
- upload bazel cache by default. buildkite runners on PR's do not have the permission to upload.

this reduces the number of build args and input files required for building the ci-base-test image.
