### PR TITLE
[air] New `train.Checkpoint` API: Update lightning, transformers, and tf integrations

### DIFF
--- a/python/ray/air/integrations/keras.py
+++ b/python/ray/air/integrations/keras.py
@@ -3,7 +3,8 @@ from typing import Dict, List, Optional, Union
 from tensorflow.keras.callbacks import Callback as KerasCallback
 
 import ray
-from ray.train.tensorflow import LegacyTensorflowCheckpoint
+from ray.train._internal.storage import _use_storage_context
+from ray.train.tensorflow import TensorflowCheckpoint, LegacyTensorflowCheckpoint
 from ray.util.annotations import PublicAPI, Deprecated
 
 
@@ -157,11 +158,13 @@ class ReportCheckpointCallback(_Callback):
 
         metrics = self._get_reported_metrics(logs)
 
-        if when in self._checkpoint_on:
-            checkpoint = LegacyTensorflowCheckpoint.from_model(self.model)
-        else:
-            checkpoint = None
-
+        should_checkpoint = when in self._checkpoint_on
+        checkpoint = None
+        if should_checkpoint:
+            if _use_storage_context():
+                checkpoint = TensorflowCheckpoint.from_model(self.model)
+            else:
+                checkpoint = LegacyTensorflowCheckpoint.from_model(self.model)
         ray.train.report(metrics, checkpoint=checkpoint)
 
     def _get_reported_metrics(self, logs: Dict) -> Dict:

--- a/python/ray/train/backend.py
+++ b/python/ray/train/backend.py
@@ -79,6 +79,7 @@ class Backend(metaclass=Singleton):
         Session API is available at this point."""
         pass
 
+    # TODO(justinvyu): [code_removal]
     @classmethod
     def _encode_data(cls, checkpoint: Checkpoint) -> Checkpoint:
         """Temporary method until ``encode_data`` is deprecated."""

--- a/python/ray/train/horovod/config.py
+++ b/python/ray/train/horovod/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import ray
 from ray.air.checkpoint import Checkpoint
 from ray.train.backend import BackendConfig, Backend, _warn_about_bad_checkpoint_type
+from ray.train._internal.storage import _use_storage_context
 from ray.train._internal.utils import update_env_vars
 from ray.train._internal.worker_group import WorkerGroup, Worker
 
@@ -144,8 +145,12 @@ class _HorovodBackend(Backend):
 
         worker_group.execute(update_env_vars, coordinator_envs)
 
+    # TODO(justinvyu): [code_removal]
     @classmethod
     def _encode_data(cls, checkpoint: Checkpoint):
+        if _use_storage_context():
+            return checkpoint
+
         checkpoint = super()._encode_data(checkpoint)
         if type(checkpoint) is Checkpoint:
             if checkpoint.get_internal_representation()[0] == "data_dict":

--- a/python/ray/train/huggingface/transformers/_transformers_utils.py
+++ b/python/ray/train/huggingface/transformers/_transformers_utils.py
@@ -8,13 +8,16 @@ from tempfile import TemporaryDirectory
 from torch.utils.data import DataLoader, Dataset, IterableDataset
 
 import ray
-from ray.air import session
+from ray import train
 from ray.data import DataIterator
 from ray.data.iterator import _IterableFromIterator
 from ray.data.dataset import MaterializedDataset
 from ray.data._internal.iterator.stream_split_iterator import StreamSplitDataIterator
 from ray.train import Checkpoint
+from ray.train._checkpoint import Checkpoint as NewCheckpoint
+from ray.train._internal.storage import _use_storage_context
 from ray.train.huggingface.transformers.transformers_checkpoint import (
+    TransformersCheckpoint,
     LegacyTransformersCheckpoint,
 )
 from ray.util import PublicAPI
@@ -195,14 +198,17 @@ class TrainReportCallback(TrainerCallback):
             transformers.trainer.get_last_checkpoint(args.output_dir)
         ).absolute()
         if checkpoint_path:
-            # Use LegacyTransformersCheckpoint here to avoid a warning in _TrainSession
-            self.delayed_report[
-                "checkpoint"
-            ] = LegacyTransformersCheckpoint.from_directory(str(checkpoint_path))
+            if _use_storage_context():
+                checkpoint = TransformersCheckpoint.from_directory(str(checkpoint_path))
+            else:
+                checkpoint = LegacyTransformersCheckpoint.from_directory(
+                    str(checkpoint_path)
+                )
+            self.delayed_report["checkpoint"] = checkpoint
 
     def _report(self):
         if self.delayed_report["metrics"]:
-            session.report(**self.delayed_report)
+            train.report(**self.delayed_report)
             self.last_metrics = self.delayed_report["metrics"]
             self.delayed_report = {"metrics": {}, "checkpoint": None}
 
@@ -270,7 +276,10 @@ class RayTrainReportCallback(TrainerCallback):
             source_ckpt_path = transformers.trainer.get_last_checkpoint(args.output_dir)
             target_ckpt_path = os.path.join(tmpdir, "checkpoint")
             shutil.copytree(source_ckpt_path, target_ckpt_path)
-            checkpoint = Checkpoint.from_directory(tmpdir)
+            if _use_storage_context():
+                checkpoint = NewCheckpoint.from_directory(tmpdir)
+            else:
+                checkpoint = Checkpoint.from_directory(tmpdir)
 
             # Report latest metrics and checkpoint to Ray Train
             ray.train.report(metrics=metrics, checkpoint=checkpoint)

--- a/python/ray/train/tensorflow/config.py
+++ b/python/ray/train/tensorflow/config.py
@@ -7,6 +7,7 @@ from typing import List
 import ray
 from ray.air.checkpoint import Checkpoint
 from ray.train.backend import BackendConfig, Backend, _warn_about_bad_checkpoint_type
+from ray.train._internal.storage import _use_storage_context
 from ray.train._internal.utils import get_address_and_port
 from ray.train._internal.worker_group import WorkerGroup
 from ray.train.tensorflow.tensorflow_checkpoint import LegacyTensorflowCheckpoint
@@ -62,8 +63,12 @@ class _TensorflowBackend(Backend):
             )
         ray.get(setup_futures)
 
+    # TODO(justinvyu): [code_removal]
     @classmethod
     def _encode_data(cls, checkpoint: Checkpoint):
+        if _use_storage_context():
+            return checkpoint
+
         checkpoint = super()._encode_data(checkpoint)
         if type(checkpoint) is Checkpoint:
             _warn_about_bad_checkpoint_type(LegacyTensorflowCheckpoint)

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -8,6 +8,7 @@ import ray
 from ray.air.checkpoint import Checkpoint
 from ray.train.backend import BackendConfig, Backend, _warn_about_bad_checkpoint_type
 from ray.train.constants import DEFAULT_NCCL_SOCKET_IFNAME
+from ray.train._internal.storage import _use_storage_context
 from ray.train._internal.worker_group import WorkerGroup
 from ray.train._internal.utils import get_address_and_port
 from ray.train.torch.torch_checkpoint import LegacyTorchCheckpoint
@@ -217,8 +218,12 @@ class _TorchBackend(Backend):
     ):
         worker_group.execute(_set_torch_distributed_env_vars)
 
+    # TODO(justinvyu): [code_removal]
     @classmethod
     def _encode_data(cls, checkpoint: Checkpoint):
+        if _use_storage_context():
+            return checkpoint
+
         checkpoint = super()._encode_data(checkpoint)
         if type(checkpoint) is Checkpoint:
             _warn_about_bad_checkpoint_type(LegacyTorchCheckpoint)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR updates `LightningTrainer`, `TransformersTrainer`, and the TF/Keras `ReportCheckpointCallback` to report a new `FrameworkCheckpoint` (from https://github.com/ray-project/ray/pull/38452) when the feature flag is enabled. The callbacks for the new torch integration APIs are also updated to return a new `Checkpoint` rather than the old `air.Checkpoint`.

This PR also makes `Backend._encode_data` a noop for all frameworks. This is not needed with the new checkpoints.

### Notes

* I am *not* changing the legacy trainers to report a generic `Checkpoint` because the lightning/transformers trainers are being deprecated soon, and it's ok to just keep the legacy behavior for them. (Otherwise, there'd be a bunch of unnecessary updates to make.)
* I am reporting the new `TensorflowCheckpoint` in `ReportCheckpointCallback`. This is because it's also a checkpoint that we create for the user, so the user may need some accessors to get stuff out of it. **Another option is to add a getter to `ReportCheckpointCallback` (similar to `XGBoostTrainer.get_model`) and just return a generic `Checkpoint`.**

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/38292

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
