### PR TITLE
convert pyarrow.lib.Table to Pandas Dataframe

### DIFF
--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -135,7 +135,11 @@ class PandasBlockAccessor(TableBlockAccessor):
     ROW_TYPE = PandasRow
 
     def __init__(self, table: "pandas.DataFrame"):
+        import pyarrow
+        if isinstance(self._table, pyarrow.lib.Table):
+            table = table.to_pandas()
         super().__init__(table)
+
 
     def column_names(self) -> List[str]:
         return self._table.columns.tolist()


### PR DESCRIPTION
Fix AttributeError: 'pyarrow.lib.Table' object has no attribute 'reset_index'

Issue:  https://github.com/ray-project/ray/issues/39155

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
