### PR TITLE
Increase data scale of map-batches-multiple-output-blocks benchmark

### DIFF
--- a/release/nightly_tests/dataset/map_batches_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_benchmark.py
@@ -149,11 +149,11 @@ def run_map_batches_benchmark(benchmark: Benchmark):
 
     # Test map_batches whose output is large and will be split into multiple blocks.
     # With the following configuration, the total output data size will be
-    # (num_output_blocks * 1GB).
+    # (num_output_blocks * 10GB).
     num_output_blocks = [10, 50, 100]
     input_size = 1024 * 1024
     batch_size = 1024
-    ray.data.DataContext.get_current().target_max_block_size = 1024 * 1024
+    ray.data.DataContext.get_current().target_max_block_size = 10 * 1024 * 1024
     # Disable PhysicalOperator fusion. Because we will have 2 map_batches operators.
     # And the first one will generate multiple output blocks.
     ray.data._internal.logical.optimizers.PHYSICAL_OPTIMIZER_RULES = []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Increase the data scale. Because the original is too small to trigger spilling, and streaming generator won't have meaningful perf improvements. With the new setup, streaming generator shows a 22% improvement. 

## Related issue number

https://github.com/ray-project/ray/issues/36444

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
