### PR TITLE
[data] Implement zero-copy fusion for Read op

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -49,7 +49,7 @@ class MapTransformFn:
     def __call__(
         self, input: Iterable[MapTransformFnData], ctx: TaskContext
     ) -> Iterable[MapTransformFnData]:
-        pass
+        ...
 
     @property
     def input_type(self) -> MapTransformFnDataType:

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -1,4 +1,5 @@
 import itertools
+from abc import abstractmethod
 from enum import Enum
 from typing import Any, Callable, Dict, Iterable, List, Optional, TypeVar, Union
 
@@ -31,7 +32,6 @@ class MapTransformFn:
 
     def __init__(
         self,
-        callable: MapTransformCallable[MapTransformFnData, MapTransformFnData],
         input_type: MapTransformFnDataType,
         output_type: MapTransformFnDataType,
     ):
@@ -45,10 +45,11 @@ class MapTransformFn:
         self._input_type = input_type
         self._output_type = output_type
 
+    @abstractmethod
     def __call__(
         self, input: Iterable[MapTransformFnData], ctx: TaskContext
     ) -> Iterable[MapTransformFnData]:
-        return self._callable(input, ctx)
+        pass
 
     @property
     def input_type(self) -> MapTransformFnDataType:
@@ -140,17 +141,66 @@ def create_map_transformer_from_block_fn(
     """
     return MapTransformer(
         [
-            MapTransformFn(
-                block_fn,
-                MapTransformFnDataType.Block,
-                MapTransformFnDataType.Block,
-            )
+            BlockMapTransformFn(block_fn),
         ],
         init_fn,
     )
 
 
-# Below are util `MapTransformFn`s for converting input/output data.
+# Below are subclasses of MapTransformFn.
+
+
+class RowMapTransformFn(MapTransformFn):
+    """A rows-to-rows MapTransformFn."""
+
+    def __init__(self, row_fn: MapTransformCallable[Row, Row]):
+        self._row_fn = row_fn
+        super().__init__(
+            MapTransformFnDataType.Row,
+            MapTransformFnDataType.Row,
+        )
+
+    def __call__(self, input: Iterable[Row], ctx: TaskContext) -> Iterable[Row]:
+        yield from self._row_fn(input, ctx)
+
+    def __repr__(self) -> str:
+        return f"RowMapTransformFn({self._row_fn})"
+
+
+class BatchMapTransformFn(MapTransformFn):
+    """A batch-to-batch MapTransformFn."""
+
+    def __init__(self, batch_fn: MapTransformCallable[DataBatch, DataBatch]):
+        self._batch_fn = batch_fn
+        super().__init__(
+            MapTransformFnDataType.Batch,
+            MapTransformFnDataType.Batch,
+        )
+
+    def __call__(
+        self, input: Iterable[DataBatch], ctx: TaskContext
+    ) -> Iterable[DataBatch]:
+        yield from self._batch_fn(input, ctx)
+
+    def __repr__(self) -> str:
+        return f"BatchMapTransformFn({self._batch_fn})"
+
+
+class BlockMapTransformFn(MapTransformFn):
+    """A block-to-block MapTransformFn."""
+
+    def __init__(self, block_fn: MapTransformCallable[Block, Block]):
+        self._block_fn = block_fn
+        super().__init__(
+            MapTransformFnDataType.Block,
+            MapTransformFnDataType.Block,
+        )
+
+    def __call__(self, input: Iterable[Block], ctx: TaskContext) -> Iterable[Block]:
+        yield from self._block_fn(input, ctx)
+
+    def __repr__(self) -> str:
+        return f"BlockMapTransformFn({self._block_fn})"
 
 
 class BlocksToRowsMapTransformFn(MapTransformFn):
@@ -158,14 +208,11 @@ class BlocksToRowsMapTransformFn(MapTransformFn):
 
     def __init__(self):
         super().__init__(
-            self._input_blocks_to_rows,
             MapTransformFnDataType.Block,
             MapTransformFnDataType.Row,
         )
 
-    def _input_blocks_to_rows(
-        self, blocks: Iterable[Block], _: TaskContext
-    ) -> Iterable[Row]:
+    def __call__(self, blocks: Iterable[Block], _: TaskContext) -> Iterable[Row]:
         for block in blocks:
             block = BlockAccessor.for_block(block)
             for row in block.iter_rows(public_row_format=True):
@@ -177,6 +224,9 @@ class BlocksToRowsMapTransformFn(MapTransformFn):
         if getattr(cls, "_instance", None) is None:
             cls._instance = cls()
         return cls._instance
+
+    def __repr__(self) -> str:
+        return "BlocksToRowsMapTransformFn()"
 
 
 class BlocksToBatchesMapTransformFn(MapTransformFn):
@@ -192,12 +242,11 @@ class BlocksToBatchesMapTransformFn(MapTransformFn):
         self._batch_format = batch_format
         self._ensure_copy = not zero_copy_batch and batch_size is not None
         super().__init__(
-            self._input_blocks_to_batches,
             MapTransformFnDataType.Block,
             MapTransformFnDataType.Batch,
         )
 
-    def _input_blocks_to_batches(
+    def __call__(
         self,
         blocks: Iterable[Block],
         _: TaskContext,
@@ -241,6 +290,15 @@ class BlocksToBatchesMapTransformFn(MapTransformFn):
     def zero_copy_batch(self) -> bool:
         return not self._ensure_copy
 
+    def __repr__(self) -> str:
+        return (
+            f"BlocksToBatchesMapTransformFn("
+            f"batch_size={self._batch_size}, "
+            f"batch_format={self._batch_format}, "
+            f"zero_copy_batch={self.zero_copy_batch}"
+            f")"
+        )
+
 
 class BuildOutputBlocksMapTransformFn(MapTransformFn):
     """A MapTransformFn that converts UDF-returned data to output blocks."""
@@ -252,12 +310,11 @@ class BuildOutputBlocksMapTransformFn(MapTransformFn):
         """
         self._input_type = input_type
         super().__init__(
-            self._to_output_blocks,
             input_type,
             MapTransformFnDataType.Block,
         )
 
-    def _to_output_blocks(
+    def __call__(
         self,
         iter: Iterable[MapTransformFnData],
         _: TaskContext,
@@ -306,3 +363,6 @@ class BuildOutputBlocksMapTransformFn(MapTransformFn):
         if getattr(cls, "_instance_for_blocks", None) is None:
             cls._instance_for_blocks = cls(MapTransformFnDataType.Block)
         return cls._instance_for_blocks
+
+    def __repr__(self) -> str:
+        return f"BuildOutputBlocksMapTransformFn(input_type={self._input_type})"

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -81,6 +81,11 @@ class MapTransformer:
         init_fn: A function that will be called before transforming data.
             Used for the actor-based map operator.
         """
+        self.set_transform_fns(transform_fns)
+        self._init_fn = init_fn if init_fn is not None else lambda: None
+
+    def set_transform_fns(self, transform_fns: List[MapTransformFn]) -> None:
+        """Set the transform functions."""
         assert len(transform_fns) > 0
         assert (
             transform_fns[0].input_type == MapTransformFnDataType.Block
@@ -94,9 +99,11 @@ class MapTransformer:
                 "The output type of the previous transform function must match "
                 "the input type of the next transform function."
             )
-
         self._transform_fns = transform_fns
-        self._init_fn = init_fn if init_fn is not None else lambda: None
+
+    def get_transform_fns(self) -> List[MapTransformFn]:
+        """Get the transform functions."""
+        return self._transform_fns
 
     def init(self) -> None:
         """Initialize the transformer.

--- a/python/ray/data/_internal/logical/rules/_default_optimizer_rules.py
+++ b/python/ray/data/_internal/logical/rules/_default_optimizer_rules.py
@@ -1,7 +1,7 @@
 from ray.data._internal.logical.rules.operator_fusion import OperatorFusionRule
 from ray.data._internal.logical.rules.randomize_blocks import ReorderRandomizeBlocksRule
 from ray.data._internal.logical.rules.zero_copy_map_fusion import (
-    ReadOpZeroCopyMapFusion,
+    EliminateBuildOutputBlocks,
 )
 
 
@@ -11,5 +11,5 @@ def get_logical_optimizer_rules():
 
 
 def get_physical_optimizer_rules():
-    rules = [OperatorFusionRule, ReadOpZeroCopyMapFusion]
+    rules = [OperatorFusionRule, EliminateBuildOutputBlocks]
     return rules

--- a/python/ray/data/_internal/logical/rules/_default_optimizer_rules.py
+++ b/python/ray/data/_internal/logical/rules/_default_optimizer_rules.py
@@ -11,5 +11,7 @@ def get_logical_optimizer_rules():
 
 
 def get_physical_optimizer_rules():
+    # Subclasses of ZeroCopyMapFusionRule (e.g., EliminateBuildOutputBlocks) should
+    # be run after OperatorFusionRule.
     rules = [OperatorFusionRule, EliminateBuildOutputBlocks]
     return rules

--- a/python/ray/data/_internal/logical/rules/_default_optimizer_rules.py
+++ b/python/ray/data/_internal/logical/rules/_default_optimizer_rules.py
@@ -1,7 +1,8 @@
 from ray.data._internal.logical.rules.operator_fusion import OperatorFusionRule
 from ray.data._internal.logical.rules.randomize_blocks import ReorderRandomizeBlocksRule
-
-from ray.data._internal.logical.rules.zero_copy_map_fusion import ReadOpZeroCopyMapFusion
+from ray.data._internal.logical.rules.zero_copy_map_fusion import (
+    ReadOpZeroCopyMapFusion,
+)
 
 
 def get_logical_optimizer_rules():

--- a/python/ray/data/_internal/logical/rules/_default_optimizer_rules.py
+++ b/python/ray/data/_internal/logical/rules/_default_optimizer_rules.py
@@ -1,6 +1,8 @@
 from ray.data._internal.logical.rules.operator_fusion import OperatorFusionRule
 from ray.data._internal.logical.rules.randomize_blocks import ReorderRandomizeBlocksRule
 
+from ray.data._internal.logical.rules.zero_copy_map_fusion import ReadOpZeroCopyMapFusion
+
 
 def get_logical_optimizer_rules():
     rules = [ReorderRandomizeBlocksRule]
@@ -8,5 +10,5 @@ def get_logical_optimizer_rules():
 
 
 def get_physical_optimizer_rules():
-    rules = [OperatorFusionRule]
+    rules = [OperatorFusionRule, ReadOpZeroCopyMapFusion]
     return rules

--- a/python/ray/data/_internal/logical/rules/zero_copy_map_fusion.py
+++ b/python/ray/data/_internal/logical/rules/zero_copy_map_fusion.py
@@ -16,8 +16,7 @@ class ZeroCopyMapFusionRule(Rule):
     """Base class for zero-copy map fusion rules.
 
     Subclasses implement the optimization strategies for different combinations of
-    fused map operators by dropping unnecessary data conversion MapTransformer in the
-    middle of the MapTransformer.
+    fused map operators, by dropping unnecessary data conversion `MapTransformFn`s.
     """
 
     def apply(self, plan: PhysicalPlan) -> PhysicalPlan:
@@ -29,6 +28,8 @@ class ZeroCopyMapFusionRule(Rule):
             map_transformer = op.get_map_transformer()
             transform_fns = map_transformer._transform_fns
             new_transform_fns = self._optimize(transform_fns)
+            # Physical operators won't be shared,
+            # so it's safe to modify the transform_fns in place.
             map_transformer._transform_fns = new_transform_fns
 
         for input_op in op.input_dependencies:
@@ -36,6 +37,13 @@ class ZeroCopyMapFusionRule(Rule):
 
     @abstractmethod
     def _optimize(self, transform_fns: List[MapTransformFn]) -> List[MapTransformFn]:
+        """Optimize the transform_fns chain of a MapOperator.
+
+        Args:
+            transform_fns: The old transform_fns chain.
+        Returns:
+            The optimized transform_fns chain.
+        """
         pass
 
 

--- a/python/ray/data/_internal/logical/rules/zero_copy_map_fusion.py
+++ b/python/ray/data/_internal/logical/rules/zero_copy_map_fusion.py
@@ -1,0 +1,71 @@
+from abc import abstractmethod
+from typing import List
+
+from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.map_transformer import (
+    BlockMapTransformFn,
+    BuildOutputBlocksMapTransformFn,
+    MapTransformFn,
+    MapTransformFnDataType,
+)
+from ray.data._internal.logical.interfaces.optimizer import Rule
+from ray.data._internal.logical.interfaces.physical_plan import PhysicalPlan
+
+
+class ZeroCopyMapFusionRule(Rule):
+    """Base class for zero-copy map fusion rules.
+
+    Subclasses implement the optimization strategies for different combinations of
+    fused map operators by dropping unnecessary data conversion MapTransformer in the
+    middle of the MapTransformer.
+    """
+
+    def apply(self, plan: PhysicalPlan) -> PhysicalPlan:
+        self._traverse(plan.dag)
+        return plan
+
+    def _traverse(self, op):
+        if isinstance(op, MapOperator):
+            map_transformer = op.get_map_transformer()
+            transform_fns = map_transformer._transform_fns
+            new_transform_fns = self._optimize(transform_fns)
+            map_transformer._transform_fns = new_transform_fns
+
+        for input_op in op.input_dependencies:
+            self._traverse(input_op)
+
+    @abstractmethod
+    def _optimize(self, transform_fns: List[MapTransformFn]) -> List[MapTransformFn]:
+        pass
+
+
+class ReadOpZeroCopyMapFusion(ZeroCopyMapFusionRule):
+    """Optimize Read -> Map/Write."""
+
+    def _optimize(self, transform_fns: List[MapTransformFn]) -> List[MapTransformFn]:
+        # For Read -> Map/Write, transform_fns will contain the following subsequence:
+        # 1. BlockMapTransformFn
+        # 2. BuildOutputBlocksMapTransformFn
+        # 3. Any MapTransformFn with block input.
+        # In this case, we can drop the BuildOutputBlocksMapTransformFn.
+        new_transform_fns = []
+
+        for i in range(len(transform_fns)):
+            cur_fn = transform_fns[i]
+            drop = False
+            if (
+                i > 0
+                and i < len(transform_fns) - 1
+                and isinstance(cur_fn, BuildOutputBlocksMapTransformFn)
+            ):
+                prev_fn = transform_fns[i - 1]
+                next_fn = transform_fns[i + 1]
+                if (
+                    isinstance(prev_fn, BlockMapTransformFn)
+                    and next_fn.input_type == MapTransformFnDataType.Block
+                ):
+                    drop = True
+            if not drop:
+                new_transform_fns.append(cur_fn)
+
+        return new_transform_fns

--- a/python/ray/data/_internal/logical/rules/zero_copy_map_fusion.py
+++ b/python/ray/data/_internal/logical/rules/zero_copy_map_fusion.py
@@ -12,10 +12,15 @@ from ray.data._internal.logical.interfaces.physical_plan import PhysicalPlan
 
 
 class ZeroCopyMapFusionRule(Rule):
-    """Base class for zero-copy map fusion rules.
+    """Base abstract class for all zero-copy map fusion rules.
 
-    Subclasses implement the optimization strategies for different combinations of
-    fused map operators, by dropping unnecessary data conversion `MapTransformFn`s.
+    A zero-copy map fusion rule is a rule that optimizes the transform_fn chain of
+    a fused MapOperator. The optimization is usually done by removing unnecessary
+    data conversions.
+
+    This base abstract class defines the common util functions. And subclasses
+    should implement the `_optimize` method for the concrete optimization
+    strategy.
     """
 
     def apply(self, plan: PhysicalPlan) -> PhysicalPlan:
@@ -23,6 +28,7 @@ class ZeroCopyMapFusionRule(Rule):
         return plan
 
     def _traverse(self, op):
+        """Traverse the DAG and apply the optimization to each MapOperator."""
         if isinstance(op, MapOperator):
             map_transformer = op.get_map_transformer()
             transform_fns = map_transformer.get_transform_fns()
@@ -43,7 +49,7 @@ class ZeroCopyMapFusionRule(Rule):
         Returns:
             The optimized transform_fns chain.
         """
-        pass
+        ...
 
 
 class EliminateBuildOutputBlocks(ZeroCopyMapFusionRule):

--- a/python/ray/data/_internal/logical/rules/zero_copy_map_fusion.py
+++ b/python/ray/data/_internal/logical/rules/zero_copy_map_fusion.py
@@ -26,11 +26,11 @@ class ZeroCopyMapFusionRule(Rule):
     def _traverse(self, op):
         if isinstance(op, MapOperator):
             map_transformer = op.get_map_transformer()
-            transform_fns = map_transformer._transform_fns
+            transform_fns = map_transformer.get_transform_fns()
             new_transform_fns = self._optimize(transform_fns)
             # Physical operators won't be shared,
             # so it's safe to modify the transform_fns in place.
-            map_transformer._transform_fns = new_transform_fns
+            map_transformer.set_transform_fns(new_transform_fns)
 
         for input_op in op.input_dependencies:
             self._traverse(input_op)

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -12,14 +12,14 @@ from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.map_transformer import (
+    BatchMapTransformFn,
     BlocksToBatchesMapTransformFn,
     BlocksToRowsMapTransformFn,
     BuildOutputBlocksMapTransformFn,
     MapTransformCallable,
     MapTransformer,
-    MapTransformFn,
-    MapTransformFnDataType,
     Row,
+    RowMapTransformFn,
 )
 from ray.data._internal.execution.util import make_callable_class_concurrent
 from ray.data._internal.logical.operators.map_operator import (
@@ -279,9 +279,7 @@ def _create_map_transformer_for_map_batches_op(
             zero_copy_batch=zero_copy_batch,
         ),
         # Apply the UDF.
-        MapTransformFn(
-            batch_fn, MapTransformFnDataType.Batch, MapTransformFnDataType.Batch
-        ),
+        BatchMapTransformFn(batch_fn),
         # Convert output batches to blocks.
         BuildOutputBlocksMapTransformFn.for_batches(),
     ]
@@ -298,7 +296,7 @@ def _create_map_transformer_for_row_based_map_op(
         # Convert input blocks to rows.
         BlocksToRowsMapTransformFn.instance(),
         # Apply the UDF.
-        MapTransformFn(row_fn, MapTransformFnDataType.Row, MapTransformFnDataType.Row),
+        RowMapTransformFn(row_fn),
         # Convert output rows to blocks.
         BuildOutputBlocksMapTransformFn.for_rows(),
     ]

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -4,9 +4,8 @@ from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.map_transformer import (
+    BlockMapTransformFn,
     MapTransformer,
-    MapTransformFn,
-    MapTransformFnDataType,
 )
 from ray.data._internal.logical.operators.write_operator import Write
 from ray.data.block import Block
@@ -36,9 +35,7 @@ def plan_write_op(op: Write, input_physical_dag: PhysicalOperator) -> PhysicalOp
     write_fn = generate_write_fn(op._datasource, **op._write_args)
     # Create a MapTransformer for a write operator
     transform_fns = [
-        MapTransformFn(
-            write_fn, MapTransformFnDataType.Block, MapTransformFnDataType.Block
-        ),
+        BlockMapTransformFn(write_fn),
     ]
     map_transformer = MapTransformer(transform_fns)
     return MapOperator.create(

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -325,7 +325,6 @@ def test_lazy_block_list(shutdown_only, target_max_block_size):
         assert block_metadata.schema is not None
 
 
-@pytest.mark.skip("Needs zero-copy optimization for read->map_batches.")
 def test_read_large_data(ray_start_cluster):
     # Test 20G input with single task
     num_blocks_per_task = 20

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -15,6 +15,12 @@ from ray.data._internal.execution.operators.base_physical_operator import (
 )
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.map_transformer import (
+    BatchMapTransformFn,
+    BlockMapTransformFn,
+    BlocksToBatchesMapTransformFn,
+    BuildOutputBlocksMapTransformFn,
+)
 from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.operators.zip_operator import ZipOperator
 from ray.data._internal.logical.interfaces import LogicalPlan
@@ -1467,6 +1473,60 @@ def test_schema_partial_execution(
     assert ds._plan._in_blocks._num_blocks == 1
     assert str(ds._plan._logical_plan.dag) == (
         "Read[ReadParquet->SplitBlocks(2)] -> MapBatches[MapBatches(<lambda>)]"
+    )
+
+
+def check_transform_fns(op, expected_types):
+    assert isinstance(op, MapOperator)
+    transform_fns = op.get_map_transformer().get_transform_fns()
+    assert len(transform_fns) == len(expected_types), transform_fns
+    for i, transform_fn in enumerate(transform_fns):
+        assert isinstance(transform_fn, expected_types[i]), transform_fn
+
+
+def test_zero_copy_fusion_eliminate_build_output_blocks(
+    ray_start_regular_shared, enable_optimizer
+):
+    # Test the EliminateBuildOutputBlocks optimization rule.
+    planner = Planner()
+    read_op = get_parquet_read_logical_op()
+    op = MapBatches(read_op, lambda x: x)
+    logical_plan = LogicalPlan(op)
+    physical_plan = planner.plan(logical_plan)
+
+    # Before optimization, there should be a map op and and read op.
+    # And they should have the following transform_fns.
+    map_op = physical_plan.dag
+    check_transform_fns(
+        map_op,
+        [
+            BlocksToBatchesMapTransformFn,
+            BatchMapTransformFn,
+            BuildOutputBlocksMapTransformFn,
+        ],
+    )
+    read_op = map_op.input_dependencies[0]
+    check_transform_fns(
+        read_op,
+        [
+            BlockMapTransformFn,
+            BuildOutputBlocksMapTransformFn,
+        ],
+    )
+
+    physical_plan = PhysicalOptimizer().optimize(physical_plan)
+    fused_op = physical_plan.dag
+
+    # After optimization, read and map ops should be fused as one op.
+    # And the BuidlOutputBlocksMapTransformFn in the middle should be dropped.
+    check_transform_fns(
+        fused_op,
+        [
+            BlockMapTransformFn,
+            BlocksToBatchesMapTransformFn,
+            BatchMapTransformFn,
+            BuildOutputBlocksMapTransformFn,
+        ],
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Optimize `Read -> Map/Write` fusion. In this case, we can drop the unnecessary `BuildOutputBlocks` transform_fn.

Also change `MapTransformFn` to an abstract class and enforce implementations to use subclasses. This is for optimization rules to better detecting the pattern. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
