### PR TITLE
[spark] Ray on spark support JSON format option values and set default object_spilling_config path 

### DIFF
--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -223,7 +223,7 @@ class RayClusterOnSpark:
 def _convert_ray_node_option(key, value):
     converted_key = f"--{key.replace('_', '-')}"
     if key in ["system_config", "resources", "labels"]:
-        return f"{converted_key}='{json.dumps(value)}'"
+        return f"{converted_key}={json.dumps(value)}"
     if value is None:
         return converted_key
     return f"{converted_key}={str(value)}"

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -229,17 +229,18 @@ def _convert_ray_node_option(key, value):
     return f"{converted_key}={str(value)}"
 
 
-def _convert_ray_node_options(options, *, object_spilling_path):
-    if "system_config" not in options:
-        options["system_config"] = {}
-    sys_conf = options["system_config"]
-    if "object_spilling_config" not in sys_conf:
-        sys_conf["object_spilling_config"] = json.dumps({
-          "type": "filesystem",
-          "params": {
-            "directory_path": object_spilling_path,
-          }
-        })
+def _convert_ray_node_options(options, *, object_spilling_path=None):
+    if object_spilling_path is not None:
+        if "system_config" not in options:
+            options["system_config"] = {}
+        sys_conf = options["system_config"]
+        if "object_spilling_config" not in sys_conf:
+            sys_conf["object_spilling_config"] = json.dumps({
+              "type": "filesystem",
+              "params": {
+                "directory_path": object_spilling_path,
+              }
+            })
     return [
         _convert_ray_node_option(k, v)
         for k, v in options.items()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For Ray on spark:
* support JSON format option values
* set default object_spilling_config path , this is specifically for databricks runtime, it sets spilling path to path under "/local_disk0" by default to aviod disk space overflow.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
