### PR TITLE
[Data] Support class constructor args for map() and flat_map()

### DIFF
--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -146,6 +146,7 @@ class MapRows(AbstractUDFMap):
         self,
         input_op: LogicalOperator,
         fn: UserDefinedFunction,
+        fn_constructor_args: Optional[Iterable[Any]] = None,
         compute: Optional[Union[str, ComputeStrategy]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
@@ -153,6 +154,7 @@ class MapRows(AbstractUDFMap):
             "Map",
             input_op,
             fn,
+            fn_constructor_args=fn_constructor_args,
             compute=compute,
             ray_remote_args=ray_remote_args,
         )
@@ -192,6 +194,7 @@ class FlatMap(AbstractUDFMap):
         self,
         input_op: LogicalOperator,
         fn: UserDefinedFunction,
+        fn_constructor_args: Optional[Iterable[Any]] = None,
         compute: Optional[Union[str, ComputeStrategy]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
@@ -199,6 +202,7 @@ class FlatMap(AbstractUDFMap):
             "FlatMap",
             input_op,
             fn,
+            fn_constructor_args=fn_constructor_args,
             compute=compute,
             ray_remote_args=ray_remote_args,
         )

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -5,7 +5,7 @@ import pathlib
 import sys
 import urllib.parse
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Union
 
 import numpy as np
 
@@ -406,10 +406,12 @@ def _split_list(arr: List[Any], num_splits: int) -> List[List[Any]]:
 
 
 def validate_compute(
-    fn: "UserDefinedFunction", compute: Optional[Union[str, "ComputeStrategy"]]
+    fn: "UserDefinedFunction",
+    compute: Optional[Union[str, "ComputeStrategy"]],
+    fn_constructor_args: Optional[Iterable[Any]] = None,
 ) -> None:
     # Lazily import these objects to avoid circular imports.
-    from ray.data._internal.compute import TaskPoolStrategy
+    from ray.data._internal.compute import ActorPoolStrategy, TaskPoolStrategy
     from ray.data.block import CallableClass
 
     if isinstance(fn, CallableClass) and (
@@ -420,6 +422,20 @@ def validate_compute(
             f"specify the actor compute strategy, but got: {compute}. "
             "For example, use ``compute=ray.data.ActorPoolStrategy(size=n)``."
         )
+
+    if fn_constructor_args is not None:
+        if compute is None or (
+            compute != "actors" and not isinstance(compute, ActorPoolStrategy)
+        ):
+            raise ValueError(
+                "fn_constructor_args can only be specified if using the actor "
+                f"pool compute strategy, but got: {compute}"
+            )
+        if not isinstance(fn, CallableClass):
+            raise ValueError(
+                "fn_constructor_args can only be specified if providing a "
+                f"CallableClass instance for fn, but got: {fn}"
+            )
 
 
 def capfirst(s: str):

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -286,6 +286,7 @@ class Dataset:
         fn: UserDefinedFunction[Dict[str, Any], Dict[str, Any]],
         *,
         compute: Optional[ComputeStrategy] = None,
+        fn_constructor_args: Optional[Iterable[Any]] = None,
         num_cpus: Optional[float] = None,
         num_gpus: Optional[float] = None,
         **ray_remote_args,
@@ -336,6 +337,9 @@ class Dataset:
                 tasks, ``ray.data.ActorPoolStrategy(size=n)`` to use a fixed-size actor
                 pool, or ``ray.data.ActorPoolStrategy(min_size=m, max_size=n)`` for an
                 autoscaling actor pool.
+            fn_constructor_args: Positional arguments to pass to ``fn``'s constructor.
+                You can only provide this if ``fn`` is a callable class. These arguments
+                are top-level arguments in the underlying Ray actor construction task.
             num_cpus: The number of CPUs to reserve for each parallel map worker.
             num_gpus: The number of GPUs to reserve for each parallel map worker. For
                 example, specify `num_gpus=1` to request 1 GPU for each parallel map
@@ -353,7 +357,7 @@ class Dataset:
             :meth:`~Dataset.map_batches`
                 Call this method to transform batches of data.
         """  # noqa: E501
-        validate_compute(fn, compute)
+        validate_compute(fn, compute, fn_constructor_args)
 
         transform_fn = generate_map_rows_fn()
 
@@ -370,6 +374,7 @@ class Dataset:
                 compute,
                 ray_remote_args,
                 fn=fn,
+                fn_constructor_args=fn_constructor_args,
             )
         )
 
@@ -378,6 +383,7 @@ class Dataset:
             map_op = MapRows(
                 logical_plan.dag,
                 fn,
+                fn_constructor_args=fn_constructor_args,
                 compute=compute,
                 ray_remote_args=ray_remote_args,
             )
@@ -552,22 +558,20 @@ class Dataset:
                 f"{batch_format}"
             )
 
-        validate_compute(fn, compute)
+        validate_compute(fn, compute, fn_constructor_args)
 
-        if fn_constructor_args is not None or fn_constructor_kwargs is not None:
+        if fn_constructor_kwargs is not None:
             if compute is None or (
                 compute != "actors" and not isinstance(compute, ActorPoolStrategy)
             ):
                 raise ValueError(
-                    "fn_constructor_args and fn_constructor_kwargs can only be "
-                    "specified if using the actor pool compute strategy, but got: "
-                    f"{compute}"
+                    "fn_constructor_kwargs can only be specified if using the actor "
+                    f"pool compute strategy, but got: {compute}"
                 )
             if not isinstance(fn, CallableClass):
                 raise ValueError(
-                    "fn_constructor_args and fn_constructor_kwargs can only be "
-                    "specified if providing a CallableClass instance for fn, but got: "
-                    f"{fn}"
+                    "fn_constructor_kwargs can only be specified if providing a "
+                    f"CallableClass instance for fn, but got: {fn}"
                 )
 
         transform_fn = generate_map_batches_fn(
@@ -789,6 +793,7 @@ class Dataset:
         fn: UserDefinedFunction[Dict[str, Any], List[Dict[str, Any]]],
         *,
         compute: Optional[ComputeStrategy] = None,
+        fn_constructor_args: Optional[Iterable[Any]] = None,
         num_cpus: Optional[float] = None,
         num_gpus: Optional[float] = None,
         **ray_remote_args,
@@ -833,6 +838,9 @@ class Dataset:
                 tasks, ``ray.data.ActorPoolStrategy(size=n)`` to use a fixed-size actor
                 pool, or ``ray.data.ActorPoolStrategy(min_size=m, max_size=n)`` for an
                 autoscaling actor pool.
+            fn_constructor_args: Positional arguments to pass to ``fn``'s constructor.
+                You can only provide this if ``fn`` is a callable class. These arguments
+                are top-level arguments in the underlying Ray actor construction task.
             num_cpus: The number of CPUs to reserve for each parallel map worker.
             num_gpus: The number of GPUs to reserve for each parallel map worker. For
                 example, specify `num_gpus=1` to request 1 GPU for each parallel map
@@ -848,7 +856,7 @@ class Dataset:
             :meth:`~Dataset.map`
                 Call this method to transform one row at time.
         """
-        validate_compute(fn, compute)
+        validate_compute(fn, compute, fn_constructor_args)
 
         transform_fn = generate_flat_map_fn()
 
@@ -859,7 +867,14 @@ class Dataset:
             ray_remote_args["num_gpus"] = num_gpus
 
         plan = self._plan.with_stage(
-            OneToOneStage("FlatMap", transform_fn, compute, ray_remote_args, fn=fn)
+            OneToOneStage(
+                "FlatMap",
+                transform_fn,
+                compute,
+                ray_remote_args,
+                fn=fn,
+                fn_constructor_args=fn_constructor_args,
+            )
         )
 
         logical_plan = self._logical_plan
@@ -867,6 +882,7 @@ class Dataset:
             op = FlatMap(
                 input_op=logical_plan.dag,
                 fn=fn,
+                fn_constructor_args=fn_constructor_args,
                 compute=compute,
                 ray_remote_args=ray_remote_args,
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
We get user request to support class constructor args for `Dataset.map()` and `Dataset.flat_map()`, similar to `Dataset.map_batches()`. No technical reason why we cannot support it, given they are got converted to same map function  during execution. This PR is to add them.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
