### PR TITLE
[ci] fix release infra unit test

### DIFF
--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -24,7 +24,7 @@ VALID_TEST = Test(
         "frequency": "nightly",
         "team": "release",
         "cluster": {
-            "cluster_env": "app_config.yaml",
+            "byod": {"type": "gpu"},
             "cluster_compute": "tpl_cpu_small.yaml",
             "autosuspend_mins": 10,
         },
@@ -53,7 +53,8 @@ def test_parse_test_definition():
           frequency: nightly
           team: sample
           cluster:
-            cluster_env: env.yaml
+            byod:
+              type: gpu
             cluster_compute: compute.yaml
           run:
             timeout: 100
@@ -75,7 +76,7 @@ def test_parse_test_definition():
     assert not validate_test(gce_test, schema)
     assert aws_test["name"] == "sample_test.aws"
     assert gce_test["cluster"]["cluster_compute"] == "compute_gce.yaml"
-    assert gce_test["cluster"]["cluster_env"] == "env.yaml"
+    assert gce_test["cluster"]["byod"]["type"] == "gpu"
     invalid_test_definition = test_definitions[0]
     # Intentionally make the test definition invalid by create an empty 'variations'
     # field. Check that the parser throws exception at runtime


### PR DESCRIPTION
fix broken `ray_release` unit tests after `cluster_env` removal.

