### PR TITLE
[CI] Fix error in `setup-dev`

### DIFF
--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -131,8 +131,9 @@ if __name__ == "__main__":
         local_path="../../../dashboard",
     )
 
-    for package in args.extras:
-        do_link(package, force=args.yes, skip_list=args.skip)
+    if args.extras is not None:
+        for package in args.extras:
+            do_link(package, force=args.yes, skip_list=args.skip)
 
     print(
         "Created links.\n\nIf you run into issues initializing Ray, please "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

#38247 introduced a bug. If you `--extras` isn't specified, you get an error like "Can't iterate through `NoneType`". This PR fixes the error.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
