### PR TITLE
[build_base][core] Build jemalloc into ray by default.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,11 +8,11 @@
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:defs.bzl", "py_library", "py_runtime", "py_runtime_pair")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_github_grpc_grpc//bazel:cython_library.bzl", "pyx_library")
 load("@com_github_google_flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
-load("//bazel:ray.bzl", "COPTS", "PYX_COPTS", "PYX_SRCS", "copy_to_workspace")
+load("//bazel:ray.bzl", "COPTS", "PYX_COPTS", "PYX_SRCS", "copy_to_workspace", "ray_cc_binary")
 load("@python3_9//:defs.bzl", python39 = "interpreter")
 
 package(
@@ -479,7 +479,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+ray_cc_binary(
     name = "raylet",
     srcs = ["src/ray/raylet/main.cc"],
     copts = COPTS,
@@ -549,7 +549,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+ray_cc_binary(
     name = "gcs_server",
     srcs = [
         "src/ray/gcs/gcs_server/gcs_server_main.cc",
@@ -836,7 +836,7 @@ cc_library(
     ],
 )
 
-cc_binary(
+ray_cc_binary(
     name = "mock_worker",
     copts = COPTS,
     deps = [
@@ -2530,7 +2530,7 @@ pyx_library(
     ],
 )
 
-cc_binary(
+ray_cc_binary(
     name = "libcore_worker_library_java.so",
     srcs = glob([
         "src/ray/core_worker/lib/java/*.h",

--- a/bazel/BUILD.jemalloc
+++ b/bazel/BUILD.jemalloc
@@ -1,0 +1,17 @@
+load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
+
+
+filegroup(
+    name = "all",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "libjemalloc",
+    autogen = True,
+    configure_in_place = True,
+    lib_source = ":all",
+    args = ["-j"],
+    configure_options = ["--disable-shared", "--enable-prof"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -1,7 +1,7 @@
 load("@com_github_google_flatbuffers//:build_defs.bzl", "flatbuffer_library_public")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_common//tools/maven:pom_file.bzl", "pom_file")
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test", "cc_binary")
 
 COPTS_WITHOUT_LOG = select({
     "//:opt": ["-DBAZEL_OPT"],
@@ -184,5 +184,23 @@ def ray_cc_test(name, copts = [], **kwargs):
     cc_test(
         name = name,
         copts = COPTS + copts,
+        **kwargs
+    )
+
+def ray_cc_binary(name, copts = [], deps = [], **kwargs):
+    jemalloc_deps = select({
+        "@platforms//os:linux": ["@jemalloc//:libjemalloc"],
+        "//conditions:default": []
+    })
+    jemalloc_opts = select({
+        "@platforms//os:linux": ["-ldlsym"],
+        "//conditions:default": []
+    })
+
+        
+    cc_binary(
+        name = name,
+        copts = COPTS + copts + jemalloc_opts,
+        deps = deps + jemalloc_deps,
         **kwargs
     )

--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -187,20 +187,21 @@ def ray_cc_test(name, copts = [], **kwargs):
         **kwargs
     )
 
-def ray_cc_binary(name, copts = [], deps = [], **kwargs):
-    jemalloc_deps = select({
+def ray_cc_binary(name, copts = [], deps = [], linkopts = [], **kwargs):
+    extra_deps = select({
         "@platforms//os:linux": ["@jemalloc//:libjemalloc"],
         "//conditions:default": []
     })
-    jemalloc_opts = select({
-        "@platforms//os:linux": ["-ldlsym"],
+    extra_linkopts = select({
+        "@platforms//os:linux": ["-ldl"],
         "//conditions:default": []
     })
 
         
     cc_binary(
         name = name,
-        copts = COPTS + copts + jemalloc_opts,
-        deps = deps + jemalloc_deps,
+        copts = COPTS + copts,
+        deps = deps + extra_deps,
+        linkopts = linkopts + extra_linkopts,
         **kwargs
     )

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -354,4 +354,5 @@ def ray_deps_setup():
         remote = "https://github.com/jemalloc/jemalloc.git",
         commit = "254c4847e8ac263d24720aa93c2c7d410f55a239",
         build_file = "@com_github_ray_project_ray//bazel:BUILD.jemalloc",
+        shallow_since = "1691532067 -0700",
     )

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -348,3 +348,10 @@ def ray_deps_setup():
         # When you first run this tool, it'll recommend a sha256 hash to put here with a message like: "DEBUG: Rule 'hedron_compile_commands' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = ..."
         sha256 = "7fbbbc05c112c44e9b406612e6a7a7f4789a6918d7aacefef4c35c105286930c",
     )
+
+    new_git_repository(
+        name = "jemalloc",
+        remote = "https://github.com/jemalloc/jemalloc.git",
+        commit = "254c4847e8ac263d24720aa93c2c7d410f55a239",
+        build_file = "@com_github_ray_project_ray//bazel:BUILD.jemalloc",
+    )


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR add jemalloc to Ray and enable it by default. Jemalloc should boost the performance in general and it'll be useful for us to debug the memory leak.
Features related to memory profiling and leak detection will be built on top of this.

Tested manually to enable it's working:
```
MALLOC_CONF=invalid_flag:foo ./bazel-bin/gcs_server
<jemalloc>: Invalid conf pair: invalid_flag:foo
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
