### PR TITLE
[ci] disable extra cpp for lint

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -64,6 +64,6 @@ steps:
   - label: ":lint-roller: lint: api annotations"
     instance_type: medium
     commands:
-      - pip install -e python/[all]
+      - RAY_DISABLE_EXTRA_CPP=1 pip install -e python/[all]
       - ./ci/lint/check_api_annotations.py
     depends_on: forge


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix lint build to not relay on current setup version of ray-cpp

## Related issue number

Closes https://www.notion.so/anyscale-hq/How-to-release-Ray-go-release-ray-28e4a2347577471288bbd7d64001fa88?pvs=4#82b68d7c4b384f63a850419059e03272

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
