### PR TITLE
[ci][release] Fixing test_many_runtime_envs test

### DIFF
--- a/release/nightly_tests/stress_tests/test_many_runtime_envs.py
+++ b/release/nightly_tests/stress_tests/test_many_runtime_envs.py
@@ -48,10 +48,10 @@ if __name__ == "__main__":
     )
     ray.get(
         [
-            assert_file_content.options(strategy=strategy).remote(
+            assert_file_content.options(scheduling_strategy=strategy).remote(
                 args.file_name, args.expected_content
             ),
-            assert_n_files_in_working_dir.options(strategy=strategy).remote(
+            assert_n_files_in_working_dir.options(scheduling_strategy=strategy).remote(
                 args.expected_file_count_in_working_dir
             ),
         ]

--- a/release/nightly_tests/stress_tests/test_many_runtime_envs_runner.py
+++ b/release/nightly_tests/stress_tests/test_many_runtime_envs_runner.py
@@ -50,7 +50,7 @@ def create_file_and_assert_n_times(n):
                 " python test_many_runtime_envs.py "
                 f"--file-name {file_name} "
                 f"--expected-content {shlex.quote(content)} "
-                f"--expected-file-count-in-working-dir {i + 2}"
+                f"--expected-file-count-in-working-dir {i + 2} "
                 f"--node_id {next(node_ids)}",
                 shell=True,
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Example failure: https://console.anyscale-staging.com/o/anyscale-internal/jobs/prodjob_frbhkc9bis4slv3vu8cutis1aq

```
usage: test_many_runtime_envs.py [-h] [--file-name FILE_NAME]
                                 [--expected-content EXPECTED_CONTENT]
                                 [--expected-file-count-in-working-dir EXPECTED_FILE_COUNT_IN_WORKING_DIR]
                                 [--node_id NODE_ID]
test_many_runtime_envs.py: error: argument --expected-file-count-in-working-dir: invalid int value: '2--node_id'

```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
