### PR TITLE
[dashboard] Disallow minimal mode when include_dashboard is explicitly passed

### DIFF
--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -107,14 +107,14 @@ def check_agent_register(raylet_proc, agent_pid):
 
 
 @pytest.mark.parametrize(
-    "ray_start_with_dashboard",
+    "ray_start_regular",
     [{"_system_config": {"agent_register_timeout_ms": 5000}}],
     indirect=True,
 )
-def test_basic(ray_start_with_dashboard):
+def test_basic(ray_start_regular):
     """Dashboard test that starts a Ray cluster with a dashboard server running,
     then hits the dashboard API and asserts that it receives sensible data."""
-    address_info = ray_start_with_dashboard
+    address_info = ray_start_regular
     node_id = address_info["node_id"]
     gcs_client = make_gcs_client(address_info)
     ray.experimental.internal_kv._initialize_internal_kv(gcs_client)
@@ -1039,7 +1039,7 @@ def test_agent_port_conflict(shutdown_only):
     os.environ.get("RAY_MINIMAL") != "1",
     reason="This test only works for minimal installation.",
 )
-def test_dashboard_requests_fail_on_missing_deps(ray_start_with_dashboard):
+def test_dashboard_requests_fail_on_missing_deps(ray_start_regular):
     """Check that requests from client fail with minimal installation"""
     response = None
 

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -158,6 +158,15 @@ def test_basic(ray_start_with_dashboard):
     assert agent_ports is not None
 
 
+def test_missing_imports(ray_start_dashboard_bad_import):
+    """
+    Test dashboard fails when packages are missing but inclusion
+    was explicitly specified by the user.
+    """
+    with pytest.raises(Exception):
+        ray.init("local", **init_kwargs)
+
+
 def test_raylet_and_agent_share_fate(shutdown_only):
     """Test raylet and agent share fate."""
 

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -170,7 +170,7 @@ def test_missing_imports(ray_start_dashboard_bad_import):
 def test_raylet_and_agent_share_fate(shutdown_only):
     """Test raylet and agent share fate."""
 
-    ray.init(include_dashboard=True)
+    ray.init()
     p = init_error_pubsub()
 
     node = ray._private.worker._global_node
@@ -214,7 +214,7 @@ def test_raylet_and_agent_share_fate(shutdown_only):
 def test_agent_report_unexpected_raylet_death(shutdown_only):
     """Test agent reports Raylet death if it is not SIGTERM."""
 
-    ray.init(include_dashboard=True)
+    ray.init()
     p = init_error_pubsub()
 
     node = ray._private.worker._global_node
@@ -282,6 +282,10 @@ def test_agent_report_unexpected_raylet_death_large_file(shutdown_only):
     assert "Raylet logs:" in err["error_message"], err["error_message"]
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
 @pytest.mark.parametrize(
     "ray_start_with_dashboard",
     [
@@ -292,15 +296,15 @@ def test_agent_report_unexpected_raylet_death_large_file(shutdown_only):
 )
 def test_dashboard_address_local(ray_start_with_dashboard):
     webui_url = ray_start_with_dashboard["webui_url"]
-    if os.environ.get("RAY_MINIMAL") == "1":
-        # In the minimal installation, webui url shouldn't be configured.
-        assert webui_url == ""
-    else:
-        webui_ip = webui_url.split(":")[0]
-        assert not ipaddress.ip_address(webui_ip).is_unspecified
-        assert webui_ip == "127.0.0.1"
+    webui_ip = webui_url.split(":")[0]
+    assert not ipaddress.ip_address(webui_ip).is_unspecified
+    assert webui_ip == "127.0.0.1"
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
 @pytest.mark.parametrize(
     "ray_start_with_dashboard",
     [
@@ -311,13 +315,9 @@ def test_dashboard_address_local(ray_start_with_dashboard):
 )
 def test_dashboard_address_global(ray_start_with_dashboard):
     webui_url = ray_start_with_dashboard["webui_url"]
-    if os.environ.get("RAY_MINIMAL") == "1":
-        # In the minimal installation, webui url shouldn't be configured.
-        assert webui_url == ""
-    else:
-        webui_ip = webui_url.split(":")[0]
-        assert not ipaddress.ip_address(webui_ip).is_unspecified
-        assert webui_ip == ray_start_with_dashboard["node_ip_address"]
+    webui_ip = webui_url.split(":")[0]
+    assert not ipaddress.ip_address(webui_ip).is_unspecified
+    assert webui_ip == ray_start_with_dashboard["node_ip_address"]
 
 
 @pytest.mark.skipif(

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -15,6 +15,7 @@ import threading
 import time
 import traceback
 from collections import defaultdict
+from enum import Enum
 from typing import Dict, Optional, Tuple, IO, AnyStr
 
 from filelock import FileLock
@@ -973,7 +974,9 @@ class Node:
             process_info,
         ]
 
-    def start_api_server(self, *, include_dashboard: bool, raise_on_failure: bool):
+    def start_api_server(
+        self, *, include_dashboard: Optional[bool], raise_on_failure: bool
+    ):
         """Start the dashboard.
 
         Args:
@@ -1232,17 +1235,12 @@ class Node:
 
         if self._ray_params.include_dashboard is None:
             # Default
-            include_dashboard = True
-            raise_on_api_server_failure = False
-        elif self._ray_params.include_dashboard is False:
-            include_dashboard = False
             raise_on_api_server_failure = False
         else:
-            include_dashboard = True
-            raise_on_api_server_failure = True
+            raise_on_api_server_failure = self._ray_params.include_dashboard
 
         self.start_api_server(
-            include_dashboard=include_dashboard,
+            include_dashboard=self._ray_params.include_dashboard,
             raise_on_failure=raise_on_api_server_failure,
         )
 

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -15,7 +15,6 @@ import threading
 import time
 import traceback
 from collections import defaultdict
-from enum import Enum
 from typing import Dict, Optional, Tuple, IO, AnyStr
 
 from filelock import FileLock

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1124,8 +1124,8 @@ def start_api_server(
         # dashboard inclusion, the install is not minimal.
         if include_dashboard and minimal:
             logger.error(
-                f"--include-dashboard was specified, but packages are missing. "
-                "Please check dashboard.err for the specific missing modules."
+                """--include-dashboard was specified, but packages are missing.
+                Please check dashboard.err for the specific missing modules."""
             )
             raise Exception("Cannot include dashboard with missing packages.")
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1124,8 +1124,8 @@ def start_api_server(
         # dashboard inclusion, the install is not minimal.
         if include_dashboard and minimal:
             logger.error(
-                """--include-dashboard was specified, but packages are missing.
-                Please check dashboard.err for the specific missing modules."""
+                "--include-dashboard was specified, but packages are missing. "
+                "Please check dashboard.err for the specific missing modules."
             )
             raise Exception("Cannot include dashboard with missing packages.")
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1126,7 +1126,7 @@ def start_api_server(
             logger.error(
                 "--include-dashboard was explicitly specified, but not all packages are installed."
             )
-            raise
+            raise Exception("Cannot include dashboard with missing packages.")
 
         include_dash: bool = True if include_dashboard is None else include_dashboard
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1120,9 +1120,6 @@ def start_api_server(
         # Make sure the process can start.
         minimal: bool = not ray._private.utils.check_dashboard_dependencies_installed()
 
-        if not minimal:
-            raise Exception("minimal is " + str(minimal))
-
         # Explicitly check here that when the user explicitly specifies
         # dashboard inclusion, the install is not minimal.
         if include_dashboard and minimal:

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1120,12 +1120,13 @@ def start_api_server(
         # Make sure the process can start.
         minimal: bool = not ray._private.utils.check_dashboard_dependencies_installed()
 
+        if not minimal:
+            raise Exception("minimal is " + str(minimal))
+
         # Explicitly check here that when the user explicitly specifies
         # dashboard inclusion, the install is not minimal.
-        if (include_dashboard == True) and minimal:
-            logger.error(
-                "--include-dashboard was explicitly specified, but not all packages are installed."
-            )
+        if include_dashboard and minimal:
+            logger.error("--include-dashboard was specified, but packages are missing.")
             raise Exception("Cannot include dashboard with missing packages.")
 
         include_dash: bool = True if include_dashboard is None else include_dashboard

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1123,7 +1123,10 @@ def start_api_server(
         # Explicitly check here that when the user explicitly specifies
         # dashboard inclusion, the install is not minimal.
         if include_dashboard and minimal:
-            logger.error("--include-dashboard was specified, but packages are missing.")
+            logger.error(
+                f"--include-dashboard was specified, but packages are missing. "
+                "Please check dashboard.err for the specific missing modules."
+            )
             raise Exception("Cannot include dashboard with missing packages.")
 
         include_dash: bool = True if include_dashboard is None else include_dashboard

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -388,6 +388,7 @@ def ray_start_dashboard_bad_import():
     ray.shutdown()
     # Delete the cluster address just in case.
     ray._private.utils.reset_ray_address()
+    sys.modules["aiohttp"] == __import__("aiohttp")
 
 
 @pytest.fixture

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -377,21 +377,6 @@ def ray_start_with_dashboard(request, maybe_external_redis):
 
 
 @pytest.fixture
-def ray_start_dashboard_bad_import():
-    import sys
-
-    # Replace a known optional module with something that does not exist
-    mod = sys.modules.pop("aiohttp")
-    yield
-
-    # The code after the yield will run as teardown code.
-    ray.shutdown()
-    # Delete the cluster address just in case.
-    ray._private.utils.reset_ray_address()
-    sys.modules["aiohttp"] = mod
-
-
-@pytest.fixture
 def make_sure_dashboard_http_port_unused():
     """Make sure the dashboard agent http port is unused."""
     for process in psutil.process_iter():

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -381,14 +381,14 @@ def ray_start_dashboard_bad_import():
     import sys
 
     # Replace a known optional module with something that does not exist
-    sys.modules["aiohttp"] = None
+    mod = sys.modules.pop("aiohttp")
     yield
 
     # The code after the yield will run as teardown code.
     ray.shutdown()
     # Delete the cluster address just in case.
     ray._private.utils.reset_ray_address()
-    sys.modules["aiohttp"] == __import__("aiohttp")
+    sys.modules["aiohttp"] = mod
 
 
 @pytest.fixture

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -377,6 +377,20 @@ def ray_start_with_dashboard(request, maybe_external_redis):
 
 
 @pytest.fixture
+def ray_start_dashboard_bad_import():
+    import sys
+
+    # Replace a known optional module with something that does not exist
+    sys.modules["aiohttp"] = None
+    yield
+
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+    # Delete the cluster address just in case.
+    ray._private.utils.reset_ray_address()
+
+
+@pytest.fixture
 def make_sure_dashboard_http_port_unused():
     """Make sure the dashboard agent http port is unused."""
     for process in psutil.process_iter():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Currently, we automatically detect when the user has installed Ray minimal instead of Ray default when starting the dashboard by checking whether the optional modules can be imported. In the event of Ray minimal, the dashboard will not be started.

Change the behavior so that when the user explicitly passes `--include-dashboard` as a flag, missing optional modules will raise an error. 

Note that if no flag is passed, the dashboard will be started based on the mode, and no error will be thrown.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/37931

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
