### PR TITLE
[civ2][docker/5] build ray-ml image

### DIFF
--- a/.buildkite/_forge.rayci.yml
+++ b/.buildkite/_forge.rayci.yml
@@ -8,6 +8,10 @@ steps:
 
   - name: raypy38cu118base
     wanda: ci/docker/ray.py38.cu118.base.wanda.yaml
+
+  - name: ray-mlpy38cu118base
+    wanda: ci/docker/ray-ml.py38.cu118.base.wanda.yaml
+    depends_on: raypy38cu118base
   
   - name: oss-ci-base_test
     wanda: ci/docker/base.test.wanda.yaml

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -15,7 +15,6 @@ steps:
       - forge
     job_env: forge
 
-
   - label: ":tapioca: build: jar"
     instance_type: medium
     commands:
@@ -25,12 +24,24 @@ steps:
     depends_on: manylinux
     job_env: manylinux
 
-  - label: ":tapioca: build: docker"
+  - label: ":tapioca: build: ray py38 cu118 docker"
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version py38
+      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version py38 
+        --platform cu118 --image-type ray
     depends_on: 
       - manylinux
       - forge
       - raypy38cu118base
+    job_env: forge
+
+  - label: ":tapioca: build: ray-ml py38 cu118 docker"
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version py38 
+        --platform cu118 --image-type ray-ml
+    depends_on: 
+      - manylinux
+      - forge
+      - ray-mlpy38cu118base
     job_env: forge

--- a/ci/build/build-ray-docker.sh
+++ b/ci/build/build-ray-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exuo pipefail
+set -euo pipefail
 
 WHEEL_NAME="$1"
 SOURCE_IMAGE="$2"

--- a/ci/docker/ray-ml.py38.cu118.base.wanda.yaml
+++ b/ci/docker/ray-ml.py38.cu118.base.wanda.yaml
@@ -1,0 +1,22 @@
+name: "ray-mlpy38cu118base"
+froms: ["cr.ray.io/rayproject/raypy38cu118base"]
+dockerfile: docker/ray-ml/Dockerfile
+srcs:
+  - python/requirements.txt
+  - python/requirements_compiled.txt
+  - python/requirements/ml/dl-cpu-requirements.txt
+  - python/requirements/ml/dl-gpu-requirements.txt
+  - python/requirements/ml/core-requirements.txt
+  - python/requirements/ml/data-requirements.txt
+  - python/requirements/ml/rllib-requirements.txt
+  - python/requirements/ml/rllib-test-requirements.txt
+  - python/requirements/ml/train-requirements.txt
+  - python/requirements/ml/train-test-requirements.txt
+  - python/requirements/ml/tune-requirements.txt
+  - python/requirements/ml/tune-test-requirements.txt
+  - python/requirements/docker/ray-docker-requirements.txt
+  - docker/ray-ml/install-ml-docker-requirements.sh
+build_args:
+  - FULL_BASE_IMAGE=cr.ray.io/rayproject/raypy38cu118base
+tags:
+  - cr.ray.io/rayproject/ray-mlpy38cu118base

--- a/ci/ray_ci/builder.py
+++ b/ci/ray_ci/builder.py
@@ -1,8 +1,8 @@
 import click
 
 from ci.ray_ci.builder_container import PYTHON_VERSIONS, BuilderContainer
-from ci.ray_ci.docker_container import DockerContainer
 from ci.ray_ci.forge_container import ForgeContainer
+from ci.ray_ci.docker_container import PLATFORM, DockerContainer
 from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.utils import logger, docker_login
 
@@ -19,22 +19,35 @@ from ci.ray_ci.utils import logger, docker_login
     type=click.Choice(list(PYTHON_VERSIONS.keys())),
     help=("Python version to build the wheel with"),
 )
+@click.option(
+    "--platform",
+    default="cu118",
+    type=click.Choice(list(PLATFORM)),
+    help=("Platform to build the docker with"),
+)
+@click.option(
+    "--image-type",
+    default="ray",
+    type=click.Choice(["ray", "ray-ml"]),
+)
 def main(
     artifact_type: str,
     python_version: str,
+    platform: str,
+    image_type: str,
 ) -> None:
     """
     Build a wheel or jar artifact
     """
     docker_login(_DOCKER_ECR_REPO.split("/")[0])
     if artifact_type == "wheel":
-        logger.info(f"Building wheel for Python {python_version}")
+        logger.info(f"Building wheel for {python_version}")
         build_wheel(python_version)
         return
 
     if artifact_type == "docker":
-        logger.info(f"Building ray-cpu docker for Python {python_version}")
-        build_docker(python_version)
+        logger.info(f"Building {image_type} docker for {python_version} on {platform}")
+        build_docker(python_version, platform, image_type)
         return
 
     raise ValueError(f"Invalid artifact type {artifact_type}")
@@ -48,9 +61,9 @@ def build_wheel(python_version: str) -> None:
     ForgeContainer().upload_wheel()
 
 
-def build_docker(python_version: str) -> None:
+def build_docker(python_version: str, platform: str, image_type: str) -> None:
     """
     Build a container artifact
     """
     BuilderContainer(python_version).run()
-    DockerContainer(python_version).run()
+    DockerContainer(python_version, platform, image_type).run()

--- a/ci/ray_ci/test_docker_container.py
+++ b/ci/ray_ci/test_docker_container.py
@@ -1,26 +1,49 @@
 import sys
 from typing import List
+from unittest import mock
 
 import pytest
-from unittest import mock
+
+from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.docker_container import DockerContainer
 from ci.ray_ci.test_base import RayCITestBase
+from ci.ray_ci.utils import RAY_VERSION
 
 
 class TestDockerContainer(RayCITestBase):
+    cmds = []
+
     def test_run(self) -> None:
-        def _mock_check_call(input: List[str], stdout, stderr) -> None:
-            input_str = " ".join(input)
-            assert "ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl" in input_str
-            assert "rayproject/citemp:123-raypy38cu118base" in input_str
-            assert "requirements_compiled.txt" in input_str
-            assert "rayproject/ray:123456-py38-cu118" in input_str
+        def _mock_run_script(input: List[str]) -> None:
+            self.cmds.append(input[0])
 
         with mock.patch(
             "ci.ray_ci.docker_container.docker_pull", return_value=None
-        ), mock.patch("subprocess.check_call", side_effect=_mock_check_call):
-            container = DockerContainer("py38")
+        ), mock.patch(
+            "ci.ray_ci.docker_container.Container.run_script",
+            side_effect=_mock_run_script,
+        ):
+            container = DockerContainer("py38", "cu118", "ray")
             container.run()
+            cmd = self.cmds[-1]
+            assert cmd == (
+                "./ci/build/build-ray-docker.sh "
+                f"ray-{RAY_VERSION}-cp38-cp38-manylinux2014_x86_64.whl "
+                f"{_DOCKER_ECR_REPO}:123-raypy38cu118base "
+                "requirements_compiled.txt "
+                "rayproject/ray:123456-py38-cu118"
+            )
+
+            container = DockerContainer("py37", "cpu", "ray-ml")
+            container.run()
+            cmd = self.cmds[-1]
+            assert cmd == (
+                "./ci/build/build-ray-docker.sh "
+                f"ray-{RAY_VERSION}-cp37-cp37m-manylinux2014_x86_64.whl "
+                f"{_DOCKER_ECR_REPO}:123-ray-mlpy37cpubase "
+                "requirements_compiled_py37.txt "
+                "rayproject/ray-ml:123456-py37-cpu"
+            )
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -9,6 +9,9 @@ from math import ceil
 import ci.ray_ci.bazel_sharding as bazel_sharding
 
 
+RAY_VERSION = "3.0.0.dev0"
+
+
 def chunk_into_n(list: List[str], n: int) -> List[List[str]]:
     """
     Chunk a list into n chunks
@@ -42,7 +45,7 @@ def docker_login(docker_ecr: str) -> None:
         f.flush()
         f.seek(0)
 
-        subprocess.check_run(
+        subprocess.run(
             [
                 "docker",
                 "login",
@@ -68,6 +71,7 @@ def docker_pull(image: str) -> None:
         stderr=sys.stderr,
         check=True,
     )
+
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -42,7 +42,7 @@ def docker_login(docker_ecr: str) -> None:
         f.flush()
         f.seek(0)
 
-        subprocess.run(
+        subprocess.check_run(
             [
                 "docker",
                 "login",
@@ -68,7 +68,6 @@ def docker_pull(image: str) -> None:
         stderr=sys.stderr,
         check=True,
     )
-
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)

--- a/docker/ray-ml/Dockerfile
+++ b/docker/ray-ml/Dockerfile
@@ -1,24 +1,22 @@
 ARG BASE_IMAGE
-FROM rayproject/ray:nightly"$BASE_IMAGE"
+ARG FULL_BASE_IMAGE=rayproject/ray:nightly"$BASE_IMAGE"
+FROM "$FULL_BASE_IMAGE"
 
-# We have to uninstall wrapt this way for Tensorflow compatibility
-COPY requirements.txt ./
-COPY requirements_compiled.txt ./
-COPY dl-cpu-requirements.txt ./
-COPY dl-gpu-requirements.txt ./
-COPY ray-docker-requirements.txt ./
-COPY core-requirements.txt ./
-COPY data-requirements.txt ./
-COPY rllib-requirements.txt ./
-COPY rllib-test-requirements.txt ./
-COPY tune-requirements.txt ./
-COPY tune-test-requirements.txt ./
-COPY train-requirements.txt ./
-COPY train-test-requirements.txt ./
+# The python/* paths only exist in civ2, so we put them as non-first arguments. Docker
+# will ignore non-existent paths if they are non-first arguments.
+#
+# TODO(can): simplify this once civ1 is completely deprecated.
+COPY *requirements.txt \
+     python/*requirements.txt \
+     python/requirements/ml/*requirements.txt  \
+     python/requirements/docker/*requirements.txt ./
+COPY *requirements_compiled.txt \
+     python/*requirements_compiled.txt ./
+COPY *install-ml-docker-requirements.sh \
+     docker/ray-ml/*install-ml-docker-requirements.sh ./
 
-COPY install-ml-docker-requirements.sh ./
-
-RUN sudo chmod +x install-ml-docker-requirements.sh && ./install-ml-docker-requirements.sh
+RUN sudo chmod +x install-ml-docker-requirements.sh \
+    && ./install-ml-docker-requirements.sh
 
 # Export installed packages
 RUN $HOME/anaconda3/bin/pip freeze > /home/ray/pip-freeze.txt


### PR DESCRIPTION
Build ray-ml image for py38 in civ2. This is done via:
- create a wanda called raypy38gpubase, which is a layer of ray-deps < ray-ml
- build ray-ml image by installing ray on top of raypy38gpubase

Notice that, comparing to civ1, this switches the order of ray installation and ml library installation. However, due to the requirement-compiled constraint file, the order doesn't matter.

Test:
- CI, ml image is built (not uploaded yet): https://buildkite.com/ray-project/premerge/builds/4643#018a60e7-2c8a-481a-a114-75f2d47be7f0