### PR TITLE
[train] remove SklearnTrainer and MosaicTrainer from docs

### DIFF
--- a/doc/source/train/api/api.rst
+++ b/doc/source/train/api/api.rst
@@ -153,24 +153,6 @@ LightGBM
     ~train.lightgbm.LightGBMTrainer
     ~train.lightgbm.LightGBMCheckpoint
 
-Scikit-Learn
-~~~~~~~~~~~~
-
-.. autosummary::
-    :toctree: doc/
-
-    ~train.sklearn.SklearnTrainer
-    ~train.sklearn.SklearnCheckpoint
-
-
-Mosaic
-~~~~~~
-
-.. autosummary::
-    :toctree: doc/
-
-    ~train.mosaic.MosaicTrainer
-
 
 .. _ray-train-configs-api:
 

--- a/doc/source/train/key-concepts.rst
+++ b/doc/source/train/key-concepts.rst
@@ -25,7 +25,7 @@ You can also configured trainers with :ref:`Datasets <data-ingest-torch>` and :r
 Deep Learning, Tree-Based, and other Trainers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are three categories of built-in Trainers:
+There are two categories of built-in Trainers:
 
 .. tab-set::
 
@@ -36,7 +36,6 @@ There are three categories of built-in Trainers:
         - :class:`TorchTrainer <ray.train.torch.TorchTrainer>`
         - :class:`TensorflowTrainer <ray.train.tensorflow.TensorflowTrainer>`
         - :class:`HorovodTrainer <ray.train.horovod.HorovodTrainer>`
-        - :class:`LightningTrainer <ray.train.lightning.LightningTrainer>`
 
         For these trainers, you usually define your own training function that loads the model
         and executes single-worker training steps. Refer to the following guides for more details:
@@ -58,13 +57,6 @@ There are three categories of built-in Trainers:
 
         - :doc:`Distributed XGBoost/LightGBM </train/distributed-xgboost-lightgbm>`
 
-    .. tab-item:: Other Trainers
-
-        Some trainers don't fit into the other two categories, such as:
-
-        - :class:`TransformersTrainer <ray.train.huggingface.TransformersTrainer>` for NLP
-        - :class:`RLTrainer <ray.train.rl.RLTrainer>` for reinforcement learning
-        - :class:`SklearnTrainer <ray.train.sklearn.sklearn_trainer.SklearnTrainer>` for (non-distributed) training of sklearn models.
 
 .. _train-key-concepts-config:
 

--- a/python/ray/train/mosaic/mosaic_trainer.py
+++ b/python/ray/train/mosaic/mosaic_trainer.py
@@ -156,6 +156,12 @@ class MosaicTrainer(TorchTrainer):
         resume_from_checkpoint: Optional[Checkpoint] = None,
     ):
 
+        warnings.warn(
+            "This MosaicTrainer will be deprecated in Ray 2.8. "
+            "It is recommended to use the TorchTrainer instead.",
+            DeprecationWarning,
+        )
+
         self._validate_trainer_init_per_worker(
             trainer_init_per_worker, "trainer_init_per_worker"
         )

--- a/python/ray/train/sklearn/sklearn_trainer.py
+++ b/python/ray/train/sklearn/sklearn_trainer.py
@@ -177,6 +177,13 @@ class SklearnTrainer(BaseTrainer):
         preprocessor: Optional["Preprocessor"] = None,
         **fit_params,
     ):
+
+        warnings.warn(
+            "This SklearnTrainer will be deprecated in Ray 2.8. "
+            "It is recommended to write your own training loop instead.",
+            DeprecationWarning,
+        )
+
         if fit_params.pop("resume_from_checkpoint", None):
             raise AttributeError(
                 "SklearnTrainer does not support resuming from checkpoints. "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

These Trainers are generally not being used or updated. 

1. Removing them from the Train API References to reduce user confusion.
2. Marking them for deprecation in a future release.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
