### PR TITLE
[Train][Lightning] Add barrier before `train.report` to ensure all workers finished checkpointing

### DIFF
--- a/python/ray/train/lightning/_lightning_utils.py
+++ b/python/ray/train/lightning/_lightning_utils.py
@@ -211,6 +211,9 @@ class RayTrainReportCallback(Callback):
             ckpt_path = os.path.join(tmpdir, "checkpoint.ckpt")
             trainer.save_checkpoint(ckpt_path, weights_only=False)
 
+            # Ensures all workers already finish writing their checkpoints
+            trainer.strategy.barrier()
+
             # Report to train session
             if _use_storage_context():
                 checkpoint = NewCheckpoint.from_directory(tmpdir)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
