### PR TITLE
[ci][statemachine] Keep jailed tests as being P0

### DIFF
--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -134,9 +134,7 @@ class TestStateMachine:
             return
         issue = self.ray_repo.get_issue(github_issue_number)
         issue.create_comment("Test has been failing for far too long. Jailing.")
-        labels = ["P1", "jailed-test"] + [label.name for label in issue.get_labels()]
-        if "P0" in labels:
-            labels.remove("P0")
+        labels = ["jailed-test"] + [label.name for label in issue.get_labels()]
         issue.edit(labels=labels)
 
     def _bisect_rate_limit_exceeded(self) -> bool:


### PR DESCRIPTION
Core team uses P0 as a way to identify work and priority, and folks want to fix jailed tests. This PR keeps jailed tests as P0.

Test:
- CI