### PR TITLE
[civ2][lint/2] migrate code format to civ02

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -1,7 +1,13 @@
 group: lint
 steps:
-  - label: "clang-format"
+  - label: "lint: clang format"
     commands:
       - pip install -c python/requirements_compiled.txt clang-format
       - ./ci/lint/check-git-clang-format-output.sh
+    depends_on: forge
+
+  - label: "lint: code format"
+    commands:
+      - pip install -c python/requirements_compiled.txt -r python/requirements/lint-requirements.txt
+      - FORMAT_SH_PRINT_DIFF=1 ./ci/lint/format.sh --all-scripts
     depends_on: forge

--- a/.buildkite/pipeline.build_lint.yml
+++ b/.buildkite/pipeline.build_lint.yml
@@ -1,9 +1,5 @@
 #ci:group=:book: lint (civ2)
 
-- label: "code format"
-  commands:
-    - ./ci/ray_ci/lint.sh code_format
-
 - label: "banned words"
   commands:
     - ./ci/ray_ci/lint.sh banned_words

--- a/ci/forge/Dockerfile.forge
+++ b/ci/forge/Dockerfile.forge
@@ -30,7 +30,8 @@ curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 
 apt-get update
 apt-get install -y \
-  awscli docker-ce-cli nodejs build-essential python-is-python3 python3-pip
+  awscli docker-ce-cli nodejs build-essential python-is-python3 \
+  python3-pip openjdk-8-jre wget
 
 # As a convention, we pin all python packages to a specific version. This
 # is to to make sure we can control version upgrades through code changes.

--- a/ci/lint/format.sh
+++ b/ci/lint/format.sh
@@ -51,6 +51,7 @@ check_docstyle() {
     return 0
 }
 
+# TODO(can): add shellcheck, clang-format, and google-java-format to this check
 check_python_command_exist black
 check_python_command_exist flake8
 check_python_command_exist mypy
@@ -102,7 +103,7 @@ fi
 
 if command -v clang-format >/dev/null; then
   CLANG_FORMAT_VERSION=$(clang-format --version | awk '{print $3}')
-  tool_version_check "clang-format" "$CLANG_FORMAT_VERSION" "12.0.0"
+  tool_version_check "clang-format" "$CLANG_FORMAT_VERSION" "12.0.1"
 else
     echo "WARNING: clang-format is not installed!"
 fi

--- a/python/requirements/lint-requirements.txt
+++ b/python/requirements/lint-requirements.txt
@@ -1,3 +1,4 @@
+clang-format==12.0.1
 flake8==3.9.1
 flake8-comprehensions==3.10.1
 flake8-quotes==2.0.0
@@ -7,3 +8,4 @@ types-PyYAML==6.0.12.2
 black==22.10.0
 isort==5.10.1
 semgrep==1.32.0
+shellcheck-py==0.7.1.1

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -78,6 +78,7 @@ cfn-lint==0.79.6
 charset-normalizer==3.2.0
 chess==1.7.0
 chex==0.1.7
+clang-format==12.0.1
 click==8.1.6
 click-option-group==0.5.6
 cloudpickle==2.2.0
@@ -466,6 +467,7 @@ sentencepiece==0.1.96
 sentry-sdk==1.29.2
 serpent==1.41
 setproctitle==1.3.2
+shellcheck-py==0.7.1.1
 shimmy==1.2.1
 shortuuid==1.0.1
 sigopt==7.5.0


### PR DESCRIPTION
Migrate code format to civ02. This is one of the lint that relies on most of the pip packages in lint-requirements.txt

Test: CI