### PR TITLE
[Serve] Handle actor restarts during memory profiling

### DIFF
--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -261,6 +261,7 @@ def configure_component_memory_profiler(
                     suffix=f"_memray_{restart_counter}.bin",
                 )
                 memray_file_path = os.path.join(logs_dir, memray_file_name)
+                restart_counter += 1
 
             # Memray usually tracks the memory usage of only a block of code
             # within a context manager. We explicitly call __enter__ here

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -246,9 +246,21 @@ def configure_component_memory_profiler(
                 component_name=component_name,
                 component_id=component_id,
                 component_type=component_type,
-                suffix="_memray.bin",
+                suffix="_memray_0.bin",
             )
             memray_file_path = os.path.join(logs_dir, memray_file_name)
+
+            # If the actor restarted, memray requires a new file to start
+            # tracking memory.
+            restart_counter = 1
+            while os.path.exists(memray_file_path):
+                memray_file_name = get_component_log_file_name(
+                    component_name=component_name,
+                    component_id=component_id,
+                    component_type=component_type,
+                    suffix=f"_memray_{restart_counter}.bin",
+                )
+                memray_file_path = os.path.join(logs_dir, memray_file_name)
 
             # Memray usually tracks the memory usage of only a block of code
             # within a context manager. We explicitly call __enter__ here


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When memory profiling is enabled and Serve actors restart, they attempt to use the same memray file that they used before crashing. This causes memray to raise an error, and the Serve actors crash again, entering a crash loop.

This change makes the memray file change whenever an actor restarts.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
