### PR TITLE
[Data] Use dict of dicts metrics output format in `torch_batch_inference_1_gpu_10gb` release test

### DIFF
--- a/release/air_tests/air_benchmarks/workloads/gpu_batch_inference.py
+++ b/release/air_tests/air_benchmarks/workloads/gpu_batch_inference.py
@@ -113,28 +113,28 @@ def main(data_directory: str, data_format: str, smoke_test: bool):
 
     # For structured output integration with internal tooling
     results = {"data_directory": data_directory, "data_format": data_format}
-    results["perf_metrics"] = [
-        {
+    results["perf_metrics"] = {
+        "total_time_s": {
             "perf_metric_name": "total_time_s",
             "perf_metric_value": total_time,
             "perf_metric_type": "LATENCY",
         },
-        {
+        "throughput_images_s": {
             "perf_metric_name": "throughput_images_s",
             "perf_metric_value": throughput,
             "perf_metric_type": "THROUGHPUT",
         },
-        {
+        "total_time_s_w/o_metadata_fetch": {
             "perf_metric_name": "total_time_s_w/o_metadata_fetch",
             "perf_metric_value": total_time_without_metadata_fetch,
             "perf_metric_type": "LATENCY",
         },
-        {
+        "throughput_images_s_w/o_metadata_fetch": {
             "perf_metric_name": "throughput_images_s_w/o_metadata_fetch",
             "perf_metric_value": throughput_without_metadata_fetch,
             "perf_metric_type": "THROUGHPUT",
         },
-    ]
+    }
 
     test_output_json = os.environ.get("TEST_OUTPUT_JSON", "/tmp/release_test_out.json")
     with open(test_output_json, "wt") as f:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As titled, the dict-of-dict metrics output format will allow us to more easily extract metrics values for reporting on Preset dashboards.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
