### PR TITLE
update names of guides in side nav

### DIFF
--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -62,20 +62,21 @@ parts:
           - file: train/key-concepts
             title: Key Concepts
           - file: train/getting-started-pytorch
-            title: PyTorch
+            title: "PyTorch Guide"
           - file: train/getting-started-pytorch-lightning
-            title: PyTorch Lightning
+            title: "PyTorch Lightning Guide"
           - file: train/getting-started-transformers
-            title: Hugging Face Transformers
+            title: "Hugging Face Transformers Guide"
           - file: train/more-frameworks
             sections:
               - file: train/huggingface-accelerate
-                title: Hugging Face Accelerate
+                title: Hugging Face Accelerate Guide
               - file: train/distributed-tensorflow-keras
-                title: TensorFlow & Keras
+                title: TensorFlow and Keras Guide
               - file: train/distributed-xgboost-lightgbm
-                title: XGBoost & LightGBM
+                title: XGBoost and LightGBM Guide
               - file: train/horovod
+                title: Horovod Guide
           - file: train/user-guides
             title: User Guides
           - file: train/examples

--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -62,11 +62,11 @@ parts:
           - file: train/key-concepts
             title: Key Concepts
           - file: train/getting-started-pytorch
-            title: "PyTorch Guide"
+            title: PyTorch Guide
           - file: train/getting-started-pytorch-lightning
-            title: "PyTorch Lightning Guide"
+            title: PyTorch Lightning Guide
           - file: train/getting-started-transformers
-            title: "Hugging Face Transformers Guide"
+            title: Hugging Face Transformers Guide
           - file: train/more-frameworks
             sections:
               - file: train/huggingface-accelerate

--- a/doc/source/train/user-guides/monitoring-logging.rst
+++ b/doc/source/train/user-guides/monitoring-logging.rst
@@ -1,7 +1,7 @@
 .. _train-monitoring-and-logging:
 
-Monitoring and Logging
-======================
+Monitoring and Logging Metrics
+==============================
 
 Ray Train provides an API for reporting intermediate
 results and checkpoints from the training function (run on distributed workers) up to the


### PR DESCRIPTION

## Why are these changes needed?

More descriptive and consistent naming of Guides.

## Related issue number

https://github.com/ray-project/ray/pull/37892#discussion_r1280121450

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
