### PR TITLE
[air] fix one rllib example that still uses `log_dir`

### DIFF
--- a/rllib/examples/rnnsac_stateless_cartpole.py
+++ b/rllib/examples/rnnsac_stateless_cartpole.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     # TEST
 
     checkpoint_config_path = os.path.join(
-        results.get_best_result().log_dir, "params.json"
+        results.get_best_result().path, "params.json"
     )
     with open(checkpoint_config_path, "rb") as f:
         checkpoint_config = json.load(f)

--- a/rllib/examples/rnnsac_stateless_cartpole.py
+++ b/rllib/examples/rnnsac_stateless_cartpole.py
@@ -84,9 +84,7 @@ if __name__ == "__main__":
 
     # TEST
 
-    checkpoint_config_path = os.path.join(
-        results.get_best_result().path, "params.json"
-    )
+    checkpoint_config_path = os.path.join(results.get_best_result().path, "params.json")
     with open(checkpoint_config_path, "rb") as f:
         checkpoint_config = json.load(f)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix one rllib example that still uses `log_dir`

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
