### PR TITLE
[docker] allow opt-out ray-cpp on docker building

### DIFF
--- a/docker/ray/Dockerfile
+++ b/docker/ray/Dockerfile
@@ -3,6 +3,7 @@ FROM rayproject/ray-deps:nightly"$BASE_IMAGE"
 ARG WHEEL_PATH
 ARG FIND_LINKS_PATH=".whl"
 ARG CONSTRAINTS_FILE="requirements_compiled.txt"
+ARG RAY_DISABLE_EXTRA_CPP=0
 # For Click
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
@@ -11,7 +12,8 @@ COPY requirements_compiled_py37.txt ./
 COPY $WHEEL_PATH .
 COPY $FIND_LINKS_PATH $FIND_LINKS_PATH
 
-RUN $HOME/anaconda3/bin/pip --no-cache-dir install -c $CONSTRAINTS_FILE \
+RUN RAY_DISABLE_EXTRA_CPP=$RAY_DISABLE_EXTRA_CPP \
+    $HOME/anaconda3/bin/pip --no-cache-dir install -c $CONSTRAINTS_FILE \
     `basename $WHEEL_PATH`[all] \
     --find-links $FIND_LINKS_PATH && sudo rm `basename $WHEEL_PATH`
 


### PR DESCRIPTION
`ray-cpp` is not used on dev builds anyways..

