### PR TITLE
[serve] Remove API annotation for `HandleOptions`

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -52,7 +52,7 @@ def _create_or_get_async_loop_in_thread():
 
 
 @dataclass(frozen=True)
-class HandleOptions:
+class _HandleOptions:
     """Options for each ServeHandle instance.
 
     These fields can be changed by calling `.options()` on a handle.
@@ -69,8 +69,8 @@ class HandleOptions:
         multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
         _router_cls: Union[str, DEFAULT] = DEFAULT.VALUE,
-    ) -> "HandleOptions":
-        return HandleOptions(
+    ) -> "_HandleOptions":
+        return _HandleOptions(
             method_name=(
                 self.method_name if method_name == DEFAULT.VALUE else method_name
             ),
@@ -131,12 +131,12 @@ class RayServeHandle:
         self,
         deployment_name: EndpointTag,
         *,
-        handle_options: Optional[HandleOptions] = None,
+        handle_options: Optional[_HandleOptions] = None,
         _router: Optional[Router] = None,
         _is_for_http_requests: bool = False,
     ):
         self.deployment_name = deployment_name
-        self.handle_options = handle_options or HandleOptions()
+        self.handle_options = handle_options or _HandleOptions()
         self._is_for_http_requests = _is_for_http_requests
 
         self.request_counter = metrics.Counter(

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -51,7 +51,6 @@ def _create_or_get_async_loop_in_thread():
     return _global_async_loop
 
 
-@PublicAPI(stability="beta")
 @dataclass(frozen=True)
 class HandleOptions:
     """Options for each ServeHandle instance.

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -9,7 +9,7 @@ import ray
 
 from ray import serve
 from ray.serve.exceptions import RayServeException
-from ray.serve.handle import HandleOptions, RayServeHandle, RayServeSyncHandle
+from ray.serve.handle import _HandleOptions, RayServeHandle, RayServeSyncHandle
 from ray.serve._private.router import PowerOfTwoChoicesReplicaScheduler
 from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING,
@@ -18,7 +18,7 @@ from ray.serve._private.constants import (
 
 
 def test_handle_options():
-    default_options = HandleOptions()
+    default_options = _HandleOptions()
     assert default_options.method_name == "__call__"
     assert default_options.multiplexed_model_id == ""
     assert default_options.stream is False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is not actually exposed as a public API, it's an internal wrapper for implementing the `handle.options()` API call.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
