### PR TITLE
[data] Optimization to reduce ArrowBlock building time for blocks of size 1 #38833 

### DIFF
--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -51,6 +51,11 @@ def convert_udf_returns_to_numpy(udf_return_col: Any) -> Any:
         return udf_return_col
 
     if isinstance(udf_return_col, list):
+        if len(udf_return_col) == 1 and isinstance(udf_return_col[0], np.ndarray):
+            # Optimization to avoid conversion overhead from list to np.array.
+            udf_return_col = np.expand_dims(udf_return_col[0], axis=0)
+            return udf_return_col
+
         # Try to convert list values into an numpy array via
         # np.array(), so users don't need to manually cast.
         # NOTE: we don't cast generic iterables, since types like


### PR DESCRIPTION
Many Data ops depend on converting numpy batches to Arrow blocks. A single np array -> pyarrow is normally zero-copy, but blocks with multiple rows will need a copy to make the column of np arrays into one contiguous ndarray. This PR avoids this step for blocks of a single row by using np.expand_dims to reshape the array instead of copying it.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
