### PR TITLE
[Data] Remove option to disable block splitting

### DIFF
--- a/python/ray/data/_internal/lazy_block_list.py
+++ b/python/ray/data/_internal/lazy_block_list.py
@@ -310,48 +310,29 @@ class LazyBlockList(BlockList):
         This will block on the completion of the underlying read tasks and will fetch
         all block metadata outputted by those tasks.
         """
-        context = DataContext.get_current()
         block_refs, meta_refs = [], []
         for block_ref, meta_ref in self._iter_block_partition_refs():
             block_refs.append(block_ref)
             meta_refs.append(meta_ref)
-        if context.block_splitting_enabled:
-            # If block splitting is enabled, fetch the partitions through generator.
-            read_progress_bar = ProgressBar("Read progress", total=len(block_refs))
-            # Handle duplicates (e.g. due to unioning the same dataset).
-            unique_refs = list(set(block_refs))
-            generators = read_progress_bar.fetch_until_complete(unique_refs)
-
-            ref_to_blocks = {}
-            ref_to_metadata = {}
-            for ref, generator in zip(unique_refs, generators):
-                refs_list = list(generator)
-                meta = ray.get(refs_list.pop(-1))
-                ref_to_blocks[ref] = refs_list
-                ref_to_metadata[ref] = meta
-
-            output_block_refs = []
-            for idx, ref in enumerate(block_refs):
-                output_block_refs += ref_to_blocks[ref]
-                self._cached_metadata[idx] = ref_to_metadata[ref]
-            return output_block_refs, self._flatten_metadata(self._cached_metadata)
-        if all(meta is not None for meta in self._cached_metadata):
-            # Short-circuit on cached metadata.
-            return block_refs, self._flatten_metadata(self._cached_metadata)
-        if not meta_refs:
-            # Short-circuit on empty set of block partitions.
-            assert not block_refs, block_refs
-            return [], []
-        read_progress_bar = ProgressBar("Read progress", total=len(meta_refs))
-        # Fetch the metadata in bulk.
+        # If block splitting is enabled, fetch the partitions through generator.
+        read_progress_bar = ProgressBar("Read progress", total=len(block_refs))
         # Handle duplicates (e.g. due to unioning the same dataset).
-        unique_meta_refs = set(meta_refs)
-        metadata = read_progress_bar.fetch_until_complete(list(unique_meta_refs))
-        ref_to_data = {
-            meta_ref: data for meta_ref, data in zip(unique_meta_refs, metadata)
-        }
-        self._cached_metadata = [[ref_to_data[meta_ref]] for meta_ref in meta_refs]
-        return block_refs, self._flatten_metadata(self._cached_metadata)
+        unique_refs = list(set(block_refs))
+        generators = read_progress_bar.fetch_until_complete(unique_refs)
+
+        ref_to_blocks = {}
+        ref_to_metadata = {}
+        for ref, generator in zip(unique_refs, generators):
+            refs_list = list(generator)
+            meta = ray.get(refs_list.pop(-1))
+            ref_to_blocks[ref] = refs_list
+            ref_to_metadata[ref] = meta
+
+        output_block_refs = []
+        for idx, ref in enumerate(block_refs):
+            output_block_refs += ref_to_blocks[ref]
+            self._cached_metadata[idx] = ref_to_metadata[ref]
+        return output_block_refs, self._flatten_metadata(self._cached_metadata)
 
     def compute_to_blocklist(self) -> BlockList:
         """Launch all tasks and return a concrete BlockList."""
@@ -392,16 +373,10 @@ class LazyBlockList(BlockList):
             pass
         else:
             # This blocks until the underlying read task is finished.
-            if DataContext.get_current().block_splitting_enabled:
-                # If block splitting is enabled, get metadata as the last element
-                # in generator.
-                generator = ray.get(block_partition_ref)
-                blocks_ref = list(generator)
-                metadata = ray.get(blocks_ref[-1])
-                self._cached_metadata[0] = metadata
-            else:
-                metadata = ray.get(metadata_ref)
-                self._cached_metadata[0] = [metadata]
+            generator = ray.get(block_partition_ref)
+            blocks_ref = list(generator)
+            metadata = ray.get(blocks_ref[-1])
+            self._cached_metadata[0] = metadata
         return metadata
 
     def iter_blocks(self) -> Iterator[ObjectRef[Block]]:
@@ -449,7 +424,6 @@ class LazyBlockList(BlockList):
         Returns:
             An iterator of block references and the corresponding block metadata.
         """
-        context = DataContext.get_current()
         outer = self
 
         class Iter:
@@ -464,27 +438,15 @@ class LazyBlockList(BlockList):
             def __next__(self):
                 while not self._buffer:
                     self._pos += 1
-                    if context.block_splitting_enabled:
-                        generator_ref, _ = next(self._base_iter)
-                        generator = ray.get(generator_ref)
-                        refs = list(generator)
-                        # This blocks until the read task completes, returning
-                        # fully-specified block metadata for each output block.
-                        metadata = ray.get(refs.pop(-1))
-                        assert len(metadata) == len(refs)
-                        for block_ref, meta in zip(refs, metadata):
-                            self._buffer.append((block_ref, meta))
-                    else:
-                        block_ref, metadata_ref = next(self._base_iter)
-                        if block_for_metadata:
-                            # This blocks until the read task completes, returning
-                            # fully-specified block metadata.
-                            metadata = ray.get(metadata_ref)
-                        else:
-                            # This does not block, returning (possibly under-specified)
-                            # pre-read block metadata.
-                            metadata = outer._tasks[self._pos].get_metadata()
-                        self._buffer.append((block_ref, metadata))
+                    generator_ref, _ = next(self._base_iter)
+                    generator = ray.get(generator_ref)
+                    refs = list(generator)
+                    # This blocks until the read task completes, returning
+                    # fully-specified block metadata for each output block.
+                    metadata = ray.get(refs.pop(-1))
+                    assert len(metadata) == len(refs)
+                    for block_ref, meta in zip(refs, metadata):
+                        self._buffer.append((block_ref, meta))
                 return self._buffer.pop(0)
 
         return Iter()
@@ -571,12 +533,6 @@ class LazyBlockList(BlockList):
                         self._block_partition_meta_refs[j],
                     ) = self._submit_task(j)
             assert self._block_partition_refs[i], self._block_partition_refs
-            if not DataContext.get_current().block_splitting_enabled:
-                # Only check block metadata object reference if dynamic block
-                # splitting is off.
-                assert self._block_partition_meta_refs[
-                    i
-                ], self._block_partition_meta_refs
         trace_allocation(
             self._block_partition_refs[i], f"LazyBlockList.get_or_compute({i})"
         )
@@ -602,32 +558,18 @@ class LazyBlockList(BlockList):
             ray.get(stats_actor.record_start.remote(self._stats_uuid))
             self._execution_started = True
         task = self._tasks[task_idx]
-        context = DataContext.get_current()
-        if context.block_splitting_enabled:
-            return (
-                cached_remote_fn(_execute_read_task_split)
-                .options(num_returns="dynamic", **self._remote_args)
-                .remote(
-                    i=task_idx,
-                    task=task,
-                    context=DataContext.get_current(),
-                    stats_uuid=self._stats_uuid,
-                    stats_actor=stats_actor,
-                ),
-                None,
-            )
-        else:
-            return (
-                cached_remote_fn(_execute_read_task_nosplit)
-                .options(num_returns=2, **self._remote_args)
-                .remote(
-                    i=task_idx,
-                    task=task,
-                    context=DataContext.get_current(),
-                    stats_uuid=self._stats_uuid,
-                    stats_actor=stats_actor,
-                )
-            )
+        return (
+            cached_remote_fn(_execute_read_task_split)
+            .options(num_returns="dynamic", **self._remote_args)
+            .remote(
+                i=task_idx,
+                task=task,
+                context=DataContext.get_current(),
+                stats_uuid=self._stats_uuid,
+                stats_actor=stats_actor,
+            ),
+            None,
+        )
 
     def _num_computed(self) -> int:
         i = 0

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -291,16 +291,12 @@ class DatasetStats:
             ac = self.stats_actor
             # TODO(chengsu): this is a super hack, clean it up.
             stats_map, self.time_total_s = ray.get(ac.get.remote(self.stats_uuid))
-            if DataContext.get_current().block_splitting_enabled:
-                # Only populate stats when stats from all read tasks are ready at
-                # stats actor.
-                if len(stats_map.items()) == len(self.stages["Read"]):
-                    self.stages["Read"] = []
-                    for _, blocks_metadata in sorted(stats_map.items()):
-                        self.stages["Read"] += blocks_metadata
-            else:
-                for i, metadata in stats_map.items():
-                    self.stages["Read"][i] = metadata[0]
+            # Only populate stats when stats from all read tasks are ready at
+            # stats actor.
+            if len(stats_map.items()) == len(self.stages["Read"]):
+                self.stages["Read"] = []
+                for _, blocks_metadata in sorted(stats_map.items()):
+                    self.stages["Read"] += blocks_metadata
 
         stages_stats = []
         is_substage = len(self.stages) > 1

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -31,10 +31,6 @@ DEFAULT_TARGET_MIN_BLOCK_SIZE = 1 * 1024 * 1024
 # which is very sensitive to the buffer size.
 DEFAULT_STREAMING_READ_BUFFER_SIZE = 32 * 1024 * 1024
 
-# Whether dynamic block splitting is enabled.
-# NOTE: disable dynamic block splitting when using Ray client.
-DEFAULT_BLOCK_SPLITTING_ENABLED = True
-
 # Whether pandas block format is enabled.
 # TODO (kfstorm): Remove this once stable.
 DEFAULT_ENABLE_PANDAS_BLOCK = True
@@ -147,7 +143,6 @@ class DataContext:
 
     def __init__(
         self,
-        block_splitting_enabled: bool,
         target_max_block_size: int,
         target_min_block_size: int,
         streaming_read_buffer_size: int,
@@ -178,7 +173,6 @@ class DataContext:
         enable_progress_bars: bool,
     ):
         """Private constructor (use get_current() instead)."""
-        self.block_splitting_enabled = block_splitting_enabled
         self.target_max_block_size = target_max_block_size
         self.target_min_block_size = target_min_block_size
         self.streaming_read_buffer_size = streaming_read_buffer_size
@@ -224,7 +218,6 @@ class DataContext:
         with _context_lock:
             if _default_context is None:
                 _default_context = DataContext(
-                    block_splitting_enabled=DEFAULT_BLOCK_SPLITTING_ENABLED,
                     target_max_block_size=DEFAULT_TARGET_MAX_BLOCK_SIZE,
                     target_min_block_size=DEFAULT_TARGET_MIN_BLOCK_SIZE,
                     streaming_read_buffer_size=DEFAULT_STREAMING_READ_BUFFER_SIZE,

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 import numpy as np
 
 import ray
-from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.util import _check_pyarrow_version
 from ray.data.block import Block, BlockAccessor, BlockMetadata
@@ -204,7 +203,6 @@ class ReadTask(Callable[[], Iterable[Block]]):
         return self._metadata
 
     def __call__(self) -> Iterable[Block]:
-        context = DataContext.get_current()
         result = self._read_fn()
         if not hasattr(result, "__iter__"):
             DeprecationWarning(
@@ -213,14 +211,8 @@ class ReadTask(Callable[[], Iterable[Block]]):
                 "`block`.".format(result)
             )
 
-        if context.block_splitting_enabled:
-            for block in result:
-                yield from self._do_additional_splits(block)
-        else:
-            builder = DelegatingBlockBuilder()
-            for block in result:
-                builder.add_block(block)
-            yield builder.build()
+        for block in result:
+            yield from self._do_additional_splits(block)
 
     def _set_additional_split_factor(self, k: int) -> None:
         self._additional_output_splits = k

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -327,15 +327,6 @@ def enable_auto_log_stats(request):
     ctx.enable_auto_log_stats = original
 
 
-@pytest.fixture(params=[True])
-def enable_dynamic_block_splitting(request):
-    ctx = ray.data.context.DataContext.get_current()
-    original = ctx.block_splitting_enabled
-    ctx.block_splitting_enabled = request.param
-    yield request.param
-    ctx.block_splitting_enabled = original
-
-
 @pytest.fixture(params=[1024])
 def target_max_block_size(request):
     ctx = ray.data.context.DataContext.get_current()

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -77,44 +77,21 @@ def test_bulk_lazy_eval_split_mode(shutdown_only, block_split, tmp_path):
     ray.init(num_cpus=8)
     ctx = ray.data.context.DataContext.get_current()
 
-    try:
-        original = ctx.block_splitting_enabled
+    ray.data.range(8, parallelism=8).write_csv(str(tmp_path))
+    if not block_split:
+        # Setting infinite block size effectively disables block splitting.
+        ctx.target_max_block_size = float("inf")
+    ds = ray.data.read_datasource(
+        SlowCSVDatasource(), parallelism=8, paths=str(tmp_path)
+    )
 
-        ray.data.range(8, parallelism=8).write_csv(str(tmp_path))
-        if not block_split:
-            # Setting infinite block size effectively disables block splitting.
-            ctx.target_max_block_size = float("inf")
-        ds = ray.data.read_datasource(
-            SlowCSVDatasource(), parallelism=8, paths=str(tmp_path)
-        )
+    start = time.time()
+    ds.map(lambda x: x)
+    delta = time.time() - start
 
-        start = time.time()
-        ds.map(lambda x: x)
-        delta = time.time() - start
-
-        print("full read time", delta)
-        # Should run in ~3 seconds. It takes >9 seconds if bulk read is broken.
-        assert delta < 8, delta
-    finally:
-        ctx.block_splitting_enabled = original
-
-
-def test_enable_in_ray_client(ray_start_cluster_enabled):
-    cluster = ray_start_cluster_enabled
-    cluster.add_node(num_cpus=4)
-    cluster.head_node._ray_params.ray_client_server_port = "10004"
-    cluster.head_node.start_ray_client_server()
-    address = "ray://localhost:10004"
-
-    # Import of ray.data.context module, and this triggers the initialization of
-    # default configuration values in DataContext.
-    from ray.data.context import DataContext
-
-    assert DataContext.get_current().block_splitting_enabled
-
-    # Verify Ray client also has dynamic block splitting enabled.
-    ray.init(address)
-    assert DataContext.get_current().block_splitting_enabled
+    print("full read time", delta)
+    # Should run in ~3 seconds. It takes >9 seconds if bulk read is broken.
+    assert delta < 8, delta
 
 
 @pytest.mark.parametrize(
@@ -126,7 +103,6 @@ def test_enable_in_ray_client(ray_start_cluster_enabled):
 )
 def test_dataset(
     shutdown_only,
-    enable_dynamic_block_splitting,
     target_max_block_size,
     compute,
 ):
@@ -197,9 +173,7 @@ def test_dataset(
         assert len(batch["one"]) == 10
 
 
-def test_dataset_pipeline(
-    ray_start_regular_shared, enable_dynamic_block_splitting, target_max_block_size
-):
+def test_dataset_pipeline(ray_start_regular_shared, target_max_block_size):
     # Test 10 tasks, each task returning 10 blocks, each block has 1 row and each
     # row has 1024 bytes.
     num_blocks_per_task = 10
@@ -228,9 +202,7 @@ def test_dataset_pipeline(
     assert len(dsp.take(5)) == 5
 
 
-def test_filter(
-    ray_start_regular_shared, enable_dynamic_block_splitting, target_max_block_size
-):
+def test_filter(ray_start_regular_shared, target_max_block_size):
     # Test 10 tasks, each task returning 10 blocks, each block has 1 row and each
     # row has 1024 bytes.
     num_blocks_per_task = 10
@@ -254,9 +226,7 @@ def test_filter(
     assert ds.num_blocks() == num_blocks_per_task
 
 
-def test_lazy_block_list(
-    shutdown_only, enable_dynamic_block_splitting, target_max_block_size
-):
+def test_lazy_block_list(shutdown_only, target_max_block_size):
     # Test 10 tasks, each task returning 10 blocks, each block has 1 row and each
     # row has 1024 bytes.
     num_blocks_per_task = 10
@@ -355,7 +325,7 @@ def test_lazy_block_list(
         assert block_metadata.schema is not None
 
 
-def test_read_large_data(ray_start_cluster, enable_dynamic_block_splitting):
+def test_read_large_data(ray_start_cluster):
     # Test 20G input with single task
     num_blocks_per_task = 20
     block_size = 1024 * 1024 * 1024

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -216,11 +216,9 @@ class TestReadImages:
     def test_dynamic_block_split(ray_start_regular_shared):
         ctx = ray.data.context.DataContext.get_current()
         target_max_block_size = ctx.target_max_block_size
-        block_splitting_enabled = ctx.block_splitting_enabled
         # Reduce target max block size to trigger block splitting on small input.
         # Otherwise we have to generate big input files, which is unnecessary.
         ctx.target_max_block_size = 1
-        ctx.block_splitting_enabled = True
         try:
             root = "example://image-datasets/simple"
             ds = ray.data.read_images(root, parallelism=1)
@@ -234,7 +232,6 @@ class TestReadImages:
             assert union_ds.num_blocks() == 12
         finally:
             ctx.target_max_block_size = target_max_block_size
-            ctx.block_splitting_enabled = block_splitting_enabled
 
     def test_args_passthrough(ray_start_regular_shared):
         kwargs = {

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -676,13 +676,9 @@ def test_optimize_reread_base_data(ray_start_regular_shared, local_path):
 
 @pytest.mark.skip(reason="reusing base data not enabled")
 @pytest.mark.parametrize("with_shuffle", [True, False])
-@pytest.mark.parametrize("enable_dynamic_splitting", [True, False])
 def test_optimize_lazy_reuse_base_data(
     ray_start_regular_shared, local_path, enable_dynamic_splitting, with_shuffle
 ):
-    context = DataContext.get_current()
-    context.block_splitting_enabled = enable_dynamic_splitting
-
     num_blocks = 4
     dfs = [pd.DataFrame({"one": list(range(i, i + 4))}) for i in range(num_blocks)]
     paths = [os.path.join(local_path, f"test{i}.csv") for i in range(num_blocks)]

--- a/python/ray/data/tests/test_size_estimation.py
+++ b/python/ray/data/tests/test_size_estimation.py
@@ -79,7 +79,6 @@ def test_arrow_size_add_block(ray_start_regular_shared):
 
 def test_split_read_csv(ray_start_regular_shared, tmp_path):
     ctx = ray.data.context.DataContext.get_current()
-    ctx.block_splitting_enabled = True
 
     def gen(name):
         path = os.path.join(tmp_path, name)
@@ -118,7 +117,6 @@ def test_split_read_csv(ray_start_regular_shared, tmp_path):
 
 def test_split_read_parquet(ray_start_regular_shared, tmp_path):
     ctx = ray.data.context.DataContext.get_current()
-    ctx.block_splitting_enabled = True
 
     def gen(name):
         path = os.path.join(tmp_path, name)
@@ -167,7 +165,6 @@ def test_split_map(shutdown_only, use_actors):
     # Arrow block
     ctx = ray.data.context.DataContext.get_current()
     ctx.target_max_block_size = 20_000_000
-    ctx.block_splitting_enabled = True
     ctx.target_max_block_size = 20_000_000
     ds2 = ray.data.range(1000, parallelism=1).map(lambda _: ARROW_LARGE_VALUE, **kwargs)
     nblocks = len(ds2.map(lambda x: x, **kwargs).get_internal_block_refs())
@@ -187,7 +184,6 @@ def test_split_map(shutdown_only, use_actors):
 def test_split_flat_map(ray_start_regular_shared):
     ctx = ray.data.context.DataContext.get_current()
     ctx.target_max_block_size = 20_000_000
-    ctx.block_splitting_enabled = True
     # Arrow block
     ctx.target_max_block_size = 20_000_000
     ds2 = ray.data.range(1000, parallelism=1).map(lambda _: ARROW_LARGE_VALUE)
@@ -201,7 +197,6 @@ def test_split_flat_map(ray_start_regular_shared):
 def test_split_map_batches(ray_start_regular_shared):
     ctx = ray.data.context.DataContext.get_current()
     ctx.target_max_block_size = 20_000_000
-    ctx.block_splitting_enabled = True
     # Arrow block
     ctx.target_max_block_size = 20_000_000
     ds2 = ray.data.range(1000, parallelism=1).map(lambda _: ARROW_LARGE_VALUE)

--- a/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
@@ -569,7 +569,6 @@ if __name__ == "__main__":
 
             # Enable block splitting to support larger file sizes w/o OOM.
             ctx = ray.data.context.DataContext.get_current()
-            ctx.block_splitting_enabled = True
 
             options.resource_limits.object_store_memory = 10e9
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Dynamic block splitting has been enabled by default for a couple of releases. To improve the maintainability of our codebase, this PR removes the option to disable block splitting and removes related code paths.

## Related issue number

<!-- For example: "Closes #1234" -->

Discussion in this thread: https://github.com/ray-project/ray/pull/38026

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
