### PR TITLE
[Data] Store serialized ParquetFileFragment in _ParquetDatasourceReader 

### DIFF
--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -220,7 +220,7 @@ class ParquetMetadataProvider(FileMetadataProvider):
         paths: List[str],
         schema: Optional[Union[type, "pyarrow.lib.Schema"]],
         *,
-        pieces: List["pyarrow.dataset.ParquetFileFragment"],
+        num_pieces: int,
         prefetched_metadata: Optional[List[Any]],
     ) -> BlockMetadata:
         """Resolves and returns block metadata for files of a single dataset block.
@@ -229,7 +229,8 @@ class ParquetMetadataProvider(FileMetadataProvider):
             paths: The file paths for a single dataset block.
             schema: The user-provided or inferred schema for the given file
                 paths, if any.
-            pieces: The Parquet file fragments derived from the input file paths.
+            num_pieces: The number of Parquet file fragments derived from the input
+                file paths.
             prefetched_metadata: Metadata previously returned from
                 `prefetch_file_metadata()` for each file fragment, where
                 `prefetched_metadata[i]` contains the metadata for `pieces[i]`.
@@ -277,10 +278,10 @@ class DefaultParquetMetadataProvider(ParquetMetadataProvider):
         paths: List[str],
         schema: Optional[Union[type, "pyarrow.lib.Schema"]],
         *,
-        pieces: List["pyarrow.dataset.ParquetFileFragment"],
+        num_pieces: int,
         prefetched_metadata: Optional[List["pyarrow.parquet.FileMetaData"]],
     ) -> BlockMetadata:
-        if prefetched_metadata is not None and len(prefetched_metadata) == len(pieces):
+        if prefetched_metadata is not None and len(prefetched_metadata) == num_pieces:
             # Piece metadata was available, construct a normal
             # BlockMetadata.
             block_metadata = BlockMetadata(

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -377,7 +377,7 @@ class _ParquetDatasourceReader(Reader):
         # Evenly distributed to choose which file to sample, to avoid biased prediction
         # if data is skewed.
         file_samples = [
-            self._pq_pieces
+            self._pq_pieces[idx]
             for idx in np.linspace(0, num_files - 1, num_samples).astype(int).tolist()
         ]
 

--- a/python/ray/data/tests/test_metadata_provider.py
+++ b/python/ray/data/tests/test_metadata_provider.py
@@ -70,7 +70,7 @@ def test_file_metadata_providers_not_implemented():
         meta_provider.expand_paths(["/foo/bar.csv"], None)
     meta_provider = ParquetMetadataProvider()
     with pytest.raises(NotImplementedError):
-        meta_provider(["/foo/bar.csv"], None, pieces=[], prefetched_metadata=None)
+        meta_provider(["/foo/bar.csv"], None, num_pieces=0, prefetched_metadata=None)
     assert meta_provider.prefetch_file_metadata(["test"]) is None
 
 
@@ -112,7 +112,7 @@ def test_default_parquet_metadata_provider(fs, data_path):
     meta = meta_provider(
         [p.path for p in pq_ds.pieces],
         pq_ds.schema,
-        pieces=pq_ds.pieces,
+        num_pieces=len(pq_ds.pieces),
         prefetched_metadata=file_metas,
     )
     expected_meta_size_bytes = _get_parquet_file_meta_size_bytes(file_metas)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Found regression in release test - https://github.com/ray-project/ray/issues/38790, where Parquet metdata fetching become slow. I suspect this is related to the ParquetFileFragment serialization triggered inside _ParquetDatasourceReader. So trying out this fix to see if release test gets fixed.

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/38790

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
