### PR TITLE
[Serve] refactor HTTPProxy into GenericProxy

### DIFF
--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -370,10 +370,10 @@ class GenericProxy:
     async def _timeout_response(self, scope, receive, send, request_id):
         raise NotImplementedError
 
-    async def _routes_response(self, scope, receive, send, request_id):
+    async def _routes_response(self, scope, receive, send):
         raise NotImplementedError
 
-    async def _health_response(self, scope, receive, send, request_id):
+    async def _health_response(self, scope, receive, send):
         raise NotImplementedError
 
     def _ongoing_requests_start(self):
@@ -653,12 +653,12 @@ class HTTPProxy(GenericProxy):
         )
         await response.send(scope, receive, send)
 
-    async def _routes_response(self, scope, receive, send, request_id):
+    async def _routes_response(self, scope, receive, send):
         return await starlette.responses.JSONResponse(self.route_info)(
             scope, receive, send
         )
 
-    async def _health_response(self, scope, receive, send, request_id):
+    async def _health_response(self, scope, receive, send):
         return await starlette.responses.PlainTextResponse("success")(
             scope, receive, send
         )

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -328,8 +328,8 @@ class GenericProxy(ABC):
         # The node is not draining if it's None.
         self._draining_start_time: Optional[float] = None
 
-    @abstractmethod
     @property
+    @abstractmethod
     def proxy_name(self) -> str:
         """Proxy name used for metrics.
 
@@ -421,7 +421,7 @@ class GenericProxy(ABC):
         """Wrapper for proxy request.
 
         This method is served as common entry point by the proxy. It handles the
-        routing, including `/-/routes` and `/-/healthz`, ongoing request counter,
+        routing, including routes and health checks, ongoing request counter,
         and metrics.
         """
         assert scope["type"] in {"http", "websocket"}

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -316,6 +316,7 @@ class GenericProxy:
     @property
     def proxy_name(self) -> str:
         """Proxy name used for metrics.
+
         Each proxy needs to implement its own logic for setting up the proxy name.
         """
         raise NotImplementedError
@@ -396,9 +397,9 @@ class GenericProxy:
     async def proxy_request(self, scope, receive, send):
         """Wrapper for proxy request.
 
-        This method is served as common entry point by both HTTP and
-        gRPC proxies. It handles the routing, including `/-/routes` and
-        `/-/healthz`, ongoing request counter, and metrics.
+        This method is served as common entry point by the proxy. It handles the
+        routing, including `/-/routes` and `/-/healthz`, ongoing request counter,
+        and metrics.
         """
         assert scope["type"] in {"http", "websocket"}
 
@@ -541,15 +542,6 @@ class GenericProxy:
             # request counter is decremented and possibly reset the keep alive object.
             self._ongoing_requests_end()
 
-    async def send_request_to_replica_unary(
-        self,
-        handle: RayServeHandle,
-        scope: Scope,
-        receive: Receive,
-        send: Send,
-    ) -> str:
-        raise NotImplementedError
-
     async def _assign_request_with_timeout(
         self,
         handle: RayServeHandle,
@@ -582,6 +574,20 @@ class GenericProxy:
             assignment_task.cancel()
             raise TimeoutError()
 
+    async def send_request_to_replica_unary(
+        self,
+        handle: RayServeHandle,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> str:
+        """Send the request to the replica and handle unary response.
+
+        Each proxy needs to implement its own logic for sending the request and
+        handling the unary response.
+        """
+        raise NotImplementedError
+
     def setup_request_context_and_handle(
         self,
         app_name: str,
@@ -590,6 +596,7 @@ class GenericProxy:
         scope: Scope,
     ) -> Tuple[RayServeHandle, str]:
         """Setup the request context and handle for the request.
+
         Each proxy needs to implement its own logic for setting up the request context
         and handle.
         """
@@ -604,6 +611,7 @@ class GenericProxy:
         send: Send,
     ) -> str:
         """Send the request to the replica and handle streaming response.
+
         Each proxy needs to implement its own logic for sending the request and
         handling the streaming response.
         """
@@ -853,7 +861,7 @@ class HTTPProxy(GenericProxy):
         route_path: str,
         scope: Scope,
     ) -> Tuple[RayServeHandle, str]:
-        """Setup request context and handle for the request
+        """Setup request context and handle for the request.
 
         Unpack HTTP request headers and extract info to set up request context and
         handle.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Refactor `HTTPProxy` into `GenericProxy` so we can use in `gRPCProxy` later on. No new code, just reorganize methods and determine the ones that need to be implemented vs can be shared between the subclasses.

## Related issue number

First PR to close https://github.com/ray-project/ray/issues/38193

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
