### PR TITLE
[ci] mark rllib ddpg tests as unstable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4026,6 +4026,7 @@
   working_dir: rllib_tests
 
   frequency: nightly
+  stable: false
   team: rllib
 
   cluster:
@@ -4056,6 +4057,7 @@
   working_dir: rllib_tests
 
   frequency: nightly
+  stable: false
   team: rllib
   python: "3.8"
   cluster:


### PR DESCRIPTION
Mark the two rllib ddpg tests as unstable as they are currently failing, but they should not be release blockers

Test: 
- CI