### PR TITLE
[Serve] Add max_replicas_per_node support (#38766)

### DIFF
--- a/python/ray/serve/BUILD
+++ b/python/ray/serve/BUILD
@@ -601,6 +601,14 @@ py_test(
     deps = [":serve_lib"],
 )
 
+py_test(
+    name = "test_max_replicas_per_node",
+    size = "medium",
+    srcs = serve_tests_srcs,
+    tags = ["exclusive", "team:serve"],
+    deps = [":serve_lib"],
+)
+
 # Make sure the example showing in doc is tested
 py_test(
     name = "quickstart_class",

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1008,6 +1008,10 @@ def override_deployment_info(
             "placement_group_strategy", replica_config.placement_group_strategy
         )
 
+        override_max_replicas_per_node = options.pop(
+            "max_replicas_per_node", replica_config.max_replicas_per_node
+        )
+
         merged_env = override_runtime_envs_except_env_vars(
             app_runtime_env, override_actor_options.get("runtime_env", {})
         )
@@ -1016,6 +1020,7 @@ def override_deployment_info(
         replica_config.update_placement_group_options(
             override_placement_group_bundles, override_placement_group_strategy
         )
+        replica_config.update_max_replicas_per_node(override_max_replicas_per_node)
         override_options["replica_config"] = replica_config
 
         # Override deployment config options

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -258,3 +258,10 @@ RAY_SERVE_ENABLE_MEMORY_PROFILING = (
 RAY_SERVE_ENABLE_CPU_PROFILING = (
     os.environ.get("RAY_SERVE_ENABLE_CPU_PROFILING", "0") == "1"
 )
+
+# Max value allowed for max_replicas_per_node option.
+# TODO(jjyao) the <= 100 limitation is an artificial one
+# and is due to the fact that Ray core only supports resource
+# precision up to 0.0001.
+# This limitation should be lifted in the long term.
+MAX_REPLICAS_PER_NODE_MAX_VALUE = 100

--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -1,4 +1,5 @@
 import sys
+import copy
 from typing import Callable, Dict, Tuple, List, Optional, Union, Set
 from dataclasses import dataclass
 from collections import defaultdict
@@ -47,6 +48,7 @@ class ReplicaSchedulingRequest:
     # These are optional: by default replicas do not have a placement group.
     placement_group_bundles: Optional[List[Dict[str, float]]] = None
     placement_group_strategy: Optional[str] = None
+    max_replicas_per_node: Optional[int] = None
 
 
 @dataclass
@@ -222,9 +224,20 @@ class DeploymentScheduler:
             else:
                 scheduling_strategy = "SPREAD"
 
+            actor_options = copy.copy(replica_scheduling_request.actor_options)
+            if replica_scheduling_request.max_replicas_per_node is not None:
+                if "resources" not in actor_options:
+                    actor_options["resources"] = {}
+                # Using implicit resource (resources that every node
+                # implicitly has and total is 1)
+                # to limit the number of replicas on a single node.
+                actor_options["resources"][
+                    f"{ray._raylet.IMPLICIT_RESOURCE_PREFIX}"
+                    f"{deployment_id.app}:{deployment_id.name}"
+                ] = (1.0 / replica_scheduling_request.max_replicas_per_node)
             actor_handle = replica_scheduling_request.actor_def.options(
                 scheduling_strategy=scheduling_strategy,
-                **replica_scheduling_request.actor_options,
+                **actor_options,
             ).remote(*replica_scheduling_request.actor_init_args)
 
             del self._pending_replicas[deployment_id][pending_replica_name]

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -114,6 +114,7 @@ class DeploymentTargetState:
             ray_actor_options=info.replica_config.ray_actor_options,
             placement_group_bundles=info.replica_config.placement_group_bundles,
             placement_group_strategy=info.replica_config.placement_group_strategy,
+            max_replicas_per_node=info.replica_config.max_replicas_per_node,
         )
 
         return cls(info, num_replicas, version, deleting)
@@ -430,6 +431,9 @@ class ActorReplicaWrapper:
             ),
             placement_group_strategy=(
                 deployment_info.replica_config.placement_group_strategy
+            ),
+            max_replicas_per_node=(
+                deployment_info.replica_config.max_replicas_per_node
             ),
             on_scheduled=self.on_scheduled,
         )

--- a/python/ray/serve/_private/http_state.py
+++ b/python/ray/serve/_private/http_state.py
@@ -122,13 +122,17 @@ class HTTPProxyState:
 
     def _health_check(self):
         """Perform periodic health checks."""
+        assert self._status in {HTTPProxyStatus.HEALTHY, HTTPProxyStatus.DRAINING}
+
         if self._health_check_obj_ref:
             finished, _ = ray.wait([self._health_check_obj_ref], timeout=0)
             if finished:
                 self._health_check_obj_ref = None
                 try:
                     ray.get(finished[0])
-                    self.try_update_status(HTTPProxyStatus.HEALTHY)
+                    # Call to reset _consecutive_health_check_failures
+                    # the status should be unchanged.
+                    self.try_update_status(self._status)
                 except ray.exceptions.RayActorError:
                     # The proxy actor dies.
                     self.set_status(HTTPProxyStatus.UNHEALTHY)

--- a/python/ray/serve/_private/version.py
+++ b/python/ray/serve/_private/version.py
@@ -21,6 +21,7 @@ class DeploymentVersion:
         ray_actor_options: Optional[Dict],
         placement_group_bundles: Optional[List[Dict[str, float]]] = None,
         placement_group_strategy: Optional[str] = None,
+        max_replicas_per_node: Optional[int] = None,
     ):
         if code_version is not None and not isinstance(code_version, str):
             raise TypeError(f"code_version must be str, got {type(code_version)}.")
@@ -37,6 +38,7 @@ class DeploymentVersion:
         self.ray_actor_options = ray_actor_options
         self.placement_group_bundles = placement_group_bundles
         self.placement_group_strategy = placement_group_strategy
+        self.max_replicas_per_node = max_replicas_per_node
         self.compute_hashes()
 
     @classmethod
@@ -63,6 +65,7 @@ class DeploymentVersion:
             or self.ray_actor_options_hash != new_version.ray_actor_options_hash
             or self.placement_group_options_hash
             != new_version.placement_group_options_hash
+            or self.max_replicas_per_node != new_version.max_replicas_per_node
         )
 
     def requires_actor_reconfigure(self, new_version):
@@ -109,6 +112,7 @@ class DeploymentVersion:
             self.code_version.encode("utf-8")
             + serialized_ray_actor_options
             + serialized_placement_group_options
+            + str(self.max_replicas_per_node).encode("utf-8")
             + self._get_serialized_options(
                 [
                     DeploymentOptionUpdateType.NeedsReconfigure,
@@ -129,6 +133,9 @@ class DeploymentVersion:
             placement_group_strategy=self.placement_group_strategy
             if self.placement_group_strategy is not None
             else "",
+            max_replicas_per_node=self.max_replicas_per_node
+            if self.max_replicas_per_node is not None
+            else 0,
         )
 
     @classmethod
@@ -144,6 +151,9 @@ class DeploymentVersion:
             ),
             placement_group_version=(
                 proto.placement_group_version if proto.placement_group_version else None
+            ),
+            max_replicas_per_node=(
+                proto.max_replicas_per_node if proto.max_replicas_per_node else None
             ),
         )
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -306,6 +306,7 @@ def deployment(
     ray_actor_options: Default[Dict] = DEFAULT.VALUE,
     placement_group_bundles: Optional[List[Dict[str, float]]] = DEFAULT.VALUE,
     placement_group_strategy: Optional[str] = DEFAULT.VALUE,
+    max_replicas_per_node: Default[int] = DEFAULT.VALUE,
     user_config: Default[Optional[Any]] = DEFAULT.VALUE,
     max_concurrent_queries: Default[int] = DEFAULT.VALUE,
     autoscaling_config: Default[Union[Dict, AutoscalingConfig, None]] = DEFAULT.VALUE,
@@ -370,6 +371,10 @@ def deployment(
             shut down before being forcefully killed. Defaults to 20s.
         is_driver_deployment: [EXPERIMENTAL] when set, exactly one replica of this
             deployment runs on every node (like a daemon set).
+        max_replicas_per_node: [EXPERIMENTAL] The max number of deployment replicas can
+            run on a single node. Valid values are None (no limitation)
+            or an integer in the range of [1, 100].
+            Defaults to no limitation.
 
     Returns:
         `Deployment`
@@ -443,6 +448,11 @@ def deployment(
             placement_group_strategy=(
                 placement_group_strategy
                 if placement_group_strategy is not DEFAULT.VALUE
+                else None
+            ),
+            max_replicas_per_node=(
+                max_replicas_per_node
+                if max_replicas_per_node is not DEFAULT.VALUE
                 else None
             ),
         )

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -316,6 +316,7 @@ class Deployment:
             ray_actor_options=self._replica_config.ray_actor_options,
             placement_group_bundles=self._replica_config.placement_group_bundles,
             placement_group_strategy=self._replica_config.placement_group_strategy,
+            max_replicas_per_node=self._replica_config.max_replicas_per_node,
         )
 
         return get_global_client().deploy(
@@ -396,6 +397,7 @@ class Deployment:
         ray_actor_options: Default[Optional[Dict]] = DEFAULT.VALUE,
         placement_group_bundles: Optional[List[Dict[str, float]]] = DEFAULT.VALUE,
         placement_group_strategy: Optional[str] = DEFAULT.VALUE,
+        max_replicas_per_node: Optional[int] = DEFAULT.VALUE,
         user_config: Default[Optional[Any]] = DEFAULT.VALUE,
         max_concurrent_queries: Default[int] = DEFAULT.VALUE,
         autoscaling_config: Default[
@@ -494,6 +496,9 @@ class Deployment:
         if placement_group_strategy is DEFAULT.VALUE:
             placement_group_strategy = self._replica_config.placement_group_strategy
 
+        if max_replicas_per_node is DEFAULT.VALUE:
+            max_replicas_per_node = self._replica_config.max_replicas_per_node
+
         if autoscaling_config is not DEFAULT.VALUE:
             new_deployment_config.autoscaling_config = autoscaling_config
 
@@ -523,6 +528,7 @@ class Deployment:
             ray_actor_options=ray_actor_options,
             placement_group_bundles=placement_group_bundles,
             placement_group_strategy=placement_group_strategy,
+            max_replicas_per_node=max_replicas_per_node,
         )
 
         return Deployment(
@@ -652,6 +658,7 @@ def deployment_to_schema(
         "ray_actor_options": ray_actor_options_schema,
         "placement_group_strategy": d._replica_config.placement_group_strategy,
         "placement_group_bundles": d._replica_config.placement_group_bundles,
+        "max_replicas_per_node": d._replica_config.max_replicas_per_node,
         "is_driver_deployment": d._is_driver_deployment,
     }
 
@@ -700,6 +707,11 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
     else:
         placement_group_strategy = s.placement_group_strategy
 
+    if s.max_replicas_per_node is DEFAULT.VALUE:
+        max_replicas_per_node = None
+    else:
+        max_replicas_per_node = s.max_replicas_per_node
+
     if s.is_driver_deployment is DEFAULT.VALUE:
         is_driver_deployment = False
     else:
@@ -726,6 +738,7 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
         ray_actor_options=ray_actor_options,
         placement_group_bundles=placement_group_bundles,
         placement_group_strategy=placement_group_strategy,
+        max_replicas_per_node=max_replicas_per_node,
     )
 
     return Deployment(

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -249,6 +249,16 @@ class DeploymentSchema(BaseModel, allow_population_by_field_name=True):
         ),
     )
 
+    max_replicas_per_node: int = Field(
+        default=DEFAULT.VALUE,
+        description=(
+            "[EXPERIMENTAL] The max number of deployment replicas can "
+            "run on a single node. Valid values are None (no limitation) "
+            "or an integer in the range of [1, 100]. "
+            "Defaults to no limitation."
+        ),
+    )
+
     is_driver_deployment: bool = Field(
         default=DEFAULT.VALUE,
         description="Indicate Whether the deployment is driver deployment "

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -714,6 +714,30 @@ def test_status_package_unavailable_in_controller(ray_start_stop):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
+def test_max_replicas_per_node(ray_start_stop):
+    """Test that max_replicas_per_node can be set via config file."""
+
+    config_file_name = os.path.join(
+        os.path.dirname(__file__), "test_config_files", "max_replicas_per_node.yaml"
+    )
+
+    subprocess.check_output(["serve", "deploy", config_file_name])
+
+    def check_application_status():
+        cli_output = subprocess.check_output(
+            ["serve", "status", "-a", "http://localhost:52365/"]
+        )
+        status = yaml.safe_load(cli_output)["applications"]
+        assert (
+            status["valid"]["status"] == "RUNNING"
+            and status["invalid"]["status"] == "DEPLOY_FAILED"
+        )
+        return True
+
+    wait_for_condition(check_application_status, timeout=15)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
 def test_replica_placement_group_options(ray_start_stop):
     """Test that placement group options can be set via config file."""
 

--- a/python/ray/serve/tests/test_config.py
+++ b/python/ray/serve/tests/test_config.py
@@ -197,6 +197,60 @@ class TestReplicaConfig:
             with pytest.raises(ValueError):
                 ReplicaConfig.create(Class, ray_actor_options={option: None})
 
+    def test_max_replicas_per_node_validation(self):
+        class Class:
+            pass
+
+        ReplicaConfig.create(
+            Class,
+            tuple(),
+            dict(),
+            max_replicas_per_node=5,
+        )
+
+        # Invalid type
+        with pytest.raises(TypeError, match="Get invalid type"):
+            ReplicaConfig.create(
+                Class,
+                tuple(),
+                dict(),
+                max_replicas_per_node="1",
+            )
+
+        # Invalid: not in the range of [1, 100]
+        with pytest.raises(
+            ValueError,
+            match="Valid values are None or an integer in the range of \[1, 100\]",
+        ):
+            ReplicaConfig.create(
+                Class,
+                tuple(),
+                dict(),
+                max_replicas_per_node=0,
+            )
+
+        with pytest.raises(
+            ValueError,
+            match="Valid values are None or an integer in the range of \[1, 100\]",
+        ):
+            ReplicaConfig.create(
+                Class,
+                tuple(),
+                dict(),
+                max_replicas_per_node=110,
+            )
+
+        with pytest.raises(
+            ValueError,
+            match="Valid values are None or an integer in the range of \[1, 100\]",
+        ):
+            ReplicaConfig.create(
+                Class,
+                tuple(),
+                dict(),
+                max_replicas_per_node=-1,
+            )
+
     def test_placement_group_options_validation(self):
         class Class:
             pass

--- a/python/ray/serve/tests/test_config_files/max_replicas_per_node.py
+++ b/python/ray/serve/tests/test_config_files/max_replicas_per_node.py
@@ -1,0 +1,10 @@
+from ray import serve
+
+
+@serve.deployment
+class D:
+    def __call__(self, *args):
+        return "hi"
+
+
+app = D.bind()

--- a/python/ray/serve/tests/test_config_files/max_replicas_per_node.yaml
+++ b/python/ray/serve/tests/test_config_files/max_replicas_per_node.yaml
@@ -1,0 +1,15 @@
+applications:
+  - name: valid
+    route_prefix: /valid
+    import_path: ray.serve.tests.test_config_files.max_replicas_per_node.app
+    deployments:
+      - name: D
+        max_replicas_per_node: 2
+
+  - name: invalid
+    route_prefix: /invalid
+    import_path: ray.serve.tests.test_config_files.max_replicas_per_node.app
+    deployments:
+      - name: D
+        # Non-positive max_replicas_per_node.
+        max_replicas_per_node: 0

--- a/python/ray/serve/tests/test_deployment_version.py
+++ b/python/ray/serve/tests/test_deployment_version.py
@@ -205,6 +205,40 @@ def test_ray_actor_options():
     assert hash(v1) != hash(v3)
 
 
+def test_max_replicas_per_node():
+    v1 = DeploymentVersion("1", DeploymentConfig(), {"num_cpus": 0.1})
+    v2 = DeploymentVersion(
+        "1",
+        DeploymentConfig(),
+        {"num_cpus": 0.1},
+        max_replicas_per_node=1,
+    )
+    v3 = DeploymentVersion(
+        "1",
+        DeploymentConfig(),
+        {"num_cpus": 0.1},
+        max_replicas_per_node=1,
+    )
+    v4 = DeploymentVersion(
+        "1",
+        DeploymentConfig(),
+        {"num_cpus": 0.1},
+        max_replicas_per_node=2,
+    )
+
+    assert v1 != v2
+    assert hash(v1) != hash(v2)
+    assert v1.requires_actor_restart(v2)
+
+    assert v2 == v3
+    assert hash(v2) == hash(v3)
+    assert not v2.requires_actor_restart(v3)
+
+    assert v3 != v4
+    assert hash(v3) != hash(v4)
+    assert v3.requires_actor_restart(v4)
+
+
 def test_placement_group_options():
     v1 = DeploymentVersion("1", DeploymentConfig(), {"num_cpus": 0.1})
     v2 = DeploymentVersion(

--- a/python/ray/serve/tests/test_http_state.py
+++ b/python/ray/serve/tests/test_http_state.py
@@ -850,6 +850,63 @@ def test_update_draining(all_nodes, setup_controller, number_of_worker_nodes):
     )
 
 
+@patch("ray.serve._private.http_state.PROXY_HEALTH_CHECK_PERIOD_S", 0.1)
+def test_proxy_actor_healthy_during_draining():
+    """Test that the proxy will remain DRAINING even if health check succeeds."""
+
+    @ray.remote(num_cpus=0)
+    class NewMockHTTPProxyActor:
+        def __init__(self):
+            self.num_health_checks = 0
+
+        def get_num_health_checks(self) -> int:
+            return self.num_health_checks
+
+        async def ready(self):
+            return json.dumps(["mock_worker_id", "mock_log_file_path"])
+
+        async def check_health(self):
+            self.num_health_checks = self.num_health_checks + 1
+            return "Success!"
+
+        async def update_draining(self, draining, _after):
+            pass
+
+        async def is_drained(self, _after):
+            return False
+
+    proxy_state = _create_http_proxy_state(proxy_actor_class=NewMockHTTPProxyActor)
+
+    # Wait for the proxy to become ready.
+    wait_for_condition(
+        condition_predictor=_update_and_check_proxy_status,
+        state=proxy_state,
+        status=HTTPProxyStatus.HEALTHY,
+    )
+
+    # Drain the proxy.
+    proxy_state.update(draining=True)
+    assert proxy_state.status == HTTPProxyStatus.DRAINING
+
+    cur_num_health_checks = ray.get(
+        proxy_state.actor_handle.get_num_health_checks.remote()
+    )
+
+    def _update_until_two_more_health_checks():
+        # Check 2 more health checks to make sure the proxy state
+        # at least sees the first successful health check.
+        proxy_state.update(draining=True)
+        return (
+            ray.get(proxy_state.actor_handle.get_num_health_checks.remote())
+            == cur_num_health_checks + 2
+        )
+
+    wait_for_condition(_update_until_two_more_health_checks)
+
+    # Make sure the status is still DRAINING not HEALTHY
+    assert proxy_state.status == HTTPProxyStatus.DRAINING
+
+
 @patch("ray.serve._private.http_state.PROXY_HEALTH_CHECK_PERIOD_S", 1)
 @patch("ray.serve._private.http_state.PROXY_DRAIN_CHECK_PERIOD_S", 0.1)
 @pytest.mark.parametrize("number_of_worker_nodes", [1])

--- a/python/ray/serve/tests/test_max_replicas_per_node.py
+++ b/python/ray/serve/tests/test_max_replicas_per_node.py
@@ -1,0 +1,145 @@
+import sys
+from collections import defaultdict
+
+import pytest
+
+import ray
+from ray import serve
+from ray.cluster_utils import AutoscalingCluster
+from ray.util.state import list_actors
+from ray.serve.drivers import DAGDriver
+
+
+def get_node_to_deployment_to_num_replicas():
+    actors = list_actors()
+    print(actors)
+    # {node_id: {deployment_name: num_replicas}}
+    node_to_deployment_to_num_replicas = defaultdict(dict)
+    for actor in actors:
+        if "app#deploy" not in actor["name"] or actor["state"] != "ALIVE":
+            continue
+        deployment_name = None
+        if "deploy1" in actor["name"]:
+            deployment_name = "deploy1"
+        else:
+            assert "deploy2" in actor["name"]
+            deployment_name = "deploy2"
+        node_to_deployment_to_num_replicas[actor["node_id"]][deployment_name] = (
+            node_to_deployment_to_num_replicas[actor["node_id"]].get(deployment_name, 0)
+            + 1
+        )
+
+    return node_to_deployment_to_num_replicas
+
+
+def test_basic():
+    """Test that max_replicas_per_node is honored."""
+
+    cluster = AutoscalingCluster(
+        head_resources={"CPU": 0},
+        worker_node_types={
+            "cpu_node": {
+                "resources": {
+                    "CPU": 9999,
+                },
+                "node_config": {},
+                "min_workers": 0,
+                "max_workers": 100,
+            },
+        },
+    )
+
+    cluster.start()
+    ray.init()
+
+    @serve.deployment
+    class D:
+        def __call__(self):
+            return "hello"
+
+    deployments = {
+        "/deploy1": D.options(
+            num_replicas=6, max_replicas_per_node=3, name="deploy1"
+        ).bind(),
+        "/deploy2": D.options(
+            num_replicas=2, max_replicas_per_node=1, name="deploy2"
+        ).bind(),
+    }
+    serve.run(DAGDriver.bind(deployments), name="app")
+
+    # 2 worker nodes should be started.
+    # Each worker node should run 3 deploy1 replicas
+    # and 1 deploy2 replicas.
+    assert len(ray.nodes()) == 3
+    node_to_deployment_to_num_replicas = get_node_to_deployment_to_num_replicas()
+
+    assert len(node_to_deployment_to_num_replicas) == 2
+    for _, deployment_to_num_replicas in node_to_deployment_to_num_replicas.items():
+        assert deployment_to_num_replicas["deploy1"] == 3
+        assert deployment_to_num_replicas["deploy2"] == 1
+
+    serve.shutdown()
+    ray.shutdown()
+    cluster.shutdown()
+
+
+def test_update_max_replicas_per_node():
+    """Test re-deploying a deployment with different max_replicas_per_node."""
+
+    cluster = AutoscalingCluster(
+        head_resources={"CPU": 0},
+        worker_node_types={
+            "cpu_node": {
+                "resources": {
+                    "CPU": 9999,
+                },
+                "node_config": {},
+                "min_workers": 0,
+                "max_workers": 100,
+            },
+        },
+    )
+
+    cluster.start()
+    ray.init()
+
+    @serve.deployment
+    class D:
+        def __call__(self):
+            return "hello"
+
+    # Requires 2 worker nodes.
+    serve.run(
+        D.options(num_replicas=3, max_replicas_per_node=2, name="deploy1").bind(),
+        name="app",
+    )
+
+    assert len(ray.nodes()) == 3
+    node_to_deployment_to_num_replicas = get_node_to_deployment_to_num_replicas()
+
+    assert len(node_to_deployment_to_num_replicas) == 2
+    # One node has 2 replicas and the other has 1 replica.
+    for _, deployment_to_num_replicas in node_to_deployment_to_num_replicas.items():
+        assert deployment_to_num_replicas["deploy1"] in {1, 2}
+
+    # Redeploy, requires 3 worker nodes.
+    serve.run(
+        D.options(num_replicas=3, max_replicas_per_node=1, name="deploy1").bind(),
+        name="app",
+    )
+
+    assert len(ray.nodes()) == 4
+    node_to_deployment_to_num_replicas = get_node_to_deployment_to_num_replicas()
+
+    assert len(node_to_deployment_to_num_replicas) == 3
+    for _, deployment_to_num_replicas in node_to_deployment_to_num_replicas.items():
+        # Every node has 1 replica.
+        assert deployment_to_num_replicas["deploy1"] == 1
+
+    serve.shutdown()
+    ray.shutdown()
+    cluster.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -824,7 +824,7 @@ def test_implicit_resource(ray_start_regular):
     assert actors[0]["state"] == "PENDING_CREATION"
 
 
-def test_implicit_resource_autoscaling():
+def test_implicit_resource_autoscaling(shutdown_only):
     from ray.cluster_utils import AutoscalingCluster
 
     cluster = AutoscalingCluster(

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -160,6 +160,7 @@ message DeploymentVersion {
   string ray_actor_options = 3;
   string placement_group_bundles = 4;
   string placement_group_strategy = 5;
+  int32 max_replicas_per_node = 6;
 }
 
 message ReplicaConfig {
@@ -170,6 +171,7 @@ message ReplicaConfig {
   string ray_actor_options = 5;
   string placement_group_bundles = 6;
   string placement_group_strategy = 7;
+  int32 max_replicas_per_node = 8;
 }
 
 message DeploymentInfo {


### PR DESCRIPTION
Add a max_replicas_per_node replica config: this allows users to config how many replicas to lose for a node failure.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Cherry pick #38766
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
