### PR TITLE
[Core][Label Scheduling 6/n] Add validation for NodeLabelSchedulingStrategy to ensure that the hard and soft parameters cannot both be empty

### DIFF
--- a/python/ray/tests/test_node_label_scheduling_strategy.py
+++ b/python/ray/tests/test_node_label_scheduling_strategy.py
@@ -264,6 +264,13 @@ def test_node_label_scheduling_invalid_paramter(call_ray_start):
             scheduling_strategy=NodeLabelSchedulingStrategy({"gpu_type": "1111"})
         )
 
+    with pytest.raises(
+        ValueError,
+        match="The `hard` and `soft` parameter "
+        "of NodeLabelSchedulingStrategy cannot both be empty.",
+    ):
+        MyActor.options(scheduling_strategy=NodeLabelSchedulingStrategy(hard={}))
+
 
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/util/scheduling_strategies.py
+++ b/python/ray/util/scheduling_strategies.py
@@ -146,6 +146,14 @@ class NodeLabelSchedulingStrategy:
     ):
         self.hard = _convert_map_to_expressions(hard, "hard")
         self.soft = _convert_map_to_expressions(soft, "soft")
+        self._check_usage()
+
+    def _check_usage(self):
+        if not (self.hard or self.soft):
+            raise ValueError(
+                "The `hard` and `soft` parameter "
+                "of NodeLabelSchedulingStrategy cannot both be empty."
+            )
 
 
 def _convert_map_to_expressions(map_expressions: LabelMatchExpressionsT, param: str):


### PR DESCRIPTION
## Why are these changes needed?

Add validation for NodeLabelSchedulingStrategy to ensure that the hard and soft parameters cannot both be empty
```
    with pytest.raises(
        ValueError,
        match="The `hard` and `soft` parameter "
        "of NodeLabelSchedulingStrategy cannot both be empty.",
    ):
        MyActor.options(scheduling_strategy=NodeLabelSchedulingStrategy(hard={}))
```

## Related issue number

#34894

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
