### PR TITLE
Update unaccounted tooltip to make it more clear that these old tasks did not get killed by ray

### DIFF
--- a/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
+++ b/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
@@ -165,7 +165,11 @@ export const ProgressBar = ({
           {
             value: finalTotal - segmentTotal,
             label: unaccountedLabel ?? "Unaccounted",
-            hint: "Unaccounted tasks can happen when there are too many tasks. Ray drops older tasks to conserve memory.",
+            hint:
+              "Unaccounted tasks can happen when there are too many tasks for the Ray Dashboard " +
+              "to keep track of. Ray Dashboard will garbage collect old task data to conserve memory.\n" +
+              "NOTE: This is only an UI limitation. Ray Dashboard only garbage collects tasks that have " +
+              "already finished or errored.",
             color: "#EEEEEE",
           },
         ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Users were getting confused that ray core was actually being overloaded and their tasks were being killed mid-execution.

Screenshot coming. Need to debug why `num_filtered` value seems to have changed.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
