### PR TITLE
updates to setup-dev.py to work around the types.py import issues

### DIFF
--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -16,7 +16,7 @@ if this_dir in sys.path:
         f"Removing {this_dir} from sys.path to avoid "
         "conflict errors with `types.py` in this directory."
     )
-    cur = sys.path.remove(this_dir)
+    sys.path.remove(this_dir)
     sys.path.append(this_dir)
 
 import subprocess  # nopep8 - these need to be imported after the above sys.path workaround

--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -10,17 +10,20 @@ import sys
 # types.py can conflict with stdlib's types.py in some python versions,
 # see https://github.com/python/cpython/issues/101210.
 # To avoid import errors, we move the current working dir to the end of sys.path.
-this_dir = os.path.dirname(__file__)
+this_dir = os.path.abspath(os.path.dirname(__file__))
 if this_dir in sys.path:
+    print(
+        f"Removing {this_dir} from sys.path to avoid "
+        "conflict errors with `types.py` in this directory."
+    )
     cur = sys.path.remove(this_dir)
     sys.path.append(this_dir)
 
-import argparse
-import click
-import shutil
-import subprocess
-
-import ray
+import subprocess  # nopep8 - these need to be imported after the above sys.path workaround
+import shutil  # nopep8
+import click  # nopep8
+import argparse  # nopep8
+import ray  # nopep8
 
 
 def do_link(package, force=False, skip_list=None, local_path=None):


### PR DESCRIPTION

## Why are these changes needed?

Addresses #29587 by utilizing an absolute path to remove the scripts' current directory from sys.path.

This sidesteps the core issue is that python is getting confused about where to resolve imports for `types` since there is a file called `types.py` in the same directory as `setup-dev.py`

This PR augments the original solution discussed by @krfricke in #31458 and originally fixed by #31829 

## Related issue number

Closes #29587 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] ~~I've included any doc changes needed for https://docs.ray.io/en/master/.~~
    - [ ] ~~I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.~~
- [ ] ~~I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/~~
- ~~Testing Strategy~~
   - [ ] ~~Unit tests~~
   - [ ] ~~Release tests~~
   - [x] This PR is not tested :(  (it is a dev setup script which I've tested locally)
