### PR TITLE
[ci] change to small instances for ci unit tests

### DIFF
--- a/.buildkite/cicd.rayci.yml
+++ b/.buildkite/cicd.rayci.yml
@@ -4,10 +4,12 @@ steps:
     commands:
       # TODO(aslonnie): wrap this in a script, and upload test telemetry.
       - bazel test --test_tag_filters=ci_unit //ci/ray_ci/...
+    instance_type: small
     depends_on: forge
 
   - label: "CI/CD: release test infra"
     commands:
       # TODO(aslonnie): wrap this in a script, and upload test telemetry.
       - bazel test --test_tag_filters=release_unit //release/...
+    instance_type: small
     depends_on: forge


### PR DESCRIPTION
default is large, and we do not need large.