### PR TITLE
[Core] Unify the way to update local resource view of remote nodes

### DIFF
--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -183,7 +183,6 @@ class MockNodeResourceInfoAccessor : public NodeResourceInfoAccessor {
               (const std::shared_ptr<rpc::ResourcesData> &data_ptr,
                const StatusCallback &callback),
               (override));
-  MOCK_METHOD(void, AsyncReReportResourceUsage, (), (override));
   MOCK_METHOD(Status,
               AsyncGetAllResourceUsage,
               (const ItemCallback<rpc::ResourceUsageBatchData> &callback),

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -732,17 +732,6 @@ Status NodeResourceInfoAccessor::AsyncReportResourceUsage(
   return Status::OK();
 }
 
-void NodeResourceInfoAccessor::AsyncReReportResourceUsage() {
-  absl::MutexLock lock(&mutex_);
-  if (cached_resource_usage_.has_resources()) {
-    RAY_LOG(INFO) << "Rereport resource usage.";
-    FillResourceUsageRequest(cached_resource_usage_);
-    client_impl_->GetGcsRpcClient().ReportResourceUsage(
-        cached_resource_usage_,
-        [](const Status &status, const rpc::ReportResourceUsageReply &reply) {});
-  }
-}
-
 void NodeResourceInfoAccessor::FillResourceUsageRequest(
     rpc::ReportResourceUsageRequest &resources) {
   NodeResources cached_resources = *GetLastResourceUsage();
@@ -755,7 +744,6 @@ void NodeResourceInfoAccessor::FillResourceUsageRequest(
   }
 
   resources_data->clear_resources_available();
-  resources_data->set_resources_available_changed(true);
   for (const auto &resource_pair : cached_resources.available.GetResourceMap()) {
     (*resources_data->mutable_resources_available())[resource_pair.first] =
         resource_pair.second;

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -462,9 +462,6 @@ class NodeResourceInfoAccessor {
       const std::shared_ptr<rpc::ResourcesData> &data_ptr,
       const StatusCallback &callback);
 
-  /// Resend resource usage when GCS restarts from a failure.
-  virtual void AsyncReReportResourceUsage();
-
   /// Return resources in last report. Used by light heartbeat.
   virtual const std::shared_ptr<NodeResources> &GetLastResourceUsage() {
     return last_resource_usage_;

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -615,7 +615,6 @@ TEST_P(GcsClientTest, TestNodeResourceUsageWithLightResourceUsageReport) {
   // Report changed resource usage of a node to GCS.
   auto resource1 = std::make_shared<rpc::ResourcesData>();
   resource1->set_node_id(node_id.Binary());
-  resource1->set_resources_available_changed(true);
   ASSERT_TRUE(ReportResourceUsage(resource1));
 }
 
@@ -632,7 +631,6 @@ TEST_P(GcsClientTest, TestGetAllAvailableResources) {
   auto resource = std::make_shared<rpc::ResourcesData>();
   resource->set_node_id(node_id.Binary());
   // Set this flag to indicate resources has changed.
-  resource->set_resources_available_changed(true);
   (*resource->mutable_resources_available())["CPU"] = 1.0;
   (*resource->mutable_resources_available())["GPU"] = 10.0;
   (*resource->mutable_resources_total())["CPU"] = 1.0;
@@ -645,46 +643,6 @@ TEST_P(GcsClientTest, TestGetAllAvailableResources) {
   EXPECT_EQ(resources[0].resources_available_size(), 2);
   EXPECT_EQ((*resources[0].mutable_resources_available())["CPU"], 1.0);
   EXPECT_EQ((*resources[0].mutable_resources_available())["GPU"], 10.0);
-}
-
-TEST_P(GcsClientTest, TestGetAllAvailableResourcesWithLightResourceUsageReport) {
-  // Register node.
-  auto node_info = Mocker::GenNodeInfo();
-  node_info->mutable_resources_total()->insert({"CPU", 1.0});
-  node_info->mutable_resources_total()->insert({"GPU", 10.0});
-
-  RAY_CHECK(RegisterNode(*node_info));
-
-  // Report resource usage of a node to GCS.
-  NodeID node_id = NodeID::FromBinary(node_info->node_id());
-  auto resource = std::make_shared<rpc::ResourcesData>();
-  resource->set_node_id(node_id.Binary());
-  resource->set_resources_available_changed(true);
-  (*resource->mutable_resources_available())["CPU"] = 1.0;
-  (*resource->mutable_resources_available())["GPU"] = 10.0;
-  (*resource->mutable_resources_total())["CPU"] = 1.0;
-  (*resource->mutable_resources_total())["GPU"] = 10.0;
-  ASSERT_TRUE(ReportResourceUsage(resource));
-
-  // Assert get all available resources right.
-  std::vector<rpc::AvailableResources> resources = GetAllAvailableResources();
-  EXPECT_EQ(resources.size(), 1);
-  EXPECT_EQ(resources[0].resources_available_size(), 2);
-  EXPECT_EQ((*resources[0].mutable_resources_available())["CPU"], 1.0);
-  EXPECT_EQ((*resources[0].mutable_resources_available())["GPU"], 10.0);
-
-  // Report unchanged resource usage of a node to GCS.
-  auto resource1 = std::make_shared<rpc::ResourcesData>();
-  resource1->set_node_id(node_id.Binary());
-  (*resource1->mutable_resources_available())["GPU"] = 8.0;
-  ASSERT_TRUE(ReportResourceUsage(resource1));
-
-  // The value would remain unchanged.
-  std::vector<rpc::AvailableResources> resources1 = GetAllAvailableResources();
-  EXPECT_EQ(resources1.size(), 1);
-  EXPECT_EQ(resources1[0].resources_available_size(), 2);
-  EXPECT_EQ((*resources1[0].mutable_resources_available())["CPU"], 1.0);
-  EXPECT_EQ((*resources1[0].mutable_resources_available())["GPU"], 10.0);
 }
 
 TEST_P(GcsClientTest, TestWorkerInfo) {

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -206,7 +206,7 @@ TEST_P(GlobalStateAccessorTest, TestGetAllResourceUsage) {
   heartbeat2->set_node_id(node_table_data->node_id());
   (*heartbeat2->mutable_resources_total())["CPU"] = 1;
   (*heartbeat2->mutable_resources_total())["GPU"] = 10;
-  heartbeat2->set_resources_available_changed(true);
+  (*heartbeat2->mutable_resources_available())["CPU"] = 1;
   (*heartbeat2->mutable_resources_available())["GPU"] = 5;
   RAY_CHECK_OK(gcs_client_->NodeResources().AsyncReportResourceUsage(
       heartbeat2, [&promise2](Status status) { promise2.set_value(status.ok()); }));
@@ -219,28 +219,8 @@ TEST_P(GlobalStateAccessorTest, TestGetAllResourceUsage) {
   ASSERT_EQ(resources_data.resources_total_size(), 2);
   ASSERT_EQ((*resources_data.mutable_resources_total())["CPU"], 1.0);
   ASSERT_EQ((*resources_data.mutable_resources_total())["GPU"], 10.0);
-  ASSERT_EQ(resources_data.resources_available_size(), 1);
-  ASSERT_EQ((*resources_data.mutable_resources_available())["GPU"], 5.0);
-
-  // Report unchanged resource usage. (Only works with light resource usage report
-  // enabled)
-  std::promise<bool> promise3;
-  auto heartbeat3 = std::make_shared<rpc::ResourcesData>();
-  heartbeat3->set_node_id(node_table_data->node_id());
-  (*heartbeat3->mutable_resources_available())["CPU"] = 1;
-  (*heartbeat3->mutable_resources_available())["GPU"] = 6;
-  RAY_CHECK_OK(gcs_client_->NodeResources().AsyncReportResourceUsage(
-      heartbeat3, [&promise3](Status status) { promise3.set_value(status.ok()); }));
-  WaitReady(promise3.get_future(), timeout_ms_);
-
-  resources = global_state_->GetAllResourceUsage();
-  resource_usage_batch_data.ParseFromString(*resources.get());
-  ASSERT_EQ(resource_usage_batch_data.batch_size(), 1);
-  resources_data = resource_usage_batch_data.mutable_batch()->at(0);
-  ASSERT_EQ(resources_data.resources_total_size(), 2);
-  ASSERT_EQ((*resources_data.mutable_resources_total())["CPU"], 1.0);
-  ASSERT_EQ((*resources_data.mutable_resources_total())["GPU"], 10.0);
-  ASSERT_EQ(resources_data.resources_available_size(), 1);
+  ASSERT_EQ(resources_data.resources_available_size(), 2);
+  ASSERT_EQ((*resources_data.mutable_resources_available())["CPU"], 1.0);
   ASSERT_EQ((*resources_data.mutable_resources_available())["GPU"], 5.0);
 }
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -274,7 +274,6 @@ void GcsResourceManager::UpdateNodeResourceUsage(const NodeID &node_id,
       (*iter->second.mutable_resources_total()) = resources.resources_total();
     }
 
-    RAY_CHECK(resources.resources_available_changed());
     (*iter->second.mutable_resources_available()) = resources.resources_available();
 
     if (resources.resources_normal_task_changed()) {

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -273,9 +273,10 @@ void GcsResourceManager::UpdateNodeResourceUsage(const NodeID &node_id,
     if (resources.resources_total_size() > 0) {
       (*iter->second.mutable_resources_total()) = resources.resources_total();
     }
-    if (resources.resources_available_changed()) {
-      (*iter->second.mutable_resources_available()) = resources.resources_available();
-    }
+
+    RAY_CHECK(resources.resources_available_changed());
+    (*iter->second.mutable_resources_available()) = resources.resources_available();
+
     if (resources.resources_normal_task_changed()) {
       (*iter->second.mutable_resources_normal_task()) = resources.resources_normal_task();
     }

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -135,8 +135,8 @@ void GcsResourceManager::UpdateFromResourceReport(const rpc::ResourcesData &data
   if (RayConfig::instance().gcs_actor_scheduling_enabled()) {
     UpdateNodeNormalTaskResources(node_id, data);
   } else {
-    if (!cluster_resource_manager_.UpdateNodeAvailableResourcesIfExist(
-            scheduling::NodeID(node_id.Binary()), data)) {
+    if (!cluster_resource_manager_.UpdateNode(scheduling::NodeID(node_id.Binary()),
+                                              data)) {
       RAY_LOG(INFO)
           << "[UpdateFromResourceReport]: received resource usage from unknown node id "
           << node_id;

--- a/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
@@ -150,7 +150,6 @@ class GcsAutoscalerStateManagerTest : public ::testing::Test {
       const NodeID &node_id,
       const absl::flat_hash_map<std::string, double> &available_resources,
       const absl::flat_hash_map<std::string, double> &total_resources,
-      bool available_resources_changed,
       int64_t idle_ms = 0,
       bool is_draining = false) {
     rpc::ResourcesData resources_data;
@@ -158,7 +157,6 @@ class GcsAutoscalerStateManagerTest : public ::testing::Test {
                               node_id,
                               available_resources,
                               total_resources,
-                              available_resources_changed,
                               idle_ms,
                               is_draining);
     gcs_resource_manager_->UpdateFromResourceReport(resources_data);
@@ -368,8 +366,7 @@ TEST_F(GcsAutoscalerStateManagerTest, TestNodeAddUpdateRemove) {
   {
     UpdateFromResourceReportSync(NodeID::FromBinary(node->node_id()),
                                  {/* available */ {"CPU", 1.75}},
-                                 /* total*/ {{"CPU", 2}, {"GPU", 1}},
-                                 /* available_changed*/ true);
+                                 /* total*/ {{"CPU", 2}, {"GPU", 1}});
 
     const auto &state = GetClusterResourceStateSync();
     ASSERT_EQ(state.node_states_size(), 1);
@@ -727,7 +724,6 @@ TEST_F(GcsAutoscalerStateManagerTest, TestDrainingStatus) {
   UpdateFromResourceReportSync(NodeID::FromBinary(node->node_id()),
                                {/* available */ {"CPU", 2}, {"GPU", 1}},
                                /* total*/ {{"CPU", 2}, {"GPU", 1}},
-                               /* available_changed*/ true,
                                /* idle_duration_ms */ 10,
                                /* is_draining */ true);
   {
@@ -765,7 +761,6 @@ TEST_F(GcsAutoscalerStateManagerTest, TestIdleTime) {
   UpdateFromResourceReportSync(NodeID::FromBinary(node->node_id()),
                                {/* available */ {"CPU", 2}, {"GPU", 1}},
                                /* total*/ {{"CPU", 2}, {"GPU", 1}},
-                               /* available_changed*/ true,
                                /* idle_duration_ms */ 10);
 
   // Check report idle time is set.

--- a/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
@@ -36,7 +36,6 @@ class GcsResourceManagerTest : public ::testing::Test {
       const NodeID &node_id,
       const absl::flat_hash_map<std::string, double> &available_resources,
       const absl::flat_hash_map<std::string, double> &total_resources,
-      bool available_resources_changed,
       int64_t idle_ms = 0,
       bool is_draining = false) {
     rpc::ResourcesData resources_data;
@@ -44,7 +43,6 @@ class GcsResourceManagerTest : public ::testing::Test {
                               node_id,
                               available_resources,
                               total_resources,
-                              available_resources_changed,
                               idle_ms,
                               is_draining);
     gcs_resource_manager_->UpdateFromResourceReport(resources_data);
@@ -143,7 +141,6 @@ TEST_F(GcsResourceManagerTest, TestSetAvailableResourcesWhenNodeDead) {
   resources_data.set_node_id(node->node_id());
   resources_data.mutable_resources_total()->insert({"CPU", 5});
   resources_data.mutable_resources_available()->insert({"CPU", 5});
-  resources_data.set_resources_available_changed(true);
   gcs_resource_manager_->UpdateFromResourceReport(resources_data);
   ASSERT_EQ(cluster_resource_manager_.GetResourceView().size(), 0);
 }
@@ -175,7 +172,6 @@ TEST_F(GcsResourceManagerTest, TestGetDrainingNodes) {
   UpdateFromResourceReportSync(NodeID::FromBinary(node1->node_id()),
                                {/* available */ {"CPU", 10}},
                                /* total*/ {{"CPU", 10}},
-                               /* available_changed*/ true,
                                /* idle_duration_ms */ 8,
                                /* is_draining */ true);
 
@@ -185,7 +181,6 @@ TEST_F(GcsResourceManagerTest, TestGetDrainingNodes) {
   UpdateFromResourceReportSync(NodeID::FromBinary(node2->node_id()),
                                {/* available */ {"CPU", 1}},
                                /* total*/ {{"CPU", 1}},
-                               /* available_changed*/ true,
                                /* idle_duration_ms */ 5,
                                /* is_draining */ false);
 

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -313,7 +313,6 @@ struct Mocker {
       const NodeID &node_id,
       const absl::flat_hash_map<std::string, double> &available_resources,
       const absl::flat_hash_map<std::string, double> &total_resources,
-      bool available_resources_changed,
       int64_t idle_ms = 0,
       bool is_draining = false) {
     resources_data.set_node_id(node_id.Binary());
@@ -323,7 +322,6 @@ struct Mocker {
     for (const auto &resource : total_resources) {
       (*resources_data.mutable_resources_total())[resource.first] = resource.second;
     }
-    resources_data.set_resources_available_changed(available_resources_changed);
     resources_data.set_idle_duration_ms(idle_ms);
     resources_data.set_is_draining(is_draining);
   }

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -504,13 +504,11 @@ message ResourceLoad {
 }
 
 message ResourcesData {
+  reserved 3;
   // Node id.
   bytes node_id = 1;
   // Resource capacity currently available on this node manager.
   map<string, double> resources_available = 2;
-  // Indicates whether available resources is changed. Only used when light
-  // heartbeat enabled.
-  bool resources_available_changed = 3;
   // Total resource capacity configured for this node manager.
   map<string, double> resources_total = 4;
   // Aggregate outstanding resource load on this node manager.

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -89,6 +89,12 @@ bool ClusterResourceManager::UpdateNode(scheduling::NodeID node_id,
     local_view.object_pulls_queued = resource_data.object_pulls_queued();
   }
 
+  // Update the idle duration for the node in terms of resources usage.
+  local_view.idle_resource_duration_ms = resource_data.idle_duration_ms();
+
+  // Last update time to the local node resources view.
+  local_view.last_resource_update_time = absl::Now();
+
   local_view.is_draining = resource_data.is_draining();
 
   AddOrUpdateNode(node_id, local_view);
@@ -229,39 +235,6 @@ bool ClusterResourceManager::AddNodeAvailableResources(scheduling::NodeID node_i
       node_resources->available.Set(resource_id, new_available);
     }
   }
-  return true;
-}
-
-bool ClusterResourceManager::UpdateNodeAvailableResourcesIfExist(
-    scheduling::NodeID node_id, const rpc::ResourcesData &resource_data) {
-  auto iter = nodes_.find(node_id);
-  if (iter == nodes_.end()) {
-    return false;
-  }
-
-  if (!resource_data.resources_available_changed()) {
-    return true;
-  }
-
-  auto resources =
-      ResourceMapToResourceRequest(MapFromProtobuf(resource_data.resources_available()),
-                                   /*requires_object_store_memory=*/false);
-  auto node_resources = iter->second.GetMutableLocalView();
-  // Note, by iterating over "total", we only update existing resources.
-  // Do not iterating over "available", because some resources may have been removed
-  // from available.
-  for (auto &resource_id : node_resources->total.ResourceIds()) {
-    node_resources->available.Set(resource_id, resources.Get(resource_id));
-  }
-
-  // Update the idle duration for the node in terms of resources usage.
-  node_resources->idle_resource_duration_ms = resource_data.idle_duration_ms();
-
-  // Last update time to the local node resources view.
-  node_resources->last_resource_update_time = absl::Now();
-
-  node_resources->is_draining = resource_data.is_draining();
-
   return true;
 }
 

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -84,7 +84,6 @@ bool ClusterResourceManager::UpdateNode(scheduling::NodeID node_id,
   RAY_CHECK(GetNodeResources(node_id, &local_view));
 
   local_view.total = node_resources.total;
-  RAY_CHECK(resource_data.resources_available_changed())
   local_view.available = node_resources.available;
   local_view.object_pulls_queued = resource_data.object_pulls_queued();
 

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -84,10 +84,9 @@ bool ClusterResourceManager::UpdateNode(scheduling::NodeID node_id,
   RAY_CHECK(GetNodeResources(node_id, &local_view));
 
   local_view.total = node_resources.total;
-  if (resource_data.resources_available_changed()) {
-    local_view.available = node_resources.available;
-    local_view.object_pulls_queued = resource_data.object_pulls_queued();
-  }
+  RAY_CHECK(resource_data.resources_available_changed())
+  local_view.available = node_resources.available;
+  local_view.object_pulls_queued = resource_data.object_pulls_queued();
 
   // Update the idle duration for the node in terms of resources usage.
   local_view.idle_resource_duration_ms = resource_data.idle_duration_ms();

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -109,15 +109,6 @@ class ClusterResourceManager {
   bool AddNodeAvailableResources(scheduling::NodeID node_id,
                                  const ResourceSet &resource_set);
 
-  /// Update node available resources.
-  /// NOTE: This method only updates the existing resources of the node, and the
-  /// nonexistent resources will be filtered out, whitch is different from `UpdateNode`.
-  /// Return false if such node doesn't exist.
-  /// TODO(Shanly): This method will be replaced with UpdateNode once we have resource
-  /// version.
-  bool UpdateNodeAvailableResourcesIfExist(scheduling::NodeID node_id,
-                                           const rpc::ResourcesData &resource_data);
-
   /// Update node normal task resources.
   /// Return false if such node doesn't exist.
   /// TODO(Shanly): Integrated this method into `UpdateNode` later.

--- a/src/ray/raylet/scheduling/cluster_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager_test.cc
@@ -118,22 +118,6 @@ TEST_F(ClusterResourceManagerTest, SubtractAndAddNodeAvailableResources) {
   ASSERT_TRUE(node_resources.available.Get(ResourceID::CPU()) == 1);
 }
 
-TEST_F(ClusterResourceManagerTest, UpdateNodeAvailableResourcesIfExist) {
-  const auto &node_resources = manager->GetNodeResources(node0);
-  ASSERT_TRUE(node_resources.available.Get(ResourceID::CPU()) == 1);
-
-  rpc::ResourcesData resources_data;
-  resources_data.set_resources_available_changed(true);
-  (*resources_data.mutable_resources_available())["CPU"] = 0;
-
-  manager->UpdateNodeAvailableResourcesIfExist(node0, resources_data);
-  ASSERT_TRUE(node_resources.available.Get(ResourceID::CPU()) == 0);
-
-  (*resources_data.mutable_resources_available())["CUSTOM_RESOURCE"] = 1;
-  manager->UpdateNodeAvailableResourcesIfExist(node0, resources_data);
-  ASSERT_FALSE(node_resources.total.Has(ResourceID("CUSTOM_RESOURCE")));
-}
-
 TEST_F(ClusterResourceManagerTest, UpdateNodeNormalTaskResources) {
   const auto &node_resources = manager->GetNodeResources(node0);
   ASSERT_TRUE(node_resources.normal_task_resources.IsEmpty());

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -39,13 +39,6 @@ using namespace std;
     ASSERT_EQ(total[kCPU_ResourceLabel], expected_total);             \
   }
 
-#define ASSERT_RESOURCES_EMPTY(data)                   \
-  {                                                    \
-    ASSERT_FALSE(data->resources_available_changed()); \
-    ASSERT_TRUE(data->resources_available().empty());  \
-    ASSERT_TRUE(data->resources_total().empty());      \
-  }
-
 namespace ray {
 
 namespace scheduling {

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -429,8 +429,6 @@ std::optional<syncer::RaySyncMessage> LocalResourceManager::CreateSyncMessage(
     resources_data.set_object_pulls_queued(resources.object_pulls_queued);
   }
 
-  resources_data.set_resources_available_changed(true);
-
   const auto now = absl::Now();
   resources_data.set_idle_duration_ms(
       absl::ToInt64Milliseconds(now - GetResourceIdleTime().value_or(now)));

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -420,7 +420,6 @@ std::optional<syncer::RaySyncMessage> LocalResourceManager::CreateSyncMessage(
     auto total = resources.total.Get(resource_id);
     auto available = resources.available.Get(resource_id);
 
-    resources_data.set_resources_available_changed(true);
     (*resources_data.mutable_resources_available())[label] = available.Double();
     (*resources_data.mutable_resources_total())[label] = total.Double();
   }
@@ -428,7 +427,6 @@ std::optional<syncer::RaySyncMessage> LocalResourceManager::CreateSyncMessage(
   if (get_pull_manager_at_capacity_ != nullptr) {
     resources.object_pulls_queued = get_pull_manager_at_capacity_();
     resources_data.set_object_pulls_queued(resources.object_pulls_queued);
-    resources_data.set_resources_available_changed(true);
   }
 
   resources_data.set_resources_available_changed(true);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, raylet calls `UpdateNode` and gcs calls `UpdateNodeAvailableResourcesIfExist` to update the local resource view of remote nodes. This PR unifies them to just use `UpdateNode`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
