### PR TITLE
[train] enable train + tune tests and examples

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -48,13 +48,13 @@
       python/ray/train/...
 
 - label: ":steam_locomotive: :octopus: Train + Tune tests and examples"
- conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
- instance_size: medium
- commands:
-   - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-   - TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh
-   - ./ci/env/env_info.sh
-   - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=tune,-gpu_only,-ray_air,-gpu,-doctest python/ray/train/...
+  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
+  instance_size: medium
+  commands:
+    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+    - TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh
+    - ./ci/env/env_info.sh
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=tune,-gpu_only,-ray_air,-gpu,-doctest python/ray/train/...
 
 
 - label: ":brain: RLlib: Benchmarks (Torch 2.x)"

--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -47,16 +47,14 @@
       --test_tag_filters=-gpu_only,-gpu,-minimal,-tune,-doctest
       python/ray/train/...
 
-
-# Currently empty test suite
-#- label: ":steam_locomotive: :octopus: Train + Tune tests and examples"
-#  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
-#  instance_size: medium
-#  commands:
-#    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-#    - TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh
-#    - ./ci/env/env_info.sh
-#    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=tune,-gpu_only,-ray_air,-gpu,-doctest,-new_storage python/ray/train/...
+- label: ":steam_locomotive: :octopus: Train + Tune tests and examples"
+ conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
+ instance_size: medium
+ commands:
+   - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+   - TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh
+   - ./ci/env/env_info.sh
+   - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=tune,-gpu_only,-ray_air,-gpu,-doctest python/ray/train/...
 
 
 - label: ":brain: RLlib: Benchmarks (Torch 2.x)"
@@ -360,19 +358,6 @@
 
 
 ##### STORAGE REFACTOR
-
-# TODO(krfricke): Add new test for this suite
-# - label: ":steam_locomotive: :octopus: :floppy_disk: New persistence mode: Train + Tune tests and examples"
-#   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
-#   instance_size: medium
-#   commands:
-#     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-#     - TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh
-#     - ./ci/env/env_info.sh
-#     - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only 
-#       --test_tag_filters=tune,-gpu_only,-ray_air,-gpu,-doctest,-no_new_storage
-#       --test_env=RAY_AIR_NEW_PERSISTENCE_MODE=1
-#       python/ray/train/...
 
 
 - label: ":octopus: :floppy_disk: New persistence mode: Tune tests and examples (small)"

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -32,6 +32,7 @@ from ray.air.result import Result
 
 usage_lib.record_library_usage("train")
 
+
 __all__ = [
     "get_checkpoint",
     "get_context",

--- a/python/ray/train/tests/test_tune.py
+++ b/python/ray/train/tests/test_tune.py
@@ -219,7 +219,12 @@ def test_retry_with_max_failures(ray_start_4_cpus):
     assert len(df[TRAINING_ITERATION]) == 4
 
 
-def test_restore_with_new_trainer(ray_start_4_cpus, tmpdir, propagate_logs, caplog):
+def test_restore_with_new_trainer(
+    ray_start_4_cpus, tmpdir, propagate_logs, caplog, monkeypatch
+):
+
+    monkeypatch.setenv("RAY_AIR_LOCAL_CACHE_DIR", str(tmpdir))
+
     def train_func(config):
         raise RuntimeError("failing!")
 
@@ -227,7 +232,7 @@ def test_restore_with_new_trainer(ray_start_4_cpus, tmpdir, propagate_logs, capl
         train_func,
         backend_config=TestConfig(),
         scaling_config=ScalingConfig(num_workers=1),
-        run_config=RunConfig(local_dir=str(tmpdir), name="restore_new_trainer"),
+        run_config=RunConfig(name="restore_new_trainer"),
         datasets={"train": ray.data.from_items([{"a": i} for i in range(10)])},
     )
     results = Tuner(trainer).fit()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
1. Combines `:steam_locomotive: :octopus: Train + Tune tests and examples` and `:steam_locomotive: :octopus: :floppy_disk: New persistence mode: Train + Tune tests and examples` into one suite again that always has the new persistence path.
2. Enable the tests.
3. Fixes the test to use `RAY_AIR_LOCAL_CACHE_DIR` instead of `RunConfig.local_dir`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

Successful run [here](https://buildkite.com/ray-project/oss-ci-build-pr/builds/34150#018a3f0b-a48c-4181-82fe-d87464ddd866).

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
