### PR TITLE
[ci] jail //python/ray/tests:test_object_assign_owner_client_mode

### DIFF
--- a/ci/ray_ci/serverless.tests.yml
+++ b/ci/ray_ci/serverless.tests.yml
@@ -2,3 +2,4 @@ flaky_tests:
   - //python/ray/tests:test_autoscaler
   - //python/ray/tests:test_client_builder
   - //python/ray/tests:test_client_library_integration
+  - //python/ray/tests:test_object_assign_owner_client_mode


### PR DESCRIPTION
Jail one more serverless test. Jail them all until postmerge is green.

Test failure example: https://buildkite.com/ray-project/postmerge/builds/245

Test:
- CI