### PR TITLE
[serve] Deflake autoscaling test_e2e_bursty

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -229,9 +229,7 @@ RAY_SERVE_CONTROLLER_CALLBACK_IMPORT_PATH = os.environ.get(
 # Serve gauge metric set period.
 RAY_SERVE_GAUGE_METRIC_SET_PERIOD_S = 1
 # How often autoscaling metrics are recorded on Serve replicas.
-RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S = float(
-    os.environ.get("RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S", "0.5")
-)
+RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S = 0.5
 
 # Serve multiplexed matching timeout.
 # This is the timeout for the matching process of multiplexed requests. To avoid

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -229,7 +229,9 @@ RAY_SERVE_CONTROLLER_CALLBACK_IMPORT_PATH = os.environ.get(
 # Serve gauge metric set period.
 RAY_SERVE_GAUGE_METRIC_SET_PERIOD_S = 1
 # How often autoscaling metrics are recorded on Serve replicas.
-RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S = 0.5
+RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S = float(
+    os.environ.get("RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S", "0.5")
+)
 
 # Serve multiplexed matching timeout.
 # This is the timeout for the matching process of multiplexed requests. To avoid

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -538,7 +538,10 @@ class RayServeReplica:
             )
             self.metrics_pusher.register_task(
                 lambda: {self.replica_tag: self.get_num_pending_and_running_requests()},
-                RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S,
+                min(
+                    RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S,
+                    config.metrics_interval_s,
+                ),
                 self._add_autoscaling_metrics_point,
             )
 

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -707,6 +707,13 @@ def test_e2e_bursty(serve_instance):
         graceful_shutdown_timeout_s=1,
         max_concurrent_queries=1000,
         version="v1",
+        ray_actor_options={
+            "runtime_env": {
+                "env_vars": {
+                    "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"
+                }
+            }
+        },
     )
     class A:
         def __init__(self):
@@ -737,6 +744,7 @@ def test_e2e_bursty(serve_instance):
     # it back to 0. This bursty behavior should be smoothed by the delay
     # parameters.
     for _ in range(5):
+        ray.get(signal.send.remote(clear=True))
         assert check_autoscale_num_replicas(controller, "A") == num_replicas
         refs = [handle.remote() for _ in range(100)]
         signal.send.remote()

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -221,6 +221,13 @@ def test_e2e_basic_scale_up_down(min_replicas, serve_instance):
         graceful_shutdown_timeout_s=1,
         max_concurrent_queries=1000,
         version="v1",
+        ray_actor_options={
+            "runtime_env": {
+                "env_vars": {
+                    "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"
+                }
+            }
+        },
     )
     class A:
         def __call__(self):
@@ -274,6 +281,13 @@ def test_e2e_basic_scale_up_down_with_0_replica(serve_instance, smoothing_factor
         graceful_shutdown_timeout_s=1,
         max_concurrent_queries=1000,
         version="v1",
+        ray_actor_options={
+            "runtime_env": {
+                "env_vars": {
+                    "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"
+                }
+            }
+        },
     )
     class A:
         def __call__(self):
@@ -784,6 +798,13 @@ def test_e2e_intermediate_downscaling(serve_instance):
         graceful_shutdown_timeout_s=1,
         max_concurrent_queries=1000,
         version="v1",
+        ray_actor_options={
+            "runtime_env": {
+                "env_vars": {
+                    "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"
+                }
+            }
+        },
     )
     class A:
         def __call__(self):
@@ -853,6 +874,13 @@ def test_e2e_update_autoscaling_deployment(serve_instance):
                 },
                 "graceful_shutdown_timeout_s": 1,
                 "max_concurrent_queries": 1000,
+                "ray_actor_options": {
+                    "runtime_env": {
+                        "env_vars": {
+                            "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"  # noqa: E501
+                        }
+                    }
+                },
             }
         ],
     }
@@ -955,6 +983,13 @@ def test_e2e_raise_min_replicas(serve_instance):
                 },
                 "graceful_shutdown_timeout_s": 1,
                 "max_concurrent_queries": 1000,
+                "ray_actor_options": {
+                    "runtime_env": {
+                        "env_vars": {
+                            "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"  # noqa: E501
+                        }
+                    }
+                },
             }
         ],
     }

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -221,13 +221,6 @@ def test_e2e_basic_scale_up_down(min_replicas, serve_instance):
         graceful_shutdown_timeout_s=1,
         max_concurrent_queries=1000,
         version="v1",
-        ray_actor_options={
-            "runtime_env": {
-                "env_vars": {
-                    "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"
-                }
-            }
-        },
     )
     class A:
         def __call__(self):
@@ -281,13 +274,6 @@ def test_e2e_basic_scale_up_down_with_0_replica(serve_instance, smoothing_factor
         graceful_shutdown_timeout_s=1,
         max_concurrent_queries=1000,
         version="v1",
-        ray_actor_options={
-            "runtime_env": {
-                "env_vars": {
-                    "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"
-                }
-            }
-        },
     )
     class A:
         def __call__(self):
@@ -721,13 +707,6 @@ def test_e2e_bursty(serve_instance):
         graceful_shutdown_timeout_s=1,
         max_concurrent_queries=1000,
         version="v1",
-        ray_actor_options={
-            "runtime_env": {
-                "env_vars": {
-                    "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"
-                }
-            }
-        },
     )
     class A:
         def __init__(self):
@@ -798,13 +777,6 @@ def test_e2e_intermediate_downscaling(serve_instance):
         graceful_shutdown_timeout_s=1,
         max_concurrent_queries=1000,
         version="v1",
-        ray_actor_options={
-            "runtime_env": {
-                "env_vars": {
-                    "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"
-                }
-            }
-        },
     )
     class A:
         def __call__(self):
@@ -874,13 +846,6 @@ def test_e2e_update_autoscaling_deployment(serve_instance):
                 },
                 "graceful_shutdown_timeout_s": 1,
                 "max_concurrent_queries": 1000,
-                "ray_actor_options": {
-                    "runtime_env": {
-                        "env_vars": {
-                            "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"  # noqa: E501
-                        }
-                    }
-                },
             }
         ],
     }
@@ -983,13 +948,6 @@ def test_e2e_raise_min_replicas(serve_instance):
                 },
                 "graceful_shutdown_timeout_s": 1,
                 "max_concurrent_queries": 1000,
-                "ray_actor_options": {
-                    "runtime_env": {
-                        "env_vars": {
-                            "RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S": "0.1"  # noqa: E501
-                        }
-                    }
-                },
             }
         ],
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I think the autoscaling test `test_e2e_bursty` has become flaky for either of the following reasons (or both):
* `metrics_interval_s` is set to 0.1s in the test, but the metrics are still being recorded on the replica once every 0.5s. Since `metrics_interval_s` is exposed to the user and configurable, the frequency at which we record metrics on the replica should be at least as frequent as what the user sets for `metrics_interval_s`.
* The signal actor is unblocked before it enters the for loop, so requests aren’t queued up on the replica. We will be executing 100 no-ops on the replica, so if metrics are collected at the wrong time then the metrics will tell the controller to scale down.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
