### PR TITLE
[core] ray stop forcefully killing processes wait until killed process terminate with timeout

### DIFF
--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -656,10 +656,6 @@ def test_get_cluster_status(ray_start_with_dashboard):
 )
 def test_get_nodes_summary(call_ray_start):
 
-    # The sleep is needed since it seems a previous shutdown could be not yet
-    # done when the next test starts. This prevents a previous cluster to be
-    # connected the current test session.
-    time.sleep(5)
     address_info = ray.init(address=call_ray_start)
     webui_url = address_info["webui_url"]
     webui_url = format_web_url(webui_url)

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -656,6 +656,10 @@ def test_get_cluster_status(ray_start_with_dashboard):
 )
 def test_get_nodes_summary(call_ray_start):
 
+    # The sleep is needed since it seems a previous shutdown could be not yet
+    # done when the next test starts. This prevents a previous cluster to be
+    # connected the current test session.
+    time.sleep(5)
     address_info = ray.init(address=call_ray_start)
     webui_url = address_info["webui_url"]
     webui_url = format_web_url(webui_url)

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -605,7 +605,7 @@ def call_ray_start_context(request):
     # Disconnect from the Ray cluster.
     ray.shutdown()
     # Kill the Ray cluster.
-    subprocess.check_call(["ray", "stop"], env=env)
+    subprocess.check_call(["ray", "stop", "--force"], env=env)
     # Delete the cluster address just in case.
     ray._private.utils.reset_ray_address()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We were waiting "a little" for forcefully killed processes to kill. While this should be fine most of the time, but we never know for sure if all forcefully killed processes are killed when `ray stop --force` returns. 

This PR waits for the forcefully killed processed to die with timeout, and print a warning if they are not. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
