### PR TITLE
Revert "Task Profile/CPU Flaming Graph"

### DIFF
--- a/dashboard/client/src/common/ProfilingLink.tsx
+++ b/dashboard/client/src/common/ProfilingLink.tsx
@@ -10,52 +10,6 @@ type CpuProfilingLinkProps = PropsWithChildren<
   } & ClassNameProps
 >;
 
-type TaskProfilingStackTraceProps = {
-  taskId: string | null | undefined;
-  attemptNumber: number;
-  nodeId: string;
-};
-
-export const TaskCpuProfilingLink = ({
-  taskId,
-  attemptNumber,
-  nodeId,
-}: TaskProfilingStackTraceProps) => {
-  if (!taskId) {
-    return null;
-  }
-  return (
-    <Link
-      href={`task/cpu_profile?task_id=${taskId}&attempt_number=${attemptNumber}&node_id=${nodeId}`}
-      target="_blank"
-      title="Profile the Python worker for 5 seconds (default) and display a CPU flame graph."
-      rel="noreferrer"
-    >
-      CPU&nbsp;Flame&nbsp;Graph
-    </Link>
-  );
-};
-
-export const TaskCpuStackTraceLink = ({
-  taskId,
-  attemptNumber,
-  nodeId,
-}: TaskProfilingStackTraceProps) => {
-  if (!taskId) {
-    return null;
-  }
-  return (
-    <Link
-      href={`task/traceback?task_id=${taskId}&attempt_number=${attemptNumber}&node_id=${nodeId}`}
-      target="_blank"
-      title="Sample the current Python stack trace for this worker."
-      rel="noreferrer"
-    >
-      Stack&nbsp;Trace
-    </Link>
-  );
-};
-
 export const CpuProfilingLink = ({
   pid,
   ip,
@@ -64,6 +18,7 @@ export const CpuProfilingLink = ({
   if (!pid || !ip || typeof pid === "undefined" || typeof ip === "undefined") {
     return <div></div>;
   }
+
   return (
     <Link
       href={`worker/traceback?pid=${pid}&ip=${ip}&native=0`}

--- a/dashboard/client/src/components/TaskTable.tsx
+++ b/dashboard/client/src/components/TaskTable.tsx
@@ -19,16 +19,13 @@ import { Link as RouterLink } from "react-router-dom";
 import { CodeDialogButton } from "../common/CodeDialogButton";
 import { DurationText } from "../common/DurationText";
 import { ActorLink, NodeLink } from "../common/links";
-import {
-  TaskCpuProfilingLink,
-  TaskCpuStackTraceLink,
-} from "../common/ProfilingLink";
 import rowStyles from "../common/RowStyles";
 import { Task } from "../type/task";
 import { useFilter } from "../util/hook";
 import StateCounter from "./StatesCounter";
 import { StatusChip } from "./StatusChip";
 import { HelpInfo } from "./Tooltip";
+
 export type TaskTableProps = {
   tasks: Task[];
   jobId?: string;
@@ -74,10 +71,6 @@ const TaskTable = ({
           tasks.
           <br />- Error: For tasks that have failed, show a stack trace for the
           faiure.
-          <br /> Stack Trace: Get a stacktrace of the worker process where the
-          task is running.
-          <br />- CPU Flame Graph: Get a flame graph of the next 5 seconds of
-          the worker process where the task is running.
         </Typography>
       ),
     },
@@ -337,29 +330,11 @@ const TaskTableActions = ({ task }: TaskTableActionsProps) => {
       ? `Error Type: ${task.error_type}\n\n${task.error_message}`
       : undefined;
 
-  const isTaskActive = task.state === "RUNNING" && task.worker_id;
-
   return (
     <React.Fragment>
       <Link component={RouterLink} to={`tasks/${task.task_id}`}>
         Log
       </Link>
-      {isTaskActive && (
-        <React.Fragment>
-          <br />
-          <TaskCpuProfilingLink
-            taskId={task.task_id}
-            attemptNumber={task.attempt_number}
-            nodeId={task.node_id}
-          />
-          <br />
-          <TaskCpuStackTraceLink
-            taskId={task.task_id}
-            attemptNumber={task.attempt_number}
-            nodeId={task.node_id}
-          />
-        </React.Fragment>
-      )}
       <br />
 
       {errorDetails && (

--- a/dashboard/client/src/pages/task/TaskPage.tsx
+++ b/dashboard/client/src/pages/task/TaskPage.tsx
@@ -10,10 +10,6 @@ import {
   MultiTabLogViewer,
   MultiTabLogViewerTabDetails,
 } from "../../common/MultiTabLogViewer";
-import {
-  TaskCpuProfilingLink,
-  TaskCpuStackTraceLink,
-} from "../../common/ProfilingLink";
 import { Section } from "../../common/Section";
 import Loading from "../../components/Loading";
 import { MetadataSection } from "../../components/MetadataSection";
@@ -82,7 +78,6 @@ const TaskPageContents = ({
   }
 
   const {
-    attempt_number,
     task_id,
     actor_id,
     end_time_ms,
@@ -97,7 +92,6 @@ const TaskPageContents = ({
     func_or_class_name,
     name,
   } = task;
-  const isTaskActive = task.state === "RUNNING" && task.worker_id;
 
   return (
     <div>
@@ -223,29 +217,6 @@ const TaskPageContents = ({
               }
             ),
           },
-          isTaskActive
-            ? {
-                label: "Actions",
-                content: (
-                  <React.Fragment>
-                    <TaskCpuProfilingLink
-                      taskId={task_id}
-                      attemptNumber={attempt_number}
-                      nodeId={node_id}
-                    />
-                    <br />
-                    <TaskCpuStackTraceLink
-                      taskId={task_id}
-                      attemptNumber={attempt_number}
-                      nodeId={node_id}
-                    />
-                  </React.Fragment>
-                ),
-              }
-            : {
-                label: "",
-                content: undefined,
-              },
         ]}
       />
       <CollapsibleSection title="Logs" startExpanded>

--- a/dashboard/client/src/type/task.ts
+++ b/dashboard/client/src/type/task.ts
@@ -24,7 +24,6 @@ export enum TypeTaskType {
 export type Task = {
   task_id: string;
   name: string;
-  attempt_number: number;
   state: TypeTaskStatus;
   job_id: string;
   node_id: string;

--- a/dashboard/modules/log/log_agent.py
+++ b/dashboard/modules/log/log_agent.py
@@ -214,7 +214,7 @@ async def _stream_log_in_chunk(
     """
     assert "b" in file.mode, "Only binary file is supported."
     assert not (
-        keep_alive_interval_sec >= 0 and end_offset != -1
+        keep_alive_interval_sec >= 0 and end_offset is not -1
     ), "Keep-alive is not allowed when specifying an end offset"
 
     file.seek(start_offset, 0)

--- a/dashboard/modules/reporter/reporter_head.py
+++ b/dashboard/modules/reporter/reporter_head.py
@@ -2,8 +2,6 @@ import json
 import logging
 import asyncio
 import aiohttp.web
-from typing import Optional, Tuple, List
-
 
 import ray
 import ray._private.services
@@ -25,30 +23,8 @@ from ray.dashboard.datacenter import DataSource
 from ray._private.usage.usage_constants import CLUSTER_METADATA_KEY
 from ray.autoscaler._private.commands import debug_status
 
-from ray.util.state.common import (
-    ListApiOptions,
-)
-from ray.dashboard.state_aggregator import StateAPIManager
-from ray.util.state.state_manager import (
-    StateDataSourceClient,
-)
-
 logger = logging.getLogger(__name__)
 routes = dashboard_optional_utils.ClassMethodRouteTable
-
-EMOJI_WARNING = "&#x26A0;&#xFE0F;"
-WARNING_FOR_MULTI_TASK_IN_A_WORKER = (
-    "Warning: This task is running in a worker process that is running multiple tasks. "
-    "This can happen if you are profiling a task right as it finishes or if you"
-    "are using the Async Actor or Threaded Actors pattern. "
-    "The information that follows may come from any of these tasks:"
-)
-SVG_STYLE = """<style>
-    svg {
-        width: 100%;
-        height: 100%;
-    }
-</style>\n"""
 
 
 class ReportHead(dashboard_utils.DashboardHeadModule):
@@ -66,7 +42,6 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
         temp_dir = dashboard_head.temp_dir
         self.service_discovery = PrometheusServiceDiscoveryWriter(gcs_address, temp_dir)
         self._gcs_aio_client = dashboard_head.gcs_aio_client
-        self._state_api = None
 
     async def _update_stubs(self, change):
         if change.old:
@@ -141,272 +116,6 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
                 cluster_status=debug_status(formatted_status_string, error),
             )
 
-    async def get_task_ids_running_in_a_worker(self, worker_id: str) -> List[str]:
-        """
-        Retrieves the task IDs of running tasks associated with a specific worker.
-
-        Args:
-            worker_id: The ID of the worker.
-
-        Returns:
-            List[str]: A list containing the task IDs
-            of all the running tasks associated with the worker.
-        """
-        option = ListApiOptions(
-            filters=[("worker_id", "=", worker_id), ("state", "=", "RUNNING")],
-            detail=True,
-            timeout=10,
-        )
-        # Call the state API to get all tasks in a worker
-        tasks_in_a_worker_result = await self._state_api.list_tasks(option=option)
-        tasks_in_a_worker = tasks_in_a_worker_result.result
-
-        # Get task_id from each task in a worker
-        task_ids_in_a_worker = [
-            task.get("task_id")
-            for task in tasks_in_a_worker
-            if task and "task_id" in task
-        ]
-        return task_ids_in_a_worker
-
-    async def get_worker_details_for_running_task(
-        self, task_id: str, attempt_number: int
-    ) -> Tuple[Optional[int], Optional[str]]:
-        """
-        Retrieves worker details for a specific task and attempt number.
-
-        Args:
-            task_id: The ID of the task.
-            attempt_number: The attempt number of the task.
-
-        Returns:
-            Tuple[Optional[int], Optional[str]]: A tuple
-            containing the worker's PID (process ID),
-            and worker's ID.
-
-        Raises:
-            ValueError: If the task attempt is not running or
-            the state APi is not initialized.
-        """
-        if self._state_api is None:
-            raise ValueError("The state API is not initialized yet. Please retry.")
-        option = ListApiOptions(
-            filters=[
-                ("task_id", "=", task_id),
-                ("attempt_number", "=", attempt_number),
-            ],
-            detail=True,
-            timeout=10,
-        )
-
-        result = await self._state_api.list_tasks(option=option)
-        tasks = result.result
-        if not tasks:
-            return None, None
-
-        pid = tasks[0]["worker_pid"]
-        worker_id = tasks[0]["worker_id"]
-
-        state = tasks[0]["state"]
-        if state != "RUNNING":
-            raise ValueError(
-                f"The task attempt is not running: the current state is {state}."
-            )
-
-        return pid, worker_id
-
-    @routes.get("/task/traceback")
-    async def get_task_traceback(self, req) -> aiohttp.web.Response:
-        """
-        Retrieves the traceback information for a specific task.
-        Note that one worker process works on one task at a time
-        or one worker works on multiple async tasks.
-
-        Args:
-            req (aiohttp.web.Request): The HTTP request object.
-
-        Returns:
-            aiohttp.web.Response: The HTTP response containing
-            the traceback information.
-
-        Raises:
-            ValueError: If the "task_id" parameter
-            is missing in the request query.
-            ValueError: If the "attempt_number" parameter
-            is missing in the request query.
-            ValueError: If the worker begins working on
-            another task during the traceback retrieval.
-            aiohttp.web.HTTPInternalServerError: If there is
-            an internal server error during the traceback retrieval.
-        """
-
-        if "task_id" not in req.query:
-            raise ValueError("task_id is required")
-        if "attempt_number" not in req.query:
-            raise ValueError("task's attempt number is required")
-        if "node_id" not in req.query:
-            raise ValueError("node_id is required")
-
-        task_id = req.query.get("task_id")
-        attempt_number = req.query.get("attempt_number")
-        node_id = req.query.get("node_id")
-
-        ip = DataSource.node_id_to_ip[node_id]
-
-        reporter_stub = self._stubs[ip]
-
-        # Default not using `--native` for profiling
-        native = req.query.get("native", False) == "1"
-
-        try:
-            (pid, _) = await self.get_worker_details_for_running_task(
-                task_id, attempt_number
-            )
-        except ValueError as e:
-            raise aiohttp.web.HTTPInternalServerError(text=str(e))
-
-        logger.info(
-            "Sending stack trace request to {}:{} with native={}".format(
-                ip, pid, native
-            )
-        )
-        reply = await reporter_stub.GetTraceback(
-            reporter_pb2.GetTracebackRequest(pid=pid, native=native)
-        )
-
-        """
-            In order to truly confirm whether there are any other tasks
-            running during the profiling, we need to retrieve all tasks
-            that are currently running or have finished, and then parse
-            the task events (i.e., their start and finish times) to check
-            for any potential overlap. However, this process can be
-            quite extensive, so here we will make our best efforts
-            to check for any overlapping tasks.
-            Therefore, we will check if the task is still running
-        """
-        try:
-            (_, worker_id) = await self.get_worker_details_for_running_task(
-                task_id, attempt_number
-            )
-
-        except ValueError as e:
-            raise aiohttp.web.HTTPInternalServerError(text=str(e))
-        if not reply.success:
-            return aiohttp.web.HTTPInternalServerError(text=reply.output)
-
-        logger.info("Returning stack trace, size {}".format(len(reply.output)))
-
-        task_ids_in_a_worker = await self.get_task_ids_running_in_a_worker(worker_id)
-        return aiohttp.web.Response(
-            text=WARNING_FOR_MULTI_TASK_IN_A_WORKER
-            + str(task_ids_in_a_worker)
-            + "\n"
-            + reply.output
-            if len(task_ids_in_a_worker) > 1
-            else reply.output
-        )
-
-    @routes.get("/task/cpu_profile")
-    async def get_task_cpu_profile(self, req) -> aiohttp.web.Response:
-        """
-        Retrieves the CPU profile for a specific task.
-        Note that one worker process works on one task at a time
-        or one worker works on multiple async tasks.
-
-        Args:
-            req (aiohttp.web.Request): The HTTP request object.
-
-        Returns:
-            aiohttp.web.Response: The HTTP response containing the CPU profile data.
-
-        Raises:
-            ValueError: If the "task_id" parameter is
-            missing in the request query.
-            ValueError: If the "attempt_number" parameter is
-            missing in the request query.
-            ValueError: If the maximum duration allowed is exceeded.
-            ValueError: If the worker begins working on
-            another task during the profile retrieval.
-            aiohttp.web.HTTPInternalServerError: If there is
-            an internal server error during the profile retrieval.
-            aiohttp.web.HTTPInternalServerError: If the CPU Flame
-            Graph information for the task is not found.
-        """
-        if "task_id" not in req.query:
-            raise ValueError("task_id is required")
-        if "attempt_number" not in req.query:
-            raise ValueError("task's attempt number is required")
-        if "node_id" not in req.query:
-            raise ValueError("node_id is required")
-
-        task_id = req.query.get("task_id")
-        attempt_number = req.query.get("attempt_number")
-        node_id = req.query.get("node_id")
-
-        ip = DataSource.node_id_to_ip[node_id]
-
-        duration = int(req.query.get("duration", 5))
-        if duration > 60:
-            raise ValueError(f"The max duration allowed is 60: {duration}.")
-        format = req.query.get("format", "flamegraph")
-
-        # Default not using `--native` for profiling
-        native = req.query.get("native", False) == "1"
-        reporter_stub = self._stubs[ip]
-
-        try:
-            (pid, _) = await self.get_worker_details_for_running_task(
-                task_id, attempt_number
-            )
-        except ValueError as e:
-            raise aiohttp.web.HTTPInternalServerError(text=str(e))
-
-        logger.info(
-            "Sending CPU profiling request to {}:{} for {} with native={}".format(
-                ip, pid, task_id, native
-            )
-        )
-
-        reply = await reporter_stub.CpuProfiling(
-            reporter_pb2.CpuProfilingRequest(
-                pid=pid, duration=duration, format=format, native=native
-            )
-        )
-
-        """
-            In order to truly confirm whether there are any other tasks
-            running during the profiling, we need to retrieve all tasks
-            that are currently running or have finished, and then parse
-            the task events (i.e., their start and finish times) to check
-            for any potential overlap. However, this process can be quite
-            extensive, so here we will make our best efforts to check
-            for any overlapping tasks. Therefore, we will check if
-            the task is still running
-        """
-        try:
-            (_, worker_id) = await self.get_worker_details_for_running_task(
-                task_id, attempt_number
-            )
-        except ValueError as e:
-            raise aiohttp.web.HTTPInternalServerError(text=str(e))
-
-        if not reply.success:
-            return aiohttp.web.HTTPInternalServerError(text=reply.output)
-        logger.info("Returning profiling response, size {}".format(len(reply.output)))
-
-        task_ids_in_a_worker = await self.get_task_ids_running_in_a_worker(worker_id)
-        return aiohttp.web.Response(
-            body='<p style="color: #E37400;">{} {} </br> </p> </br>'.format(
-                EMOJI_WARNING,
-                WARNING_FOR_MULTI_TASK_IN_A_WORKER + str(task_ids_in_a_worker),
-            )
-            + SVG_STYLE
-            + (reply.output)
-            if len(task_ids_in_a_worker) > 1
-            else SVG_STYLE + reply.output,
-            headers={"Content-Type": "text/html"},
-        )
-
     @routes.get("/worker/traceback")
     async def get_traceback(self, req) -> aiohttp.web.Response:
         if "ip" in req.query:
@@ -470,13 +179,6 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
             return aiohttp.web.HTTPInternalServerError(text=reply.output)
 
     async def run(self, server):
-        gcs_channel = self._dashboard_head.aiogrpc_gcs_channel
-        self._state_api_data_source_client = StateDataSourceClient(
-            gcs_channel, self._dashboard_head.gcs_aio_client
-        )
-        # Set up the state API in order to fetch task information.
-        self._state_api = StateAPIManager(self._state_api_data_source_client)
-
         # Need daemon True to avoid dashboard hangs at exit.
         self.service_discovery.daemon = True
         self.service_discovery.start()

--- a/dashboard/modules/reporter/tests/test_reporter.py
+++ b/dashboard/modules/reporter/tests/test_reporter.py
@@ -2,11 +2,12 @@ import logging
 import os
 import sys
 
+import pytest
 import requests
 import numpy as np
 import time
 import copy
-import pytest
+
 from collections import defaultdict
 from multiprocessing import Process
 from unittest.mock import MagicMock
@@ -694,116 +695,6 @@ def test_reporter_worker_cpu_percent():
                 child_proc.kill()
         if agent_mock.is_alive():
             agent_mock.kill()
-
-
-TASK = {
-    "task_id": "32d950ec0ccf9d2affffffffffffffffffffffff01000000",
-    "attempt_number": 0,
-    "node_id": "ffffffffffffffffffffffffffffffffffffffff01000000",
-}
-
-
-def test_get_task_traceback_running_task(shutdown_only):
-    """
-    Verify that we throw an error for a non-running task.
-
-    """
-    address_info = ray.init()
-    webui_url = format_web_url(address_info["webui_url"])
-
-    @ray.remote
-    def f():
-        pass
-
-    @ray.remote
-    def long_running_task():
-        print("Long-running task began.")
-        time.sleep(1000)
-        print("Long-running task completed.")
-
-    ray.get([f.remote() for _ in range(5)])
-
-    task = long_running_task.remote()
-
-    params = {
-        "task_id": task.task_id().hex(),
-        "attempt_number": 0,
-        "node_id": ray.get_runtime_context().node_id.hex(),
-    }
-
-    def verify():
-        resp = requests.get(f"{webui_url}/task/traceback", params=params)
-        print(f"resp.text {type(resp.text)}: {resp.text}")
-
-        assert "Process" in resp.text
-        return True
-
-    wait_for_condition(verify, timeout=20)
-
-
-def test_get_task_traceback_non_running_task(shutdown_only):
-    """
-    Verify that we throw an error for a non-running task.
-    """
-
-    # The sleep is needed since it seems a previous shutdown could be not yet
-    # done when the next test starts. This prevents a previous cluster to be
-    # connected the current test session.
-
-    address_info = ray.init()
-    webui_url = format_web_url(address_info["webui_url"])
-
-    @ray.remote
-    def f():
-        pass
-
-    ray.get([f.remote() for _ in range(5)])
-
-    params = {
-        "task_id": TASK["task_id"],
-        "attempt_number": TASK["attempt_number"],
-        "node_id": TASK["node_id"],
-    }
-
-    # Make sure the API works.
-    def verify():
-        with pytest.raises(requests.exceptions.HTTPError) as exc_info:
-            resp = requests.get(f"{webui_url}/task/traceback", params=params)
-            resp.raise_for_status()
-        assert isinstance(exc_info.value, requests.exceptions.HTTPError)
-        return True
-
-    wait_for_condition(verify, timeout=10)
-
-
-def test_get_cpu_profile_non_running_task(shutdown_only):
-    """
-    Verify that we throw an error for a non-running task.
-    """
-    address_info = ray.init()
-    webui_url = format_web_url(address_info["webui_url"])
-
-    @ray.remote
-    def f():
-        pass
-
-    ray.get([f.remote() for _ in range(5)])
-
-    params = {
-        "task_id": TASK["task_id"],
-        "attempt_number": TASK["attempt_number"],
-        "node_id": TASK["node_id"],
-    }
-
-    # Make sure the API works.
-    def verify():
-        with pytest.raises(requests.exceptions.HTTPError) as exc_info:
-            resp = requests.get(f"{webui_url}/task/cpu_profile", params=params)
-            resp.raise_for_status()
-        assert isinstance(exc_info.value, requests.exceptions.HTTPError)
-        return True
-
-    wait_for_condition(verify, timeout=10)
 
 
 if __name__ == "__main__":

--- a/python/ray/util/state/state_manager.py
+++ b/python/ray/util/state/state_manager.py
@@ -310,6 +310,10 @@ class StateDataSourceClient:
             else:
                 continue
 
+            # Remove the filter from the list so that we don't have to
+            # filter it again later.
+            filters.remove(filter)
+
         req_filters.exclude_driver = exclude_driver
 
         request = GetTaskEventsRequest(limit=limit, filters=req_filters)


### PR DESCRIPTION
Reverts ray-project/ray#38263

![image](https://github.com/ray-project/ray/assets/125417081/e0515044-8dcd-48b6-997f-b1aa25433793)

It seems that this PR breaks the test case in test_reporter.py. However, the traceback I observed from the [Buildkite link](https://buildkite.com/ray-project/oss-ci-build-branch/builds/5646#018a2264-1622-4f6f-8061-1fd28ee8518f/9191-12326) doesn't appear to be related to the changes I made.

I plan to revert it to verify my hypothesis.

![image](https://github.com/ray-project/ray/assets/125417081/e704e261-a942-4033-9051-47ed0202cdeb)
