### PR TITLE
[ci][air] Turn off an air feature flag for rayci tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -160,6 +160,7 @@ test:ci --nocache_test_results
 test:ci --spawn_strategy=local
 test:ci --test_output=errors
 test:ci --test_verbose_timeout_warnings
+test:air-new-persistence-mode-off --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
 test:ci-debug -c dbg
 test:ci-debug --copt="-g"
 test:ci-debug --flaky_test_attempts=3

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -58,7 +58,8 @@ def _run_tests_in_docker(test_targets: List[str], team: str) -> subprocess.Popen
             ]
         )
     commands.append(
-        "bazel test --config=ci $(./ci/run/bazel_export_options) "
+        "bazel test --config=ci --config=air-new-persistence-mode-off "
+        "$(./ci/run/bazel_export_options) "
         f"{' '.join(test_targets)}",
     )
     return subprocess.Popen(_docker_run_bash_script("\n".join(commands), team))


### PR DESCRIPTION
Set RAY_AIR_NEW_PERSISTENCE_MODE=0 for rayci tests, as requested by @matthewdeng . We need this get this in before branch cut so a hacky solution for now. I'll support test_env at the bazel command level at another time.

Test:
- CI