### PR TITLE
[train] enable new persistence mode for core and serve tests

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -211,7 +211,6 @@
       --test_env=CONDA_SHLVL
       --test_env=CONDA_PREFIX
       --test_env=CONDA_DEFAULT_ENV
-      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
       python/ray/tests/...
 
 - label: ":book: Doctest (CPU)"

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -95,7 +95,6 @@
       --test_env=DOCKER_CERT_PATH=/certs/client
       --test_env=DOCKER_TLS_CERTDIR=/certs
       --test_env=RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=0
-      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
       $(cat test_shard.txt)
 
 - label: ":serverless: Serve Tests (streaming and routing FFs off)"
@@ -130,7 +129,6 @@
       --test_env=DOCKER_TLS_CERTDIR=/certs
       --test_env=RAY_SERVE_ENABLE_NEW_ROUTING=0
       --test_env=RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=0
-      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
       $(cat test_shard.txt)
 
 - label: ":python: Minimal install Python {{matrix}}"

--- a/.buildkite/pipeline.build_py37.yml
+++ b/.buildkite/pipeline.build_py37.yml
@@ -141,5 +141,4 @@
       --test_env=DOCKER_TLS_VERIFY=1
       --test_env=DOCKER_CERT_PATH=/certs/client
       --test_env=DOCKER_TLS_CERTDIR=/certs
-      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
       $(cat test_shard.txt)

--- a/.buildkite/pipeline.build_redis.yml
+++ b/.buildkite/pipeline.build_redis.yml
@@ -22,7 +22,6 @@
     - DL=1 ./ci/env/install-dependencies.sh
     - ./ci/env/env_info.sh
     - ./ci/ci.sh test_large --test_env=TEST_EXTERNAL_REDIS=1
-      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
 
 - label: ":redis: (External Redis) (Medium A-J)"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]

--- a/.buildkite/pipeline.gpu.yml
+++ b/.buildkite/pipeline.gpu.yml
@@ -43,7 +43,6 @@
     - ./ci/env/install-dependencies.sh
     - pip install -Ur ./python/requirements/ml/dl-gpu-requirements.txt
     - bazel test --config=ci $(./ci/run/bazel_export_options) --test_tag_filters=gpu 
-      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
       python/ray/serve/...
 
 # Todo: enable once tests pass

--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -37,6 +37,7 @@ steps:
     - . ./ci/ci.sh init
     - ./ci/ci.sh build
     - export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER="1"
+    - export RAY_AIR_NEW_PERSISTENCE_MODE="0"
     - if [ "${BUILDKITE_PARALLEL_JOB}" = "0" ]; then ./ci/ci.sh test_core; fi
     # The next command will be sharded into $parallelism shards.
     - ./ci/ci.sh test_python

--- a/.buildkite/pipeline.windows.yml
+++ b/.buildkite/pipeline.windows.yml
@@ -37,7 +37,6 @@ steps:
     - . ./ci/ci.sh init
     - ./ci/ci.sh build
     - export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER="1"
-    - export RAY_AIR_NEW_PERSISTENCE_MODE="0"
     - if [ "${BUILDKITE_PARALLEL_JOB}" = "0" ]; then ./ci/ci.sh test_core; fi
     # The next command will be sharded into $parallelism shards.
     - ./ci/ci.sh test_python

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -59,8 +59,6 @@ def _run_tests_in_docker(test_targets: List[str], team: str) -> subprocess.Popen
         )
     commands.append(
         "bazel test --config=ci "
-        # TODO(matthewdeng): Remove this env var as part of #38570.
-        "--test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0 "
         "$(./ci/run/bazel_export_options) "
         f"{' '.join(test_targets)}",
     )

--- a/python/ray/serve/tests/test_air_integrations.py
+++ b/python/ray/serve/tests/test_air_integrations.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -10,6 +10,7 @@ from starlette.requests import Request
 from fastapi import Depends, FastAPI
 
 import ray
+import ray.cloudpickle as ray_pickle
 from ray import serve
 from ray.train import Checkpoint
 from ray.serve.air_integrations import _BatchingManager
@@ -128,6 +129,22 @@ class TestBatchingFunctionFunctions:
         )
 
 
+def create_dict_checkpoint(
+    data: Dict[str, Any], directory: Optional[str] = None
+) -> Checkpoint:
+    if not directory:
+        directory = tempfile.mkdtemp()
+    with open(os.path.join(directory, "data.pkl"), "wb") as f:
+        ray_pickle.dump(data, f)
+    return Checkpoint.from_directory(directory)
+
+
+def load_dict_checkpoint(checkpoint: Checkpoint) -> Dict[str, Any]:
+    with checkpoint.as_directory() as checkpoint_dir:
+        with open(os.path.join(checkpoint_dir, "data.pkl"), "rb") as f:
+            return ray_pickle.load(f)
+
+
 class AdderPredictor(Predictor):
     def __init__(self, increment: int, do_double: bool) -> None:
         self.increment = increment
@@ -137,7 +154,7 @@ class AdderPredictor(Predictor):
     def from_checkpoint(
         cls, checkpoint: Checkpoint, do_double: bool = False
     ) -> "AdderPredictor":
-        return cls(checkpoint.to_dict()["increment"], do_double)
+        return cls(load_dict_checkpoint(checkpoint)["increment"], do_double)
 
     def predict(
         self, data: np.ndarray, override_increment: Optional[int] = None
@@ -170,7 +187,7 @@ def test_simple_adder(serve_instance):
             return self.predictor.predict(np.array(data["array"]))
 
     AdderDeployment.options(name="Adder").deploy(
-        checkpoint=Checkpoint.from_dict({"increment": 2}),
+        checkpoint=create_dict_checkpoint({"increment": 2}),
     )
     resp = ray.get(send_request.remote(json={"array": [40]}))
     assert resp == [{"value": 42, "batch_size": 1}]
@@ -189,7 +206,7 @@ def test_predictor_kwargs(serve_instance):
             )
 
     AdderDeployment.options(name="Adder").deploy(
-        checkpoint=Checkpoint.from_dict({"increment": 2}),
+        checkpoint=create_dict_checkpoint({"increment": 2}),
     )
 
     resp = ray.get(send_request.remote(json={"array": [40]}))
@@ -207,7 +224,7 @@ def test_predictor_from_checkpoint_kwargs(serve_instance):
             return self.predictor.predict(np.array(data["array"]))
 
     AdderDeployment.options(name="Adder").deploy(
-        checkpoint=Checkpoint.from_dict({"increment": 2}),
+        checkpoint=create_dict_checkpoint({"increment": 2}),
     )
     resp = ray.get(send_request.remote(json={"array": [40]}))
     assert resp == [{"value": 84, "batch_size": 1}]
@@ -226,7 +243,7 @@ def test_batching(serve_instance):
             return self.predictor.predict(batch)
 
     AdderDeployment.options(name="Adder").deploy(
-        checkpoint=Checkpoint.from_dict({"increment": 2}),
+        checkpoint=create_dict_checkpoint({"increment": 2}),
     )
 
     refs = [send_request.remote(json={"array": [40]}) for _ in range(2)]
@@ -250,8 +267,7 @@ class Ingress:
 
 def test_air_integrations_in_pipeline(serve_instance):
     path = tempfile.mkdtemp()
-    uri = f"file://{path}/test_uri"
-    Checkpoint.from_dict({"increment": 2}).to_uri(uri)
+    create_dict_checkpoint({"increment": 2}, path)
 
     @serve.deployment
     class AdderDeployment:
@@ -263,7 +279,7 @@ def test_air_integrations_in_pipeline(serve_instance):
 
     with InputNode() as dag_input:
         m1 = AdderDeployment.bind(
-            checkpoint=Checkpoint.from_uri(uri),
+            checkpoint=Checkpoint.from_directory(path),
         )
         dag = m1.__call__.bind(dag_input)
     deployments = build(Ingress.bind(dag), "")
@@ -278,8 +294,7 @@ def test_air_integrations_in_pipeline(serve_instance):
 
 def test_air_integrations_reconfigure(serve_instance):
     path = tempfile.mkdtemp()
-    uri = f"file://{path}/test_uri"
-    Checkpoint.from_dict({"increment": 2}).to_uri(uri)
+    create_dict_checkpoint({"increment": 2}, path)
 
     @serve.deployment
     class AdderDeployment:
@@ -288,7 +303,7 @@ def test_air_integrations_reconfigure(serve_instance):
 
         def reconfigure(self, config):
             self.predictor = AdderPredictor.from_checkpoint(
-                Checkpoint.from_dict(config["checkpoint"])
+                create_dict_checkpoint(config["checkpoint"])
             )
 
         async def __call__(self, data):
@@ -300,7 +315,7 @@ def test_air_integrations_reconfigure(serve_instance):
 
     with InputNode() as dag_input:
         m1 = AdderDeployment.options(user_config=additional_config).bind(
-            checkpoint=Checkpoint.from_uri(uri),
+            checkpoint=Checkpoint.from_directory(path),
         )
         dag = m1.__call__.bind(dag_input)
     deployments = build(Ingress.bind(dag), "")

--- a/python/ray/serve/tests/test_air_integrations_gpu.py
+++ b/python/ray/serve/tests/test_air_integrations_gpu.py
@@ -38,9 +38,14 @@ def test_automatic_enable_gpu(serve_instance):
         async def __call__(self, data):
             return self.predictor.predict(data)
 
+    import tempfile
+
+    tmpdir = tempfile.mkdtemp()
+    checkpoint = Checkpoint.from_directory(tmpdir)
+
     serve.run(
         DAGDriver.bind(
-            DummyGPUDeployment.options(name="GPU").bind(Checkpoint.from_dict({"x": 1})),
+            DummyGPUDeployment.options(name="GPU").bind(checkpoint),
             http_adapter=json_to_ndarray,
         )
     )

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -277,14 +277,15 @@ def test_run_driver_twice(ray_start_regular):
     address_info = ray_start_regular
     driver_script = """
 import ray
+import ray.train
 import ray.tune as tune
 import os
 import time
 
-def train_func(config, reporter):  # add a reporter arg
+def train_func(config):
     for i in range(2):
         time.sleep(0.1)
-        reporter(timesteps_total=i, mean_accuracy=i+97)  # report metrics
+        ray.train.report(dict(timesteps_total=i, mean_accuracy=i+97))  # report metrics
 
 os.environ["TUNE_RESUME_PROMPT_OFF"] = "True"
 ray.init(address="{}", namespace="default_test_namespace")

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -434,6 +434,7 @@ def test_parent_task_id_tune_e2e(shutdown_only):
     script = """
 import numpy as np
 import ray
+import ray.train
 from ray import tune
 import time
 
@@ -448,7 +449,7 @@ def train_function(config):
     for i in range(5):
         loss = config["mean"] * np.random.randn() + ray.get(
             train_step_1.remote())
-        tune.report(loss=loss, nodes=ray.nodes())
+        ray.train.report(dict(loss=loss, nodes=ray.nodes()))
 
 
 def tune_function():

--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -1206,9 +1206,7 @@ provider:
         if os.environ.get("RAY_MINIMAL") != "1":
             expected_payload["tune_scheduler"] = "FIFOScheduler"
             expected_payload["tune_searcher"] = "BasicVariantGenerator"
-            expected_payload["air_storage_configuration"] = "driver"
             expected_payload["air_entrypoint"] = "Tuner.fit"
-            expected_payload["air_env_vars"] = '["RAY_AIR_NEW_PERSISTENCE_MODE"]'
         assert payload["extra_usage_tags"] == expected_payload
         assert payload["total_num_nodes"] == 1
         assert payload["total_num_running_jobs"] == 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This enables the new persistence mode for the following tests:

| Test | Root Cause |
|--------|--------|
| :cold_face: :python: :serverless: Python 3.7 Serve Tests | `test_air_integrations.py` |
| :ray-serve: serve: serve tests | `test_air_integrations.py` |
| :ray: core: python tests | `test_multi_node_3.py`, `test_usage_stats.py` |
| :tv: :serverless: Serve Tests | `test_air_integrations_gpu.py` | 
| :redis: (External Redis) (Large) | Flaky | 
| :serverless: Serve Tests (streaming FF off) | `test_air_integrations.py` | 
| :serverless: Serve Tests (streaming and routing FFs off) | `test_air_integrations.py` | 
| :python: (ASAN tests) | Flaky | 
| :kubernetes: :mending_heart: :ray-serve: serve chaos network delay test | Flaky | 

I originally also included `:windows: Build & Test`, but there is a failure in `test_client_library_integration` that might require code changes: 
<details><summary><b>Stacktrace</b></summary>
<p>

```
_bk;t=1693015964187================================== FAILURES ===================================
_bk;t=1693015964187_________________________ test_rllib_integration_tune _________________________
_bk;t=1693015964187
_bk;t=1693015964187ray_start_regular = RayContext(dashboard_url='127.0.0.1:8265', python_version='3.8.10', ray_version='3.0.0.dev0', ray_commit='{{RAY_COMMIT_SHA}}', protocol_version=None)
_bk;t=1693015964187
_bk;t=1693015964187    def test_rllib_integration_tune(ray_start_regular):
_bk;t=1693015964187        with ray_start_client_server():
_bk;t=1693015964187            # Confirming the behavior of this context manager.
_bk;t=1693015964187            # (Client mode hook not yet enabled.)
_bk;t=1693015964187            assert not client_mode_should_convert()
_bk;t=1693015964187            # Need to enable this for client APIs to be used.
_bk;t=1693015964187            with enable_client_mode():
_bk;t=1693015964187                # Confirming mode hook is enabled.
_bk;t=1693015964187                assert client_mode_should_convert()
_bk;t=1693015964187>               tune.run(
_bk;t=1693015964187                    "DQN", config={"env": "CartPole-v1"}, stop={"training_iteration": 2}
_bk;t=1693015964187                )
_bk;t=1693015964187
_bk;t=1693015964187\\?\C:\Users\ContainerAdministrator\AppData\Local\Temp\Bazel.runfiles_qgfvjrfp\runfiles\com_github_ray_project_ray\python\ray\tests\test_client_library_integration.py:46: 
_bk;t=1693015964187_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
_bk;t=1693015964187c:\install\ray\python\ray\tune\tune.py:608: in run
_bk;t=1693015964187    return ray.get(remote_future)
_bk;t=1693015964187c:\install\ray\python\ray\_private\auto_init_hook.py:24: in auto_init_wrapper
_bk;t=1693015964187    return fn(*args, **kwargs)
_bk;t=1693015964187c:\install\ray\python\ray\_private\auto_init_hook.py:24: in auto_init_wrapper
_bk;t=1693015964187    return fn(*args, **kwargs)
_bk;t=1693015964187c:\install\ray\python\ray\_private\client_mode_hook.py:102: in wrapper
_bk;t=1693015964187    return getattr(ray, func.__name__)(*args, **kwargs)
_bk;t=1693015964187c:\install\ray\python\ray\util\client\api.py:42: in get
_bk;t=1693015964187    return self.worker.get(vals, timeout=timeout)
_bk;t=1693015964187c:\install\ray\python\ray\util\client\worker.py:434: in get
_bk;t=1693015964187    res = self._get(to_get, op_timeout)
_bk;t=1693015964187_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
_bk;t=1693015964187
_bk;t=1693015964187self = <ray.util.client.worker.Worker object at 0x000001B3FF148130>
_bk;t=1693015964187ref = [ClientObjectRef(ff82f6faafdd0e77ffffffffffffffffffffffff0100000001000000)]
_bk;t=1693015964187timeout = 2.0
_bk;t=1693015964187
_bk;t=1693015964187    def _get(self, ref: List[ClientObjectRef], timeout: float):
_bk;t=1693015964187        req = ray_client_pb2.GetRequest(ids=[r.id for r in ref], timeout=timeout)
_bk;t=1693015964187        data = bytearray()
_bk;t=1693015964187        try:
_bk;t=1693015964187            resp = self._get_object_iterator(req, metadata=self.metadata)
_bk;t=1693015964187            for chunk in resp:
_bk;t=1693015964187                if not chunk.valid:
_bk;t=1693015964187                    try:
_bk;t=1693015964187                        err = cloudpickle.loads(chunk.error)
_bk;t=1693015964187                    except (pickle.UnpicklingError, TypeError):
_bk;t=1693015964187                        logger.exception("Failed to deserialize {}".format(chunk.error))
_bk;t=1693015964187                        raise
_bk;t=1693015964187>                   raise err
_bk;t=1693015964187E                   ray.exceptions.RayTaskError(AssertionError): [36mray::run()[39m (pid=3876, ip=172.17.161.116)
_bk;t=1693015964187E                     File "python\ray\_raylet.pyx", line 1613, in ray._raylet.execute_task
_bk;t=1693015964187E                     File "c:\install\ray\python\ray\tune\tune.py", line 852, in run
_bk;t=1693015964187E                       experiments[i] = Experiment(
_bk;t=1693015964187E                     File "c:\install\ray\python\ray\tune\experiment\experiment.py", line 204, in __init__
_bk;t=1693015964187E                       self.storage = StorageContext(
_bk;t=1693015964187E                     File "c:\install\ray\python\ray\train\_internal\storage.py", line 486, in __init__
_bk;t=1693015964187E                       self._check_validation_file()
_bk;t=1693015964187E                     File "c:\install\ray\python\ray\train\_internal\storage.py", line 514, in _check_validation_file
_bk;t=1693015964187E                       if not _exists_at_fs_path(fs=self.storage_filesystem, fs_path=valid_file):
_bk;t=1693015964187E                     File "c:\install\ray\python\ray\train\_internal\storage.py", line 255, in _exists_at_fs_path
_bk;t=1693015964187E                       assert not is_uri(fs_path), fs_path
_bk;t=1693015964187E                   AssertionError: C:/tmp/4lhdprva/execroot/com_github_ray_project_ray/_tmp/76795314268c91c8b7ca920989e00292\DQN_2023-08-26_02-12-13\.validate_storage_marker

```

</p>
</details> 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

See https://buildkite.com/ray-project/oss-ci-build-pr/builds/33892

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
