### PR TITLE
[Core] Raise TaskCancelledError instead of `RayTaskError` when a task is cancelled in the middle of execution (#38973)

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -143,7 +143,9 @@ class RayTaskError(RayError):
         if issubclass(RayTaskError, cause_cls):
             return self  # already satisfied
 
-        if issubclass(cause_cls, RayError):
+        if issubclass(cause_cls, RayError) and not issubclass(
+            cause_cls, TaskCancelledError
+        ):
             return self  # don't try to wrap ray internal errors
 
         error_msg = str(self)


### PR DESCRIPTION
## Why are these changes needed?

Cherry-pick https://github.com/ray-project/ray/pull/38973.

This is required for https://github.com/ray-project/ray/issues/38743 and must be picked before https://github.com/ray-project/ray/pull/38897.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
