### PR TITLE
[civ2][docker/4] build ray.py38.cu118 docker image

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -24,3 +24,13 @@ steps:
       - ./ci/build/copy_build_artifacts.sh jar
     depends_on: manylinux
     job_env: manylinux
+
+  - label: ":tapioca: build: docker"
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version py38
+    depends_on: 
+      - manylinux
+      - forge
+      - raypy38cu118base
+    job_env: forge

--- a/ci/build/build-ray-docker.sh
+++ b/ci/build/build-ray-docker.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -exuo pipefail
+
+WHEEL_NAME="$1"
+SOURCE_IMAGE="$2"
+CONSTRAINTS_FILE="$3"
+DEST_IMAGE="$4"
+
+CPU_TMP="$(mktemp -d)"
+
+mkdir -p "${CPU_TMP}/.whl"
+
+cp .whl/"$WHEEL_NAME" "${CPU_TMP}/.whl/${WHEEL_NAME}"
+cp docker/ray/Dockerfile "${CPU_TMP}/Dockerfile"
+cp python/requirements_compiled.txt "${CPU_TMP}/."
+cp python/requirements_compiled_py37.txt "${CPU_TMP}/."
+
+cd "${CPU_TMP}"
+tar --mtime="UTC 2020-01-01" -c -f - . \
+    | docker build --progress=plain \
+        --build-arg FULL_BASE_IMAGE="$SOURCE_IMAGE" \
+        --build-arg WHEEL_PATH=".whl/${WHEEL_NAME}" \
+        --build-arg CONSTRAINTS_FILE="$CONSTRAINTS_FILE" \
+        -t "$DEST_IMAGE" -f Dockerfile -

--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -29,6 +29,12 @@ py_library(
     ],
 )
 
+py_library(
+    name = "ray_ci_lib_test",
+    srcs = ["test_base.py"],
+    visibility = ["//visibility:private"],
+)
+
 py_binary(
     name = "test_in_docker",
     srcs = ["test_in_docker.py"],
@@ -51,6 +57,7 @@ py_test(
     ],
     deps = [
         ":ray_ci_lib",
+        ":ray_ci_lib_test",
         ci_require("pytest"),
     ],
 )
@@ -65,6 +72,7 @@ py_test(
     ],
     deps = [
         ":ray_ci_lib",
+        ":ray_ci_lib_test",
         ci_require("pytest"),
     ],
 )
@@ -80,6 +88,7 @@ py_test(
     ],
     deps = [
         ":ray_ci_lib",
+        ":ray_ci_lib_test",
         ci_require("pytest"),
     ],
 )
@@ -94,6 +103,22 @@ py_test(
     ],
     deps = [
         ":ray_ci_lib",
+        ":ray_ci_lib_test",
+        ci_require("pytest"),
+    ],
+)
+
+py_test(
+    name = "test_docker_container",
+    size = "small",
+    srcs = ["test_docker_container.py"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":ray_ci_lib",
+        ":ray_ci_lib_test",
         ci_require("pytest"),
     ],
 )
@@ -109,6 +134,7 @@ py_test(
     ],
     deps = [
         ":ray_ci_lib",
+        ":ray_ci_lib_test",
         ci_require("pytest"),
     ],
 )

--- a/ci/ray_ci/builder.py
+++ b/ci/ray_ci/builder.py
@@ -1,6 +1,7 @@
 import click
 
 from ci.ray_ci.builder_container import PYTHON_VERSIONS, BuilderContainer
+from ci.ray_ci.docker_container import DockerContainer
 from ci.ray_ci.forge_container import ForgeContainer
 from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.utils import logger, docker_login
@@ -10,7 +11,7 @@ from ci.ray_ci.utils import logger, docker_login
 @click.argument(
     "artifact_type",
     required=True,
-    type=click.Choice(["wheel", "jar"]),
+    type=click.Choice(["wheel", "docker"]),
 )
 @click.option(
     "--python-version",
@@ -28,10 +29,28 @@ def main(
     docker_login(_DOCKER_ECR_REPO.split("/")[0])
     if artifact_type == "wheel":
         logger.info(f"Building wheel for Python {python_version}")
-        BuilderContainer(python_version).run()
-        ForgeContainer().upload_wheel()
-        logger.info("Successfully built wheel. Artifacts are in ray/.whl")
-    elif artifact_type == "jar":
-        raise NotImplementedError("Jar build not implemented yet")
-    else:
-        raise ValueError(f"Invalid artifact type {artifact_type}")
+        build_wheel(python_version)
+        return
+
+    if artifact_type == "docker":
+        logger.info(f"Building ray-cpu docker for Python {python_version}")
+        build_docker(python_version)
+        return
+
+    raise ValueError(f"Invalid artifact type {artifact_type}")
+
+
+def build_wheel(python_version: str) -> None:
+    """
+    Build a wheel artifact
+    """
+    BuilderContainer(python_version).run()
+    ForgeContainer().upload_wheel()
+
+
+def build_docker(python_version: str) -> None:
+    """
+    Build a container artifact
+    """
+    BuilderContainer(python_version).run()
+    DockerContainer(python_version).run()

--- a/ci/ray_ci/docker_container.py
+++ b/ci/ray_ci/docker_container.py
@@ -1,0 +1,54 @@
+import os
+
+from ci.ray_ci.container import Container, _DOCKER_ECR_REPO
+from ci.ray_ci.builder_container import PYTHON_VERSIONS
+from ci.ray_ci.utils import docker_pull
+
+
+RAY_VERSION = "3.0.0.dev0"
+
+
+class DockerContainer(Container):
+    """
+    Container for building and publishing ray docker images
+    """
+
+    def __init__(self, python_version: str) -> None:
+        assert "RAYCI_CHECKOUT_DIR" in os.environ, "RAYCI_CHECKOUT_DIR not set"
+        rayci_checkout_dir = os.environ["RAYCI_CHECKOUT_DIR"]
+        self.python_version = python_version
+
+        super().__init__(
+            "forge",
+            volumes=[
+                f"{rayci_checkout_dir}:/rayci",
+                "/var/run/docker.sock:/var/run/docker.sock",
+            ],
+        )
+
+    def run(self) -> None:
+        """
+        Build and publish ray docker images
+        """
+        assert "RAYCI_BUILD_ID" in os.environ, "RAYCI_BUILD_ID not set"
+        rayci_build_id = os.environ["RAYCI_BUILD_ID"]
+
+        base_image = f"{_DOCKER_ECR_REPO}:{rayci_build_id}-raypy38cu118base"
+        docker_pull(base_image)
+
+        bin_path = PYTHON_VERSIONS[self.python_version]["bin_path"]
+        wheel_name = f"ray-{RAY_VERSION}-{bin_path}-manylinux2014_x86_64.whl"
+
+        constraints_file = "requirements_compiled.txt"
+        if self.python_version == "py37":
+            constraints_file = "requirements_compiled_py37.txt"
+
+        version_tag = os.environ["BUILDKITE_COMMIT"][:6]
+        ray_image = f"rayproject/ray:{version_tag}-{self.python_version}-cu118"
+
+        self.run_script(
+            [
+                "./ci/build/build-ray-docker.sh "
+                f"{wheel_name} {base_image} {constraints_file} {ray_image}"
+            ]
+        )

--- a/ci/ray_ci/test_base.py
+++ b/ci/ray_ci/test_base.py
@@ -1,0 +1,14 @@
+import os
+import unittest
+
+
+class RayCITestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ.update(
+            {
+                "RAYCI_CHECKOUT_DIR": "/ray",
+                "RAYCI_BUILD_ID": "123",
+                "RAYCI_WORK_REPO": "rayproject/citemp",
+                "BUILDKITE_COMMIT": "123456",
+            }
+        )

--- a/ci/ray_ci/test_docker_container.py
+++ b/ci/ray_ci/test_docker_container.py
@@ -1,0 +1,27 @@
+import sys
+from typing import List
+
+import pytest
+from unittest import mock
+from ci.ray_ci.docker_container import DockerContainer
+from ci.ray_ci.test_base import RayCITestBase
+
+
+class TestDockerContainer(RayCITestBase):
+    def test_run(self) -> None:
+        def _mock_check_output(input: List[str]) -> None:
+            input_str = " ".join(input)
+            assert "ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl" in input_str
+            assert "rayproject/citemp:123-raypy38cu118base" in input_str
+            assert "requirements_compiled.txt" in input_str
+            assert "rayproject/ray:123456-py38-cu118" in input_str
+
+        with mock.patch(
+            "ci.ray_ci.docker_container.docker_pull", return_value=None
+        ), mock.patch("subprocess.check_output", side_effect=_mock_check_output):
+            container = DockerContainer("py38")
+            container.run()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/ci/ray_ci/test_utils.py
+++ b/ci/ray_ci/test_utils.py
@@ -14,7 +14,11 @@ def test_chunk_into_n() -> None:
 
 def test_docker_login() -> None:
     def _mock_subprocess_run(
-        cmd: List[str], stdin=None, stdout=None, stderr=None
+        cmd: List[str],
+        stdin=None,
+        stdout=None,
+        stderr=None,
+        check=True,
     ) -> None:
         assert cmd == ["pip", "install", "awscli"] or stdin.read() == b"password"
 

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -54,7 +54,20 @@ def docker_login(docker_ecr: str) -> None:
             stdin=f,
             stdout=sys.stdout,
             stderr=sys.stderr,
+            check=True,
         )
+
+
+def docker_pull(image: str) -> None:
+    """
+    Pull docker image
+    """
+    subprocess.run(
+        ["docker", "pull", image],
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        check=True,
+    )
 
 
 logger = logging.getLogger()

--- a/docker/ray/Dockerfile
+++ b/docker/ray/Dockerfile
@@ -1,5 +1,7 @@
 ARG BASE_IMAGE
-FROM rayproject/ray-deps:nightly"$BASE_IMAGE"
+ARG FULL_BASE_IMAGE=rayproject/ray-deps:nightly"$BASE_IMAGE"
+FROM $FULL_BASE_IMAGE
+
 ARG WHEEL_PATH
 ARG FIND_LINKS_PATH=".whl"
 ARG CONSTRAINTS_FILE="requirements_compiled.txt"


### PR DESCRIPTION
As title, build ray.py38.cu118 docker image. Essentially, install ray on top of raypy38cu118base wanda image.

Test:
- CI
- Docker is generated (not uploaded yet): https://buildkite.com/ray-project/premerge/builds/4490#018a5117-099b-42f8-8d8f-13ab162723d7/129-2169