### PR TITLE
[spark] Fix ray on spark UI dashboard link

### DIFF
--- a/python/ray/tests/spark/test_basic.py
+++ b/python/ray/tests/spark/test_basic.py
@@ -11,7 +11,7 @@ import ray
 
 import ray.util.spark.cluster_init
 from ray.util.spark import setup_ray_cluster, shutdown_ray_cluster, MAX_NUM_WORKER_NODES
-from ray.util.spark.utils import check_port_open
+from ray.util.spark.utils import is_port_in_use
 from pyspark.sql import SparkSession
 import time
 import logging
@@ -157,7 +157,7 @@ class RayOnSparkCPUClusterTestBase(ABC):
         time.sleep(2)  # wait ray head node exit.
         # assert ray head node exit by checking head port being closed.
         hostname, port = cluster.address.split(":")
-        assert not check_port_open(hostname, int(port))
+        assert not is_port_in_use(hostname, int(port))
 
     def test_background_spark_job_exit_trigger_ray_head_exit(self):
         with _setup_ray_cluster(num_worker_nodes=self.max_spark_tasks) as cluster:
@@ -169,7 +169,7 @@ class RayOnSparkCPUClusterTestBase(ABC):
 
             # assert ray head node exit by checking head port being closed.
             hostname, port = cluster.address.split(":")
-            assert not check_port_open(hostname, int(port))
+            assert not is_port_in_use(hostname, int(port))
 
 
 class TestBasicSparkCluster(RayOnSparkCPUClusterTestBase):

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -107,9 +107,10 @@ class RayClusterOnSpark:
             raise RuntimeError(
                 "The ray cluster has been shut down or it failed to start."
             )
+
         try:
-            # connect to the ray cluster.
-            self.connect()
+            ray.init(address=self.address)
+
             if (
                 self.ray_dashboard_port is not None and
                 check_port_open(self.address.split(":")[0], self.ray_dashboard_port)
@@ -125,11 +126,6 @@ class RayClusterOnSpark:
                         "pip install ray[default]."
                     )
 
-        except Exception:
-            self.shutdown()
-            raise
-
-        try:
             last_alive_worker_count = 0
             last_progress_move_time = time.time()
             while True:

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -16,7 +16,7 @@ from ray._private.storage import _load_class
 
 from .utils import (
     exec_cmd,
-    check_port_open,
+    is_port_in_use,
     get_random_unused_port,
     get_spark_session,
     get_spark_application_driver_host,
@@ -113,7 +113,7 @@ class RayClusterOnSpark:
 
             if (
                 self.ray_dashboard_port is not None and
-                check_port_open(self.address.split(":")[0], self.ray_dashboard_port)
+                is_port_in_use(self.address.split(":")[0], self.ray_dashboard_port)
             ):
                 self.start_hook.on_ray_dashboard_created(self.ray_dashboard_port)
             else:
@@ -523,7 +523,7 @@ def _setup_ray_cluster(
     # wait ray head node spin up.
     time.sleep(_RAY_HEAD_STARTUP_TIMEOUT)
 
-    if not check_port_open(ray_head_ip, ray_head_port):
+    if not is_port_in_use(ray_head_ip, ray_head_port):
         if ray_head_proc.poll() is None:
             # Ray head GCS service is down. Kill ray head node.
             ray_head_proc.terminate()

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -110,7 +110,10 @@ class RayClusterOnSpark:
         try:
             # connect to the ray cluster.
             self.connect()
-            if check_port_open(self.address.split(":")[0], self.ray_dashboard_port):
+            if (
+                self.ray_dashboard_port is not None and
+                check_port_open(self.address.split(":")[0], self.ray_dashboard_port)
+            ):
                 self.start_hook.on_ray_dashboard_created(self.ray_dashboard_port)
             else:
                 try:

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -109,9 +109,8 @@ class RayClusterOnSpark:
             )
         try:
             # connect to the ray cluster.
-            ray_ctx = ray.init(address=self.address)
-            webui_url = ray_ctx.address_info.get("webui_url", None)
-            if webui_url:
+            self.connect()
+            if check_port_open(self.address.split(":")[0], self.ray_dashboard_port):
                 self.start_hook.on_ray_dashboard_created(self.ray_dashboard_port)
             else:
                 try:

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -111,9 +111,8 @@ class RayClusterOnSpark:
         try:
             ray.init(address=self.address)
 
-            if (
-                self.ray_dashboard_port is not None and
-                is_port_in_use(self.address.split(":")[0], self.ray_dashboard_port)
+            if self.ray_dashboard_port is not None and is_port_in_use(
+                self.address.split(":")[0], self.ray_dashboard_port
             ):
                 self.start_hook.on_ray_dashboard_created(self.ray_dashboard_port)
             else:

--- a/python/ray/util/spark/utils.py
+++ b/python/ray/util/spark/utils.py
@@ -81,7 +81,7 @@ def exec_cmd(
         )
 
 
-def check_port_open(host, port):
+def is_port_in_use(host, port):
     import socket
     from contextlib import closing
 
@@ -103,7 +103,7 @@ def get_random_unused_port(
         port = rng.randint(min_port, max_port)
         if port in exclude_list:
             continue
-        if not check_port_open(host, port):
+        if not is_port_in_use(host, port):
             return port
     raise RuntimeError(
         f"Get available port between range {min_port} and {max_port} failed."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In Ray on spark code, currently, we check `ray_ctx.address_info.get("webui_url", None)` attribute to know whether UI dashboard service is started successfully, but this does not work in some cases, because `webui_url` attribute is empty during a short period after Ray head node started. This issue causes that sometimes on databricks, the UI dashboard link cannot be displayed.

In this PR, I change the logic to check whether the UI dashboard port is open. In my test it addresses the issue perfectly.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
