### PR TITLE
[Data] Add a benchmark for map_batches that outputs many blocks

### DIFF
--- a/release/nightly_tests/dataset/map_batches_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_benchmark.py
@@ -154,7 +154,8 @@ def run_map_batches_benchmark(benchmark: Benchmark):
     input_size = 1024 * 1024
     batch_size = 1024
     ray.data.DataContext.get_current().target_max_block_size = 1024 * 1024
-    # Disable PhysicalOperator fusion.
+    # Disable PhysicalOperator fusion. Because we will have 2 map_batches operators.
+    # And the first one will generate multiple output blocks.
     ray.data._internal.logical.optimizers.PHYSICAL_OPTIMIZER_RULES = []
     parallelism = input_size // batch_size
     input_ds = ray.data.range(input_size, parallelism=parallelism).materialize()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Today, without streaming generator, if an operator outputs many blocks, we cannot stream the output blocks. This benchmark is used to test the perf of this case. 

## Related issue number
https://github.com/ray-project/ray/issues/36444
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
