### PR TITLE
[train] remove preprocessor logic for XGBoost/LightGBM Trainers

### DIFF
--- a/python/ray/train/gbdt_trainer.py
+++ b/python/ray/train/gbdt_trainer.py
@@ -3,10 +3,9 @@ import logging
 import tempfile
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 
 from ray import train, tune
-from ray.air._internal.checkpointing import save_preprocessor_to_dir
 from ray.air.checkpoint import Checkpoint as LegacyCheckpoint
 from ray.train._checkpoint import Checkpoint
 from ray.air.config import RunConfig, ScalingConfig
@@ -15,7 +14,6 @@ from ray.train.constants import MODEL_KEY, TRAIN_DATASET_KEY
 from ray.train.trainer import BaseTrainer, GenDataset
 from ray.tune import Trainable
 from ray.tune.execution.placement_groups import PlacementGroupFactory
-from ray.tune.trainable.util import TrainableUtil
 from ray.util.annotations import DeveloperAPI
 from ray._private.dict import flatten_dict
 
@@ -116,10 +114,8 @@ class GBDTTrainer(BaseTrainer):
 
     Args:
         datasets: Datasets to use for training and validation. Must include a
-            "train" key denoting the training dataset. If a ``preprocessor``
-            is provided and has not already been fit, it will be fit on the training
-            dataset. All datasets will be transformed by the ``preprocessor`` if
-            one is provided. All non-training datasets will be used as separate
+            "train" key denoting the training dataset.
+            All non-training datasets will be used as separate
             validation sets, each reporting a separate metric.
         label_column: Name of the label column. A column with this name
             must be present in the training dataset.
@@ -165,7 +161,7 @@ class GBDTTrainer(BaseTrainer):
         num_boost_round: int = _DEFAULT_NUM_ITERATIONS,
         scaling_config: Optional[ScalingConfig] = None,
         run_config: Optional[RunConfig] = None,
-        preprocessor: Optional["Preprocessor"] = None,
+        preprocessor: Optional["Preprocessor"] = None,  # Deprecated
         resume_from_checkpoint: Optional[LegacyCheckpoint] = None,
         metadata: Optional[Dict[str, Any]] = None,
         **train_kwargs,
@@ -223,7 +219,7 @@ class GBDTTrainer(BaseTrainer):
     def _load_checkpoint(
         self,
         checkpoint: LegacyCheckpoint,
-    ) -> Tuple[Any, Optional["Preprocessor"]]:
+    ) -> Any:
         raise NotImplementedError
 
     def _train(self, **kwargs):
@@ -300,7 +296,7 @@ class GBDTTrainer(BaseTrainer):
 
         init_model = None
         if self.starting_checkpoint:
-            init_model, _ = self._load_checkpoint(self.starting_checkpoint)
+            init_model = self._load_checkpoint(self.starting_checkpoint)
 
         config.setdefault("verbose_eval", False)
         config.setdefault("callbacks", [])
@@ -361,15 +357,6 @@ class GBDTTrainer(BaseTrainer):
         default_ray_params = self._default_ray_params
 
         class GBDTTrainable(trainable_cls):
-            def save_checkpoint(self, tmp_checkpoint_dir: str = ""):
-                checkpoint_path = super().save_checkpoint()
-                parent_dir = TrainableUtil.find_checkpoint_dir(checkpoint_path)
-
-                preprocessor = self._merged_config.get("preprocessor", None)
-                if parent_dir and preprocessor:
-                    save_preprocessor_to_dir(preprocessor, parent_dir)
-                return checkpoint_path
-
             @classmethod
             def default_resource_request(cls, config):
                 # `config["scaling_config"] is a dataclass when passed via the

--- a/python/ray/train/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/lightgbm/lightgbm_trainer.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Any, Optional, Tuple, Union, TYPE_CHECKING
+from typing import Dict, Any, Union
 
 try:
     from packaging.version import Version
@@ -10,15 +10,11 @@ from ray.air.checkpoint import Checkpoint
 from ray.air.constants import MODEL_KEY
 from ray.train.gbdt_trainer import GBDTTrainer
 from ray.util.annotations import PublicAPI
-from ray.train.lightgbm.lightgbm_checkpoint import LegacyLightGBMCheckpoint
 
 import lightgbm
 import lightgbm_ray
 import xgboost_ray
 from lightgbm_ray.tune import TuneReportCheckpointCallback
-
-if TYPE_CHECKING:
-    from ray.data.preprocessor import Preprocessor
 
 
 @PublicAPI(stability="beta")
@@ -111,12 +107,8 @@ class LightGBMTrainer(GBDTTrainer):
     def _train(self, **kwargs):
         return lightgbm_ray.train(**kwargs)
 
-    def _load_checkpoint(
-        self, checkpoint: Checkpoint
-    ) -> Tuple[lightgbm.Booster, Optional["Preprocessor"]]:
-        # TODO(matt): Replace this when preprocessor arg is removed.
-        checkpoint = LegacyLightGBMCheckpoint.from_checkpoint(checkpoint)
-        return checkpoint.get_model(), checkpoint.get_preprocessor()
+    def _load_checkpoint(self, checkpoint: Checkpoint) -> lightgbm.Booster:
+        return self.__class__.get_model(checkpoint)
 
     def _save_model(self, model: lightgbm.LGBMModel, path: str):
         model.booster_.save_model(path)

--- a/python/ray/train/xgboost/xgboost_trainer.py
+++ b/python/ray/train/xgboost/xgboost_trainer.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict
 
 try:
     from packaging.version import Version
@@ -9,15 +9,11 @@ except ImportError:
 from ray.air.checkpoint import Checkpoint
 from ray.air.constants import MODEL_KEY
 from ray.train.gbdt_trainer import GBDTTrainer
-from ray.train.xgboost.xgboost_checkpoint import LegacyXGBoostCheckpoint
 from ray.util.annotations import PublicAPI
 
 import xgboost
 import xgboost_ray
 from xgboost_ray.tune import TuneReportCheckpointCallback
-
-if TYPE_CHECKING:
-    from ray.data.preprocessor import Preprocessor
 
 
 @PublicAPI(stability="beta")
@@ -104,12 +100,8 @@ class XGBoostTrainer(GBDTTrainer):
     def _train(self, **kwargs):
         return xgboost_ray.train(**kwargs)
 
-    def _load_checkpoint(
-        self, checkpoint: Checkpoint
-    ) -> Tuple[xgboost.Booster, Optional["Preprocessor"]]:
-        # TODO(matt): Replace this when preprocessor arg is removed.
-        checkpoint = LegacyXGBoostCheckpoint.from_checkpoint(checkpoint)
-        return checkpoint.get_model(), checkpoint.get_preprocessor()
+    def _load_checkpoint(self, checkpoint: Checkpoint) -> xgboost.Booster:
+        return self.__class__.get_model(checkpoint)
 
     def _save_model(self, model: xgboost.Booster, path: str):
         model.save_model(path)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Follow-up to #38640. Preprocessors are deprecated for Trainers, so now we can remove the logic for saving preprocessors to the (legacy) checkpoint.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
