### PR TITLE
[Serve] Add more log in the router init step

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1084,8 +1084,9 @@ class Router:
             )
         else:
             self._replica_scheduler = RoundRobinReplicaScheduler(event_loop)
+
         logger.info(
-            f"Using router {self._replica_scheduler.__class__}.",
+            f"Router of type {self._replica_scheduler.__class__} for deployment `{deployment_id}` is under initialization.",
             extra={"log_to_stderr": False},
         )
 
@@ -1146,6 +1147,11 @@ class Router:
             self.metrics_pusher.start()
         else:
             self.autoscaling_enabled = False
+
+        logger.info(
+            f"Router of type {self._replica_scheduler.__class__} for deployment `{deployment_id}` has been successfully initiated.",
+            extra={"log_to_stderr": False},
+        )
 
     def _collect_handle_queue_metrics(self) -> Dict[str, int]:
         return {self.deployment_id: self.num_queued_queries}

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1086,7 +1086,8 @@ class Router:
             self._replica_scheduler = RoundRobinReplicaScheduler(event_loop)
 
         logger.info(
-            f"Router of type {self._replica_scheduler.__class__} for deployment `{deployment_id}` is under initialization.",
+            f"Router of type {self._replica_scheduler.__class__} for deployment "
+            f"'{deployment_id}' is under initialization.",
             extra={"log_to_stderr": False},
         )
 
@@ -1149,7 +1150,8 @@ class Router:
             self.autoscaling_enabled = False
 
         logger.info(
-            f"Router of type {self._replica_scheduler.__class__} for deployment `{deployment_id}` has been successfully initiated.",
+            f"Router of type {self._replica_scheduler.__class__} for deployment "
+            f"'{deployment_id}' has been successfully initiated.",
             extra={"log_to_stderr": False},
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add log to understand whether the router init is stuck at controller blocking call.

In the http proxy log:
```
INFO 2023-08-25 17:04:10,948 http_proxy 127.0.0.1 942aa811-1739-4519-97d9-b66d8496aaa4 / default router.py:1088 - Router of type <class 'ray.serve._private.router.PowerOfTwoChoicesReplicaScheduler'> for deployment 'default_fn' is under initialization.
INFO 2023-08-25 17:04:10,953 http_proxy 127.0.0.1 942aa811-1739-4519-97d9-b66d8496aaa4 / default router.py:1152 - Router of type <class 'ray.serve._private.router.PowerOfTwoChoicesReplicaScheduler'> for deployment 'default_fn' has been successfully initiated.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
