### PR TITLE
[tune] Replace deprecated np.bool8

### DIFF
--- a/python/ray/tune/logger/aim.py
+++ b/python/ray/tune/logger/aim.py
@@ -54,7 +54,7 @@ class AimLoggerCallback(LoggerCallback):
     """
 
     VALID_HPARAMS = (str, bool, int, float, list, type(None))
-    VALID_NP_HPARAMS = (np.bool8, np.float32, np.float64, np.int32, np.int64)
+    VALID_NP_HPARAMS = (np.bool_, np.float32, np.float64, np.int32, np.int64)
 
     def __init__(
         self,

--- a/python/ray/tune/logger/tensorboardx.py
+++ b/python/ray/tune/logger/tensorboardx.py
@@ -38,7 +38,7 @@ class TBXLogger(Logger):
     """
 
     VALID_HPARAMS = (str, bool, int, float, list, type(None))
-    VALID_NP_HPARAMS = (np.bool8, np.float32, np.float64, np.int32, np.int64)
+    VALID_NP_HPARAMS = (np.bool_, np.float32, np.float64, np.int32, np.int64)
 
     def _init(self):
         try:
@@ -166,7 +166,7 @@ class TBXLoggerCallback(LoggerCallback):
     _SAVED_FILE_TEMPLATES = ["events.out.tfevents.*"]
 
     VALID_HPARAMS = (str, bool, int, float, list, type(None))
-    VALID_NP_HPARAMS = (np.bool8, np.float32, np.float64, np.int32, np.int64)
+    VALID_NP_HPARAMS = (np.bool_, np.float32, np.float64, np.int32, np.int64)
 
     def __init__(self):
         try:

--- a/python/ray/tune/tests/test_logger.py
+++ b/python/ray/tune/tests/test_logger.py
@@ -205,7 +205,7 @@ class LoggerSuite(unittest.TestCase):
             "b": [1, 2],
             "c": {"c": {"D": 123}},
             "d": np.int64(1),
-            "e": np.bool8(True),
+            "e": np.bool_(True),
             "f": None,
         }
         t = Trial(evaluated_params=config, trial_id="tbx", logdir=self.test_dir)
@@ -224,7 +224,7 @@ class LoggerSuite(unittest.TestCase):
             "c": {"c": {"D": 123}},
             "int32": np.int32(1),
             "int64": np.int64(2),
-            "bool8": np.bool8(True),
+            "bool8": np.bool_(True),
             "float32": np.float32(3),
             "float64": np.float64(4),
             "bad": np.float128(4),
@@ -321,7 +321,7 @@ class AimLoggerSuite(unittest.TestCase):
             "c": {"d": {"e": 123}},
             "int32": np.int32(1),
             "int64": np.int64(2),
-            "bool8": np.bool8(True),
+            "bool8": np.bool_(True),
             "float32": np.float32(3),
             "float64": np.float64(4),
             "bad": Dummy(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```
  DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
