### PR TITLE
[Data][Doc] Use kwargs for ActorPoolStrategy

### DIFF
--- a/doc/source/data/data-internals.rst
+++ b/doc/source/data/data-internals.rst
@@ -171,7 +171,7 @@ The following code is a hello world example which invokes the execution with
    for _ in (
        ray.data.range_tensor(5000, shape=(80, 80, 3), parallelism=200)
        .map_batches(sleep, num_cpus=2)
-       .map_batches(sleep, compute=ray.data.ActorPoolStrategy(2, 4))
+       .map_batches(sleep, compute=ray.data.ActorPoolStrategy(min_size=2, max_size=4))
        .map_batches(sleep, num_cpus=1)
        .iter_batches()
    ):


### PR DESCRIPTION
After Ray 2.5, ActorPoolStrategy() requires using kwargs, otherwise a ValueError will be raised. This updates the example code with keyword arguments.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The example code in data/data-internals's streaming execution section no longer works, because ray only allows keyword arguments after 2.5 version, so using positional argument will cause "ValueError: In Ray 2.5, ActorPoolStrategy requires min_size and max_size to be explicit kwargs". This patch will fix it.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
