### PR TITLE
[train] New persistence mode: Finish migrating `xgb`, `lgbm` and `sklearn` trainers, checkpoints + tests

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -36,7 +36,7 @@
 - label: ":steam_locomotive: Train tests and examples"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
   instance_size: large
-  parallelism: 3
+  parallelism: 4
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
     # Todo (krfricke): Move mosaicml to train-test-requirements.txt
@@ -45,8 +45,7 @@
     - ./ci/env/env_info.sh
     - ./ci/run/run_bazel_test_with_sharding.sh
       --config=ci $(./ci/run/bazel_export_options)
-      --test_tag_filters=-gpu_only,-gpu,-minimal,-tune,-doctest,-new_storage
-      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
+      --test_tag_filters=-gpu_only,-gpu,-minimal,-tune,-doctest
       python/ray/train/...
 
 
@@ -357,22 +356,6 @@
 
 
 ##### STORAGE REFACTOR
-
-- label: ":steam_locomotive: :floppy_disk: New persistence mode: Train tests and examples"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
-  instance_size: large
-  parallelism: 3
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    # Todo (krfricke): Move mosaicml to train-test-requirements.txt
-    - pip install "mosaicml==0.12.1"
-    - TRAIN_TESTING=1 DATA_PROCESSING_TESTING=1 INSTALL_HOROVOD=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - ./ci/run/run_bazel_test_with_sharding.sh
-      --config=ci $(./ci/run/bazel_export_options)
-      --test_tag_filters=-gpu_only,-gpu,-minimal,-tune,-doctest,-no_new_storage
-      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=1
-      python/ray/train/...
 
 # TODO(krfricke): Add new test for this suite
 # - label: ":steam_locomotive: :octopus: :floppy_disk: New persistence mode: Train + Tune tests and examples"

--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -51,7 +51,7 @@ py_test(
     size = "small",
     main = "examples/mlflow_simple_example.py",
     srcs = ["examples/mlflow_simple_example.py"],
-    tags = ["team:ml", "exclusive", "no_main", "new_storage"],
+    tags = ["team:ml", "exclusive", "no_main"],
     deps = [":train_lib"],
 )
 
@@ -60,7 +60,7 @@ py_test(
     size = "medium",
     main = "examples/tf/tensorflow_quick_start.py",
     srcs = ["examples/tf/tensorflow_quick_start.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"]
 )
 
@@ -69,7 +69,7 @@ py_test(
     size = "small",
     main = "examples/pytorch/torch_quick_start.py",
     srcs = ["examples/pytorch/torch_quick_start.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"]
 )
 
@@ -78,7 +78,7 @@ py_test(
     size = "medium",
     main = "examples/pytorch/tune_cifar_torch_pbt_example.py",
     srcs = ["examples/pytorch/tune_cifar_torch_pbt_example.py"],
-    tags = ["team:ml", "exclusive", "pytorch", "tune", "new_storage"],
+    tags = ["team:ml", "exclusive", "pytorch", "tune"],
     deps = [":train_lib"],
     args = ["--smoke-test"]
 )
@@ -88,7 +88,7 @@ py_test(
     size = "small",
     main = "examples/pytorch/tune_torch_regression_example.py",
     srcs = ["examples/pytorch/tune_torch_regression_example.py"],
-    tags = ["team:ml", "exclusive", "tune", "new_storage"],
+    tags = ["team:ml", "exclusive", "tune"],
     deps = [":train_lib"],
     args = ["--smoke-test"]
 )
@@ -109,7 +109,7 @@ py_test(
     name = "horovod_cifar_pbt_example",
     size = "small",
     srcs = ["examples/horovod/horovod_cifar_pbt_example.py"],
-    tags = ["team:ml", "exlusive", "new_storage"],
+    tags = ["team:ml", "exlusive"],
     deps = [":train_lib"],
     args = ["--smoke-test"]
 )
@@ -118,7 +118,7 @@ py_test(
     name = "horovod_pytorch_example",
     size = "small",
     srcs = ["examples/horovod/horovod_pytorch_example.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"],
     args = ["--num-epochs=1"]
 )
@@ -127,7 +127,7 @@ py_test(
     name = "horovod_tune_example",
     size = "small",
     srcs = ["examples/horovod/horovod_tune_example.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"],
     args = ["--smoke-test"]
 )
@@ -137,7 +137,7 @@ py_test (
     size = "medium",
     srcs = ["examples/huggingface/huggingface_basic_language_modeling_example.py"],
     args = ["--smoke-test", "--num-epochs 3"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"]
 )
 
@@ -146,7 +146,7 @@ py_test(
     size = "medium",
     main = "examples/tf/tensorflow_regression_example.py",
     srcs = ["examples/tf/tensorflow_regression_example.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"],
     args = ["--smoke-test"]
 )
@@ -189,7 +189,7 @@ py_test(
     size = "medium",
     main = "examples/pytorch/torch_regression_example.py",
     srcs = ["examples/pytorch/torch_regression_example.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"],
     args = ["--smoke-test"]
 )
@@ -210,7 +210,7 @@ py_test(
     size = "medium",
     main = "examples/tf/tune_tensorflow_mnist_example.py",
     srcs = ["examples/tf/tune_tensorflow_mnist_example.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"],
     args = ["--smoke-test"]
 )
@@ -232,7 +232,7 @@ py_test(
     name = "test_backend",
     size = "large",
     srcs = ["tests/test_backend.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib",  ":conftest"]
 )
 
@@ -240,7 +240,7 @@ py_test(
     name = "test_base_trainer",
     size = "medium",
     srcs = ["tests/test_base_trainer.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -248,7 +248,7 @@ py_test(
     name = "test_checkpoint",
     size = "small",
     srcs = ["tests/test_checkpoint.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"]
 )
 
@@ -256,7 +256,7 @@ py_test(
     name = "test_checkpoint_manager",
     size = "small",
     srcs = ["tests/test_checkpoint_manager.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"]
 )
 
@@ -264,7 +264,7 @@ py_test(
     name = "test_data_parallel_trainer",
     size = "medium",
     srcs = ["tests/test_data_parallel_trainer.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -272,7 +272,7 @@ py_test(
     name = "test_data_parallel_trainer_checkpointing",
     size = "medium",
     srcs = ["tests/test_data_parallel_trainer_checkpointing.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -280,7 +280,7 @@ py_test(
     name = "test_examples",
     size = "large",
     srcs = ["tests/test_examples.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -328,7 +328,7 @@ py_test(
     name = "test_huggingface",
     size = "small",
     srcs = ["tests/test_huggingface.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"]
 )
 
@@ -344,7 +344,7 @@ py_test(
     name = "test_horovod_trainer",
     size = "large",
     srcs = ["tests/test_horovod_trainer.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -352,7 +352,7 @@ py_test(
     name = "test_mosaic_trainer",
     size = "medium",
     srcs = ["tests/test_mosaic_trainer.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "torch_1_11", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air", "torch_1_11"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -360,7 +360,7 @@ py_test(
     name = "test_lightgbm_predictor",
     size = "small",
     srcs = ["tests/test_lightgbm_predictor.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -368,7 +368,7 @@ py_test(
     name = "test_lightgbm_trainer",
     size = "medium",
     srcs = ["tests/test_lightgbm_trainer.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "no_new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -400,7 +400,7 @@ py_test(
     name = "test_lightning_predictor",
     size = "medium",
     srcs = ["tests/test_lightning_predictor.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "gpu", "ptl_v2", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air", "gpu", "ptl_v2"],
     deps = [":train_lib"]
 )
 
@@ -440,7 +440,7 @@ py_test(
     name = "test_new_persistence",
     size = "large",
     srcs = ["tests/test_new_persistence.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -448,7 +448,7 @@ py_test(
     name = "test_predictor",
     size = "small",
     srcs = ["tests/test_predictor.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -456,7 +456,7 @@ py_test(
     name = "test_session",
     size = "small",
     srcs = ["tests/test_session.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -464,7 +464,7 @@ py_test(
     name = "test_sklearn_predictor",
     size = "small",
     srcs = ["tests/test_sklearn_predictor.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -472,7 +472,7 @@ py_test(
     name = "test_sklearn_trainer",
     size = "medium",
     srcs = ["tests/test_sklearn_trainer.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "no_new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -480,7 +480,7 @@ py_test(
     name = "test_tensorflow_checkpoint",
     size = "small",
     srcs = ["tests/test_tensorflow_checkpoint.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"]
 )
 
@@ -488,7 +488,7 @@ py_test(
     name = "test_tensorflow_predictor",
     size = "small",
     srcs = ["tests/test_tensorflow_predictor.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "gpu", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air", "gpu"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -496,7 +496,7 @@ py_test(
     name = "test_tensorflow_trainer",
     size = "medium",
     srcs = ["tests/test_tensorflow_trainer.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -504,7 +504,7 @@ py_test(
     name = "test_torch_checkpoint",
     size = "small",
     srcs = ["tests/test_torch_checkpoint.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -512,7 +512,7 @@ py_test(
     name = "test_torch_predictor",
     size = "medium",
     srcs = ["tests/test_torch_predictor.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "gpu", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air", "gpu"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -520,7 +520,7 @@ py_test(
     name = "test_torch_detection_predictor",
     size = "medium",
     srcs = ["tests/test_torch_detection_predictor.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "gpu", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air", "gpu"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -528,7 +528,7 @@ py_test(
     name = "test_torch_trainer",
     size = "large",
     srcs = ["tests/test_torch_trainer.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -536,7 +536,7 @@ py_test(
     name = "test_torch_utils",
     size = "small",
     srcs = ["tests/test_torch_utils.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -544,7 +544,7 @@ py_test(
     name = "test_training_iterator",
     size = "large",
     srcs = ["tests/test_training_iterator.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -552,7 +552,7 @@ py_test(
     name = "test_transformers_checkpoint",
     size = "small",
     srcs = ["tests/test_transformers_checkpoint.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -560,7 +560,7 @@ py_test(
     name = "test_transformers_predictor",
     size = "medium",
     srcs = ["tests/test_transformers_predictor.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -568,7 +568,7 @@ py_test(
     name = "test_transformers_trainer_steps",
     size = "enormous", # TODO: Reduce this.
     srcs = ["tests/test_transformers_trainer_steps.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -576,7 +576,7 @@ py_test(
     name = "test_transformers_trainer",
     size = "large",
     srcs = ["tests/test_transformers_trainer.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 
@@ -584,7 +584,7 @@ py_test(
     name = "test_tune",
     size = "large",
     srcs = ["tests/test_tune.py"],
-    tags = ["team:ml", "exclusive", "tune", "new_storage"],
+    tags = ["team:ml", "exclusive", "tune"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -592,7 +592,7 @@ py_test(
     name = "test_utils",
     size = "small",
     srcs = ["tests/test_utils.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"]
 )
 
@@ -600,7 +600,7 @@ py_test(
     name = "test_e2e_wandb_integration",
     size = "small",
     srcs = ["tests/test_e2e_wandb_integration.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"]
 )
 
@@ -608,7 +608,7 @@ py_test(
     name = "test_worker_group",
     size = "medium",
     srcs = ["tests/test_worker_group.py"],
-    tags = ["team:ml", "exclusive", "new_storage"],
+    tags = ["team:ml", "exclusive"],
     deps = [":train_lib"]
 )
 
@@ -616,7 +616,7 @@ py_test(
     name = "test_xgboost_predictor",
     size = "small",
     srcs = ["tests/test_xgboost_predictor.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib", ":conftest"]
 )
 
@@ -624,7 +624,7 @@ py_test(
     name = "test_xgboost_trainer",
     size = "medium",
     srcs = ["tests/test_xgboost_trainer.py"],
-    tags = ["team:ml", "exclusive", "ray_air", "no_new_storage"],
+    tags = ["team:ml", "exclusive", "ray_air"],
     deps = [":train_lib"]
 )
 

--- a/python/ray/train/gbdt_trainer.py
+++ b/python/ray/train/gbdt_trainer.py
@@ -275,7 +275,7 @@ class GBDTTrainer(BaseTrainer):
             tune.report(**result_dict)
         else:
             with tempfile.TemporaryDirectory() as checkpoint_dir:
-                self._save_model(model, path=os.path.join(checkpoint_dir, MODEL_KEY))
+                self._save_model(model, path=checkpoint_dir)
 
                 if _use_storage_context():
                     checkpoint = Checkpoint.from_directory(checkpoint_dir)

--- a/python/ray/train/lightgbm/__init__.py
+++ b/python/ray/train/lightgbm/__init__.py
@@ -1,13 +1,9 @@
-from ray.train.lightgbm.lightgbm_checkpoint import (
-    LightGBMCheckpoint,
-    LegacyLightGBMCheckpoint,
-)
+from ray.train.lightgbm.lightgbm_checkpoint import LightGBMCheckpoint
 from ray.train.lightgbm.lightgbm_predictor import LightGBMPredictor
 from ray.train.lightgbm.lightgbm_trainer import LightGBMTrainer
 
 __all__ = [
     "LightGBMCheckpoint",
-    "LegacyLightGBMCheckpoint",
     "LightGBMPredictor",
     "LightGBMTrainer",
 ]

--- a/python/ray/train/lightgbm/lightgbm_checkpoint.py
+++ b/python/ray/train/lightgbm/lightgbm_checkpoint.py
@@ -4,10 +4,7 @@ from typing import TYPE_CHECKING, Optional
 
 import lightgbm
 
-from ray.air._internal.checkpointing import save_preprocessor_to_dir
-from ray.air.checkpoint import Checkpoint
 from ray.train._internal.framework_checkpoint import FrameworkCheckpoint
-from ray.air.constants import MODEL_KEY
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
@@ -62,64 +59,3 @@ class LightGBMCheckpoint(FrameworkCheckpoint):
             return lightgbm.Booster(
                 model_file=os.path.join(checkpoint_path, self.MODEL_FILENAME)
             )
-
-
-@PublicAPI(stability="beta")
-class LegacyLightGBMCheckpoint(Checkpoint):
-    """A :py:class:`~ray.air.checkpoint.Checkpoint` with LightGBM-specific
-    functionality.
-
-    Create this from a generic :py:class:`~ray.air.checkpoint.Checkpoint` by calling
-    ``LightGBMCheckpoint.from_checkpoint(ckpt)``.
-    """
-
-    @classmethod
-    def from_model(
-        cls,
-        booster: lightgbm.Booster,
-        *,
-        preprocessor: Optional["Preprocessor"] = None,
-    ) -> "LightGBMCheckpoint":
-        """Create a :py:class:`~ray.air.checkpoint.Checkpoint` that stores a LightGBM
-        model.
-
-        Args:
-            booster: The LightGBM model to store in the checkpoint.
-            preprocessor: A fitted preprocessor to be applied before inference.
-
-        Returns:
-            An :py:class:`LightGBMCheckpoint` containing the specified ``Estimator``.
-
-        Examples:
-            >>> import lightgbm
-            >>> import numpy as np
-            >>> from ray.train.lightgbm import LegacyLightGBMCheckpoint
-            >>>
-            >>> train_X = np.array([[1, 2], [3, 4]])
-            >>> train_y = np.array([0, 1])
-            >>>
-            >>> model = lightgbm.LGBMClassifier().fit(train_X, train_y)
-            >>> checkpoint = LegacyLightGBMCheckpoint.from_model(model.booster_)
-
-            You can use a :py:class:`LightGBMCheckpoint` to create an
-            :py:class:`~ray.train.lightgbm.LightGBMPredictor` and preform inference.
-
-            >>> from ray.train.lightgbm import LightGBMPredictor
-            >>>
-            >>> predictor = LightGBMPredictor.from_checkpoint(checkpoint)
-        """
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            booster.save_model(os.path.join(tmpdirname, MODEL_KEY))
-
-            if preprocessor:
-                save_preprocessor_to_dir(preprocessor, tmpdirname)
-
-            checkpoint = cls.from_directory(tmpdirname)
-            ckpt_dict = checkpoint.to_dict()
-
-        return cls.from_dict(ckpt_dict)
-
-    def get_model(self) -> lightgbm.Booster:
-        """Retrieve the LightGBM model stored in this checkpoint."""
-        with self.as_directory() as checkpoint_path:
-            return lightgbm.Booster(model_file=os.path.join(checkpoint_path, MODEL_KEY))

--- a/python/ray/train/lightgbm/lightgbm_trainer.py
+++ b/python/ray/train/lightgbm/lightgbm_trainer.py
@@ -7,8 +7,8 @@ except ImportError:
     from distutils.version import LooseVersion as Version
 
 from ray.air.checkpoint import Checkpoint
-from ray.air.constants import MODEL_KEY
 from ray.train.gbdt_trainer import GBDTTrainer
+from ray.train.lightgbm import LightGBMCheckpoint
 from ray.util.annotations import PublicAPI
 
 import lightgbm
@@ -102,7 +102,11 @@ class LightGBMTrainer(GBDTTrainer):
     def get_model(checkpoint: Checkpoint) -> lightgbm.Booster:
         """Retrieve the LightGBM model stored in this checkpoint."""
         with checkpoint.as_directory() as checkpoint_path:
-            return lightgbm.Booster(model_file=os.path.join(checkpoint_path, MODEL_KEY))
+            return lightgbm.Booster(
+                model_file=os.path.join(
+                    checkpoint_path, LightGBMCheckpoint.MODEL_FILENAME
+                )
+            )
 
     def _train(self, **kwargs):
         return lightgbm_ray.train(**kwargs)
@@ -111,7 +115,7 @@ class LightGBMTrainer(GBDTTrainer):
         return self.__class__.get_model(checkpoint)
 
     def _save_model(self, model: lightgbm.LGBMModel, path: str):
-        model.booster_.save_model(path)
+        model.booster_.save_model(os.path.join(path, LightGBMCheckpoint.MODEL_FILENAME))
 
     def _model_iteration(
         self, model: Union[lightgbm.LGBMModel, lightgbm.Booster]

--- a/python/ray/train/sklearn/__init__.py
+++ b/python/ray/train/sklearn/__init__.py
@@ -1,13 +1,9 @@
-from ray.train.sklearn.sklearn_checkpoint import (
-    SklearnCheckpoint,
-    LegacySklearnCheckpoint,
-)
+from ray.train.sklearn.sklearn_checkpoint import SklearnCheckpoint
 from ray.train.sklearn.sklearn_predictor import SklearnPredictor
 from ray.train.sklearn.sklearn_trainer import SklearnTrainer
 
 __all__ = [
     "SklearnCheckpoint",
-    "LegacySklearnCheckpoint",
     "SklearnPredictor",
     "SklearnTrainer",
 ]

--- a/python/ray/train/sklearn/sklearn_checkpoint.py
+++ b/python/ray/train/sklearn/sklearn_checkpoint.py
@@ -3,9 +3,6 @@ import tempfile
 from typing import TYPE_CHECKING, Optional, Union
 
 from sklearn.base import BaseEstimator
-from ray.air._internal.checkpointing import save_preprocessor_to_dir
-from ray.air.checkpoint import Checkpoint
-from ray.air.constants import MODEL_KEY
 from ray.train._internal.framework_checkpoint import FrameworkCheckpoint
 import ray.cloudpickle as cpickle
 from ray.util.annotations import PublicAPI
@@ -62,65 +59,5 @@ class SklearnCheckpoint(FrameworkCheckpoint):
         """Retrieve the ``Estimator`` stored in this checkpoint."""
         with self.as_directory() as checkpoint_path:
             estimator_path = os.path.join(checkpoint_path, self.MODEL_FILENAME)
-            with open(estimator_path, "rb") as f:
-                return cpickle.load(f)
-
-
-@PublicAPI(stability="alpha")
-class LegacySklearnCheckpoint(Checkpoint):
-    """A :py:class:`~ray.air.checkpoint.Checkpoint` with sklearn-specific
-    functionality.
-
-    Create this from a generic :py:class:`~ray.air.checkpoint.Checkpoint` by calling
-    ``SklearnCheckpoint.from_checkpoint(ckpt)``
-    """
-
-    @classmethod
-    def from_estimator(
-        cls,
-        estimator: BaseEstimator,
-        *,
-        path: os.PathLike,
-        preprocessor: Optional["Preprocessor"] = None,
-    ) -> "SklearnCheckpoint":
-        """Create a :py:class:`~ray.air.checkpoint.Checkpoint` that stores an sklearn
-        ``Estimator``.
-
-        Args:
-            estimator: The ``Estimator`` to store in the checkpoint.
-            path: The directory where the checkpoint will be stored.
-            preprocessor: A fitted preprocessor to be applied before inference.
-
-        Returns:
-            An :py:class:`SklearnCheckpoint` containing the specified ``Estimator``.
-
-        Examples:
-            >>> from ray.train.sklearn import LegacySklearnCheckpoint
-            >>> from sklearn.ensemble import RandomForestClassifier
-            >>>
-            >>> estimator = RandomForestClassifier()
-            >>> checkpoint = LegacySklearnCheckpoint.from_estimator(estimator, path=".")
-
-            You can use a :py:class:`SklearnCheckpoint` to create an
-            :py:class:`~ray.train.sklearn.SklearnPredictor` and preform inference.
-
-            >>> from ray.train.sklearn import SklearnPredictor
-            >>>
-            >>> predictor = SklearnPredictor.from_checkpoint(checkpoint)
-        """
-        with open(os.path.join(path, MODEL_KEY), "wb") as f:
-            cpickle.dump(estimator, f)
-
-        if preprocessor:
-            save_preprocessor_to_dir(preprocessor, path)
-
-        checkpoint = cls.from_directory(path)
-
-        return checkpoint
-
-    def get_estimator(self) -> BaseEstimator:
-        """Retrieve the ``Estimator`` stored in this checkpoint."""
-        with self.as_directory() as checkpoint_path:
-            estimator_path = os.path.join(checkpoint_path, MODEL_KEY)
             with open(estimator_path, "rb") as f:
                 return cpickle.load(f)

--- a/python/ray/train/tests/test_lightgbm_trainer.py
+++ b/python/ray/train/tests/test_lightgbm_trainer.py
@@ -8,8 +8,8 @@ import ray
 from ray import tune
 from ray.train.constants import TRAIN_DATASET_KEY
 
-from ray.train.lightgbm import LegacyLightGBMCheckpoint, LightGBMTrainer
-from ray.train import Checkpoint, ScalingConfig
+from ray.train.lightgbm import LightGBMTrainer
+from ray.train import ScalingConfig
 
 from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
@@ -83,16 +83,8 @@ def test_resume_from_checkpoint(ray_start_6_cpus, tmpdir):
         datasets={TRAIN_DATASET_KEY: train_dataset, "valid": valid_dataset},
     )
     result = trainer.fit()
-    checkpoint = result.checkpoint
-    checkpoint = LegacyLightGBMCheckpoint.from_checkpoint(result.checkpoint)
-    model = checkpoint.get_model()
+    model = LightGBMTrainer.get_model(result.checkpoint)
     assert get_num_trees(model) == 5
-
-    # Move checkpoint to a different directory.
-    checkpoint_dict = result.checkpoint.to_dict()
-    checkpoint = Checkpoint.from_dict(checkpoint_dict)
-    checkpoint_path = checkpoint.to_directory(tmpdir)
-    resume_from = Checkpoint.from_directory(checkpoint_path)
 
     trainer = LightGBMTrainer(
         scaling_config=scale_config,
@@ -100,7 +92,7 @@ def test_resume_from_checkpoint(ray_start_6_cpus, tmpdir):
         params=params,
         num_boost_round=10,
         datasets={TRAIN_DATASET_KEY: train_dataset, "valid": valid_dataset},
-        resume_from_checkpoint=resume_from,
+        resume_from_checkpoint=result.checkpoint,
     )
     result = trainer.fit()
     checkpoint = result.checkpoint
@@ -139,14 +131,11 @@ def test_checkpoint_freq(ray_start_6_cpus, freq_end_expected):
 
     # Assert number of checkpoints
     assert len(result.best_checkpoints) == expected, str(
-        [
-            (metrics["training_iteration"], _cp._local_path)
-            for _cp, metrics in result.best_checkpoints
-        ]
+        [(metrics["training_iteration"], cp) for cp, metrics in result.best_checkpoints]
     )
 
     # Assert checkpoint numbers are increasing
-    cp_paths = [cp._local_path for cp, _ in result.best_checkpoints]
+    cp_paths = [cp.path for cp, _ in result.best_checkpoints]
     assert cp_paths == sorted(cp_paths), str(cp_paths)
 
 

--- a/python/ray/train/tests/test_sklearn_trainer.py
+++ b/python/ray/train/tests/test_sklearn_trainer.py
@@ -5,7 +5,7 @@ import ray
 from ray import tune
 from ray.train.constants import TRAIN_DATASET_KEY
 
-from ray.train.sklearn import LegacySklearnCheckpoint, SklearnTrainer
+from ray.train.sklearn import SklearnTrainer
 from ray.train import ScalingConfig
 
 from sklearn.datasets import load_breast_cancer
@@ -77,9 +77,7 @@ def test_no_auto_cpu_params(ray_start_4_cpus, tmpdir):
         set_estimator_cpus=False,
     )
     result = trainer.fit()
-
-    checkpoint = LegacySklearnCheckpoint.from_checkpoint(result.checkpoint)
-    model = checkpoint.get_estimator()
+    model = SklearnTrainer.get_model(result.checkpoint)
     assert model.n_jobs == 1
 
 

--- a/python/ray/train/tests/test_xgboost_trainer.py
+++ b/python/ray/train/tests/test_xgboost_trainer.py
@@ -5,11 +5,11 @@ import pandas as pd
 import xgboost as xgb
 
 import ray
-from ray import tune
-from ray.train import Checkpoint, ScalingConfig
+from ray import train, tune
+from ray.train import ScalingConfig
 from ray.train.constants import TRAIN_DATASET_KEY
 
-from ray.train.xgboost import LegacyXGBoostCheckpoint, XGBoostTrainer
+from ray.train.xgboost import XGBoostTrainer
 
 from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
@@ -64,7 +64,7 @@ def test_fit(ray_start_4_cpus):
 
 class ScalingConfigAssertingXGBoostTrainer(XGBoostTrainer):
     def training_loop(self) -> None:
-        pgf = tune.get_trial_resources()
+        pgf = train.get_context().get_trial_resources()
         assert pgf.strategy == "SPREAD"
         assert pgf._kwargs["_max_cpu_fraction_per_node"] == 0.9
         return super().training_loop()
@@ -103,23 +103,16 @@ def test_resume_from_checkpoint(ray_start_4_cpus, tmpdir):
     xgb_model = XGBoostTrainer.get_model(checkpoint)
     assert get_num_trees(xgb_model) == 5
 
-    # Move checkpoint to a different directory.
-    checkpoint_dict = result.checkpoint.to_dict()
-    checkpoint = Checkpoint.from_dict(checkpoint_dict)
-    checkpoint_path = checkpoint.to_directory(tmpdir)
-    resume_from = Checkpoint.from_directory(checkpoint_path)
-
     trainer = XGBoostTrainer(
         scaling_config=scale_config,
         label_column="target",
         params=params,
         num_boost_round=10,
         datasets={TRAIN_DATASET_KEY: train_dataset, "valid": valid_dataset},
-        resume_from_checkpoint=resume_from,
+        resume_from_checkpoint=result.checkpoint,
     )
     result = trainer.fit()
-    checkpoint = LegacyXGBoostCheckpoint.from_checkpoint(result.checkpoint)
-    model = checkpoint.get_model()
+    model = XGBoostTrainer.get_model(result.checkpoint)
     assert get_num_trees(model) == 10
 
 
@@ -154,14 +147,11 @@ def test_checkpoint_freq(ray_start_4_cpus, freq_end_expected):
 
     # Assert number of checkpoints
     assert len(result.best_checkpoints) == expected, str(
-        [
-            (metrics["training_iteration"], _cp._local_path)
-            for _cp, metrics in result.best_checkpoints
-        ]
+        [(metrics["training_iteration"], cp) for cp, metrics in result.best_checkpoints]
     )
 
     # Assert checkpoint numbers are increasing
-    cp_paths = [cp._local_path for cp, _ in result.best_checkpoints]
+    cp_paths = [cp.path for cp, _ in result.best_checkpoints]
     assert cp_paths == sorted(cp_paths), str(cp_paths)
 
 

--- a/python/ray/train/xgboost/__init__.py
+++ b/python/ray/train/xgboost/__init__.py
@@ -1,13 +1,9 @@
-from ray.train.xgboost.xgboost_checkpoint import (
-    XGBoostCheckpoint,
-    LegacyXGBoostCheckpoint,
-)
+from ray.train.xgboost.xgboost_checkpoint import XGBoostCheckpoint
 from ray.train.xgboost.xgboost_predictor import XGBoostPredictor
 from ray.train.xgboost.xgboost_trainer import XGBoostTrainer
 
 __all__ = [
     "XGBoostCheckpoint",
-    "LegacyXGBoostCheckpoint",
     "XGBoostPredictor",
     "XGBoostTrainer",
 ]

--- a/python/ray/train/xgboost/xgboost_checkpoint.py
+++ b/python/ray/train/xgboost/xgboost_checkpoint.py
@@ -4,9 +4,6 @@ from typing import TYPE_CHECKING, Optional
 
 import xgboost
 
-from ray.air._internal.checkpointing import save_preprocessor_to_dir
-from ray.air.checkpoint import Checkpoint
-from ray.air.constants import MODEL_KEY
 from ray.train._internal.framework_checkpoint import FrameworkCheckpoint
 from ray.util.annotations import PublicAPI
 
@@ -18,7 +15,7 @@ if TYPE_CHECKING:
 class XGBoostCheckpoint(FrameworkCheckpoint):
     """A :py:class:`~ray.train.Checkpoint` with XGBoost-specific functionality."""
 
-    MODEL_FILENAME = "model.pkl"
+    MODEL_FILENAME = "model.json"
 
     @classmethod
     def from_model(
@@ -66,73 +63,4 @@ class XGBoostCheckpoint(FrameworkCheckpoint):
         with self.as_directory() as checkpoint_path:
             booster = xgboost.Booster()
             booster.load_model(os.path.join(checkpoint_path, self.MODEL_FILENAME))
-            return booster
-
-
-@PublicAPI(stability="beta")
-class LegacyXGBoostCheckpoint(Checkpoint):
-    """A :py:class:`~ray.air.checkpoint.Checkpoint` with XGBoost-specific
-    functionality.
-
-    Create this from a generic :py:class:`~ray.air.checkpoint.Checkpoint` by calling
-    ``XGBoostCheckpoint.from_checkpoint(ckpt)``.
-    """
-
-    @classmethod
-    def from_model(
-        cls,
-        booster: xgboost.Booster,
-        *,
-        preprocessor: Optional["Preprocessor"] = None,
-    ) -> "XGBoostCheckpoint":
-        """Create a :py:class:`~ray.air.checkpoint.Checkpoint` that stores an XGBoost
-        model.
-
-        Args:
-            booster: The XGBoost model to store in the checkpoint.
-            preprocessor: A fitted preprocessor to be applied before inference.
-
-        Returns:
-            An :py:class:`XGBoostCheckpoint` containing the specified ``Estimator``.
-
-        Examples:
-
-            ... testcode::
-
-                import numpy as np
-                import ray
-                from ray.train.xgboost import XGBoostCheckpoint
-                import xgboost
-
-                train_X = np.array([[1, 2], [3, 4]])
-                train_y = np.array([0, 1])
-
-                model = xgboost.XGBClassifier().fit(train_X, train_y)
-                checkpoint = XGBoostCheckpoint.from_model(model.get_booster())
-
-            You can use a :py:class:`XGBoostCheckpoint` to create an
-            :py:class:`~ray.train.xgboost.XGBoostPredictor` and preform inference.
-
-            ... testcode::
-
-                from ray.train.xgboost import XGBoostPredictor
-                predictor = XGBoostPredictor.from_checkpoint(checkpoint)
-
-        """
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            booster.save_model(os.path.join(tmpdirname, MODEL_KEY))
-
-            if preprocessor:
-                save_preprocessor_to_dir(preprocessor, tmpdirname)
-
-            checkpoint = cls.from_directory(tmpdirname)
-            ckpt_dict = checkpoint.to_dict()
-
-        return cls.from_dict(ckpt_dict)
-
-    def get_model(self) -> xgboost.Booster:
-        """Retrieve the XGBoost model stored in this checkpoint."""
-        with self.as_directory() as checkpoint_path:
-            booster = xgboost.Booster()
-            booster.load_model(os.path.join(checkpoint_path, MODEL_KEY))
             return booster

--- a/python/ray/train/xgboost/xgboost_trainer.py
+++ b/python/ray/train/xgboost/xgboost_trainer.py
@@ -7,8 +7,8 @@ except ImportError:
     from distutils.version import LooseVersion as Version
 
 from ray.air.checkpoint import Checkpoint
-from ray.air.constants import MODEL_KEY
 from ray.train.gbdt_trainer import GBDTTrainer
+from ray.train.xgboost import XGBoostCheckpoint
 from ray.util.annotations import PublicAPI
 
 import xgboost
@@ -94,7 +94,9 @@ class XGBoostTrainer(GBDTTrainer):
         """Retrieve the XGBoost model stored in this checkpoint."""
         with checkpoint.as_directory() as checkpoint_path:
             booster = xgboost.Booster()
-            booster.load_model(os.path.join(checkpoint_path, MODEL_KEY))
+            booster.load_model(
+                os.path.join(checkpoint_path, XGBoostCheckpoint.MODEL_FILENAME)
+            )
             return booster
 
     def _train(self, **kwargs):
@@ -104,7 +106,7 @@ class XGBoostTrainer(GBDTTrainer):
         return self.__class__.get_model(checkpoint)
 
     def _save_model(self, model: xgboost.Booster, path: str):
-        model.save_model(path)
+        model.save_model(os.path.join(path, XGBoostCheckpoint.MODEL_FILENAME))
 
     def _model_iteration(self, model: xgboost.Booster) -> int:
         if not hasattr(model, "num_boosted_rounds"):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR fixes `SklearnTrainer` to use `train.report` and the new `Checkpoint` API. It also introduces `SklearnTrainer.get_model` which is used in the same way as `XGBoostTrainer.get_model`.

This PR migrates the last 3 Train tests and fully enables the test suite w/ the new persistence mode.

This PR also removes the legacy xgb, lightgbm, and sklearn AIR checkpoints that aren't used anymore.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
