### PR TITLE
[Data] Remove unnecessary filesystem wrapping

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -314,9 +314,6 @@ class FileBasedDatasource(Datasource):
                     # if an S3 URI is provided.
                     tmp = _add_creatable_buckets_param_if_s3_uri(path)
                     filesystem.create_dir(tmp, recursive=True)
-                filesystem = _wrap_s3_serialization_workaround(filesystem)
-
-            fs = _unwrap_s3_serialization_workaround(filesystem)
 
             if self._WRITE_FILE_PER_ROW:
                 for row_index, row in enumerate(

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -326,7 +326,9 @@ class FileBasedDatasource(Datasource):
                     )
                     write_path = os.path.join(path, filename)
                     logger.get_logger().debug(f"Writing {write_path} file.")
-                    with filesystem.open_output_stream(write_path, **open_stream_args) as f:
+                    with filesystem.open_output_stream(
+                        write_path, **open_stream_args
+                    ) as f:
                         _write_row_to_file(
                             f,
                             row,

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -326,7 +326,7 @@ class FileBasedDatasource(Datasource):
                     )
                     write_path = os.path.join(path, filename)
                     logger.get_logger().debug(f"Writing {write_path} file.")
-                    with fs.open_output_stream(write_path, **open_stream_args) as f:
+                    with filesystem.open_output_stream(write_path, **open_stream_args) as f:
                         _write_row_to_file(
                             f,
                             row,
@@ -344,7 +344,7 @@ class FileBasedDatasource(Datasource):
                     file_format=file_format,
                 )
                 logger.get_logger().debug(f"Writing {write_path} file.")
-                with fs.open_output_stream(write_path, **open_stream_args) as f:
+                with filesystem.open_output_stream(write_path, **open_stream_args) as f:
                     _write_block_to_file(
                         f,
                         block,

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -315,6 +315,8 @@ class FileBasedDatasource(Datasource):
                     tmp = _add_creatable_buckets_param_if_s3_uri(path)
                     filesystem.create_dir(tmp, recursive=True)
 
+            fs = _unwrap_s3_serialization_workaround(filesystem)
+
             if self._WRITE_FILE_PER_ROW:
                 for row_index, row in enumerate(
                     block.iter_rows(public_row_format=False)
@@ -326,9 +328,7 @@ class FileBasedDatasource(Datasource):
                     )
                     write_path = os.path.join(path, filename)
                     logger.get_logger().debug(f"Writing {write_path} file.")
-                    with filesystem.open_output_stream(
-                        write_path, **open_stream_args
-                    ) as f:
+                    with fs.open_output_stream(write_path, **open_stream_args) as f:
                         _write_row_to_file(
                             f,
                             row,
@@ -346,7 +346,7 @@ class FileBasedDatasource(Datasource):
                     file_format=file_format,
                 )
                 logger.get_logger().debug(f"Writing {write_path} file.")
-                with filesystem.open_output_stream(write_path, **open_stream_args) as f:
+                with fs.open_output_stream(write_path, **open_stream_args) as f:
                     _write_block_to_file(
                         f,
                         block,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In `FileBasedDatasource.write`, we wrap then immediately unwrap the `filesystem` object. Since there's no point in wrapping the `filesystem` object, this PR removes the line. For context, this logic is likely from legacy code that was refactored by https://github.com/ray-project/ray/pull/37986.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
