### PR TITLE
return 1 if `ray job submit` and the job failed.

### DIFF
--- a/dashboard/BUILD
+++ b/dashboard/BUILD
@@ -32,6 +32,7 @@ py_test_run_all_subdirectory(
     extra_srcs = [],
     data = [
         "modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh",
+        "modules/job/tests/backwards_compatibility_scripts/script.py",
         "modules/job/tests/pip_install_test-0.5-py3-none-any.whl",
         "modules/snapshot/snapshot_schema.json",
         "modules/tests/test_config_files/basic_runtime_env.yaml",
@@ -56,6 +57,7 @@ py_test(
     srcs = ["modules/job/tests/test_http_job_server.py"],
     data = [
         "modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh",
+        "modules/job/tests/backwards_compatibility_scripts/script.py",
         "modules/job/tests/pip_install_test-0.5-py3-none-any.whl",
         "modules/snapshot/snapshot_schema.json",
         "modules/tests/test_config_files/basic_runtime_env.yaml",

--- a/dashboard/modules/job/cli.py
+++ b/dashboard/modules/job/cli.py
@@ -293,7 +293,8 @@ def submit(
                 "Tailing logs until the job exits " "(disable with --no-wait):"
             )
             job_status = get_or_create_event_loop().run_until_complete(
-                _tail_logs(client, job_id))
+                _tail_logs(client, job_id)
+            )
             if job_status == JobStatus.FAILED:
                 sys.exit(1)
         else:

--- a/dashboard/modules/job/cli.py
+++ b/dashboard/modules/job/cli.py
@@ -212,6 +212,9 @@ def submit(
 ):
     """Submits a job to be run on the cluster.
 
+    By default (if --no-wait is not set), streams logs to stdout until the job finishes.
+    If the job succeeded, exits with 0. If it failed, exits with 1.
+
     Example:
         `ray job submit -- python my_script.py --arg=val`
     """

--- a/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
+++ b/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -ex
+
 unset RAY_ADDRESS
 
 if ! [ -x "$(command -v conda)" ]; then

--- a/dashboard/modules/job/tests/test_cli_integration.py
+++ b/dashboard/modules/job/tests/test_cli_integration.py
@@ -189,6 +189,12 @@ class TestJobSubmit:
         assert "hello" in stdout
         assert "succeeded" in stdout
 
+    def test_job_failed(self, ray_start_stop):
+        cmd = (
+            "python -c 'import ray; ray.init(); assert 1 == 2;'"
+        )
+        _run_cmd(f"ray job submit -- {cmd}", should_fail=True)
+
 
 class TestRuntimeEnv:
     def test_bad_runtime_env(self, ray_start_stop):

--- a/dashboard/modules/job/tests/test_cli_integration.py
+++ b/dashboard/modules/job/tests/test_cli_integration.py
@@ -190,9 +190,7 @@ class TestJobSubmit:
         assert "succeeded" in stdout
 
     def test_job_failed(self, ray_start_stop):
-        cmd = (
-            "python -c 'import ray; ray.init(); assert 1 == 2;'"
-        )
+        cmd = "python -c 'import ray; ray.init(); assert 1 == 2;'"
         _run_cmd(f"ray job submit -- {cmd}", should_fail=True)
 
 

--- a/dashboard/modules/job/tests/test_cli_integration.py
+++ b/dashboard/modules/job/tests/test_cli_integration.py
@@ -202,6 +202,7 @@ class TestRuntimeEnv:
         stdout, _ = _run_cmd(
             'ray job submit --runtime-env-json=\'{"pip": '
             '["does-not-exist"]}\' -- echo hi',
+            should_fail=True,
         )
         assert "Tailing logs until the job exits" in stdout
         assert "runtime_env setup failed" in stdout


### PR DESCRIPTION
If you submit a job, the CLI waits for logs, and exits when the job finished. Problem is, no matter the job succeeded or failed, the CLI always has exit code 0. This commit checks the job status and sets exit code to 1 if the job status is FAILED. It still exits with 0 if the job status is SUCCEEDED, STOPPED or unrecognized.