### PR TITLE
[autoscaler] Set new_config logging to debug in autoscaler

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -1037,7 +1037,8 @@ class StandardAutoscaler:
                         exc_info=e,
                     )
             logger.debug(
-                f"New config after validation: {new_config}, of type: {type(new_config)}"
+                f"New config after validation: {new_config},"
+                f" of type: {type(new_config)}"
             )
             (new_runtime_hash, new_file_mounts_contents_hash) = hash_runtime_conf(
                 new_config["file_mounts"],

--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -1036,7 +1036,9 @@ class StandardAutoscaler:
                         "available until you upgrade ray on your cluster.",
                         exc_info=e,
                     )
-            print("new config", new_config, type(new_config))
+            logger.debug(
+                f"New config after validation: {new_config}, of type: {type(new_config)}"
+            )
             (new_runtime_hash, new_file_mounts_contents_hash) = hash_runtime_conf(
                 new_config["file_mounts"],
                 new_config["cluster_synced_files"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, it's really hard to debug autoscaler failures using monitor.out as it logs redundant new_config continuously in recent change. [Fix is to move from print to DEBUG](https://github.com/ray-project/ray/blob/8a00f221dbbe27c0fd331f1484ba88b69fe40a25/python/ray/autoscaler/_private/autoscaler.py#L1039)

```
ubuntu@ip-10-0-143-38:~$ ls -lah /tmp/ray/session_latest/logs/monitor*
-rw-rw-r-- 1 ubuntu ubuntu 2.2K Aug 22 01:19 /tmp/ray/session_latest/logs/monitor.err
-rw-rw-r-- 1 ubuntu ubuntu 7.8M Aug 22 16:23 /tmp/ray/session_latest/logs/monitor.log
-rw-rw-r-- 1 ubuntu ubuntu 124M Aug 22 16:23 /tmp/ray/session_latest/logs/monitor.out
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

"Closes #38727"

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] ~~I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.~~
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
