### PR TITLE
[Serve] Make DeploymentScheduler an ABC with a default implementation

### DIFF
--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -1,6 +1,19 @@
-from ray.serve._private.cluster_node_info_cache import DefaultClusterNodeInfoCache
+from ray.serve._private.cluster_node_info_cache import (
+    ClusterNodeInfoCache,
+    DefaultClusterNodeInfoCache,
+)
+from ray.serve._private.deployment_scheduler import (
+    DeploymentScheduler,
+    DefaultDeploymentScheduler,
+)
 from ray._raylet import GcsClient
 
 
-def create_cluster_node_info_cache(gcs_client: GcsClient):
+def create_cluster_node_info_cache(gcs_client: GcsClient) -> ClusterNodeInfoCache:
     return DefaultClusterNodeInfoCache(gcs_client)
+
+
+def create_deployment_scheduler(
+    cluster_node_info_cache: ClusterNodeInfoCache,
+) -> DeploymentScheduler:
+    return DefaultDeploymentScheduler(cluster_node_info_cache)

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -56,14 +56,15 @@ from ray.serve._private.utils import (
     check_obj_ref_ready_nowait,
 )
 from ray.serve._private.version import DeploymentVersion, VersionedReplica
-from ray.serve._private import deployment_scheduler
 from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
 from ray.serve._private.deployment_scheduler import (
     SpreadDeploymentSchedulingPolicy,
     DriverDeploymentSchedulingPolicy,
     ReplicaSchedulingRequest,
     DeploymentDownscaleRequest,
+    DeploymentScheduler,
 )
+from ray.serve._private import default_impl
 from ray.serve import metrics
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -1158,7 +1159,7 @@ class DeploymentState:
         controller_name: str,
         detached: bool,
         long_poll_host: LongPollHost,
-        deployment_scheduler: deployment_scheduler.DeploymentScheduler,
+        deployment_scheduler: DeploymentScheduler,
         cluster_node_info_cache: ClusterNodeInfoCache,
         _save_checkpoint_func: Callable,
     ):
@@ -2128,7 +2129,7 @@ class DriverDeploymentState(DeploymentState):
         controller_name: str,
         detached: bool,
         long_poll_host: LongPollHost,
-        deployment_scheduler: deployment_scheduler.DeploymentScheduler,
+        deployment_scheduler: DeploymentScheduler,
         cluster_node_info_cache: ClusterNodeInfoCache,
         _save_checkpoint_func: Callable,
     ):
@@ -2276,7 +2277,7 @@ class DeploymentStateManager:
         self._kv_store = kv_store
         self._long_poll_host = long_poll_host
         self._cluster_node_info_cache = cluster_node_info_cache
-        self._deployment_scheduler = deployment_scheduler.DeploymentScheduler(
+        self._deployment_scheduler = default_impl.create_deployment_scheduler(
             cluster_node_info_cache
         )
 

--- a/python/ray/serve/tests/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/test_deployment_scheduler.py
@@ -7,7 +7,7 @@ from ray._raylet import GcsClient
 from ray.tests.conftest import *  # noqa
 from ray.serve._private.common import DeploymentID
 from ray.serve._private.deployment_scheduler import (
-    DeploymentScheduler,
+    DefaultDeploymentScheduler,
     SpreadDeploymentSchedulingPolicy,
     DriverDeploymentSchedulingPolicy,
     ReplicaSchedulingRequest,
@@ -51,7 +51,7 @@ def test_spread_deployment_scheduling_policy_upscale(
     )
     cluster_node_info_cache.update()
 
-    scheduler = DeploymentScheduler(cluster_node_info_cache)
+    scheduler = DefaultDeploymentScheduler(cluster_node_info_cache)
     dep_id = DeploymentID("deployment1", "default")
     scheduler.on_deployment_created(dep_id, SpreadDeploymentSchedulingPolicy())
     replica_actor_handles = []
@@ -139,7 +139,7 @@ def test_spread_deployment_scheduling_policy_downscale_multiple_deployments(
     )
     cluster_node_info_cache.update()
 
-    scheduler = DeploymentScheduler(cluster_node_info_cache)
+    scheduler = DefaultDeploymentScheduler(cluster_node_info_cache)
     d1_id = DeploymentID("deployment1", "default")
     d2_id = DeploymentID("deployment2", "default")
     scheduler.on_deployment_created(d1_id, SpreadDeploymentSchedulingPolicy())
@@ -206,7 +206,7 @@ def test_spread_deployment_scheduling_policy_downscale_single_deployment(
     )
     cluster_node_info_cache.update()
 
-    scheduler = DeploymentScheduler(cluster_node_info_cache)
+    scheduler = DefaultDeploymentScheduler(cluster_node_info_cache)
     dep_id = DeploymentID("deployment1", "my_app")
     scheduler.on_deployment_created(dep_id, SpreadDeploymentSchedulingPolicy())
     scheduler.on_replica_running(dep_id, "replica1", "node1")
@@ -289,7 +289,7 @@ def test_spread_deployment_scheduling_policy_downscale_head_node(ray_start_clust
     )
     cluster_node_info_cache.update()
 
-    scheduler = DeploymentScheduler(cluster_node_info_cache)
+    scheduler = DefaultDeploymentScheduler(cluster_node_info_cache)
     dep_id = DeploymentID("deployment1", "my_app")
     scheduler.on_deployment_created(dep_id, SpreadDeploymentSchedulingPolicy())
     scheduler.on_replica_running(dep_id, "replica1", head_node_id)
@@ -342,7 +342,7 @@ def test_driver_deployment_scheduling_policy_upscale(ray_start_cluster):
     )
     cluster_node_info_cache.update()
 
-    scheduler = DeploymentScheduler(cluster_node_info_cache)
+    scheduler = DefaultDeploymentScheduler(cluster_node_info_cache)
     dep_id = DeploymentID("deployment1", "my_app")
     scheduler.on_deployment_created(dep_id, DriverDeploymentSchedulingPolicy())
 

--- a/python/ray/serve/tests/test_deployment_state.py
+++ b/python/ray/serve/tests/test_deployment_state.py
@@ -2245,9 +2245,8 @@ def mock_deployment_state_manager_full(
         "ray.serve._private.deployment_state.ActorReplicaWrapper",
         new=MockReplicaActorWrapper,
     ), patch(
-        "ray.serve._private.deployment_scheduler.DeploymentScheduler",
-        new=MockDeploymentScheduler,
-    ), patch(
+        "ray.serve._private.default_impl.create_deployment_scheduler",
+    ) as mock_create_deployment_scheduler, patch(
         "time.time", new=timer.time
     ), patch(
         "ray.serve._private.long_poll.LongPollHost"
@@ -2266,6 +2265,10 @@ def mock_deployment_state_manager_full(
 
             if placement_group_names is None:
                 placement_group_names = []
+
+            mock_create_deployment_scheduler.return_value = MockDeploymentScheduler(
+                cluster_node_info_cache
+            )
 
             return DeploymentStateManager(
                 "name",
@@ -2494,9 +2497,8 @@ def mock_deployment_state_manager(request) -> Tuple[DeploymentStateManager, Mock
         "ray.serve._private.deployment_state.ActorReplicaWrapper",
         new=MockReplicaActorWrapper,
     ), patch(
-        "ray.serve._private.deployment_scheduler.DeploymentScheduler",
-        new=MockDeploymentScheduler,
-    ), patch(
+        "ray.serve._private.default_impl.create_deployment_scheduler",
+    ) as mock_create_deployment_scheduler, patch(
         "time.time", new=timer.time
     ), patch(
         "ray.serve._private.long_poll.LongPollHost"
@@ -2504,6 +2506,9 @@ def mock_deployment_state_manager(request) -> Tuple[DeploymentStateManager, Mock
 
         kv_store = RayInternalKVStore("test")
         cluster_node_info_cache = MockClusterNodeInfoCache()
+        mock_create_deployment_scheduler.return_value = MockDeploymentScheduler(
+            cluster_node_info_cache
+        )
         all_current_actor_names = []
         all_current_placement_group_names = []
         deployment_state_manager = DeploymentStateManager(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Make DeploymentScheduler an ABC with a default implementation
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
