### PR TITLE
[Docs][Serve] Add model serve using AWS NeuronCore

### DIFF
--- a/doc/BUILD
+++ b/doc/BUILD
@@ -130,7 +130,7 @@ py_test_run_all_subdirectory(
     size = "medium",
     include = ["source/serve/doc_code/**/*.py"],
     exclude = [
-        "source/serve/doc_code/aws_neuron_core_inference_serve.py"
+        "source/serve/doc_code/aws_neuron_core_inference_serve.py",
         "source/serve/doc_code/distilbert.py",
         "source/serve/doc_code/stable_diffusion.py",
         "source/serve/doc_code/object_detection.py",

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -130,6 +130,7 @@ py_test_run_all_subdirectory(
     size = "medium",
     include = ["source/serve/doc_code/**/*.py"],
     exclude = [
+        "source/serve/doc_code/aws_neuron_core_inference_serve.py"
         "source/serve/doc_code/distilbert.py",
         "source/serve/doc_code/stable_diffusion.py",
         "source/serve/doc_code/object_detection.py",
@@ -160,7 +161,9 @@ py_test_run_all_subdirectory(
         "source/serve/doc_code/stable_diffusion.py",
         "source/serve/doc_code/object_detection.py",
     ],
-    exclude = [],
+    exclude = [
+        "source/serve/doc_code/aws_neuron_core_inference_serve.py"
+    ],
     extra_srcs = [],
     tags = ["exclusive", "team:serve", "gpu"],
     env = {"RAY_SERVE_PROXY_READY_CHECK_TIMEOUT_S": "60"},

--- a/doc/source/ray-overview/examples.rst
+++ b/doc/source/ray-overview/examples.rst
@@ -228,6 +228,13 @@ Ray Examples
         Serving a Distilbert Model
 
     .. grid-item-card:: :bdg-secondary:`Code example`
+        :class-item: gallery-item serving inference aws-neuron-core
+        :link: /serve/tutorials/aws-neuron-core-inference
+        :link-type: doc
+
+        Serving a Bert Model on AWS NeuronCore
+
+    .. grid-item-card:: :bdg-secondary:`Code example`
         :class-item: gallery-item cv serving
         :link: /serve/tutorials/object-detection
         :link-type: doc

--- a/doc/source/serve/doc_code/aws_neuron_core_inference_serve.py
+++ b/doc/source/serve/doc_code/aws_neuron_core_inference_serve.py
@@ -1,0 +1,115 @@
+from contextlib import contextmanager
+
+# __compile_neuron_code_start__
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+import torch, torch_neuronx  # noqa
+
+hf_model = "j-hartmann/emotion-english-distilroberta-base"
+neuron_model = "./sentiment_neuron.pt"
+
+model = AutoModelForSequenceClassification.from_pretrained(hf_model)
+tokenizer = AutoTokenizer.from_pretrained(hf_model)
+sequence_0 = "The company HuggingFace is based in New York City"
+sequence_1 = "HuggingFace's headquarters are situated in Manhattan"
+example_inputs = tokenizer.encode_plus(
+    sequence_0,
+    sequence_1,
+    return_tensors="pt",
+    padding="max_length",
+    truncation=True,
+    max_length=128,
+)
+neuron_inputs = example_inputs["input_ids"], example_inputs["attention_mask"]
+n_model = torch_neuronx.trace(model, neuron_inputs)
+n_model.save(neuron_model)
+print(f"Saved Neuron-compiled model {neuron_model}")
+# __compile_neuron_code_end__
+
+
+# __neuron_serve_code_start__
+from fastapi import FastAPI  # noqa
+from ray import serve  # noqa
+
+import torch  # noqa
+
+app = FastAPI()
+
+hf_model = "j-hartmann/emotion-english-distilroberta-base"
+neuron_model = "./sentiment_neuron.pt"
+
+
+@serve.deployment(num_replicas=1, route_prefix="/")
+@serve.ingress(app)
+class APIIngress:
+    def __init__(self, bert_base_model_handle) -> None:
+        self.handle = bert_base_model_handle
+
+    @app.get("/infer")
+    async def infer(self, sentence: str):
+        ref = await self.handle.infer.remote(sentence)
+        result = await ref
+        return result
+
+
+@serve.deployment(
+    ray_actor_options={"resources": {"neuron_cores": 1}},
+    autoscaling_config={"min_replicas": 1, "max_replicas": 2},
+)
+class BertBaseModel:
+    def __init__(self):
+        import torch, torch_neuronx  # noqa
+        from transformers import AutoTokenizer
+
+        self.model = torch.jit.load(neuron_model)
+        self.tokenizer = AutoTokenizer.from_pretrained(hf_model)
+        self.classmap = {
+            0: "anger",
+            1: "disgust",
+            2: "fear",
+            3: "joy",
+            4: "neutral",
+            5: "sadness",
+            6: "surprise",
+        }
+
+    def infer(self, sentence: str):
+        inputs = self.tokenizer.encode_plus(
+            sentence,
+            return_tensors="pt",
+            padding="max_length",
+            truncation=True,
+            max_length=128,
+        )
+        output = self.model(*(inputs["input_ids"], inputs["attention_mask"]))
+        class_id = torch.argmax(output["logits"], dim=1).item()
+        return self.classmap[class_id]
+
+
+entrypoint = APIIngress.bind(BertBaseModel.bind())
+
+
+# __neuron_serve_code_end__
+
+
+@contextmanager
+def serve_session(deployment):
+    handle = serve.run(deployment)
+    try:
+        yield handle
+    finally:
+        serve.shutdown()
+
+
+if __name__ == "__main__":
+    import requests
+    import ray
+
+    # On inf2.8xlarge instance, there will be 2 neuron cores.
+    ray.init(resources={"neuron_cores": 2})
+
+    with serve_session(entrypoint):
+        prompt = "Ray is super cool."
+        resp = requests.get(f"http://127.0.0.1:8000/infer?sentence={prompt}")
+        print(resp.status_code, resp.json())
+
+        assert resp.status_code == 200

--- a/doc/source/serve/tutorials/aws-neuron-core-inference.md
+++ b/doc/source/serve/tutorials/aws-neuron-core-inference.md
@@ -1,0 +1,75 @@
+(aws-neuron-core-inference-tutorial)=
+
+# Serving an inference model on AWS NeuronCores using Fast API (Experimental)
+This example compiles bert based model and deploys the traced model on AWS Inferentia (Inf2) or Tranium (Trn1)
+instance using Ray Serve and Fast API.
+
+
+:::{note}
+  The setup assumes that the user has followed the
+  [PyTorch Neuron](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/setup/torch-neuronx.html#setup-torch-neuronx)
+  setup guide and installed AWS NeuronCore drivers/tools and torch-neuronx based on the instance-type.
+
+
+```bash
+python -m pip install "ray[serve]" requests transformers
+```
+
+This example uses the [j-hartmann/emotion-english-distilroberta-base](https://huggingface.co/j-hartmann/emotion-english-distilroberta-base) model and [FastAPI](https://fastapi.tiangolo.com/).
+
+Use the following code to compile the model:
+```{literalinclude} ../doc_code/aws_neuron_core_inference_serve.py
+:language: python
+:start-after: __compile_neuron_code_start__
+:end-before: __compile_neuron_code_end__
+```
+
+:::
+
+For compiling the model, you should see the following logs:
+```text
+Downloading (…)lve/main/config.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.00k/1.00k [00:00<00:00, 242kB/s]
+Downloading pytorch_model.bin: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 329M/329M [00:01<00:00, 217MB/s]
+Downloading (…)okenizer_config.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 294/294 [00:00<00:00, 305kB/s]
+Downloading (…)olve/main/vocab.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 798k/798k [00:00<00:00, 22.0MB/s]
+Downloading (…)olve/main/merges.txt: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 456k/456k [00:00<00:00, 57.0MB/s]
+Downloading (…)/main/tokenizer.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.36M/1.36M [00:00<00:00, 6.16MB/s]
+Downloading (…)cial_tokens_map.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 239/239 [00:00<00:00, 448kB/s]
+huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
+To disable this warning, you can either:
+        - Avoid using `tokenizers` before the fork if possible
+        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
+Saved Neuron-compiled model ./sentiment_neuron.pt
+```
+
+The traced model should be ready for deployment. Save the following code to a file named aws_neuron_core_inference_serve.py.
+Use `serve run aws_neuron_core_inference_serve:entrypoint` to start the serve application.
+```{literalinclude} ../doc_code/aws_neuron_core_inference_serve.py
+:language: python
+:start-after: __neuron_serve_code_start__
+:end-before: __neuron_serve_code_end__
+```
+
+To 
+```text
+(ServeController pid=43105) INFO 2023-08-23 20:29:32,694 controller 43105 deployment_state.py:1372 - Deploying new version of deployment default_BertBaseModel.
+(ServeController pid=43105) INFO 2023-08-23 20:29:32,695 controller 43105 deployment_state.py:1372 - Deploying new version of deployment default_APIIngress.
+(HTTPProxyActor pid=43147) INFO 2023-08-23 20:29:32,620 http_proxy 10.0.1.234 http_proxy.py:1328 - Proxy actor 8be14f6b6b10c0190cd0c39101000000 starting on node 46a7f740898fef723c3360ef598c1309701b07d11fb9dc45e236620a.
+(HTTPProxyActor pid=43147) INFO:     Started server process [43147]
+(ServeController pid=43105) INFO 2023-08-23 20:29:32,799 controller 43105 deployment_state.py:1654 - Adding 1 replica to deployment default_BertBaseModel.
+(ServeController pid=43105) INFO 2023-08-23 20:29:32,801 controller 43105 deployment_state.py:1654 - Adding 1 replica to deployment default_APIIngress.
+2023-08-23 20:29:44,690 SUCC scripts.py:462 -- Deployed Serve app successfully.
+```
+
+Use the following code to send requests:
+```python
+import requests
+
+response = requests.get(f"http://127.0.0.1:8000/infer?sentence=Ray is super cool")
+print(response.status_code, response.json())
+```
+The response includes status code and the classifier
+
+```text
+200 joy
+```

--- a/doc/source/serve/tutorials/aws-neuron-core-inference.md
+++ b/doc/source/serve/tutorials/aws-neuron-core-inference.md
@@ -10,6 +10,7 @@ instance using Ray Serve and Fast API.
   [PyTorch Neuron](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/setup/torch-neuronx.html#setup-torch-neuronx)
   setup guide and installed AWS NeuronCore drivers/tools and torch-neuronx based on the instance-type.
 
+:::
 
 ```bash
 python -m pip install "ray[serve]" requests transformers
@@ -24,7 +25,6 @@ Use the following code to compile the model:
 :end-before: __compile_neuron_code_end__
 ```
 
-:::
 
 For compiling the model, you should see the following logs:
 ```text
@@ -43,6 +43,7 @@ Saved Neuron-compiled model ./sentiment_neuron.pt
 ```
 
 The traced model should be ready for deployment. Save the following code to a file named aws_neuron_core_inference_serve.py.
+
 Use `serve run aws_neuron_core_inference_serve:entrypoint` to start the serve application.
 ```{literalinclude} ../doc_code/aws_neuron_core_inference_serve.py
 :language: python
@@ -50,7 +51,8 @@ Use `serve run aws_neuron_core_inference_serve:entrypoint` to start the serve ap
 :end-before: __neuron_serve_code_end__
 ```
 
-To 
+
+You should see the following logs for a successful deployment:
 ```text
 (ServeController pid=43105) INFO 2023-08-23 20:29:32,694 controller 43105 deployment_state.py:1372 - Deploying new version of deployment default_BertBaseModel.
 (ServeController pid=43105) INFO 2023-08-23 20:29:32,695 controller 43105 deployment_state.py:1372 - Deploying new version of deployment default_APIIngress.
@@ -68,7 +70,7 @@ import requests
 response = requests.get(f"http://127.0.0.1:8000/infer?sentence=Ray is super cool")
 print(response.status_code, response.json())
 ```
-The response includes status code and the classifier
+The response includes status code and the classifier output
 
 ```text
 200 joy

--- a/doc/source/serve/tutorials/index.md
+++ b/doc/source/serve/tutorials/index.md
@@ -13,6 +13,7 @@ serve-ml-models
 stable-diffusion
 text-classification
 object-detection
+aws-neuron-core-inference
 rllib
 gradio-integration
 batch


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Example of AWS NeuronCore usage by compiling a model and deploying it using Ray Serve.

## Related issue number

* "Closes #38810"

* "#33504"

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Manual testing

### Manual Testing
Tested on a Inferentia(inf2.8xl) instance (with 2 neuron_cores).


Serve deployment
```
2023-08-23 22:33:58,267 INFO worker.py:1640 -- Started a local Ray instance. View the dashboard at http://127.0.0.1:8265
(HTTPProxyActor pid=51626) INFO 2023-08-23 22:33:59,693 http_proxy 10.0.1.234 http_proxy.py:1328 - Proxy actor 442c87516b8f2fb93876c13e01000000 starting on node 7695235f0ea52a3784bfcd9df9e7860f32589150d8137dd3a4cf6ce0.
(ServeController pid=51586) INFO 2023-08-23 22:33:59,769 controller 51586 deployment_state.py:1372 - Deploying new version of deployment default_BertBaseModel.
(ServeController pid=51586) INFO 2023-08-23 22:33:59,770 controller 51586 deployment_state.py:1372 - Deploying new version of deployment default_APIIngress.
(HTTPProxyActor pid=51626) INFO:     Started server process [51626]
(ServeController pid=51586) INFO 2023-08-23 22:33:59,874 controller 51586 deployment_state.py:1654 - Adding 1 replica to deployment default_BertBaseModel.
(ServeController pid=51586) INFO 2023-08-23 22:33:59,876 controller 51586 deployment_state.py:1654 - Adding 1 replica to deployment default_APIIngress.
2023-08-23 22:34:11,767 SUCC scripts.py:462 -- Deployed Serve app successfully.
(ServeReplica:default_BertBaseModel pid=51656) INFO 2023-08-23 22:35:11,030 default_BertBaseModel default_BertBaseModel#ypldKT fb7a88ea-fae6-48a8-b9fb-8abce5d9ddaa /infer default replica.py:727 - INFER OK 63.1ms
(ServeReplica:default_APIIngress pid=51657) INFO 2023-08-23 22:35:11,032 default_APIIngress default_APIIngress#WPhXHi fb7a88ea-fae6-48a8-b9fb-8abce5d9ddaa /infer default replica.py:727 - __CALL__ OK 82.4ms
(ServeReplica:default_BertBaseModel pid=51656) INFO 2023-08-23 22:36:33,731 default_BertBaseModel default_BertBaseModel#ypldKT 6a456015-9789-404e-9cff-9a2b69df6156 /infer default replica.py:727 - INFER OK 1.7ms
(ServeReplica:default_APIIngress pid=51657) INFO 2023-08-23 22:36:33,732 default_APIIngress default_APIIngress#WPhXHi 6a456015-9789-404e-9cff-9a2b69df6156 /infer default replica.py:727 - __CALL__ OK 6.7ms
(ServeReplica:default_BertBaseModel pid=51656) INFO 2023-08-23 22:36:51,046 default_BertBaseModel default_BertBaseModel#ypldKT ec8feb78-0805-46be-be1a-ffcd0775b998 /infer default replica.py:727 - INFER OK 1.1ms
(ServeReplica:default_APIIngress pid=51657) INFO 2023-08-23 22:36:51,046 default_APIIngress default_APIIngress#WPhXHi ec8feb78-0805-46be-be1a-ffcd0775b998 /infer default replica.py:727 - __CALL__ OK 5.9ms
```

```
>>> resp = requests.get(f"http://127.0.0.1:8000/infer?sentence=Ray is super cool")
>>> print(resp.status_code, resp.json())
200 joy
>>>
```


```
                                                                                                                    neuron-top 2.12.2.0 running on i-xxx (inf2.8xlarge)

 NeuronCore v2 Utilization (Avg:  0.00%)
                                                                            NC0                                                                                                                                               NC1
 ND0  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[ 0.00%] |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[ 0.00%]

 vCPU Utilization
 System vCPU Usage  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[ 0.19%, 0.03%]
 Runtime vCPU Usage ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[ 0.00%, 0.00%]

 Memory Usage Summary
 Host Used Memory          Total: 527.4MB                               Tensors: 0.0B                                Constants: 0.0B                              DMA Buffers: 256.0KB                         App. Memory: 527.1MB
 Device Used Memory        Total: 380.3MB                               Tensors: 0.0B                                Constants: 282.7MB                           Model Code: 97.6MB                           Runtime Memory: 1.1KB                        Model Scratchpad: 0.0B

 Memory Usage Details
                                                                                                                                                                 Model ID                                     Device Memory                                Host Memory
  [-] ND 0                                                                                                                                                                                                     380.3MB                                      20.0KB
      [-] NC 0                                                                                                                                                                                                 380.3MB                                      20.0KB
          [+] /tmp/tmp_9ord0xt/graph.neff                                                                                                                        10001                                         283.3MB                                      20.0KB
          Model Code                                                                                                                                                                                           97.0MB                                       0.0B
          Runtime Memory                                                                                                                                                                                       1.1KB                                        0.0B
      NC 1
```
