### PR TITLE
[core] Do not overwrite session keys when pushing to the key value store during start

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1052,7 +1052,6 @@ class Node:
         # when possible.
         self._gcs_address = f"{self._node_ip_address}:" f"{gcs_server_port}"
         # Initialize gcs client, which also waits for GCS to start running.
-        self._init_gcs_client()
 
     def start_raylet(
         self,
@@ -1178,26 +1177,26 @@ class Node:
         self.get_gcs_client().internal_kv_put(
             b"session_name",
             self._session_name.encode(),
-            True,
+            False,
             ray_constants.KV_NAMESPACE_SESSION,
         )
         self.get_gcs_client().internal_kv_put(
             b"session_dir",
             self._session_dir.encode(),
-            True,
+            False,
             ray_constants.KV_NAMESPACE_SESSION,
         )
         self.get_gcs_client().internal_kv_put(
             b"temp_dir",
             self._temp_dir.encode(),
-            True,
+            False,
             ray_constants.KV_NAMESPACE_SESSION,
         )
         if self._ray_params.storage is not None:
             self.get_gcs_client().internal_kv_put(
                 b"storage",
                 self._ray_params.storage.encode(),
-                True,
+                False,
                 ray_constants.KV_NAMESPACE_SESSION,
             )
         # Add tracing_startup_hook to redis / internal kv manually
@@ -1206,7 +1205,7 @@ class Node:
             self.get_gcs_client().internal_kv_put(
                 b"tracing_startup_hook",
                 self._ray_params.tracing_startup_hook.encode(),
-                True,
+                False,
                 ray_constants.KV_NAMESPACE_TRACING,
             )
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1328,7 +1328,6 @@ def start_gcs_server(
 
     command = [
         GCS_SERVER_EXECUTABLE,
-        f"--log_dir={log_dir}",
         f"--config_list={serialize_config(config)}",
         f"--gcs_server_port={gcs_server_port}",
         f"--metrics-agent-port={metrics_agent_port}",

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -112,7 +112,7 @@ class GcsServer {
   /// Generate the redis client options
   RedisClientOptions GetRedisClientOptions() const;
 
-  void DoStart(const GcsInitData &gcs_init_data);
+  void DoStart(const GcsInitData &gcs_init_data, const std::string &&session_name);
 
   /// Initialize gcs node manager.
   void InitGcsNodeManager(const GcsInitData &gcs_init_data);
@@ -148,7 +148,7 @@ class GcsServer {
   void InitGcsTaskManager();
 
   /// Initialize gcs autoscaling manager.
-  void InitGcsAutoscalerStateManager();
+  void InitGcsAutoscalerStateManager(const std::string &&session_name);
 
   /// Initialize usage stats client.
   void InitUsageStatsClient();
@@ -193,6 +193,9 @@ class GcsServer {
   /// a new one and persist as necessary.
   /// Expected to be idempotent while server is up.
   void GetOrGenerateClusterId(std::function<void(ClusterID cluster_id)> &&continuation);
+
+  /// Get session name if persisted.
+  void GetSessionName(std::function<void(const std::string &&session_name)> &&continuation);
 
   /// Print the asio event loop stats for debugging.
   void PrintAsioStats();

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -26,7 +26,7 @@
 DEFINE_string(redis_address, "", "The ip address of redis.");
 DEFINE_bool(redis_enable_ssl, false, "Use tls/ssl in redis connection.");
 DEFINE_int32(redis_port, -1, "The port of redis.");
-DEFINE_string(log_dir, "", "The path of the dir where log files are created.");
+// DEFINE_string(log_dir, "", "The path of the dir where log files are created.");
 DEFINE_int32(gcs_server_port, 0, "The port of gcs server.");
 DEFINE_int32(metrics_agent_port, -1, "The port of metrics agent.");
 DEFINE_string(config_list, "", "The config list of raylet.");

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -158,6 +158,21 @@ class GcsTableWithJobId : public GcsTable<Key, Data> {
   absl::flat_hash_map<JobID, absl::flat_hash_set<Key>> index_ GUARDED_BY(mutex_);
 };
 
+class GcsKVTable : public GcsTable<JobID, JobTableData> {
+  public:
+   explicit GcsKVTable(std::shared_ptr<StoreClient> store_client) : GcsTable(std::move(store_client)) {
+    table_name_ = TablePrefix_Name(TablePrefix::KV);
+   }
+
+  private:
+std::string MakeKey(const std::string &ns, const std::string &key) {
+  if (ns.empty()) {
+    return key;
+  }
+  return absl::StrCat(kNamespacePrefix, ns, kNamespaceSep, key);
+}
+};
+
 class GcsJobTable : public GcsTable<JobID, JobTableData> {
  public:
   explicit GcsJobTable(std::shared_ptr<StoreClient> store_client)

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -42,7 +42,7 @@ class StatsConfig final {
   static StatsConfig &instance();
 
   /// Get the current global tags.
-  const TagsType &GetGlobalTags() const;
+  const TagsType GetGlobalTags() const;
 
   /// Get whether or not stats are enabled.
   bool IsStatsDisabled() const;
@@ -69,6 +69,8 @@ class StatsConfig final {
   void SetIsDisableStats(bool disable_stats);
   /// Set the global tags that will be appended to all metrics in this process.
   void SetGlobalTags(const TagsType &global_tags);
+  /// Sets a single global tag.
+  void SetGlobalTag(const TagKeyType &key, const std::string &value);
   /// Add the initializer
   void AddInitializer(std::function<void()> func) {
     initializers_.push_back(std::move(func));
@@ -97,6 +99,9 @@ class StatsConfig final {
   // Whether or not if the stats has been initialized.
   bool is_initialized_ = false;
   std::vector<std::function<void()>> initializers_;
+
+  // To protect the tags mutex.
+  mutable absl::Mutex mu_ = absl::Mutex();
 };
 
 /// A thin wrapper that wraps the `opencensus::tag::measure` for using it simply.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Right now, we overwrite various session keys during a restart. If these values are persisted, we should just directly reuse them.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/38796

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
