### PR TITLE
[spark] Improve Ray node memory config calculation logic

### DIFF
--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -875,13 +875,14 @@ def setup_ray_cluster(
             has GPUs.
         object_store_memory_worker_node: Object store memory available to per-ray worker
             node, but it is capped by
-            "dev_shm_available_size * 0.8 / num_tasks_per_spark_worker".
+            "dev_shm_available_size * 0.8 / max_num_ray_node_per_spark_worker".
             The default value equals to
             "0.3 * spark_worker_physical_memory * 0.8 / num_tasks_per_spark_worker".
         object_store_memory_head_node: Object store memory available to Ray head
-            node, but it is capped by "dev_shm_available_size * 0.8".
+            node, but it is capped by
+            "dev_shm_available_size * 0.8 / max_num_ray_node_per_spark_driver".
             The default value equals to
-            "0.3 * spark_driver_physical_memory * 0.8".
+            "0.3 * spark_driver_physical_memory * 0.8 / max_num_ray_node_per_spark_driver".
         head_node_options: A dict representing Ray head node extra options, these
             options will be passed to `ray start` script. Note you need to convert
             `ray start` options key from `--foo-bar` format to `foo_bar` format.
@@ -1151,7 +1152,9 @@ def setup_ray_cluster(
         object_store_memory_head_node = 128 * 1024 * 1024
     else:
         heap_memory_head_node, object_store_memory_head_node = calc_mem_ray_head_node(
-            object_store_memory_head_node
+            num_cpus_head_node,
+            num_gpus_head_node,
+            object_store_memory_head_node,
         )
 
     with _active_ray_cluster_rwlock:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Improve Ray node memory config calculation logic:

1. Boundary check: If user provided Ray node config sets Ray node cpu / GPU number exceeding hosting machine CPU / GPU numbers, then raise explicit error. Previously the code does not have this boundary check and it causes code continue executing and then raise intricate error.

2. For Ray head node memory config calculation, allocate memory size according to the proportion of Ray head node cpu / GPU numbers to the hosting machine CPU / GPU numbers.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
