### PR TITLE
[Core] Deflake test_memory_pressure

### DIFF
--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -72,7 +72,7 @@ def ray_with_memory_monitor_no_oom_retry(shutdown_only):
         object_store_memory=100 * 1024 * 1024,
         _system_config={
             "memory_usage_threshold": memory_usage_threshold,
-            "memory_monitor_refresh_ms": 100,
+            "memory_monitor_refresh_ms": memory_monitor_refresh_ms,
             "metrics_report_interval_ms": 100,
             "task_failure_entry_ttl_ms": 2 * 60 * 1000,
             "task_oom_retries": 0,
@@ -571,6 +571,7 @@ def test_one_actor_max_fifo_kill_previous_actor(shutdown_only):
         _system_config={
             "worker_killing_policy": "retriable_fifo",
             "memory_usage_threshold": 0.7,
+            "memory_monitor_refresh_ms": memory_monitor_refresh_ms,
         },
     ):
         bytes_to_alloc = get_additional_bytes_to_reach_memory_usage_pct(0.5)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Test `test_one_actor_max_fifo_kill_previous_actor` doesn't overwrite `memory_monitor_refresh_ms` config to 100ms while in the code it expects the `memory_monitor_refresh_ms` to be 100ms.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #37483
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
