### PR TITLE
[ci] Jail //python/ray/tests:test_actor_cancel test

### DIFF
--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -1,4 +1,5 @@
 flaky_tests:
+  - //python/ray/tests:test_actor_cancel
   - //python/ray/tests:test_gcs_fault_tolerance
   - //python/ray/tests:test_object_manager
   - //python/ray/tests:test_placement_group_3


### PR DESCRIPTION
The test_actor_cancel is added recently and it seems to be flaky out of the box (https://flaky-tests.ray.io/?owner=core). Jail it for now so it won't block people randomly on PR.

Test:
- CI

