### PR TITLE
[serve] use get_global_client() to get serve client in release tests

### DIFF
--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -57,12 +57,12 @@ def setup_anyscale_cluster():
         # to reduce spam.
         runtime_env={"env_vars": {"SERVE_ENABLE_SCALING_LOG": "0"}},
     )
-    serve_client = serve.start(http_options={"location": DeploymentMode.EveryNode})
+    serve.start(http_options={"location": DeploymentMode.EveryNode})
 
     # Print memory usage on the head node to help diagnose/debug memory leaks.
     monitor_memory_usage()
 
-    return serve_client
+    return get_global_client()
 
 
 @ray.remote

--- a/release/serve_tests/workloads/serve_test_cluster_utils.py
+++ b/release/serve_tests/workloads/serve_test_cluster_utils.py
@@ -57,7 +57,7 @@ def setup_anyscale_cluster():
         # to reduce spam.
         runtime_env={"env_vars": {"SERVE_ENABLE_SCALING_LOG": "0"}},
     )
-    serve.start(http_options={"location": DeploymentMode.EveryNode})
+    serve.start(proxy_location=DeploymentMode.EveryNode)
 
     # Print memory usage on the head node to help diagnose/debug memory leaks.
     monitor_memory_usage()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With the recent api changes `serve.start` no longer returns serve client. Use `get_global_client()` for release tests running on anyscale platform.

## Related issue number

Closes:
- https://github.com/ray-project/ray/issues/38989
- https://github.com/ray-project/ray/issues/38990
- https://github.com/ray-project/ray/issues/38991
- https://github.com/ray-project/ray/issues/38992
- https://github.com/ray-project/ray/issues/38993

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
