### PR TITLE
[civ2][docker/2] move wheel building to ray_ci

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -3,17 +3,18 @@ steps:
   - label: ":tapioca: build: wheel {{matrix}}"
     instance_type: medium
     commands:
-      - ./ci/build/build-manylinux-ray.sh
-      - ./ci/build/build-manylinux-wheel.sh {{matrix}}
-      - ./ci/build/copy_build_artifacts.sh wheel
+      - bazel run //ci/ray_ci:build_in_docker -- wheel --python-version {{matrix}}
     matrix:
-      - cp37-cp37m 1.14.5
-      - cp38-cp38 1.14.5
-      - cp39-cp39 1.19.3
-      - cp310-cp310 1.22.0
-      - cp311-cp311 1.22.0
-    depends_on: manylinux
-    job_env: manylinux
+      - py37
+      - py38
+      - py39
+      - py310
+      - py311
+    depends_on: 
+      - manylinux
+      - forge
+    job_env: forge
+
 
   - label: ":tapioca: build: jar"
     instance_type: medium

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -24,3 +24,6 @@ if [ -d "/tmp/artifacts" ]; then
     echo "Artifact directory contents after cleanup:"
     find /tmp/artifacts -print || true
 fi
+
+RAYCI_CHECKOUT_DIR="$(pwd)"
+export RAYCI_CHECKOUT_DIR

--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -19,6 +19,7 @@ py_library(
         exclude = [
             "test_*.py",
             "test_in_docker.py",
+            "build_in_docker.py",
         ],
     ),
     visibility = ["//visibility:private"],
@@ -31,6 +32,12 @@ py_library(
 py_binary(
     name = "test_in_docker",
     srcs = ["test_in_docker.py"],
+    deps = [":ray_ci_lib"],
+)
+
+py_binary(
+    name = "build_in_docker",
+    srcs = ["build_in_docker.py"],
     deps = [":ray_ci_lib"],
 )
 

--- a/ci/ray_ci/build_in_docker.py
+++ b/ci/ray_ci/build_in_docker.py
@@ -1,0 +1,4 @@
+from ci.ray_ci.builder import main
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/builder.py
+++ b/ci/ray_ci/builder.py
@@ -1,0 +1,37 @@
+import click
+
+from ci.ray_ci.builder_container import PYTHON_VERSIONS, BuilderContainer
+from ci.ray_ci.forge_container import ForgeContainer
+from ci.ray_ci.container import _DOCKER_ECR_REPO
+from ci.ray_ci.utils import logger, docker_login
+
+
+@click.command()
+@click.argument(
+    "artifact_type",
+    required=True,
+    type=click.Choice(["wheel", "jar"]),
+)
+@click.option(
+    "--python-version",
+    default="py38",
+    type=click.Choice(list(PYTHON_VERSIONS.keys())),
+    help=("Python version to build the wheel with"),
+)
+def main(
+    artifact_type: str,
+    python_version: str,
+) -> None:
+    """
+    Build a wheel or jar artifact
+    """
+    docker_login(_DOCKER_ECR_REPO.split("/")[0])
+    if artifact_type == "wheel":
+        logger.info(f"Building wheel for Python {python_version}")
+        BuilderContainer(python_version).run()
+        ForgeContainer().upload_wheel()
+        logger.info("Successfully built wheel. Artifacts are in ray/.whl")
+    elif artifact_type == "jar":
+        raise NotImplementedError("Jar build not implemented yet")
+    else:
+        raise ValueError(f"Invalid artifact type {artifact_type}")

--- a/ci/ray_ci/builder_container.py
+++ b/ci/ray_ci/builder_container.py
@@ -1,0 +1,40 @@
+import os
+from typing import TypedDict
+
+from ci.ray_ci.container import Container
+
+
+class PythonVersionInfo(TypedDict):
+    bin_path: str
+    numpy_version: str
+
+
+PYTHON_VERSIONS = {
+    "py37": PythonVersionInfo(bin_path="cp37-cp37m", numpy_version="1.14.5"),
+    "py38": PythonVersionInfo(bin_path="cp38-cp38", numpy_version="1.19.3"),
+    "py39": PythonVersionInfo(bin_path="cp39-cp39", numpy_version="1.19.3"),
+    "py310": PythonVersionInfo(bin_path="cp310-cp310", numpy_version="1.22.0"),
+    "py311": PythonVersionInfo(bin_path="cp311-cp311", numpy_version="1.22.0"),
+}
+
+
+class BuilderContainer(Container):
+    def __init__(self, python_version: str) -> None:
+        super().__init__(
+            "manylinux",
+            volumes=[f"{os.environ.get('RAYCI_CHECKOUT_DIR')}:/rayci"],
+        )
+        python_version_info = PYTHON_VERSIONS.get(python_version)
+        self.bin_path = python_version_info["bin_path"]
+        self.numpy_version = python_version_info["numpy_version"]
+
+    def run(self) -> None:
+        # chown is required to allow forge to upload the wheel
+        self.run_script(
+            [
+                "./ci/build/build-manylinux-ray.sh",
+                "./ci/build/build-manylinux-wheel.sh "
+                f"{self.bin_path} {self.numpy_version}",
+                "chown -R 2000:100 /artifact-mount",
+            ]
+        )

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from typing import List
+from typing import List, Optional
 
 _DOCKER_ECR_REPO = os.environ.get(
     "RAYCI_WORK_REPO",
@@ -28,16 +28,17 @@ class Container:
     A wrapper for running commands in ray ci docker container
     """
 
-    def __init__(self, docker_tag: str) -> None:
+    def __init__(self, docker_tag: str, volumes: Optional[List[str]] = None) -> None:
         self.docker_tag = docker_tag
+        self.volumes = volumes or []
 
-    def run_script(self, script: str) -> bytes:
+    def run_script(self, script: List[str]) -> bytes:
         """
         Run a script in container
         """
         return subprocess.check_output(self._get_run_command(script))
 
-    def _get_run_command(self, script: str) -> List[str]:
+    def _get_run_command(self, script: List[str]) -> List[str]:
         command = [
             "docker",
             "run",
@@ -46,6 +47,8 @@ class Container:
             "--volume",
             "/tmp/artifacts:/artifact-mount",
         ]
+        for volume in self.volumes:
+            command += ["--volume", volume]
         for env in _DOCKER_ENV:
             command += ["--env", env]
         for cap in _DOCKER_CAP_ADD:
@@ -56,8 +59,10 @@ class Container:
             "--shm-size=2.5gb",
             self._get_docker_image(),
             "/bin/bash",
-            "-ice",
-            script,
+            "-iecuo",
+            "pipefail",
+            "--",
+            "\n".join(script),
         ]
 
         return command

--- a/ci/ray_ci/forge_container.py
+++ b/ci/ray_ci/forge_container.py
@@ -1,0 +1,14 @@
+import os
+
+from ci.ray_ci.container import Container
+
+
+class ForgeContainer(Container):
+    def __init__(self) -> None:
+        super().__init__(
+            "forge",
+            volumes=[f"{os.environ.get('RAYCI_CHECKOUT_DIR')}:/rayci"],
+        )
+
+    def upload_wheel(self) -> None:
+        self.run_script(["./ci/build/copy_build_artifacts.sh wheel"])

--- a/ci/ray_ci/test_container.py
+++ b/ci/ray_ci/test_container.py
@@ -12,10 +12,10 @@ def test_get_docker_image() -> None:
 
 
 def test_get_run_command() -> None:
-    command = " ".join(Container("test")._get_run_command("echo hello"))
+    command = " ".join(Container("test")._get_run_command(["hi", "hello"]))
     assert "-env BUILDKITE_JOB_ID" in command
     assert "--cap-add SYS_PTRACE" in command
-    assert "/bin/bash -ice echo hello" in command
+    assert "/bin/bash -iecuo pipefail -- hi\nhello" in command
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -1,5 +1,4 @@
 import sys
-
 import pytest
 from unittest import mock
 from typing import List
@@ -37,11 +36,11 @@ def test_run_tests_in_docker() -> None:
 def test_run_script_in_docker() -> None:
     def _mock_check_output(input: List[str]) -> None:
         input_str = " ".join(input)
-        assert "/bin/bash -ice run command" in input_str
+        assert "/bin/bash -iecuo pipefail -- run command" in input_str
 
     with mock.patch("subprocess.check_output", side_effect=_mock_check_output):
         container = TesterContainer("team")
-        container.run_script("run command")
+        container.run_script(["run command"])
 
 
 def test_run_tests() -> None:

--- a/ci/ray_ci/test_utils.py
+++ b/ci/ray_ci/test_utils.py
@@ -1,13 +1,26 @@
 import sys
 import pytest
+from unittest import mock
+from typing import List
 
-from ci.ray_ci.utils import chunk_into_n
+from ci.ray_ci.utils import chunk_into_n, docker_login
 
 
 def test_chunk_into_n() -> None:
     assert chunk_into_n([1, 2, 3, 4, 5], 2) == [[1, 2, 3], [4, 5]]
     assert chunk_into_n([1, 2], 3) == [[1], [2], []]
     assert chunk_into_n([1, 2], 1) == [[1, 2]]
+
+
+def test_docker_login() -> None:
+    def _mock_subprocess_run(
+        cmd: List[str], stdin=None, stdout=None, stderr=None
+    ) -> None:
+        assert cmd == ["pip", "install", "awscli"] or stdin.read() == b"password"
+
+    with mock.patch("subprocess.check_output", return_value=b"password"):
+        with mock.patch("subprocess.run", side_effect=_mock_subprocess_run):
+            docker_login("docker_ecr")
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -146,7 +146,9 @@ def _get_all_test_targets(
 
     test_targets = (
         container.run_script(
-            f'bazel query "{_get_all_test_query(targets, team, except_tags)}"',
+            [
+                f'bazel query "{_get_all_test_query(targets, team, except_tags)}"',
+            ]
         )
         .decode("utf-8")
         .split("\n")

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -67,4 +67,4 @@ class TesterContainer(Container):
             test_cmd += f"--test_env {env} "
         test_cmd += f"{' '.join(test_targets)}"
         commands.append(test_cmd)
-        return subprocess.Popen(self._get_run_command("\n".join(commands)))
+        return subprocess.Popen(self._get_run_command(commands))


### PR DESCRIPTION
Move wheel building logic to ray_ci so that we can use bazel to build the wheel. 

This requires https://github.com/ray-project/rayci/pull/99 for it to pass.

Test:
- CI