### PR TITLE
[Data] Add `read_images` benchmark for 100 million images

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5865,7 +5865,7 @@
 
   run:
     timeout: 1800
-    script: python read_images_benchmark.py
+    script: python read_images_benchmark.py --single-node
 
   variations:
     - __suffix__: aws
@@ -5874,6 +5874,23 @@
       frequency: manual
       cluster:
         cluster_compute: single_node_benchmark_compute_gce.yaml
+
+- name: read_images_benchmark_multi_node
+  group: data-tests
+  working_dir: nightly_tests/dataset
+
+  frequency: nightly
+  team: data
+
+  cluster:
+    byod:
+      type: gpu
+    cluster_compute: multi_node_benchmark_compute.yaml
+  
+  run:
+    timeout: 10000
+    script: python read_images_benchmark.py --multi-node
+
 
 - name: read_images_comparison_microbenchmark_single_node
   group: data-tests


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Adds a benchmark for reading 100 million images. The paths do not all share the same parent directory.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
