### PR TITLE
[serve] Fix long_running_serve_failure.aws (#39063)

### DIFF
--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -93,8 +93,8 @@ class RandomKiller:
         routers = list(ray.get(controller.get_http_proxies.remote()).values())
         all_handles = routers + [controller]
         replica_dict = ray.get(controller._all_running_replicas.remote())
-        for deployment_name, replica_info_list in replica_dict.items():
-            if deployment_name not in self.sanctuary:
+        for deployment_id, replica_info_list in replica_dict.items():
+            if deployment_id.name not in self.sanctuary:
                 for replica_info in replica_info_list:
                     all_handles.append(replica_info.actor_handle)
 


### PR DESCRIPTION
We recently changed ServeController#_all_running_replicas from returning a dictionary of "deployment name" and list of replica infos to "deployment id" and list of replica infos. This caused the test unable to safely create the deployment before they are randomly killed. Use the name property on the deployment id to be the correct matching and exclude from getting killed before starting.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To fix a serve related release test

## Related issue number

Pick of https://github.com/ray-project/ray/pull/39063

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
