### PR TITLE
[train] group consecutive workers by IP

### DIFF
--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -129,9 +129,10 @@ class BackendExecutor:
         # trainable, thus allowing for lazy checkpoint transfer to be used.
         # See https://github.com/ray-project/ray/issues/33073
         # for more context.
-        # TODO remove
-        if self._trial_info and self._trial_info.driver_ip:
-            self.worker_group._move_workers_with_ip_to_front(self._trial_info.driver_ip)
+        # TODO remove passing in trial_driver_ip.
+
+        trial_driver_ip = self._trial_info.driver_ip if self._trial_info else None
+        self.worker_group.group_workers_by_ip(trial_driver_ip)
 
         worker_locs = [
             f"{w.metadata.pid} ({w.metadata.node_ip})"

--- a/python/ray/train/tests/test_backend.py
+++ b/python/ray/train/tests/test_backend.py
@@ -163,7 +163,7 @@ def test_node_ranks(ray_2_node_2_cpu):
             return train.get_context().get_node_rank()
 
         e.start_training(train_func, datasets={}, data_config=DataConfig())
-        assert list(e.finish_training()) == [0, 1, 0]
+        assert list(e.finish_training()) == [0, 0, 1]
 
 
 def test_train_failure(ray_start_2_cpus):

--- a/python/ray/train/tests/test_backend.py
+++ b/python/ray/train/tests/test_backend.py
@@ -150,7 +150,7 @@ def test_local_world_size(ray_2_node_2_cpu):
             return train.get_context().get_local_world_size()
 
         e.start_training(train_func, datasets={}, data_config=DataConfig())
-        assert list(e.finish_training()) == [2, 1, 2]
+        assert list(e.finish_training()) == [2, 2, 1]
 
 
 def test_node_ranks(ray_2_node_2_cpu):

--- a/python/ray/train/tests/test_worker_group.py
+++ b/python/ray/train/tests/test_worker_group.py
@@ -81,7 +81,7 @@ def test_execute_args(ray_start_2_cpus):
     assert all(o == 1 for o in outputs)
 
 
-def test_group_workers_by_ip():
+def test_group_workers_by_ip(ray_start_2_cpus):
     
     def create_worker_group(ips):
         wg = WorkerGroup(num_workers=2)

--- a/python/ray/train/tests/test_worker_group.py
+++ b/python/ray/train/tests/test_worker_group.py
@@ -82,7 +82,6 @@ def test_execute_args(ray_start_2_cpus):
 
 
 def test_group_workers_by_ip(ray_start_2_cpus):
-    
     def create_worker_group(ips):
         wg = WorkerGroup(num_workers=2)
         wg.workers = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Some libraries (e.g. Deepspeed) may have expectations that consecutive global rank workers will have the same ordering of local ranks.

In general, this should also make debugging things slightly easier.

### Logic

For now, I did the simplest implementation which is to retain the original sequencing of IPs (i.e. node rank), and group the IPs together.

```
group_workers_by_ip()

[2, 3, 2, 4, 2, 1, 3] --> [2, 2, 2, 3, 3, 4, 1]
```


This extends existing logic which moves existing logic which moves workers from the Driver IP to the front of the list. Based on this existing, I assuming that moving workers around here is generally safe. The `"LOCAL_RANK"` and (world) `"RANK"` will be calculated from the final list.

```
group_workers_by_ip(4)

[2, 3, 2, 4, 2, 1, 3] --> [4, 2, 2, 2, 3, 3, 1]
```

**Note:** This logic can be extended in the future if new requirements come up, e.g. if the IPs need to be sorted by a certain order.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
