### PR TITLE
[serve] Stabilize metrics pusher

### DIFF
--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -628,10 +628,8 @@ class MetricsPusher:
                         logger.warning(
                             f"MetricsPusher thread failed to run metric task: {e}"
                         )
-                duration_s = time.time() - start
-                remaining_time = least_interval_s - duration_s
-                if remaining_time > 0:
-                    time.sleep(remaining_time)
+
+                time.sleep(least_interval_s)
 
         self.pusher_thread = threading.Thread(target=send_forever)
         # Making this a daemon thread so it doesn't leak upon shutdown, and it

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -600,7 +600,6 @@ class MetricsPusher:
         """
 
         def send_forever():
-
             while True:
                 if self.stop_event.is_set():
                     return
@@ -608,7 +607,7 @@ class MetricsPusher:
                 start = time.time()
                 for task in self.tasks:
                     try:
-                        if start - task.last_call_succeeded_time > task.interval_s:
+                        if start - task.last_call_succeeded_time >= task.interval_s:
                             if task.last_ref:
                                 ready_refs, _ = ray.wait([task.last_ref], timeout=0)
                                 if len(ready_refs) == 0:

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -634,6 +634,9 @@ class MetricsPusher:
 
                 time.sleep(max(least_interval_s, 0))
 
+        if len(self.tasks) == 0:
+            raise ValueError("MetricsPusher has zero tasks registered.")
+
         self.pusher_thread = threading.Thread(target=send_forever)
         # Making this a daemon thread so it doesn't leak upon shutdown, and it
         # doesn't need to block the replica's shutdown.

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -624,6 +624,8 @@ class MetricsPusher:
                             f"MetricsPusher thread failed to run metric task: {e}"
                         )
 
+                # For all tasks, check when the task should be executed
+                # next. Sleep until the next closest time.
                 least_interval_s = math.inf
                 for task in self.tasks:
                     time_until_next_push = task.interval_s - (

--- a/python/ray/serve/tests/test_application_state.py
+++ b/python/ray/serve/tests/test_application_state.py
@@ -18,10 +18,10 @@ from ray.serve._private.common import (
     ReplicaConfig,
     DeploymentInfo,
 )
+from ray.serve.tests.utils import MockKVStore
 from ray.serve._private.utils import get_random_letters
 from ray.serve.exceptions import RayServeException
 from ray.serve.schema import ServeApplicationSchema, DeploymentSchema
-from ray.serve.tests.test_deployment_state import MockKVStore
 
 
 class MockEndpointState:

--- a/python/ray/serve/tests/test_deployment_state.py
+++ b/python/ray/serve/tests/test_deployment_state.py
@@ -1,5 +1,4 @@
 import sys
-import time
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch, Mock
 from collections import defaultdict
@@ -19,6 +18,7 @@ from ray.serve._private.common import (
 from ray.serve._private.deployment_scheduler import (
     ReplicaSchedulingRequest,
 )
+from ray.serve.tests.utils import MockTimer, MockKVStore
 from ray.serve._private.deployment_state import (
     ActorReplicaWrapper,
     DeploymentState,
@@ -290,32 +290,6 @@ class MockDeploymentScheduler:
         return deployment_to_replicas_to_stop
 
 
-class MockKVStore:
-    def __init__(self):
-        self.store = dict()
-
-    def put(self, key: str, val: Any) -> bool:
-        if not isinstance(key, str):
-            raise TypeError("key must be a string, got: {}.".format(type(key)))
-        self.store[key] = val
-        return True
-
-    def get(self, key: str) -> Any:
-        if not isinstance(key, str):
-            raise TypeError("key must be a string, got: {}.".format(type(key)))
-        return self.store.get(key, None)
-
-    def delete(self, key: str) -> bool:
-        if not isinstance(key, str):
-            raise TypeError("key must be a string, got: {}.".format(type(key)))
-
-        if key in self.store:
-            del self.store[key]
-            return True
-
-        return False
-
-
 def deployment_info(
     version: Optional[str] = None,
     num_replicas: Optional[int] = 1,
@@ -348,19 +322,6 @@ def deployment_info(
 
 def deployment_version(code_version) -> DeploymentVersion:
     return DeploymentVersion(code_version, DeploymentConfig(), {})
-
-
-class MockTimer:
-    def __init__(self, start_time=None):
-        if start_time is None:
-            start_time = time.time()
-        self._curr = start_time
-
-    def time(self):
-        return self._curr
-
-    def advance(self, by):
-        self._curr += by
 
 
 class MockClusterNodeInfoCache:

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import tempfile
 from copy import deepcopy
+import time
 from unittest.mock import patch
 
 import numpy as np
@@ -24,6 +25,7 @@ from ray.serve._private.utils import (
     dict_keys_snake_to_camel_case,
     get_all_live_placement_group_names,
     get_head_node_id,
+    MetricsPusher,
 )
 from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
 
@@ -663,6 +665,21 @@ def test_get_all_live_placement_group_names(ray_instance):
     assert pg8.wait()
 
     assert set(get_all_live_placement_group_names()) == {"pg3", "pg4", "pg5", "pg6"}
+
+
+def test_metrics_pusher():
+    counter = {"val": 0}
+
+    def task(c):
+        time.sleep(0.001)
+        c["val"] += 1
+
+    metrics_pusher = MetricsPusher()
+    metrics_pusher.register_task(lambda: task(counter), 0.5)
+    metrics_pusher.start()
+
+    time.sleep(10.4)
+    assert counter["val"] == 20
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -678,6 +678,9 @@ def test_metrics_pusher_basic():
     metrics_pusher.register_task(lambda: task(counter), 0.5)
     metrics_pusher.start()
 
+    # At 10 seconds, the task should have executed 20 times.
+    # Sleep until just under 10 + 0.5 seconds to give leeway
+    # for accumulated error.
     time.sleep(10.4)
     assert counter["val"] == 20
 
@@ -690,11 +693,15 @@ def test_metrics_pusher_multiple_tasks():
         c[key] += 1
 
     metrics_pusher = MetricsPusher()
+    # Each task interval is different, and they don't divide each other.
     metrics_pusher.register_task(lambda: task(counter, "A"), 0.2)
     metrics_pusher.register_task(lambda: task(counter, "B"), 0.5)
     metrics_pusher.register_task(lambda: task(counter, "C"), 0.7)
     metrics_pusher.start()
 
+    # At 7 seconds, tasks A, B, C should have executed 35, 14, and 10
+    # times respectively. Sleep until just under 7 + 0.2 seconds to
+    # give leeway for accumulated error
     time.sleep(7.19)
     assert counter["A"] == 35
     assert counter["B"] == 14

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -667,7 +667,7 @@ def test_get_all_live_placement_group_names(ray_instance):
     assert set(get_all_live_placement_group_names()) == {"pg3", "pg4", "pg5", "pg6"}
 
 
-def test_metrics_pusher():
+def test_metrics_pusher_basic():
     counter = {"val": 0}
 
     def task(c):
@@ -680,6 +680,25 @@ def test_metrics_pusher():
 
     time.sleep(10.4)
     assert counter["val"] == 20
+
+
+def test_metrics_pusher_multiple_tasks():
+    counter = {"A": 0, "B": 0, "C": 0}
+
+    def task(c, key):
+        time.sleep(0.001)
+        c[key] += 1
+
+    metrics_pusher = MetricsPusher()
+    metrics_pusher.register_task(lambda: task(counter, "A"), 0.2)
+    metrics_pusher.register_task(lambda: task(counter, "B"), 0.5)
+    metrics_pusher.register_task(lambda: task(counter, "C"), 0.7)
+    metrics_pusher.start()
+
+    time.sleep(7.19)
+    assert counter["A"] == 35
+    assert counter["B"] == 14
+    assert counter["C"] == 10
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -705,6 +705,8 @@ def test_metrics_pusher_basic():
                 assert result["val"] == expected_result
                 break
 
+        assert result["val"] == expected_result
+
 
 def test_metrics_pusher_multiple_tasks():
     start = 0
@@ -741,6 +743,10 @@ def test_metrics_pusher_multiple_tasks():
                 assert result[key] == expected_results[key]
             if len(result) == 3:
                 break
+
+        # Check there are three results set and all are expected.
+        for key in expected_results.keys():
+            assert result[key] == expected_results[key]
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -668,6 +668,13 @@ def test_get_all_live_placement_group_names(ray_instance):
     assert set(get_all_live_placement_group_names()) == {"pg3", "pg4", "pg5", "pg6"}
 
 
+def test_metrics_pusher_no_tasks():
+    """Test that a metrics pusher can't be started with zero tasks."""
+    metrics_pusher = MetricsPusher()
+    with pytest.raises(ValueError):
+        metrics_pusher.start()
+
+
 def test_metrics_pusher_basic():
     start = 0
     timer = MockTimer(start)

--- a/python/ray/serve/tests/utils.py
+++ b/python/ray/serve/tests/utils.py
@@ -1,0 +1,44 @@
+import time
+from typing import Any
+
+
+class MockTimer:
+    def __init__(self, start_time=None):
+        if start_time is None:
+            start_time = time.time()
+        self._curr = start_time
+
+    def time(self):
+        return self._curr
+
+    def advance(self, by):
+        self._curr += by
+
+    def realistic_sleep(self, amt):
+        self._curr += amt + 0.001
+
+
+class MockKVStore:
+    def __init__(self):
+        self.store = dict()
+
+    def put(self, key: str, val: Any) -> bool:
+        if not isinstance(key, str):
+            raise TypeError("key must be a string, got: {}.".format(type(key)))
+        self.store[key] = val
+        return True
+
+    def get(self, key: str) -> Any:
+        if not isinstance(key, str):
+            raise TypeError("key must be a string, got: {}.".format(type(key)))
+        return self.store.get(key, None)
+
+    def delete(self, key: str) -> bool:
+        if not isinstance(key, str):
+            raise TypeError("key must be a string, got: {}.".format(type(key)))
+
+        if key in self.store:
+            del self.store[key]
+            return True
+
+        return False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR solves two problems.
First, suppose there is one task registered on the metrics pusher with interval 2 seconds.
What the metrics pusher does repeatedly:
1. Record `start = time.time()`
2. Execute task
3. Record task `last_call_succeeded_time`
9. Sleep until `time = start + 2`

The problem:
Strictly speaking, `start + 2 < task.last_call_succeeded_time` because `start < task.last_call_succeeded_time`. This is not always a problem because the task execution is very fast (1-5ms) and `time.sleep(2)` sleeps for "at least 2 seconds", so oftentimes the thread actually wakes up at a time that is after `task.last_call_succeeded_time + 2`. However sometimes the thread wakes up before `task.last_call_succeeded_time + 2` meaning it doesn't satisfy the if statement and doesn't execute the task to push the metric. This causes the metrics pusher to "skip" intervals.
Since all our tasks and callback functions are essentially no-ops, we should just sleep until at least `last_call_succeeded_time + 2`.


Second, suppose there is more than one task registered on the shared metrics pusher, one with interval 8s and one with interval 10s. Currently, the thread on the metrics pusher will wake up every 8 seconds to check if any tasks need executing. This means the first task will be executed every 8 seconds, and the second task every 16 seconds.

Instead of setting `least_interval_s` to `min(task.interval_s for all tasks)`, we should check at every interval when is the next time any task needs to be executed, so the sleep time is always varying. E.g. with an 8s interval task and 10s interval task, the thread should roughly sleep 8 seconds then 2 seconds and repeat.

## Related issue number

Closes https://github.com/ray-project/ray/issues/38360
Closes https://github.com/ray-project/ray/issues/38361

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
