### PR TITLE
[Test] Move implicit resource tests to its own file (#39013)

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -179,6 +179,7 @@ py_test_module_list(
     "test_streaming_generator_2.py",
     "test_streaming_generator_3.py",
     "test_scheduling_performance.py",
+    "test_implicit_resource.py",
   ],
   size = "medium",
   tags = ["exclusive", "medium_size_python_tests_k_to_z", "team:core"],

--- a/python/ray/tests/test_implicit_resource.py
+++ b/python/ray/tests/test_implicit_resource.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import time
+
+import ray
+from ray.util.state import list_actors
+
+
+def test_implicit_resource(ray_start_regular):
+    @ray.remote(num_cpus=1, resources={ray._raylet.IMPLICIT_RESOURCE_PREFIX + "a": 1})
+    class Actor:
+        def ping(self):
+            return ray.get_runtime_context().get_node_id()
+
+    # The first actor is schedulable.
+    a1 = Actor.remote()
+    ray.get(a1.ping.remote())
+
+    # The second actor will be pending since
+    # only one such actor can run on a single node.
+    a2 = Actor.remote()
+    time.sleep(2)
+    actors = list_actors(filters=[("actor_id", "=", a2._actor_id.hex())])
+    assert actors[0]["state"] == "PENDING_CREATION"
+
+
+def test_implicit_resource_autoscaling(shutdown_only):
+    from ray.cluster_utils import AutoscalingCluster
+
+    cluster = AutoscalingCluster(
+        head_resources={"CPU": 0},
+        worker_node_types={
+            "cpu_node": {
+                "resources": {
+                    "CPU": 8,
+                },
+                "node_config": {},
+                "min_workers": 1,
+                "max_workers": 100,
+            },
+        },
+    )
+
+    cluster.start()
+    ray.init()
+
+    @ray.remote(num_cpus=1, resources={ray._raylet.IMPLICIT_RESOURCE_PREFIX + "a": 0.5})
+    class Actor:
+        def ping(self):
+            return ray.get_runtime_context().get_node_id()
+
+    actors = [Actor.remote() for _ in range(2)]
+    for actor in actors:
+        ray.get(actor.ping.remote())
+
+    # No new worker nodes should be started.
+    assert len(ray.nodes()) == 2
+
+    # 3 more worker nodes should be started.
+    actors.extend([Actor.remote() for _ in range(5)])
+    node_id_to_num_actors = {}
+    for actor in actors:
+        node_id = ray.get(actor.ping.remote())
+        node_id_to_num_actors[node_id] = node_id_to_num_actors.get(node_id, 0) + 1
+    assert len(ray.nodes()) == 5
+    assert len(node_id_to_num_actors) == 4
+    num_actors_per_node = list(node_id_to_num_actors.values())
+    num_actors_per_node.sort()
+    assert num_actors_per_node == [1, 2, 2, 2]
+
+    cluster.shutdown()
+
+
+if __name__ == "__main__":
+    import pytest
+
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -21,7 +21,6 @@ from ray.util.scheduling_strategies import (
     NodeAffinitySchedulingStrategy,
     PlacementGroupSchedulingStrategy,
 )
-from ray.util.state import list_actors
 
 
 @pytest.mark.skipif(
@@ -804,71 +803,6 @@ def test_workload_placement_metrics(ray_start_regular):
         ],
     )
     wait_for_condition(placement_metric_condition, timeout=60)
-
-
-def test_implicit_resource(ray_start_regular):
-    @ray.remote(num_cpus=1, resources={ray._raylet.IMPLICIT_RESOURCE_PREFIX + "a": 1})
-    class Actor:
-        def ping(self):
-            return ray.get_runtime_context().get_node_id()
-
-    # The first actor is schedulable.
-    a1 = Actor.remote()
-    ray.get(a1.ping.remote())
-
-    # The second actor will be pending since
-    # only one such actor can run on a single node.
-    a2 = Actor.remote()
-    time.sleep(2)
-    actors = list_actors(filters=[("actor_id", "=", a2._actor_id.hex())])
-    assert actors[0]["state"] == "PENDING_CREATION"
-
-
-def test_implicit_resource_autoscaling(shutdown_only):
-    from ray.cluster_utils import AutoscalingCluster
-
-    cluster = AutoscalingCluster(
-        head_resources={"CPU": 0},
-        worker_node_types={
-            "cpu_node": {
-                "resources": {
-                    "CPU": 8,
-                },
-                "node_config": {},
-                "min_workers": 1,
-                "max_workers": 100,
-            },
-        },
-    )
-
-    cluster.start()
-    ray.init()
-
-    @ray.remote(num_cpus=1, resources={ray._raylet.IMPLICIT_RESOURCE_PREFIX + "a": 0.5})
-    class Actor:
-        def ping(self):
-            return ray.get_runtime_context().get_node_id()
-
-    actors = [Actor.remote() for _ in range(2)]
-    for actor in actors:
-        ray.get(actor.ping.remote())
-
-    # No new worker nodes should be started.
-    assert len(ray.nodes()) == 2
-
-    # 3 more worker nodes should be started.
-    actors.extend([Actor.remote() for _ in range(5)])
-    node_id_to_num_actors = {}
-    for actor in actors:
-        node_id = ray.get(actor.ping.remote())
-        node_id_to_num_actors[node_id] = node_id_to_num_actors.get(node_id, 0) + 1
-    assert len(ray.nodes()) == 5
-    assert len(node_id_to_num_actors) == 4
-    num_actors_per_node = list(node_id_to_num_actors.values())
-    num_actors_per_node.sort()
-    assert num_actors_per_node == [1, 2, 2, 2]
-
-    cluster.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Move implicit resource tests to its own file and don't run it in asan mode since it's easy to hit the bug mentioned in #38189

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Cherry pick #39013
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
