### PR TITLE
[civ2] python is python3, and add release infra unit tests.

### DIFF
--- a/.buildkite/cicd.rayci.yml
+++ b/.buildkite/cicd.rayci.yml
@@ -5,3 +5,9 @@ steps:
       # TODO(aslonnie): wrap this in a script, and upload test telemetry.
       - bazel test --test_tag_filters=ci_unit //ci/ray_ci/...
     depends_on: forge
+
+  - label: "CI/CD: release test infra"
+    commands:
+      # TODO(aslonnie): wrap this in a script, and upload test telemetry.
+      - bazel test --test_tag_filters=release_unit //release/...
+    depends_on: forge

--- a/.buildkite/pipeline.test.yml
+++ b/.buildkite/pipeline.test.yml
@@ -6,31 +6,6 @@
     - ./ci/ci.sh check_sphinx_links
   soft_fail: True
 
-
-- label: ":python: Release test package unit tests"
-  conditions: ["ALWAYS"]
-  instance_size: small
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options)
-      --build_tests_only
-      --test_tag_filters=release_unit
-      release/...
-
-- label: ":python: CI test package unit tests"
-  conditions: ["ALWAYS"]
-  instance_size: small
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options)
-      --build_tests_only
-      --test_tag_filters=ci_unit
-      ci/...
-
-
 - label: ":octopus: Tune soft imports test"
   conditions: ["RAY_CI_TUNE_AFFECTED"]
   instance_size: small

--- a/ci/forge/Dockerfile.forge
+++ b/ci/forge/Dockerfile.forge
@@ -28,7 +28,8 @@ curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 # Install packages
 
 apt-get update
-apt-get install -y awscli docker-ce-cli nodejs build-essential
+apt-get install -y \
+  awscli docker-ce-cli nodejs build-essential python-is-python3
 
 # Needs to be synchronized to the host group id as we map /var/run/docker.sock
 # into the container.


### PR DESCRIPTION
make release test infra unit tests, so that people cannot break them.

also stops running these tests on civ1.