### PR TITLE
[core][ci] Add some core release tests to autoscaler v2 project for nightly tests

### DIFF
--- a/release/ray_release/environments/aws_pa.env
+++ b/release/ray_release/environments/aws_pa.env
@@ -1,4 +1,3 @@
-# For Integration with Anyscale Autoscaler
 ANYSCALE_HOST=https://console.anyscale-staging.com
 RELEASE_AWS_ANYSCALE_SECRET_ARN="arn:aws:secretsmanager:us-west-2:029272617770:secret:release-automation/anyscale-staging-token20221014164754935800000001-pfQunc"
 RELEASE_DEFAULT_CLOUD_ID="cld_kvedZWag2qA8i5BjxUevf5i7"

--- a/release/ray_release/environments/aws_pa.env
+++ b/release/ray_release/environments/aws_pa.env
@@ -2,5 +2,5 @@
 ANYSCALE_HOST=https://console.anyscale-staging.com
 RELEASE_AWS_ANYSCALE_SECRET_ARN="arn:aws:secretsmanager:us-west-2:029272617770:secret:release-automation/anyscale-staging-token20221014164754935800000001-pfQunc"
 RELEASE_DEFAULT_CLOUD_ID="cld_kvedZWag2qA8i5BjxUevf5i7"
-RELEASE_DEFAULT_PROJECT="prj_qC3ZfndQWYYjx2cz8KWGNUL4"
+RELEASE_DEFAULT_PROJECT="prj_a1x9vj2wl72sl67v5myw6f5en3"
 ANYSCALE_PROJECT="prj_a1x9vj2wl72sl67v5myw6f5en3"

--- a/release/ray_release/environments/aws_pg.env
+++ b/release/ray_release/environments/aws_pg.env
@@ -1,0 +1,6 @@
+# For Integration with Anyscale Autoscaler
+ANYSCALE_HOST=https://console.anyscale-staging.com
+RELEASE_AWS_ANYSCALE_SECRET_ARN="arn:aws:secretsmanager:us-west-2:029272617770:secret:release-automation/anyscale-staging-token20221014164754935800000001-pfQunc"
+RELEASE_DEFAULT_CLOUD_ID="cld_kvedZWag2qA8i5BjxUevf5i7"
+RELEASE_DEFAULT_PROJECT="prj_qC3ZfndQWYYjx2cz8KWGNUL4"
+ANYSCALE_PROJECT="prj_a1x9vj2wl72sl67v5myw6f5en3"

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5107,6 +5107,8 @@
         cluster_compute: stress_tests/stress_tests_compute_gce.yaml
       smoke_test:
         frequency: manual
+    - __suffix__: aws_pa
+      env: aws_pa
 
 - name: stress_test_dead_actors
   group: core-daily-test
@@ -5147,6 +5149,8 @@
         cluster_compute: stress_tests/stress_tests_compute_gce.yaml
       smoke_test:
         frequency: manual
+    - __suffix__: aws_pa
+      env: aws_pa
 
 # The full test is not stable, so run the smoke test only.
 # See https://github.com/ray-project/ray/issues/23244.
@@ -5175,6 +5179,8 @@
       frequency: manual
       cluster:
         cluster_compute: stress_tests/smoke_test_compute_gce.yaml
+    - __suffix__: aws_pa
+      env: aws_pa
 
 # - name: threaded_actors_stress_test
 #   group: core-daily-test
@@ -5235,6 +5241,8 @@
         cluster_compute: stress_tests/smoke_test_compute_gce.yaml
       smoke_test:
         frequency: manual
+    - __suffix__: aws_pa
+      env: aws_pa
 
 - name: single_node_oom
   group: core-daily-test
@@ -5328,6 +5336,8 @@
       frequency: manual
       cluster:
         cluster_compute: distributed/many_nodes_tests/compute_config_gce.yaml
+    - __suffix__: aws_pa
+      env: aws_pa
 
 #- name: many_nodes_multi_master_test
 #  group: core-daily-test
@@ -5366,6 +5376,8 @@
       frequency: manual
       cluster:
         cluster_compute: placement_group_tests/compute_gce.yaml
+    - __suffix__: aws_pa
+      env: aws_pa
 
 - name: placement_group_performance_test
   group: core-daily-test
@@ -5390,6 +5402,8 @@
       frequency: manual
       cluster:
         cluster_compute: placement_group_tests/pg_perf_test_compute_gce.yaml
+    - __suffix__: aws_pa
+      env: aws_pa
 
 
 #########################
@@ -5448,6 +5462,8 @@
       frequency: manual
       cluster:
         cluster_compute: object_store_gce.yaml
+    - __suffix__: aws_pa
+      env: aws_pa
 
 - name: many_actors
   group: core-scalability-test
@@ -5475,6 +5491,8 @@
       frequency: manual
       cluster:
         cluster_compute: distributed_gce.yaml
+    - __suffix__: aws_pa
+      env: aws_pa
 
 - name: many_actors_smoke_test
   group: core-scalability-test
@@ -5522,6 +5540,8 @@
       frequency: manual
       cluster:
         cluster_compute: distributed_gce.yaml
+    - __suffix__: aws_pa
+      env: aws_pa
 
 - name: many_pgs
   group: core-scalability-test
@@ -5549,6 +5569,8 @@
       frequency: manual
       cluster:
         cluster_compute: distributed_gce.yaml
+    - __suffix__: aws_pa
+      env: aws_pa
 
 
 - name: many_pgs_smoke_test
@@ -5597,6 +5619,8 @@
       frequency: manual
       cluster:
         cluster_compute: many_nodes_gce.yaml
+    - __suffix__: aws_pa
+      env: aws_pa
 
 - name: scheduling_test_many_0s_tasks_many_nodes
   group: core-scalability-test
@@ -5629,6 +5653,8 @@
       frequency: manual
       cluster:
         cluster_compute: scheduling_gce.yaml
+    - __suffix__: aws_pa
+      env: aws_pa
 
 
 # - name: scheduling_test_many_5s_tasks_single_node


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This adds a variant of release tests for core that would use Autoscaler V2 when run. 

**What's changed**
This means for the tests changed in this PR, they will run on both V1 and V2 autoscaler. 

**Which tests**
Tests that are:
1. core nightly tests AND
2. use multiple nodes


i.e.: 
- stress_test_many_tasks
- stress_test_dead_actors
- threaded_actors_stress_test
- stress_test_many_runtime_envs
- many_nodes_actor_test_on_v2
- pg_autoscaling_regression_test
- placement_group_performance_test
- object_store
- many_actors
- many_tasks
- many_pgs
- many_nodes
- scheduling_test_many_0s_tasks_many_nodes
- 



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
