### PR TITLE
[Core] Make get_next_unordered return None with ignore_if_timeout=True

### DIFF
--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -199,7 +199,10 @@ def test_get_next_unordered_timeout(init):
 
     pool.submit(lambda a, v: a.f.remote(v), 0)
     with pytest.raises(TimeoutError):
-        pool.get_next_unordered(timeout=0.1)
+        pool.get_next_unordered(timeout=0.1, ignore_if_timeout=False)
+
+    pool.submit(lambda a, v: a.f.remote(v), 0)
+    assert pool.get_next_unordered(timeout=0.1, ignore_if_timeout=True) is None
 
 
 def test_multiple_returns(init):
@@ -215,6 +218,9 @@ def test_multiple_returns(init):
 
     while pool.has_next():
         assert pool.get_next(timeout=None) == [1, 2]
+
+    pool.submit(lambda a, v: a.bar.remote(), None)
+    pool.get_next(timeout=1, ignore_if_timeout=True)
 
 
 def test_pop_idle(init):

--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -289,7 +289,7 @@ class ActorPool:
         timeout_msg = "Timed out waiting for result"
         raise_timeout_after_ignore = False
         if timeout is not None:
-            res, _ = ray.wait([future], timeout=timeout)
+            res, _ = ray.wait(future if isinstance(future, list) else [future], timeout=timeout)
             if not res:
                 if not ignore_if_timedout:
                     raise TimeoutError(timeout_msg)
@@ -314,7 +314,9 @@ class ActorPool:
         This returns some result produced by submit(), blocking for up to
         the specified timeout until it is available. Unlike get_next(), the
         results are not always returned in same order as submitted, which can
-        improve performance.
+        improve performance. If timed out, setting ignore_if_timedout to True
+        will make this method ignore timeout and return None, indicating
+        no task is finished; otherwise a TimeoutError will be raised.
 
         Returns:
             The next result.
@@ -351,22 +353,17 @@ class ActorPool:
         # TODO(ekl) bulk wait for performance
         res, _ = ray.wait(list(self._future_to_actor), num_returns=1, timeout=timeout)
         timeout_msg = "Timed out waiting for result"
-        raise_timeout_after_ignore = False
         if res:
             [future] = res
         else:
             if not ignore_if_timedout:
                 raise TimeoutError(timeout_msg)
             else:
-                raise_timeout_after_ignore = True
+                return None
         i, a = self._future_to_actor.pop(future)
         self._return_actor(a)
         del self._index_to_future[i]
         self._next_return_index = max(self._next_return_index, i + 1)
-        if raise_timeout_after_ignore:
-            raise TimeoutError(
-                timeout_msg + ". The task {} has been ignored.".format(future)
-            )
         return ray.get(future)
 
     def _return_actor(self, actor):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This ignore_if_timeout was meant to ignore tasks that caller waits too long. However, get_next_unordered doesn't wait for any specific future. It just waits for whichever task that can finish first within timeout period. If there is no future finished, ActorPool doesn't know which future to be ignored. If ignore_if_timeout is set to true, ActorPool will try to pop the ignored future, which doesn't exist, so it will trigger an error as specified in the related issue below.

With this patch, ignore_if_timeout will ignore the TimeoutError and return None instead to indicate no task is finished.

It also fixed a typo in get_next() method: ignore_if_timedout -> ignore_if_timeout 

## Related issue number

#38635 

## Checks

The original tests are enough so I didn't add any new tests.

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
