### PR TITLE
[ci] remove sourcing of deps install script

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -597,8 +597,7 @@ init() {
 
   configure_system
 
-  # shellcheck disable=SC2031
-  . "${ROOT_DIR}"/env/install-dependencies.sh  # Script is sourced to propagate up environment changes
+  "${ROOT_DIR}/env/install-dependencies.sh"
 }
 
 build() {


### PR DESCRIPTION
the script `ci/ci.sh` is never sourced, and the `init()` function in the script always runs independently. the sourcing of `install-dependencies.sh` does nothing useful.
