### PR TITLE
[serve] Rename http proxies to proxies + add docstrings

### DIFF
--- a/dashboard/client/src/pages/serve/ServeApplicationsListPage.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeApplicationsListPage.component.test.tsx
@@ -34,7 +34,7 @@ describe("ServeApplicationsListPage", () => {
     mockGetServeApplications.mockResolvedValue({
       data: {
         http_options: { host: "1.2.3.4", port: 8000 },
-        http_proxies: {
+        proxies: {
           foo: {
             node_id: "node:12345",
             status: ServeSystemActorStatus.STARTING,

--- a/dashboard/client/src/pages/serve/ServeSystemDetailPage.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeSystemDetailPage.component.test.tsx
@@ -35,7 +35,7 @@ describe("ServeSystemDetailPage", () => {
       data: {
         http_options: { host: "1.2.3.4", port: 8000 },
         grpc_options: { port: 9000 },
-        http_proxies: {
+        proxies: {
           foo: {
             node_id: "node:12345",
             status: ServeSystemActorStatus.STARTING,

--- a/dashboard/client/src/pages/serve/hook/useServeApplications.ts
+++ b/dashboard/client/src/pages/serve/hook/useServeApplications.ts
@@ -67,8 +67,8 @@ export const useServeApplications = () => {
     : [];
 
   const httpProxies =
-    data && data.http_proxies
-      ? Object.values(data.http_proxies).sort(
+    data && data.proxies
+      ? Object.values(data.proxies).sort(
           (a, b) =>
             SERVE_HTTP_PROXY_STATUS_SORT_ORDER[b.status] -
             SERVE_HTTP_PROXY_STATUS_SORT_ORDER[a.status],
@@ -211,7 +211,7 @@ export const useServeHTTPProxyDetails = (httpProxyId: string | undefined) => {
     { refreshInterval: API_REFRESH_INTERVAL_MS },
   );
 
-  const httpProxy = httpProxyId ? data?.http_proxies?.[httpProxyId] : undefined;
+  const httpProxy = httpProxyId ? data?.proxies?.[httpProxyId] : undefined;
 
   // Need to expose loading because it's not clear if undefined values
   // for proxies means loading or missing data.

--- a/dashboard/client/src/type/serve.ts
+++ b/dashboard/client/src/type/serve.ts
@@ -119,7 +119,7 @@ export type ServeApplicationsRsp = {
   };
   proxy_location: ServeDeploymentMode;
   controller_info: ServeSystemActor;
-  http_proxies: {
+  proxies: {
     [name: string]: ServeHttpProxy;
   } | null;
   applications: {

--- a/dashboard/modules/serve/tests/test_serve_agent.py
+++ b/dashboard/modules/serve/tests/test_serve_agent.py
@@ -19,7 +19,7 @@ from ray.serve._private.common import (
     ApplicationStatus,
     DeploymentStatus,
     ReplicaState,
-    HTTPProxyStatus,
+    ProxyStatus,
 )
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 
@@ -564,8 +564,8 @@ def test_get_serve_instance_details(ray_start_stop, f_deployment_options):
     )
 
     # Check HTTP Proxy statuses
-    for proxy in serve_details.http_proxies.values():
-        assert proxy.status == HTTPProxyStatus.HEALTHY
+    for proxy in serve_details.proxies.values():
+        assert proxy.status == ProxyStatus.HEALTHY
         assert os.path.exists("/tmp/ray/session_latest/logs" + proxy.log_file_path)
     print("Checked HTTP Proxy details.")
     # Check controller info

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -443,7 +443,7 @@ class ServeDeployMode(str, Enum):
 
 # Keep in sync with ServeSystemActorStatus in
 # python/ray/dashboard/client/src/type/serve.ts
-class HTTPProxyStatus(str, Enum):
+class ProxyStatus(str, Enum):
     STARTING = "STARTING"
     HEALTHY = "HEALTHY"
     UNHEALTHY = "UNHEALTHY"

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -899,7 +899,7 @@ class ServeController:
             proxy_location=http_config.location,
             http_options=http_options,
             grpc_options=grpc_options,
-            http_proxies=self.http_proxy_state_manager.get_http_proxy_details()
+            proxies=self.http_proxy_state_manager.get_proxy_details()
             if self.http_proxy_state_manager
             else None,
             deploy_mode=self.deploy_mode,

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -14,7 +14,7 @@ from ray.serve._private.common import (
     StatusOverview,
     ReplicaState,
     ServeDeployMode,
-    HTTPProxyStatus,
+    ProxyStatus,
 )
 from ray.serve.config import DeploymentMode
 from ray.serve._private.utils import DEFAULT, dict_keys_snake_to_camel_case
@@ -703,7 +703,7 @@ class ApplicationStatusOverview:
 @PublicAPI(stability="alpha")
 @dataclass(eq=True)
 class ServeStatus:
-    proxies: Dict[str, HTTPProxyStatus] = field(default_factory=dict)
+    proxies: Dict[str, ProxyStatus] = field(default_factory=dict)
     applications: Dict[str, ApplicationStatusOverview] = field(default_factory=dict)
 
 
@@ -848,8 +848,8 @@ class ApplicationDetails(BaseModel, extra=Extra.forbid, frozen=True):
 
 
 @PublicAPI(stability="alpha")
-class HTTPProxyDetails(ServeActorDetails, frozen=True):
-    status: HTTPProxyStatus = Field(description="Current status of the HTTP Proxy.")
+class ProxyDetails(ServeActorDetails, frozen=True):
+    status: ProxyStatus = Field(description="Current status of the Proxy.")
 
 
 @PublicAPI(stability="alpha")
@@ -874,7 +874,7 @@ class ServeInstanceDetails(BaseModel, extra=Extra.forbid):
     )
     http_options: Optional[HTTPOptionsSchema] = Field(description="HTTP Proxy options.")
     grpc_options: Optional[gRPCOptionsSchema] = Field(description="gRPC Proxy options.")
-    http_proxies: Dict[str, HTTPProxyDetails] = Field(
+    proxies: Dict[str, ProxyDetails] = Field(
         description=(
             "Mapping from node_id to details about the HTTP Proxy running on that node."
         )
@@ -899,15 +899,13 @@ class ServeInstanceDetails(BaseModel, extra=Extra.forbid):
         return {
             "deploy_mode": "UNSET",
             "controller_info": {},
-            "http_proxies": {},
+            "proxies": {},
             "applications": {},
         }
 
     def _get_status(self) -> ServeStatus:
         return ServeStatus(
-            proxies={
-                node_id: proxy.status for node_id, proxy in self.http_proxies.items()
-            },
+            proxies={node_id: proxy.status for node_id, proxy in self.proxies.items()},
             applications={
                 app_name: ApplicationStatusOverview(
                     status=app.status,

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -686,6 +686,16 @@ class ServeDeploySchema(BaseModel):
 @PublicAPI(stability="alpha")
 @dataclass
 class DeploymentStatusOverview:
+    """Describes the status of a deployment.
+
+    Attributes:
+        status: The current status of the deployment.
+        replica_states: A map indicating how many replicas there are of
+            each replica state.
+        message: A message describing the deployment status in more
+            detail.
+    """
+
     status: DeploymentStatus
     replica_states: Dict[ReplicaState, int]
     message: str
@@ -694,6 +704,17 @@ class DeploymentStatusOverview:
 @PublicAPI(stability="alpha")
 @dataclass
 class ApplicationStatusOverview:
+    """Describes the status of an application and all its deployments.
+
+    Attributes:
+        status: The current status of the application.
+        message: A message describing the application status in more
+            detail.
+        last_deployed_time_s: The time at which the application was
+            deployed. A Unix timestamp in seconds.
+        deployments: The deployments in this application.
+    """
+
     status: ApplicationStatus
     message: str
     last_deployed_time_s: float
@@ -703,6 +724,14 @@ class ApplicationStatusOverview:
 @PublicAPI(stability="alpha")
 @dataclass(eq=True)
 class ServeStatus:
+    """Describes the status of Serve.
+
+    Attributes:
+        proxies: The proxy actors running on each node in the cluster.
+            A map from node ID to proxy status.
+        applications: The live applications in the cluster.
+    """
+
     proxies: Dict[str, ProxyStatus] = field(default_factory=dict)
     applications: Dict[str, ApplicationStatusOverview] = field(default_factory=dict)
 

--- a/python/ray/serve/tests/test_callback.py
+++ b/python/ray/serve/tests/test_callback.py
@@ -12,7 +12,7 @@ import ray
 from ray.exceptions import RayActorError
 from ray import serve
 from ray._private.test_utils import wait_for_condition
-from ray.serve._private.common import HTTPProxyStatus
+from ray.serve._private.common import ProxyStatus
 from ray.serve._private.utils import call_function_from_import_path
 from ray.serve.context import get_global_client
 from ray.serve.schema import ServeInstanceDetails
@@ -233,8 +233,8 @@ def test_http_proxy_calllback_failures(ray_instance, capsys):
         prev_actor_id = None
         while True:
             serve_details = ServeInstanceDetails(**client.get_serve_details())
-            for _, proxy_info in serve_details.http_proxies.items():
-                if proxy_info.status != HTTPProxyStatus.STARTING:
+            for _, proxy_info in serve_details.proxies.items():
+                if proxy_info.status != ProxyStatus.STARTING:
                     return False
                 if prev_actor_id is None:
                     prev_actor_id = proxy_info.actor_id


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. Rename `http_proxies` to `proxies` in `ServeInstanceDetails` because the proxy can be both HTTP and gRPC.
Note: this is a breaking change, but we are intentionally making it for Ray 2.7 since it has been marked alpha thus far, and it's unlikely anyone is using this right now. Making the change now will save us a lot of headaches in the future.
2. Add docstrings for dataclasses returned from `serve.status()`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
