### PR TITLE
[Serve] Make sure multiple handle sharing with same router object

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -181,6 +181,10 @@ class RayServeHandle:
             multiplexed_model_id=multiplexed_model_id,
             stream=stream,
         )
+
+        if self._router is None:
+            self._get_or_create_router()
+
         return self.__class__(
             self.deployment_name,
             handle_options=new_handle_options,

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -353,6 +353,19 @@ def test_call_function_with_argument(serve_instance):
     assert ray.get(h.remote("sned")) == "Hi sned"
 
 
+def test_handle_options_with_same_router(serve_instance):
+    """Make sure that multiple handles share same router object."""
+
+    @serve.deployment
+    def echo(name: str):
+        return f"Hi {name}"
+
+    handle = serve.run(echo.bind())
+    handle2 = handle.options(multiplexed_model_id="model2")
+    assert handle._router
+    assert id(handle2._router) == id(handle._router)
+
+
 if __name__ == "__main__":
     import sys
     import pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are race condition that multiple handles with same deployment having multiple routers, which means potentially routing mechanism is not working as expected.
With this pr, we can make sure router is created whenever `.options` is called.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
