### PR TITLE
[serve] Fix state when a bad runtime env is used for a deployment

### DIFF
--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -427,7 +427,7 @@ def test_deploy_application_unhealthy(serve_instance):
         time.sleep(0.1)
 
 
-def test_deploy_bad_working_dir_deployment(serve_instance):
+def test_deploy_bad_pip_package_deployment(serve_instance):
     """Test deploying with a bad runtime env at deployment level."""
 
     @serve.deployment(ray_actor_options={"runtime_env": {"pip": ["does_not_exist"]}})
@@ -444,7 +444,7 @@ def test_deploy_bad_working_dir_deployment(serve_instance):
         assert "No matching distribution found for does_not_exist" in deployment_message
         return True
 
-    wait_for_condition(check_fail)
+    wait_for_condition(check_fail, timeout=15)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -427,5 +427,25 @@ def test_deploy_application_unhealthy(serve_instance):
         time.sleep(0.1)
 
 
+def test_deploy_bad_working_dir_deployment(serve_instance):
+    """Test deploying with a bad runtime env at deployment level."""
+
+    @serve.deployment(ray_actor_options={"runtime_env": {"pip": ["does_not_exist"]}})
+    class Model:
+        def __call__(self):
+            return "hello world"
+
+    serve.run(Model.bind(), _blocking=False)
+
+    def check_fail():
+        app_status = serve.status().applications["default"]
+        assert app_status.status == ApplicationStatus.DEPLOY_FAILED
+        deployment_message = app_status.deployments["default_Model"].message
+        assert "No matching distribution found for does_not_exist" in deployment_message
+        return True
+
+    wait_for_condition(check_fail)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See issue.

## Related issue number

Closes https://github.com/ray-project/ray/issues/38407

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
