### PR TITLE
[civ2] build the wheel

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -1,0 +1,25 @@
+group: build
+steps:
+  - label: ":tapioca: build: wheel {{matrix}}"
+    instance_type: medium
+    commands:
+      - ./ci/build/build-manylinux-ray.sh
+      - ./ci/build/build-manylinux-wheel.sh {{matrix}}
+      - ./ci/build/copy_build_artifacts.sh wheel
+    matrix:
+      - cp37-cp37m 1.14.5
+      - cp38-cp38 1.14.5
+      - cp39-cp39 1.19.3
+      - cp310-cp310 1.22.0
+      - cp311-cp311 1.22.0
+    depends_on: manylinux
+    job_env: manylinux
+
+  - label: ":tapioca: build: jar"
+    instance_type: medium
+    commands:
+      - ./ci/build/build-manylinux-ray.sh
+      - ./ci/build/build-manylinux-jar.sh
+      - ./ci/build/copy_build_artifacts.sh jar
+    depends_on: manylinux
+    job_env: manylinux

--- a/.buildkite/forge.rayci.yml
+++ b/.buildkite/forge.rayci.yml
@@ -2,6 +2,9 @@ group: forge
 steps:
   - name: forge
     wanda: ci/docker/forge.wanda.yaml
+
+  - name: manylinux
+    wanda: ci/docker/manylinux.wanda.yaml
   
   - name: oss-ci-base_test
     wanda: ci/docker/base.test.wanda.yaml

--- a/.buildkite/pipeline.build_release.yml
+++ b/.buildkite/pipeline.build_release.yml
@@ -1,28 +1,5 @@
 #ci:group=:ferris_wheel: Wheels and containers
 
-- label: ":ferris_wheel: Wheels and Jars"
-  conditions:
-    [
-        "RAY_CI_LINUX_WHEELS_AFFECTED",
-        "RAY_CI_JAVA_AFFECTED",
-    ]
-  instance_size: medium
-  commands:
-    # Build the wheels and jars
-    - export RAY_INSTALL_JAVA=1
-    - UPLOAD_WHEELS_AS_ARTIFACTS=1 LINUX_WHEELS=1 LINUX_JARS=1 ./ci/ci.sh build
-    # Upload the wheels and jars
-    # We don't want to push on PRs, in fact, the copy_files will fail because unauthenticated.
-    - if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then exit 0; fi
-    - pip install -q docker aws_requests_auth boto3
-    - ./ci/env/env_info.sh
-    # Upload to branch directory.
-    - python .buildkite/copy_files.py --destination branch_wheels --path ./.whl
-    - python .buildkite/copy_files.py --destination branch_jars --path ./.jar/linux
-    # Upload to latest directory.
-    - if [ "$BUILDKITE_BRANCH" == "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
-    - if [ "$BUILDKITE_BRANCH" == "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/linux; fi
-
 - label: ":ferris_wheel: Post-wheel tests"
   conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
   instance_size: medium

--- a/ci/build/build-manylinux-forge.sh
+++ b/ci/build/build-manylinux-forge.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Build an environment for building ray wheels for the manylinux2014 platform.
+
+set -exuo pipefail
+
+if [[ ! -e /usr/bin/nproc ]]; then
+  echo -e '#!/bin/bash\necho 10' > "/usr/bin/nproc"
+  chmod +x /usr/bin/nproc
+fi
+
+# Install ray cpp dependencies.
+yum -y install unzip zip sudo openssl xz
+if [[ "${HOSTTYPE-}" == "x86_64" ]]; then
+  yum -y install libasan-4.8.5-44.el7.x86_64 libubsan-7.3.1-5.10.el7.x86_64 \
+    devtoolset-8-libasan-devel.x86_64
+fi
+
+# Install ray java dependencies.
+if [[ "${RAY_INSTALL_JAVA}" == "1" ]]; then
+  yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel maven
+  java -version
+  JAVA_BIN="$(readlink -f "$(command -v java)")"
+  echo "java_bin path ${JAVA_BIN}"
+  export JAVA_HOME="${JAVA_BIN%jre/bin/java}"
+fi
+
+# Install ray dashboard dependencies.
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+source "$HOME"/.nvm/nvm.sh
+
+NODE_VERSION="14"
+nvm install "$NODE_VERSION"
+nvm use "$NODE_VERSION"
+
+# Install bazel
+npm install -g @bazel/bazelisk
+ln -s "$(which bazelisk)" /usr/local/bin/bazel
+
+{
+  echo "build --config=ci"
+  echo "build --announce_rc"
+  echo "build --incompatible_linkopts_to_linklibs"
+  echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+} > ~/.bazelrc

--- a/ci/build/build-manylinux-jar.sh
+++ b/ci/build/build-manylinux-jar.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -exuo pipefail
+
+if [[ "${RAY_INSTALL_JAVA}" == "1" ]]; then
+  if [[ "${BUILD_JAR-}" == "1" ]]; then
+    echo "--- Build JAR"
+    ./java/build-jar-multiplatform.sh linux
+  fi
+fi

--- a/ci/build/build-manylinux-ray.sh
+++ b/ci/build/build-manylinux-ray.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -exuo pipefail
+
+# Do not upload results to remote cache for pull requests
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ]]; then
+  echo "build --remote_upload_local_results=false" >> ~/.bazelrc
+fi
+
+# Build ray java
+if [[ "${RAY_INSTALL_JAVA}" == "1" ]]; then
+  bazel build //java:ray_java_pkg
+fi
+
+# Build ray dashboard
+cd python/ray/dashboard/client
+npm ci
+npm run build

--- a/ci/build/build-manylinux-wheel.sh
+++ b/ci/build/build-manylinux-wheel.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -exuo pipefail
+
+PYTHON="$1"
+NUMPY_VERSION="$2"
+TRAVIS_COMMIT="${TRAVIS_COMMIT:-$BUILDKITE_COMMIT}"
+
+mkdir -p .whl
+cd python
+# Fix the numpy version because this will be the oldest numpy version we can
+# support.
+/opt/python/"${PYTHON}"/bin/pip install -q numpy=="${NUMPY_VERSION}" cython==0.29.32
+# Set the commit SHA in __init__.py.
+if [[ -n "$TRAVIS_COMMIT" ]]; then
+  sed -i.bak "s/{{RAY_COMMIT_SHA}}/$TRAVIS_COMMIT/g" ray/__init__.py && rm ray/__init__.py.bak
+else
+  echo "TRAVIS_COMMIT variable not set - required to populated ray.__commit__."
+  exit 1
+fi
+
+# When building the wheel, we always set RAY_INSTALL_JAVA=0 because we
+# have already built the Java code above.
+
+# build ray wheel
+PATH="/opt/python/${PYTHON}/bin:$PATH" RAY_INSTALL_JAVA=0 \
+"/opt/python/${PYTHON}/bin/python" setup.py -q bdist_wheel
+
+# build ray-cpp wheel
+PATH="/opt/python/${PYTHON}/bin:$PATH" RAY_INSTALL_JAVA=0 \
+RAY_INSTALL_CPP=1 "/opt/python/${PYTHON}/bin/python" setup.py -q bdist_wheel
+
+# Rename the wheels so that they can be uploaded to PyPI. TODO(rkn): This is a
+# hack, we should use auditwheel instead.
+for path in dist/*.whl; do
+  if [[ -f "${path}" ]]; then
+    out="${path//-linux/-manylinux2014}"
+    if [[ "$out" != "$path" ]]; then
+      mv "${path}" "${out}"
+    fi
+  fi
+done
+mv dist/*.whl ../.whl/

--- a/ci/build/copy_build_artifacts.sh
+++ b/ci/build/copy_build_artifacts.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+ARTIFACT_TYPE=${1:-wheel}
+
+if [[ "$ARTIFACT_TYPE" != "wheel" && "$ARTIFACT_TYPE" != "jar" ]]; then
+  echo "Invalid artifact type: $ARTIFACT_TYPE"
+  exit 1
+fi
+
+if [[ "$ARTIFACT_TYPE" == "wheel" ]]; then
+  BRANCH_DESTINATION="branch_wheels"
+  MASTER_DESTINATION="wheels"
+  ARTIFACT_PATH=".whl"
+else
+  BRANCH_DESTINATION="branch_jars"
+  MASTER_DESTINATION="jars"
+  ARTIFACT_PATH=".jar/linux"
+fi
+
+export PATH=/opt/python/cp38-cp38/bin:$PATH
+pip install -q aws_requests_auth boto3
+./ci/env/env_info.sh
+
+# Sync the directory to buildkite artifacts
+rm -rf /artifact-mount/"$ARTIFACT_PATH" || true
+mkdir -p /artifact-mount/"$ARTIFACT_PATH"
+cp -r "$ARTIFACT_PATH" /artifact-mount/"$ARTIFACT_PATH"
+chmod -R 777 /artifact-mount/"$ARTIFACT_PATH"
+
+# Don't upload to artifacts if this is a pull request.
+if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then exit 0; fi
+
+# Upload to branch directory.
+python .buildkite/copy_files.py --destination "$BRANCH_DESTINATION" --path "./$ARTIFACT_PATH"
+
+# Upload to latest directory.
+if [ "$BUILDKITE_BRANCH" == "master" ]; then python .buildkite/copy_files.py --destination "$MASTER_DESTINATION" --path "./$ARTIFACT_PATH"; fi

--- a/ci/docker/manylinux.Dockerfile
+++ b/ci/docker/manylinux.Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1.3-labs
+
+FROM quay.io/pypa/manylinux2014_x86_64:2022-12-20-b4884d9
+
+ARG BUILDKITE_BAZEL_CACHE_URL
+
+ENV BUILD_JAR=1
+ENV RAY_INSTALL_JAVA=1
+ENV BUILDKITE_BAZEL_CACHE_URL=$BUILDKITE_BAZEL_CACHE_URL
+
+COPY ci/build/build-manylinux-forge.sh /tmp/build-manylinux-forge.sh
+RUN /tmp/build-manylinux-forge.sh

--- a/ci/docker/manylinux.wanda.yaml
+++ b/ci/docker/manylinux.wanda.yaml
@@ -1,0 +1,8 @@
+name: "manylinux"
+froms:
+  - quay.io/pypa/manylinux2014_x86_64:2022-12-20-b4884d9
+srcs:
+  - ci/build/build-manylinux-forge.sh
+build_args:
+  - BUILDKITE_BAZEL_CACHE_URL
+dockerfile: ci/docker/manylinux.Dockerfile


### PR DESCRIPTION
Migrate wheel building job to civ2. There seems to be a lot of changes here, but it just splitting one big file into smaller files.
- Refactor the existing build-wheel-manylinux2014.sh into three pieces: forge, ray-building, wheel/jar building
- forge is used to build the manylinux container for civ2
- ray-building is run on top of forge
- wheel/jar is run on top of ray-building, depending on whether wheel or jar is produced

Test:
- CI