### PR TITLE
[serve] Allow pluggable router classes via handle config (experimental)

### DIFF
--- a/python/ray/_private/storage.py
+++ b/python/ray/_private/storage.py
@@ -1,4 +1,3 @@
-import importlib
 import os
 import re
 import urllib
@@ -6,7 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 from ray._private.client_mode_hook import client_mode_hook
-from ray._private.utils import _add_creatable_buckets_param_if_s3_uri
+from ray._private.utils import _add_creatable_buckets_param_if_s3_uri, load_class
 from ray._private.auto_init_hook import wrap_auto_init
 
 if TYPE_CHECKING:
@@ -487,15 +486,6 @@ def _reset() -> None:
     _storage_uri = _filesystem = _storage_prefix = None
 
 
+# TODO(ekl): remove this indirection.
 def _load_class(path):
-    """Load a class at runtime given a full path.
-
-    Example of the path: mypkg.mysubpkg.myclass
-    """
-    class_data = path.split(".")
-    if len(class_data) < 2:
-        raise ValueError("You need to pass a valid path like mymodule.provider_class")
-    module_path = ".".join(class_data[:-1])
-    class_str = class_data[-1]
-    module = importlib.import_module(module_path)
-    return getattr(module, class_str)
+    return load_class(path)

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1987,3 +1987,17 @@ def pasre_pg_formatted_resources_to_original(
         original_resources[key] = value
 
     return original_resources
+
+
+def load_class(path):
+    """Load a class at runtime given a full path.
+
+    Example of the path: mypkg.mysubpkg.myclass
+    """
+    class_data = path.split(".")
+    if len(class_data) < 2:
+        raise ValueError("You need to pass a valid path like mymodule.provider_class")
+    module_path = ".".join(class_data[:-1])
+    class_str = class_data[-1]
+    module = importlib.import_module(module_path)
+    return getattr(module, class_str)

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -904,23 +904,17 @@ class Router:
         self._event_loop = event_loop
 
         if _router_cls:
-            self._replica_scheduler = load_class(_router_cls)()
+            self._replica_scheduler = load_class(_router_cls)(
+                event_loop=event_loop, deployment_name=deployment_name
+            )
         elif _use_new_routing:
             self._replica_scheduler = PowerOfTwoChoicesReplicaScheduler(
                 event_loop, deployment_name
             )
-            logger.info(
-                "Using PowerOfTwoChoicesReplicaScheduler.",
-                extra={"log_to_stderr": False},
-            )
         else:
             self._replica_scheduler = RoundRobinReplicaScheduler(event_loop)
-            logger.info(
-                "Using RoundRobinReplicaScheduler.",
-                extra={"log_to_stderr": False},
-            )
         logger.info(
-            f"Using {self._replica_scheduler.__class__}.",
+            f"Using router {self._replica_scheduler.__class__}.",
             extra={"log_to_stderr": False},
         )
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -28,6 +28,7 @@ from ray.actor import ActorHandle
 from ray.dag.py_obj_scanner import _PyObjScanner
 from ray.exceptions import RayActorError, RayTaskError
 from ray.util import metrics
+from ray._private.storage import _load_class
 from ray._private.utils import make_asyncio_event_version_compat
 
 from ray.serve._private.common import RunningReplicaInfo, DeploymentInfo
@@ -894,6 +895,7 @@ class Router:
         deployment_name: str,
         event_loop: asyncio.BaseEventLoop = None,
         _use_new_routing: bool = False,
+        _router_cls: str = "",
     ):
         """Used to assign requests to downstream replicas for a deployment.
 
@@ -901,7 +903,10 @@ class Router:
         wrapper that adds metrics and logging.
         """
         self._event_loop = event_loop
-        if _use_new_routing:
+
+        if _router_cls:
+            self._replica_scheduler = _load_class(_router_cls)()
+        elif _use_new_routing:
             self._replica_scheduler = PowerOfTwoChoicesReplicaScheduler(
                 event_loop, deployment_name
             )

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -190,13 +190,13 @@ class RayServeHandle:
             _router_cls=_router_cls,
         )
 
-        if self._router is None and not _router_cls:
+        if self._router is None and _router_cls == DEFAULT.VALUE:
             self._get_or_create_router()
 
         return self.__class__(
             self.deployment_name,
             handle_options=new_handle_options,
-            _router=None if _router_cls else self._router,
+            _router=None if _router_cls != DEFAULT.VALUE else self._router,
             _is_for_http_requests=self._is_for_http_requests,
         )
 

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -62,12 +62,14 @@ class HandleOptions:
     method_name: str = "__call__"
     multiplexed_model_id: str = ""
     stream: bool = False
+    _router_cls: str = ""
 
     def copy_and_update(
         self,
         method_name: Union[str, DEFAULT] = DEFAULT.VALUE,
         multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
+        _router_cls: Union[str, DEFAULT] = DEFAULT.VALUE,
     ) -> "HandleOptions":
         return HandleOptions(
             method_name=(
@@ -79,6 +81,9 @@ class HandleOptions:
                 else multiplexed_model_id
             ),
             stream=self.stream if stream == DEFAULT.VALUE else stream,
+            _router_cls=self._router_cls
+            if _router_cls == DEFAULT.VALUE
+            else _router_cls,
         )
 
 
@@ -157,6 +162,7 @@ class RayServeHandle:
                 self.deployment_name,
                 event_loop=get_or_create_event_loop(),
                 _use_new_routing=RAY_SERVE_ENABLE_NEW_ROUTING,
+                _router_cls=self.handle_options._router_cls,
             )
 
         return self._router
@@ -175,11 +181,13 @@ class RayServeHandle:
         method_name: Union[str, DEFAULT] = DEFAULT.VALUE,
         multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
+        _router_cls: Union[str, DEFAULT] = DEFAULT.VALUE,
     ):
         new_handle_options = self.handle_options.copy_and_update(
             method_name=method_name,
             multiplexed_model_id=multiplexed_model_id,
             stream=stream,
+            _router_cls=_router_cls,
         )
 
         if self._router is None:
@@ -198,6 +206,7 @@ class RayServeHandle:
         method_name: Union[str, DEFAULT] = DEFAULT.VALUE,
         multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
+        _router_cls: Union[str, DEFAULT] = DEFAULT.VALUE,
     ) -> "RayServeHandle":
         """Set options for this handle and return an updated copy of it.
 
@@ -215,6 +224,7 @@ class RayServeHandle:
             method_name=method_name,
             multiplexed_model_id=multiplexed_model_id,
             stream=stream,
+            _router_cls=_router_cls,
         )
 
     def _remote(self, deployment_name, handle_options, args, kwargs) -> Coroutine:
@@ -323,6 +333,7 @@ class RayServeSyncHandle(RayServeHandle):
                 self.deployment_name,
                 event_loop=_create_or_get_async_loop_in_thread(),
                 _use_new_routing=RAY_SERVE_ENABLE_NEW_ROUTING,
+                _router_cls=self.handle_options.router_cls,
             )
 
         return self._router

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -190,13 +190,13 @@ class RayServeHandle:
             _router_cls=_router_cls,
         )
 
-        if self._router is None:
+        if self._router is None and not _router_cls:
             self._get_or_create_router()
 
         return self.__class__(
             self.deployment_name,
             handle_options=new_handle_options,
-            _router=self._router,
+            _router=None if _router_cls else self._router,
             _is_for_http_requests=self._is_for_http_requests,
         )
 
@@ -333,7 +333,7 @@ class RayServeSyncHandle(RayServeHandle):
                 self.deployment_name,
                 event_loop=_create_or_get_async_loop_in_thread(),
                 _use_new_routing=RAY_SERVE_ENABLE_NEW_ROUTING,
-                _router_cls=self.handle_options.router_cls,
+                _router_cls=self.handle_options._router_cls,
             )
 
         return self._router
@@ -344,6 +344,7 @@ class RayServeSyncHandle(RayServeHandle):
         method_name: Union[str, DEFAULT] = DEFAULT.VALUE,
         multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
+        _router_cls: Union[str, DEFAULT] = DEFAULT.VALUE,
     ) -> "RayServeSyncHandle":
         """Set options for this handle and return an updated copy of it.
 
@@ -361,6 +362,7 @@ class RayServeSyncHandle(RayServeHandle):
             method_name=method_name,
             multiplexed_model_id=multiplexed_model_id,
             stream=stream,
+            _router_cls=_router_cls,
         )
 
     def remote(self, *args, **kwargs) -> ray.ObjectRef:

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -379,7 +379,7 @@ def test_handle_options_custom_router(serve_instance):
     handle = serve.run(echo.bind())
     handle2 = handle.options(_router_cls="ray.serve.tests.test_handle.MyRouter")
     ray.get(handle2.remote("HI"))
-    assert handle2._router
+    print("Router class used", handle2._router._replica_scheduler)
     assert isinstance(
         handle2._router._replica_scheduler, MyRouter
     ), handle2._router._replica_scheduler

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -11,6 +11,7 @@ from ray import serve
 from ray.serve.context import get_global_client
 from ray.serve.exceptions import RayServeException
 from ray.serve.handle import HandleOptions, RayServeHandle, RayServeSyncHandle
+from ray.serve._private.router import PowerOfTwoChoicesReplicaScheduler
 from ray.serve._private.constants import (
     DEPLOYMENT_NAME_PREFIX_SEPARATOR,
     RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING,
@@ -364,6 +365,24 @@ def test_handle_options_with_same_router(serve_instance):
     handle2 = handle.options(multiplexed_model_id="model2")
     assert handle._router
     assert id(handle2._router) == id(handle._router)
+
+
+class MyRouter(PowerOfTwoChoicesReplicaScheduler):
+    pass
+
+
+def test_handle_options_custom_router(serve_instance):
+    @serve.deployment
+    def echo(name: str):
+        return f"Hi {name}"
+
+    handle = serve.run(echo.bind())
+    handle2 = handle.options(_router_cls="ray.serve.tests.test_handle.MyRouter")
+    ray.get(handle2.remote("HI"))
+    assert handle2._router
+    assert isinstance(
+        handle2._router._replica_scheduler, MyRouter
+    ), handle2._router._replica_scheduler
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -380,8 +380,8 @@ def test_handle_options_custom_router(serve_instance):
     handle2 = handle.options(_router_cls="ray.serve.tests.test_handle.MyRouter")
     ray.get(handle2.remote("HI"))
     print("Router class used", handle2._router._replica_scheduler)
-    assert isinstance(
-        handle2._router._replica_scheduler, MyRouter
+    assert (
+        "MyRouter" in handle2._router._replica_scheduler.__class__.__name__
     ), handle2._router._replica_scheduler
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add a way to configure the router via the handle config. This can be used to implement custom routing strategies. It may be better in the long term to make the routing configured via the deployment decorator.

TODO:
- [x] Add unit test