### PR TITLE
[data][fault tolerance] workaround streaming gen reconstruction bug

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -75,7 +75,7 @@ class MapOperator(OneToOneOperator, ABC):
         # All active `MetadataOpTask`s.
         self._metadata_tasks: Dict[int, MetadataOpTask] = {}
         self._next_metadata_task_idx = 0
-        # Keep track of which streaming generators have finished.
+        # Keep track of all finished streaming generators.
         # TODO(hchen): This is a workaround for a bug of lineage reconstruction.
         # When the streaming generator ref is GC'ed, the objects it generated
         # cannot be reconstructed. Should remove it once Ray Core fixes the bug.

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -75,6 +75,11 @@ class MapOperator(OneToOneOperator, ABC):
         # All active `MetadataOpTask`s.
         self._metadata_tasks: Dict[int, MetadataOpTask] = {}
         self._next_metadata_task_idx = 0
+        # Keep track of which streaming generators have finished.
+        # TODO(hchen): This is a workaround for a bug of lineage reconstruction.
+        # When the streaming generator ref is GC'ed, the objects it generated
+        # cannot be reconstructed. Should remove it once Ray Core fixes the bug.
+        self._finished_streaming_gens: List[StreamingObjectRefGenerator] = []
         super().__init__(name, input_op)
 
     @classmethod
@@ -274,7 +279,8 @@ class MapOperator(OneToOneOperator, ABC):
             freed = inputs.size_bytes()
             self._metrics.freed += freed
             self._metrics.cur -= freed
-            self._data_tasks.pop(task_index)
+            task = self._data_tasks.pop(task_index)
+            self._finished_streaming_gens.append(task.get_waitable())
             # Notify output queue that this task is complete.
             self._output_queue.notify_task_completed(task_index)
             if task_done_callback:

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -348,9 +348,10 @@ class MapOperator(OneToOneOperator, ABC):
     def get_map_transformer(self) -> MapTransformer:
         return self._map_transformer
 
-    @abstractmethod
     def shutdown(self):
-        pass
+        self._data_tasks.clear()
+        self._metadata_tasks.clear()
+        self._finished_streaming_gens.clear()
 
     @abstractmethod
     def current_resource_usage(self) -> ExecutionResources:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Lineage reconstruction a bug. If an object is generated from a streaming generator and the streaming generator has already been GC'ed, the object cannot be reconstructed.

This PR works around this bug by keeping track of all finished streaming generators at Ray Data layer.

## Related issue number

https://github.com/ray-project/ray/issues/38698
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
