### PR TITLE
[Train] Remove Path when processing uris from remote storage

### DIFF
--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -5,6 +5,7 @@ import logging
 import os
 from pathlib import Path
 import tempfile
+from urllib.parse import urlparse, urlunparse
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
 import warnings
 
@@ -483,7 +484,14 @@ class BaseTrainer(abc.ABC):
 
         tempdir = tempfile.mkdtemp("tmp_experiment_dir")
         local_path = os.path.join(tempdir, _TRAINER_PKL)
-        
+
+        parsed_url = urlparse(restore_path)
+        parsed_url = parsed_url._replace(
+            path=os.path.join(parsed_url.path, _TRAINER_PKL)
+        )
+        restore_path = urlunparse(parsed_url)
+        print(restore_path)
+
         download_from_uri(restore_path, local_path)
         return Path(local_path)
 

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -490,7 +490,6 @@ class BaseTrainer(abc.ABC):
             path=os.path.join(parsed_url.path, _TRAINER_PKL)
         )
         restore_path = urlunparse(parsed_url)
-        print(restore_path)
 
         download_from_uri(restore_path, local_path)
         return Path(local_path)

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -479,13 +479,13 @@ class BaseTrainer(abc.ABC):
             str: Local directory containing the trainer state
         """
         if not is_non_local_path_uri(restore_path):
-            return Path(os.path.expanduser(restore_path)) / _TRAINER_PKL
+            return os.path.join(os.path.expanduser(restore_path), _TRAINER_PKL)
 
-        tempdir = Path(tempfile.mkdtemp("tmp_experiment_dir"))
-
-        path = Path(restore_path)
-        download_from_uri(str(path / _TRAINER_PKL), str(tempdir / _TRAINER_PKL))
-        return tempdir / _TRAINER_PKL
+        tempdir = tempfile.mkdtemp("tmp_experiment_dir")
+        local_path = os.path.join(tempdir, _TRAINER_PKL)
+        
+        download_from_uri(restore_path, local_path)
+        return Path(local_path)
 
     def setup(self) -> None:
         """Called during fit() to perform initial setup on the Trainer.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

I wanted to run the restore from s3 path, but due to the use of `pathlib.Path` in `BaseTrainer.restore _maybe_sync_down_trainer_state` method, `'//'` is converted to `'/'` and I could not run the restore from s3 path. I changed this to use `os.path`, `urlparse`. This allows me to properly parse the remote path uri in the BaseTrainer.restore method.

It applies urlunparse to merge the remote path uri and the Trainer.pkl path, as well as any queries that were injected into the path of the remote path uri, so that they don't affect subsequent logic.

## Related issue number

#37697

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
