### PR TITLE
[ci] mark many_pgs as unstable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5451,6 +5451,7 @@
 
   frequency: nightly-3x
   team: core
+  stable: false
   cluster:
     byod:
       type: gpu


### PR DESCRIPTION
Mark many_pgs release tests as unstable; they don't need to be fixed for the next release, according to https://github.com/ray-project/ray/issues/38404

Test:
- CI