### PR TITLE
[docs] add huggingface tag to gptj-fine-tuning example

### DIFF
--- a/doc/source/ray-overview/examples.rst
+++ b/doc/source/ray-overview/examples.rst
@@ -61,7 +61,7 @@ Ray Examples
         How OpenAI Uses Ray to Train Tools like ChatGPT
 
     .. grid-item-card:: :bdg-secondary:`Code example`
-        :class-item: gallery-item llm gen-ai
+        :class-item: gallery-item llm gen-ai huggingface
         :link: /ray-air/examples/gptj_deepspeed_fine_tuning
         :link-type: doc
 


### PR DESCRIPTION
## Why are these changes needed?

In the Examples Gallery, if you filter for HF examples, the GPTJ fine tuning example does not appear, but it is a HF example and one of our best ones so we should tag it as an HF example.


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
