### PR TITLE
[ci][release-test] replace cu118 with gpu

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -942,7 +942,7 @@
   team: ml
   cluster:
     byod:
-      type: cu118
+      type: gpu
       pip:
         - myst-parser==0.15.2
         - myst-nb==0.13.1
@@ -1014,7 +1014,7 @@
   team: serve
   cluster:
     byod:
-      type: cu118
+      type: gpu
     cluster_compute: ../testing/compute_configs/gpu/aws.yaml
 
   run:
@@ -1037,7 +1037,7 @@
   team: ml
   cluster:
     byod:
-      type: cu118
+      type: gpu
     cluster_compute: ../testing/compute_configs/04_finetuning_llms_with_deepspeed/aws_7b.yaml
 
   run:


### PR DESCRIPTION
cu118 and gpu are the same two images, so replace cu118 with gpu. This helps tests to pass in runtime since runtime doen't build cu118 image.

Test:
- CI
- Release test