### PR TITLE
[serve] Clean up `asyncio.Event`s used in `LongPollHost` when the client times out

### DIFF
--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -6,7 +6,7 @@ from enum import Enum, auto
 import logging
 import os
 import random
-from typing import Any, Tuple, Callable, DefaultDict, Dict, Set, Union
+from typing import Any, Callable, DefaultDict, Dict, Optional, Set, Tuple, Union
 from ray._private.utils import get_or_create_event_loop
 
 from ray.serve._private.common import ReplicaName
@@ -197,7 +197,7 @@ class LongPollHost:
     the object is updated.
     """
 
-    def __init__(self):
+    def __init__(self, listen_for_change_request_timeout_s: Tuple[int, int] = LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S):
         # Map object_key -> int
         self.snapshot_ids: DefaultDict[KeyType, int] = defaultdict(
             lambda: random.randint(0, 1_000_000)
@@ -208,6 +208,17 @@ class LongPollHost:
         self.notifier_events: DefaultDict[KeyType, Set[asyncio.Event]] = defaultdict(
             set
         )
+
+        self._listen_for_change_request_timeout_s = listen_for_change_request_timeout_s
+
+    def _get_num_notifier_events(self, key: Optional[KeyType] = None):
+        """Used for testing."""
+        if key is not None:
+            return len(self.notifier_events[key])
+        else:
+            return sum(
+                len(events) for events in self.notifier_events.values()
+            )
 
     async def listen_for_change(
         self,
@@ -233,33 +244,33 @@ class LongPollHost:
             return client_outdated_keys
 
         # Otherwise, register asyncio events to be waited.
+        async_task_to_events = {}
         async_task_to_watched_keys = {}
         for key in watched_keys:
-            # Create a new asyncio event for this key
+            # Create a new asyncio event for this key.
             event = asyncio.Event()
 
             # Make sure future caller of notify_changed will unblock this
             # asyncio Event.
             self.notifier_events[key].add(event)
 
-            async def wait_for_event():
-                try:
-                    await event.wait()
-                except asyncio.CancelledError:
-                    if key in self.notifier_events:
-                        self.notifier_events[key].pop(event)
-
             task = get_or_create_event_loop().create_task(event.wait())
+            async_task_to_events[task] = event
             async_task_to_watched_keys[task] = key
 
         done, not_done = await asyncio.wait(
             async_task_to_watched_keys.keys(),
             return_when=asyncio.FIRST_COMPLETED,
-            timeout=random.uniform(*LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S),
+            timeout=random.uniform(*self._listen_for_change_request_timeout_s),
         )
 
         for task in not_done:
             task.cancel()
+            try:
+                event = async_task_to_events[task]
+                self.notifier_events[async_task_to_watched_keys[task]].remove(event)
+            except KeyError:
+                pass
 
         if len(done) == 0:
             return LongPollState.TIME_OUT

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -197,7 +197,12 @@ class LongPollHost:
     the object is updated.
     """
 
-    def __init__(self, listen_for_change_request_timeout_s: Tuple[int, int] = LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S):
+    def __init__(
+        self,
+        listen_for_change_request_timeout_s: Tuple[
+            int, int
+        ] = LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S,
+    ):
         # Map object_key -> int
         self.snapshot_ids: DefaultDict[KeyType, int] = defaultdict(
             lambda: random.randint(0, 1_000_000)
@@ -216,9 +221,7 @@ class LongPollHost:
         if key is not None:
             return len(self.notifier_events[key])
         else:
-            return sum(
-                len(events) for events in self.notifier_events.values()
-            )
+            return sum(len(events) for events in self.notifier_events.values())
 
     async def listen_for_change(
         self,
@@ -270,6 +273,8 @@ class LongPollHost:
                 event = async_task_to_events[task]
                 self.notifier_events[async_task_to_watched_keys[task]].remove(event)
             except KeyError:
+                # Because we use `FIRST_COMPLETED` above, a task in `not_done` may
+                # actually have had its event removed in `notify_changed`.
                 pass
 
         if len(done) == 0:

--- a/python/ray/serve/tests/test_long_poll.py
+++ b/python/ray/serve/tests/test_long_poll.py
@@ -8,7 +8,6 @@ import pytest
 
 import ray
 from ray._private.utils import get_or_create_event_loop
-from ray._private.test_utils import wait_for_condition
 from ray.serve._private.common import EndpointTag, EndpointInfo, RunningReplicaInfo
 from ray.serve._private.long_poll import (
     LongPollClient,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We currently leak `asyncio.Event`s when:

- Clients time out waiting for updates.
- `notify_changed` is never called for that key.

This change removes the events when the timeout happens on the `LongPollHost`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
