### PR TITLE
[Core] Fix `test_placement_group_parallel_submission` to actually test parallel pg submission instead of serial.

### DIFF
--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -225,14 +225,15 @@ def test_placement_group_max_cpu_frac_edge_cases(ray_start_cluster):
 
 
 @pytest.mark.parametrize(
-    "scheduling_strategy", ["SPREAD", "STRICT_SPREAD", "PACK", "STRICT_PACK"]
+    "scheduling_strategy", ["SPREAD", "STRICT_SPREAD", "PACK", "STRICT_PACK"],
+    "dummy_int", range(100),
 )
-def test_placement_group_parallel_submission(ray_start_cluster, scheduling_strategy):
+def test_placement_group_parallel_submission(ray_start_cluster, scheduling_strategy, dummy_int):
     @ray.remote(resources={"custom_resource": 1})
     def task(input):
         return input
 
-    @ray.remote
+    @ray.remote(num_cpus=0)
     def manage_tasks(input):
         pg = ray.util.placement_group(
             [{"custom_resource": 1, "CPU": 1}], strategy=scheduling_strategy

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -225,9 +225,9 @@ def test_placement_group_max_cpu_frac_edge_cases(ray_start_cluster):
 
 
 @pytest.mark.parametrize(
-    "scheduling_strategy,dummy_int", [("SPREAD", x) for x in range(25)] + [("STRICT_SPREAD", x) for x in range(25)] + [("PACK", x) for x in range(25)] + [("STRICT_PACK", x) for x in range(25)],
+    "scheduling_strategy", ["SPREAD", "STRICT_SPREAD", "PACK", "STRICT_PACK"]
 )
-def test_placement_group_parallel_submission(ray_start_cluster, scheduling_strategy, dummy_int):
+def test_placement_group_parallel_submission(ray_start_cluster, scheduling_strategy):
     @ray.remote(resources={"custom_resource": 1})
     def task(input):
         return input

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -225,8 +225,7 @@ def test_placement_group_max_cpu_frac_edge_cases(ray_start_cluster):
 
 
 @pytest.mark.parametrize(
-    "scheduling_strategy", ["SPREAD", "STRICT_SPREAD", "PACK", "STRICT_PACK"],
-    "dummy_int", range(100),
+    "scheduling_strategy,dummy_int", [("SPREAD", x) for x in range(25)] + [("STRICT_SPREAD", x) for x in range(25)] + [("PACK", x) for x in range(25)] + [("STRICT_PACK", x) for x in range(25)],
 )
 def test_placement_group_parallel_submission(ray_start_cluster, scheduling_strategy, dummy_int):
     @ray.remote(resources={"custom_resource": 1})


### PR DESCRIPTION
The unit test `test_placement_group_parallel_submission` has become flaky on MacOS. The test schedules a task, which creates a placement group and schedules another task within the placement group, then waits for the task and deletes the placement group. The unit test is designed to run with 20 tasks in parallel, but seems it is misconfigured as the each of the 20 run in serial.

This PR fixes the unit test by making the task which creates placement groups require num_cpus=0. This makes the test run in parallel instead of serial, and tests the parallel scheduling of placement groups as desired.

Before this fix, the failure rate was 8/20 ~= 40%. After this fix, the failure rate is 3/164 ~= 2%.

Closes https://github.com/ray-project/ray/issues/36922