### PR TITLE
[data][tests] Update image classification benchmarks

### DIFF
--- a/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
@@ -209,7 +209,7 @@ def train_loop_for_worker(config):
             print("epoch time", epoch, epoch_time_s)
 
 
-def crop_and_flip_image_batch(image_batch):
+def crop_and_flip_image(row):
     transform = torchvision.transforms.Compose(
         [
             torchvision.transforms.RandomResizedCrop(
@@ -220,12 +220,9 @@ def crop_and_flip_image_batch(image_batch):
             torchvision.transforms.RandomHorizontalFlip(),
         ]
     )
-    batch_size, height, width, channels = image_batch["image"].shape
-    tensor_shape = (batch_size, channels, height, width)
-    image_batch["image"] = transform(
-        torch.Tensor(image_batch["image"].reshape(tensor_shape))
-    )
-    return image_batch
+    # Make sure to use torch.tensor here to avoid a copy from numpy.
+    row["image"] = transform(torch.tensor(np.transpose(row["image"], axes=(2, 0, 1))))
+    return row
 
 
 def decode_tf_record_batch(tf_record_batch: pd.DataFrame) -> pd.DataFrame:
@@ -326,10 +323,7 @@ def build_dataset(
             convert_class_to_idx,
             fn_kwargs={"classes": classes},
         )
-        ds = ds.map_batches(
-            crop_and_flip_image_batch,
-            zero_copy_batch=True,
-        )
+        ds = ds.map(crop_and_flip_image)
     else:
         filenames = get_tfrecords_filenames(
             data_root, num_images_per_epoch, num_images_per_input_file

--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -133,6 +133,7 @@ def crop_and_flip_image_batch(image_batch):
     transform = get_transform(False)
     image_batch["image"] = transform(
         # Make sure to use torch.tensor here to avoid a copy from numpy.
+        # Original dims are (batch_size, channels, height, width).
         torch.tensor(np.transpose(image_batch["image"], axes=(0, 3, 1, 2)))
     )
     return image_batch

--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -138,12 +138,12 @@ def crop_and_flip_image_batch(image_batch):
     )
     return image_batch
 
+
 def crop_and_flip_image(row):
     transform = get_transform(False)
     # Make sure to use torch.tensor here to avoid a copy from numpy.
     row["image"] = transform(torch.tensor(np.transpose(row["image"], axes=(2, 0, 1))))
     return row
-
 
 
 if __name__ == "__main__":

--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -6,6 +6,7 @@ import os
 import time
 import json
 import tensorflow as tf
+import numpy as np
 
 
 DEFAULT_IMAGE_SIZE = 224
@@ -130,12 +131,18 @@ def get_transform(to_torch_tensor):
 
 def crop_and_flip_image_batch(image_batch):
     transform = get_transform(False)
-    batch_size, height, width, channels = image_batch["image"].shape
-    tensor_shape = (batch_size, channels, height, width)
     image_batch["image"] = transform(
-        torch.Tensor(image_batch["image"].reshape(tensor_shape))
+        # Make sure to use torch.tensor here to avoid a copy from numpy.
+        torch.tensor(np.transpose(image_batch["image"], axes=(0, 3, 1, 2)))
     )
     return image_batch
+
+def crop_and_flip_image(row):
+    transform = get_transform(False)
+    # Make sure to use torch.tensor here to avoid a copy from numpy.
+    row["image"] = transform(torch.tensor(np.transpose(row["image"], axes=(2, 0, 1))))
+    return row
+
 
 
 if __name__ == "__main__":
@@ -185,6 +192,15 @@ if __name__ == "__main__":
     for i in range(args.num_epochs):
         iterate(torch_dataset, "torch+transform", args.batch_size, metrics)
 
+    ray_dataset = ray.data.read_images(args.data_root).map(crop_and_flip_image)
+    for i in range(args.num_epochs):
+        iterate(
+            ray_dataset.iter_torch_batches(batch_size=args.batch_size),
+            "ray_data+map_transform",
+            args.batch_size,
+            metrics,
+        )
+
     ray_dataset = ray.data.read_images(args.data_root).map_batches(
         crop_and_flip_image_batch
     )
@@ -212,28 +228,6 @@ if __name__ == "__main__":
         iterate(
             ray_dataset.iter_torch_batches(batch_size=args.batch_size),
             "ray_data",
-            args.batch_size,
-            metrics,
-        )
-
-    ray_dataset = ray.data.read_images(args.data_root).map_batches(
-        lambda x: x, batch_format="pyarrow", batch_size=args.batch_size
-    )
-    for i in range(args.num_epochs):
-        iterate(
-            ray_dataset.iter_torch_batches(batch_size=args.batch_size),
-            "ray_data+dummy_pyarrow_transform",
-            args.batch_size,
-            metrics,
-        )
-
-    ray_dataset = ray.data.read_images(args.data_root).map_batches(
-        lambda x: x, batch_format="numpy", batch_size=args.batch_size
-    )
-    for i in range(args.num_epochs):
-        iterate(
-            ray_dataset.iter_torch_batches(batch_size=args.batch_size),
-            "ray_data+dummy_np_transform",
             args.batch_size,
             metrics,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This updates includes a few fixes for image classification benchmarks:
- use `Dataset.map` instead of `Dataset.map_batches`. #38789 ensures these will get fused with the Read, but `map_batches` also has some batch formatting overhead.
- fix a bug in the benchmark related to image array dimensions
- avoid a copy in the map transform

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
