### PR TITLE
[Jobs] Make sure JobConfig specified in the init script is not being overridden by the SupervisorActor

### DIFF
--- a/dashboard/modules/job/tests/conftest.py
+++ b/dashboard/modules/job/tests/conftest.py
@@ -1,0 +1,35 @@
+import os
+
+import ray
+from ray._private.gcs_utils import GcsAioClient
+from ray.dashboard.modules.job.job_manager import (
+    JobManager,
+)
+
+
+TEST_NAMESPACE = "jobs_test_namespace"
+
+
+def create_ray_cluster(_tracing_startup_hook=None):
+    return ray.init(
+        num_cpus=16,
+        num_gpus=1,
+        resources={"Custom": 1},
+        namespace=TEST_NAMESPACE,
+        log_to_driver=True,
+        _tracing_startup_hook=_tracing_startup_hook,
+    )
+
+
+def create_job_manager(ray_cluster, tmp_path):
+    address_info = ray_cluster
+    gcs_aio_client = GcsAioClient(
+        address=address_info["gcs_address"], nums_reconnect_retry=0
+    )
+    return JobManager(gcs_aio_client, tmp_path)
+
+
+def _driver_script_path(file_name: str) -> str:
+    return os.path.join(
+        os.path.dirname(__file__), "subprocess_driver_scripts", file_name
+    )

--- a/dashboard/modules/job/tests/subprocess_driver_scripts/check_code_search_path_is_propagated.py
+++ b/dashboard/modules/job/tests/subprocess_driver_scripts/check_code_search_path_is_propagated.py
@@ -1,7 +1,7 @@
 """
 A dummy ray driver script that executes in subprocess.
-Prints global worker's `load_code_from_local` property that ought to be set whenever `JobConfig.code_search_path`
-is specified
+Prints global worker's `load_code_from_local` property that ought to be set
+whenever `JobConfig.code_search_path` is specified
 """
 
 
@@ -22,8 +22,8 @@ def run():
     # Step 1: Print the statement indicating that the code_search_path have been
     #         properly respected
     print(f"Code search path is {statement}")
-    # Step 2: Print the whole runtime_env to validate that it's been passed appropriately
-    #         from submit_job API
+    # Step 2: Print the whole runtime_env to validate that it's been passed
+    #         appropriately from submit_job API
     print(ray.get_runtime_context().runtime_env)
 
 

--- a/dashboard/modules/job/tests/subprocess_driver_scripts/check_code_search_path_is_propagated.py
+++ b/dashboard/modules/job/tests/subprocess_driver_scripts/check_code_search_path_is_propagated.py
@@ -1,0 +1,31 @@
+"""
+A dummy ray driver script that executes in subprocess.
+Prints global worker's `load_code_from_local` property that ought to be set whenever `JobConfig.code_search_path`
+is specified
+"""
+
+import ray
+from ray.job_config import JobConfig
+
+
+def run():
+    ray.init(job_config=JobConfig(code_search_path=["/home/code/"]))
+
+    @ray.remote
+    def foo() -> bool:
+        return ray.global_worker.load_code_from_local
+
+    load_code_from_local = ray.get(foo.remote())
+
+    statement = "propagated" if load_code_from_local else "NOT propagated"
+
+    # Step 1: Print the statement indicating that the code_search_path have been
+    #         properly respected
+    print(f"Code search path is {statement}")
+    # Step 2: Print the whole runtime_env to validate that it's been passed appropriately
+    #         from submit_job API
+    print(ray.get_runtime_context().runtime_env)
+
+
+if __name__ == "__main__":
+    run()

--- a/dashboard/modules/job/tests/subprocess_driver_scripts/check_code_search_path_is_propagated.py
+++ b/dashboard/modules/job/tests/subprocess_driver_scripts/check_code_search_path_is_propagated.py
@@ -4,11 +4,11 @@ Prints global worker's `load_code_from_local` property that ought to be set when
 is specified
 """
 
-import ray
-from ray.job_config import JobConfig
-
 
 def run():
+    import ray
+    from ray.job_config import JobConfig
+
     ray.init(job_config=JobConfig(code_search_path=["/home/code/"]))
 
     @ray.remote

--- a/dashboard/modules/job/tests/subprocess_driver_scripts/check_code_search_path_is_propagated.py
+++ b/dashboard/modules/job/tests/subprocess_driver_scripts/check_code_search_path_is_propagated.py
@@ -13,7 +13,7 @@ def run():
 
     @ray.remote
     def foo() -> bool:
-        return ray.global_worker.load_code_from_local
+        return ray._private.worker.global_worker.load_code_from_local
 
     load_code_from_local = ray.get(foo.remote())
 

--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -32,6 +32,7 @@ from ray.dashboard.consts import (
     RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR,
     RAY_JOB_START_TIMEOUT_SECONDS_ENV_VAR,
 )
+from ray.dashboard.modules.job.tests.conftest import create_ray_cluster, create_job_manager, _driver_script_path
 from ray.job_submission import JobStatus
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy  # noqa: F401
 from ray.tests.conftest import call_ray_start  # noqa: F401
@@ -256,41 +257,16 @@ def shared_ray_instance():
     # submissions.
     old_ray_address = os.environ.pop(RAY_ADDRESS_ENVIRONMENT_VARIABLE, None)
 
-    yield from create_ray_cluster()
+    yield create_ray_cluster()
 
     if old_ray_address is not None:
         os.environ[RAY_ADDRESS_ENVIRONMENT_VARIABLE] = old_ray_address
-
-
-def create_ray_cluster(_tracing_startup_hook=None):
-    return ray.init(
-        num_cpus=16,
-        num_gpus=1,
-        resources={"Custom": 1},
-        namespace=TEST_NAMESPACE,
-        log_to_driver=True,
-        _tracing_startup_hook=_tracing_startup_hook,
-    )
 
 
 @pytest.mark.asyncio
 @pytest.fixture
 async def job_manager(shared_ray_instance, tmp_path):
     yield create_job_manager(shared_ray_instance, tmp_path)
-
-
-def create_job_manager(ray_cluster, tmp_path):
-    address_info = ray_cluster
-    gcs_aio_client = GcsAioClient(
-        address=address_info["gcs_address"], nums_reconnect_retry=0
-    )
-    return JobManager(gcs_aio_client, tmp_path)
-
-
-def _driver_script_path(file_name: str) -> str:
-    return os.path.join(
-        os.path.dirname(__file__), "subprocess_driver_scripts", file_name
-    )
 
 
 async def _run_hanging_command(job_manager, tmp_dir, start_signal_actor=None):
@@ -622,56 +598,6 @@ class TestRuntimeEnv:
         )
         assert token in logs, logs
         assert "JOB_1_VAR" in logs
-
-    @pytest.mark.parametrize(
-        "tracing_enabled",
-        [
-            False,
-            # TODO(issues/38633): local code loading is broken when tracing is enabled
-            # True,
-        ],
-    )
-    async def test_user_provided_job_config_honored_by_worker(
-        self, tracing_enabled, tmp_path
-    ):
-        """Ensures that the JobConfig instance injected into ray.init in the driver
-        script is honored even in case when job is submitted via JobManager.submit_job
-        API (involving RAY_JOB_CONFIG_JSON_ENV_VAR being set in child process env)
-        """
-
-        if tracing_enabled:
-            tracing_startup_hook = (
-                "ray.util.tracing.setup_local_tmp_tracing:setup_tracing"
-            )
-        else:
-            tracing_startup_hook = None
-
-        with create_ray_cluster(_tracing_startup_hook=tracing_startup_hook) as cluster:
-            job_manager = create_job_manager(cluster, tmp_path)
-
-            driver_script_path = _driver_script_path(
-                "check_code_search_path_is_propagated.py"
-            )
-
-            job_id = await job_manager.submit_job(
-                entrypoint=f"python {driver_script_path}",
-                # NOTE: We inject runtime_env in here, but also specify the JobConfig in
-                #       the driver script: settings to JobConfig (other than the
-                #       runtime_env) passed in via ray.init(...) have to be respected
-                #       along with the runtime_env passed from submit_job API
-                runtime_env={"env_vars": {"TEST_SUBPROCESS_RANDOM_VAR": "0xDEEDDEED"}},
-            )
-
-            await async_wait_for_condition_async_predicate(
-                check_job_succeeded, job_manager=job_manager, job_id=job_id
-            )
-
-            logs = job_manager.get_job_logs(job_id)
-
-            print("[DBG] job logs:\n", logs)
-
-            assert "Code search path is propagated" in logs, logs
-            assert "0xDEEDDEED" in logs, logs
 
     async def test_failed_runtime_env_validation(self, job_manager):
         """Ensure job status is correctly set as failed if job has an invalid

--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -619,12 +619,16 @@ class TestRuntimeEnv:
         script is honored even in case when job is submitted via JobManager.submit_job
         API (involving RAY_JOB_CONFIG_JSON_ENV_VAR being set in child process env)
         """
+        driver_script_path = _driver_script_path(
+            "check_code_search_path_is_propagated.py"
+        )
+
         job_id = await job_manager.submit_job(
-            entrypoint=f"python {_driver_script_path('check_code_search_path_is_propagated.py')}",
-            # NOTE: We inject runtime_env in here, but also specify the JobConfig in the
-            #       driver script: settings to JobConfig (other than the runtime_env) passed in
-            #       via ray.init(...) have to be respected along with the runtime_env passed from
-            #       submit_job API
+            entrypoint=f"python {driver_script_path}",
+            # NOTE: We inject runtime_env in here, but also specify the JobConfig in
+            #       the driver script: settings to JobConfig (other than the
+            #       runtime_env) passed in via ray.init(...) have to be respected
+            #       along with the runtime_env passed from submit_job API
             runtime_env={"env_vars": {"TEST_SUBPROCESS_RANDOM_VAR": "0xDEEDDEED"}},
         )
 

--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -631,6 +631,7 @@ class TestRuntimeEnv:
         await async_wait_for_condition_async_predicate(
             check_job_succeeded, job_manager=job_manager, job_id=job_id
         )
+
         logs = job_manager.get_job_logs(job_id)
 
         assert "Code search path is propagated" in logs, logs

--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -624,19 +624,25 @@ class TestRuntimeEnv:
         assert "JOB_1_VAR" in logs
 
     @pytest.mark.parametrize(
-        "tracing_enabled", [
+        "tracing_enabled",
+        [
             False,
-            True,
+            # TODO(issues/38633): local code loading is broken when tracing is enabled
+            # True,
         ],
     )
-    async def test_user_provided_job_config_honored_by_worker(self, tracing_enabled, tmp_path):
+    async def test_user_provided_job_config_honored_by_worker(
+        self, tracing_enabled, tmp_path
+    ):
         """Ensures that the JobConfig instance injected into ray.init in the driver
         script is honored even in case when job is submitted via JobManager.submit_job
         API (involving RAY_JOB_CONFIG_JSON_ENV_VAR being set in child process env)
         """
 
         if tracing_enabled:
-            tracing_startup_hook = "ray.util.tracing.setup_local_tmp_tracing:setup_tracing"
+            tracing_startup_hook = (
+                "ray.util.tracing.setup_local_tmp_tracing:setup_tracing"
+            )
         else:
             tracing_startup_hook = None
 

--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -256,26 +256,35 @@ def shared_ray_instance():
     # submissions.
     old_ray_address = os.environ.pop(RAY_ADDRESS_ENVIRONMENT_VARIABLE, None)
 
-    yield ray.init(
-        num_cpus=16,
-        num_gpus=1,
-        resources={"Custom": 1},
-        namespace=TEST_NAMESPACE,
-        log_to_driver=True,
-    )
+    yield from create_ray_cluster()
 
     if old_ray_address is not None:
         os.environ[RAY_ADDRESS_ENVIRONMENT_VARIABLE] = old_ray_address
 
 
+def create_ray_cluster(_tracing_startup_hook=None):
+    return ray.init(
+        num_cpus=16,
+        num_gpus=1,
+        resources={"Custom": 1},
+        namespace=TEST_NAMESPACE,
+        log_to_driver=True,
+        _tracing_startup_hook=_tracing_startup_hook,
+    )
+
+
 @pytest.mark.asyncio
 @pytest.fixture
 async def job_manager(shared_ray_instance, tmp_path):
-    address_info = shared_ray_instance
+    yield create_job_manager(shared_ray_instance, tmp_path)
+
+
+def create_job_manager(ray_cluster, tmp_path):
+    address_info = ray_cluster
     gcs_aio_client = GcsAioClient(
         address=address_info["gcs_address"], nums_reconnect_retry=0
     )
-    yield JobManager(gcs_aio_client, tmp_path)
+    return JobManager(gcs_aio_client, tmp_path)
 
 
 def _driver_script_path(file_name: str) -> str:
@@ -614,32 +623,49 @@ class TestRuntimeEnv:
         assert token in logs, logs
         assert "JOB_1_VAR" in logs
 
-    async def test_user_provided_job_config_honored_by_worker(self, job_manager):
+    @pytest.mark.parametrize(
+        "tracing_enabled", [
+            False,
+            True,
+        ],
+    )
+    async def test_user_provided_job_config_honored_by_worker(self, tracing_enabled, tmp_path):
         """Ensures that the JobConfig instance injected into ray.init in the driver
         script is honored even in case when job is submitted via JobManager.submit_job
         API (involving RAY_JOB_CONFIG_JSON_ENV_VAR being set in child process env)
         """
-        driver_script_path = _driver_script_path(
-            "check_code_search_path_is_propagated.py"
-        )
 
-        job_id = await job_manager.submit_job(
-            entrypoint=f"python {driver_script_path}",
-            # NOTE: We inject runtime_env in here, but also specify the JobConfig in
-            #       the driver script: settings to JobConfig (other than the
-            #       runtime_env) passed in via ray.init(...) have to be respected
-            #       along with the runtime_env passed from submit_job API
-            runtime_env={"env_vars": {"TEST_SUBPROCESS_RANDOM_VAR": "0xDEEDDEED"}},
-        )
+        if tracing_enabled:
+            tracing_startup_hook = "ray.util.tracing.setup_local_tmp_tracing:setup_tracing"
+        else:
+            tracing_startup_hook = None
 
-        await async_wait_for_condition_async_predicate(
-            check_job_succeeded, job_manager=job_manager, job_id=job_id
-        )
+        with create_ray_cluster(_tracing_startup_hook=tracing_startup_hook) as cluster:
+            job_manager = create_job_manager(cluster, tmp_path)
 
-        logs = job_manager.get_job_logs(job_id)
+            driver_script_path = _driver_script_path(
+                "check_code_search_path_is_propagated.py"
+            )
 
-        assert "Code search path is propagated" in logs, logs
-        assert "0xDEEDDEED" in logs, logs
+            job_id = await job_manager.submit_job(
+                entrypoint=f"python {driver_script_path}",
+                # NOTE: We inject runtime_env in here, but also specify the JobConfig in
+                #       the driver script: settings to JobConfig (other than the
+                #       runtime_env) passed in via ray.init(...) have to be respected
+                #       along with the runtime_env passed from submit_job API
+                runtime_env={"env_vars": {"TEST_SUBPROCESS_RANDOM_VAR": "0xDEEDDEED"}},
+            )
+
+            await async_wait_for_condition_async_predicate(
+                check_job_succeeded, job_manager=job_manager, job_id=job_id
+            )
+
+            logs = job_manager.get_job_logs(job_id)
+
+            print("[DBG] job logs:\n", logs)
+
+            assert "Code search path is propagated" in logs, logs
+            assert "0xDEEDDEED" in logs, logs
 
     async def test_failed_runtime_env_validation(self, job_manager):
         """Ensure job status is correctly set as failed if job has an invalid

--- a/dashboard/modules/job/tests/test_job_manager.py
+++ b/dashboard/modules/job/tests/test_job_manager.py
@@ -32,7 +32,11 @@ from ray.dashboard.consts import (
     RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR,
     RAY_JOB_START_TIMEOUT_SECONDS_ENV_VAR,
 )
-from ray.dashboard.modules.job.tests.conftest import create_ray_cluster, create_job_manager, _driver_script_path
+from ray.dashboard.modules.job.tests.conftest import (
+    create_ray_cluster,
+    create_job_manager,
+    _driver_script_path,
+)
 from ray.job_submission import JobStatus
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy  # noqa: F401
 from ray.tests.conftest import call_ray_start  # noqa: F401

--- a/dashboard/modules/job/tests/test_job_manager_standalone.py
+++ b/dashboard/modules/job/tests/test_job_manager_standalone.py
@@ -1,0 +1,74 @@
+import pytest
+import sys
+
+from ray._private.test_utils import (
+    async_wait_for_condition_async_predicate,
+)
+from ray.dashboard.modules.job.tests.conftest import (
+    create_ray_cluster,
+    create_job_manager,
+    _driver_script_path,
+)
+from ray.dashboard.modules.job.tests.test_job_manager import check_job_succeeded
+
+
+class TestRuntimeEnvStandalone:
+    """NOTE: PLEASE READ CAREFULLY BEFORE MODIFYING
+    This test is extracted into a standalone module such that it can bootstrap its own (standalone)
+    Ray cluster while avoiding affecting the shared one used by other JobManager tests
+    """
+
+    @pytest.mark.parametrize(
+        "tracing_enabled",
+        [
+            False,
+            # TODO(issues/38633): local code loading is broken when tracing is enabled
+            # True,
+        ],
+    )
+    async def test_user_provided_job_config_honored_by_worker(
+        self, tracing_enabled, tmp_path
+    ):
+        """Ensures that the JobConfig instance injected into ray.init in the driver
+        script is honored even in case when job is submitted via JobManager.submit_job
+        API (involving RAY_JOB_CONFIG_JSON_ENV_VAR being set in child process env)
+
+        """
+
+        if tracing_enabled:
+            tracing_startup_hook = (
+                "ray.util.tracing.setup_local_tmp_tracing:setup_tracing"
+            )
+        else:
+            tracing_startup_hook = None
+
+        with create_ray_cluster(_tracing_startup_hook=tracing_startup_hook) as cluster:
+            job_manager = create_job_manager(cluster, tmp_path)
+
+            driver_script_path = _driver_script_path(
+                "check_code_search_path_is_propagated.py"
+            )
+
+            job_id = await job_manager.submit_job(
+                entrypoint=f"python {driver_script_path}",
+                # NOTE: We inject runtime_env in here, but also specify the JobConfig in
+                #       the driver script: settings to JobConfig (other than the
+                #       runtime_env) passed in via ray.init(...) have to be respected
+                #       along with the runtime_env passed from submit_job API
+                runtime_env={"env_vars": {"TEST_SUBPROCESS_RANDOM_VAR": "0xDEEDDEED"}},
+            )
+
+            await async_wait_for_condition_async_predicate(
+                check_job_succeeded, job_manager=job_manager, job_id=job_id
+            )
+
+            logs = job_manager.get_job_logs(job_id)
+
+            print("[DBG] job logs:\n", logs)
+
+            assert "Code search path is propagated" in logs, logs
+            assert "0xDEEDDEED" in logs, logs
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/dashboard/modules/job/tests/test_job_manager_standalone.py
+++ b/dashboard/modules/job/tests/test_job_manager_standalone.py
@@ -15,8 +15,9 @@ from ray.dashboard.modules.job.tests.test_job_manager import check_job_succeeded
 @pytest.mark.asyncio
 class TestRuntimeEnvStandalone:
     """NOTE: PLEASE READ CAREFULLY BEFORE MODIFYING
-    This test is extracted into a standalone module such that it can bootstrap its own (standalone)
-    Ray cluster while avoiding affecting the shared one used by other JobManager tests
+    This test is extracted into a standalone module such that it can bootstrap its own
+    (standalone) Ray cluster while avoiding affecting the shared one used by other
+    JobManager tests
     """
 
     @pytest.mark.parametrize(

--- a/dashboard/modules/job/tests/test_job_manager_standalone.py
+++ b/dashboard/modules/job/tests/test_job_manager_standalone.py
@@ -12,6 +12,7 @@ from ray.dashboard.modules.job.tests.conftest import (
 from ray.dashboard.modules.job.tests.test_job_manager import check_job_succeeded
 
 
+@pytest.mark.asyncio
 class TestRuntimeEnvStandalone:
     """NOTE: PLEASE READ CAREFULLY BEFORE MODIFYING
     This test is extracted into a standalone module such that it can bootstrap its own (standalone)
@@ -63,8 +64,6 @@ class TestRuntimeEnvStandalone:
             )
 
             logs = job_manager.get_job_logs(job_id)
-
-            print("[DBG] job logs:\n", logs)
 
             assert "Code search path is propagated" in logs, logs
             assert "0xDEEDDEED" in logs, logs

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2344,7 +2344,7 @@ def connect(
         b"tracing_startup_hook", ray_constants.KV_NAMESPACE_TRACING
     )
     if tracing_hook_val is not None:
-        ray.util.tracing.tracing_helper._enbale_tracing()
+        ray.util.tracing.tracing_helper._enable_tracing()
         if not getattr(ray, "__traced__", False):
             _setup_tracing = _import_from_string(tracing_hook_val.decode("utf-8"))
             _setup_tracing()

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1432,7 +1432,7 @@ def init(
 
         if ray_constants.RAY_RUNTIME_ENV_HOOK in os.environ and not _skip_env_hook:
             runtime_env = _load_class(os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(
-                job_config.runtime_env
+                runtime_env
             )
 
         job_config.set_runtime_env(runtime_env)

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1437,7 +1437,7 @@ def init(
 
         job_config.set_runtime_env(runtime_env)
         # Similarly, we prefer metadata provided via job submission API
-        for key, value in injected_job_config.metadata:
+        for key, value in injected_job_config.metadata.items():
             job_config.set_metadata(key, value)
 
     # RAY_JOB_CONFIG_JSON_ENV_VAR is only set at ray job manager level and has

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1408,6 +1408,9 @@ def init(
         logger.debug("Could not import resource module (on Windows)")
         pass
 
+    if job_config is None:
+        job_config = ray.job_config.JobConfig()
+
     if RAY_JOB_CONFIG_JSON_ENV_VAR in os.environ:
         if runtime_env:
             logger.warning(
@@ -1416,16 +1419,26 @@ def init(
                 "job_config. Please ensure no runtime_env is used in driver "
                 "script's ray.init() when using job submission API."
             )
-        # Set runtime_env in job_config if passed as env variable, such as
-        # ray job submission with driver script executed in subprocess
-        job_config_json = json.loads(os.environ.get(RAY_JOB_CONFIG_JSON_ENV_VAR))
-        job_config = ray.job_config.JobConfig.from_json(job_config_json)
+        injected_job_config_json = json.loads(
+            os.environ.get(RAY_JOB_CONFIG_JSON_ENV_VAR)
+        )
+        injected_job_config: ray.job_config.JobConfig = (
+            ray.job_config.JobConfig.from_json(injected_job_config_json)
+        )
+        # NOTE: We always prefer runtime_env injected via RAY_JOB_CONFIG_JSON_ENV_VAR,
+        #       as compared to via ray.init(runtime_env=...) to make sure runtime_env
+        #       specified via job submission API takes precedence
+        runtime_env = injected_job_config.runtime_env
 
         if ray_constants.RAY_RUNTIME_ENV_HOOK in os.environ and not _skip_env_hook:
             runtime_env = _load_class(os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(
                 job_config.runtime_env
             )
-            job_config.set_runtime_env(runtime_env)
+
+        job_config.set_runtime_env(runtime_env)
+        # Similarly, we prefer metadata provided via job submission API
+        for key, value in injected_job_config.metadata:
+            job_config.set_metadata(key, value)
 
     # RAY_JOB_CONFIG_JSON_ENV_VAR is only set at ray job manager level and has
     # higher priority in case user also provided runtime_env for ray.init()
@@ -1437,8 +1450,6 @@ def init(
 
         if runtime_env:
             # Set runtime_env in job_config if passed in as part of ray.init()
-            if job_config is None:
-                job_config = ray.job_config.JobConfig()
             job_config.set_runtime_env(runtime_env)
 
     redis_address, gcs_address = None, None

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -589,11 +589,16 @@ def call_ray_start_context(request):
     except Exception as e:
         print(type(e), e)
         raise
+
     # Get the redis address from the output.
     redis_substring_prefix = "--address='"
-    address_location = out.find(redis_substring_prefix) + len(redis_substring_prefix)
-    address = out[address_location:]
-    address = address.split("'")[0]
+    idx = out.find(redis_substring_prefix)
+    if idx >= 0:
+        address_location = idx + len(redis_substring_prefix)
+        address = out[address_location:]
+        address = address.split("'")[0]
+    else:
+        address = None
 
     yield address
 

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -340,6 +340,11 @@ def _inject_tracing_into_function(function):
         ),
     )
 
+    # Skip wrapping if tracing is disabled (still add _ray_trace_ctx however to make
+    # sure _ray_trace_ctx could be passed)
+    if not _is_tracing_enabled():
+        return function
+
     @wraps(function)
     def _function_with_tracing(
         *args: Any,

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -95,7 +95,7 @@ def _is_tracing_enabled() -> bool:
     return _global_is_tracing_enabled
 
 
-def _enbale_tracing():
+def _enable_tracing():
     global _global_is_tracing_enabled, _opentelemetry
     _global_is_tracing_enabled = True
     _opentelemetry = _OpenTelemetryProxy()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

NOTE: This is a revert of the [revert](https://github.com/ray-project/ray/pull/38655), addressing broken tests

Currently when executing the job submitted via Ray Job submission API, `SupervisorActor` will be overriding whole of the `JobConfig` making it impossible to specify additional params like `JobConfig.code_search_path` for ex.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
