### PR TITLE
[runtime env] dedup pip installs

### DIFF
--- a/python/ray/tests/test_runtime_env_conda_and_pip_3.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_3.py
@@ -18,49 +18,6 @@ if not os.environ.get("CI"):
     os.environ["RAY_RUNTIME_ENV_LOCAL_DEV_MODE"] = "1"
 
 
-def test_multiple_pip_installs(start_cluster, monkeypatch):
-    """Test that multiple pip installs don't interfere with each other."""
-    monkeypatch.setenv("RUNTIME_ENV_RETRY_TIMES", "0")
-    cluster, address = start_cluster
-
-    if sys.platform == "win32" and "ray" not in address:
-        pytest.skip(
-            "Failing on windows, as python.exe is in use during deletion attempt."
-        )
-
-    ray.init(
-        address,
-        runtime_env={
-            "pip": ["pip-install-test"],
-            "env_vars": {"TEST_VAR_1": "test_1"},
-        },
-    )
-
-    @ray.remote
-    def f():
-        return True
-
-    @ray.remote(
-        runtime_env={
-            "pip": ["pip-install-test"],
-            "env_vars": {"TEST_VAR_2": "test_2"},
-        }
-    )
-    def f2():
-        return True
-
-    @ray.remote(
-        runtime_env={
-            "pip": ["pip-install-test"],
-            "env_vars": {"TEST_VAR_3": "test_3"},
-        }
-    )
-    def f3():
-        return True
-
-    assert all(ray.get([f.remote(), f2.remote(), f3.remote()]))
-
-
 class TestGC:
     @pytest.mark.skipif(
         os.environ.get("CI") and sys.platform != "linux",

--- a/python/ray/tests/test_runtime_env_conda_and_pip_4.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_4.py
@@ -32,6 +32,49 @@ def test_in_virtualenv(start_cluster):
     assert ray.get(f.remote())
 
 
+def test_multiple_pip_installs(start_cluster, monkeypatch):
+    """Test that multiple pip installs don't interfere with each other."""
+    monkeypatch.setenv("RUNTIME_ENV_RETRY_TIMES", "0")
+    cluster, address = start_cluster
+
+    if sys.platform == "win32" and "ray" not in address:
+        pytest.skip(
+            "Failing on windows, as python.exe is in use during deletion attempt."
+        )
+
+    ray.init(
+        address,
+        runtime_env={
+            "pip": ["pip-install-test"],
+            "env_vars": {"TEST_VAR_1": "test_1"},
+        },
+    )
+
+    @ray.remote
+    def f():
+        return True
+
+    @ray.remote(
+        runtime_env={
+            "pip": ["pip-install-test"],
+            "env_vars": {"TEST_VAR_2": "test_2"},
+        }
+    )
+    def f2():
+        return True
+
+    @ray.remote(
+        runtime_env={
+            "pip": ["pip-install-test"],
+            "env_vars": {"TEST_VAR_3": "test_3"},
+        }
+    )
+    def f3():
+        return True
+
+    assert all(ray.get([f.remote(), f2.remote(), f3.remote()]))
+
+
 class TestGC:
     @pytest.mark.skipif(
         os.environ.get("CI") and sys.platform != "linux",


### PR DESCRIPTION
If you have 2 concurrent pip installs, e.g. from 2 different runtime envs who have the same pip requirements; and your ray is in a virtualenv, you will hit the problem that ray tries to pip install to an existing virtualenv dir, which is complained by virtualenv-clone.

This PR records already-installed pip URIs and if a new request comes, early returns OK (with number of bytes).

Fixes https://github.com/ray-project/ray/issues/38312.