### PR TITLE
[Data] Bump up timeout for test_numpy

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -219,7 +219,7 @@ py_test(
 
 py_test(
     name = "test_numpy",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_numpy.py"],
     tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
See more timeout for `test_numpy`, such as

```
(15:56:39) [269 / 347] 24 / 78 tests; Testing //python/ray/data:test_numpy; 63s local
--
  |  
  | TIMEOUT: //python/ray/data:test_numpy (Summary)
```

So bump up timeout here for test_numpy.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
