### PR TITLE
[Serve] Revisited Serve agent to avoid rejecting Serve configs in case HTTP options diverge

### DIFF
--- a/dashboard/modules/serve/serve_agent.py
+++ b/dashboard/modules/serve/serve_agent.py
@@ -295,9 +295,9 @@ class ServeAgent(dashboard_utils.DashboardAgentModule):
 
         if divergent_http_options:
             logger.warning(
-                f"Serve is already running on this Ray cluster and it's not possible to update "
-                f"its HTTP options without restarting it. Following options are attempted to be updated: "
-                f"{divergent_http_options}."
+                f"Serve is already running on this Ray cluster and it's not possible "
+                f"to update its HTTP options without restarting it. Following options "
+                f"are attempted to be updated: {divergent_http_options}."
             )
 
     async def get_serve_controller(self):

--- a/dashboard/modules/serve/serve_agent.py
+++ b/dashboard/modules/serve/serve_agent.py
@@ -270,16 +270,9 @@ class ServeAgent(dashboard_utils.DashboardAgentModule):
             )
 
         # Serve ignores HTTP options if it was already running when
-        # serve_start_async() is called. We explicitly return an error response
-        # here if Serve's HTTP options don't match the config's options.
-        for option, requested_value in full_http_options.items():
-            conflict_response = self.check_http_options(
-                option,
-                getattr(client.http_config, option),
-                requested_value,
-            )
-            if conflict_response is not None:
-                return conflict_response
+        # serve_start_async() is called. Therefore we validate that no
+        # existing HTTP options are updated and print warning in case they are
+        self.validate_http_options(client, full_http_options)
 
         try:
             client.deploy_apps(config)
@@ -292,21 +285,19 @@ class ServeAgent(dashboard_utils.DashboardAgentModule):
         else:
             return Response()
 
-    def check_http_options(self, option: str, old: str, new: str):
-        http_mismatch_message = (
-            "Serve is already running on this Ray cluster. Its HTTP {option} is set to "
-            '"{old}". However, the requested {option} is "{new}". The requested '
-            "{option} must match the running Serve instance's HTTP {option}. To change "
-            "the Serve HTTP {option}, shut down Serve on this Ray cluster using "
-            "the `serve shutdown` CLI command or by sending a DELETE request to the "
-            '"/api/serve/applications/" endpoint. CAUTION: shutting down Serve will '
-            "also shut down all Serve applications."
-        )
+    def validate_http_options(self, client, http_options):
+        divergent_http_options = []
 
-        if not old == new:
-            return Response(
-                status=400,
-                text=http_mismatch_message.format(option=option, old=old, new=new),
+        for option, new_value in http_options.items():
+            prev_value = getattr(client.http_config, option)
+            if prev_value != new_value:
+                divergent_http_options.append(option)
+
+        if divergent_http_options:
+            logger.warning(
+                f"Serve is already running on this Ray cluster and it's not possible to update "
+                f"its HTTP options without restarting it. Following options are attempted to be updated: "
+                f"{divergent_http_options}."
             )
 
     async def get_serve_controller(self):

--- a/dashboard/modules/serve/tests/test_serve_agent.py
+++ b/dashboard/modules/serve/tests/test_serve_agent.py
@@ -13,7 +13,7 @@ import ray._private.ray_constants as ray_constants
 from ray.util.state import list_actors
 from ray.serve._private.constants import SERVE_NAMESPACE, MULTI_APP_MIGRATION_MESSAGE
 from ray.serve.tests.conftest import *  # noqa: F401 F403
-from ray.serve.schema import ServeInstanceDetails
+from ray.serve.schema import ServeInstanceDetails, HTTPOptionsSchema
 from ray.serve._private.common import (
     ApplicationStatus,
     DeploymentStatus,
@@ -742,7 +742,6 @@ def test_serve_namespace(ray_start_stop):
     serve.shutdown()
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on OSX.")
 @pytest.mark.parametrize(
     "option,override",
     [
@@ -756,19 +755,22 @@ def test_put_with_http_options(ray_start_stop, option, override):
     """Submits a config with HTTP options specified.
 
     Trying to submit a config to the serve agent with the HTTP options modified should
-    fail, since users are required to shutdown Serve and restart it if they want to
-    change HTTP options.
+    NOT fail:
+      - If Serve is NOT running, HTTP options will be honored when starting Serve
+      - If Serve is running, HTTP options will be ignored, and warning will be logged
+      urging users to restart Serve if they want their options to take effect
     """
 
     pizza_import_path = "ray.serve.tests.test_config_files.pizza.serve_dag"
     world_import_path = "ray.serve.tests.test_config_files.world.DagNode"
-    original_config = {
+    original_http_options_json = {
+        "host": "127.0.0.1",
+        "port": 8000,
+        "root_path": "/serve",
+    }
+    original_serve_config_json = {
         "proxy_location": "EveryNode",
-        "http_options": {
-            "host": "127.0.0.1",
-            "port": 8000,
-            "root_path": "/serve",
-        },
+        "http_options": original_http_options_json,
         "applications": [
             {
                 "name": "app1",
@@ -782,7 +784,7 @@ def test_put_with_http_options(ray_start_stop, option, override):
             },
         ],
     }
-    deploy_config_multi_app(original_config)
+    deploy_config_multi_app(original_serve_config_json)
 
     # Wait for deployments to be up
     wait_for_condition(
@@ -798,11 +800,19 @@ def test_put_with_http_options(ray_start_stop, option, override):
         timeout=15,
     )
 
-    modified_config = copy.deepcopy(original_config)
-    modified_config[option] = override
+    updated_serve_config_json = copy.deepcopy(original_serve_config_json)
+    updated_serve_config_json[option] = override
 
-    put_response = requests.put(GET_OR_PUT_URL_V2, json=modified_config, timeout=5)
-    assert put_response.status_code == 400
+    put_response = requests.put(GET_OR_PUT_URL_V2, json=updated_serve_config_json, timeout=5)
+    assert put_response.status_code == 200
+
+    # Fetch Serve status and confirm that HTTP options are unchanged
+    get_response = requests.get(GET_OR_PUT_URL_V2, timeout=5)
+    serve_details = ServeInstanceDetails.parse_obj(get_response.json())
+
+    original_http_options = HTTPOptionsSchema.parse_obj(original_http_options_json)
+
+    assert original_http_options == serve_details.http_options.dict(exclude_unset=True)
 
     # Deployments should still be up
     assert (

--- a/dashboard/modules/serve/tests/test_serve_agent.py
+++ b/dashboard/modules/serve/tests/test_serve_agent.py
@@ -803,7 +803,9 @@ def test_put_with_http_options(ray_start_stop, option, override):
     updated_serve_config_json = copy.deepcopy(original_serve_config_json)
     updated_serve_config_json[option] = override
 
-    put_response = requests.put(GET_OR_PUT_URL_V2, json=updated_serve_config_json, timeout=5)
+    put_response = requests.put(
+        GET_OR_PUT_URL_V2, json=updated_serve_config_json, timeout=5
+    )
     assert put_response.status_code == 200
 
     # Fetch Serve status and confirm that HTTP options are unchanged

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -920,14 +920,11 @@ class ServeController:
         # except for the route_prefix in the deployment_config of each deployment, since
         # route_prefix is set instead in each application.
         # Eventually we want to remove route_prefix from DeploymentSchema.
+        http_options = HTTPOptionsSchema.parse_obj(http_config.dict(exclude_unset=True))
         return ServeInstanceDetails(
             controller_info=self._actor_details,
             proxy_location=http_config.location,
-            http_options=HTTPOptionsSchema(
-                host=http_config.host,
-                port=http_config.port,
-                request_timeout_s=http_config.request_timeout_s,
-            ),
+            http_options=http_options,
             http_proxies=self.http_proxy_state_manager.get_http_proxy_details()
             if self.http_proxy_state_manager
             else None,

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -516,7 +516,7 @@ class ServeApplicationSchema(BaseModel, extra=Extra.forbid):
 
 
 @PublicAPI(stability="alpha")
-class HTTPOptionsSchema(BaseModel, extra=Extra.forbid):
+class HTTPOptionsSchema(BaseModel):
     """Options to start the HTTP Proxy with."""
 
     host: str = Field(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change revisits Serve agent handling of updated HTTP options when Serve application is already running:

 - Previously: agent would reject PUT /api/serve/applications/ request, in case provided HTTP options are divergent from the ones Serve application was started with
 - Now: agent would log as warning all options that diverged, and then proceed to ignore them, however still accepting the rest of the config

This change is necessary to avoid complexity of external handling of HTTP option changes: we configure Serve application programmatically, and that includes some of its HTTP options that might change dynamically (request, keep-alive timeouts, etc). 

We want to make sure that as these programmatic changes make their way into the updated Serve configs, they don't block other Serve application changes (like deploying application changes itself) and are just silently ignored.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
