### PR TITLE
[CI] Fix typo in Semgrep config

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -23,6 +23,6 @@ rules:
 
     languages:
       - generic
-    message: Don't use 'code-block:: python', it's not tested! Use 'testcode' instead! For more information, see https://docs.ray.io/en/master/ray-contribute/writing-code-snippets.html.
+    message: "Don't use 'code-block:: python', it's not tested! Use 'testcode' instead! For more information, see https://docs.ray.io/en/master/ray-contribute/writing-code-snippets.html."
     pattern: "code-block:: python"
     severity: ERROR


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

#38126 attempted to correct an unnecessary newline in the error message:

```
         Don't use 'code-block:: python', it's not tested! Use 'testcode'
  instead! For more
          information, see
  https://docs.ray.io/en/master/ray-contribute/writing-code-snippets.html.
```

But, the updated error message is missing quotes. As a result, the CI is always passing.

![image (2)](https://github.com/ray-project/ray/assets/26107013/60b3cd14-5ea3-4f09-9894-e2112be9e5fe)


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
