### PR TITLE
[Serve] Relaxed input Serve config's schemas to allow extra params

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -201,7 +201,6 @@ class DeploymentConfig(BaseModel):
 
     class Config:
         validate_assignment = True
-        extra = "forbid"
         arbitrary_types_allowed = True
 
     # Dynamic default for max_concurrent_queries
@@ -712,7 +711,6 @@ class HTTPOptions(pydantic.BaseModel):
 
     class Config:
         validate_assignment = True
-        extra = "forbid"
         arbitrary_types_allowed = True
 
 

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -57,7 +57,7 @@ def _route_prefix_format(cls, v):
 
 
 @PublicAPI(stability="beta")
-class RayActorOptionsSchema(BaseModel, extra=Extra.forbid):
+class RayActorOptionsSchema(BaseModel):
     """Options with which to start a replica actor."""
 
     runtime_env: dict = Field(
@@ -137,9 +137,7 @@ class RayActorOptionsSchema(BaseModel, extra=Extra.forbid):
 
 
 @PublicAPI(stability="beta")
-class DeploymentSchema(
-    BaseModel, extra=Extra.forbid, allow_population_by_field_name=True
-):
+class DeploymentSchema(BaseModel, allow_population_by_field_name=True):
     """
     Specifies options for one deployment within a Serve application. For each deployment
     this can optionally be included in `ServeApplicationSchema` to override deployment

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -314,7 +314,7 @@ def _deployment_info_to_schema(name: str, info: DeploymentInfo) -> DeploymentSch
 
 
 @PublicAPI(stability="beta")
-class ServeApplicationSchema(BaseModel, extra=Extra.forbid):
+class ServeApplicationSchema(BaseModel):
     """
     Describes one Serve application, and currently can also be used as a standalone
     config to deploy a single application to a Ray cluster.
@@ -508,7 +508,12 @@ class ServeApplicationSchema(BaseModel, extra=Extra.forbid):
 
 @PublicAPI(stability="alpha")
 class HTTPOptionsSchema(BaseModel):
-    """Options to start the HTTP Proxy with."""
+    """Options to start the HTTP Proxy with.
+
+    NOTE: This config allows extra parameters to make it forward-compatible (ie
+          older versions of Serve are able to accept configs from a newer versions,
+          simply ignoring new parameters)
+    """
 
     host: str = Field(
         default="0.0.0.0",
@@ -547,13 +552,17 @@ class HTTPOptionsSchema(BaseModel):
 
 
 @PublicAPI(stability="alpha")
-class ServeDeploySchema(BaseModel, extra=Extra.forbid):
+class ServeDeploySchema(BaseModel):
     """
     Multi-application config for deploying a list of Serve applications to the Ray
     cluster.
 
     This is the request JSON schema for the v2 REST API
     `PUT "/api/serve/applications/"`.
+
+    NOTE: This config allows extra parameters to make it forward-compatible (ie
+          older versions of Serve are able to accept configs from a newer versions,
+          simply ignoring new parameters)
     """
 
     proxy_location: DeploymentMode = Field(

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -310,7 +310,7 @@ def test_deploy_duplicate_routes(ray_start_stop):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
-def test_deploy_bad_config1(ray_start_stop):
+def test_deploy_bad_v2_config(ray_start_stop):
     """Deploy a bad config with field applications, should try to parse as v2 config."""
 
     config_file = os.path.join(
@@ -321,12 +321,16 @@ def test_deploy_bad_config1(ray_start_stop):
         subprocess.check_output(
             ["serve", "deploy", config_file], stderr=subprocess.STDOUT
         )
-    assert "ValidationError" in e.value.output.decode("utf-8")
-    assert "ServeDeploySchema" in e.value.output.decode("utf-8")
+
+    output = e.value.output.decode("utf-8")
+
+    assert "ValidationError" in output, output
+    assert "ServeDeploySchema" in output, output
+    assert "Please ensure each application's route_prefix is unique" in output
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
-def test_deploy_bad_config2(ray_start_stop):
+def test_deploy_bad_v1_config(ray_start_stop):
     """
     Deploy a bad config without field applications, should try to parse as v1 config.
     """
@@ -339,8 +343,12 @@ def test_deploy_bad_config2(ray_start_stop):
         subprocess.check_output(
             ["serve", "deploy", config_file], stderr=subprocess.STDOUT
         )
-    assert "ValidationError" in e.value.output.decode("utf-8")
-    assert "ServeApplicationSchema" in e.value.output.decode("utf-8")
+
+    output = e.value.output.decode("utf-8")
+
+    assert "none is not an allowed value" in output
+    assert "ValidationError" in output, output
+    assert "ServeApplicationSchema" in output, output
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")

--- a/python/ray/serve/tests/test_config.py
+++ b/python/ray/serve/tests/test_config.py
@@ -65,9 +65,8 @@ def test_autoscaling_config_validation():
 
 class TestDeploymentConfig:
     def test_deployment_config_validation(self):
-        # Test unknown key.
-        with pytest.raises(ValidationError):
-            DeploymentConfig(unknown_key=-1)
+        # Test config ignoring unknown keys (required for forward-compatibility)
+        DeploymentConfig(new_version_key=-1)
 
         # Test num_replicas validation.
         DeploymentConfig(num_replicas=1)
@@ -349,10 +348,11 @@ class TestReplicaConfig:
         assert config.init_kwargs == dict()
 
 
-def test_input_config_schemas_forward_compatible():
+def test_config_schemas_forward_compatible():
+    # Test configs ignoring unknown keys (required for forward-compatibility)
     ServeDeploySchema(
         http_options=HTTPOptionsSchema(
-            new_version_config="this config is from newer version of Ray"
+            new_version_config_key="this config is from newer version of Ray"
         ),
         applications=[
             ServeApplicationSchema(
@@ -360,19 +360,23 @@ def test_input_config_schemas_forward_compatible():
                 deployments=[
                     DeploymentSchema(
                         name="deployment",
-                        new_version_config="this config is from newer version of Ray",
+                        new_version_config_key="this config is from newer version of Ray",
                     )
                 ],
-                new_version_config="this config is from newer version of Ray",
+                new_version_config_key="this config is from newer version of Ray",
             ),
         ],
-        new_version_config="this config is from newer version of Ray",
+        new_version_config_key="this config is from newer version of Ray",
     )
 
 
 def test_http_options():
     HTTPOptions()
     HTTPOptions(host="8.8.8.8", middlewares=[object()])
+
+    # Test configs ignoring unknown keys (required for forward-compatibility)
+    HTTPOptions(new_version_config_key="this config is from newer version of Ray")
+
     assert HTTPOptions(host=None).location == "NoServer"
     assert HTTPOptions(location=None).location == "NoServer"
     assert HTTPOptions(location=DeploymentMode.EveryNode).location == "EveryNode"

--- a/python/ray/serve/tests/test_config.py
+++ b/python/ray/serve/tests/test_config.py
@@ -14,6 +14,12 @@ from ray.serve.config import AutoscalingConfig
 from ray.serve._private.utils import DEFAULT
 from ray.serve.generated.serve_pb2_grpc import add_UserDefinedServiceServicer_to_server
 from ray.serve._private.constants import DEFAULT_GRPC_PORT
+from ray.serve.schema import (
+    ServeDeploySchema,
+    HTTPOptionsSchema,
+    ServeApplicationSchema,
+    DeploymentSchema,
+)
 
 
 def test_autoscaling_config_validation():
@@ -341,6 +347,27 @@ class TestReplicaConfig:
         assert config.deployment_def() == "Check this out!"
         assert config.init_args == tuple()
         assert config.init_kwargs == dict()
+
+
+def test_input_config_schemas_forward_compatible():
+    ServeDeploySchema(
+        http_options=HTTPOptionsSchema(
+            new_version_config="this config is from newer version of Ray"
+        ),
+        applications=[
+            ServeApplicationSchema(
+                import_path="module.app",
+                deployments=[
+                    DeploymentSchema(
+                        name="deployment",
+                        new_version_config="this config is from newer version of Ray",
+                    )
+                ],
+                new_version_config="this config is from newer version of Ray",
+            ),
+        ],
+        new_version_config="this config is from newer version of Ray",
+    )
 
 
 def test_http_options():

--- a/python/ray/serve/tests/test_config.py
+++ b/python/ray/serve/tests/test_config.py
@@ -360,7 +360,8 @@ def test_config_schemas_forward_compatible():
                 deployments=[
                     DeploymentSchema(
                         name="deployment",
-                        new_version_config_key="this config is from newer version of Ray",
+                        new_version_config_key="this config is from newer version"
+                        " of Ray",
                     )
                 ],
                 new_version_config_key="this config is from newer version of Ray",

--- a/python/ray/serve/tests/test_config_files/bad_multi_config.yaml
+++ b/python/ray/serve/tests/test_config_files/bad_multi_config.yaml
@@ -12,6 +12,7 @@ applications:
           increment: 1
 
   - name: "app2"
+    # Route prefixes should be unique across all apps!
     route_prefix: "/app1"
     import_path: ray.serve.tests.test_config_files.pizza.serve_dag
     deployments:

--- a/python/ray/serve/tests/test_config_files/bad_single_config.yaml
+++ b/python/ray/serve/tests/test_config_files/bad_single_config.yaml
@@ -1,7 +1,8 @@
-import_path: ray.serve.tests.test_config_files.test_dag.conditional_dag.serve_dag
+# Import path is a required field
+import_path:
 
 deployments:
 
   - name: Multiplier
     user_config:
-    factor: 1
+      factor: 1

--- a/python/ray/serve/tests/test_schema.py
+++ b/python/ray/serve/tests/test_schema.py
@@ -187,10 +187,9 @@ class TestRayActorOptionsSchema:
         # Schema should be createable with valid fields
         RayActorOptionsSchema.parse_obj(ray_actor_options_schema)
 
-        # Schema should raise error when a nonspecified field is included
-        ray_actor_options_schema["fake_field"] = None
-        with pytest.raises(ValidationError):
-            RayActorOptionsSchema.parse_obj(ray_actor_options_schema)
+        # Schema should NOT raise error when extra field is included
+        ray_actor_options_schema["extra_field"] = None
+        RayActorOptionsSchema.parse_obj(ray_actor_options_schema)
 
     def test_dict_defaults_ray_actor_options(self):
         # Dictionary fields should have empty dictionaries as defaults, not None
@@ -339,10 +338,9 @@ class TestDeploymentSchema:
         # Schema should be createable with valid fields
         DeploymentSchema.parse_obj(deployment_schema)
 
-        # Schema should raise error when a nonspecified field is included
-        deployment_schema["fake_field"] = None
-        with pytest.raises(ValidationError):
-            DeploymentSchema.parse_obj(deployment_schema)
+        # Schema should NOT raise error when extra field is included
+        deployment_schema["extra_field"] = None
+        DeploymentSchema.parse_obj(deployment_schema)
 
     @pytest.mark.parametrize(
         "option",
@@ -430,10 +428,9 @@ class TestServeApplicationSchema:
         # Schema should be createable with valid fields
         ServeApplicationSchema.parse_obj(serve_application_schema)
 
-        # Schema should raise error when a nonspecified field is included
-        serve_application_schema["fake_field"] = None
-        with pytest.raises(ValidationError):
-            ServeApplicationSchema.parse_obj(serve_application_schema)
+        # Schema should NOT raise error when extra field is included
+        serve_application_schema["extra_field"] = None
+        ServeApplicationSchema.parse_obj(serve_application_schema)
 
     @pytest.mark.parametrize("env", get_valid_runtime_envs())
     def test_serve_application_valid_runtime_env(self, env):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change is needed to make Serve configs [forward-compatible](https://en.wikipedia.org/wiki/Forward_compatibility#:~:text=Forward%20compatibility%20or%20upward%20compatibility,file%20formats%2C%20and%20programming%20languages.).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Addresses https://github.com/ray-project/ray/issues/38744

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
