### PR TITLE
[core][dashboard] Make intentional ray system exit from worker exit non task failing

### DIFF
--- a/python/ray/tests/test_exit_observability.py
+++ b/python/ray/tests/test_exit_observability.py
@@ -8,7 +8,7 @@ from ray._private.state_api_test_utils import verify_failed_task
 
 import ray
 from ray._private.test_utils import run_string_as_driver, wait_for_condition
-from ray.util.state import list_workers, list_nodes
+from ray.util.state import list_workers, list_nodes, list_tasks
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
@@ -156,9 +156,11 @@ ray.shutdown()
         type = worker["exit_type"]
         detail = worker["exit_detail"]
         assert type == "INTENDED_USER_EXIT" and "exit_actor" in detail
-        return verify_failed_task(
-            name="exit", error_type="ACTOR_DIED", error_message="INTENDED_USER_EXIT"
-        )
+
+        t = list_tasks(filters=[("name", "=", "exit")])[0]
+        # exit_actor should be shown as non-task failure.
+        assert t["state"] == "FINISHED"
+        return True
 
     wait_for_condition(verify_worker_exit_actor)
 
@@ -172,11 +174,10 @@ ray.shutdown()
         type = worker["exit_type"]
         detail = worker["exit_detail"]
         assert type == "INTENDED_USER_EXIT" and "exit code 0" in detail
-        return verify_failed_task(
-            name="exit_with_exit_code",
-            error_type="ACTOR_DIED",
-            error_message=["INTENDED_USER_EXIT", "exit code 0"],
-        )
+        t = list_tasks(filters=[("name", "=", "exit_with_exit_code")])[0]
+        # exit_actor should be shown as non-task failure.
+        assert t["state"] == "FINISHED"
+        return True
 
     wait_for_condition(verify_exit_code_0)
 

--- a/src/ray/core_worker/transport/direct_actor_task_submitter.h
+++ b/src/ray/core_worker/transport/direct_actor_task_submitter.h
@@ -278,8 +278,8 @@ class CoreWorkerDirectActorTaskSubmitter
     /// notification, in this case we'll wait for a fixed timeout value and then mark it
     /// as failed.
     /// pair key: timestamp in ms when this task should be considered as timeout.
-    /// pair value: task specification
-    std::deque<std::pair<int64_t, TaskSpecification>> wait_for_death_info_tasks;
+    /// pair value: task specification, and associated task execution status.
+    std::deque<std::pair<int64_t, std::pair<TaskSpecification, Status>>> wait_for_death_info_tasks;
 
     /// A force-kill request that should be sent to the actor once an RPC
     /// client to the actor is available.

--- a/src/ray/core_worker/transport/direct_actor_task_submitter.h
+++ b/src/ray/core_worker/transport/direct_actor_task_submitter.h
@@ -279,7 +279,8 @@ class CoreWorkerDirectActorTaskSubmitter
     /// as failed.
     /// pair key: timestamp in ms when this task should be considered as timeout.
     /// pair value: task specification, and associated task execution status.
-    std::deque<std::pair<int64_t, std::pair<TaskSpecification, Status>>> wait_for_death_info_tasks;
+    std::deque<std::pair<int64_t, std::pair<TaskSpecification, Status>>>
+        wait_for_death_info_tasks;
 
     /// A force-kill request that should be sent to the actor once an RPC
     /// client to the actor is available.


### PR DESCRIPTION
'

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We were marking tasks to be failed when the worker exits as a result of a remote task execution, e.g. 
1. `__ray__terminate` is called on an actor
2. `ray.actor.exit_actor()` from an actor function
3. Task ends with worker termination due to `max_calls` reached
4. tasks that exit(0) normally as per python's standard. 

However, in these cases, worker exits are expected and tasks shouldn't be surfaced as failure.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/32220
Closes https://github.com/ray-project/ray/issues/36877
Closes https://github.com/ray-project/ray/issues/32762

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
