### PR TITLE
[WIP] [Serve] Broadcast diffs for `RunningReplicaInfo`

### DIFF
--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -46,9 +46,6 @@ class LongPollNamespace(Enum):
     ROUTE_TABLE = auto()
 
 
-T, Diff = Any, Any
-
-
 class LongPollNamespacePartialUpdateInterface:
     """Interface for partial updates in the LongPollClient and LongPollHost.
 
@@ -60,6 +57,8 @@ class LongPollNamespacePartialUpdateInterface:
     coalesced into a single diff using `join_diffs` Each LongPollNamespace
     option must have corresponding `diff`, `join`, and `join_diffs` methods.
     """
+
+    T, Diff = Any, Any
 
     @staticmethod
     def diff(base_obj: T, updated_obj: T) -> Diff:
@@ -139,9 +138,16 @@ class LongPollNamespaceDiffConfig:
     # The number of diffs to store for this namespace.
     num_diffs_stored: int
 
-    # The interface to use when calculating diffs.
+    # The class containing the interface to use when calculating diffs.
     # Can be None only if num_diffs_stored is 0.
-    partial_update_methods: Optional[LongPollNamespacePartialUpdateInterface]
+    partial_update_method_class: Optional[type[LongPollNamespacePartialUpdateInterface]]
+
+
+LONG_POLL_NAMESPACE_DIFF_CONFIGS = {
+    LongPollNamespace.RUNNING_REPLICAS: LongPollNamespaceDiffConfig(
+        num_diffs_stored=5, partial_update_methods=RunningReplicasPartialUpdate
+    )
+}
 
 
 @dataclass

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -6,7 +6,18 @@ from enum import Enum, auto
 import logging
 import os
 import random
-from typing import Any, Callable, DefaultDict, Dict, Optional, Set, Tuple, Union, List
+from typing import (
+    Any,
+    Callable,
+    DefaultDict,
+    Dict,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    List,
+    Type,
+)
 from ray._private.utils import get_or_create_event_loop
 
 from ray.serve._private.common import ReplicaName, RunningReplicaInfo
@@ -140,7 +151,7 @@ class LongPollNamespaceDiffConfig:
 
     # The class containing the interface to use when calculating diffs.
     # Can be None only if num_diffs_stored is 0.
-    partial_update_method_class: Optional[type[LongPollNamespacePartialUpdateInterface]]
+    partial_update_method_class: Optional[Type[LongPollNamespacePartialUpdateInterface]]
 
 
 LONG_POLL_NAMESPACE_DIFF_CONFIGS = {

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -156,7 +156,7 @@ class LongPollNamespaceDiffConfig:
 
 LONG_POLL_NAMESPACE_DIFF_CONFIGS = {
     LongPollNamespace.RUNNING_REPLICAS: LongPollNamespaceDiffConfig(
-        num_diffs_stored=5, partial_update_methods=RunningReplicasPartialUpdate
+        num_diffs_stored=5, partial_update_method_class=RunningReplicasPartialUpdate
     )
 }
 

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -134,15 +134,14 @@ class RunningReplicasPartialUpdate(LongPollNamespacePartialUpdateInterface):
         }
 
 
-class RouteTablePartialUpdate(LongPollNamespacePartialUpdateInterface):
-    ...
+@dataclass
+class LongPollNamespaceDiffConfig:
+    # The number of diffs to store for this namespace.
+    num_diffs_stored: int
 
-
-# The number of diffs to store for each LongPollNamespace option. Default is 0.
-LongPollNamespaceDiffConfigs = {
-    LongPollNamespace.RUNNING_REPLICAS: 5,
-    LongPollNamespace.ROUTE_TABLE: 0,
-}
+    # The interface to use when calculating diffs.
+    # Can be None only if num_diffs_stored is 0.
+    partial_update_methods: Optional[LongPollNamespacePartialUpdateInterface]
 
 
 @dataclass


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, the `LongPollHost` broadcasts all replica information whenever any single replica starts running or stops running. E.g. On a 100-node cluster with 1600 replicas and 100 proxies, if any replica stops running, the controller broadcasts the other 1599 replica handles to the 100 proxies.

This change makes the `LongPollHost` broadcast only diffs in the common case. The `LongPollClient` reconstructs the updated object using the diffs. In the 100-node example, the controller would broadcast only 1 actor handle (the stopped replica) to the 100 proxies, and the proxies would remove the stopped replica from their local datastructures.

The number of diffs is configurable. This change sets it to 5, so the last 5 updates to `RunningReplicaInfo` are stored as diffs. If a `LongPollClient` is more than 5 updates behind, the `LongPollHost` will broadcast the full object.

## TODO

- [X] Create the `diff`/`join`/`join_diffs` logic for the `RunningReplicaInfo` namespace
- [ ] Use the diff logic inside the `LongPollHost`
- [ ] Use the diff logic inside the `LongPollClient`
- [ ] Add unit tests

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
