### PR TITLE
[Serve] Set timeout for `test_http_state` to `medium`

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -115,7 +115,7 @@ py_test(
 
 py_test(
     name = "test_http_state",
-    size = "small",
+    size = "medium",
     srcs = serve_tests_srcs,
     tags = ["exclusive", "team:serve"],
     deps = [":serve_lib"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_http_state` has been failing on Windows due to timeout recently:

<img width="1335" alt="Screen Shot 2023-08-14 at 3 58 38 PM" src="https://github.com/ray-project/ray/assets/92341594/493323ce-b535-4dd2-b5bc-a85563912912">

Sample traceback ([link](https://buildkite.com/ray-project/oss-ci-build-branch/builds/5432#0189e839-c78b-4561-aab6-8de1253f65e1/6-12179)):

```console
//python/ray/serve:test_http_state                                      TIMEOUT in 3 out of 3 in 60.1s
--
  | Stats over 3 runs: max = 60.1s, min = 60.0s, avg = 60.1s, dev = 0.0s
  | C:/tmp/4lhdprva/execroot/com_github_ray_project_ray/bazel-out/x64_windows-opt/testlogs/python/ray/serve/test_http_state/test.log
  | C:/tmp/4lhdprva/execroot/com_github_ray_project_ray/bazel-out/x64_windows-opt/testlogs/python/ray/serve/test_http_state/test_attempts/attempt_1.log
  | C:/tmp/4lhdprva/execroot/com_github_ray_project_ray/bazel-out/x64_windows-opt/testlogs/python/ray/serve/test_http_state/test_attempts/attempt_2.log
```

This change updates `test_http_state`'s duration to medium, so it doesn't time out.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change updates the timeout for `test_http_state`.
