### PR TITLE
[serve] clean up in-memory metrics when replicas are removed

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -359,6 +359,15 @@ class ReplicaName:
         )
         return cls(deployment_tag=parsed[0], replica_suffix=parsed[1])
 
+    @classmethod
+    def from_replica_tag(cls, tag):
+        parsed = tag.split(cls.delimiter)
+        assert len(parsed) == 2, (
+            f"Given replica name {tag} didn't match pattern, please "
+            f"ensure it has exactly two fields with delimiter {cls.delimiter}"
+        )
+        return cls(deployment_tag=parsed[0], replica_suffix=parsed[1])
+
     def __str__(self):
         return self.replica_tag
 

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1173,6 +1173,8 @@ class DeploymentState:
             self._name, DeploymentStatus.UPDATING
         )
 
+        self.replica_average_ongoing_requests: Dict[str, float] = dict()
+
         self.health_check_gauge = metrics.Gauge(
             "serve_deployment_replica_healthy",
             description=(
@@ -1435,17 +1437,28 @@ class DeploymentState:
         self._set_target_state(deployment_info)
         return True
 
-    def autoscale(
-        self,
-        current_num_ongoing_requests: List[float],
-        current_handle_queued_queries: int,
-    ):
+    def get_replica_current_ongoing_requests(self) -> List[float]:
+        """Return list of replica average ongoing requests.
+
+        The length of list indicate the number of replicas.
+        """
+
+        running_replicas = self._replicas.get([ReplicaState.RUNNING])
+
+        current_num_ongoing_requests = []
+        for replica in running_replicas:
+            replica_tag = replica.replica_tag
+            if replica_tag in self.replica_average_ongoing_requests:
+                current_num_ongoing_requests.append(
+                    self.replica_average_ongoing_requests[replica_tag]
+                )
+        return current_num_ongoing_requests
+
+    def autoscale(self, current_handle_queued_queries: int):
         """
         Autoscale the deployment based on metrics
 
         Args:
-            current_num_ongoing_requests: a list of number of running requests of all
-                replicas in the deployment
             current_handle_queued_queries: The number of handle queued queries,
                 if there are multiple handles, the max number of queries at
                 a single handle should be passed in
@@ -1453,6 +1466,7 @@ class DeploymentState:
         if self._target_state.deleting:
             return
 
+        current_num_ongoing_requests = self.get_replica_current_ongoing_requests()
         autoscaling_policy = self._target_state.info.autoscaling_policy
         decision_num_replicas = autoscaling_policy.get_decision_num_replicas(
             curr_target_num_replicas=self._target_state.num_replicas,
@@ -1984,6 +1998,11 @@ class DeploymentState:
                 self._replicas.add(ReplicaState.STOPPING, replica)
             else:
                 logger.info(f"Replica {replica.replica_tag} is stopped.")
+                # NOTE(zcin): We need to remove the replica from in-memory metrics store
+                # here instead of _stop_replica because the replica will continue to
+                # send metrics while it's still alive.
+                if replica.replica_tag in self.replica_average_ongoing_requests:
+                    del self.replica_average_ongoing_requests[replica.replica_tag]
 
     def _stop_replicas_on_draining_nodes(self):
         draining_nodes = self._cluster_node_info_cache.get_draining_node_ids()
@@ -2040,6 +2059,11 @@ class DeploymentState:
             upscale=upscale,
             downscale=downscale,
         )
+
+    def record_autoscaling_metrics(self, replica_tag: str, window_avg: float) -> None:
+        """Records average ongoing requests at replicas."""
+
+        self.replica_average_ongoing_requests[replica_tag] = window_avg
 
     def record_multiplexed_model_ids(
         self, replica_name: str, multiplexed_model_ids: List[str]
@@ -2234,7 +2258,6 @@ class DeploymentStateManager:
         )
 
         # TODO(simon): move autoscaling related stuff into a manager.
-        self.replica_average_ongoing_requests = dict()
         self.handle_metrics_store = InMemoryMetricsStore()
 
     def _create_driver_deployment_state(self, name):
@@ -2270,7 +2293,10 @@ class DeploymentStateManager:
     def record_autoscaling_metrics(self, data, send_timestamp: float):
         replica_tag, window_avg = data
         if window_avg is not None:
-            self.replica_average_ongoing_requests[replica_tag] = window_avg
+            replica_name = ReplicaName.from_replica_tag(replica_tag)
+            self._deployment_states[
+                replica_name.deployment_tag
+            ].record_autoscaling_metrics(replica_tag, window_avg)
 
     def record_handle_metrics(self, data: Dict[str, float], send_timestamp: float):
         self.handle_metrics_store.add_metrics_point(data, send_timestamp)
@@ -2279,7 +2305,10 @@ class DeploymentStateManager:
         """
         Return autoscaling metrics (used for dumping from controller)
         """
-        return self.replica_average_ongoing_requests
+        return {
+            deployment: deployment_state.replica_average_ongoing_requests
+            for deployment, deployment_state in self._deployment_states.items()
+        }
 
     def _map_actor_names_to_deployment(
         self, all_current_actor_names: List[str]
@@ -2572,32 +2601,6 @@ class DeploymentStateManager:
         if deployment_name in self._deployment_states:
             self._deployment_states[deployment_name].delete()
 
-    def get_replica_ongoing_request_metrics(
-        self, deployment_name: str, look_back_period_s
-    ) -> List[float]:
-        """
-        Return replica average ongoing requests
-        Args:
-            deployment_name: deployment name
-            look_back_period_s: the look back time period to collect the requests
-                metrics
-        Returns:
-            List of ongoing requests, the length of list indicate the number
-                of replicas
-        """
-
-        replicas = self._deployment_states[deployment_name]._replicas
-        running_replicas = replicas.get([ReplicaState.RUNNING])
-
-        current_num_ongoing_requests = []
-        for replica in running_replicas:
-            replica_tag = replica.replica_tag
-            if replica_tag in self.replica_average_ongoing_requests:
-                current_num_ongoing_requests.append(
-                    self.replica_average_ongoing_requests[replica_tag]
-                )
-        return current_num_ongoing_requests
-
     def get_handle_queueing_metrics(
         self, deployment_name: str, look_back_period_s
     ) -> int:
@@ -2631,17 +2634,11 @@ class DeploymentStateManager:
 
         for deployment_name, deployment_state in self._deployment_states.items():
             if deployment_state.should_autoscale():
-                current_num_ongoing_requests = self.get_replica_ongoing_request_metrics(
-                    deployment_name,
-                    deployment_state.get_autoscale_metric_lookback_period(),
-                )
                 current_handle_queued_queries = self.get_handle_queueing_metrics(
                     deployment_name,
                     deployment_state.get_autoscale_metric_lookback_period(),
                 )
-                deployment_state.autoscale(
-                    current_num_ongoing_requests, current_handle_queued_queries
-                )
+                deployment_state.autoscale(current_handle_queued_queries)
 
             deployment_state_update_result = deployment_state.update()
             if deployment_state_update_result.upscale:

--- a/python/ray/serve/tests/test_autoscaling_metrics.py
+++ b/python/ray/serve/tests/test_autoscaling_metrics.py
@@ -4,6 +4,7 @@ import ray
 from ray import serve
 from ray._private.test_utils import wait_for_condition
 from ray.serve._private.autoscaling_metrics import InMemoryMetricsStore
+from ray.serve._private.common import ReplicaState
 
 
 class TestInMemoryMetricsStore:
@@ -75,38 +76,64 @@ def test_e2e(serve_instance):
         autoscaling_config={
             "metrics_interval_s": 0.1,
             "min_replicas": 1,
-            "max_replicas": 1,
+            "max_replicas": 2,
+            "target_num_ongoing_requests_per_replica": 1,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "look_back_period_s": 1,
         },
         # We will send over a lot of queries. This will make sure replicas are
         # killed quickly during cleanup.
         graceful_shutdown_timeout_s=1,
-        max_concurrent_queries=1000,
+        max_concurrent_queries=25,
         version="v1",
     )
     class A:
         def __call__(self):
-            time.sleep(0.5)
+            time.sleep(0.1)
 
     handle = serve.run(A.bind())
-    [handle.remote() for _ in range(100)]
+    dep_id = "default_A"
+    [handle.remote() for _ in range(50)]
 
     # Wait for metrics to propagate
     def get_data():
-        return ray.get(
+        data = ray.get(
             serve_instance._controller._dump_autoscaling_metrics_for_testing.remote()
-        )
+        )[dep_id]
+        print(data)
+        return data
 
     wait_for_condition(lambda: len(get_data()) > 0)
+    print("Autoscaling metrics started recording on controller.")
 
     # Many queries should be inflight.
     def last_timestamp_value_high():
         data = get_data()
-        only_key = list(data.keys())[0]
-        print(data[only_key])
-        assert data[only_key] > 50
+        metrics = list(data.values())
+        assert len(metrics) == 2
+        assert metrics[0] > 0 and metrics[1] > 0
+        assert sum(metrics) > 25
         return True
 
     wait_for_condition(last_timestamp_value_high)
+    print("Confirmed there are metrics from 2 replicas, and many queries are inflight.")
+
+    def check_running_replicas(expected):
+        replicas = ray.get(
+            serve_instance._controller._dump_replica_states_for_testing.remote(dep_id)
+        )
+        running_replicas = replicas.get([ReplicaState.RUNNING])
+        assert len(running_replicas) == expected
+        return True
+
+    # After traffic stops, num replica should drop to 1
+    wait_for_condition(check_running_replicas, expected=1, timeout=15)
+    print("Num replicas dropped to 1.")
+
+    # The metrics stored on controller should only have info on the remaining replica
+    wait_for_condition(lambda: len(get_data()) == 1)
+    print("Metrics stored on the controller reduced to 1 replica.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Prevent in-memory metrics store from growing unbounded.

* changed the metrics store to be per-deployment --> moved into `DeploymentState`.
* extended the autoscaling metrics test to check that the replica is removed from in-memory metrics store after it scales down.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
