### PR TITLE
[ci] remove sourcing from "bazel.sh"

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -37,9 +37,6 @@ install_bazel() {
   fi
 
   "${SCRIPT_DIR}"/install-bazel.sh
-  if [ -f /etc/profile.d/bazel.sh ]; then
-    . /etc/profile.d/bazel.sh
-  fi
 }
 
 install_base() {


### PR DESCRIPTION
no one/nothing uses that `bazel.sh` file in `/etc/profile.d`, especially on CI.