### PR TITLE
[Serve] Add ClusterNodeInfoCache class to be a central place to access node info

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -210,6 +210,14 @@ py_test(
 )
 
 py_test(
+    name = "test_cluster_node_info_cache",
+    size = "small",
+    srcs = serve_tests_srcs,
+    tags = ["exclusive", "team:serve"],
+    deps = [":serve_lib"],
+)
+
+py_test(
     name = "test_deployment_scheduler",
     size = "small",
     srcs = serve_tests_srcs,

--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -66,4 +66,4 @@ class DefaultClusterNodeInfoCache(ClusterNodeInfoCache):
         super().__init__(gcs_client)
 
     def get_draining_node_ids(self) -> Set[str]:
-        return set()
+        return ray._private.state.state.get_draining_nodes()

--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -51,6 +51,7 @@ class ClusterNodeInfoCache(ABC):
     @abstractmethod
     def get_draining_node_ids(self) -> Set[str]:
         """Get IDs of all draining nodes in the cluster."""
+        raise NotImplementedError
 
     def get_active_node_ids(self) -> Set[str]:
         """Get IDs of all active nodes in the cluster.

--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -66,4 +66,4 @@ class DefaultClusterNodeInfoCache(ClusterNodeInfoCache):
         super().__init__(gcs_client)
 
     def get_draining_node_ids(self) -> Set[str]:
-        return ray._private.state.state.get_draining_nodes()
+        return set()

--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import (
     Set,
     List,
@@ -9,7 +10,7 @@ from ray._raylet import GcsClient
 from ray.serve._private.constants import RAY_GCS_RPC_TIMEOUT_S
 
 
-class ClusterNodeInfoCache:
+class ClusterNodeInfoCache(ABC):
     """Provide access to cached node information in the cluster."""
 
     def __init__(self, gcs_client: GcsClient):
@@ -47,9 +48,9 @@ class ClusterNodeInfoCache:
         """Get IDs of all live nodes in the cluster."""
         return {node_id for node_id, _ in self.get_alive_nodes()}
 
+    @abstractmethod
     def get_draining_node_ids(self) -> Set[str]:
         """Get IDs of all draining nodes in the cluster."""
-        return set()
 
     def get_active_node_ids(self) -> Set[str]:
         """Get IDs of all active nodes in the cluster.
@@ -57,3 +58,11 @@ class ClusterNodeInfoCache:
         A node is active if it's schedulable for new tasks and actors.
         """
         return self.get_alive_node_ids() - self.get_draining_node_ids()
+
+
+class DefaultClusterNodeInfoCache(ClusterNodeInfoCache):
+    def __init__(self, gcs_client: GcsClient):
+        super().__init__(gcs_client)
+
+    def get_draining_node_ids(self) -> Set[str]:
+        return set()

--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -19,10 +19,10 @@ class ClusterNodeInfoCache:
     def update(self):
         """Update the cache by fetching latest node information from GCS.
 
-        This should be called once in each update cycle and within an update
-        cycle, everyone will see the same cached node info avoiding
-        any potential issues caused by inconsistent node info
-        seen by different components.
+        This should be called once in each update cycle.
+        Within an update cycle, everyone will see the same
+        cached node info avoiding any potential issues
+        caused by inconsistent node info seen by different components.
         """
         nodes = self._gcs_client.get_all_node_info(timeout=RAY_GCS_RPC_TIMEOUT_S)
         alive_nodes = [
@@ -44,10 +44,16 @@ class ClusterNodeInfoCache:
         return self._cached_alive_nodes
 
     def get_alive_node_ids(self) -> Set[str]:
+        """Get IDs of all live nodes in the cluster."""
         return {node_id for node_id, _ in self.get_alive_nodes()}
 
     def get_draining_node_ids(self) -> Set[str]:
+        """Get IDs of all draining nodes in the cluster."""
         return set()
 
     def get_active_node_ids(self) -> Set[str]:
+        """Get IDs of all active nodes in the cluster.
+
+        A node is active if it's schedulable for new tasks and actors.
+        """
         return self.get_alive_node_ids() - self.get_draining_node_ids()

--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -5,12 +5,14 @@ from typing import (
 )
 
 import ray
+from ray._raylet import GcsClient
 from ray.serve._private.constants import RAY_GCS_RPC_TIMEOUT_S
 
+
 class ClusterNodeInfoCache:
-    """Provide access to cached node information in the cluster.
-    """
-    def __init__(self, gcs_client):
+    """Provide access to cached node information in the cluster."""
+
+    def __init__(self, gcs_client: GcsClient):
         self._gcs_client = gcs_client
         self._cached_alive_nodes = None
 

--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -1,0 +1,51 @@
+from typing import (
+    Set,
+    List,
+    Tuple,
+)
+
+import ray
+from ray.serve._private.constants import RAY_GCS_RPC_TIMEOUT_S
+
+class ClusterNodeInfoCache:
+    """Provide access to cached node information in the cluster.
+    """
+    def __init__(self, gcs_client):
+        self._gcs_client = gcs_client
+        self._cached_alive_nodes = None
+
+    def update(self):
+        """Update the cache by fetching latest node information from GCS.
+
+        This should be called once in each update cycle and within an update
+        cycle, everyone will see the same cached node info avoiding
+        any potential issues caused by inconsistent node info
+        seen by different components.
+        """
+        nodes = self._gcs_client.get_all_node_info(timeout=RAY_GCS_RPC_TIMEOUT_S)
+        alive_nodes = [
+            (ray.NodeID.from_binary(node_id).hex(), node["node_name"].decode("utf-8"))
+            for (node_id, node) in nodes.items()
+            if node["state"] == ray.core.generated.gcs_pb2.GcsNodeInfo.ALIVE
+        ]
+
+        # Sort on NodeID to ensure the ordering is deterministic across the cluster.
+        sorted(alive_nodes)
+        self._cached_alive_nodes = alive_nodes
+
+    def get_alive_nodes(self) -> List[Tuple[str, str]]:
+        """Get IDs and IPs for all live nodes in the cluster.
+
+        Returns a list of (node_id: str, ip_address: str). The node_id can be
+        passed into the Ray SchedulingPolicy API.
+        """
+        return self._cached_alive_nodes
+
+    def get_alive_node_ids(self) -> Set[str]:
+        return {node_id for node_id, _ in self.get_alive_nodes()}
+
+    def get_draining_node_ids(self) -> Set[str]:
+        return set()
+
+    def get_active_node_ids(self) -> Set[str]:
+        return self.get_alive_node_ids() - self.get_draining_node_ids()

--- a/python/ray/serve/_private/cluster_node_info_cache_factory.py
+++ b/python/ray/serve/_private/cluster_node_info_cache_factory.py
@@ -1,6 +1,0 @@
-from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
-from ray._raylet import GcsClient
-
-
-def create_cluster_node_info_cache(gcs_client: GcsClient):
-    return ClusterNodeInfoCache(gcs_client)

--- a/python/ray/serve/_private/cluster_node_info_cache_factory.py
+++ b/python/ray/serve/_private/cluster_node_info_cache_factory.py
@@ -1,0 +1,6 @@
+from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
+from ray._raylet import GcsClient
+
+
+def create_cluster_node_info_cache(gcs_client: GcsClient):
+    return ClusterNodeInfoCache(gcs_client)

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -1,0 +1,6 @@
+from ray.serve._private.cluster_node_info_cache import DefaultClusterNodeInfoCache
+from ray._raylet import GcsClient
+
+
+def create_cluster_node_info_cache(gcs_client: GcsClient):
+    return DefaultClusterNodeInfoCache(gcs_client)

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2035,7 +2035,7 @@ class DriverDeploymentState(DeploymentState):
         if num_running_replicas >= self._target_state.num_replicas:
             # Cancel starting replicas when driver deployment state creates
             # more replicas than alive nodes.
-            # For example, get_all_node_ids returns 4 nodes when
+            # For example, get_active_node_ids returns 4 nodes when
             # the driver deployment state decides the target number of replicas
             # but later on when the deployment scheduler schedules these 4 replicas,
             # there are only 3 alive nodes (1 node dies in between).

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1924,7 +1924,7 @@ class DeploymentState:
             if not stopped:
                 self._replicas.add(ReplicaState.STOPPING, replica)
 
-    def _draining_replicas(self):
+    def _stop_replicas_on_draining_nodes(self):
         draining_nodes = self._cluster_node_info_cache.get_draining_node_ids()
         for replica in self._replicas.pop(
             states=[ReplicaState.UPDATING, ReplicaState.RUNNING]
@@ -1957,7 +1957,7 @@ class DeploymentState:
             # Check the state of existing replicas and transition if necessary.
             self._check_and_update_replicas()
 
-            self._draining_replicas()
+            self._stop_replicas_on_draining_nodes()
 
             upscale, downscale = self._scale_deployment_replicas()
 
@@ -2110,7 +2110,7 @@ class DriverDeploymentState(DeploymentState):
                         new_config.version = self._target_state.version.code_version
                     self._set_target_state(new_config)
 
-                self._draining_replicas()
+                self._stop_replicas_on_draining_nodes()
 
                 max_to_stop = self._calculate_max_replicas_to_stop()
                 self._stop_or_update_outdated_version_replicas(max_to_stop)

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1931,8 +1931,8 @@ class DeploymentState:
         ):
             if replica.actor_node_id in draining_nodes:
                 logger.info(
-                    f"Draining replica {replica.replica_tag} of deployment "
-                    f"{self._name}."
+                    f"Stopping replica {replica.replica_tag} of deployment "
+                    f"{self._name} on draining node {replica.actor_node_id}."
                 )
                 self._stop_replica(replica, graceful_stop=True)
             else:

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2161,7 +2161,7 @@ class DeploymentStateManager:
         self._long_poll_host = long_poll_host
         self._cluster_node_info_cache = cluster_node_info_cache
         self._deployment_scheduler = deployment_scheduler.DeploymentScheduler(
-            self._cluster_node_info_cache
+            cluster_node_info_cache
         )
 
         self._deployment_states: Dict[str, DeploymentState] = dict()

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -54,20 +54,18 @@ from ray.serve._private.utils import (
     get_random_letters,
     msgpack_serialize,
     msgpack_deserialize,
-    get_all_node_ids,
     check_obj_ref_ready_nowait,
 )
 from ray.serve._private.version import DeploymentVersion, VersionedReplica
 from ray.serve._private import deployment_scheduler
+from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
 from ray.serve._private.deployment_scheduler import (
     SpreadDeploymentSchedulingPolicy,
     DriverDeploymentSchedulingPolicy,
     ReplicaSchedulingRequest,
     DeploymentDownscaleRequest,
 )
-
 from ray.serve import metrics
-from ray._raylet import GcsClient
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -1104,6 +1102,7 @@ class DeploymentState:
         detached: bool,
         long_poll_host: LongPollHost,
         deployment_scheduler: deployment_scheduler.DeploymentScheduler,
+        cluster_node_info_cache: ClusterNodeInfoCache,
         _save_checkpoint_func: Callable,
     ):
 
@@ -1112,6 +1111,7 @@ class DeploymentState:
         self._detached: bool = detached
         self._long_poll_host: LongPollHost = long_poll_host
         self._deployment_scheduler = deployment_scheduler
+        self._cluster_node_info_cache = cluster_node_info_cache
         self._save_checkpoint_func = _save_checkpoint_func
 
         # Each time we set a new deployment goal, we're trying to save new
@@ -1924,6 +1924,20 @@ class DeploymentState:
             if not stopped:
                 self._replicas.add(ReplicaState.STOPPING, replica)
 
+    def _draining_replicas(self):
+        draining_nodes = self._cluster_node_info_cache.get_draining_node_ids()
+        for replica in self._replicas.pop(
+            states=[ReplicaState.UPDATING, ReplicaState.RUNNING]
+        ):
+            if replica.actor_node_id in draining_nodes:
+                logger.info(
+                    f"Draining replica {replica.replica_tag} of deployment "
+                    f"{self._name}."
+                )
+                self._stop_replica(replica, graceful_stop=True)
+            else:
+                self._replicas.add(replica.actor_details.state, replica)
+
     def update(self) -> DeploymentStateUpdateResult:
         """Attempts to reconcile this deployment to match its goal state.
 
@@ -1942,6 +1956,8 @@ class DeploymentState:
 
             # Check the state of existing replicas and transition if necessary.
             self._check_and_update_replicas()
+
+            self._draining_replicas()
 
             upscale, downscale = self._scale_deployment_replicas()
 
@@ -2000,8 +2016,8 @@ class DriverDeploymentState(DeploymentState):
         detached: bool,
         long_poll_host: LongPollHost,
         deployment_scheduler: deployment_scheduler.DeploymentScheduler,
+        cluster_node_info_cache: ClusterNodeInfoCache,
         _save_checkpoint_func: Callable,
-        gcs_client: GcsClient = None,
     ):
         super().__init__(
             name,
@@ -2009,16 +2025,9 @@ class DriverDeploymentState(DeploymentState):
             detached,
             long_poll_host,
             deployment_scheduler,
+            cluster_node_info_cache,
             _save_checkpoint_func,
         )
-        if gcs_client:
-            self._gcs_client = gcs_client
-        else:
-            self._gcs_client = GcsClient(address=ray.get_runtime_context().gcs_address)
-
-    def _get_all_node_ids(self):
-        # Test mock purpose
-        return get_all_node_ids(self._gcs_client)
 
     def _deploy_driver(self) -> List[ReplicaSchedulingRequest]:
         """Deploy the driver deployment to each node."""
@@ -2069,7 +2078,7 @@ class DriverDeploymentState(DeploymentState):
         return replica_changed
 
     def _calculate_max_replicas_to_stop(self) -> int:
-        num_nodes = len(self._get_all_node_ids())
+        num_nodes = len(self._cluster_node_info_cache.get_active_node_ids())
         rollout_size = max(int(0.2 * num_nodes), 1)
         old_running_replicas = self._replicas.count(
             exclude_version=self._target_state.version,
@@ -2089,7 +2098,7 @@ class DriverDeploymentState(DeploymentState):
             if self._target_state.deleting:
                 self._stop_all_replicas()
             else:
-                num_nodes = len(self._get_all_node_ids())
+                num_nodes = len(self._cluster_node_info_cache.get_active_node_ids())
                 # For driver deployment, when there are new node,
                 # it is supposed to update the target state.
                 if self._target_state.num_replicas != num_nodes:
@@ -2100,6 +2109,8 @@ class DriverDeploymentState(DeploymentState):
                     if new_config.version is None:
                         new_config.version = self._target_state.version.code_version
                     self._set_target_state(new_config)
+
+                self._draining_replicas()
 
                 max_to_stop = self._calculate_max_replicas_to_stop()
                 self._stop_or_update_outdated_version_replicas(max_to_stop)
@@ -2141,13 +2152,17 @@ class DeploymentStateManager:
         kv_store: KVStoreBase,
         long_poll_host: LongPollHost,
         all_current_actor_names: List[str],
+        cluster_node_info_cache: ClusterNodeInfoCache,
     ):
 
         self._controller_name = controller_name
         self._detached = detached
         self._kv_store = kv_store
         self._long_poll_host = long_poll_host
-        self._deployment_scheduler = deployment_scheduler.DeploymentScheduler()
+        self._cluster_node_info_cache = cluster_node_info_cache
+        self._deployment_scheduler = deployment_scheduler.DeploymentScheduler(
+            self._cluster_node_info_cache
+        )
 
         self._deployment_states: Dict[str, DeploymentState] = dict()
         self._deleted_deployment_metadata: Dict[str, DeploymentInfo] = OrderedDict()
@@ -2169,6 +2184,7 @@ class DeploymentStateManager:
             self._detached,
             self._long_poll_host,
             self._deployment_scheduler,
+            self._cluster_node_info_cache,
             self._save_checkpoint_func,
         )
 
@@ -2183,6 +2199,7 @@ class DeploymentStateManager:
             self._detached,
             self._long_poll_host,
             self._deployment_scheduler,
+            self._cluster_node_info_cache,
             self._save_checkpoint_func,
         )
 

--- a/python/ray/serve/_private/http_state.py
+++ b/python/ray/serve/_private/http_state.py
@@ -10,7 +10,6 @@ import ray
 from ray.actor import ActorHandle
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
-from ray._raylet import GcsClient
 from ray.serve.config import HTTPOptions, DeploymentMode
 from ray.serve._private.constants import (
     ASYNC_CONCURRENCY,
@@ -26,9 +25,9 @@ from ray.serve._private.constants import (
 from ray.serve._private import http_proxy
 from ray.serve._private.utils import (
     format_actor_name,
-    get_all_node_ids,
 )
 from ray.serve._private.common import NodeId, HTTPProxyStatus
+from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
 from ray.serve.schema import HTTPProxyDetails
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -314,7 +313,7 @@ class HTTPProxyStateManager:
         detached: bool,
         config: HTTPOptions,
         head_node_id: str,
-        gcs_client: GcsClient,
+        cluster_node_info_cache: ClusterNodeInfoCache,
     ):
         self._controller_name = controller_name
         self._detached = detached
@@ -325,7 +324,7 @@ class HTTPProxyStateManager:
         self._proxy_states: Dict[NodeId, HTTPProxyState] = dict()
         self._head_node_id: str = head_node_id
 
-        self._gcs_client = gcs_client
+        self._cluster_node_info_cache = cluster_node_info_cache
 
         assert isinstance(head_node_id, str)
 
@@ -395,7 +394,7 @@ class HTTPProxyStateManager:
 
         target_nodes = [
             (node_id, ip_address)
-            for node_id, ip_address in get_all_node_ids(self._gcs_client)
+            for node_id, ip_address in self._cluster_node_info_cache.get_alive_nodes()
             if node_id in http_proxy_nodes
         ]
 
@@ -505,10 +504,10 @@ class HTTPProxyStateManager:
 
         Removes proxy actors from any nodes that no longer exist or unhealthy proxy.
         """
-        all_node_ids = {node_id for node_id, _ in get_all_node_ids(self._gcs_client)}
+        alive_node_ids = self._cluster_node_info_cache.get_alive_node_ids()
         to_stop = []
         for node_id, proxy_state in self._proxy_states.items():
-            if node_id not in all_node_ids:
+            if node_id not in alive_node_ids:
                 logger.info(f"Removing HTTP proxy on removed node '{node_id}'.")
                 to_stop.append(node_id)
             elif proxy_state.status == HTTPProxyStatus.UNHEALTHY:

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -34,7 +34,6 @@ from ray.actor import ActorHandle
 from ray.exceptions import RayTaskError
 from ray.serve._private.constants import (
     HTTP_PROXY_TIMEOUT,
-    RAY_GCS_RPC_TIMEOUT_S,
     SERVE_LOGGER_NAME,
 )
 from ray.types import ObjectRef
@@ -172,24 +171,6 @@ def format_actor_name(actor_name, controller_name=None, *modifiers):
         name += "-{}".format(modifier)
 
     return name
-
-
-def get_all_node_ids(gcs_client) -> List[Tuple[str, str]]:
-    """Get IDs for all live nodes in the cluster.
-
-    Returns a list of (node_id: str, ip_address: str). The node_id can be
-    passed into the Ray SchedulingPolicy API.
-    """
-    nodes = gcs_client.get_all_node_info(timeout=RAY_GCS_RPC_TIMEOUT_S)
-    node_ids = [
-        (ray.NodeID.from_binary(node_id).hex(), node["node_name"].decode("utf-8"))
-        for (node_id, node) in nodes.items()
-        if node["state"] == ray.core.generated.gcs_pb2.GcsNodeInfo.ALIVE
-    ]
-
-    # Sort on NodeID to ensure the ordering is deterministic across the cluster.
-    sorted(node_ids)
-    return node_ids
 
 
 def compute_iterable_delta(old: Iterable, new: Iterable) -> Tuple[set, set, set]:

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -61,7 +61,7 @@ from ray.serve._private.utils import (
     record_serve_tag,
 )
 from ray.serve._private.application_state import ApplicationStateManager
-from ray.serve._private.cluster_node_info_cache_factory import (
+from ray.serve._private.default_impl import (
     create_cluster_node_info_cache,
 )
 

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -171,6 +171,7 @@ class ServeController:
             self.kv_store,
             self.long_poll_host,
             all_serve_actor_names,
+            self.cluster_node_info_cache,
         )
 
         # Manage all applications' state

--- a/python/ray/serve/tests/test_cluster_node_info_cache.py
+++ b/python/ray/serve/tests/test_cluster_node_info_cache.py
@@ -33,6 +33,10 @@ def test_get_alive_nodes(ray_start_cluster):
         head_node_id,
         worker_node_id,
     }
+    assert (
+        cluster_node_info_cache.get_alive_node_ids()
+        == cluster_node_info_cache.get_active_node_ids()
+    )
 
     cluster.remove_node(worker_node)
     cluster.wait_for_nodes()
@@ -43,6 +47,10 @@ def test_get_alive_nodes(ray_start_cluster):
         (head_node_id, ray.nodes()[0]["NodeName"])
     ]
     assert cluster_node_info_cache.get_alive_node_ids() == {head_node_id}
+    assert (
+        cluster_node_info_cache.get_alive_node_ids()
+        == cluster_node_info_cache.get_active_node_ids()
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_cluster_node_info_cache.py
+++ b/python/ray/serve/tests/test_cluster_node_info_cache.py
@@ -1,0 +1,27 @@
+import pytest
+
+import ray
+from ray._raylet import GcsClient
+from ray.serve._private.cluster_node_info_cache_factory import (
+    create_cluster_node_info_cache,
+)
+
+
+def test_get_alive_nodes(ray_shutdown):
+    ray.init()
+
+    gcs_client = GcsClient(address=ray.get_runtime_context().gcs_address)
+    cluster_node_info_cache = create_cluster_node_info_cache(gcs_client)
+    cluster_node_info_cache.update()
+    assert cluster_node_info_cache.get_alive_nodes() == [
+        (ray.get_runtime_context().get_node_id(), ray.nodes()[0]["NodeName"])
+    ]
+    assert cluster_node_info_cache.get_alive_node_ids() == {
+        ray.get_runtime_context().get_node_id()
+    }
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/test_deployment_scheduler.py
@@ -13,7 +13,7 @@ from ray.serve._private.deployment_scheduler import (
     DeploymentDownscaleRequest,
 )
 from ray.serve._private.utils import get_head_node_id
-from ray.serve._private.cluster_node_info_cache_factory import (
+from ray.serve._private.default_impl import (
     create_cluster_node_info_cache,
 )
 

--- a/python/ray/serve/tests/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/test_deployment_scheduler.py
@@ -3,6 +3,7 @@ import sys
 import pytest
 
 import ray
+from ray._raylet import GcsClient
 from ray.tests.conftest import *  # noqa
 from ray.serve._private.deployment_scheduler import (
     DeploymentScheduler,
@@ -12,6 +13,9 @@ from ray.serve._private.deployment_scheduler import (
     DeploymentDownscaleRequest,
 )
 from ray.serve._private.utils import get_head_node_id
+from ray.serve._private.cluster_node_info_cache_factory import (
+    create_cluster_node_info_cache,
+)
 
 
 @ray.remote(num_cpus=1)
@@ -28,7 +32,12 @@ def test_spread_deployment_scheduling_policy_upscale(ray_start_cluster):
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
-    scheduler = DeploymentScheduler()
+    cluster_node_info_cache = create_cluster_node_info_cache(
+        GcsClient(address=ray.get_runtime_context().gcs_address)
+    )
+    cluster_node_info_cache.update()
+
+    scheduler = DeploymentScheduler(cluster_node_info_cache)
     scheduler.on_deployment_created("deployment1", SpreadDeploymentSchedulingPolicy())
     replica_actor_handles = []
     deployment_to_replicas_to_stop = scheduler.schedule(
@@ -87,7 +96,12 @@ def test_spread_deployment_scheduling_policy_downscale(ray_start_cluster):
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
-    scheduler = DeploymentScheduler()
+    cluster_node_info_cache = create_cluster_node_info_cache(
+        GcsClient(address=ray.get_runtime_context().gcs_address)
+    )
+    cluster_node_info_cache.update()
+
+    scheduler = DeploymentScheduler(cluster_node_info_cache)
     scheduler.on_deployment_created("deployment1", SpreadDeploymentSchedulingPolicy())
     scheduler.on_replica_running("deployment1", "replica1", "node1")
     scheduler.on_replica_running("deployment1", "replica2", "node1")
@@ -173,7 +187,12 @@ def test_spread_deployment_scheduling_policy_downscale_head_node(ray_start_clust
     ray.init(address=cluster.address)
     head_node_id = get_head_node_id()
 
-    scheduler = DeploymentScheduler()
+    cluster_node_info_cache = create_cluster_node_info_cache(
+        GcsClient(address=ray.get_runtime_context().gcs_address)
+    )
+    cluster_node_info_cache.update()
+
+    scheduler = DeploymentScheduler(cluster_node_info_cache)
     scheduler.on_deployment_created("deployment1", SpreadDeploymentSchedulingPolicy())
     scheduler.on_replica_running("deployment1", "replica1", head_node_id)
     scheduler.on_replica_running("deployment1", "replica2", "node2")
@@ -230,7 +249,12 @@ def test_driver_deployment_scheduling_policy_upscale(ray_start_cluster):
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
-    scheduler = DeploymentScheduler()
+    cluster_node_info_cache = create_cluster_node_info_cache(
+        GcsClient(address=ray.get_runtime_context().gcs_address)
+    )
+    cluster_node_info_cache.update()
+
+    scheduler = DeploymentScheduler(cluster_node_info_cache)
     scheduler.on_deployment_created("deployment1", DriverDeploymentSchedulingPolicy())
 
     replica_actor_handles = []
@@ -292,6 +316,7 @@ def test_driver_deployment_scheduling_policy_upscale(ray_start_cluster):
     scheduler.on_replica_recovering("deployment1", "replica4")
     cluster.add_node(num_cpus=3)
     cluster.wait_for_nodes()
+    cluster_node_info_cache.update()
 
     deployment_to_replicas_to_stop = scheduler.schedule(upscales={}, downscales={})
     assert not deployment_to_replicas_to_stop

--- a/python/ray/serve/tests/test_http_state.py
+++ b/python/ray/serve/tests/test_http_state.py
@@ -16,9 +16,10 @@ from ray.serve._private.http_proxy import HTTPProxyActor
 from ray.serve._private.constants import SERVE_CONTROLLER_NAME, SERVE_NAMESPACE
 from ray.serve.controller import ServeController
 from ray.serve._private.utils import get_head_node_id
-from ray.serve._private.cluster_node_info_cache_factory import (
+from ray.serve._private.default_impl import (
     create_cluster_node_info_cache,
 )
+from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
 
 
 HEAD_NODE_ID = "node_id-index-head"
@@ -39,13 +40,16 @@ def _make_http_proxy_state_manager(
     http_options: HTTPOptions,
     head_node_id: str = HEAD_NODE_ID,
     cluster_node_info_cache=MockClusterNodeInfoCache(),
-) -> HTTPProxyStateManager:
-    return HTTPProxyStateManager(
-        SERVE_CONTROLLER_NAME,
-        detached=True,
-        config=http_options,
-        head_node_id=head_node_id,
-        cluster_node_info_cache=cluster_node_info_cache,
+) -> (HTTPProxyStateManager, ClusterNodeInfoCache):
+    return (
+        HTTPProxyStateManager(
+            SERVE_CONTROLLER_NAME,
+            detached=True,
+            config=http_options,
+            head_node_id=head_node_id,
+            cluster_node_info_cache=cluster_node_info_cache,
+        ),
+        cluster_node_info_cache,
     )
 
 
@@ -137,31 +141,31 @@ def _update_and_check_http_proxy_state_manager(
 def test_node_selection(all_nodes):
     all_node_ids = {node_id for node_id, _ in all_nodes}
     # Test NoServer
-    manager = _make_http_proxy_state_manager(
+    manager, cluster_node_info_cache = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.NoServer)
     )
-    manager._cluster_node_info_cache.alive_nodes = all_nodes
+    cluster_node_info_cache.alive_nodes = all_nodes
     assert manager._get_target_nodes(all_node_ids) == []
 
     # Test HeadOnly
-    manager = _make_http_proxy_state_manager(
+    manager, cluster_node_info_cache = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.HeadOnly)
     )
-    manager._cluster_node_info_cache.alive_nodes = all_nodes
+    cluster_node_info_cache.alive_nodes = all_nodes
     assert manager._get_target_nodes(all_node_ids) == all_nodes[:1]
 
     # Test EveryNode
-    manager = _make_http_proxy_state_manager(
+    manager, cluster_node_info_cache = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.EveryNode)
     )
-    manager._cluster_node_info_cache.alive_nodes = all_nodes
+    cluster_node_info_cache.alive_nodes = all_nodes
     assert manager._get_target_nodes(all_node_ids) == all_nodes
 
     # Test FixedReplica
-    manager = _make_http_proxy_state_manager(
+    manager, cluster_node_info_cache = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.FixedNumber, fixed_number_replicas=5)
     )
-    manager._cluster_node_info_cache.alive_nodes = all_nodes
+    cluster_node_info_cache.alive_nodes = all_nodes
     selected_nodes = manager._get_target_nodes(all_node_ids)
 
     # it should have selection a subset of 5 nodes.
@@ -172,24 +176,24 @@ def test_node_selection(all_nodes):
         # The selection should be deterministic.
         assert selected_nodes == manager._get_target_nodes(all_node_ids)
 
-    manager = _make_http_proxy_state_manager(
+    manager, cluster_node_info_cache = _make_http_proxy_state_manager(
         HTTPOptions(
             location=DeploymentMode.FixedNumber,
             fixed_number_replicas=5,
             fixed_number_selection_seed=42,
         )
     )
-    manager._cluster_node_info_cache.alive_nodes = all_nodes
+    cluster_node_info_cache.alive_nodes = all_nodes
     another_seed = manager._get_target_nodes(all_node_ids)
     assert len(another_seed) == 5
     assert set(all_nodes).issuperset(set(another_seed))
     assert set(another_seed) != set(selected_nodes)
 
     # Test specific nodes
-    manager = _make_http_proxy_state_manager(
+    manager, cluster_node_info_cache = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.EveryNode)
     )
-    manager._cluster_node_info_cache.alive_nodes = all_nodes
+    cluster_node_info_cache.alive_nodes = all_nodes
     assert manager._get_target_nodes({HEAD_NODE_ID}) == [(HEAD_NODE_ID, "fake-head-ip")]
 
 
@@ -206,14 +210,14 @@ def test_http_state_update_restarts_unhealthy_proxies(ray_shutdown):
     ray.init(num_cpus=5)
     head_node_id = get_head_node_id()
 
-    manager = _make_http_proxy_state_manager(
+    manager, cluster_node_info_cache = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.HeadOnly),
         head_node_id,
         create_cluster_node_info_cache(
             GcsClient(address=ray.get_runtime_context().gcs_address)
         ),
     )
-    manager._cluster_node_info_cache.update()
+    cluster_node_info_cache.update()
     manager._proxy_states[head_node_id] = _create_http_proxy_state(
         status=HTTPProxyStatus.STARTING
     )
@@ -682,10 +686,10 @@ def test_update_draining(all_nodes, setup_controller, number_of_worker_nodes):
     node http proxy should continue to be healthy while worker node http proxy should
     be healthy.
     """
-    manager = _make_http_proxy_state_manager(
+    manager, cluster_node_info_cache = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.EveryNode)
     )
-    manager._cluster_node_info_cache.alive_nodes = all_nodes
+    cluster_node_info_cache.alive_nodes = all_nodes
 
     for node_id, node_ip_address in all_nodes:
         manager._proxy_states[node_id] = _create_http_proxy_state(
@@ -737,10 +741,10 @@ def test_proxy_actor_unhealthy_during_draining(
     all_nodes, setup_controller, number_of_worker_nodes
 ):
     """Test the state transition from DRAINING to UNHEALTHY for the proxy actor."""
-    manager = _make_http_proxy_state_manager(
+    manager, cluster_node_info_cache = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.EveryNode)
     )
-    manager._cluster_node_info_cache.alive_nodes = all_nodes
+    cluster_node_info_cache.alive_nodes = all_nodes
 
     worker_node_id = None
     for node_id, node_ip_address in all_nodes:
@@ -805,10 +809,10 @@ def test_is_ready_for_shutdown(all_nodes):
     `shutdown()` is called and all proxy actor are killed, `is_ready_for_shutdown()`
     should return true.
     """
-    manager = _make_http_proxy_state_manager(
+    manager, cluster_node_info_cache = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.EveryNode)
     )
-    manager._cluster_node_info_cache.alive_nodes = all_nodes
+    cluster_node_info_cache.alive_nodes = all_nodes
 
     for node_id, node_ip_address in all_nodes:
         manager._proxy_states[node_id] = _create_http_proxy_state(

--- a/python/ray/serve/tests/test_http_state.py
+++ b/python/ray/serve/tests/test_http_state.py
@@ -16,22 +16,36 @@ from ray.serve._private.http_proxy import HTTPProxyActor
 from ray.serve._private.constants import SERVE_CONTROLLER_NAME, SERVE_NAMESPACE
 from ray.serve.controller import ServeController
 from ray.serve._private.utils import get_head_node_id
+from ray.serve._private.cluster_node_info_cache_factory import (
+    create_cluster_node_info_cache,
+)
 
 
 HEAD_NODE_ID = "node_id-index-head"
 
 
+class MockClusterNodeInfoCache:
+    def __init__(self):
+        self.alive_nodes = []
+
+    def get_alive_nodes(self):
+        return self.alive_nodes
+
+    def get_alive_node_ids(self):
+        return {node_id for node_id, _ in self.alive_nodes}
+
+
 def _make_http_proxy_state_manager(
     http_options: HTTPOptions,
     head_node_id: str = HEAD_NODE_ID,
-    gcs_client: GcsClient = None,
+    cluster_node_info_cache=MockClusterNodeInfoCache(),
 ) -> HTTPProxyStateManager:
     return HTTPProxyStateManager(
         SERVE_CONTROLLER_NAME,
         detached=True,
         config=http_options,
         head_node_id=head_node_id,
-        gcs_client=gcs_client,
+        cluster_node_info_cache=cluster_node_info_cache,
     )
 
 
@@ -46,13 +60,6 @@ def all_nodes(number_of_worker_nodes) -> List[Tuple[str, str]]:
         (f"worker-node-id-{i}", f"fake-worker-ip-{i}")
         for i in range(number_of_worker_nodes)
     ]
-
-
-@pytest.fixture()
-def mock_get_all_node_ids(all_nodes):
-    with patch("ray.serve._private.http_state.get_all_node_ids") as func:
-        func.return_value = all_nodes
-        yield
 
 
 @pytest.fixture()
@@ -127,30 +134,34 @@ def _update_and_check_http_proxy_state_manager(
     )
 
 
-def test_node_selection(all_nodes, mock_get_all_node_ids):
+def test_node_selection(all_nodes):
     all_node_ids = {node_id for node_id, _ in all_nodes}
     # Test NoServer
     manager = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.NoServer)
     )
+    manager._cluster_node_info_cache.alive_nodes = all_nodes
     assert manager._get_target_nodes(all_node_ids) == []
 
     # Test HeadOnly
     manager = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.HeadOnly)
     )
+    manager._cluster_node_info_cache.alive_nodes = all_nodes
     assert manager._get_target_nodes(all_node_ids) == all_nodes[:1]
 
     # Test EveryNode
     manager = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.EveryNode)
     )
+    manager._cluster_node_info_cache.alive_nodes = all_nodes
     assert manager._get_target_nodes(all_node_ids) == all_nodes
 
     # Test FixedReplica
     manager = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.FixedNumber, fixed_number_replicas=5)
     )
+    manager._cluster_node_info_cache.alive_nodes = all_nodes
     selected_nodes = manager._get_target_nodes(all_node_ids)
 
     # it should have selection a subset of 5 nodes.
@@ -161,13 +172,15 @@ def test_node_selection(all_nodes, mock_get_all_node_ids):
         # The selection should be deterministic.
         assert selected_nodes == manager._get_target_nodes(all_node_ids)
 
-    another_seed = _make_http_proxy_state_manager(
+    manager = _make_http_proxy_state_manager(
         HTTPOptions(
             location=DeploymentMode.FixedNumber,
             fixed_number_replicas=5,
             fixed_number_selection_seed=42,
         )
-    )._get_target_nodes(all_node_ids)
+    )
+    manager._cluster_node_info_cache.alive_nodes = all_nodes
+    another_seed = manager._get_target_nodes(all_node_ids)
     assert len(another_seed) == 5
     assert set(all_nodes).issuperset(set(another_seed))
     assert set(another_seed) != set(selected_nodes)
@@ -176,6 +189,7 @@ def test_node_selection(all_nodes, mock_get_all_node_ids):
     manager = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.EveryNode)
     )
+    manager._cluster_node_info_cache.alive_nodes = all_nodes
     assert manager._get_target_nodes({HEAD_NODE_ID}) == [(HEAD_NODE_ID, "fake-head-ip")]
 
 
@@ -195,8 +209,11 @@ def test_http_state_update_restarts_unhealthy_proxies(ray_shutdown):
     manager = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.HeadOnly),
         head_node_id,
-        GcsClient(address=ray.get_runtime_context().gcs_address),
+        create_cluster_node_info_cache(
+            GcsClient(address=ray.get_runtime_context().gcs_address)
+        ),
     )
+    manager._cluster_node_info_cache.update()
     manager._proxy_states[head_node_id] = _create_http_proxy_state(
         status=HTTPProxyStatus.STARTING
     )
@@ -657,9 +674,7 @@ def test_unhealthy_retry_correct_number_of_times():
 
 @patch("ray.serve._private.http_state.PROXY_HEALTH_CHECK_PERIOD_S", 0.1)
 @pytest.mark.parametrize("number_of_worker_nodes", [0, 1, 2, 3])
-def test_update_draining(
-    mock_get_all_node_ids, all_nodes, setup_controller, number_of_worker_nodes
-):
+def test_update_draining(all_nodes, setup_controller, number_of_worker_nodes):
     """Test update draining logics.
 
     When update nodes to inactive, head node http proxy should never be draining while
@@ -670,6 +685,7 @@ def test_update_draining(
     manager = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.EveryNode)
     )
+    manager._cluster_node_info_cache.alive_nodes = all_nodes
 
     for node_id, node_ip_address in all_nodes:
         manager._proxy_states[node_id] = _create_http_proxy_state(
@@ -718,12 +734,13 @@ def test_update_draining(
 @patch("ray.serve._private.http_state.PROXY_DRAIN_CHECK_PERIOD_S", 0.1)
 @pytest.mark.parametrize("number_of_worker_nodes", [1])
 def test_proxy_actor_unhealthy_during_draining(
-    mock_get_all_node_ids, all_nodes, setup_controller, number_of_worker_nodes
+    all_nodes, setup_controller, number_of_worker_nodes
 ):
     """Test the state transition from DRAINING to UNHEALTHY for the proxy actor."""
     manager = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.EveryNode)
     )
+    manager._cluster_node_info_cache.alive_nodes = all_nodes
 
     worker_node_id = None
     for node_id, node_ip_address in all_nodes:
@@ -781,7 +798,7 @@ def test_proxy_actor_unhealthy_during_draining(
     assert manager._proxy_states[HEAD_NODE_ID].status == HTTPProxyStatus.HEALTHY
 
 
-def test_is_ready_for_shutdown(mock_get_all_node_ids, all_nodes):
+def test_is_ready_for_shutdown(all_nodes):
     """Test `is_ready_for_shutdown()` returns True the correct state.
 
     Before `shutdown()` is called, `is_ready_for_shutdown()` should return false. After
@@ -791,6 +808,7 @@ def test_is_ready_for_shutdown(mock_get_all_node_ids, all_nodes):
     manager = _make_http_proxy_state_manager(
         HTTPOptions(location=DeploymentMode.EveryNode)
     )
+    manager._cluster_node_info_cache.alive_nodes = all_nodes
 
     for node_id, node_ip_address in all_nodes:
         manager._proxy_states[node_id] = _create_http_proxy_state(

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -414,6 +414,7 @@ def test_multiple_routers(ray_cluster):
     # Add a new node to the cluster. This should trigger a new router to get
     # started.
     new_node = cluster.add_node(num_cpus=4)
+    cluster_node_info_cache.update()
 
     wait_for_condition(lambda: len(get_proxy_names()) == 3)
     (third_proxy,) = set(get_proxy_names()) - set(original_proxy_names)
@@ -433,6 +434,7 @@ def test_multiple_routers(ray_cluster):
     # Remove the newly-added node from the cluster. The corresponding actor
     # should be removed as well.
     cluster.remove_node(new_node)
+    cluster_node_info_cache.update()
 
     def third_actor_removed():
         try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add ClusterNodeInfoCache class to be a central place to access node info
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
