### PR TITLE
[train][rllib] temporarily disable new persistence mode for rllib tests

### DIFF
--- a/.buildkite/pipeline.build_py37.yml
+++ b/.buildkite/pipeline.build_py37.yml
@@ -73,7 +73,9 @@
     - pip install -r python/requirements/compat/requirements_py37_compat.txt
     - ./ci/env/env_info.sh
     - ./ci/run/run_bazel_test_with_sharding.sh --config=ci $(./ci/run/bazel_export_options) --build_tests_only
-      --test_tag_filters=tests_dir,-multi_gpu --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 rllib/...
+      --test_tag_filters=tests_dir,-multi_gpu --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
+      rllib/...
 
 
 - label: ":cold_face: :python: :brain: Python 3.7 RLlib: Learning tests Pytorch (With Ray Data)"

--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -124,6 +124,7 @@
       --build_tests_only
       --test_tag_filters=fake_gpus,-torch_only,-tf2_only,-no_tf_static_graph,-multi_gpu
       --test_arg=--framework=tf
+      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
       rllib/...
 
 # TODO: (sven) tf2 (eager) multi-GPU
@@ -222,7 +223,9 @@
     - ./ci/run/run_bazel_test_with_sharding.sh --config=ci $(./ci/run/bazel_export_options)
       --build_tests_only
       --test_tag_filters=-learning_tests,-memory_leak_tests,-examples,-tests_dir,-documentation,-multi_gpu,-no_cpu,-torch_2.x_only_benchmark
-      --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 rllib/...
+      --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 
+      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
+      rllib/...
 
 - label: ":brain: RLlib: RLModule tests"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_DIRECTLY_AFFECTED"]
@@ -260,7 +263,9 @@
     - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
     - ./ci/env/env_info.sh
     - ./ci/run/run_bazel_test_with_sharding.sh --config=ci $(./ci/run/bazel_export_options) --build_tests_only
-      --test_tag_filters=tests_dir,-multi_gpu --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 rllib/...
+      --test_tag_filters=tests_dir,-multi_gpu --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
+      rllib/...
 
 - label: ":brain: RLlib: Documentation code/examples"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_DIRECTLY_AFFECTED"]
@@ -271,6 +276,7 @@
     - ./ci/env/env_info.sh
     - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only
       --test_tag_filters=documentation --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+      --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=0
       rllib/...
 
 - label: ":octopus: Tune tests and examples (small)"

--- a/rllib/__init__.py
+++ b/rllib/__init__.py
@@ -42,6 +42,7 @@ _setup_logger()
 
 usage_lib.record_library_usage("rllib")
 
+
 __all__ = [
     "Policy",
     "TFPolicy",

--- a/rllib/__init__.py
+++ b/rllib/__init__.py
@@ -42,7 +42,6 @@ _setup_logger()
 
 usage_lib.record_library_usage("rllib")
 
-
 __all__ = [
     "Policy",
     "TFPolicy",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This flag was enabled by default in https://github.com/ray-project/ray/pull/38844, but did not trigger the CI for these in the PR.

This PR updates the tests that have been failing in master to disable the flag. 

The flag will be re-enabled for these tests in future PRs, e.g. https://github.com/ray-project/ray/pull/38947.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
See https://buildkite.com/ray-project/oss-ci-build-pr/builds/33969

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
