### PR TITLE
[data][fault tolerance] Do not eagerly free root RefBundles

### DIFF
--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -220,7 +220,10 @@ def _blocks_to_input_buffer(blocks: BlockList, owns_blocks: bool) -> PhysicalOpe
                             cleaned_metadata(read_task),
                         )
                     ],
-                    owns_blocks=True,
+                    # `owns_blocks` is False, because these refs are the root of the
+                    # DAG. We shouldn't eagerly free them. Otherwise, the DAG cannot
+                    # be reconstructed.
+                    owns_blocks=False,
                 )
                 for read_task in read_tasks
             ]

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -93,25 +93,24 @@ def plan_read_op(op: Read) -> PhysicalOperator:
     See Planner.plan() for more details.
     """
 
-    def get_input_data() -> List[RefBundle]:
-        read_tasks = op._reader.get_read_tasks(op._parallelism)
-        return [
-            RefBundle(
-                [
-                    (
-                        # TODO(chengsu): figure out a better way to pass read
-                        # tasks other than ray.put().
-                        ray.put(read_task),
-                        cleaned_metadata(read_task),
-                    )
-                ],
-                owns_blocks=True,
-            )
-            for read_task in read_tasks
-        ]
+    read_tasks = op._reader.get_read_tasks(op._parallelism)
+    input_data = [
+        RefBundle(
+            [
+                (
+                    # TODO(chengsu): figure out a better way to pass read
+                    # tasks other than ray.put().
+                    ray.put(read_task),
+                    cleaned_metadata(read_task),
+                )
+            ],
+            owns_blocks=True,
+        )
+        for read_task in read_tasks
+    ]
 
     inputs = InputDataBuffer(
-        input_data_factory=get_input_data, num_output_blocks=op._estimated_num_blocks
+        input_data=input_data, num_output_blocks=op._estimated_num_blocks
     )
 
     def do_read(blocks: Iterable[ReadTask], _: TaskContext) -> Iterable[Block]:

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -105,7 +105,7 @@ def plan_read_op(op: Read) -> PhysicalOperator:
                         cleaned_metadata(read_task),
                     )
                 ],
-                owns_blocks=True,
+                owns_blocks=False,
             )
             for read_task in read_tasks
         ]

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -105,6 +105,9 @@ def plan_read_op(op: Read) -> PhysicalOperator:
                         cleaned_metadata(read_task),
                     )
                 ],
+                # `owns_blocks` is False, because these refs are the root of the DAG.
+                # We shouldn't eagerly free them. Otherwise, the DAG cannot be
+                # reconstructed.
                 owns_blocks=False,
             )
             for read_task in read_tasks

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -105,9 +105,9 @@ def plan_read_op(op: Read) -> PhysicalOperator:
                         cleaned_metadata(read_task),
                     )
                 ],
-                # `owns_blocks` is False, because these refs are the root of the DAG.
-                # We shouldn't eagerly free them. Otherwise, the DAG cannot be
-                # reconstructed.
+                # `owns_blocks` is False, because these refs are the root of the
+                # DAG. We shouldn't eagerly free them. Otherwise, the DAG cannot
+                # be reconstructed.
                 owns_blocks=False,
             )
             for read_task in read_tasks

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -93,24 +93,25 @@ def plan_read_op(op: Read) -> PhysicalOperator:
     See Planner.plan() for more details.
     """
 
-    read_tasks = op._reader.get_read_tasks(op._parallelism)
-    input_data = [
-        RefBundle(
-            [
-                (
-                    # TODO(chengsu): figure out a better way to pass read
-                    # tasks other than ray.put().
-                    ray.put(read_task),
-                    cleaned_metadata(read_task),
-                )
-            ],
-            owns_blocks=True,
-        )
-        for read_task in read_tasks
-    ]
+    def get_input_data() -> List[RefBundle]:
+        read_tasks = op._reader.get_read_tasks(op._parallelism)
+        return [
+            RefBundle(
+                [
+                    (
+                        # TODO(chengsu): figure out a better way to pass read
+                        # tasks other than ray.put().
+                        ray.put(read_task),
+                        cleaned_metadata(read_task),
+                    )
+                ],
+                owns_blocks=True,
+            )
+            for read_task in read_tasks
+        ]
 
     inputs = InputDataBuffer(
-        input_data=input_data, num_output_blocks=op._estimated_num_blocks
+        input_data_factory=get_input_data, num_output_blocks=op._estimated_num_blocks
     )
 
     def do_read(blocks: Iterable[ReadTask], _: TaskContext) -> Iterable[Block]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix the issue that we eagerly free the root RefBundles. This bug broke fault tolerance.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
