### PR TITLE
[train] New persistence mode: Mark legacy trainable sync config logic for deletion

### DIFF
--- a/python/ray/train/_internal/syncer.py
+++ b/python/ray/train/_internal/syncer.py
@@ -122,8 +122,6 @@ class SyncConfig:
                 self.upload_dir = None
             if self.syncer == _DEPRECATED_VALUE:
                 self.syncer = "auto"
-            if self.sync_artifacts == _DEPRECATED_VALUE:
-                self.sync_artifacts = True
             if self.sync_on_checkpoint == _DEPRECATED_VALUE:
                 self.sync_on_checkpoint = True
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This was causing some spammy deprecation warnings due to the old syncing logic in the Trainable constructor still being run (even though it's not used in the new path). Keeping this gated behind the FF and labeled for code removal until the migration is done. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
