### PR TITLE
[ci][fix] Remove python: 3.7 in release tests

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5512,8 +5512,6 @@
   group: core-scalability-test
   working_dir: benchmarks
 
-  python: "3.7"
-
   frequency: nightly
   team: core
   python: "3.8"
@@ -6349,8 +6347,6 @@
   group: data-tests
   working_dir: nightly_tests
 
-  python: "3.7"
-
   frequency: weekly
   team: data
   python: "3.8"
@@ -6687,8 +6683,6 @@
 - name: k8s_serve_ha_test
   group: k8s-test
   working_dir: k8s_tests
-
-  python: "3.7"
 
   stable: false
 


### PR DESCRIPTION
Some release tests declare them self as python: 3.7 due to some merge errors. Release tests can only run on 3.8+. Remove these entries. These tests start to fail today due to some other changes.

Test:
- CI