### PR TITLE
[core][serve][autoscaler] Fix resource time rounding down makes idle reporting incorrect

### DIFF
--- a/python/ray/autoscaler/v2/schema.py
+++ b/python/ray/autoscaler/v2/schema.py
@@ -49,6 +49,21 @@ class NodeInfo:
     # Descriptive details.
     details: Optional[str] = None
 
+    def total_resources(self) -> Dict[str, float]:
+        if self.resource_usage is None:
+            return {}
+        return {r.resource_name: r.total for r in self.resource_usage.usage}
+
+    def available_resources(self) -> Dict[str, float]:
+        if self.resource_usage is None:
+            return {}
+        return {r.resource_name: r.total - r.used for r in self.resource_usage.usage}
+
+    def used_resources(self) -> Dict[str, float]:
+        if self.resource_usage is None:
+            return {}
+        return {r.resource_name: r.used for r in self.resource_usage.usage}
+
 
 @dataclass
 class LaunchRequest:

--- a/python/ray/autoscaler/v2/tests/test_e2e.py
+++ b/python/ray/autoscaler/v2/tests/test_e2e.py
@@ -262,7 +262,7 @@ def test_serve_num_replica_idle_node():
             return "hello"
 
     try:
-        cluster.start()
+        cluster.start(override_env={"RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S": "2"})
         # 5 workers nodes should be busy and have 2(replicas) * 2(cpus per replicas)
         # = 4 cpus used
         serve.run(Deployment.options(num_replicas=10).bind())
@@ -305,7 +305,7 @@ def test_serve_num_replica_idle_node():
             return True
 
         # A long sleep is needed for serve proxy to be removed.
-        wait_for_condition(verify, timeout=45, retry_interval_ms=1000)
+        wait_for_condition(verify, timeout=15, retry_interval_ms=1000)
 
     finally:
         ray.shutdown()

--- a/python/ray/autoscaler/v2/tests/test_e2e.py
+++ b/python/ray/autoscaler/v2/tests/test_e2e.py
@@ -284,7 +284,7 @@ def test_serve_num_replica_idle_node():
 
         wait_for_condition(verify)
 
-        # Downscale to 1 replicas, 1 workers nodes should be idle.
+        # Downscale to 1 replicas, 4 workers nodes should be idle.
         serve.run(Deployment.options(num_replicas=1).bind())
 
         def verify():

--- a/python/ray/autoscaler/v2/tests/test_e2e.py
+++ b/python/ray/autoscaler/v2/tests/test_e2e.py
@@ -305,7 +305,7 @@ def test_serve_num_replica_idle_node():
             return True
 
         # A long sleep is needed for serve proxy to be removed.
-        wait_for_condition(verify, timeout=30, retry_interval_ms=1000)
+        wait_for_condition(verify, timeout=45, retry_interval_ms=1000)
 
     finally:
         ray.shutdown()

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import tempfile
 import time
+from typing import Dict, Optional
 
 import yaml
 
@@ -58,7 +59,7 @@ class AutoscalingCluster:
         custom_config.update(config_kwargs)
         return custom_config
 
-    def start(self, _system_config=None):
+    def start(self, _system_config=None, override_env: Optional[Dict] = None):
         """Start the cluster.
 
         After this call returns, you can connect to the cluster with
@@ -88,6 +89,8 @@ class AutoscalingCluster:
             )
         env = os.environ.copy()
         env.update({"AUTOSCALER_UPDATE_INTERVAL_S": "1", "RAY_FAKE_CLUSTER": "1"})
+        if override_env:
+            env.update(override_env)
         subprocess.check_call(cmd, env=env)
 
     def shutdown(self):

--- a/release/nightly_tests/stress_tests/test_many_runtime_envs_runner.py
+++ b/release/nightly_tests/stress_tests/test_many_runtime_envs_runner.py
@@ -50,7 +50,7 @@ def create_file_and_assert_n_times(n):
                 " python test_many_runtime_envs.py "
                 f"--file-name {file_name} "
                 f"--expected-content {shlex.quote(content)} "
-                f"--expected-file-count-in-working-dir {i + 2} "
+                f"--expected-file-count-in-working-dir {i + 2}"
                 f"--node_id {next(node_ids)}",
                 shell=True,
             )

--- a/release/nightly_tests/stress_tests/test_many_runtime_envs_runner.py
+++ b/release/nightly_tests/stress_tests/test_many_runtime_envs_runner.py
@@ -50,7 +50,7 @@ def create_file_and_assert_n_times(n):
                 " python test_many_runtime_envs.py "
                 f"--file-name {file_name} "
                 f"--expected-content {shlex.quote(content)} "
-                f"--expected-file-count-in-working-dir {i + 2}"
+                f"--expected-file-count-in-working-dir {i + 2} "
                 f"--node_id {next(node_ids)}",
                 shell=True,
             )

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -433,8 +433,6 @@ std::optional<syncer::RaySyncMessage> LocalResourceManager::CreateSyncMessage(
   if (idle_time.has_value()) {
     // We round up the idle duration to the nearest millisecond such that the idle
     // reporting would be correct even if it's less than 1 millisecond.
-    // This is needed since we will not be reporting resource usage if there's no more
-    // change due to lightweight resource reporting.
     const auto now = absl::Now();
     resources_data.set_idle_duration_ms(
         std::max(1L, absl::ToInt64Milliseconds(now - idle_time.value())));

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -434,8 +434,8 @@ std::optional<syncer::RaySyncMessage> LocalResourceManager::CreateSyncMessage(
     // We round up the idle duration to the nearest millisecond such that the idle
     // reporting would be correct even if it's less than 1 millisecond.
     const auto now = absl::Now();
-    resources_data.set_idle_duration_ms(
-        std::max(1L, absl::ToInt64Milliseconds(now - idle_time.value())));
+    resources_data.set_idle_duration_ms(std::max(
+        static_cast<int64_t>(1), absl::ToInt64Milliseconds(now - idle_time.value())));
   }
 
   resources_data.set_is_draining(IsLocalNodeDraining());

--- a/src/ray/raylet/scheduling/local_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager_test.cc
@@ -44,7 +44,7 @@ class LocalResourceManagerTest : public ::testing::Test {
     }
   }
 
-  rpc::ResourcesData GetSyncMessageForResourceReport() const {
+  rpc::ResourcesData GetSyncMessageForResourceReport() {
     auto msg = manager->CreateSyncMessage(0, syncer::MessageType::RESOURCE_VIEW);
     rpc::ResourcesData resources_data;
     resources_data.ParseFromString(msg->sync_message());

--- a/src/ray/raylet/scheduling/local_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager_test.cc
@@ -14,11 +14,10 @@
 
 // Don't know why macro redefinition happens, but this is failing windows
 // build.
-#pragma warning(disable : 4005)
-
 #include "ray/raylet/scheduling/local_resource_manager.h"
 
 #include "gtest/gtest.h"
+#include "ray/common/grpc_util.h"
 
 namespace ray {
 

--- a/src/ray/raylet/scheduling/local_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager_test.cc
@@ -44,6 +44,13 @@ class LocalResourceManagerTest : public ::testing::Test {
     }
   }
 
+  rpc::ResourcesData GetSyncMessageForResourceReport() const {
+    auto msg = manager->CreateSyncMessage(0, syncer::MessageType::RESOURCE_VIEW);
+    rpc::ResourcesData resources_data;
+    resources_data.ParseFromString(msg->sync_message());
+    return resources_data;
+  }
+
   scheduling::NodeID local_node_id = scheduling::NodeID(0);
   std::unique_ptr<LocalResourceManager> manager;
 };
@@ -272,6 +279,9 @@ TEST_F(LocalResourceManagerTest, IdleResourceTimeTest) {
     {
       auto idle_time = manager->GetResourceIdleTime();
       ASSERT_EQ(idle_time, absl::nullopt);
+
+      const auto &resources_data = GetSyncMessageForResourceReport();
+      ASSERT_EQ(resources_data.idle_duration_ms(), 0);
     }
 
     // Deallocate the resource
@@ -290,6 +300,10 @@ TEST_F(LocalResourceManagerTest, IdleResourceTimeTest) {
       auto dur = absl::Now() - *idle_time;
       ASSERT_GE(dur, absl::ZeroDuration());
       ASSERT_LE(dur, absl::Seconds(1));
+
+      const auto &resources_data = GetSyncMessageForResourceReport();
+      ASSERT_GE(resources_data.idle_duration_ms(), 0);
+      ASSERT_LE(resources_data.idle_duration_ms(), 1 * 1000);
     }
   }
 
@@ -299,6 +313,9 @@ TEST_F(LocalResourceManagerTest, IdleResourceTimeTest) {
     manager->UpdateAvailableObjectStoreMemResource();
     auto idle_time = manager->GetResourceIdleTime();
     ASSERT_EQ(idle_time, absl::nullopt);
+
+    const auto &resources_data = GetSyncMessageForResourceReport();
+    ASSERT_EQ(resources_data.idle_duration_ms(), 0);
   }
 
   // Free object store memory usage should make node resource idle.
@@ -309,6 +326,10 @@ TEST_F(LocalResourceManagerTest, IdleResourceTimeTest) {
     ASSERT_TRUE(idle_time.has_value());
     auto dur = absl::Now() - *idle_time;
     ASSERT_GE(dur, absl::ZeroDuration());
+
+    // And syncer messages should be created correctly for resource reporting.
+    const auto &resources_data = GetSyncMessageForResourceReport();
+    ASSERT_GE(resources_data.idle_duration_ms(), 0);
   }
 }
 

--- a/src/ray/raylet/scheduling/local_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager_test.cc
@@ -17,7 +17,6 @@
 #include "ray/raylet/scheduling/local_resource_manager.h"
 
 #include "gtest/gtest.h"
-#include "ray/common/grpc_util.h"
 
 namespace ray {
 

--- a/src/ray/raylet/scheduling/local_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager_test.cc
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Don't know why macro redefinition happens, but this is failing windows
+// build.
+#pragma warning(disable : 4005)
+
 #include "ray/raylet/scheduling/local_resource_manager.h"
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/issues/38690

This makes sure when a node is idle (from resources perspective), it will always report idle time in miliseconds even if it's been idle less than 1 millisecond. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Fixes https://github.com/ray-project/ray/issues/38690

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
