### PR TITLE
[Data] Add `Dataset.write_images`

### DIFF
--- a/doc/source/data/api/input_output.rst
+++ b/doc/source/data/api/input_output.rst
@@ -65,6 +65,7 @@ Images
    :toctree: doc/
 
    read_images
+   Dataset.write_images
 
 Binary
 ------

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -250,10 +250,21 @@ and :ref:`Transforming batches with actors <transforming_data_actors>`.
 Saving images
 -------------
 
-Save images with formats like Parquet, NumPy, and JSON. To view all supported formats,
+Save images with formats like PNG, Parquet, and Numpy. To view all supported formats,
 see the :ref:`Input/Output reference <input-output>`.
 
 .. tab-set::
+
+    .. tab-item:: Images
+
+        To save images as image files, call :meth:`~ray.data.Dataset.write_images`.
+
+        .. testcode::
+
+            import ray
+
+            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
+            ds.write_images("/tmp/simple", column="image", file_format="png")
 
     .. tab-item:: Parquet
 
@@ -277,16 +288,5 @@ see the :ref:`Input/Output reference <input-output>`.
 
             ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
             ds.write_numpy("/tmp/simple", column="image")
-
-    .. tab-item:: JSON
-
-        To save images in a JSON file, call :meth:`~ray.data.Dataset.write_json`.
-
-        .. testcode::
-
-            import ray
-
-            ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
-            ds.write_json("/tmp/simple")
 
 For more information on saving data, see :ref:`Saving data <loading_data>`.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2804,10 +2804,6 @@ class Dataset:
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to images.
 
-        The number of files is determined by the number of blocks in the dataset.
-        To control the number of number of blocks, call
-        :meth:`~ray.data.Dataset.repartition`.
-
         Examples:
             >>> import ray
             >>> ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
@@ -2819,7 +2815,9 @@ class Dataset:
             path: The path to the destination root directory, where
                 the images are written to.
             column: The column containing the data you want to write to images.
-            file_format: The image file format to write with.
+            file_format: The image file format to write with. For available options,
+                see `Image file formats <https://pillow.readthedocs.io/en/latest\
+                /handbook/image-file-formats.html>`.
             filesystem: The pyarrow filesystem implementation to write to.
                 These filesystems are specified in the
                 `pyarrow docs <https://arrow.apache.org/docs\

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2789,6 +2789,7 @@ class Dataset:
             **pandas_json_args,
         )
 
+    @PublicAPI(stability="alpha")
     @ConsumptionAPI
     def write_images(
         self,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -116,6 +116,7 @@ from ray.data.datasource import (
     CSVDatasource,
     Datasource,
     DefaultBlockWritePathProvider,
+    ImageDatasource,
     JSONDatasource,
     NumpyDatasource,
     ParquetDatasource,
@@ -2786,6 +2787,66 @@ class Dataset:
             block_path_provider=block_path_provider,
             write_args_fn=pandas_json_args_fn,
             **pandas_json_args,
+        )
+
+    @ConsumptionAPI
+    def write_images(
+        self,
+        path: str,
+        column: str,
+        file_format: str = "png",
+        *,
+        filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+        try_create_dir: bool = True,
+        arrow_open_stream_args: Optional[Dict[str, Any]] = None,
+        ray_remote_args: Dict[str, Any] = None,
+    ) -> None:
+        """Writes the :class:`~ray.data.Dataset` to images.
+
+        The number of files is determined by the number of blocks in the dataset.
+        To control the number of number of blocks, call
+        :meth:`~ray.data.Dataset.repartition`.
+
+        Examples:
+            >>> import ray
+            >>> ds = ray.data.read_images("s3://anonymous@ray-example-data/image-datasets/simple")
+            >>> ds.write_images("local:///tmp/images", column="image")
+
+        Time complexity: O(dataset size / parallelism)
+
+        Args:
+            path: The path to the destination root directory, where
+                the images are written to.
+            column: The column containing the data you want to write to images.
+            file_format: The image file format to write with.
+            filesystem: The pyarrow filesystem implementation to write to.
+                These filesystems are specified in the
+                `pyarrow docs <https://arrow.apache.org/docs\
+                /python/api/filesystems.html#filesystem-implementations>`_.
+                Specify this if you need to provide specific configurations to the
+                filesystem. By default, the filesystem is automatically selected based
+                on the scheme of the paths. For example, if the path begins with
+                ``s3://``, the ``S3FileSystem`` is used.
+            try_create_dir: If ``True``, attempts to create all directories in the
+                destination path. Does nothing if all directories already
+                exist. Defaults to ``True``.
+            arrow_open_stream_args: kwargs passed to
+                `pyarrow.fs.FileSystem.open_output_stream <https://arrow.apache.org\
+                /docs/python/generated/pyarrow.fs.FileSystem.html\
+                #pyarrow.fs.FileSystem.open_output_stream>`_, which is used when
+                opening the file to write to.
+            ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
+        """  # noqa: E501
+        self.write_datasource(
+            ImageDatasource(),
+            ray_remote_args=ray_remote_args,
+            path=path,
+            dataset_uuid=self._uuid,
+            filesystem=filesystem,
+            try_create_dir=try_create_dir,
+            open_stream_args=arrow_open_stream_args,
+            column=column,
+            file_format=file_format,
         )
 
     @ConsumptionAPI

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -209,6 +209,9 @@ class FileBasedDatasource(Datasource):
         JSONDatasource, CSVDatasource, NumpyDatasource, BinaryDatasource
     """
 
+    # If `_WRITE_FILE_PER_ROW` is `True`, this datasource calls `_write_row` and writes 
+    # each row to a file. Otherwise, this datasource calls `_write_block` and writes
+    # each block to a file.
     _WRITE_FILE_PER_ROW = False
     _FILE_EXTENSION: Optional[Union[str, List[str]]] = None
 
@@ -389,7 +392,8 @@ class FileBasedDatasource(Datasource):
     ):
         """Writes a row to a single file, passing all kwargs to the writer.
 
-        If `_WRITE_FILE_PER_ROW` is set to `True`, this method will be called.
+        If `_WRITE_FILE_PER_ROW` is set to `True`, this method will be called instead
+        of `_write_block()`.
         """
         raise NotImplementedError
 

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -274,7 +274,7 @@ class FileBasedDatasource(Datasource):
         **write_args,
     ) -> WriteResult:
         """Write blocks for a file-based datasource."""
-        # `FileBasedDatasource` subclasses expose a `_FILE_EXTENSION` attribute. It 
+        # `FileBasedDatasource` subclasses expose a `_FILE_EXTENSION` attribute. It
         # represents a list of supported file extensions. If the user doesn't specify
         # a file format, we default to the first extension in the list.
         if file_format is None:
@@ -335,7 +335,7 @@ class FileBasedDatasource(Datasource):
                             **write_args,
                         )
             else:
-                 write_path = block_path_provider(
+                write_path = block_path_provider(
                     path,
                     filesystem=filesystem,
                     dataset_uuid=dataset_uuid,

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -273,6 +273,9 @@ class FileBasedDatasource(Datasource):
         **write_args,
     ) -> WriteResult:
         """Write blocks for a file-based datasource."""
+        # `FileBasedDatasource` subclasses expose a `_FILE_EXTENSION` attribute. It 
+        # represents a list of supported file extensions. If the user doesn't specify
+        # a file format, we default to the first extension in the list.
         if file_format is None:
             file_format = self._FILE_EXTENSION
             if isinstance(file_format, list):

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -387,6 +387,10 @@ class FileBasedDatasource(Datasource):
         writer_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
         **writer_args,
     ):
+        """Writes a row to a single file, passing all kwargs to the writer.
+
+        If `_WRITE_FILE_PER_ROW` is set to `True`, this method will be called.
+        """
         raise NotImplementedError
 
     @classmethod

--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -1,7 +1,7 @@
 import io
 import logging
 import time
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -103,6 +103,24 @@ class ImageDatasource(BinaryDatasource):
         block = builder.build()
 
         return block
+
+    def _write_row(
+        self,
+        f: "pyarrow.NativeFile",
+        row,
+        writer_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
+        column: str = None,
+        file_format: str = None,
+        **writer_args,
+    ):
+        import io
+
+        from PIL import Image
+
+        image = Image.fromarray(row[column])
+        buffer = io.BytesIO()
+        image.save(buffer, format=file_format)
+        f.write(buffer.getvalue())
 
 
 class _ImageFileMetadataProvider(DefaultFileMetadataProvider):

--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -42,6 +42,7 @@ IMAGE_ENCODING_RATIO_ESTIMATE_LOWER_BOUND = 0.5
 class ImageDatasource(BinaryDatasource):
     """A datasource that lets you read images."""
 
+    _WRITE_FILE_PER_ROW = True
     _FILE_EXTENSION = ["png", "jpg", "jpeg", "tif", "tiff", "bmp", "gif"]
 
     def create_reader(

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -268,16 +268,14 @@ class TestWriteImages:
     @pytest.mark.parametrize("file_format", [None, "png"])
     def test_write_images(ray_start_regular_shared, file_format, tmp_path):
         ds = ray.data.read_images("example://image-datasets/simple")
-        ds.write_datasource(
-            ImageDatasource(),
+        ds.write_images(
             path=tmp_path,
-            file_format=file_format,
             column="image",
-            dataset_uuid=ds._uuid,
+            file_format=file_format,
         )
 
         assert len(os.listdir(tmp_path)) == ds.count()
-        
+
         for filename in os.listdir(tmp_path):
             path = os.path.join(tmp_path, filename)
             Image.open(path)

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -7,6 +7,7 @@ import numpy as np
 import pyarrow as pa
 import pytest
 from fsspec.implementations.local import LocalFileSystem
+from PIL import Image
 
 import ray
 from ray.data.datasource import Partitioning, PathPartitionFilter
@@ -261,6 +262,25 @@ class TestReadImages:
         with tempfile.NamedTemporaryFile(suffix=".png") as file:
             with pytest.raises(ValueError):
                 ray.data.read_images(paths=file.name).materialize()
+
+
+class TestWriteImages:
+    @pytest.mark.parametrize("file_format", [None, "png"])
+    def test_write_images(ray_start_regular_shared, file_format, tmp_path):
+        ds = ray.data.read_images("example://image-datasets/simple")
+        ds.write_datasource(
+            ImageDatasource(),
+            path=tmp_path,
+            file_format=file_format,
+            column="image",
+            dataset_uuid=ds._uuid,
+        )
+
+        assert len(os.listdir(tmp_path)) == ds.count()
+        
+        for filename in os.listdir(tmp_path):
+            path = os.path.join(tmp_path, filename)
+            Image.open(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Users want to write images back to S3 (for example, segmentation masks from batch inference). So, this PR adds a `Dataset.write_images` API.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
