### PR TITLE
[train/tune] Use env vars to configure Train/Tune artifact storage

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -22,6 +22,7 @@ import pyarrow.fs
 from ray._private.storage import _get_storage_uri
 from ray._private.thirdparty.tabulate.tabulate import tabulate
 from ray.air.constants import WILDCARD_KEY
+from ray.train._internal.storage import _get_artifact_storage_uri
 from ray.util.annotations import PublicAPI, Deprecated
 from ray.widgets import Template, make_table_html_repr
 from ray.data.preprocessor import Preprocessor
@@ -813,7 +814,7 @@ class RunConfig:
             self.local_dir = None
 
         if not remote_path:
-            remote_path = _get_storage_uri()
+            remote_path = _get_storage_uri() or _get_artifact_storage_uri()
             if remote_path:
                 logger.info(
                     "Using configured Ray storage URI as storage path: "

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -267,7 +267,7 @@ def _resolve_and_validate_storage_path(
         remote_path = _get_storage_uri() or _get_artifact_storage_uri()
         if remote_path:
             logger.info(
-                "Using configured Ray storage URI as storage path: " f"{remote_path}"
+                "Using configured Ray storage URI as storage path: {remote_path}"
             )
 
     sync_config.validate_upload_dir(remote_path)

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -28,7 +28,7 @@ from ray.air import CheckpointConfig
 from ray.air._internal import usage as air_usage
 from ray.air._internal.usage import AirEntrypoint
 from ray.air.util.node import _force_on_current_node
-from ray.train._internal.storage import _use_storage_context
+from ray.train._internal.storage import _use_storage_context, _get_artifact_storage_uri
 from ray.tune.analysis import ExperimentAnalysis
 from ray.tune.callback import Callback
 from ray.tune.error import TuneError
@@ -264,7 +264,7 @@ def _resolve_and_validate_storage_path(
 
     if not remote_path:
         # If no remote path is set, try to get Ray Storage URI
-        remote_path = _get_storage_uri()
+        remote_path = _get_storage_uri() or _get_artifact_storage_uri()
         if remote_path:
             logger.info(
                 "Using configured Ray storage URI as storage path: " f"{remote_path}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Users currently have to default the `storage_path`. For some settings (e.g. Ray jobs) it's handy to configure this using an environment variable instead. 

We currently default to the `RAY_STORAGE` system, but this needs to be set on cluster startup time, and doesn't allow for changes on runtime.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
