### PR TITLE
[core][ci] Deflaky test_output from fixing the autoscaler event log test on windows

### DIFF
--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -371,9 +371,9 @@ time.sleep(3)
 
     ray.init(_system_config={"enable_autoscaler_v2": True})
 
-    proc = run_string_as_driver_nonblocking(
-        script, env={"RAY_LOG_TO_DRIVER_EVENT_LEVEL": event_level}
-    )
+    env = os.environ.copy()
+    env["RAY_LOG_TO_DRIVER_EVENT_LEVEL"] = event_level
+    proc = run_string_as_driver_nonblocking(script, env=env)
 
     def verify():
         out_str = proc.stdout.read().decode("ascii")

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -328,7 +328,6 @@ time.sleep(3)
     wait_for_condition(verify)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize(
     "event_level,expected_msg,unexpected_msg",
     [
@@ -372,20 +371,27 @@ time.sleep(3)
 
     ray.init(_system_config={"enable_autoscaler_v2": True})
 
-    out_str = run_string_as_driver(
+    proc = run_string_as_driver_nonblocking(
         script, env={"RAY_LOG_TO_DRIVER_EVENT_LEVEL": event_level}
     )
 
-    print(out_str)
-    # Filter only autoscaler prints.
-    assert out_str
+    def verify():
+        out_str = proc.stdout.read().decode("ascii")
+        print(out_str)
+        # Filter only autoscaler prints.
+        assert out_str
 
-    out_str = "".join([line for line in out_str.splitlines() if "autoscaler" in line])
-    for expected in expected_msg.split(","):
-        assert expected in out_str
-    if unexpected_msg:
-        for unexpected in unexpected_msg.split(","):
-            assert unexpected not in out_str
+        out_str = "".join(
+            [line for line in out_str.splitlines() if "autoscaler" in line]
+        )
+        for expected in expected_msg.split(","):
+            assert expected in out_str
+        if unexpected_msg:
+            for unexpected in unexpected_msg.split(","):
+                assert unexpected not in out_str
+        return True
+
+    wait_for_condition(verify)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -328,6 +328,7 @@ time.sleep(3)
     wait_for_condition(verify)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize(
     "event_level,expected_msg,unexpected_msg",
     [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fix windows non-compatible with running the driver script. 



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/33476


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
