### PR TITLE
[docs] quick fix for incorrectly rendered AIR API refs

### DIFF
--- a/doc/source/ray-air/api/configs.rst
+++ b/doc/source/ray-air/api/configs.rst
@@ -4,20 +4,21 @@ Ray AIR Configurations
 
 .. TODO(ml-team): Add a general configuration guide that covers all of these configs.
 
-.. currentmodule:: ray
-
-
 .. note::
 
     We are changing the import path of the configurations classes from `ray.air` to `ray.train` starting from Ray 2.7, 
     please see the :ref:`Ray Train API reference <ray-train-configs-api>` for the latest APIs.
 
+.. currentmodule:: ray.train
+
 .. autosummary::
 
-    air.RunConfig
-    air.ScalingConfig
-    air.CheckpointConfig
-    air.FailureConfig
+    RunConfig
+    ScalingConfig
+    CheckpointConfig
+    FailureConfig
+
+.. currentmodule:: ray
 
 .. autosummary::
 


### PR DESCRIPTION
Links here don't work on master: https://docs.ray.io/en/master/ray-air/api/configs.html. This is a quick workaround.