### PR TITLE
[Serve] Increase timeout for `tutorial_rllib` test

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -585,7 +585,7 @@ py_test(
 
 py_test(
     name = "tutorial_rllib",
-    size = "small",
+    size = "medium",
     srcs = serve_tests_srcs,
     main = "test_myst_doc.py",
     args = ["--path", "doc/source/serve/tutorials/rllib.md"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `tutorial_rllib` test has been flaking recently on Windows:

<img width="1329" alt="Screen Shot 2023-08-15 at 11 55 13 AM" src="https://github.com/ray-project/ray/assets/92341594/f76044e3-9914-4014-b1da-47821001525f">

Based on the tracebacks, it seems that `tutorial_rllib` sometimes hits the 60s timeout for `small` tests. Example ([link](https://buildkite.com/ray-project/oss-ci-build-branch/builds/5456#0189f656-509f-4337-82c5-30a1894b3c09/11027-12296)):

```console
//python/ray/serve:tutorial_rllib                                         FLAKY, failed in 1 out of 2 in 60.1s
--
  | Stats over 2 runs: max = 60.1s, min = 49.9s, avg = 55.0s, dev = 5.1s
  | C:/tmp/4lhdprva/execroot/com_github_ray_project_ray/bazel-out/x64_windows-opt/testlogs/python/ray/serve/tutorial_rllib/test_attempts/attempt_1.log
```

This change increases the test's size to `medium`.

**Note:** the first PR (#38350) where this test started flaking also seemed to cause `test_http_state` to start flaking due to timeout (related PR #38435):

<img width="1335" alt="Screen Shot 2023-08-15 at 11 57 11 AM" src="https://github.com/ray-project/ray/assets/92341594/6bf01cd5-0dac-4e49-8042-e06ab44416d6">

It seems to have cause a slight performance regression, but it's probably not worth rolling that change back.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change deflakes the `tutorial_rllib` test.