### PR TITLE
[serve] API cleanup for `serve.run` and `serve.start` (#38362)

### DIFF
--- a/doc/source/serve/doc_code/production_fruit_example.py
+++ b/doc/source/serve/doc_code/production_fruit_example.py
@@ -104,9 +104,12 @@ deployment_graph = DAGDriver.bind(net_price, http_adapter=json_request)
 
 # Test example's behavior
 import requests  # noqa: E402
-from ray.serve.schema import ServeApplicationSchema  # noqa: E402
-from ray.serve.api import build  # noqa: E402
+
 from ray._private.test_utils import wait_for_condition  # noqa: E402
+
+from ray.serve.api import build  # noqa: E402
+from ray.serve.context import get_global_client  # noqa: E402
+from ray.serve.schema import ServeApplicationSchema  # noqa: E402
 
 
 def check_fruit_deployment_graph():
@@ -145,7 +148,8 @@ except requests.exceptions.ConnectionError:
 print("Deployments have been torn down.")
 
 # Check for regression in remote repository
-client = serve.start(detached=True)
+serve.start()
+client = get_global_client()
 config1 = {
     "import_path": "fruit.deployment_graph",
     "runtime_env": {

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 import json
 import logging
 import math
@@ -8,6 +7,7 @@ import time
 import traceback
 from collections import defaultdict, OrderedDict
 from copy import copy
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1,8 +1,9 @@
 import collections
 import inspect
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+import warnings
 from functools import wraps
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from fastapi import APIRouter, FastAPI
 
@@ -12,11 +13,11 @@ from ray.dag import DAGNode
 from ray.util.annotations import Deprecated, PublicAPI, DeveloperAPI
 
 from ray.serve.built_application import BuiltApplication
-from ray.serve._private.client import ServeControllerClient
 from ray.serve.config import (
+    gRPCOptions,
     AutoscalingConfig,
     DeploymentConfig,
-    gRPCOptions,
+    DeploymentMode,
     ReplicaConfig,
     HTTPOptions,
 )
@@ -63,52 +64,66 @@ from ray.serve._private import api as _private_api
 logger = logging.getLogger(__file__)
 
 
-@guarded_deprecation_warning(instructions=MIGRATION_MESSAGE)
-@Deprecated(message=MIGRATION_MESSAGE)
+@PublicAPI(stability="beta")
 def start(
-    detached: bool = False,
+    detached: bool = True,
+    proxy_location: Optional[Union[str, DeploymentMode]] = None,
     http_options: Optional[Union[dict, HTTPOptions]] = None,
     dedicated_cpu: bool = False,
     grpc_options: Optional[gRPCOptions] = None,
     **kwargs,
-) -> ServeControllerClient:
+):
     """Start Serve on the cluster.
 
-    By default, the instance will be scoped to the lifetime of the returned
-    Client object (or when the script exits). If detached is set to True, the
-    instance will instead persist until serve.shutdown() is called. This is
-    only relevant if connecting to a long-running Ray cluster (e.g., with
-    ray.init(address="auto") or ray.init("ray://<remote_addr>")).
+    Used to set cluster-scoped configurations such as HTTP options. In most cases, this
+    does not need to be called manually and Serve will be started when an application is
+    first deployed to the cluster.
+
+    These cluster-scoped options cannot be updated dynamically. To update them, start a
+    new cluster or shut down Serve on the cluster and start it again.
+
+    These options can also be set in the config file deployed via REST API.
 
     Args:
-        detached: Whether not the instance should be detached from this
+        detached: [DEPRECATED: in the future, this will always be `True`]
+          Whether or not the instance should be detached from this
           script. If set, the instance will live on the Ray cluster until it is
           explicitly stopped with serve.shutdown().
-        http_options: Configuration options
-          for HTTP proxy. You can pass in a dictionary or HTTPOptions object
-          with fields:
+        proxy_location: Where to run proxies that handle ingress traffic to the
+          cluster. Defaults to `EveryNode`. Supported options are:
 
-            - host: Host for HTTP servers to listen on. Defaults to
+            - "EveryNode": run one proxy on every node in the cluster (default).
+            - "HeadOnly": run only one proxy on the head node of the cluster.
+            - "NoServer" or None: disable the proxies entirely.
+
+        http_options: HTTP-related configuration options for the cluster. These can
+          be passed as an unstructured dictionary or the structured `HTTPOptions` class.
+          Supported options:
+
+            - host: Host that the proxies will listen for HTTP on. Defaults to
               "127.0.0.1". To expose Serve publicly, you probably want to set
               this to "0.0.0.0".
-            - port: Port for HTTP server. Defaults to 8000.
-            - root_path: Root path to mount the serve application
-              (for example, "/serve"). All deployment routes will be prefixed
-              with this path. Defaults to "".
-            - middlewares: A list of Starlette middlewares that will be
-              applied to the HTTP servers in the cluster. Defaults to [].
-            - location(str, serve.config.DeploymentMode): The deployment
+            - port: Port that the proxies will listen for HTTP on. Defaults to 8000.
+            - root_path: An optional root path to mount the serve application
+              (for example, "/prefix"). All deployment routes will be prefixed
+              with this path.
+            - request_timeout_s: End-to-end timeout for HTTP requests.
+            - keep_alive_timeout_s: Duration to keep idle connections alive when no
+              requests are ongoing.
+
+            - location: [DEPRECATED: use `proxy_location` field instead] The deployment
               location of HTTP servers:
 
                 - "HeadOnly": start one HTTP server on the head node. Serve
                   assumes the head node is the node you executed serve.start
                   on. This is the default.
                 - "EveryNode": start one HTTP server per node.
-                - "NoServer" or None: disable HTTP server.
-            - num_cpus: The number of CPU cores to reserve for each
-              internal Serve HTTP proxy actor.  Defaults to 0.
-        dedicated_cpu: Whether to reserve a CPU core for the internal
-          Serve controller actor.  Defaults to False.
+                - "NoServer": disable HTTP server.
+
+            - num_cpus: [DEPRECATED] The number of CPU cores to reserve for each
+              internal Serve HTTP proxy actor.
+        dedicated_cpu: [DEPRECATED] Whether to reserve a CPU core for the
+          Serve controller actor.
         grpc_options: [Experimental] Configuration options for gRPC proxy. You can pass
           in a gRPCOptions object with fields:
 
@@ -117,7 +132,33 @@ def start(
               empty list, meaning not to start the gRPC server.
             - port: Port for gRPC server. Defaults to 9000.
     """
-    client = _private_api.serve_start(
+    if not detached:
+        warnings.warn(
+            "Setting `detached=False` in `serve.start` is deprecated and will be "
+            "removed in a future version."
+        )
+
+    if dedicated_cpu:
+        warnings.warn(
+            "Setting `dedicated_cpu=True` in `serve.start` is deprecated and will be "
+            "removed in a future version."
+        )
+
+    if proxy_location is None:
+        if http_options is None:
+            http_options = HTTPOptions(location=DeploymentMode.EveryNode)
+    else:
+        if http_options is None:
+            http_options = HTTPOptions()
+        elif isinstance(http_options, dict):
+            http_options = HTTPOptions(**http_options)
+
+        if isinstance(proxy_location, str):
+            proxy_location = DeploymentMode(proxy_location)
+
+        http_options.location = proxy_location
+
+    _private_api.serve_start(
         detached=detached,
         http_options=http_options,
         dedicated_cpu=dedicated_cpu,
@@ -125,14 +166,9 @@ def start(
         **kwargs,
     )
 
-    # Record after Ray has been started.
-    ServeUsageTag.API_VERSION.record("v1")
-
-    return client
-
 
 @PublicAPI(stability="stable")
-def shutdown() -> None:
+def shutdown():
     """Completely shut down Serve on the cluster.
 
     Deletes all applications and shuts down Serve system actors.
@@ -483,10 +519,12 @@ def run(
     Args:
         target:
             A Serve application returned by `Deployment.bind()`.
-        host: Host for HTTP servers to listen on. Defaults to
+        host: [DEPRECATED: use `serve.start` to set HTTP options]
+            Host for HTTP servers to listen on. Defaults to
             "127.0.0.1". To expose Serve publicly, you probably want to set
             this to "0.0.0.0".
-        port: Port for HTTP server. Defaults to 8000.
+        port: [DEPRECATED: use `serve.start` to set HTTP options]
+            Port for HTTP server. Defaults to 8000.
         name: Application name. If not provided, this will be the only
             application running on the cluster (it will delete all others).
         route_prefix: Route prefix for HTTP requests. If not provided, it will use
@@ -498,6 +536,13 @@ def run(
     """
     if len(name) == 0:
         raise RayServeException("Application name must a non-empty string.")
+
+    if host != DEFAULT_HTTP_HOST or port != DEFAULT_HTTP_PORT:
+        warnings.warn(
+            "Specifying host and port in `serve.run` is deprecated and will be "
+            "removed in a future version. To specify custom HTTP options, use "
+            "`serve.start`."
+        )
 
     client = _private_api.serve_start(
         detached=True,

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -95,9 +95,6 @@ def _set_internal_replica_context(
 def _connect(raise_if_no_controller_running: bool = True) -> ServeControllerClient:
     """Connect to an existing Serve application on this Ray cluster.
 
-    If calling from the driver program, the Serve app on this Ray cluster
-    must first have been initialized using `serve.start(detached=True)`.
-
     If called from within a replica, this will connect to the same Serve
     app that the replica is running in.
 
@@ -129,10 +126,7 @@ def _connect(raise_if_no_controller_running: bool = True) -> ServeControllerClie
     except ValueError:
         if raise_if_no_controller_running:
             raise RayServeException(
-                "There is no Serve "
-                "instance running on this Ray cluster. Please "
-                "call `serve.start(detached=True) to start "
-                "one."
+                "There is no Serve instance running on this Ray cluster."
             )
         return
 

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -12,6 +12,7 @@ from ray._private.test_utils import wait_for_condition
 from ray._private.usage import usage_lib
 
 from ray import serve
+from ray.serve.context import get_global_client
 from ray.serve.tests.utils import check_ray_stopped, TELEMETRY_ROUTE_PREFIX
 
 # https://tools.ietf.org/html/rfc6335#section-6
@@ -74,7 +75,8 @@ def _shared_serve_instance():
         _metrics_export_port=9999,
         _system_config={"metrics_report_interval_ms": 1000, "task_retry_delay_ms": 50},
     )
-    yield serve.start(detached=True, http_options={"host": "0.0.0.0"})
+    serve.start(http_options={"host": "0.0.0.0"})
+    yield get_global_client()
 
 
 @pytest.fixture

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -131,8 +131,6 @@ def test_starlette_response(serve_instance):
 
 @pytest.mark.parametrize("use_async", [False, True])
 def test_deploy_function_no_params(serve_instance, use_async):
-    serve.start()
-
     if use_async:
         expected_output = "async!"
         deployment_cls = async_d
@@ -150,8 +148,6 @@ def test_deploy_function_no_params(serve_instance, use_async):
 
 @pytest.mark.parametrize("use_async", [False, True])
 def test_deploy_function_no_params_call_with_param(serve_instance, use_async):
-    serve.start()
-
     if use_async:
         expected_output = "async!"
         deployment_cls = async_d
@@ -175,11 +171,11 @@ def test_deploy_function_no_params_call_with_param(serve_instance, use_async):
 
 @pytest.mark.parametrize("use_async", [False, True])
 def test_deploy_class_no_params(serve_instance, use_async):
-    serve.start()
     if use_async:
         deployment_cls = AsyncCounter
     else:
         deployment_cls = Counter
+
     handle = serve.run(deployment_cls.bind())
 
     assert requests.get(f"http://127.0.0.1:8000/{deployment_cls.name}").json() == {
@@ -360,9 +356,6 @@ def test_start_idempotent(serve_instance):
     func.deploy()
 
     assert "start" in serve.list_deployments()
-    serve.start(detached=True)
-    serve.start()
-    serve.start(detached=True)
     serve.start()
     assert "start" in serve.list_deployments()
 

--- a/python/ray/serve/tests/test_cli_2.py
+++ b/python/ray/serve/tests/test_cli_2.py
@@ -641,7 +641,7 @@ def test_idempotence_after_controller_death(ray_start_stop, use_command: bool):
     assert success_message_fragment in deploy_response
 
     ray.init(address="auto", namespace=SERVE_NAMESPACE)
-    serve.start(detached=True)
+    serve.start()
     wait_for_condition(
         lambda: len(list_actors(filters=[("state", "=", "ALIVE")])) == 4,
         timeout=15,
@@ -662,7 +662,7 @@ def test_idempotence_after_controller_death(ray_start_stop, use_command: bool):
     assert success_message_fragment in deploy_response
 
     # Restore testing controller
-    serve.start(detached=True)
+    serve.start()
     wait_for_condition(
         lambda: len(list_actors(filters=[("state", "=", "ALIVE")])) == 4,
         timeout=15,

--- a/python/ray/serve/tests/test_cross_language.py
+++ b/python/ray/serve/tests/test_cross_language.py
@@ -2,10 +2,12 @@ import pytest
 
 import ray
 from ray.job_config import JobConfig
+from ray.tests.conftest import shutdown_only, maybe_external_redis  # noqa: F401
+
 from ray import serve
 from ray.serve.config import ReplicaConfig, DeploymentConfig
+from ray.serve.context import get_global_client
 from ray.serve.generated.serve_pb2 import JAVA, RequestMetadata
-from ray.tests.conftest import shutdown_only, maybe_external_redis  # noqa: F401
 
 
 @pytest.mark.skip(reason="TIMEOUT, see https://github.com/ray-project/ray/issues/26513")
@@ -16,7 +18,8 @@ def test_controller_starts_java_replica(shutdown_only):  # noqa: F811
         # A dummy code search path to enable cross language.
         job_config=JobConfig(code_search_path=["."]),
     )
-    client = serve.start(detached=True)
+    serve.start()
+    client = get_global_client()
 
     controller = client._controller
 

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -11,14 +11,21 @@ import requests
 import ray
 import ray.actor
 import ray._private.state
+from ray.tests.conftest import call_ray_stop_only  # noqa: F401
 from ray.util.state import list_actors, list_tasks
-
-from ray import serve
 from ray._private.test_utils import (
     wait_for_condition,
     SignalActor,
 )
+
+from ray import serve
+from ray.serve.context import get_global_client
 from ray.serve.exceptions import RayServeException
+from ray.serve.schema import (
+    ServeApplicationSchema,
+    ServeDeploySchema,
+    ServeInstanceDetails,
+)
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import (
     DeploymentID,
@@ -26,12 +33,6 @@ from ray.serve._private.common import (
     DeploymentStatus,
 )
 from ray.serve._private.constants import SERVE_NAMESPACE, SERVE_DEFAULT_APP_NAME
-from ray.serve.schema import (
-    ServeApplicationSchema,
-    ServeDeploySchema,
-    ServeInstanceDetails,
-)
-from ray.tests.conftest import call_ray_stop_only  # noqa: F401
 
 
 @pytest.fixture
@@ -79,7 +80,8 @@ def client(start_and_shutdown_ray_cli_module, shutdown_ray_and_serve):
         timeout=15,
     )
     ray.init(address="auto", namespace=SERVE_NAMESPACE)
-    yield serve.start(detached=True)
+    serve.start()
+    yield get_global_client()
 
 
 def check_running(_client: ServeControllerClient):
@@ -754,7 +756,8 @@ def test_controller_recover_and_deploy(client: ServeControllerClient):
     )
 
     serve.shutdown()
-    client = serve.start(detached=True)
+    serve.start()
+    client = get_global_client()
 
     # Ensure config checkpoint has been deleted
     assert SERVE_DEFAULT_APP_NAME not in serve.status().applications

--- a/python/ray/serve/tests/test_gcs_failure.py
+++ b/python/ray/serve/tests/test_gcs_failure.py
@@ -6,11 +6,15 @@ import pytest
 import requests
 
 import ray
-import ray.serve as serve
-from ray._private.test_utils import wait_for_condition
-from ray.serve._private.storage.kv_store import KVStoreError, RayInternalKVStore
 from ray.tests.conftest import external_redis  # noqa: F401
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
+from ray._private.test_utils import wait_for_condition
+
+from ray import serve
+from ray.serve.context import get_global_client
+from ray.serve._private.constants import (
+    SERVE_DEFAULT_APP_NAME,
+)
+from ray.serve._private.storage.kv_store import KVStoreError, RayInternalKVStore
 
 
 @pytest.fixture(scope="function")
@@ -22,7 +26,8 @@ def serve_ha(external_redis, monkeypatch):  # noqa: F811
         _metrics_export_port=9999,
         _system_config={"metrics_report_interval_ms": 1000, "task_retry_delay_ms": 50},
     )
-    yield (address_info, serve.start(detached=True))
+    serve.start()
+    yield (address_info, get_global_client())
     ray.shutdown()
 
 

--- a/python/ray/serve/tests/test_ray_client.py
+++ b/python/ray/serve/tests/test_ray_client.py
@@ -64,7 +64,7 @@ ray.util.connect("{}", namespace="default_test_namespace")
 
 from ray import serve
 
-serve.start(detached=True)
+serve.start()
 """.format(
         ray_client_instance
     )
@@ -134,8 +134,6 @@ A.deploy()
 
 
 def test_quickstart_class(serve_with_client):
-    serve.start()
-
     @serve.deployment
     def hello(request):
         name = request.query_params["name"]

--- a/python/ray/serve/tests/test_runtime_env.py
+++ b/python/ray/serve/tests/test_runtime_env.py
@@ -112,7 +112,7 @@ from ray import serve
 
 job_config = ray.job_config.JobConfig(runtime_env={"working_dir": "."})
 ray.init(address="auto", namespace="serve", job_config=job_config)
-serve.start(detached=True)
+serve.start()
 
 @serve.deployment(version="1")
 class Test:
@@ -135,7 +135,7 @@ from ray import serve
 
 job_config = ray.job_config.JobConfig(runtime_env={"working_dir": "."})
 ray.init(address="auto", namespace="serve", job_config=job_config)
-serve.start(detached=True)
+serve.start()
 
 Test = serve.get_deployment("Test")
 Test.options(num_replicas=2).deploy()

--- a/python/ray/serve/tests/test_schema.py
+++ b/python/ray/serve/tests/test_schema.py
@@ -7,11 +7,14 @@ from pydantic import ValidationError
 from typing import List, Dict
 
 import ray
+from ray.util.accelerators.accelerators import NVIDIA_TESLA_V100, NVIDIA_TESLA_P4
+
 from ray import serve
-from ray.serve._private.common import (
-    StatusOverview,
-    DeploymentStatusInfo,
-    ApplicationStatusInfo,
+from ray.serve.config import AutoscalingConfig
+from ray.serve.context import get_global_client
+from ray.serve.deployment import (
+    deployment_to_schema,
+    schema_to_deployment,
 )
 from ray.serve.schema import (
     RayActorOptionsSchema,
@@ -21,11 +24,10 @@ from ray.serve.schema import (
     ServeDeploySchema,
     serve_status_to_schema,
 )
-from ray.util.accelerators.accelerators import NVIDIA_TESLA_V100, NVIDIA_TESLA_P4
-from ray.serve.config import AutoscalingConfig
-from ray.serve.deployment import (
-    deployment_to_schema,
-    schema_to_deployment,
+from ray.serve._private.common import (
+    StatusOverview,
+    DeploymentStatusInfo,
+    ApplicationStatusInfo,
 )
 
 
@@ -813,7 +815,8 @@ def test_status_schema_helpers():
     def f2():
         pass
 
-    client = serve.start()
+    serve.start()
+    client = get_global_client()
     serve.run(f1.bind(), name="app1")
     serve.run(f2.bind(), name="app2")
 

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -22,7 +22,7 @@ from ray._private.test_utils import (
     wait_for_condition,
 )
 from ray.cluster_utils import Cluster, cluster_not_supported
-from ray.serve.config import HTTPOptions
+from ray.serve.config import DeploymentMode, HTTPOptions
 from ray.serve._private.constants import (
     SERVE_DEFAULT_APP_NAME,
     SERVE_NAMESPACE,
@@ -71,7 +71,8 @@ def lower_slow_startup_threshold_and_reset():
     os.environ["SERVE_SLOW_STARTUP_WARNING_PERIOD_S"] = "1"
 
     ray.init(num_cpus=2)
-    client = serve.start(detached=True)
+    serve.start()
+    client = get_global_client()
 
     yield client
 
@@ -145,7 +146,7 @@ def test_v1_shutdown_actors(ray_shutdown):
     deletes all actors (controller, http proxy, all replicas) in the "serve" namespace.
     """
     ray.init(num_cpus=16)
-    serve.start(http_options=dict(port=8003), detached=True)
+    serve.start(http_options=dict(port=8003))
 
     @serve.deployment
     def f():
@@ -183,7 +184,7 @@ def test_single_app_shutdown_actors(ray_shutdown):
     deletes all actors (controller, http proxy, all replicas) in the "serve" namespace.
     """
     ray.init(num_cpus=16)
-    serve.start(http_options=dict(port=8003), detached=True)
+    serve.start(http_options=dict(port=8003))
 
     @serve.deployment
     def f():
@@ -221,7 +222,7 @@ def test_multi_app_shutdown_actors(ray_shutdown):
     deletes all actors (controller, http proxy, all replicas) in the "serve" namespace.
     """
     ray.init(num_cpus=16)
-    serve.start(http_options=dict(port=8003), detached=True)
+    serve.start(http_options=dict(port=8003))
 
     @serve.deployment
     def f():
@@ -263,7 +264,7 @@ def test_detached_deployment(ray_cluster):
     # Create first job, check we can run a simple serve endpoint
     ray.init(head_node.address, namespace=SERVE_NAMESPACE)
     first_job_id = ray.get_runtime_context().get_job_id()
-    serve.start(detached=True)
+    serve.start()
 
     @serve.deployment(route_prefix="/say_hi_f")
     def f(*args):
@@ -664,7 +665,8 @@ def test_fixed_number_proxies(monkeypatch, ray_cluster):
 
 def test_serve_shutdown(ray_shutdown):
     ray.init(namespace="serve")
-    client = serve.start(detached=True)
+    serve.start()
+    client = get_global_client()
 
     @serve.deployment
     class A:
@@ -676,7 +678,8 @@ def test_serve_shutdown(ray_shutdown):
     assert len(client.list_deployments()) == 1
 
     serve.shutdown()
-    client = serve.start(detached=True)
+    serve.start()
+    client = get_global_client()
 
     assert len(client.list_deployments()) == 0
 
@@ -687,13 +690,13 @@ def test_serve_shutdown(ray_shutdown):
 
 def test_detached_namespace_default_ray_init(ray_shutdown):
     # Can start detached instance when ray is not initialized.
-    serve.start(detached=True)
+    serve.start()
 
 
 def test_detached_instance_in_non_anonymous_namespace(ray_shutdown):
     # Can start detached instance in non-anonymous namespace.
     ray.init(namespace="foo")
-    serve.start(detached=True)
+    serve.start()
 
 
 def test_checkpoint_isolation_namespace(ray_shutdown):
@@ -707,7 +710,7 @@ from ray import serve
 
 ray.init(address="{address}", namespace="{namespace}")
 
-serve.start(detached=True, http_options={{"port": {port}}})
+serve.start(http_options={{"port": {port}}})
 
 @serve.deployment
 class A:
@@ -736,12 +739,12 @@ def test_serve_start_different_http_checkpoint_options_warning(propagate_logs, c
     logger.addHandler(WarningHandler())
 
     ray.init(namespace="serve-test")
-    serve.start(detached=True)
+    serve.start()
 
     # create a different config
     test_http = dict(host="127.1.1.8", port=new_port())
 
-    serve.start(detached=True, http_options=test_http)
+    serve.start(http_options=test_http)
 
     for test_config, msg in zip([["host", "port"]], warning_msg):
         for test_msg in test_config:
@@ -757,7 +760,8 @@ def test_recovering_controller_no_redeploy():
     """Ensure controller doesn't redeploy running deployments when recovering."""
     ray_context = ray.init(namespace="x")
     address = ray_context.address_info["address"]
-    client = serve.start(detached=True)
+    serve.start()
+    client = get_global_client()
 
     @serve.deployment
     def f():
@@ -863,7 +867,8 @@ def test_run_graph_task_uses_zero_cpus():
     """Check that the run_graph() task uses zero CPUs."""
 
     ray.init(num_cpus=2)
-    client = serve.start(detached=True)
+    serve.start()
+    client = get_global_client()
 
     config = {"import_path": "ray.serve.tests.test_standalone.WaiterNode"}
     config = ServeApplicationSchema.parse_obj(config)
@@ -879,6 +884,63 @@ def test_run_graph_task_uses_zero_cpus():
 
     serve.shutdown()
     ray.shutdown()
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {
+            "proxy_location": None,
+            "http_options": None,
+            "expected": HTTPOptions(location=DeploymentMode.EveryNode),
+        },
+        {
+            "proxy_location": None,
+            "http_options": HTTPOptions(location="NoServer"),
+            "expected": HTTPOptions(location=DeploymentMode.NoServer),
+        },
+        {
+            "proxy_location": None,
+            "http_options": {"location": "NoServer"},
+            "expected": HTTPOptions(location=DeploymentMode.NoServer),
+        },
+        {
+            "proxy_location": "NoServer",
+            "http_options": None,
+            "expected": HTTPOptions(location=DeploymentMode.NoServer),
+        },
+        {
+            "proxy_location": "NoServer",
+            "http_options": {},
+            "expected": HTTPOptions(location=DeploymentMode.NoServer),
+        },
+        {
+            "proxy_location": "NoServer",
+            "http_options": HTTPOptions(host="foobar"),
+            "expected": HTTPOptions(location=DeploymentMode.NoServer, host="foobar"),
+        },
+        {
+            "proxy_location": "NoServer",
+            "http_options": {"host": "foobar"},
+            "expected": HTTPOptions(location=DeploymentMode.NoServer, host="foobar"),
+        },
+        {
+            "proxy_location": "NoServer",
+            "http_options": {"location": "HeadOnly"},
+            "expected": HTTPOptions(location=DeploymentMode.NoServer),
+        },
+        {
+            "proxy_location": DeploymentMode.NoServer,
+            "http_options": HTTPOptions(location=DeploymentMode.HeadOnly),
+            "expected": HTTPOptions(location=DeploymentMode.NoServer),
+        },
+    ],
+)
+def test_serve_start_proxy_location(ray_shutdown, options):
+    expected_options = options.pop("expected")
+    serve.start(**options)
+    client = get_global_client()
+    assert ray.get(client._controller.get_http_config.remote()) == expected_options
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_standalone_2.py
+++ b/python/ray/serve/tests/test_standalone_2.py
@@ -221,7 +221,6 @@ def test_controller_deserialization_deployment_def(
             app.deployments[name].set_options(ray_actor_options={"num_cpus": 0.1})
 
         # Run the graph locally on the cluster
-        serve.start(detached=True)
         serve.run(graph)
 
     # Start Serve controller in a directory without access to the graph code
@@ -232,7 +231,7 @@ def test_controller_deserialization_deployment_def(
             "working_dir": os.path.join(os.path.dirname(__file__), "storage_tests")
         },
     )
-    serve.start(detached=True)
+    serve.start()
     serve.context._global_client = None
     ray.shutdown()
 
@@ -251,9 +250,8 @@ def test_controller_deserialization_deployment_def(
 
 def test_controller_deserialization_args_and_kwargs(shutdown_ray_and_serve):
     """Ensures init_args and init_kwargs stay serialized in controller."""
-
-    ray.init()
-    client = serve.start()
+    serve.start()
+    client = get_global_client()
 
     class PidBasedString(str):
         pass
@@ -293,7 +291,8 @@ def test_controller_recover_and_delete(shutdown_ray_and_serve):
     """Ensure that in-progress deletion can finish even after controller dies."""
 
     ray_context = ray.init()
-    client = serve.start()
+    serve.start()
+    client = get_global_client()
 
     num_replicas = 10
 

--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -233,7 +233,7 @@ def test_shutdown_remote(start_and_shutdown_ray_cli_function):
         "from ray import serve\n"
         "\n"
         'ray.init(address="auto", namespace="x")\n'
-        "serve.start(detached=True)\n"
+        "serve.start()\n"
         "\n"
         "@serve.deployment\n"
         "def f(*args):\n"
@@ -279,8 +279,6 @@ def test_handle_early_detect_failure(shutdown_ray):
 
     It should detect replica raises ActorError and take them out of the replicas set.
     """
-    ray.init()
-    serve.start(detached=True)
 
     @serve.deployment(num_replicas=2, max_concurrent_queries=1)
     def f(do_crash: bool = False):
@@ -304,7 +302,6 @@ def test_handle_early_detect_failure(shutdown_ray):
     assert len(set(pids)) == 1
 
     # Restart the controller, and then clean up all the replicas
-    serve.start(detached=True)
     serve.shutdown()
 
 

--- a/python/ray/serve/tests/test_telemetry.py
+++ b/python/ray/serve/tests/test_telemetry.py
@@ -351,7 +351,8 @@ def test_lightweight_config_options(
     }
 
     # Deploy first config
-    client = serve.start(detached=True)
+    serve.start()
+    client = get_global_client()
     client.deploy_apps(ServeDeploySchema(**config))
     wait_for_condition(
         lambda: serve.status().applications["receiver_app"].status

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -3,10 +3,12 @@ import logging
 
 import ray
 import requests
-from ray import serve
 from ray._private.test_utils import monitor_memory_usage
 from ray.cluster_utils import Cluster
+
+from ray import serve
 from ray.serve.config import DeploymentMode
+from ray.serve.context import get_global_client
 
 logger = logging.getLogger(__file__)
 
@@ -34,11 +36,9 @@ def setup_local_single_node_cluster(
             resources={str(i): 2, "proxy": 1},
         )
     ray.init(address=cluster.address, dashboard_host="0.0.0.0", namespace=namespace)
-    serve_client = serve.start(
-        detached=True, http_options={"location": DeploymentMode.EveryNode}
-    )
+    serve.start(detached=True, proxy_location=DeploymentMode.EveryNode)
 
-    return serve_client, cluster
+    return get_global_client(), cluster
 
 
 def setup_anyscale_cluster():


### PR DESCRIPTION
## Why are these changes needed?

Cherry-pick https://github.com/ray-project/ray/pull/38362

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
