### PR TITLE
[RLlib] Fix using a wrong original observation space in slateq.

### DIFF
--- a/rllib/algorithms/slateq/slateq_torch_model.py
+++ b/rllib/algorithms/slateq/slateq_torch_model.py
@@ -30,7 +30,7 @@ class QValueModel(nn.Module):
         """
         super().__init__()
 
-        self.orig_obs_space = obs_space
+        self.orig_obs_space = obs_space.original_space
         self.embedding_size = self.orig_obs_space["doc"]["0"].shape[0]
         self.num_candidates = len(self.orig_obs_space["doc"])
         assert self.orig_obs_space["user"].shape[0] == self.embedding_size


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In slateq algorithm, we wrappered the observation in a dict, like {'user': original_observations} as the observation, which shouldn't be accessed directly.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/39031
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
