### PR TITLE
Skip Task Profile/Traceback unit tests #38881

### DIFF
--- a/dashboard/modules/reporter/tests/test_reporter.py
+++ b/dashboard/modules/reporter/tests/test_reporter.py
@@ -696,13 +696,15 @@ def test_reporter_worker_cpu_percent():
             agent_mock.kill()
 
 
-TASK = {
-    "task_id": "32d950ec0ccf9d2affffffffffffffffffffffff01000000",
-    "attempt_number": 0,
-    "node_id": "ffffffffffffffffffffffffffffffffffffffff01000000",
-}
-
-
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
+@pytest.mark.skipif(sys.platform == "win32", reason="No py-spy on Windows.")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Fails on OSX: https://github.com/ray-project/ray/issues/30114",
+)
 def test_get_task_traceback_running_task(shutdown_only):
     """
     Verify that we throw an error for a non-running task.
@@ -741,6 +743,22 @@ def test_get_task_traceback_running_task(shutdown_only):
     wait_for_condition(verify, timeout=20)
 
 
+TASK = {
+    "task_id": "32d950ec0ccf9d2affffffffffffffffffffffff01000000",
+    "attempt_number": 0,
+    "node_id": "ffffffffffffffffffffffffffffffffffffffff01000000",
+}
+
+
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
+@pytest.mark.skipif(sys.platform == "win32", reason="No py-spy on Windows.")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Fails on OSX: https://github.com/ray-project/ray/issues/30114",
+)
 def test_get_task_traceback_non_running_task(shutdown_only):
     """
     Verify that we throw an error for a non-running task.
@@ -776,6 +794,15 @@ def test_get_task_traceback_non_running_task(shutdown_only):
     wait_for_condition(verify, timeout=10)
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
+@pytest.mark.skipif(sys.platform == "win32", reason="No py-spy on Windows.")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Fails on OSX: https://github.com/ray-project/ray/issues/30114",
+)
 def test_get_cpu_profile_non_running_task(shutdown_only):
     """
     Verify that we throw an error for a non-running task.


### PR DESCRIPTION
The test cases for task profile not works for macbook. Add `pytest.skipif` to avoid the test cases
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Pick of https://github.com/ray-project/ray/pull/38881

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
