### PR TITLE
[ci] fix tempfile.mktemp() usage in ci tests

### DIFF
--- a/release/ray_release/tests/test_run_script.py
+++ b/release/ray_release/tests/test_run_script.py
@@ -115,17 +115,17 @@ def test_parameters(setup):
     state_file, test_script = setup
 
     os.environ["RAY_TEST_SCRIPT"] = "ray_release/tests/_test_catch_args.py"
-    argv_file = tempfile.mktemp()
 
-    subprocess.check_call(
-        f"{test_script} " f"{argv_file} " f"--smoke-test",
-        shell=True,
-    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        argv_file = os.path.join(tmpdir, "argv.json")
 
-    with open(argv_file, "rt") as fp:
-        data = json.load(fp)
+        subprocess.check_call(
+            f"{test_script} " f"{argv_file} " f"--smoke-test",
+            shell=True,
+        )
 
-    os.unlink(argv_file)
+        with open(argv_file, "rt") as fp:
+            data = json.load(fp)
 
     assert "--smoke-test" in data
 


### PR DESCRIPTION
use `tempfile.TemporaryDirectory()` instead