### PR TITLE
[Core] Increase sleep time to reduce flakiness for test_actor_cancel

### DIFF
--- a/python/ray/tests/test_actor_cancel.py
+++ b/python/ray/tests/test_actor_cancel.py
@@ -65,7 +65,7 @@ def test_async_actor_cancel(shutdown_only):
         async def f(self, verify_actor):
             try:
                 ray.get(verify_actor.set_running.remote())
-                await asyncio.sleep(1)
+                await asyncio.sleep(10)
             except asyncio.CancelledError:
                 # It is False until this except block is finished.
                 print(asyncio.current_task().cancelled())


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When I merged the previous PR, I used 1 second sleep by mistake. Longer sleep will make it more reliable

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
