### PR TITLE
[Data] Fix excessive object store usage in `read_images_train_4_cpu` train benchmark

### DIFF
--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -123,11 +123,7 @@ def get_transform(to_torch_tensor):
             ),
             torchvision.transforms.RandomHorizontalFlip(),
         ]
-        + (
-            [torchvision.transforms.ToTensor()]
-            if to_torch_tensor
-            else []
-        )
+        + ([torchvision.transforms.ToTensor()] if to_torch_tensor else [])
     )
     return transform
 

--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -123,9 +123,11 @@ def get_transform(to_torch_tensor):
             ),
             torchvision.transforms.RandomHorizontalFlip(),
         ]
-        + [torchvision.transforms.ToTensor()]
-        if to_torch_tensor
-        else []
+        + (
+            [torchvision.transforms.ToTensor()]
+            if to_torch_tensor
+            else []
+        )
     )
     return transform
 

--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -93,11 +93,7 @@ def get_transform(to_torch_tensor):
             ),
             torchvision.transforms.RandomHorizontalFlip(),
         ]
-        + (
-            [torchvision.transforms.ToTensor()]
-            if to_torch_tensor
-            else []
-        )
+        + ([torchvision.transforms.ToTensor()] if to_torch_tensor else [])
     )
     return transform
 

--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -146,7 +146,7 @@ if __name__ == "__main__":
     torch_trainer = TorchTrainer(
         train_loop_per_worker,
         datasets={"train": ray_dataset},
-        scaling_config=ScalingConfig(num_workers=args.num_workers),
+        scaling_config=ScalingConfig(num_workers=args.num_workers, use_gpu=True),
         dataset_config=ray.train.DataConfig(
             execution_options=options,
         ),

--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -93,9 +93,11 @@ def get_transform(to_torch_tensor):
             ),
             torchvision.transforms.RandomHorizontalFlip(),
         ]
-        + [torchvision.transforms.ToTensor()]
-        if to_torch_tensor
-        else []
+        + (
+            [torchvision.transforms.ToTensor()]
+            if to_torch_tensor
+            else []
+        )
     )
     return transform
 
@@ -176,4 +178,5 @@ if __name__ == "__main__":
     with open(test_output_json, "wt") as f:
         json.dump(result_dict, f)
 
-    print(f"Finished benchmark, metrics exported to {test_output_json}.")
+    print(f"Finished benchmark, metrics exported to {test_output_json}:")
+    print(result_dict)

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -6017,7 +6017,7 @@
   group: data-tests
   working_dir: nightly_tests/dataset
 
-  frequency: manual
+  frequency: nightly
   team: data
   python: "3.8"
   cluster:
@@ -6041,7 +6041,7 @@
   group: data-tests
   working_dir: nightly_tests/dataset
 
-  frequency: manual
+  frequency: nightly
   team: data
   python: "3.8"
   cluster:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There is a bug (see https://github.com/ray-project/ray/issues/37918) in the multi-node train benchmark (currently only triggered manually), which caused high object store usage upon data ingestion. The root cause is that due to a code bug, the benchmark skips all data preprocessing; since this preprocessing includes a random crop to a smaller image size, the benchmark was using high object storage because it was ingesting uncropped images, which are much larger than anticipated.

This PR addresses the bug and re-enables these tests to run nightly.

Sample output for the 1 worker case:
```
{"read_image_train_1workers": {"ray_TorchTrainer_fit": {"THROUGHPUT": 152.03294220557285}}, "success": 1}
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #37918

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
