### PR TITLE
Check the existence of __version__ in pydantic before use

### DIFF
--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -34,8 +34,12 @@ try:
     # In pydantic 2, dataclass no longer needs the `init=True` kwarg to
     # generate an __init__ method. Additionally, it will raise an error if
     # it detects `init=True` to be set.
-    is_pydantic_2 = pydantic.__version__.startswith("2")
-
+    # In pydantic <1.9.0, __version__ attribute is missing, issue ref:
+    # https://github.com/pydantic/pydantic/issues/2572, so we need to check
+    # the existence prior to comparison.
+    is_pydantic_2 = hasattr(
+        pydantic, "__version__"
+    ) and pydantic.__version__.startswith("2")
 except ImportError:
     # pydantic is not available in the dashboard.
     # We will use the dataclass from the standard library.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Pydantic_2 checks introduced incompatibility with pydantic < 1.9.0. In older versions the `__version__` -attribute was missing from pydantic, and the checks caused immediate exception in all `ray` command executions:

```
% pip install pydantic==1.8.1
Successfully installed pydantic-1.8.1
(ray-fix) jrosti@pai ray % python -c 'import ray.util.state.common'                 
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/jrosti/.pyenv/versions/ray-fix/lib/python3.9/site-packages/ray/util/state/__init__.py", line 1, in <module>
    from ray.util.state.api import (
  File "/Users/jrosti/.pyenv/versions/ray-fix/lib/python3.9/site-packages/ray/util/state/api.py", line 17, in <module>
    from ray.util.state.common import (
  File "/Users/jrosti/.pyenv/versions/ray-fix/lib/python3.9/site-packages/ray/util/state/common.py", line 38, in <module>
    is_pydantic_2 = pydantic.__version__.startswith("2")
AttributeError: module 'pydantic' has no attribute '__version__'
```

## Related issue number

PR is discussed here:

https://ray-distributed.slack.com/archives/C01DLHZHRBJ/p1691663217273319
with  @richardliaw

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
   
   Tested manually that the fix works with Pydantic 1.8.*.  Expecting the functionality to be covered by current unit tests. 