### PR TITLE
[Train] Remove custom labels from Llama-2 compute config

### DIFF
--- a/doc/source/templates/04_finetuning_llms_with_deepspeed/compute_configs/aws_7b_or_13b.yaml
+++ b/doc/source/templates/04_finetuning_llms_with_deepspeed/compute_configs/aws_7b_or_13b.yaml
@@ -1,22 +1,16 @@
-# 1 g5.16xlarge + 15 g5.4xlarge --> 16 GPUs, 256G RAM on trainer and 64G RAM on workers
+# Autoscale to 16 g5.4xlarge --> 16 A10Gs
 region: us-west1
 allowed_azs: [any]
 head_node_type:
     name: head_node
-    instance_type: g5.16xlarge
-    resources:
-      custom_resources: 
-        large_cpu_mem: 1
+    instance_type: m5.xlarge
 
 worker_node_types:
     - name: worker_node
       instance_type: g5.4xlarge
-      min_workers: 15
-      max_workers: 15
+      min_workers: 0
+      max_workers: 16
       use_spot: false
-      resources:
-        custom_resources: 
-          medium_cpu_mem: 1
 
 aws:
   TagSpecifications:

--- a/doc/source/templates/04_finetuning_llms_with_deepspeed/finetune_hf_llm.py
+++ b/doc/source/templates/04_finetuning_llms_with_deepspeed/finetune_hf_llm.py
@@ -615,11 +615,6 @@ def main():
             ),
         ),
         scaling_config=train.ScalingConfig(
-            # This forces the trainer + Rank 0 worker to get scheduled on the large cpu
-            # RAM instance, making the checkpointing easier.
-            # "large_cpu_mem" is the tag used to identify this machine type in the
-            # cluster config.
-            trainer_resources={"large_cpu_mem": 0.01},
             num_workers=args.num_devices,
             use_gpu=True,
             resources_per_worker={"GPU": 1},

--- a/doc/source/templates/testing/compute_configs/04_finetuning_llms_with_deepspeed/aws_7b.yaml
+++ b/doc/source/templates/testing/compute_configs/04_finetuning_llms_with_deepspeed/aws_7b.yaml
@@ -1,23 +1,17 @@
-# 1 g5.16xlarge + 15 g5.4xlarge --> 16 GPUs, 256G RAM on trainer and 64G RAM on workers
+# Autoscale to 16 g5.4xlarge --> 16 A10Gs
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
 head_node_type:
     name: head_node
-    instance_type: g5.16xlarge
-    resources:
-      custom_resources: 
-        large_cpu_mem: 1
+    instance_type: m5.xlarge
 
 worker_node_types:
     - name: worker_node
       instance_type: g5.4xlarge
-      min_workers: 15
-      max_workers: 15
+      min_workers: 0
+      max_workers: 16
       use_spot: false
-      resources:
-        custom_resources: 
-          medium_cpu_mem: 1
 
 aws:
   TagSpecifications:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1038,7 +1038,7 @@
   cluster:
     byod:
       type: cu118
-    cluster_compute: ../testing/compute_configs/04_finetuning_llms_with_deepspeed/aws_7b_or_13b.yaml
+    cluster_compute: ../testing/compute_configs/04_finetuning_llms_with_deepspeed/aws_7b.yaml
 
   run:
     timeout: 600
@@ -1054,30 +1054,6 @@
       #     cluster_compute: ../testing/compute_configs/04_finetuning_llms_with_deepspeed/gce_7b_or_13b.yaml
 
 
-
-- name: workspace_template_finetuning_llms_with_deepspeed_llama_2_13b
-  group: Workspace templates
-  working_dir: workspace_templates/04_finetuning_llms_with_deepspeed
-  python: "3.9"
-  frequency: nightly-3x
-  team: ml
-  cluster:
-    byod:
-      type: cu118
-    cluster_compute: ../testing/compute_configs/04_finetuning_llms_with_deepspeed/aws_7b_or_13b.yaml
-
-  run:
-    timeout: 1200
-    script: chmod +x ./run_llama_ft.sh && RAY_AIR_NEW_PERSISTENCE_MODE=1 ./run_llama_ft.sh --size=13b --as-test
-
-  variations:
-      - __suffix__: aws
-      # TODO (Kourosh): Enable once GCE is ready
-      # - __suffix__: gce
-      #   env: gce
-      #   frequency: manual
-      #   cluster:
-      #     cluster_compute: ../testing/compute_configs/04_finetuning_llms_with_deepspeed/gce_7b_or_13b.yaml
 
 #######################
 # XGBoost release tests


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It is often hard to explain why we need large_cpu_mem = 0.01 in the custom resources, and also I have found that g5.16xlarge nodes are not that available anymore. So launching this template may get blocked because of the in-availability of the resources. 

This PR makes a simplification by separating 7B and 13B compute configs. This allows me to specificy 16xg5.4xlarge nodes for 7B so that I can quickly start with something. It also allows me to use g5.12xlarge nodes for 13B (subject to availability).

Since g5.12xlarge can be tricky to get, I removed the release test for 13B models. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
