### PR TITLE
[Data] Move ReadTasks' ouptut merging/splitting to MapTransformer

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -269,7 +269,7 @@ class BuildOutputBlocksMapTransformFn(MapTransformFn):
                 must match self._input_type.
         """
         output_buffer = BlockOutputBuffer(
-            None, DataContext.get_current().target_max_block_size
+            DataContext.get_current().target_max_block_size
         )
         if self._input_type == MapTransformFnDataType.Block:
             add_fn = output_buffer.add_block

--- a/python/ray/data/_internal/output_buffer.py
+++ b/python/ray/data/_internal/output_buffer.py
@@ -31,10 +31,9 @@ class BlockOutputBuffer:
     """
 
     def __init__(
-        self, block_udf: Optional[Callable[[Block], Block]], target_max_block_size: int
+        self, target_max_block_size: int
     ):
         self._target_max_block_size = target_max_block_size
-        self._block_udf = block_udf
         self._buffer = DelegatingBlockBuilder()
         self._returned_at_least_one_block = False
         self._finalized = False
@@ -72,9 +71,6 @@ class BlockOutputBuffer:
         """Returns the next complete output block."""
         assert self.has_next()
         block = self._buffer.build()
-        accessor = BlockAccessor.for_block(block)
-        if self._block_udf and accessor.num_rows() > 0:
-            block = self._block_udf(block)
         self._buffer = DelegatingBlockBuilder()
         self._returned_at_least_one_block = True
         return block

--- a/python/ray/data/_internal/output_buffer.py
+++ b/python/ray/data/_internal/output_buffer.py
@@ -1,7 +1,7 @@
-from typing import Any, Callable, Optional
+from typing import Any
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
-from ray.data.block import Block, BlockAccessor, DataBatch
+from ray.data.block import Block, DataBatch
 
 
 class BlockOutputBuffer:
@@ -30,9 +30,7 @@ class BlockOutputBuffer:
         ...     yield output.next() # doctest: +SKIP
     """
 
-    def __init__(
-        self, target_max_block_size: int
-    ):
+    def __init__(self, target_max_block_size: int):
         self._target_max_block_size = target_max_block_size
         self._buffer = DelegatingBlockBuilder()
         self._returned_at_least_one_block = False

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Callable, Iterable, List, Optional
+from typing import Iterable, List, Optional
 
 import ray
 import ray.cloudpickle as cloudpickle

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -59,6 +59,8 @@ def _splitrange(n, k):
 def _do_additional_splits(
     blocks: Iterable[Block], _: TaskContext, additional_output_splits: int
 ) -> Iterable[Block]:
+    """ Do additional splits to the output blocks of a ReadTask.
+    """
     assert additional_output_splits > 1
     for block in blocks:
         block = BlockAccessor.for_block(block)

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -56,7 +56,9 @@ def _splitrange(n, k):
     return output
 
 
-def _do_additional_splits(blocks: Iterable[Block], _: TaskContext, additional_output_splits: int) -> Iterable[Block]:
+def _do_additional_splits(
+    blocks: Iterable[Block], _: TaskContext, additional_output_splits: int
+) -> Iterable[Block]:
     assert additional_output_splits > 1
     for block in blocks:
         block = BlockAccessor.for_block(block)
@@ -104,18 +106,19 @@ def plan_read_op(op: Read) -> PhysicalOperator:
         MapTransformFn(
             do_read, MapTransformFnDataType.Block, MapTransformFnDataType.Block
         ),
+        blocks_to_output_blocks,
     ]
     if op._additional_split_factor is not None:
         transform_fns.append(
             MapTransformFn(
-                functools.partial(_do_additional_splits, additional_output_splits=op._additional_split_factor),
+                functools.partial(
+                    _do_additional_splits,
+                    additional_output_splits=op._additional_split_factor,
+                ),
                 MapTransformFnDataType.Block,
                 MapTransformFnDataType.Block,
             )
         )
-    else:
-        transform_fns.append(blocks_to_output_blocks)
-
 
     map_transformer = MapTransformer(transform_fns)
 

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -154,7 +154,7 @@ def apply_output_blocks_handling_to_read_tasks(
 
     This function is only used for compability with the legacy LazyBlockList code path.
     """
-    map_transformer = _generate_output_transform_fn(additional_split_factor)
+    output_transform_fn = _generate_output_transform_fn(additional_split_factor)
 
     for read_task in read_tasks:
         original_read_fn = read_task._read_fn
@@ -163,6 +163,6 @@ def apply_output_blocks_handling_to_read_tasks(
             blocks = original_read_fn()
             # We pass None as the TaskContext because we don't have access to it here.
             # This is okay because the transform functions don't use the TaskContext.
-            return map_transformer.apply_transform(blocks, None)  # type: ignore
+            return output_transform_fn(blocks, None)  # type: ignore
 
         read_task._read_fn = new_read_fn

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -156,9 +156,7 @@ def plan_read_op(op: Read) -> PhysicalOperator:
     ]
     block_udf = getattr(op._reader, "_block_udf", None)
     if block_udf is not None:
-        transform_fns.append(
-            _generate_block_udf_transform_fn(block_udf)
-        )
+        transform_fns.append(_generate_block_udf_transform_fn(block_udf))
     transform_fns.append(_generate_output_transform_fn(op._additional_split_factor))
 
     map_transformer = MapTransformer(transform_fns)
@@ -182,9 +180,7 @@ def apply_output_blocks_handling_to_read_task(
     transform_fns = []
     block_udf = getattr(read_task, "_block_udf", None)
     if block_udf is not None:
-        transform_fns.append(
-            _generate_block_udf_transform_fn(block_udf)
-        )
+        transform_fns.append(_generate_block_udf_transform_fn(block_udf))
     transform_fns.append(_generate_output_transform_fn(additional_split_factor))
     map_transformer = MapTransformer(transform_fns)
 

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -89,7 +89,7 @@ def _generate_output_transform_fn(
         return MapTransformFn(
             functools.partial(
                 _do_additional_splits,
-                additional_output_splits=op._additional_split_factor,
+                additional_output_splits=additional_split_factor,
             ),
             MapTransformFnDataType.Block,
             MapTransformFnDataType.Block,

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -59,8 +59,7 @@ def _splitrange(n, k):
 def _do_additional_splits(
     blocks: Iterable[Block], _: TaskContext, additional_output_splits: int
 ) -> Iterable[Block]:
-    """ Do additional splits to the output blocks of a ReadTask.
-    """
+    """Do additional splits to the output blocks of a ReadTask."""
     assert additional_output_splits > 1
     for block in blocks:
         block = BlockAccessor.for_block(block)

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -8,10 +8,10 @@ from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.map_transformer import (
+    BuildOutputBlocksMapTransformFn,
     MapTransformer,
     MapTransformFn,
     MapTransformFnDataType,
-    blocks_to_output_blocks,
 )
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data.block import Block, BlockAccessor
@@ -82,7 +82,7 @@ def _generate_output_transform_fn(
     if additional_split_factor is None:
         # If additional_split_factor is None, we build output blocks from the
         # output blocks of the read tasks.
-        return blocks_to_output_blocks
+        return BuildOutputBlocksMapTransformFn.for_blocks()
     else:
         # If additional_split_factor is not None, we do additional splits to the
         # output blocks of the read tasks.

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -154,9 +154,10 @@ def plan_read_op(op: Read) -> PhysicalOperator:
             do_read, MapTransformFnDataType.Block, MapTransformFnDataType.Block
         ),
     ]
-    if hasattr(op._reader, "_block_udf"):
+    block_udf = getattr(op._reader, "_block_udf", None)
+    if block_udf is not None:
         transform_fns.append(
-            _generate_block_udf_transform_fn(op._reader._block_udf)  # type: ignore
+            _generate_block_udf_transform_fn(block_udf)
         )
     transform_fns.append(_generate_output_transform_fn(op._additional_split_factor))
 
@@ -179,9 +180,10 @@ def apply_output_blocks_handling_to_read_task(
     This function is only used for compability with the legacy LazyBlockList code path.
     """
     transform_fns = []
-    if hasattr(read_task, "_block_udf"):
+    block_udf = getattr(read_task, "_block_udf", None)
+    if block_udf is not None:
         transform_fns.append(
-            _generate_block_udf_transform_fn(read_task._block_udf)  # type: ignore
+            _generate_block_udf_transform_fn(block_udf)
         )
     transform_fns.append(_generate_output_transform_fn(additional_split_factor))
     map_transformer = MapTransformer(transform_fns)

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -156,11 +156,9 @@ def plan_read_op(op: Read) -> PhysicalOperator:
     ]
     if hasattr(op._reader, "_block_udf"):
         transform_fns.append(
-            _generate_block_udf_transform_fn(op._reader._block_udf) # type: ignore
+            _generate_block_udf_transform_fn(op._reader._block_udf)  # type: ignore
         )
-    transform_fns.append(
-        _generate_output_transform_fn(op._additional_split_factor)
-    )
+    transform_fns.append(_generate_output_transform_fn(op._additional_split_factor))
 
     map_transformer = MapTransformer(transform_fns)
 
@@ -183,11 +181,9 @@ def apply_output_blocks_handling_to_read_task(
     transform_fns = []
     if hasattr(read_task, "_block_udf"):
         transform_fns.append(
-            _generate_block_udf_transform_fn(read_task._block_udf) # type: ignore
+            _generate_block_udf_transform_fn(read_task._block_udf)  # type: ignore
         )
-    transform_fns.append(
-        _generate_output_transform_fn(additional_split_factor)
-    )
+    transform_fns.append(_generate_output_transform_fn(additional_split_factor))
     map_transformer = MapTransformer(transform_fns)
 
     original_read_fn = read_task._read_fn

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -210,7 +210,6 @@ class ReadTask(Callable[[], Iterable[Block]]):
     def __init__(self, read_fn: Callable[[], Iterable[Block]], metadata: BlockMetadata):
         self._metadata = metadata
         self._read_fn = read_fn
-        self._additional_output_splits = 1
 
     def get_metadata(self) -> BlockMetadata:
         return self._metadata

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -325,8 +325,7 @@ class _ParquetDatasourceReader(Reader):
                 )
             else:
                 default_read_batch_size = PARQUET_READER_ROW_BATCH_SIZE
-            block_udf, reader_args, columns, schema = (
-                self._block_udf,
+            reader_args, columns, schema = (
                 self._reader_args,
                 self._columns,
                 self._schema,
@@ -334,7 +333,6 @@ class _ParquetDatasourceReader(Reader):
             read_tasks.append(
                 ReadTask(
                     lambda p=serialized_pieces: _read_pieces(
-                        block_udf,
                         reader_args,
                         default_read_batch_size,
                         columns,
@@ -345,6 +343,8 @@ class _ParquetDatasourceReader(Reader):
                 )
             )
 
+        for task in read_tasks:
+            task._block_udf = self._block_udf
         return read_tasks
 
     def _estimate_files_encoding_ratio(self) -> float:
@@ -401,7 +401,6 @@ class _ParquetDatasourceReader(Reader):
 
 
 def _read_pieces(
-    block_udf,
     reader_args,
     default_read_batch_size,
     columns,

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -422,8 +422,6 @@ def _read_pieces(
     import pyarrow as pa
     from pyarrow.dataset import _get_partition_keys
 
-    ctx = DataContext.get_current()
-
     logger.debug(f"Reading {len(pieces)} parquet pieces")
     use_threads = reader_args.pop("use_threads", False)
     batch_size = reader_args.pop("batch_size", default_read_batch_size)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -31,7 +31,7 @@ from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.optimizers import LogicalPlan
 from ray.data._internal.plan import ExecutionPlan
 from ray.data._internal.planner.plan_read_op import (
-    apply_output_block_building_and_additional_splitting_to_read_tasks,
+    apply_output_blocks_handling_to_read_tasks,
 )
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.stats import DatasetStats
@@ -414,7 +414,7 @@ def read_datasource(
     else:
         estimated_num_blocks = 0
 
-    apply_output_block_building_and_additional_splitting_to_read_tasks(
+    apply_output_blocks_handling_to_read_tasks(
         read_tasks,
         additional_split_factor,
     )

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -31,7 +31,7 @@ from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.optimizers import LogicalPlan
 from ray.data._internal.plan import ExecutionPlan
 from ray.data._internal.planner.plan_read_op import (
-    apply_output_blocks_handling_to_read_tasks,
+    apply_output_blocks_handling_to_read_task,
 )
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.stats import DatasetStats
@@ -414,10 +414,11 @@ def read_datasource(
     else:
         estimated_num_blocks = 0
 
-    apply_output_blocks_handling_to_read_tasks(
-        read_tasks,
-        additional_split_factor,
-    )
+    for read_task in read_tasks:
+        apply_output_blocks_handling_to_read_task(
+            read_task,
+            additional_split_factor,
+        )
 
     read_stage_name = f"Read{datasource.get_name()}"
     available_cpu_slots = ray.available_resources().get("CPU", 1)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -368,12 +368,7 @@ def read_datasource(
             _get_reader, retry_exceptions=False, num_cpus=0
         ).options(scheduling_strategy=scheduling_strategy)
 
-        (
-            requested_parallelism,
-            min_safe_parallelism,
-            inmemory_size,
-            reader,
-        ) = ray.get(
+        (requested_parallelism, min_safe_parallelism, inmemory_size, reader,) = ray.get(
             get_reader.remote(
                 datasource,
                 ctx,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -404,8 +404,6 @@ def read_datasource(
                 f"To satisfy the requested parallelism of {requested_parallelism}, "
                 f"each read task output is split into {k} smaller blocks."
             )
-            for r in read_tasks:
-                r._set_additional_split_factor(k)
             estimated_num_blocks = estimated_num_blocks * k
             additional_split_factor = k
         logger.debug("Estimated num output blocks {estimated_num_blocks}")
@@ -1118,7 +1116,7 @@ def read_csv(
         variety       string
 
         Convert a date column with a custom format from a CSV file. For more uses of ConvertOptions see https://arrow.apache.org/docs/python/generated/pyarrow.csv.ConvertOptions.html  # noqa: #501
-        
+
         >>> from pyarrow import csv
         >>> convert_options = csv.ConvertOptions(
         ...     timestamp_parsers=["%m/%d/%Y"])
@@ -1167,14 +1165,14 @@ def read_csv(
         arrow_open_stream_args: kwargs passed to
             `pyarrow.fs.FileSystem.open_input_file <https://arrow.apache.org/docs/\
                 python/generated/pyarrow.fs.FileSystem.html\
-                    #pyarrow.fs.FileSystem.open_input_stream>`_. 
+                    #pyarrow.fs.FileSystem.open_input_stream>`_.
             when opening input files to read.
         meta_provider: A :ref:`file metadata provider <metadata_provider>`. Custom
             metadata providers may be able to resolve file metadata more quickly and/or
-            accurately. In most cases, you do not need to set this. If ``None``, this 
+            accurately. In most cases, you do not need to set this. If ``None``, this
             function uses a system-chosen implementation.
-        partition_filter: A 
-            :class:`~ray.data.datasource.partitioning.PathPartitionFilter`. 
+        partition_filter: A
+            :class:`~ray.data.datasource.partitioning.PathPartitionFilter`.
             Use with a custom callback to read only selected partitions of a
             dataset. By default, no files are filtered.
             To filter out all file paths except those whose file extension
@@ -1186,11 +1184,11 @@ def read_csv(
                 hive-style-partitioning/>`_.
         ignore_missing_paths: If True, ignores any file paths in ``paths`` that are not
             found. Defaults to False.
-        arrow_csv_args: CSV read options to pass to 
+        arrow_csv_args: CSV read options to pass to
             `pyarrow.csv.open_csv <https://arrow.apache.org/docs/python/generated/\
-            pyarrow.csv.open_csv.html#pyarrow.csv.open_csv>`_ 
+            pyarrow.csv.open_csv.html#pyarrow.csv.open_csv>`_
             when opening CSV files.
-        
+
 
     Returns:
         :class:`~ray.data.Dataset` producing records read from the specified paths.

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -325,6 +325,7 @@ def test_lazy_block_list(shutdown_only, target_max_block_size):
         assert block_metadata.schema is not None
 
 
+@pytest.skip("Needs zero-copy optimization for read->map_batches.")
 def test_read_large_data(ray_start_cluster):
     # Test 20G input with single task
     num_blocks_per_task = 20

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -325,7 +325,7 @@ def test_lazy_block_list(shutdown_only, target_max_block_size):
         assert block_metadata.schema is not None
 
 
-@pytest.skip("Needs zero-copy optimization for read->map_batches.")
+@pytest.mark.skip("Needs zero-copy optimization for read->map_batches.")
 def test_read_large_data(ray_start_cluster):
     # Test 20G input with single task
     num_blocks_per_task = 20

--- a/python/ray/data/tests/test_splitblocks.py
+++ b/python/ray/data/tests/test_splitblocks.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import ray
-from ray.data.datasource.datasource import _splitrange
+from ray.data._internal.planner.plan_read_op import _splitrange
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Follow-up of #38546.  Move the output merging/splitting code from within the read tasks to MapTransformer.

## Related issue number
https://github.com/ray-project/ray/issues/37630
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
