### PR TITLE
[Serve] Deflake `test_telemetry.py`

### DIFF
--- a/python/ray/serve/tests/test_telemetry.py
+++ b/python/ray/serve/tests/test_telemetry.py
@@ -448,7 +448,7 @@ def test_lightweight_config_options(
 
     wait_for_condition(
         lambda: ray.get(storage.get_reports_received.remote()) > current_num_reports,
-        timeout=5,
+        timeout=10,
     )
     report = ray.get(storage.get_report.remote())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_telemtry.py` has been flaky on `master` recently:

<img width="1328" alt="Screen Shot 2023-08-30 at 5 29 02 PM" src="https://github.com/ray-project/ray/assets/92341594/43164481-a8ef-4fdc-888b-89e5f1ea434e">

[Example traceback link](https://buildkite.com/ray-project/oss-ci-build-branch/builds/5810#018a4699-2b03-4fe4-80ee-e35efafc9cbe/3546-3981).

This change extends the timeout.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
