### PR TITLE
[experiment][core] grpc: add wait_for_ready everywhere

### DIFF
--- a/src/ray/common/ray_syncer/ray_syncer.cc
+++ b/src/ray/common/ray_syncer/ray_syncer.cc
@@ -139,6 +139,7 @@ RayClientBidiReactor::RayClientBidiReactor(
       cleanup_cb_(std::move(cleanup_cb)),
       stub_(std::move(stub)) {
   client_context_.AddMetadata("node_id", NodeID::FromBinary(local_node_id).Hex());
+  client_context_.set_wait_for_ready(true);
   stub_->async()->StartSync(&client_context_, this);
   // Prevent this call from being terminated.
   // Check https://github.com/grpc/proposal/blob/master/L67-cpp-callback-api.md

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -601,6 +601,7 @@ Status PythonCheckGcsHealth(const std::string &gcs_address,
     context.set_deadline(std::chrono::system_clock::now() +
                          std::chrono::milliseconds(timeout_ms));
   }
+  context.set_wait_for_ready(true);
   rpc::CheckAliveRequest request;
   rpc::CheckAliveReply reply;
   grpc::Status status = stub->CheckAlive(&context, request, &reply);

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -257,6 +257,7 @@ class RAY_EXPORT PythonGcsClient {
     if (!cluster_id_.IsNil()) {
       context.AddMetadata(kClusterIdKey, cluster_id_.Hex());
     }
+    context.set_wait_for_ready(true);
   }
 
   ClusterID cluster_id_;

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
@@ -87,6 +87,8 @@ void GcsHealthCheckManager::HealthCheckContext::StartHealthCheck() {
   auto deadline =
       std::chrono::system_clock::now() + std::chrono::milliseconds(manager_->timeout_ms_);
   context_.set_deadline(deadline);
+  context_.set_wait_for_ready(true);
+
   stub_->async()->Check(
       &context_, &request_, &response_, [this, now = absl::Now()](::grpc::Status status) {
         // This callback is done in gRPC's thread pool.

--- a/src/ray/gcs/pubsub/gcs_pub_sub.cc
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.cc
@@ -246,6 +246,7 @@ Status PythonGcsPublisher::DoPublishWithRetries(const rpc::GcsPublishRequest &re
       context.set_deadline(std::chrono::system_clock::now() +
                            std::chrono::milliseconds(timeout_ms));
     }
+    context.set_wait_for_ready(true);
     status = pubsub_stub_->GcsPublish(&context, request, &reply);
     if (status.error_code() == grpc::StatusCode::OK) {
       if (reply.status().code() != static_cast<int>(StatusCode::OK)) {
@@ -318,6 +319,7 @@ Status PythonGcsSubscriber::Subscribe() {
   }
 
   grpc::ClientContext context;
+  context.set_wait_for_ready(true);
 
   rpc::GcsSubscriberCommandBatchRequest request;
   request.set_subscriber_id(subscriber_id_);
@@ -349,6 +351,7 @@ Status PythonGcsSubscriber::DoPoll(int64_t timeout_ms, rpc::PubMessage *message)
       current_polling_context_->set_deadline(std::chrono::system_clock::now() +
                                              std::chrono::milliseconds(timeout_ms));
     }
+    current_polling_context_->set_wait_for_ready(true);
     rpc::GcsSubscriberPollRequest request;
     request.set_subscriber_id(subscriber_id_);
     request.set_max_processed_sequence_id(max_processed_sequence_id_);
@@ -448,6 +451,7 @@ Status PythonGcsSubscriber::Close() {
   }
 
   grpc::ClientContext context;
+  context.set_wait_for_ready(true);
 
   rpc::GcsSubscriberCommandBatchRequest request;
   request.set_subscriber_id(subscriber_id_);

--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -82,6 +82,7 @@ class ClientCallImpl : public ClientCall {
     if (!cluster_id.IsNil()) {
       context_.AddMetadata(kClusterIdKey, cluster_id.Hex());
     }
+    context_.set_wait_for_ready(true);
   }
 
   Status GetStatus() override {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

gRPC has a separation between a stub, an RPC call and a channel. When you do `stub.MyMethod()`, it will ask the channel to send the message. The channel can have a TRANSIENT_FAILURE state which it will wait for a while and reconnect. During the state, a stub method fails fast.

Adding a wait_for_ready config to make sure that a stub RPC invocation waits for the channel to reconnect and be ready, or until it times out.

This helps especially in the high delay cluster. Our default initial reconnect timeout is 100ms, so in the chaos testing (200ms) the initial connection is guaranteed to fail. And the stub fails fast, regardless of a long timeout value. Now it should wait for a reconnect which should work.

DO NOT SUBMIT: waiting for the CI and see.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
