### PR TITLE
[data] revert changes on building empty blocks in map_batches

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -182,7 +182,7 @@ def input_blocks_to_batches(
     if first is None:
         return []
     blocks = itertools.chain([first], block_iter)
-    empty_block = BlockAccessor.for_block(first).slice(0, 0, copy=True)
+    empty_block = BlockAccessor.for_block(first).builder().build()
     # Don't hold the first block in memory, so we reset the reference.
     first = None
 

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -912,8 +912,7 @@ def test_map_batches_preserves_empty_block_format(ray_start_regular_shared):
 
     block_refs = ds.get_internal_block_refs()
     assert len(block_refs) == 1
-    block = ray.get(block_refs[0])
-    assert type(block) == pd.DataFrame
+    assert type(ray.get(block_refs[0])) == pd.DataFrame
 
 
 def test_random_sample(ray_start_regular_shared):

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -914,7 +914,6 @@ def test_map_batches_preserves_empty_block_format(ray_start_regular_shared):
     assert len(block_refs) == 1
     block = ray.get(block_refs[0])
     assert type(block) == pd.DataFrame
-    assert block.columns == df.columns
 
 
 def test_random_sample(ray_start_regular_shared):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#38546 tried to fix the issue of missing schema in empty blocks. But that approach doesn't work for ragged tensor arrays. 
Reverting that change. Per discussion, we'll stop scheduling empty blocks for the map operator instead. 

## Related issue number

Fixes #38653 #38659

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
