### PR TITLE
[Data] Deflake `test_batching_pyarrow_table_with_many_chunks`

### DIFF
--- a/python/ray/data/tests/test_batcher.py
+++ b/python/ray/data/tests/test_batcher.py
@@ -203,7 +203,7 @@ def test_batching_pyarrow_table_with_many_chunks():
     while shuffling_batcher.has_any():
         shuffling_batcher.next_batch()
     duration = time.perf_counter() - start
-    assert duration < 20
+    assert duration < 30
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`test_batching_pyarrow_table_with_many_chunks` checks that it takes less than 20 seconds to batch a PyArrow table. Sometimes, it takes slightly longer than expected, so the test fails. This PR deflakes the test by increasing the threshold.

See https://buildkite.com/anyscale/runtime/builds/292#0189bbd2-a266-4e7d-bebd-240cd2f7a5bd.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
