### PR TITLE
[ci] Reduce train tests+examples parallelism

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -32,7 +32,7 @@
 - label: ":steam_locomotive: Train tests and examples"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
   instance_size: large
-  parallelism: 4
+  parallelism: 3
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
     # Todo (krfricke): Move mosaicml to train-test-requirements.txt
@@ -343,7 +343,7 @@
 - label: ":steam_locomotive: :floppy_disk: New persistence mode: Train tests and examples"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
   instance_size: large
-  parallelism: 4
+  parallelism: 3
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
     # Todo (krfricke): Move mosaicml to train-test-requirements.txt

--- a/python/ray/train/_checkpoint.py
+++ b/python/ray/train/_checkpoint.py
@@ -30,9 +30,9 @@ _CHECKPOINT_TEMP_DIR_PREFIX = "checkpoint_tmp_"
 class Checkpoint:
     """A reference to data persisted as a directory in local or remote storage.
 
-    Access checkpoint contents locally using `checkpoint.to_directory()`.
+    Access checkpoint contents locally using ``checkpoint.to_directory()``.
 
-    Example creating a checkpoint using `Checkpoint.from_directory`:
+    Example creating a checkpoint using ``Checkpoint.from_directory``:
 
         >>> from ray.train._checkpoint import Checkpoint
         >>> checkpoint = Checkpoint.from_directory("/tmp/example_checkpoint_dir")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The "Train tests and examples" pipeline is being thinned out in scope of the storage API refactor. After #38759 was merged, one of the jobs doesn't contain any tests anymore. This is not correctly detected by the sharding script, so bazel complains about an empty test suite.

This PR reduces the parallelism of this job so that it's not empty anymore. This does not change any Ray code. (There's only a trivial change to trigger testing).

<img width="502" alt="Screenshot 2023-08-24 at 10 31 54" src="https://github.com/ray-project/ray/assets/14904111/8d4a2233-da39-4d0a-89b9-4f8e4717d641">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
