### PR TITLE
[Data] Turn on rest of multi-node Data+Train benchmarks

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -6065,7 +6065,7 @@
   group: data-tests
   working_dir: nightly_tests/dataset
 
-  frequency: manual
+  frequency: nightly
   team: data
   python: "3.8"
   cluster:
@@ -6089,7 +6089,7 @@
   group: data-tests
   working_dir: nightly_tests/dataset
 
-  frequency: manual
+  frequency: nightly
   team: data
   python: "3.8"
   cluster:
@@ -6113,7 +6113,7 @@
   group: data-tests
   working_dir: nightly_tests/dataset
 
-  frequency: manual
+  frequency: nightly
   team: data
   python: "3.8"
   cluster:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As a followup to https://github.com/ray-project/ray/pull/38244, re-enable the rest of the multi-node Data+Train benchmarks to run nightly.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
