### PR TITLE
[ci][mac] persist ray logs as buildkite artifacts

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -22,6 +22,9 @@ prelude_commands: &prelude_commands |-
   ./ci/env/env_info.sh
 
 epilogue_commands: &epilogue_commands |-
+  # Persist ray logs
+  mkdir -p /tmp/artifacts/.ray/
+  tar -cvzf /tmp/artifacts/.ray/logs.tgz /tmp/ray
   # Cleanup runtime environment to save storage
   rm -rf /tmp/ray || true
   # Cleanup local caches - this should not clean up global disk cache


### PR DESCRIPTION
This is a feature request from core team to persist all ray logs as a buildkite artifacts, so they can download it for debugging purpose.

Test:
- CI
- See the artifact tab in https://buildkite.com/ray-project/oss-ci-build-branch/builds/6438#018b24d9-6272-4cd5-b93a-9a3732194888