### PR TITLE
Revert "Remove grpcio from minimal dependency"

### DIFF
--- a/dashboard/optional_deps.py
+++ b/dashboard/optional_deps.py
@@ -16,4 +16,3 @@ from aiohttp import hdrs  # noqa: F401
 from aiohttp.typedefs import PathLike  # noqa: F401
 from aiohttp.web import RouteDef  # noqa: F401
 import pydantic  # noqa: F401
-import grpc  # noqa: F401

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -50,7 +50,7 @@ class DashboardAgentModule(abc.ABC):
         """
         Run the module in an asyncio loop. An agent module can provide
         servicers to the server.
-        :param server: Asyncio GRPC server, or None if ray is minimal.
+        :param server: Asyncio GRPC server.
         """
 
     @staticmethod
@@ -79,7 +79,7 @@ class DashboardHeadModule(abc.ABC):
         """
         Run the module in an asyncio loop. A head module can provide
         servicers to the server.
-        :param server: Asyncio GRPC server, or None if ray is minimal.
+        :param server: Asyncio GRPC server.
         """
 
     @staticmethod

--- a/doc/source/cluster/running-applications/job-submission/ray-client.rst
+++ b/doc/source/cluster/running-applications/job-submission/ray-client.rst
@@ -3,9 +3,6 @@
 Ray Client
 ==========
 
-.. warning::
-   Ray Client requires pip package `ray[client]`. If you installed the minimal Ray (e.g. `pip install ray`), please reinstall by executing `pip install ray[client]`.
-
 **What is the Ray Client?**
 
 The Ray Client is an API that connects a Python script to a **remote** Ray cluster. Effectively, it allows you to leverage a remote Ray cluster just like you would with Ray running on your local machine.

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -6,9 +6,7 @@ import pkg_resources
 import ray._private.ray_constants as ray_constants
 from ray._private.utils import (
     validate_node_labels,
-    check_ray_client_dependencies_installed,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -399,12 +397,8 @@ class RayParams:
                     raise ValueError(
                         "max_worker_port must be higher than min_worker_port."
                     )
+
         if self.ray_client_server_port is not None:
-            if not check_ray_client_dependencies_installed():
-                raise ValueError(
-                    "Ray Client requires pip package `ray[client]`. "
-                    "If you installed the minimal Ray (e.g. `pip install ray`), "
-                    "please reinstall by executing `pip install ray[client]`.")
             if (
                 self.ray_client_server_port < 1024
                 or self.ray_client_server_port > 65535

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 import requests
 from ray._raylet import Config
 
+import grpc
 import numpy as np
 import psutil  # We must import psutil after ray because we bundle it with ray.
 from ray._private import (
@@ -31,6 +32,7 @@ from ray._private import (
 )
 from ray._private.worker import RayContext
 import yaml
+from grpc._channel import _InactiveRpcError
 
 import ray
 import ray._private.gcs_utils as gcs_utils
@@ -43,7 +45,9 @@ from ray._raylet import GcsClientOptions, GlobalStateAccessor
 from ray.core.generated import (
     gcs_pb2,
     node_manager_pb2,
+    node_manager_pb2_grpc,
     gcs_service_pb2,
+    gcs_service_pb2_grpc,
 )
 from ray.util.queue import Empty, Queue, _QueueActor
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
@@ -1470,9 +1474,6 @@ def get_and_run_node_killer(
             return self.killed_nodes
 
         def _kill_raylet(self, ip, port, graceful=False):
-            import grpc
-            from grpc._channel import _InactiveRpcError
-            from ray.core.generated import node_manager_pb2_grpc
             raylet_address = f"{ip}:{port}"
             channel = grpc.insecure_channel(raylet_address)
             stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
@@ -1693,8 +1694,6 @@ def wandb_setup_api_key_hook():
 
 # Get node stats from node manager.
 def get_node_stats(raylet, num_retry=5, timeout=2):
-    import grpc
-    from ray.core.generated import node_manager_pb2_grpc
     raylet_address = f'{raylet["NodeManagerAddress"]}:{raylet["NodeManagerPort"]}'
     channel = ray._private.utils.init_grpc_channel(raylet_address)
     stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
@@ -1712,7 +1711,6 @@ def get_node_stats(raylet, num_retry=5, timeout=2):
 
 # Gets resource usage assuming gcs is local.
 def get_resource_usage(gcs_address, timeout=10):
-    from ray.core.generated import gcs_service_pb2_grpc
     if not gcs_address:
         gcs_address = ray.worker._global_node.gcs_address
 
@@ -1741,9 +1739,6 @@ def get_load_metrics_report(webui_url):
 
 # Send a RPC to the raylet to have it self-destruct its process.
 def kill_raylet(raylet, graceful=False):
-    import grpc
-    from grpc._channel import _InactiveRpcError
-    from ray.core.generated import node_manager_pb2_grpc
     raylet_address = f'{raylet["NodeManagerAddress"]}:{raylet["NodeManagerPort"]}'
     channel = grpc.insecure_channel(raylet_address)
     stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)

--- a/python/ray/_private/tls_utils.py
+++ b/python/ray/_private/tls_utils.py
@@ -2,6 +2,8 @@ import datetime
 import os
 import socket
 
+import grpc
+
 
 def generate_self_signed_tls_certs():
     """Create self-signed key/cert pair for testing.
@@ -66,7 +68,6 @@ def generate_self_signed_tls_certs():
 
 
 def add_port_to_grpc_server(server, address):
-    import grpc
     if os.environ.get("RAY_USE_TLS", "0").lower() in ("1", "true"):
         server_cert_chain, private_key, ca_cert = load_certs_from_env()
         credentials = grpc.ssl_server_credentials(

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -268,7 +268,7 @@ def hex_to_binary(hex_identifier):
 # once we separate `WorkerID` from `UniqueID`.
 def compute_job_id_from_driver(driver_id):
     assert isinstance(driver_id, ray.WorkerID)
-    return ray.JobID(driver_id.binary()[0: ray.JobID.size()])
+    return ray.JobID(driver_id.binary()[0 : ray.JobID.size()])
 
 
 def compute_driver_id_from_job(job_id):
@@ -1191,7 +1191,7 @@ def import_attr(full_path: str):
     else:
         last_period_idx = full_path.rfind(".")
         module_name = full_path[:last_period_idx]
-        attr_name = full_path[last_period_idx + 1:]
+        attr_name = full_path[last_period_idx + 1 :]
 
     module = importlib.import_module(module_name)
     return getattr(module, attr_name)
@@ -1347,18 +1347,6 @@ def check_dashboard_dependencies_installed() -> bool:
     try:
         import ray.dashboard.optional_deps  # noqa: F401
 
-        return True
-    except ImportError:
-        return False
-
-
-def check_ray_client_dependencies_installed() -> bool:
-    """Returns True if Ray Client dependencies are installed.
-
-    See documents for check_dashboard_dependencies_installed.
-    """
-    try:
-        import grpc  # noqa: F401
         return True
     except ImportError:
         return False

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1153,7 +1153,7 @@ def init(
 
     To connect to an existing remote cluster, use this as follows (substituting
     in the appropriate address). Note the addition of "ray://" at the beginning
-    of the address. This requires `ray[client]`.
+    of the address.
 
     .. testcode::
         :skipif: True

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -184,7 +184,6 @@ import ray._private.ray_constants as ray_constants
 import ray.cloudpickle as ray_pickle
 from ray.core.generated.common_pb2 import ActorDiedErrorContext
 from ray.core.generated.gcs_pb2 import JobTableData
-from ray.core.generated.gcs_service_pb2 import GetAllResourceUsageReply
 from ray._private.async_compat import (
     sync_to_async,
     get_new_event_loop,
@@ -216,7 +215,6 @@ OPTIMIZED = __OPTIMIZE__
 GRPC_STATUS_CODE_UNAVAILABLE = CGrpcStatusCode.UNAVAILABLE
 GRPC_STATUS_CODE_UNKNOWN = CGrpcStatusCode.UNKNOWN
 GRPC_STATUS_CODE_DEADLINE_EXCEEDED = CGrpcStatusCode.DEADLINE_EXCEEDED
-GRPC_STATUS_CODE_RESOURCE_EXHAUSTED = CGrpcStatusCode.RESOURCE_EXHAUSTED
 
 logger = logging.getLogger(__name__)
 
@@ -2540,18 +2538,6 @@ cdef class GcsClient:
             result[job_info.job_id] = job_info
         return result
 
-    @_auto_reconnect
-    def get_all_resource_usage(self, timeout=None) -> GetAllResourceUsageReply:
-        cdef:
-            int64_t timeout_ms = round(1000 * timeout) if timeout else -1
-            c_string serialized_reply
-            
-        with nogil:
-            check_status(self.inner.get().GetAllResourceUsage(timeout_ms, serialized_reply))
-        
-        reply = GetAllResourceUsageReply()
-        reply.ParseFromString(serialized_reply)
-        return reply
     ########################################################
     # Interface for rpc::autoscaler::AutoscalerStateService
     ########################################################
@@ -2599,22 +2585,6 @@ cdef class GcsClient:
                 node_id, reason, reason_message, timeout_ms, is_accepted))
 
         return is_accepted
-
-    @_auto_reconnect
-    def drain_nodes(self, node_ids, timeout=None):
-        cdef:
-            c_vector[c_string] c_node_ids
-            int64_t timeout_ms = round(1000 * timeout) if timeout else -1
-            c_vector[c_string] c_drained_node_ids
-        for node_id in node_ids:
-            c_node_ids.push_back(node_id)
-        with nogil:
-            check_status(self.inner.get().DrainNodes(
-                c_node_ids, timeout_ms, c_drained_node_ids))
-        result = []
-        for drain_node_id in c_drained_node_ids:
-            result.append(drain_node_id)
-        return result
 
     #############################################################
     # Interface for rpc::autoscaler::AutoscalerStateService ends

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, FrozenSet, List, Optional, Set, Tuple, Union
 
+import grpc
 import yaml
 
 from ray.autoscaler._private.constants import (
@@ -75,8 +76,7 @@ from ray.autoscaler.tags import (
     TAG_RAY_RUNTIME_CONFIG,
     TAG_RAY_USER_NODE_TYPE,
 )
-from ray._raylet import GcsClient
-from ray.exceptions import RpcError
+from ray.core.generated import gcs_service_pb2, gcs_service_pb2_grpc
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +184,7 @@ class StandardAutoscaler:
         # TODO(ekl): require config reader to be a callable always.
         config_reader: Union[str, Callable[[], dict]],
         load_metrics: LoadMetrics,
-        gcs_client: GcsClient,
+        gcs_node_info_stub: gcs_service_pb2_grpc.NodeInfoGcsServiceStub,
         session_name: Optional[str] = None,
         max_launch_batch: int = AUTOSCALER_MAX_LAUNCH_BATCH,
         max_concurrent_launches: int = AUTOSCALER_MAX_CONCURRENT_LAUNCHES,
@@ -214,8 +214,8 @@ class StandardAutoscaler:
             prefix_cluster_info: Whether to add the cluster name to info strs.
             event_summarizer: Utility to consolidate duplicated messages.
             prom_metrics: Prometheus metrics for autoscaler-related operations.
-            gcs_client: client for interactions with the GCS. Used to drain nodes
-                before termination.
+            gcs_node_info_stub: Stub for interactions with Ray nodes via gRPC
+                request to the GCS. Used to drain nodes before termination.
         """
 
         if isinstance(config_reader, str):
@@ -355,7 +355,7 @@ class StandardAutoscaler:
             for remote, local in self.config["file_mounts"].items()
         }
 
-        self.gcs_client = gcs_client
+        self.gcs_node_info_stub = gcs_node_info_stub
 
         for local_path in self.config["file_mounts"].values():
             assert os.path.exists(local_path)
@@ -675,21 +675,39 @@ class StandardAutoscaler:
 
         logger.info(f"Draining {len(raylet_ids_to_drain)} raylet(s).")
         try:
+            request = gcs_service_pb2.DrainNodeRequest(
+                drain_node_data=[
+                    gcs_service_pb2.DrainNodeData(node_id=raylet_id)
+                    for raylet_id in raylet_ids_to_drain
+                ]
+            )
+
             # A successful response indicates that the GCS has marked the
             # desired nodes as "drained." The cloud provider can then terminate
             # the nodes without the GCS printing an error.
+            response = self.gcs_node_info_stub.DrainNode(request, timeout=5)
+
             # Check if we succeeded in draining all of the intended nodes by
             # looking at the RPC response.
-            drained_raylet_ids = set(self.gcs_client.drain_nodes(
-                raylet_ids_to_drain, timeout=5))
+            drained_raylet_ids = {
+                status_item.node_id for status_item in response.drain_node_status
+            }
             failed_to_drain = raylet_ids_to_drain - drained_raylet_ids
             if failed_to_drain:
                 self.prom_metrics.drain_node_exceptions.inc()
                 logger.error(f"Failed to drain {len(failed_to_drain)} raylet(s).")
-        except RpcError:
-            # Otherwise, it's a plane old RPC error and we should log it.
-            self.prom_metrics.drain_node_exceptions.inc()
-            logger.exception("Failed to drain Ray nodes. Traceback follows.")
+
+        # If we get a gRPC error with an UNIMPLEMENTED code, fail silently.
+        # This error indicates that the GCS is using Ray version < 1.8.0,
+        # for which DrainNode is not implemented.
+        except grpc.RpcError as e:
+            # If the code is UNIMPLEMENTED, pass.
+            if e.code() == grpc.StatusCode.UNIMPLEMENTED:
+                pass
+            # Otherwise, it's a plane old gRPC error and we should log it.
+            else:
+                self.prom_metrics.drain_node_exceptions.inc()
+                logger.exception("Failed to drain Ray nodes. Traceback follows.")
         except Exception:
             # We don't need to interrupt the autoscaler update with an
             # exception, but we should log what went wrong and record the

--- a/python/ray/client_builder.py
+++ b/python/ray/client_builder.py
@@ -14,10 +14,7 @@ from ray._private.ray_constants import (
     RAY_NAMESPACE_ENVIRONMENT_VARIABLE,
     RAY_RUNTIME_ENV_ENVIRONMENT_VARIABLE,
 )
-from ray._private.utils import (
-    split_address,
-    check_ray_client_dependencies_installed,
-)
+from ray._private.utils import split_address
 from ray._private.worker import BaseContext
 from ray._private.worker import init as ray_driver_init
 from ray.job_config import JobConfig
@@ -98,12 +95,6 @@ class ClientBuilder:
     """
 
     def __init__(self, address: Optional[str]) -> None:
-        if not check_ray_client_dependencies_installed():
-            raise ValueError(
-                "Ray Client requires pip package `ray[client]`. "
-                "If you installed the minimal Ray (e.g. `pip install ray`), "
-                "please reinstall by executing `pip install ray[client]`.")
-
         self.address = address
         self._job_config = JobConfig()
         self._remote_init_kwargs = {}

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -361,7 +361,6 @@ cdef extern from "ray/gcs/gcs_client/gcs_client.h" nogil:
         UNAVAILABLE "grpc::StatusCode::UNAVAILABLE",
         UNKNOWN "grpc::StatusCode::UNKNOWN",
         DEADLINE_EXCEEDED "grpc::StatusCode::DEADLINE_EXCEEDED",
-        RESOURCE_EXHAUSTED "grpc::StatusCode::RESOURCE_EXHAUSTED"
 
     cdef cppclass CGcsClientOptions "ray::gcs::GcsClientOptions":
         CGcsClientOptions(const c_string &gcs_address)
@@ -395,14 +394,13 @@ cdef extern from "ray/gcs/gcs_client/gcs_client.h" nogil:
         CRayStatus InternalKVExists(
             const c_string &ns, const c_string &key,
             int64_t timeout_ms, c_bool &exists)
+
         CRayStatus PinRuntimeEnvUri(
             const c_string &uri, int expiration_s, int64_t timeout_ms)
         CRayStatus GetAllNodeInfo(
             int64_t timeout_ms, c_vector[CGcsNodeInfo]& result)
         CRayStatus GetAllJobInfo(
             int64_t timeout_ms, c_vector[CJobTableData]& result)
-        CRayStatus GetAllResourceUsage(
-            int64_t timeout_ms, c_string& serialized_reply)
         CRayStatus RequestClusterResourceConstraint(
             int64_t timeout_ms,
             const c_vector[unordered_map[c_string, double]] &bundles,
@@ -417,10 +415,6 @@ cdef extern from "ray/gcs/gcs_client/gcs_client.h" nogil:
             const c_string &reason_message,
             int64_t timeout_ms,
             c_bool &is_accepted)
-        CRayStatus DrainNodes(
-            const c_vector[c_string]& node_ids,
-            int64_t timeout_ms,
-            c_vector[c_string]& drained_node_ids)
 
 cdef extern from "ray/gcs/gcs_client/gcs_client.h" namespace "ray::gcs" nogil:
     unordered_map[c_string, double] PythonGetResourcesTotal(

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -22,7 +22,6 @@ import ray
 import ray._private.ray_constants as ray_constants
 import ray._private.services as services
 from ray._private.utils import (
-    check_ray_client_dependencies_installed,
     parse_resources_json,
     parse_node_labels_json,
 )
@@ -346,9 +345,8 @@ def debug(address):
     "--ray-client-server-port",
     required=False,
     type=int,
-    default=None,
-    help="the port number the ray client server binds on, default to 10001, "
-    "or None if ray[client] is not installed.",
+    default=10001,
+    help="the port number the ray client server binds on, default to 10001.",
 )
 @click.option(
     "--memory",
@@ -625,15 +623,6 @@ def start(
         temp_dir = None
 
     redirect_output = None if not no_redirect_output else True
-
-    # no  client, no  port -> ok
-    # no  port, has client -> default to 10001
-    # has port, no  client -> value error
-    # has port, has client -> ok, check port validity
-    has_ray_client = check_ray_client_dependencies_installed()
-    if has_ray_client and ray_client_server_port is None:
-        ray_client_server_port = 10001
-
     ray_params = ray._private.parameter.RayParams(
         node_ip_address=node_ip_address,
         node_name=node_name if node_name else node_ip_address,

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -20,6 +20,7 @@ import pytest
 
 import ray
 import ray._private.ray_constants as ray_constants
+import ray.util.client.server.server as ray_client_server
 from ray._private.conftest_utils import set_override_dashboard_url  # noqa: F401
 from ray._private.runtime_env.pip import PipProcessor
 from ray._private.runtime_env.plugin_schema_manager import RuntimeEnvPluginSchemaManager
@@ -628,8 +629,6 @@ def call_ray_start_with_external_redis(request):
 
 @pytest.fixture
 def init_and_serve():
-    import ray.util.client.server.server as ray_client_server
-
     server_handle, _ = ray_client_server.init_and_serve("localhost:50051")
     yield server_handle
     ray_client_server.shutdown_with_server(server_handle.grpc_server)
@@ -650,9 +649,6 @@ def call_ray_stop_only():
 def start_cluster(ray_start_cluster_enabled, request):
     assert request.param in {"ray_client", "no_ray_client"}
     use_ray_client: bool = request.param == "ray_client"
-    if os.environ.get("RAY_MINIMAL") == "1" and use_ray_client:
-        pytest.skip("Skipping due to we don't have ray client in minimal.")
-
     cluster = ray_start_cluster_enabled
     cluster.add_node(num_cpus=4, dashboard_agent_listen_port=find_free_port())
     if use_ray_client:

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1101,10 +1101,8 @@ def test_failed_task(ray_start_shared_local_modes, error_pubsub):
 
 def test_import_ray_does_not_import_grpc():
     # First unload grpc and ray
-    if "grpc" in sys.modules:
-        del sys.modules["grpc"]
-    if "ray" in sys.modules:
-        del sys.modules["ray"]
+    del sys.modules["grpc"]
+    del sys.modules["ray"]
 
     # Then import ray from scratch
     import ray  # noqa: F401
@@ -1113,11 +1111,7 @@ def test_import_ray_does_not_import_grpc():
     assert "grpc" not in sys.modules
 
     # Load grpc back so other tests will not be affected
-    try:
-        import grpc  # noqa: F401
-    except ImportError:
-        # It's ok if we don't have grpc installed.
-        pass
+    import grpc  # noqa: F401
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_env_ray_minimal.py
+++ b/python/ray/tests/test_runtime_env_ray_minimal.py
@@ -43,6 +43,23 @@ def _test_task_and_actor():
     os.environ.get("RAY_MINIMAL") != "1",
     reason="This test is only run in CI with a minimal Ray installation.",
 )
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ["ray start --head --ray-client-server-port 25553 --port 0"],
+    indirect=True,
+)
+def test_ray_client_task_actor(call_ray_start):
+    ray.init("ray://localhost:25553")
+    _test_task_and_actor()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="runtime_env unsupported on Windows."
+)
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") != "1",
+    reason="This test is only run in CI with a minimal Ray installation.",
+)
 def test_task_actor(shutdown_only):
     ray.init()
     _test_task_and_actor()
@@ -64,6 +81,24 @@ def test_ray_init(shutdown_only):
 
     with pytest.raises(RuntimeEnvSetupError, match="install virtualenv"):
         ray.get(f.remote())
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="runtime_env unsupported on Windows."
+)
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") != "1",
+    reason="This test is only run in CI with a minimal Ray installation.",
+)
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ["ray start --head --ray-client-server-port 25552 --port 0"],
+    indirect=True,
+)
+def test_ray_client_init(call_ray_start):
+    with pytest.raises(ConnectionAbortedError) as excinfo:
+        ray.init("ray://localhost:25552", runtime_env={"pip": ["requests"]})
+    assert "install virtualenv" in str(excinfo.value)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -125,8 +125,6 @@ def reset_ray_version_commit():
 def test_get_extra_usage_tags_to_report(
     monkeypatch, call_ray_start, reset_usage_stats, ray_client, gcs_storage_type
 ):
-    if os.environ.get("RAY_MINIMAL") == "1" and ray_client:
-        pytest.skip("Skipping due to we don't have ray client in minimal.")
     with monkeypatch.context() as m:
         # Test a normal case.
         m.setenv("RAY_USAGE_STATS_EXTRA_TAGS", "key=val;key2=val2")

--- a/python/ray/tune/experiment/experiment.py
+++ b/python/ray/tune/experiment/experiment.py
@@ -2,6 +2,7 @@ import copy
 import datetime
 import warnings
 from functools import partial
+import grpc
 import logging
 import os
 from pathlib import Path
@@ -21,7 +22,6 @@ from typing import (
     TYPE_CHECKING,
 )
 
-import ray
 from ray.air import CheckpointConfig
 from ray.air._internal.uri_utils import URI
 from ray.exceptions import RpcError
@@ -184,7 +184,7 @@ class Experiment:
         try:
             self._run_identifier = Experiment.register_if_needed(run)
         except RpcError as e:
-            if e.rpc_code == ray._raylet.GRPC_STATUS_CODE_RESOURCE_EXHAUSTED:
+            if e.rpc_code == grpc.StatusCode.RESOURCE_EXHAUSTED.value[0]:
                 raise TuneError(
                     f"The Trainable/training function is too large for grpc resource "
                     f"limit. Check that its definition is not implicitly capturing a "

--- a/python/setup.py
+++ b/python/setup.py
@@ -256,8 +256,6 @@ if setup_spec.type == SetupType.RAY:
             "py-spy >= 0.2.0",
             "requests",
             "gpustat >= 1.0.0",  # for windows
-            "grpcio >= 1.32.0; python_version < '3.10'",  # noqa:E501
-            "grpcio >= 1.42.0; python_version >= '3.10'",  # noqa:E501
             "opencensus",
             "pydantic < 2",  # 2.0.0 brings breaking changes
             "prometheus_client >= 0.7.1",
@@ -326,6 +324,8 @@ if setup_spec.type == SetupType.RAY:
     setup_spec.install_requires = [
         "click >= 7.0",
         "filelock",
+        "grpcio >= 1.32.0; python_version < '3.10'",  # noqa:E501
+        "grpcio >= 1.42.0; python_version >= '3.10'",  # noqa:E501
         "jsonschema",
         "msgpack >= 1.0.0, < 2.0.0",
         "numpy >= 1.16; python_version < '3.9'",

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -229,7 +229,7 @@ class RAY_EXPORT PythonGcsClient {
   Status PinRuntimeEnvUri(const std::string &uri, int expiration_s, int64_t timeout_ms);
   Status GetAllNodeInfo(int64_t timeout_ms, std::vector<rpc::GcsNodeInfo> &result);
   Status GetAllJobInfo(int64_t timeout_ms, std::vector<rpc::JobTableData> &result);
-  Status GetAllResourceUsage(int64_t timeout_ms, std::string &serialized_reply);
+
   // For rpc::autoscaler::AutoscalerStateService
   Status RequestClusterResourceConstraint(
       int64_t timeout_ms,
@@ -241,9 +241,6 @@ class RAY_EXPORT PythonGcsClient {
                    const std::string &reason_message,
                    int64_t timeout_ms,
                    bool &is_accepted);
-  Status DrainNodes(const std::vector<std::string> &node_ids,
-                    int64_t timeout_ms,
-                    std::vector<std::string> &drained_node_ids);
 
   const ClusterID &GetClusterId() const { return cluster_id_; }
 
@@ -263,7 +260,6 @@ class RAY_EXPORT PythonGcsClient {
   std::unique_ptr<rpc::InternalKVGcsService::Stub> kv_stub_;
   std::unique_ptr<rpc::RuntimeEnvGcsService::Stub> runtime_env_stub_;
   std::unique_ptr<rpc::NodeInfoGcsService::Stub> node_info_stub_;
-  std::unique_ptr<rpc::NodeResourceInfoGcsService::Stub> node_resource_info_stub_;
   std::unique_ptr<rpc::JobInfoGcsService::Stub> job_info_stub_;
   std::unique_ptr<rpc::autoscaler::AutoscalerStateService::Stub> autoscaler_stub_;
   std::shared_ptr<grpc::Channel> channel_;


### PR DESCRIPTION
Reverts ray-project/ray#38243

It seems to reliably fail `test_autoscaler` (and linting also failed which I fixed in https://github.com/ray-project/ray/pull/38446 -- but better to revert the original PR given the problems with test_autoscaler).