### PR TITLE
[ci] fix realpath on third_party deps vendoring

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -511,8 +511,8 @@ install_pip_packages() {
 }
 
 install_thirdparty_packages() {
+  mkdir -p "${WORKSPACE_DIR}/python/ray/thirdparty_files"
   RAY_THIRDPARTY_FILES="$(realpath "${WORKSPACE_DIR}/python/ray/thirdparty_files")"
-  mkdir -p "${RAY_THIRDPARTY_FILES}"
   CC=gcc python -m pip install psutil setproctitle==1.2.2 colorama --target="${RAY_THIRDPARTY_FILES}"
 }
 


### PR DESCRIPTION
needs to call realpath after the directory is made; otherwise realpath will fail.

this might be breaking the build process of master ci-base images