### PR TITLE
[data] standarize funtion names in planner.py

### DIFF
--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -17,7 +17,7 @@ from ray.data._internal.planner.repartition import generate_repartition_fn
 from ray.data._internal.planner.sort import generate_sort_fn
 
 
-def _plan_all_to_all_op(
+def plan_all_to_all_op(
     op: AbstractAllToAll,
     input_physical_dag: PhysicalOperator,
 ) -> AllToAllOperator:

--- a/python/ray/data/_internal/planner/plan_from_op.py
+++ b/python/ray/data/_internal/planner/plan_from_op.py
@@ -3,5 +3,5 @@ from ray.data._internal.execution.operators.input_data_buffer import InputDataBu
 from ray.data._internal.logical.operators.from_operators import AbstractFrom
 
 
-def _plan_from_op(op: AbstractFrom) -> PhysicalOperator:
+def plan_from_op(op: AbstractFrom) -> PhysicalOperator:
     return InputDataBuffer(op.input_data)

--- a/python/ray/data/_internal/planner/plan_input_data_op.py
+++ b/python/ray/data/_internal/planner/plan_input_data_op.py
@@ -3,7 +3,7 @@ from ray.data._internal.execution.operators.input_data_buffer import InputDataBu
 from ray.data._internal.logical.operators.input_data_operator import InputData
 
 
-def _plan_input_data_op(op: InputData) -> PhysicalOperator:
+def plan_input_data_op(op: InputData) -> PhysicalOperator:
     """Get the corresponding DAG of physical operators for InputData."""
 
     return InputDataBuffer(

--- a/python/ray/data/_internal/planner/plan_limit_op.py
+++ b/python/ray/data/_internal/planner/plan_limit_op.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from ray.data._internal.logical.operators.one_to_one_operator import Limit
 
 
-def _plan_limit_op(
+def plan_limit_op(
     op: "Limit", input_physical_dag: "PhysicalOperator"
 ) -> "PhysicalOperator":
     """Get the corresponding DAG of physical operators for Limit.

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -16,10 +16,10 @@ from ray.data._internal.logical.operators.n_ary_operator import Union, Zip
 from ray.data._internal.logical.operators.one_to_one_operator import Limit
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.operators.write_operator import Write
-from ray.data._internal.planner.plan_all_to_all_op import _plan_all_to_all_op
-from ray.data._internal.planner.plan_from_op import _plan_from_op
-from ray.data._internal.planner.plan_input_data_op import _plan_input_data_op
-from ray.data._internal.planner.plan_limit_op import _plan_limit_op
+from ray.data._internal.planner.plan_all_to_all_op import plan_all_to_all_op
+from ray.data._internal.planner.plan_from_op import plan_from_op
+from ray.data._internal.planner.plan_input_data_op import plan_input_data_op
+from ray.data._internal.planner.plan_limit_op import plan_limit_op
 from ray.data._internal.planner.plan_read_op import plan_read_op
 from ray.data._internal.planner.plan_udf_map_op import plan_udf_map_op
 from ray.data._internal.planner.plan_write_op import plan_write_op
@@ -51,19 +51,19 @@ class Planner:
             physical_op = plan_read_op(logical_op)
         elif isinstance(logical_op, InputData):
             assert not physical_children
-            physical_op = _plan_input_data_op(logical_op)
+            physical_op = plan_input_data_op(logical_op)
         elif isinstance(logical_op, Write):
             assert len(physical_children) == 1
             physical_op = plan_write_op(logical_op, physical_children[0])
         elif isinstance(logical_op, AbstractFrom):
             assert not physical_children
-            physical_op = _plan_from_op(logical_op)
+            physical_op = plan_from_op(logical_op)
         elif isinstance(logical_op, AbstractUDFMap):
             assert len(physical_children) == 1
             physical_op = plan_udf_map_op(logical_op, physical_children[0])
         elif isinstance(logical_op, AbstractAllToAll):
             assert len(physical_children) == 1
-            physical_op = _plan_all_to_all_op(logical_op, physical_children[0])
+            physical_op = plan_all_to_all_op(logical_op, physical_children[0])
         elif isinstance(logical_op, Zip):
             assert len(physical_children) == 2
             physical_op = ZipOperator(physical_children[0], physical_children[1])
@@ -72,7 +72,7 @@ class Planner:
             physical_op = UnionOperator(*physical_children)
         elif isinstance(logical_op, Limit):
             assert len(physical_children) == 1
-            physical_op = _plan_limit_op(logical_op, physical_children[0])
+            physical_op = plan_limit_op(logical_op, physical_children[0])
         else:
             raise ValueError(
                 f"Found unknown logical operator during planning: {logical_op}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

These `_plan_xxx` functions are public. Shouldn't start with a `_`. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
