### PR TITLE
[ci] remove unused var `PIPELINE_POSTMERGE`

### DIFF
--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -11,7 +11,6 @@ _DOCKER_ECR_REPO = os.environ.get(
     "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp",
 )
 _RAYCI_BUILD_ID = os.environ.get("RAYCI_BUILD_ID", "unknown")
-_PIPELINE_POSTMERGE = "0189e759-8c96-4302-b6b5-b4274406bf89"
 
 
 def run_tests(


### PR DESCRIPTION
check is moved to upload script. the id here is not used anywhere.