### PR TITLE
[ci] allow BUILDKITE_PULL_REQUEST to be unset in determine_tests_to_run

### DIFF
--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -43,7 +43,7 @@ def is_pull_request():
 
     if (
         os.environ.get("BUILDKITE")
-        and os.environ.get("BUILDKITE_PULL_REQUEST") != "false"
+        and os.environ.get("BUILDKITE_PULL_REQUEST", "false") != "false"
     ):
         event_type = "pull_request"
 


### PR DESCRIPTION
this allows fallback to default non PR case gracefully without exceptions.

required for some of the base ci images to build without setting `BUILDKITE_PULL_REQUEST`. we would like to unset `BUILDKITE_PULL_REQUEST` for better caching on CI base images.