### PR TITLE
[ci][core][autoscaler] Deflaky e2e test with async wait 

### DIFF
--- a/python/ray/autoscaler/v2/tests/test_e2e.py
+++ b/python/ray/autoscaler/v2/tests/test_e2e.py
@@ -193,7 +193,7 @@ def test_placement_group_removal_idle_node():
                 assert node.resource_usage.idle_time_ms >= 1000
 
             return True
-        
+
         wait_for_condition(verify)
     finally:
         ray.shutdown()

--- a/python/ray/autoscaler/v2/tests/test_e2e.py
+++ b/python/ray/autoscaler/v2/tests/test_e2e.py
@@ -181,16 +181,20 @@ def test_placement_group_removal_idle_node():
         time.sleep(2)
         remove_placement_group(pg)
 
-        time.sleep(1)
         from ray.autoscaler.v2.sdk import get_cluster_status
 
-        cluster_state = get_cluster_status()
+        def verify():
+            cluster_state = get_cluster_status()
 
-        # Verify that nodes are idle.
-        assert len((cluster_state.healthy_nodes)) == 3
-        for node in cluster_state.healthy_nodes:
-            assert node.node_status == "IDLE"
-            assert node.resource_usage.idle_time_ms >= 1000
+            # Verify that nodes are idle.
+            assert len((cluster_state.healthy_nodes)) == 3
+            for node in cluster_state.healthy_nodes:
+                assert node.node_status == "IDLE"
+                assert node.resource_usage.idle_time_ms >= 1000
+
+            return True
+        
+        wait_for_condition(verify)
     finally:
         ray.shutdown()
         cluster.shutdown()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Closes https://github.com/ray-project/ray/issues/38181
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
