### PR TITLE
[Serve] fix flaky grpc tests in `test_cli_2`

### DIFF
--- a/python/ray/serve/tests/test_cli_2.py
+++ b/python/ray/serve/tests/test_cli_2.py
@@ -924,7 +924,9 @@ def test_serving_request_through_grpc_proxy(ray_start_stop):
     channel = grpc.insecure_channel("localhost:9000")
 
     # Ensures ListApplications method succeeding.
-    ping_grpc_list_applications(channel, app_names)
+    wait_for_condition(
+        ping_grpc_list_applications, channel=channel, app_names=app_names
+    )
 
     # Ensures Healthz method succeeding.
     ping_grpc_healthz(channel)
@@ -964,7 +966,9 @@ def test_grpc_proxy_model_composition(ray_start_stop):
     channel = grpc.insecure_channel("localhost:9000")
 
     # Ensures ListApplications method succeeding.
-    ping_grpc_list_applications(channel, app_names)
+    wait_for_condition(
+        ping_grpc_list_applications, channel=channel, app_names=app_names
+    )
 
     # Ensures Healthz method succeeding.
     ping_grpc_healthz(channel)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`serve deploy` is running in separate thread and need to use `wait_for_condition` to wait until the deployments exist before the gRPC `ListApplication` call will be able to match the applications 

## Related issue number

Address flaky test in build: https://buildkite.com/ray-project/premerge/builds/3259#_

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
