### PR TITLE
[Doc] Make vm launcher docs consistent regarding ray team vs community support

### DIFF
--- a/doc/source/cluster/getting-started.rst
+++ b/doc/source/cluster/getting-started.rst
@@ -16,7 +16,7 @@ Where can I deploy Ray clusters?
 
 Ray provides native cluster deployment support on the following technology stacks:
 
-* On :ref:`AWS and GCP <cloud-vm-index>`. Community-supported Azure and Aliyun integrations also exist.
+* On :ref:`AWS and GCP <cloud-vm-index>`. Community-supported Azure, Aliyun and vSphere integrations also exist.
 * On :ref:`Kubernetes <kuberay-index>`, via the officially supported KubeRay project.
 
 Advanced users may want to :ref:`deploy Ray manually <on-prem>`

--- a/doc/source/cluster/vms/getting-started.rst
+++ b/doc/source/cluster/vms/getting-started.rst
@@ -102,8 +102,8 @@ Next, if you're not set up to use your cloud provider from the command line, you
 
          .. tab:: Aliyun
 
-            First, install the Aliyun client package (``pip install aliyun-python-sdk-core aliyun-python-sdk-ecs``).
             Obtain and set the AccessKey pair of the Aliyun account as described in `the docs <https://www.alibabacloud.com/help/en/doc-detail/175967.htm>`__.
+
             Make sure to grant the necessary permissions to the RAM user and set the AccessKey pair in your cluster config file.
             Refer to the provided `aliyun/example-full.yaml </ray/python/ray/autoscaler/aliyun/example-full.yaml>`__ for a sample cluster config.
 

--- a/doc/source/cluster/vms/getting-started.rst
+++ b/doc/source/cluster/vms/getting-started.rst
@@ -24,62 +24,97 @@ Requirements
 To run this demo, you will need:
 
 * Python installed on your development machine (typically your laptop), and
-* an account at your preferred cloud provider (AWS, Azure or GCP).
+* an account at your preferred cloud provider (AWS, GCP, Azure, Aliyun, or vSphere).
 
 Setup
 ~~~~~
 
 Before we start, you will need to install some Python dependencies as follows:
 
-.. tab-set::
+.. tabs::
 
-    .. tab-item:: AWS
+   .. tab:: Ray Team Supported
 
-        .. code-block:: shell
+      .. tabs::
 
-            $ pip install -U "ray[default]" boto3
+         .. tab:: AWS
 
-    .. tab-item:: Azure
+            .. code-block:: shell
 
-        .. code-block:: shell
+                $ pip install -U "ray[default]" boto3
 
-            $ pip install -U "ray[default]" azure-cli azure-core
+         .. tab:: GCP
 
-    .. tab-item:: GCP
+            .. code-block:: shell
 
-        .. code-block:: shell
+                $ pip install -U "ray[default]" google-api-python-client
 
-            $ pip install -U "ray[default]" google-api-python-client
+   .. tab:: Community Supported
 
-    .. tab-item:: vSphere
+      .. tabs::
 
-        .. code-block:: shell
+         .. tab:: Azure
 
-            $ pip install vsphere-automation-sdk-python
+            .. code-block:: shell
+
+                $ pip install -U "ray[default]" azure-cli azure-core
+
+         .. tab:: Aliyun
+
+            .. code-block:: shell
+
+                $ pip install -U "ray[default]" aliyun-python-sdk-core aliyun-python-sdk-ecs
+            
+            Aliyun Cluster Launcher Maintainers (GitHub handles): @zhuangzhuang131419, @chenk008
+
+         .. tab:: vSphere
+
+            .. code-block:: shell
+
+                $ pip install -U "ray[default]" vsphere-automation-sdk-python
+
+            vSphere Cluster Launcher Maintainers (GitHub handles): @vinodkri, @LaynePeng
+
 
 Next, if you're not set up to use your cloud provider from the command line, you'll have to configure your credentials:
 
-.. tab-set::
+.. tabs::
 
-    .. tab-item:: AWS
+   .. tab:: Ray Team Supported
 
-        Configure your credentials in ``~/.aws/credentials`` as described in `the AWS docs <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html>`_.
+      .. tabs::
 
-    .. tab-item:: Azure
+         .. tab:: AWS
 
-        Log in using ``az login``, then configure your credentials with ``az account set -s <subscription_id>``.
+            Configure your credentials in ``~/.aws/credentials`` as described in `the AWS docs <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html>`_.
 
-    .. tab-item:: GCP
+         .. tab:: GCP
 
-        Set the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable as described in `the GCP docs <https://cloud.google.com/docs/authentication/getting-started>`_.
+            Set the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable as described in `the GCP docs <https://cloud.google.com/docs/authentication/getting-started>`_.
 
-    .. tab-item:: vSphere
-        
-        .. code-block:: shell
+   .. tab:: Community Supported
 
-            $ export VSPHERE_SERVER = 192.168.0.1 # Enter your vSphere IP
-            $ export VSPHERE_USER = user # Enter your user name
-            $ export VSPHERE_PASSWORD = password # Enter your password
+      .. tabs::
+
+         .. tab:: Azure
+
+            Log in using ``az login``, then configure your credentials with ``az account set -s <subscription_id>``.
+
+         .. tab:: Aliyun
+
+            First, install the Aliyun client package (``pip install aliyun-python-sdk-core aliyun-python-sdk-ecs``).
+            Obtain and set the AccessKey pair of the Aliyun account as described in `the docs <https://www.alibabacloud.com/help/en/doc-detail/175967.htm>`__.
+            Make sure to grant the necessary permissions to the RAM user and set the AccessKey pair in your cluster config file.
+            Refer to the provided `aliyun/example-full.yaml </ray/python/ray/autoscaler/aliyun/example-full.yaml>`__ for a sample cluster config.
+
+         .. tab:: vSphere
+
+            .. code-block:: shell
+
+                $ export VSPHERE_SERVER=192.168.0.1 # Enter your vSphere IP
+                $ export VSPHERE_USER=user # Enter your username
+                $ export VSPHERE_PASSWORD=password # Enter your password
+
 
 Create a (basic) Python application
 -----------------------------------
@@ -172,72 +207,86 @@ To start a Ray Cluster, first we need to define the cluster configuration. The c
 
 A minimal sample cluster configuration file looks as follows:
 
-.. tab-set::
+.. tabs::
 
-    .. tab-item:: AWS
+   .. tab:: Ray Team Supported
 
-        .. literalinclude:: ../../../../python/ray/autoscaler/aws/example-minimal.yaml
-            :language: yaml
+      .. tabs::
 
+         .. tab:: AWS
 
-    .. tab-item:: Azure
+            .. literalinclude:: ../../../../python/ray/autoscaler/aws/example-minimal.yaml
+               :language: yaml
 
-        .. code-block:: yaml
+         .. tab:: GCP
 
-            # An unique identifier for the head node and workers of this cluster.
-            cluster_name: minimal
+            .. code-block:: yaml
 
-            # Cloud-provider specific configuration.
-            provider:
-                type: azure
-                location: westus2
-                resource_group: ray-cluster
+                # A unique identifier for the head node and workers of this cluster.
+                cluster_name: minimal
 
-            # How Ray will authenticate with newly launched nodes.
-            auth:
-                ssh_user: ubuntu
-                # you must specify paths to matching private and public key pair files
-                # use `ssh-keygen -t rsa -b 4096` to generate a new ssh key pair
-                ssh_private_key: ~/.ssh/id_rsa
-                # changes to this should match what is specified in file_mounts
-                ssh_public_key: ~/.ssh/id_rsa.pub
+                # Cloud-provider specific configuration.
+                provider:
+                    type: gcp
+                    region: us-west1
 
-    .. tab-item:: GCP
+   .. tab:: Community Supported
 
-        .. code-block:: yaml
+      .. tabs::
 
-            # A unique identifier for the head node and workers of this cluster.
-            cluster_name: minimal
+         .. tab:: Azure
 
-            # Cloud-provider specific configuration.
-            provider:
-                type: gcp
-                region: us-west1
+            .. code-block:: yaml
 
-    .. tab-item:: vSphere
+                # An unique identifier for the head node and workers of this cluster.
+                cluster_name: minimal
 
-        .. code-block:: yaml
+                # Cloud-provider specific configuration.
+                provider:
+                    type: azure
+                    location: westus2
+                    resource_group: ray-cluster
 
-            # A unique identifier for the head node and workers of this cluster.
-            cluster_name: minimal
+                # How Ray will authenticate with newly launched nodes.
+                auth:
+                    ssh_user: ubuntu
+                    # you must specify paths to matching private and public key pair files
+                    # use `ssh-keygen -t rsa -b 4096` to generate a new ssh key pair
+                    ssh_private_key: ~/.ssh/id_rsa
+                    # changes to this should match what is specified in file_mounts
+                    ssh_public_key: ~/.ssh/id_rsa.pub
 
-            # Cloud-provider specific configuration.
-            provider:
-                type: vsphere
-            
-            auth:
-                ssh_user: ray # The VMs are initialised with an user called ray. 
+         .. tab:: Aliyun
 
-            available_node_types:
-                ray.head.default:
-                    node_config:
-                        resource_pool: ray # Resource pool where the Ray cluster will get created
-                        library_item: ray-head-debian # OVF file name from which the head will be created
+            Please refer to `example-full.yaml </ray/python/ray/autoscaler/aliyun/example-full.yaml>`__. 
 
-                worker:
-                    node_config:
-                        clone: True # If True, all the workers will be instant-cloned from a frozen VM
-                        library_item: ray-frozen-debian # The OVF file from which a frozen VM will be created
+            Make sure your account balance is not less than 100 RMB, otherwise you will receive the error `InvalidAccountStatus.NotEnoughBalance`.
+
+         .. tab:: vSphere
+
+            .. code-block:: yaml
+
+                # A unique identifier for the head node and workers of this cluster.
+                cluster_name: minimal
+
+                # Cloud-provider specific configuration.
+                provider:
+                    type: vsphere
+                
+                auth:
+                    ssh_user: ray # The VMs are initialised with an user called ray. 
+
+                available_node_types:
+                    ray.head.default:
+                        node_config:
+                            resource_pool: ray # Resource pool where the Ray cluster will get created
+                            library_item: ray-head-debian # OVF file name from which the head will be created
+
+                    worker:
+                        node_config:
+                            clone: True # If True, all the workers will be instant-cloned from a frozen VM
+                            library_item: ray-frozen-debian # The OVF file from which a frozen VM will be created
+
 
 Save this configuration file as ``config.yaml``. You can specify a lot more details in the configuration file: instance types to use, minimum and maximum number of workers to start, autoscaling strategy, files to sync, and more. For a full reference on the available configuration properties, please refer to the :ref:`cluster YAML configuration options reference <cluster-config>`.
 

--- a/doc/source/cluster/vms/index.md
+++ b/doc/source/cluster/vms/index.md
@@ -4,7 +4,7 @@
 ## Overview
 
 In this section we cover how to launch Ray clusters on Cloud VMs. Ray ships with built-in support
-for launching AWS and GCP clusters, and also has community-maintained integrations for Azure and Aliyun.
+for launching AWS and GCP clusters, and also has community-maintained integrations for Azure, Aliyun and vSphere.
 Each Ray cluster consists of a head node and a collection of worker nodes. Optional
 [autoscaling](vms-autoscaling) support allows the Ray cluster to be sized according to the
 requirements of your Ray workload, adding and removing worker nodes as needed. Ray supports


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Add back Aliyun cluster launcher documentation that was removed (not sure why, I'm guessing it got lost in the shuffle when the cluster docs were reorganized last year.)
- Group cluster launcher tabs into "Ray Team Supported" and "Community Supported"
- Add vSphere to lists of community-supported cluster launchers

This makes the type of support more clear to users. This is what the tabs look like:

<img width="848" alt="Screenshot 2023-08-16 at 3 45 34 PM" src="https://github.com/ray-project/ray/assets/5459654/1a0e1d65-56b3-44cd-86df-5ba2a05f18f5">
<img width="772" alt="Screenshot 2023-08-16 at 3 46 06 PM" src="https://github.com/ray-project/ray/assets/5459654/4b2ee596-d974-4282-930b-a55fe4ead91f">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
