### PR TITLE
[train] add static Trainer methods for getting tree-based models

### DIFF
--- a/doc/source/train/distributed-xgboost-lightgbm.rst
+++ b/doc/source/train/distributed-xgboost-lightgbm.rst
@@ -61,9 +61,9 @@ Saving and Loading XGBoost and LightGBM Checkpoints
 When a new tree is trained on every boosting round,
 it's possible to save a checkpoint to snapshot the training progress so far.
 :class:`~ray.train.xgboost.XGBoostTrainer` and :class:`~ray.train.lightgbm.LightGBMTrainer`
-both implement checkpointing out of the box and will create 
-:class:`~ray.train.xgboost.XGBoostCheckpoint`\s and :class:`~ray.train.lightgbm.LightGBMCheckpoint`\s
-respectively.
+both implement checkpointing out of the box. These checkpoints can be loaded into memory
+using static methods :meth:`XGBoostTrainer.get_model <ray.train.xgboost.XGBoostTrainer.get_model>` and
+:meth:`LightGBMTrainer.get_model <ray.train.lightgbm.LightGBMTrainer.get_model>`.
 
 The only required change is to configure :class:`~ray.air.CheckpointConfig` to set
 the checkpointing frequency. For example, the following configuration will

--- a/python/ray/train/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/lightgbm/lightgbm_trainer.py
@@ -1,3 +1,4 @@
+import os
 from typing import Dict, Any, Optional, Tuple, Union, TYPE_CHECKING
 
 try:
@@ -117,7 +118,7 @@ class LightGBMTrainer(GBDTTrainer):
     def _load_checkpoint(
         self, checkpoint: Checkpoint
     ) -> Tuple[lightgbm.Booster, Optional["Preprocessor"]]:
-        # TODO(matthewdeng): Remove this when we have a clean way to get the preprocessor.
+        # TODO(matt): Remove this when we have a clean way to get the preprocessor.
         checkpoint = LightGBMCheckpoint.from_checkpoint(checkpoint)
         return checkpoint.get_model(), checkpoint.get_preprocessor()
 

--- a/python/ray/train/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/lightgbm/lightgbm_trainer.py
@@ -106,7 +106,7 @@ class LightGBMTrainer(GBDTTrainer):
     _init_model_arg_name: str = "init_model"
 
     @staticmethod
-    def get_model(cls, checkpoint: Checkpoint) -> lightgbm.Booster:
+    def get_model(checkpoint: Checkpoint) -> lightgbm.Booster:
         """Retrieve the LightGBM model stored in this checkpoint."""
         with checkpoint.as_directory() as checkpoint_path:
             return lightgbm.Booster(model_file=os.path.join(checkpoint_path, MODEL_KEY))

--- a/python/ray/train/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/lightgbm/lightgbm_trainer.py
@@ -118,7 +118,7 @@ class LightGBMTrainer(GBDTTrainer):
     def _load_checkpoint(
         self, checkpoint: Checkpoint
     ) -> Tuple[lightgbm.Booster, Optional["Preprocessor"]]:
-        # TODO(matt): Remove this when we have a clean way to get the preprocessor.
+        # TODO(matt): Replace this when preprocessor arg is removed.
         checkpoint = LightGBMCheckpoint.from_checkpoint(checkpoint)
         return checkpoint.get_model(), checkpoint.get_preprocessor()
 

--- a/python/ray/train/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/lightgbm/lightgbm_trainer.py
@@ -6,6 +6,7 @@ except ImportError:
     from distutils.version import LooseVersion as Version
 
 from ray.air.checkpoint import Checkpoint
+from ray.air.constants import MODEL_KEY
 from ray.train.gbdt_trainer import GBDTTrainer
 from ray.util.annotations import PublicAPI
 from ray.train.lightgbm.lightgbm_checkpoint import LightGBMCheckpoint
@@ -104,12 +105,19 @@ class LightGBMTrainer(GBDTTrainer):
     }
     _init_model_arg_name: str = "init_model"
 
+    @staticmethod
+    def get_model(cls, checkpoint: Checkpoint) -> lightgbm.Booster:
+        """Retrieve the LightGBM model stored in this checkpoint."""
+        with checkpoint.as_directory() as checkpoint_path:
+            return lightgbm.Booster(model_file=os.path.join(checkpoint_path, MODEL_KEY))
+
     def _train(self, **kwargs):
         return lightgbm_ray.train(**kwargs)
 
     def _load_checkpoint(
         self, checkpoint: Checkpoint
     ) -> Tuple[lightgbm.Booster, Optional["Preprocessor"]]:
+        # TODO(matthewdeng): Remove this when we have a clean way to get the preprocessor.
         checkpoint = LightGBMCheckpoint.from_checkpoint(checkpoint)
         return checkpoint.get_model(), checkpoint.get_preprocessor()
 

--- a/python/ray/train/tests/test_lightgbm_trainer.py
+++ b/python/ray/train/tests/test_lightgbm_trainer.py
@@ -68,8 +68,8 @@ def test_fit_with_categoricals(ray_start_6_cpus):
         datasets={TRAIN_DATASET_KEY: train_dataset, "valid": valid_dataset},
     )
     result = trainer.fit()
-    checkpoint = LightGBMCheckpoint.from_checkpoint(result.checkpoint)
-    model = checkpoint.get_model()
+    checkpoint = result.checkpoint
+    model = LightGBMTrainer.get_model(checkpoint)
     assert model.pandas_categorical == [["A", "B"]]
 
 
@@ -104,9 +104,9 @@ def test_resume_from_checkpoint(ray_start_6_cpus, tmpdir):
         resume_from_checkpoint=resume_from,
     )
     result = trainer.fit()
-    checkpoint = LightGBMCheckpoint.from_checkpoint(result.checkpoint)
-    xgb_model = checkpoint.get_model()
-    assert get_num_trees(xgb_model) == 10
+    checkpoint = result.checkpoint
+    model = LightGBMTrainer.get_model(checkpoint)
+    assert get_num_trees(model) == 10
 
 
 @pytest.mark.parametrize(

--- a/python/ray/train/tests/test_xgboost_trainer.py
+++ b/python/ray/train/tests/test_xgboost_trainer.py
@@ -100,8 +100,8 @@ def test_resume_from_checkpoint(ray_start_4_cpus, tmpdir):
         datasets={TRAIN_DATASET_KEY: train_dataset, "valid": valid_dataset},
     )
     result = trainer.fit()
-    checkpoint = XGBoostCheckpoint.from_checkpoint(result.checkpoint)
-    xgb_model = checkpoint.get_model()
+    checkpoint = result.checkpoint
+    xgb_model = XGBoostTrainer.get_model(checkpoint)
     assert get_num_trees(xgb_model) == 5
 
     # Move checkpoint to a different directory.

--- a/python/ray/train/xgboost/xgboost_trainer.py
+++ b/python/ray/train/xgboost/xgboost_trainer.py
@@ -111,7 +111,7 @@ class XGBoostTrainer(GBDTTrainer):
     def _load_checkpoint(
         self, checkpoint: Checkpoint
     ) -> Tuple[xgboost.Booster, Optional["Preprocessor"]]:
-        # TODO(matt): Remove this when we have a clean way to get the preprocessor.
+        # TODO(matt): Replace this when preprocessor arg is removed.
         checkpoint = XGBoostCheckpoint.from_checkpoint(checkpoint)
         return checkpoint.get_model(), checkpoint.get_preprocessor()
 

--- a/python/ray/train/xgboost/xgboost_trainer.py
+++ b/python/ray/train/xgboost/xgboost_trainer.py
@@ -6,6 +6,7 @@ except ImportError:
     from distutils.version import LooseVersion as Version
 
 from ray.air.checkpoint import Checkpoint
+from ray.air.constants import MODEL_KEY
 from ray.train.gbdt_trainer import GBDTTrainer
 from ray.train.xgboost.xgboost_checkpoint import XGBoostCheckpoint
 from ray.util.annotations import PublicAPI
@@ -95,12 +96,21 @@ class XGBoostTrainer(GBDTTrainer):
     }
     _init_model_arg_name: str = "xgb_model"
 
+    @staticmethod
+    def get_model(cls, checkpoint: Checkpoint) -> xgboost.Booster:
+        """Retrieve the XGBoost model stored in this checkpoint."""
+        with checkpoint.as_directory() as checkpoint_path:
+            booster = xgboost.Booster()
+            booster.load_model(os.path.join(checkpoint_path, MODEL_KEY))
+            return booster
+
     def _train(self, **kwargs):
         return xgboost_ray.train(**kwargs)
 
     def _load_checkpoint(
         self, checkpoint: Checkpoint
     ) -> Tuple[xgboost.Booster, Optional["Preprocessor"]]:
+        # TODO(matthewdeng): Remove this when we have a clean way to get the preprocessor.
         checkpoint = XGBoostCheckpoint.from_checkpoint(checkpoint)
         return checkpoint.get_model(), checkpoint.get_preprocessor()
 

--- a/python/ray/train/xgboost/xgboost_trainer.py
+++ b/python/ray/train/xgboost/xgboost_trainer.py
@@ -97,7 +97,7 @@ class XGBoostTrainer(GBDTTrainer):
     _init_model_arg_name: str = "xgb_model"
 
     @staticmethod
-    def get_model(cls, checkpoint: Checkpoint) -> xgboost.Booster:
+    def get_model(checkpoint: Checkpoint) -> xgboost.Booster:
         """Retrieve the XGBoost model stored in this checkpoint."""
         with checkpoint.as_directory() as checkpoint_path:
             booster = xgboost.Booster()

--- a/python/ray/train/xgboost/xgboost_trainer.py
+++ b/python/ray/train/xgboost/xgboost_trainer.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
 
 try:
@@ -110,7 +111,7 @@ class XGBoostTrainer(GBDTTrainer):
     def _load_checkpoint(
         self, checkpoint: Checkpoint
     ) -> Tuple[xgboost.Booster, Optional["Preprocessor"]]:
-        # TODO(matthewdeng): Remove this when we have a clean way to get the preprocessor.
+        # TODO(matt): Remove this when we have a clean way to get the preprocessor.
         checkpoint = XGBoostCheckpoint.from_checkpoint(checkpoint)
         return checkpoint.get_model(), checkpoint.get_preprocessor()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This moves the functionality of XGBoost/LightGBM checkpointing from the `<Framework>Checkpoint` directly into the `<Framework>Trainer`, making the Trainer more self-contained.

**Before:**
```python
result = xgboost_trainer.fit()
checkpoint = result.checkpoint
xgboost_checkpoint = XGBoostCheckpoint.from_checkpoint(checkpoint)
booster = xgboost.get_model()
```

**After:**
```python
result = xgboost_trainer.fit()
checkpoint = result.checkpoint
booster = XGBoostTrainer.get_model(checkpoint)
```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #38291.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
