### PR TITLE
[ci] Update gce tests to use a new cloud

### DIFF
--- a/release/ray_release/environments/gce.env
+++ b/release/ray_release/environments/gce.env
@@ -1,7 +1,7 @@
 ANYSCALE_HOST=https://console.anyscale-staging.com
 ANYSCALE_CLOUD_STORAGE_PROVIDER=gs
 RELEASE_AWS_ANYSCALE_SECRET_ARN="arn:aws:secretsmanager:us-west-2:029272617770:secret:release-automation/anyscale-staging-token20221014164754935800000001-pfQunc"
-RELEASE_DEFAULT_CLOUD_ID="cld_tPsS3nQz8p5cautbyWgEdr4y"
+RELEASE_DEFAULT_CLOUD_ID="cld_vy7xqacrvddvbuy95auinvuqmt"
 RELEASE_DEFAULT_PROJECT="prj_qC3ZfndQWYYjx2cz8KWGNUL4"
 ANYSCALE_PROJECT="prj_qC3ZfndQWYYjx2cz8KWGNUL4"
 GOOGLE_CLOUD_PROJECT="anyscale-oss-ci"


### PR DESCRIPTION
Update OSS release gce tests to use a new anyscale cloud. The other cloud has been deprecated.