### PR TITLE
[Data] Retry open files with expotential backoff

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -943,7 +943,7 @@ def _open_file_with_retry(
 
     if OPEN_FILE_MAX_ATTEMPTS < 1:
         raise ValueError(
-            "OPEN_FILE_MAX_ATTEMPTS cannot be negative or 0, but get: "
+            "OPEN_FILE_MAX_ATTEMPTS cannot be negative or 0. Get: "
             f"{OPEN_FILE_MAX_ATTEMPTS}"
         )
 

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -65,8 +65,8 @@ OPEN_FILE_RETRY_ON_ERRORS = ["AWS Error SLOW_DOWN"]
 # The max retry backoff in seconds for opening file.
 OPEN_FILE_RETRY_MAX_BACKOFF_SECONDS = 32
 
-# The max number of retry attempts for opening file.
-OPEN_FILE_RETRY_MAX_ATTEMPTS = 10
+# The max number of attempts for opening file.
+OPEN_FILE_MAX_ATTEMPTS = 10
 
 
 @DeveloperAPI
@@ -941,7 +941,13 @@ def _open_file_with_retry(
     import random
     import time
 
-    for i in range(OPEN_FILE_RETRY_MAX_ATTEMPTS):
+    if OPEN_FILE_MAX_ATTEMPTS < 1:
+        raise ValueError(
+            "OPEN_FILE_MAX_ATTEMPTS cannot be negative or 0, but get: "
+            f"{OPEN_FILE_MAX_ATTEMPTS}"
+        )
+
+    for i in range(OPEN_FILE_MAX_ATTEMPTS):
         try:
             return open_file()
         except Exception as e:
@@ -949,7 +955,7 @@ def _open_file_with_retry(
             is_retryable = any(
                 [error in error_message for error in OPEN_FILE_RETRY_ON_ERRORS]
             )
-            if is_retryable and i + 1 < OPEN_FILE_RETRY_MAX_ATTEMPTS:
+            if is_retryable and i + 1 < OPEN_FILE_MAX_ATTEMPTS:
                 # Retry with binary expoential backoff with random jitter.
                 backoff = min(
                     (2 ** (i + 1)) * random.random(),

--- a/python/ray/data/tests/test_file_based_datasource.py
+++ b/python/ray/data/tests/test_file_based_datasource.py
@@ -6,6 +6,10 @@ import pytest
 import ray
 from ray.data.block import BlockAccessor
 from ray.data.datasource import FileBasedDatasource
+from ray.data.datasource.file_based_datasource import (
+    OPEN_FILE_MAX_ATTEMPTS,
+    _open_file_with_retry,
+)
 
 
 class MockFileBasedDatasource(FileBasedDatasource):
@@ -35,6 +39,38 @@ def test_write_creates_dir(tmp_path, ray_start_regular_shared):
     )
 
     assert os.path.isdir(path)
+
+
+def test_open_file_with_retry(ray_start_regular_shared):
+    class FlakyFileOpener:
+        def __init__(self, max_attempts: int):
+            self.retry_attempts = 0
+            self.max_attempts = max_attempts
+
+        def open(self):
+            self.retry_attempts += 1
+            if self.retry_attempts < self.max_attempts:
+                raise OSError(
+                    "When creating key x in bucket y: AWS Error SLOW_DOWN during "
+                    "PutObject operation: Please reduce your request rate."
+                )
+            return "dummy"
+
+    original_max_attempts = OPEN_FILE_MAX_ATTEMPTS
+    try:
+        # Test openning file successfully after retries.
+        opener = FlakyFileOpener(3)
+        assert _open_file_with_retry("dummy", lambda: opener.open()) == "dummy"
+
+        # Test exhausting retries and failed eventually.
+        ray.data.datasource.file_based_datasource.OPEN_FILE_MAX_ATTEMPTS = 3
+        opener = FlakyFileOpener(4)
+        with pytest.raises(OSError):
+            _open_file_with_retry("dummy", lambda: opener.open())
+    finally:
+        ray.data.datasource.file_based_datasource.OPEN_FILE_MAX_ATTEMPTS = (
+            original_max_attempts
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -15,7 +15,7 @@ from ray.data._internal.execution.interfaces import TaskContext
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource import Datasource, DummyOutputDatasource, WriteResult
 from ray.data.datasource.file_based_datasource import (
-    OPEN_FILE_RETRY_MAX_ATTEMPTS,
+    OPEN_FILE_MAX_ATTEMPTS,
     _open_file_with_retry,
 )
 from ray.data.datasource.file_meta_provider import _handle_read_os_error
@@ -183,12 +183,12 @@ def test_open_file_with_retry(ray_start_regular_shared):
     counter = Counter()
     assert _open_file_with_retry("dummy", lambda: counter.foo(3)) == 0
 
-    original_max_attempts = OPEN_FILE_RETRY_MAX_ATTEMPTS
-    ray.data.datasource.file_based_datasource.OPEN_FILE_RETRY_MAX_ATTEMPTS = 3
+    original_max_attempts = OPEN_FILE_MAX_ATTEMPTS
+    ray.data.datasource.file_based_datasource.OPEN_FILE_MAX_ATTEMPTS = 3
     counter = Counter()
     with pytest.raises(OSError):
         _open_file_with_retry("dummy", lambda: counter.foo(4))
-    ray.data.datasource.file_based_datasource.OPEN_FILE_RETRY_MAX_ATTEMPTS = (
+    ray.data.datasource.file_based_datasource.OPEN_FILE_MAX_ATTEMPTS = (
         original_max_attempts
     )
 

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -14,10 +14,6 @@ from ray._private.test_utils import wait_for_condition
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource import Datasource, DummyOutputDatasource, WriteResult
-from ray.data.datasource.file_based_datasource import (
-    OPEN_FILE_MAX_ATTEMPTS,
-    _open_file_with_retry,
-)
 from ray.data.datasource.file_meta_provider import _handle_read_os_error
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
@@ -164,33 +160,6 @@ def test_write_datasource(ray_start_regular_shared):
     assert output.num_ok == 1
     assert output.num_failed == 1
     assert ray.get(output.data_sink.get_rows_written.remote()) == 10
-
-
-def test_open_file_with_retry(ray_start_regular_shared):
-    class Counter:
-        def __init__(self):
-            self.retry_attempts = 0
-
-        def foo(self, max_attempts: int):
-            self.retry_attempts += 1
-            if self.retry_attempts < max_attempts:
-                raise OSError(
-                    "When creating key x in bucket y: AWS Error SLOW_DOWN during "
-                    "PutObject operation: Please reduce your request rate."
-                )
-            return 0
-
-    counter = Counter()
-    assert _open_file_with_retry("dummy", lambda: counter.foo(3)) == 0
-
-    original_max_attempts = OPEN_FILE_MAX_ATTEMPTS
-    ray.data.datasource.file_based_datasource.OPEN_FILE_MAX_ATTEMPTS = 3
-    counter = Counter()
-    with pytest.raises(OSError):
-        _open_file_with_retry("dummy", lambda: counter.foo(4))
-    ray.data.datasource.file_based_datasource.OPEN_FILE_MAX_ATTEMPTS = (
-        original_max_attempts
-    )
 
 
 def test_from_tf(ray_start_regular_shared):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to retry open files call (for both read and write), with expotential backoff internally in Ray Data task. The motivation is to avoid throw throttling exception for users when reading/writing many files to remote storage, such as S3.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
