### PR TITLE
[Train/Data] Change `object_store_memory_limit` for `DataConfig` to match Datasets level default

### DIFF
--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -12,7 +12,6 @@ from ray.data import (
     Dataset,
     DataIterator,
     ExecutionOptions,
-    ExecutionResources,
     NodeIdStr,
 )
 from ray.data.preprocessor import Preprocessor
@@ -111,14 +110,14 @@ class DataConfig:
     def default_ingest_options() -> ExecutionOptions:
         """The default Ray Data options used for data ingest.
 
-        We enable output locality, which means that Ray Data will try to place tasks on
-        the node the data is consumed. We also set the object store memory limit
-        to a fixed smaller value, to avoid using too much memory per Train worker.
+        By default, output locality is enabled, which means that Ray Data will try to
+        place tasks on the node the data is consumed. The remaining configurations are
+        carried over from what is already set in DataContext.
         """
         ctx = ray.data.DataContext.get_current()
         return ExecutionOptions(
             locality_with_output=True,
-            resource_limits=ExecutionResources(object_store_memory=2e9),
+            resource_limits=ctx.execution_options.resource_limits,
             preserve_order=ctx.execution_options.preserve_order,
             verbose_progress=ctx.execution_options.verbose_progress,
         )

--- a/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
+++ b/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
@@ -14,7 +14,7 @@ import torch.optim as optim
 
 import ray
 from ray import train
-from ray.train import Checkpoint, DataConfig, RunConfig, ScalingConfig
+from ray.train import Checkpoint, RunConfig, ScalingConfig
 from ray.train.torch import TorchTrainer
 
 
@@ -108,14 +108,10 @@ def main(data_size_gb: int, num_epochs=2, num_workers=1, smoke_test: bool = Fals
     dataset = dataset.map_batches(add_fake_labels)
     dataset = dataset.map_batches(transform_image, fn_kwargs={"transform": transform})
 
-    dataset_execution_options = DataConfig.default_ingest_options()
-    dataset_execution_options.resource_limits.object_store_memory = None
-
     trainer = TorchTrainer(
         train_loop_per_worker=train_loop_per_worker,
         train_loop_config={"batch_size": 64, "num_epochs": num_epochs},
         datasets={"train": dataset},
-        dataset_config=DataConfig(execution_options=dataset_execution_options),
         scaling_config=ScalingConfig(
             num_workers=num_workers, use_gpu=int(not smoke_test)
         ),

--- a/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
+++ b/release/air_tests/air_benchmarks/workloads/pytorch_training_e2e.py
@@ -14,7 +14,7 @@ import torch.optim as optim
 
 import ray
 from ray import train
-from ray.train import Checkpoint, RunConfig, ScalingConfig
+from ray.train import Checkpoint, DataConfig, RunConfig, ScalingConfig
 from ray.train.torch import TorchTrainer
 
 
@@ -108,10 +108,14 @@ def main(data_size_gb: int, num_epochs=2, num_workers=1, smoke_test: bool = Fals
     dataset = dataset.map_batches(add_fake_labels)
     dataset = dataset.map_batches(transform_image, fn_kwargs={"transform": transform})
 
+    dataset_execution_options = DataConfig.default_ingest_options()
+    dataset_execution_options.resource_limits.object_store_memory = None
+
     trainer = TorchTrainer(
         train_loop_per_worker=train_loop_per_worker,
         train_loop_config={"batch_size": 64, "num_epochs": num_epochs},
         datasets={"train": dataset},
+        dataset_config=DataConfig(execution_options=dataset_execution_options),
         scaling_config=ScalingConfig(
             num_workers=num_workers, use_gpu=int(not smoke_test)
         ),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

When using Data+Train, overriding the object store memory limit to 2 GiB may be too low when working with data like images that are more memory intensive. This can limit the concurrency of preprocessing tasks, slowing down training.

Instead, we change this to match the Datasets level default of setting the limit to 25% of total object store memory.

Closes https://github.com/ray-project/ray/issues/38848

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
