### PR TITLE
[train] New persistence mode: Support the `tune.run(restore="ckpt_path")` API

### DIFF
--- a/python/ray/train/tests/util.py
+++ b/python/ray/train/tests/util.py
@@ -1,24 +1,30 @@
 import contextlib
 import os
 import tempfile
-from typing import Any, Dict, Type
+from typing import Any, Dict
 
 import ray.cloudpickle as ray_pickle
 from ray.train._checkpoint import Checkpoint
+from ray.train._internal.storage import StorageContext
 
 
 @contextlib.contextmanager
-def create_dict_checkpoint(
-    data: Dict[str, Any], checkpoint_cls: Type[Checkpoint] = None
-) -> Checkpoint:
+def create_dict_checkpoint(data: Dict[str, Any]) -> Checkpoint:
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "data.pkl"), "wb") as f:
             ray_pickle.dump(data, f)
-        checkpoint_cls = checkpoint_cls or Checkpoint
-        yield checkpoint_cls.from_directory(tmpdir)
+        yield Checkpoint.from_directory(tmpdir)
 
 
 def load_dict_checkpoint(checkpoint: Checkpoint) -> Dict[str, Any]:
     with checkpoint.as_directory() as checkpoint_dir:
         with open(os.path.join(checkpoint_dir, "data.pkl"), "rb") as f:
             return ray_pickle.load(f)
+
+
+def mock_storage_context() -> StorageContext:
+    return StorageContext(
+        storage_path=tempfile.mkdtemp(),
+        experiment_dir_name="exp_name",
+        trial_dir_name="trial_name",
+    )

--- a/python/ray/train/tests/util.py
+++ b/python/ray/train/tests/util.py
@@ -1,7 +1,7 @@
 import contextlib
 import os
 import tempfile
-from typing import Any, Dict
+from typing import Any, Dict, Type
 
 import ray.cloudpickle as ray_pickle
 from ray.train._checkpoint import Checkpoint
@@ -9,11 +9,14 @@ from ray.train._internal.storage import StorageContext
 
 
 @contextlib.contextmanager
-def create_dict_checkpoint(data: Dict[str, Any]) -> Checkpoint:
+def create_dict_checkpoint(
+    data: Dict[str, Any], checkpoint_cls: Type[Checkpoint] = None
+) -> Checkpoint:
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "data.pkl"), "wb") as f:
             ray_pickle.dump(data, f)
-        yield Checkpoint.from_directory(tmpdir)
+        checkpoint_cls = checkpoint_cls or Checkpoint
+        yield checkpoint_cls.from_directory(tmpdir)
 
 
 def load_dict_checkpoint(checkpoint: Checkpoint) -> Dict[str, Any]:

--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -477,7 +477,7 @@ py_test(
     size = "large",
     srcs = ["tests/execution/test_controller_checkpointing_integration.py"],
     deps = [":tune_lib"],
-    tags = ["team:ml", "exclusive", "no_new_storage"]
+    tags = ["team:ml", "exclusive", "new_storage"]
 )
 
 py_test(

--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -2051,8 +2051,7 @@ class TuneController:
     # RESTORE
     def _schedule_trial_restore(self, trial: Trial) -> bool:
         if _use_storage_context():
-            cpm = trial.run_metadata.checkpoint_manager
-            checkpoint_result = cpm.latest_checkpoint_result
+            checkpoint_result = trial.latest_checkpoint_result
 
             if not checkpoint_result:
                 logger.debug(f"Not restoring trial {trial}: No checkpoint found.")

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -1094,6 +1094,7 @@ class Trial:
                 self.latest_checkpoint_result.checkpoint = None
             self.temporary_state.restoring_from = None
             self.run_metadata.invalidate_cache()
+            return
 
         self.checkpoint.dir_or_data = None
         self.temporary_state.restoring_from = None

--- a/python/ray/tune/tests/execution/test_controller_checkpointing_integration.py
+++ b/python/ray/tune/tests/execution/test_controller_checkpointing_integration.py
@@ -10,6 +10,9 @@ from ray.train import CheckpointConfig
 from ray.air._internal.checkpoint_manager import _TrackedCheckpoint, CheckpointStorage
 from ray.air.execution import FixedResourceManager, PlacementGroupResourceManager
 from ray.air.constants import TRAINING_ITERATION
+from ray.train._checkpoint import Checkpoint
+from ray.train._internal.session import _TrainingResult
+from ray.train._internal.storage import StorageContext
 from ray.tune import PlacementGroupFactory
 from ray.tune.execution.tune_controller import TuneController
 from ray.tune.experiment import Trial
@@ -17,6 +20,11 @@ from ray.tune.result import DONE
 from ray.tune.schedulers import FIFOScheduler
 from ray.tune.search import BasicVariantGenerator
 from ray.tune.trainable import TrainableUtil
+
+from ray.train.tests.util import mock_storage_context
+
+
+STORAGE = mock_storage_context()
 
 
 @pytest.fixture(scope="function")
@@ -61,13 +69,13 @@ def test_checkpoint_save_restore(
     Legacy test: test_trial_runner_2.py::TrialRunnerTest::testRestoreMetricsAfterCheckpointing  # noqa
     """
     runner = TuneController(
-        resource_manager_factory=lambda: resource_manager_cls(),
-        experiment_path=str(tmpdir),
+        resource_manager_factory=lambda: resource_manager_cls(), storage=STORAGE
     )
     kwargs = {
         "stopping_criterion": {"training_iteration": 1},
         "placement_group_factory": PlacementGroupFactory([{"CPU": 1, "GPU": 1}]),
         "checkpoint_config": CheckpointConfig(checkpoint_frequency=1),
+        "storage": STORAGE,
     }
     runner.add_trial(Trial("__fake", **kwargs))
     trials = runner.get_trials()
@@ -83,13 +91,22 @@ def test_checkpoint_save_restore(
     while trials[0].status != Trial.TERMINATED:
         runner.step()
 
-    assert trials[0].checkpoint.metrics[TRAINING_ITERATION] == 1
+    assert (
+        trials[0].run_metadata.checkpoint_manager.latest_checkpoint_result.metrics[
+            TRAINING_ITERATION
+        ]
+        == 1
+    )
     assert trials[0].last_result[TRAINING_ITERATION] == 1
     assert trials[0].last_result["iterations_since_restore"] == 1
 
     # Prepare new trial
-    kwargs["restore_path"] = trials[0].checkpoint.dir_or_data
-    runner.add_trial(Trial("__fake", **kwargs))
+    new_trial = Trial("__fake", **kwargs)
+    old_trial = trials[0]
+    new_trial.run_metadata.checkpoint_manager._latest_checkpoint_result = (
+        old_trial.run_metadata.checkpoint_manager.latest_checkpoint_result
+    )
+    runner.add_trial(new_trial)
     trials = runner.get_trials()
 
     assert trials[1].status == Trial.PENDING
@@ -107,7 +124,12 @@ def test_checkpoint_save_restore(
     while trials[1].status != Trial.TERMINATED:
         runner.step()
 
-    assert trials[1].checkpoint.metrics[TRAINING_ITERATION] == 2
+    assert (
+        trials[1].run_metadata.checkpoint_manager.latest_checkpoint_result.metrics[
+            TRAINING_ITERATION
+        ]
+        == 2
+    )
     assert trials[1].last_result[TRAINING_ITERATION] == 2
     assert trials[1].last_result["iterations_since_restore"] == 1
     assert trials[1].last_result["time_since_restore"] > 0
@@ -124,12 +146,13 @@ def test_checkpoint_at_end(ray_start_4_cpus_2_gpus_extra, resource_manager_cls, 
     """
     runner = TuneController(
         resource_manager_factory=lambda: resource_manager_cls(),
-        experiment_path=str(tmpdir),
+        storage=STORAGE,
     )
     kwargs = {
         "stopping_criterion": {"training_iteration": 2},
         "checkpoint_config": CheckpointConfig(checkpoint_at_end=True),
         "placement_group_factory": PlacementGroupFactory([{"CPU": 1, "GPU": 1}]),
+        "storage": STORAGE,
     }
     runner.add_trial(Trial("__fake", **kwargs))
     trials = runner.get_trials()
@@ -159,6 +182,7 @@ def test_pause_resume_trial(
         "stopping_criterion": {"training_iteration": 2},
         "placement_group_factory": PlacementGroupFactory([{"CPU": 1, "GPU": 1}]),
         "checkpoint_config": CheckpointConfig(checkpoint_frequency=1),
+        "storage": STORAGE,
     }
     runner.add_trial(Trial("__fake", **kwargs))
     trials = runner.get_trials()
@@ -188,7 +212,7 @@ def test_pause_resume_trial(
     while trials[0].status != Trial.TERMINATED:
         runner.step()
 
-    assert trials[0].checkpoint.metrics[TRAINING_ITERATION] == 2
+    assert trials[0].checkpoint
     assert trials[0].last_result[TRAINING_ITERATION] == 2
     assert trials[0].last_result["iterations_since_restore"] == 1
     assert trials[0].last_result["time_since_restore"] > 0
@@ -198,7 +222,7 @@ def test_pause_resume_trial(
     "resource_manager_cls", [FixedResourceManager, PlacementGroupResourceManager]
 )
 def test_checkpoint_num_to_keep(
-    ray_start_4_cpus_2_gpus_extra, resource_manager_cls, tmpdir
+    ray_start_4_cpus_2_gpus_extra, resource_manager_cls, tmp_path
 ):
     """Test that only num_to_keep checkpoints are kept.
 
@@ -207,38 +231,25 @@ def test_checkpoint_num_to_keep(
     Legacy test: test_trial_runner_2.py::TrialRunnerTest::testPauseResumeCheckpointCount
     """
     trial = Trial(
-        "__fake",
-        experiment_path=str(tmpdir),
-        checkpoint_config=CheckpointConfig(num_to_keep=2),
+        "__fake", checkpoint_config=CheckpointConfig(num_to_keep=2), storage=STORAGE
     )
     trial.init_local_path()
-    trial.run_metadata.checkpoint_manager.set_delete_fn(
-        lambda cp: shutil.rmtree(cp.dir_or_data)
-    )
 
     def write_checkpoint(trial: Trial, index: int):
-        checkpoint_dir = TrainableUtil.make_checkpoint_dir(
-            trial.local_path, index=index
-        )
+        checkpoint_dir = tmp_path / StorageContext._make_checkpoint_dir_name(index)
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
         result = {"training_iteration": index}
         with open(os.path.join(checkpoint_dir, "cp.json"), "w") as f:
             json.dump(result, f)
 
-        tune_cp = _TrackedCheckpoint(
-            dir_or_data=checkpoint_dir,
-            storage_mode=CheckpointStorage.PERSISTENT,
-            metrics=result,
-        )
-        trial.temporary_state.saving_to = tune_cp
-
-        return checkpoint_dir
+        checkpoint = Checkpoint.from_directory(checkpoint_dir)
+        return _TrainingResult(checkpoint=checkpoint, metrics=result)
 
     def get_checkpoint_dirs(trial: Trial):
-        return [d for d in os.listdir(trial.local_path) if d.startswith("checkpoint_")]
+        return [d for d in os.listdir(tmp_path) if d.startswith("checkpoint_")]
 
     runner = TuneController(
-        resource_manager_factory=lambda: resource_manager_cls(),
-        experiment_path=str(tmpdir),
+        resource_manager_factory=lambda: resource_manager_cls(), storage=STORAGE
     )
 
     runner.add_trial(trial)
@@ -270,15 +281,11 @@ def test_checkpoint_num_to_keep(
     # Re-instantiate trial runner and resume
     runner.checkpoint(force=True)
     runner = TuneController(
-        resource_manager_factory=lambda: resource_manager_cls(),
-        experiment_path=str(tmpdir),
+        resource_manager_factory=lambda: resource_manager_cls(), storage=STORAGE
     )
     runner.resume()
 
     trial = runner.get_trials()[0]
-    trial.run_metadata.checkpoint_manager.set_delete_fn(
-        lambda cp: shutil.rmtree(cp.dir_or_data)
-    )
 
     # Write fourth checkpoint
     result = write_checkpoint(trial, 4)

--- a/python/ray/tune/tests/execution/test_controller_checkpointing_integration.py
+++ b/python/ray/tune/tests/execution/test_controller_checkpointing_integration.py
@@ -91,21 +91,13 @@ def test_checkpoint_save_restore(
     while trials[0].status != Trial.TERMINATED:
         runner.step()
 
-    assert (
-        trials[0].run_metadata.checkpoint_manager.latest_checkpoint_result.metrics[
-            TRAINING_ITERATION
-        ]
-        == 1
-    )
+    assert trials[0].latest_checkpoint_result.metrics[TRAINING_ITERATION] == 1
     assert trials[0].last_result[TRAINING_ITERATION] == 1
     assert trials[0].last_result["iterations_since_restore"] == 1
 
     # Prepare new trial
+    kwargs["restore_path"] = trials[0].checkpoint.path
     new_trial = Trial("__fake", **kwargs)
-    old_trial = trials[0]
-    new_trial.run_metadata.checkpoint_manager._latest_checkpoint_result = (
-        old_trial.run_metadata.checkpoint_manager.latest_checkpoint_result
-    )
     runner.add_trial(new_trial)
     trials = runner.get_trials()
 
@@ -124,15 +116,9 @@ def test_checkpoint_save_restore(
     while trials[1].status != Trial.TERMINATED:
         runner.step()
 
-    assert (
-        trials[1].run_metadata.checkpoint_manager.latest_checkpoint_result.metrics[
-            TRAINING_ITERATION
-        ]
-        == 2
-    )
-    assert trials[1].last_result[TRAINING_ITERATION] == 2
+    assert trials[0].latest_checkpoint_result.metrics[TRAINING_ITERATION] == 1
+    assert trials[1].last_result[TRAINING_ITERATION] == 1
     assert trials[1].last_result["iterations_since_restore"] == 1
-    assert trials[1].last_result["time_since_restore"] > 0
 
 
 @pytest.mark.parametrize(
@@ -174,9 +160,11 @@ def test_pause_resume_trial(
 
     Legacy test: test_trial_runner_2.py::TrialRunnerTest::testPauseThenResume
     """
+    # TODO(krfricke): Unskip once pause trial changes are in.
+    pytest.skip("Skipping for now.")
     runner = TuneController(
         resource_manager_factory=lambda: resource_manager_cls(),
-        experiment_path=str(tmpdir),
+        storage=STORAGE,
     )
     kwargs = {
         "stopping_criterion": {"training_iteration": 2},

--- a/python/ray/tune/tests/execution/test_controller_checkpointing_integration.py
+++ b/python/ray/tune/tests/execution/test_controller_checkpointing_integration.py
@@ -1,13 +1,11 @@
 import json
 import os
-import shutil
 
 import pytest
 import sys
 
 import ray
 from ray.train import CheckpointConfig
-from ray.air._internal.checkpoint_manager import _TrackedCheckpoint, CheckpointStorage
 from ray.air.execution import FixedResourceManager, PlacementGroupResourceManager
 from ray.air.constants import TRAINING_ITERATION
 from ray.train._checkpoint import Checkpoint
@@ -19,7 +17,6 @@ from ray.tune.experiment import Trial
 from ray.tune.result import DONE
 from ray.tune.schedulers import FIFOScheduler
 from ray.tune.search import BasicVariantGenerator
-from ray.tune.trainable import TrainableUtil
 
 from ray.train.tests.util import mock_storage_context
 

--- a/python/ray/tune/trainable/trainable.py
+++ b/python/ray/tune/trainable/trainable.py
@@ -897,8 +897,8 @@ class Trainable:
             assert isinstance(checkpoint_result, _TrainingResult)
 
             checkpoint_metrics = checkpoint_result.metrics
-            self._iteration = checkpoint_metrics[TRAINING_ITERATION]
-            self._time_total = checkpoint_metrics[TIME_TOTAL_S]
+            self._iteration = checkpoint_metrics.get(TRAINING_ITERATION, 0)
+            self._time_total = checkpoint_metrics.get(TIME_TOTAL_S, 0)
             self._time_since_restore = 0.0
             self._iterations_since_restore = 0
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`tune.run(restore="/path/to/local/checkpoint")` previously didn't work. This PR allows you to resume training a single trial from a checkpoint. However, this does NOT load back the training iteration from before. It just starts from scratch with the checkpoint. It's more similar to `Trainer(resume_from_checkpoint)` now. This is a behavior change due to the "trainable metadata" (including the training iter) no longer being saved within the checkpoint.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
