### PR TITLE
[Core] Raise TaskCancelledError instead of `RayTaskError` when a task is cancelled in the middle of execution

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -143,7 +143,9 @@ class RayTaskError(RayError):
         if issubclass(RayTaskError, cause_cls):
             return self  # already satisfied
 
-        if issubclass(cause_cls, RayError):
+        if issubclass(cause_cls, RayError) and not issubclass(
+            cause_cls, TaskCancelledError
+        ):
             return self  # don't try to wrap ray internal errors
 
         error_msg = str(self)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Right now, due to a bug where the subclass of RayError is considered as `RayTaskError` (although other exceptions are converted to the original error), If a task is cancelled in the middle of execution, Ray raises `RayTaskError` instead of `TaskCancelledError`.

This PR fixes the issue by not raising `RayTaskError` when `TaskCancelledError` is the original exception raised from a task

## Related issue number

https://github.com/ray-project/ray/pull/38973

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
