### PR TITLE
[Serve] Print fewer logs to terminal

### DIFF
--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -352,10 +352,16 @@ class HTTPProxy:
         """
 
         if draining and (not self._is_draining()):
-            logger.info(f"Start to drain the proxy actor on node {self._node_id}.")
+            logger.info(
+                f"Start to drain the proxy actor on node {self._node_id}.",
+                extra={"log_to_stderr": False},
+            )
             self._draining_start_time = time.time()
         if (not draining) and self._is_draining():
-            logger.info(f"Stop draining the proxy actor on node {self._node_id}.")
+            logger.info(
+                f"Stop draining the proxy actor on node {self._node_id}.",
+                extra={"log_to_stderr": False},
+            )
             self._draining_start_time = None
 
     async def _not_found(self, scope, receive, send):

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -356,7 +356,8 @@ class ServeController:
                     self.done_recovering_event.set()
                     logger.info(
                         "Finished recovering deployments after "
-                        f"{time.time() - start_time}s."
+                        f"{(time.time() - start_time):.2f}s.",
+                        extra={"log_to_stderr": False},
                     )
             except Exception:
                 logger.exception("Exception updating deployment state.")
@@ -403,7 +404,8 @@ class ServeController:
                     f"The last control loop was slow (took {loop_duration}s). "
                     "This is likely caused by running a large number of "
                     "replicas in a single Ray cluster. Consider using "
-                    "multiple Ray clusters."
+                    "multiple Ray clusters.",
+                    extra={"log_to_stderr": False},
                 )
             self.control_loop_duration_gauge_s.set(loop_duration)
 
@@ -501,7 +503,9 @@ class ServeController:
     def _recover_config_from_checkpoint(self):
         checkpoint = self.kv_store.get(CONFIG_CHECKPOINT_KEY)
         if checkpoint is not None:
-            logger.info("Recovering config from checkpoint.")
+            logger.info(
+                "Recovering config from checkpoint.", extra={"log_to_stderr": False}
+            )
             deployment_time, deploy_mode, config_checkpoints_dict = pickle.loads(
                 checkpoint
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change:

1. Truncates the number of seconds logged about the controller's recovery to 2 decimal places.
2. Stops printing some logs to terminal.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #38406

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
