### PR TITLE
[Data] Remove dead code from `BinaryDatasource`

### DIFF
--- a/python/ray/data/datasource/binary_datasource.py
+++ b/python/ray/data/datasource/binary_datasource.py
@@ -43,20 +43,13 @@ class BinaryDatasource(FileBasedDatasource):
         else:
             data = f.readall()
 
-        output_arrow_format = reader_args.pop("output_arrow_format", False)
-        if output_arrow_format:
-            builder = ArrowBlockBuilder()
-            if include_paths:
-                item = {self._COLUMN_NAME: data, "path": path}
-            else:
-                item = {self._COLUMN_NAME: data}
-            builder.add(item)
-            return builder.build()
+        builder = ArrowBlockBuilder()
+        if include_paths:
+            item = {self._COLUMN_NAME: data, "path": path}
         else:
-            if include_paths:
-                return [(path, data)]
-            else:
-                return [data]
+            item = {self._COLUMN_NAME: data}
+        builder.add(item)
+        return builder.build()
 
     def _rows_per_file(self):
         return 1

--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -8,7 +8,6 @@ import numpy as np
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.util import _check_import
 from ray.data.block import BlockMetadata
-from ray.data.datasource.binary_datasource import BinaryDatasource
 from ray.data.datasource.datasource import Reader
 from ray.data.datasource.file_based_datasource import (
     FileBasedDatasource,
@@ -39,7 +38,7 @@ IMAGE_ENCODING_RATIO_ESTIMATE_LOWER_BOUND = 0.5
 
 
 @DeveloperAPI
-class ImageDatasource(BinaryDatasource):
+class ImageDatasource(FileBasedDatasource):
     """A datasource that lets you read images."""
 
     _FILE_EXTENSION = ["png", "jpg", "jpeg", "tif", "tiff", "bmp", "gif"]
@@ -78,9 +77,7 @@ class ImageDatasource(BinaryDatasource):
     ) -> "pyarrow.Table":
         from PIL import Image, UnidentifiedImageError
 
-        records = super()._read_file(f, path, include_paths=True, **reader_args)
-        assert len(records) == 1
-        path, data = records[0]
+        data = f.readall()
 
         try:
             image = Image.open(io.BytesIO(data))

--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -101,6 +101,9 @@ class ImageDatasource(FileBasedDatasource):
 
         return block
 
+    def _rows_per_file(self):
+        return 1
+
 
 class _ImageFileMetadataProvider(DefaultFileMetadataProvider):
     def _set_encoding_ratio(self, encoding_ratio: int):

--- a/python/ray/data/datasource/text_datasource.py
+++ b/python/ray/data/datasource/text_datasource.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, List
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
-from ray.data.datasource.binary_datasource import BinaryDatasource
+from ray.data.datasource.file_based_datasource import FileBasedDatasource
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 
 @PublicAPI
-class TextDatasource(BinaryDatasource):
+class TextDatasource(FileBasedDatasource):
     """Text datasource, for reading and writing text files."""
 
     _COLUMN_NAME = "text"
@@ -17,9 +17,7 @@ class TextDatasource(BinaryDatasource):
     def _read_file(
         self, f: "pyarrow.NativeFile", path: str, **reader_args
     ) -> List[str]:
-        block = super()._read_file(f, path, **reader_args)
-        assert len(block) == 1
-        data = block[0]
+        data = f.readall()
 
         builder = DelegatingBlockBuilder()
 

--- a/python/ray/data/datasource/text_datasource.py
+++ b/python/ray/data/datasource/text_datasource.py
@@ -31,6 +31,3 @@ class TextDatasource(FileBasedDatasource):
 
         block = builder.build()
         return block
-
-    def _rows_per_file(self):
-        return None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`BinaryDatasource` has a separate code path if `output_arrow_format` is `False`, but this variable is always `True`, so the code path is dead. This PR cleans it up.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
