### PR TITLE
[Data] Remove `local_uri` in `reader_args` to avoid error when using pyarrow's `read_csv` method.

### DIFF
--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -32,6 +32,10 @@ class CSVDatasource(FileBasedDatasource):
         import pyarrow as pa
         from pyarrow import csv
 
+        # Remove local_uri from reader_args to avoid error in open_csv
+        if "local_uri" in reader_args:
+            reader_args.pop("local_uri")
+
         read_options = reader_args.pop(
             "read_options", csv.ReadOptions(use_threads=False)
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR fixes the issue https://github.com/ray-project/ray/issues/35133

Basically, when submitting a ray job to a ray cluster with local file: 'local://LOCAL_FILE_PATH', `reader_args` is passed to pyarrow.csv's `read_csv` method.
`reader_args` contain `local_uri` keyword, so that the `{'local_uri':True}` is passed onto pyarrow.csv's `read_csv` where the `read_csv` does not accept `local_uri` keyword.

Thus, the PR simply removes the `local_uri` in `reader_args` dict, if one exists.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #35133 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
