### PR TITLE
[DOC] Fix example gallery sidebar scrolling

### DIFF
--- a/doc/source/_static/css/examples.css
+++ b/doc/source/_static/css/examples.css
@@ -1,12 +1,18 @@
 :root {
   --ray-example-gallery-gap-x: 18px;
   --ray-example-gallery-gap-y: 22px;
+  --sidebar-top: 5em;
 }
 
 #site-navigation {
   width: 330px !important;
   border-right: none;
   margin-left: 32px;
+  overflow-y: auto;
+  max-height: calc(100vh - var(--sidebar-top));
+  position: sticky;
+  top: var(--sidebar-top) !important;
+  z-index: 1000;
 }
 
 #site-navigation h5 {


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes some irritating side bar behavior on the example gallery docs page. Currently if your browser's viewport is too short top-to-bottom, the part of the tag filter buttons side bar that you can't see won't scroll into view until you scroll all the way through all the examples in the page. This PR makes it so that the side bar can be scrolled into view if it's too big to fit into the viewport, and as a bonus it also resolves some erratic rendering that happens when the top nav bar gets hidden from view as the user scrolls down.

## Related issue number

Closes https://github.com/ray-project/ray/issues/38531.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
