### PR TITLE
fix lint test coverage

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -177,6 +177,7 @@ py_test_module_list(
     "test_draining.py",
     "test_streaming_generator.py",
     "test_streaming_generator_2.py",
+    "test_streaming_generator_3.py",
     "test_scheduling_performance.py",
   ],
   size = "medium",


### PR DESCRIPTION
the new test file `test_streaming_generator_3.py` was added without adding it in the bazel test declaration list.