### PR TITLE
[Core][Java Worker]Add a test case that task scheduling to placement group  without settings resources

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
@@ -31,10 +31,22 @@ public class RunManager {
     command.add(rayConfig.redisPassword);
     command.addAll(rayConfig.headArgs);
 
+    String numCpus = System.getProperty("num-cpus");
+    if (numCpus != null) {
+      command.add("--num-cpus");
+      command.add(numCpus);
+    }
+
     String numGpus = System.getProperty("num-gpus");
     if (numGpus != null) {
       command.add("--num-gpus");
       command.add(numGpus);
+    }
+
+    String memory = System.getProperty("memory");
+    if (memory != null) {
+      command.add("--memory");
+      command.add(memory);
     }
 
     // Set node labels.

--- a/java/test/src/main/java/io/ray/test/PlacementGroupWithResourcesTest.java
+++ b/java/test/src/main/java/io/ray/test/PlacementGroupWithResourcesTest.java
@@ -1,0 +1,81 @@
+package io.ray.test;
+
+import io.ray.api.ActorHandle;
+import io.ray.api.PlacementGroups;
+import io.ray.api.Ray;
+import io.ray.api.id.ActorId;
+import io.ray.api.options.PlacementGroupCreationOptions;
+import io.ray.api.placementgroup.PlacementGroup;
+import io.ray.api.placementgroup.PlacementStrategy;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Test(groups = "cluster")
+public class PlacementGroupWithResourcesTest extends BaseTest {
+
+  @BeforeClass
+  public void setUp() {
+    System.setProperty("num-cpus", "1");
+    // 1GB
+    System.setProperty("memory", "1073741824");
+  }
+
+  @AfterClass
+  public void tearDown() {
+    System.clearProperty("num-cpus");
+    System.clearProperty("memory");
+  }
+
+  public static int simpleFunction() {
+    return 1;
+  }
+
+  public static class Counter {
+
+    private int value;
+
+    public Counter(int initValue) {
+      this.value = initValue;
+    }
+
+    public int getValue() {
+      return value;
+    }
+
+    public static String ping() {
+      return "pong";
+    }
+  }
+
+  @Test
+  public void testActorNoResources() {
+    List<Map<String, Double>> bundles = new ArrayList<>();
+    Map<String, Double> bundle = new HashMap<>();
+    bundle.put("memory", 1073741824.0);
+    bundles.add(bundle);
+    PlacementGroupCreationOptions.Builder builder =
+        new PlacementGroupCreationOptions.Builder()
+            .setBundles(bundles)
+            .setStrategy(PlacementStrategy.PACK);
+    PlacementGroup placementGroup = PlacementGroups.createPlacementGroup(builder.build());
+    Assert.assertTrue(placementGroup.wait(60));
+
+    ActorHandle<Counter> actor =
+        Ray.actor(Counter::new, 1).setPlacementGroup(placementGroup, 0).remote();
+    Assert.assertNotEquals(actor.getId(), ActorId.NIL);
+    Assert.assertEquals(actor.task(Counter::getValue).remote().get(3000), Integer.valueOf(1));
+
+    Assert.assertEquals(
+        Ray.task(PlacementGroupWithResourcesTest::simpleFunction)
+            .setPlacementGroup(placementGroup, 0)
+            .remote()
+            .get(3000),
+        Integer.valueOf(1));
+  }
+}


### PR DESCRIPTION
## Why are these changes needed?
1. Add  the api which setting memory  and cpu for ray cluster in java test case.
```
  @BeforeClass
  public void setUp() {
    System.setProperty("num-cpus", "1");
    // 1GB
    System.setProperty("memory", "1073741824");
  }
```

![image](https://github.com/ray-project/ray/assets/11072802/58dad960-832f-4f67-89f0-4df3158d2226)

2. Add a test case that task scheduling to placement group  without settings resources
```
Assert.assertEquals(
        Ray.task(PlacementGroupWithResourcesTest::simpleFunction)
            .setPlacementGroup(placementGroup, 0)
            .remote()
            .get(3000),
        Integer.valueOf(1));
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
