### PR TITLE
[RLlib] DreamerV3: Fix forward_inference bug due to OneHotCategorical int32 type.

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2575,6 +2575,7 @@ class Algorithm(Trainable, AlgorithmBase):
             state["train_exec_impl"] = self.train_exec_impl.shared_metrics.get().save()
         else:
             state["counters"] = self._counters
+        state["training_iteration"] = self.training_iteration
 
         return state
 
@@ -2630,6 +2631,8 @@ class Algorithm(Trainable, AlgorithmBase):
             self.train_exec_impl.shared_metrics.get().restore(state["train_exec_impl"])
         elif "counters" in state:
             self._counters = state["counters"]
+
+        self._iteration = state.get("training_iteration", 0)
 
     @staticmethod
     def _checkpoint_info_to_algorithm_state(

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2632,7 +2632,8 @@ class Algorithm(Trainable, AlgorithmBase):
         elif "counters" in state:
             self._counters = state["counters"]
 
-        self._iteration = state.get("training_iteration", 0)
+        if "training_iteration" in state:
+            self._iteration = state["training_iteration"]
 
     @staticmethod
     def _checkpoint_info_to_algorithm_state(

--- a/rllib/algorithms/dreamerv3/tf/models/actor_network.py
+++ b/rllib/algorithms/dreamerv3/tf/models/actor_network.py
@@ -149,7 +149,7 @@ class ActorNetwork(tf.keras.Model):
             distr_params = action_logits
             distr = self.get_action_dist_object(distr_params)
 
-            action = tf.cast(tf.stop_gradient(distr.sample()), tf.float32) + (
+            action = tf.stop_gradient(distr.sample()) + (
                 action_probs - tf.stop_gradient(action_probs)
             )
 
@@ -187,7 +187,10 @@ class ActorNetwork(tf.keras.Model):
         """
         if isinstance(self.action_space, gym.spaces.Discrete):
             # Create the distribution object using the unimix'd logits.
-            distr = tfp.distributions.OneHotCategorical(logits=action_dist_params_T_B)
+            distr = tfp.distributions.OneHotCategorical(
+                logits=action_dist_params_T_B,
+                dtype=tf.float32,
+            )
 
         elif isinstance(self.action_space, gym.spaces.Box):
             # Compute Normal distribution from action_logits and std_logits

--- a/rllib/algorithms/dreamerv3/tf/models/actor_network.py
+++ b/rllib/algorithms/dreamerv3/tf/models/actor_network.py
@@ -108,8 +108,6 @@ class ActorNetwork(tf.keras.Model):
             h: The deterministic hidden state of the sequence model. [B, dim(h)].
             z: The stochastic discrete representations of the original
                 observation input. [B, num_categoricals, num_classes].
-            return_distr_params: Whether to return (as a second tuple item) the action
-                distribution parameter tensor created by the policy.
         """
         # Flatten last two dims of z.
         assert len(z.shape) == 3

--- a/rllib/algorithms/dreamerv3/tf/models/components/reward_predictor.py
+++ b/rllib/algorithms/dreamerv3/tf/models/components/reward_predictor.py
@@ -90,8 +90,6 @@ class RewardPredictor(tf.keras.Model):
             h: The deterministic hidden state of the sequence model. [B, dim(h)].
             z: The stochastic discrete representations of the original
                 observation input. [B, num_categoricals, num_classes].
-            return_logits: Whether to return the logits over the reward buckets
-                as a second return value (besides the expected reward).
         """
         # Flatten last two dims of z.
         assert len(z.shape) == 3

--- a/rllib/algorithms/dreamerv3/tf/models/dreamer_model.py
+++ b/rllib/algorithms/dreamerv3/tf/models/dreamer_model.py
@@ -181,9 +181,7 @@ class DreamerModel(tf.keras.Model):
             is_first=is_first,
         )
         # Compute action using our actor network and the current states.
-        _, distr_params = self.actor(
-            h=states["h"], z=states["z"], return_distr_params=True
-        )
+        _, distr_params = self.actor(h=states["h"], z=states["z"])
         # Use the mode of the distribution (Discrete=argmax, Normal=mean).
         distr = self.actor.get_action_dist_object(distr_params)
         actions = distr.mode()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

DreamerV3: Fix forward_inference bug due to OneHotCategorical int32 type.

The forward_inference call on DreamerV3's RLModule does not work if simply the last action output (sampled from a OneHotCategorical int32) is being used in the internal state. The dtypes won't match (h-state: float32, a=one-hot vector w/ int32).

A workaround would be to cast the previous (one-hot) actions to float32 before sending them in the internal state input back into the model (for next action computation).
Also, this affects only discrete action spaces.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
