### PR TITLE
[Data] Change FileMetadataShuffler interface to take tuple

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -513,10 +513,10 @@ class _FileBasedDatasourceReader(Reader):
         reader_args = self._reader_args
         partitioning = self._partitioning
 
-        paths, file_sizes = self._file_metadata_shuffler.shuffle_files(
-            self._paths,
-            self._file_sizes,
+        paths_and_sizes = self._file_metadata_shuffler.shuffle_files(
+            list(zip(self._paths, self._file_sizes))
         )
+        paths, file_sizes = list(map(list, zip(*paths_and_sizes)))
 
         read_stream = self._delegate._read_stream
         filesystem = _wrap_s3_serialization_workaround(self._filesystem)

--- a/python/ray/data/datasource/file_metadata_shuffler.py
+++ b/python/ray/data/datasource/file_metadata_shuffler.py
@@ -12,17 +12,15 @@ class FileMetadataShuffler:
 
     def shuffle_files(
         self,
-        paths: List[str],
-        file_sizes: List[int],
-    ) -> Tuple[List[str], List[int]]:
+        paths_and_sizes: List[Tuple[str, int]],
+    ) -> List[Tuple[str, int]]:
         """Shuffle files in the given paths and sizes.
 
         Args:
-            paths: The file paths to shuffle.
-            file_sizes: The size of file paths, corresponding to `paths`.
+            paths_and_sizes: The file paths and file sizes to shuffle.
 
         Returns:
-            The file paths and their size after shuffling.
+            The file paths and their sizes after shuffling.
         """
         raise NotImplementedError
 
@@ -30,8 +28,7 @@ class FileMetadataShuffler:
 class SequentialFileMetadataShuffler(FileMetadataShuffler):
     def shuffle_files(
         self,
-        paths: List[str],
-        file_sizes: List[int],
-    ) -> Tuple[List[str], List[int]]:
+        paths_and_sizes: List[Tuple[str, int]],
+    ) -> List[Tuple[str, int]]:
         """Return files in the given paths and sizes sequentially."""
-        return (paths, file_sizes)
+        return paths_and_sizes


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
This is a followup of https://github.com/ray-project/ray/pull/38373, to change interface of `FileMetadataShuffler` to take tuple instead of two lists. This guarantees the paths and sizes are the same length from API perspective.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
