### PR TITLE
[serve] Add `close` method to `ASGIMessageQueue` to avoid `receive_asgi_messages` hanging

### DIFF
--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -1042,4 +1042,9 @@ Please make sure your http-host and http-port are specified correctly."""
         pass
 
     async def receive_asgi_messages(self, request_id: str) -> bytes:
+        """Get ASGI messages for the provided `request_id`.
+
+        After the proxy has stopped receiving messages for this `request_id`,
+        this will always return immediately.
+        """
         return pickle.dumps(await self.app.receive_asgi_messages(request_id))

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -687,6 +687,8 @@ class HTTPProxy:
                 if msg["type"] == "websocket.disconnect":
                     return msg["code"]
         finally:
+            # Close the queue so any subsequent calls to fetch messages return
+            # immediately: https://github.com/ray-project/ray/issues/38368.
             queue.close()
 
     async def _assign_request_with_timeout(

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -676,15 +676,18 @@ class HTTPProxy:
         For websocket messages, the disconnect code is returned if a disconnect code is
         received.
         """
-        while True:
-            msg = await receive()
-            await queue(msg)
+        try:
+            while True:
+                msg = await receive()
+                await queue(msg)
 
-            if msg["type"] == "http.disconnect":
-                return None
+                if msg["type"] == "http.disconnect":
+                    return None
 
-            if msg["type"] == "websocket.disconnect":
-                return msg["code"]
+                if msg["type"] == "websocket.disconnect":
+                    return msg["code"]
+        finally:
+            queue.close()
 
     async def _assign_request_with_timeout(
         self,

--- a/python/ray/serve/tests/test_http_util.py
+++ b/python/ray/serve/tests/test_http_util.py
@@ -61,8 +61,11 @@ async def test_asgi_message_queue():
     assert len(list(queue.get_messages_nowait())) == 1
 
     # Check that once the queue is closed, new messages should be rejected and
-    # subsequent calls to wait for messages should return immediately.
+    # ongoing and subsequent calls to wait for messages should return immediately.
+    waiting_task = loop.create_task(queue.wait_for_message())
     queue.close()
+    await waiting_task  # Ongoing call should return.
+
     for _ in range(100):
         with pytest.raises(RuntimeError):
             await queue({"hello": "world"})

--- a/python/ray/serve/tests/test_http_util.py
+++ b/python/ray/serve/tests/test_http_util.py
@@ -60,9 +60,12 @@ async def test_asgi_message_queue():
     await waiting_task
     assert len(list(queue.get_messages_nowait())) == 1
 
-    # Check that once the queue is closed, subsequent calls return immediately.
+    # Check that once the queue is closed, new messages should be rejected and
+    # subsequent calls to wait for messages should return immediately.
     queue.close()
     for _ in range(100):
+        with pytest.raises(RuntimeError):
+            await queue({"hello": "world"})
         await queue.wait_for_message()
         assert queue.get_messages_nowait() == []
 

--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -259,7 +259,7 @@ def test_streaming_request_already_sent_and_timed_out(ray_instance, shutdown_ser
 @pytest.mark.parametrize(
     "ray_instance",
     [
-        {"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.1"},
+        {"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5"},
     ],
     indirect=True,
 )

--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -8,8 +8,9 @@ import pytest
 import requests
 
 import ray
-from ray._private.test_utils import SignalActor, wait_for_condition
 from ray.dashboard.modules.serve.sdk import ServeSubmissionClient
+from ray.util.state import list_tasks
+from ray._private.test_utils import SignalActor, wait_for_condition
 
 from ray import serve
 from ray.serve.schema import ServeInstanceDetails
@@ -253,6 +254,56 @@ def test_streaming_request_already_sent_and_timed_out(ray_instance, shutdown_ser
         with pytest.raises(requests.exceptions.ChunkedEncodingError) as request_error:
             iterator.__next__()
         assert "Connection broken" in str(request_error.value)
+
+
+@pytest.mark.parametrize(
+    "ray_instance",
+    [
+        {"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.1"},
+    ],
+    indirect=True,
+)
+@pytest.mark.skipif(
+    not RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING,
+    reason="Only relevant on streaming codepath.",
+)
+def test_request_timeout_does_not_leak_tasks(ray_instance, shutdown_serve):
+    """Verify that the ASGI-related tasks exit when a request is timed out.
+
+    See https://github.com/ray-project/ray/issues/38368 for details.
+    """
+    signal_actor = SignalActor.remote()
+
+    @serve.deployment
+    class Hang:
+        async def __call__(self):
+            await signal_actor.wait.remote()
+            return "Success!"
+
+    serve.run(Hang.bind())
+
+    def get_num_running_tasks():
+        return len(
+            list_tasks(
+                address=ray_instance["gcs_address"],
+                filters=[
+                    ("NAME", "!=", "ServeController.listen_for_change"),
+                    ("TYPE", "=", "ACTOR_TASK"),
+                    ("STATE", "=", "RUNNING"),
+                ],
+            )
+        )
+
+    assert get_num_running_tasks() == 0
+
+    # Send a number of requests that all will be timed out.
+    results = ray.get([do_request.remote() for _ in range(10)])
+    assert all(r.status_code == 408 for r in results)
+
+    # Signal the handlers to exit. After that, no actor tasks should be running
+    # aside from long poll.
+    ray.get(signal_actor.send.remote())
+    wait_for_condition(lambda: get_num_running_tasks() == 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See the issue linked below for observed behavior.

I haven't been able to reproduce this, but think I have determined the case where it can happen:

- In `receive_asgi_messages`, we first get the queue from `self.asgi_receive_queues` then call `await queue.wait_for_message()`.
- The assumption is that `receive_asgi_messages` will always return an `http.disconnect` message to finalize the request, but in cases where there is a timeout on the HTTP proxy, we cancel the `proxy_asgi_receive` task which prevents it from placing that message on the queue.
- When this happens, the queue is deleted from `self.asgi_receive_queues`. However, the task may have already fetched the queue from the map and called `await queue.wait_for_message()`.
- Because the `receive_asgi_messages` cannot be canceled, it would then hang waiting for a message that never arrives, effectively leaking a long-running task to the proxy.

This PR fixes the behavior by adding a `close` method on the queue that's called when the task is cancelled. After `close` is called, all subsequent calls will return immediately so we cannot have a task hang in this manner.

I've added a regression test to `test_request_timeout.py` that fails without this fix and passes with it.

## Related issue number

Closes https://github.com/ray-project/ray/issues/38368

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
