### PR TITLE
Reuse dashboard agent's fate sharing watcher in runtime env agent. (#…

### DIFF
--- a/python/ray/_private/process_watcher.py
+++ b/python/ray/_private/process_watcher.py
@@ -1,0 +1,159 @@
+import asyncio
+import io
+import logging
+import sys
+import os
+
+import ray
+from ray.dashboard.consts import _PARENT_DEATH_THREASHOLD
+import ray.dashboard.consts as dashboard_consts
+import ray._private.ray_constants as ray_constants
+from ray._private.utils import run_background_task
+
+# Import psutil after ray so the packaged version is used.
+import psutil
+
+
+logger = logging.getLogger(__name__)
+
+# TODO: move all consts from dashboard_consts to ray_constants and rename to remove
+# DASHBOARD_ prefixes.
+
+# Publishes at most this number of lines of Raylet logs, when the Raylet dies
+# unexpectedly.
+_RAYLET_LOG_MAX_PUBLISH_LINES = 20
+
+# Reads at most this amount of Raylet logs from the tail, for publishing and
+# checking if the Raylet was terminated gracefully.
+_RAYLET_LOG_MAX_TAIL_SIZE = 1 * 1024**2
+
+try:
+    create_task = asyncio.create_task
+except AttributeError:
+    create_task = asyncio.ensure_future
+
+
+def get_raylet_pid():
+    # TODO(edoakes): RAY_RAYLET_PID isn't properly set on Windows. This is
+    # only used for fate-sharing with the raylet and we need a different
+    # fate-sharing mechanism for Windows anyways.
+    if sys.platform in ["win32", "cygwin"]:
+        return None
+    raylet_pid = int(os.environ["RAY_RAYLET_PID"])
+    assert raylet_pid > 0
+    logger.info("raylet pid is %s", raylet_pid)
+    return raylet_pid
+
+
+def create_check_raylet_task(log_dir, gcs_address, parent_dead_callback, loop):
+    """
+    Creates an asyncio task to periodically check if the raylet process is still
+    running. If raylet is dead for _PARENT_DEATH_THREASHOLD (5) times, prepare to exit
+    as follows:
+
+    - Write logs about whether the raylet exit is graceful, by looking into the raylet
+    log and search for term "SIGTERM",
+    - Flush the logs via GcsPublisher,
+    - Exit.
+    """
+    if sys.platform in ["win32", "cygwin"]:
+        raise RuntimeError("can't check raylet process in Windows.")
+    raylet_pid = get_raylet_pid()
+    return run_background_task(
+        _check_parent(raylet_pid, log_dir, gcs_address, parent_dead_callback)
+    )
+
+
+async def _check_parent(raylet_pid, log_dir, gcs_address, parent_dead_callback):
+    """Check if raylet is dead and fate-share if it is."""
+    try:
+        curr_proc = psutil.Process()
+        parent_death_cnt = 0
+        while True:
+            parent = curr_proc.parent()
+            # If the parent is dead, it is None.
+            parent_gone = parent is None
+            init_assigned_for_parent = False
+            parent_changed = False
+
+            if parent:
+                # Sometimes, the parent is changed to the `init` process.
+                # In this case, the parent.pid is 1.
+                init_assigned_for_parent = parent.pid == 1
+                # Sometimes, the parent is dead, and the pid is reused
+                # by other processes. In this case, this condition is triggered.
+                parent_changed = raylet_pid != parent.pid
+
+            if parent_gone or init_assigned_for_parent or parent_changed:
+                parent_death_cnt += 1
+                logger.warning(
+                    f"Raylet is considered dead {parent_death_cnt} X. "
+                    f"If it reaches to {_PARENT_DEATH_THREASHOLD}, the agent "
+                    f"will kill itself. Parent: {parent}, "
+                    f"parent_gone: {parent_gone}, "
+                    f"init_assigned_for_parent: {init_assigned_for_parent}, "
+                    f"parent_changed: {parent_changed}."
+                )
+                if parent_death_cnt < _PARENT_DEATH_THREASHOLD:
+                    await asyncio.sleep(
+                        dashboard_consts.DASHBOARD_AGENT_CHECK_PARENT_INTERVAL_S
+                    )
+                    continue
+
+                log_path = os.path.join(log_dir, "raylet.out")
+                error = False
+                parent_dead_callback()
+                msg = "Raylet is terminated. "
+                try:
+                    with open(log_path, "r", encoding="utf-8") as f:
+                        # Seek to _RAYLET_LOG_MAX_TAIL_SIZE from the end if the
+                        # file is larger than that.
+                        f.seek(0, io.SEEK_END)
+                        pos = max(0, f.tell() - _RAYLET_LOG_MAX_TAIL_SIZE)
+                        f.seek(pos, io.SEEK_SET)
+                        # Read remaining logs by lines.
+                        raylet_logs = f.readlines()
+                        # Assume the SIGTERM message must exist within the last
+                        # _RAYLET_LOG_MAX_TAIL_SIZE of the log file.
+                        if any(
+                            "Raylet received SIGTERM" in line for line in raylet_logs
+                        ):
+                            msg += "Termination is graceful."
+                            logger.info(msg)
+                        else:
+                            msg += (
+                                "Termination is unexpected. Possible reasons "
+                                "include: (1) SIGKILL by the user or system "
+                                "OOM killer, (2) Invalid memory access from "
+                                "Raylet causing SIGSEGV or SIGBUS, "
+                                "(3) Other termination signals. "
+                                f"Last {_RAYLET_LOG_MAX_PUBLISH_LINES} lines "
+                                "of the Raylet logs:\n"
+                            )
+                            msg += "    " + "    ".join(
+                                raylet_logs[-_RAYLET_LOG_MAX_PUBLISH_LINES:]
+                            )
+                            error = True
+                except Exception as e:
+                    msg += f"Failed to read Raylet logs at {log_path}: {e}!"
+                    logger.exception(msg)
+                    error = True
+                if error:
+                    logger.error(msg)
+                    # TODO: switch to async if necessary.
+                    ray._private.utils.publish_error_to_driver(
+                        ray_constants.RAYLET_DIED_ERROR,
+                        msg,
+                        gcs_publisher=ray._raylet.GcsPublisher(address=gcs_address),
+                    )
+                else:
+                    logger.info(msg)
+                sys.exit(0)
+            else:
+                parent_death_cnt = 0
+            await asyncio.sleep(
+                dashboard_consts.DASHBOARD_AGENT_CHECK_PARENT_INTERVAL_S
+            )
+    except Exception:
+        logger.exception("Failed to check parent PID, exiting.")
+        sys.exit(1)

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -209,7 +209,6 @@ py_test_module_list(
     "test_mini.py",
     "test_minimal_install.py",
     "test_numba.py",
-    "test_runtime_env_agent.py",
     "test_redis_tls.py",
     "test_raylet_output.py",
     "test_top_level_api.py",
@@ -403,6 +402,14 @@ py_test(
     name = "test_actor_group",
     size = "medium",
     srcs = ["test_actor_group.py"],
+    tags = ["exclusive", "medium_size_python_tests_a_to_j", "team:core"],
+    deps = ["//:ray_lib", ":conftest"]
+)
+
+py_test(
+    name = "test_runtime_env_agent",
+    size = "medium",
+    srcs = ["test_runtime_env_agent.py"],
     tags = ["exclusive", "medium_size_python_tests_a_to_j", "team:core"],
     deps = ["//:ray_lib", ":conftest"]
 )

--- a/python/ray/tests/test_runtime_env_agent.py
+++ b/python/ray/tests/test_runtime_env_agent.py
@@ -1,9 +1,22 @@
 import sys
 import pytest
-
+import logging
+import os
+import time
 from typing import List, Tuple
+
+import ray
 from ray._private.runtime_env.agent.runtime_env_agent import UriType, ReferenceTable
+from ray._private import ray_constants
+from ray._private.test_utils import (
+    get_error_message,
+    init_error_pubsub,
+    wait_for_condition,
+)
 from ray.runtime_env import RuntimeEnv
+import psutil
+
+logger = logging.getLogger(__name__)
 
 
 def test_reference_table():
@@ -76,6 +89,143 @@ def test_reference_table():
     )
     assert not expected_unused_uris
     assert not expected_unused_runtime_env
+
+
+def search_agent(processes):
+    for p in processes:
+        try:
+            for c in p.cmdline():
+                if os.path.join("runtime_env", "agent", "main.py") in c:
+                    return p
+        except Exception:
+            pass
+
+
+def check_agent_register(raylet_proc, agent_pid):
+    # Check if agent register is OK.
+    for x in range(5):
+        logger.info("Check agent is alive.")
+        agent_proc = search_agent(raylet_proc.children())
+        assert agent_proc.pid == agent_pid
+        time.sleep(1)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="no fate sharing for windows")
+def test_raylet_and_agent_share_fate(shutdown_only):
+    """Test raylet and agent share fate."""
+
+    ray.init()
+    p = init_error_pubsub()
+
+    node = ray._private.worker._global_node
+    all_processes = node.all_processes
+    raylet_proc_info = all_processes[ray_constants.PROCESS_TYPE_RAYLET][0]
+    raylet_proc = psutil.Process(raylet_proc_info.process.pid)
+
+    wait_for_condition(lambda: search_agent(raylet_proc.children()))
+    agent_proc = search_agent(raylet_proc.children())
+    agent_pid = agent_proc.pid
+
+    check_agent_register(raylet_proc, agent_pid)
+
+    # The agent should be dead if raylet exits.
+    raylet_proc.terminate()
+    raylet_proc.wait()
+    agent_proc.wait(15)
+
+    # No error should be reported for graceful termination.
+    errors = get_error_message(p, 1, ray_constants.RAYLET_DIED_ERROR)
+    assert len(errors) == 0, errors
+
+    ray.shutdown()
+
+    ray.init()
+    all_processes = ray._private.worker._global_node.all_processes
+    raylet_proc_info = all_processes[ray_constants.PROCESS_TYPE_RAYLET][0]
+    raylet_proc = psutil.Process(raylet_proc_info.process.pid)
+    wait_for_condition(lambda: search_agent(raylet_proc.children()))
+    agent_proc = search_agent(raylet_proc.children())
+    agent_pid = agent_proc.pid
+
+    check_agent_register(raylet_proc, agent_pid)
+
+    # The raylet should be dead if agent exits.
+    agent_proc.kill()
+    agent_proc.wait()
+    raylet_proc.wait(15)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="no fate sharing for windows")
+def test_agent_report_unexpected_raylet_death(shutdown_only):
+    """Test agent reports Raylet death if it is not SIGTERM."""
+
+    ray.init()
+    p = init_error_pubsub()
+
+    node = ray._private.worker._global_node
+    all_processes = node.all_processes
+    raylet_proc_info = all_processes[ray_constants.PROCESS_TYPE_RAYLET][0]
+    raylet_proc = psutil.Process(raylet_proc_info.process.pid)
+
+    wait_for_condition(lambda: search_agent(raylet_proc.children()))
+    agent_proc = search_agent(raylet_proc.children())
+    agent_pid = agent_proc.pid
+
+    check_agent_register(raylet_proc, agent_pid)
+
+    # The agent should be dead if raylet exits.
+    raylet_proc.kill()
+    raylet_proc.wait()
+    agent_proc.wait(15)
+
+    errors = get_error_message(p, 1, ray_constants.RAYLET_DIED_ERROR)
+    assert len(errors) == 1, errors
+    err = errors[0]
+    assert err["type"] == ray_constants.RAYLET_DIED_ERROR
+    assert "Termination is unexpected." in err["error_message"], err["error_message"]
+    assert "Raylet logs:" in err["error_message"], err["error_message"]
+    assert (
+        os.path.getsize(os.path.join(node.get_session_dir_path(), "logs", "raylet.out"))
+        < 1 * 1024**2
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="no fate sharing for windows")
+def test_agent_report_unexpected_raylet_death_large_file(shutdown_only):
+    """Test agent reports Raylet death if it is not SIGTERM."""
+
+    ray.init()
+    p = init_error_pubsub()
+
+    node = ray._private.worker._global_node
+    all_processes = node.all_processes
+    raylet_proc_info = all_processes[ray_constants.PROCESS_TYPE_RAYLET][0]
+    raylet_proc = psutil.Process(raylet_proc_info.process.pid)
+
+    wait_for_condition(lambda: search_agent(raylet_proc.children()))
+    agent_proc = search_agent(raylet_proc.children())
+    agent_pid = agent_proc.pid
+
+    check_agent_register(raylet_proc, agent_pid)
+
+    # Append to the Raylet log file with data >> 1 MB.
+    with open(
+        os.path.join(node.get_session_dir_path(), "logs", "raylet.out"), "a"
+    ) as f:
+        f.write("test data\n" * 1024**2)
+
+    # The agent should be dead if raylet exits.
+    raylet_proc.kill()
+    raylet_proc.wait()
+    agent_proc.wait(15)
+
+    # Reading and publishing logs should still work.
+    errors = get_error_message(p, 1, ray_constants.RAYLET_DIED_ERROR)
+    assert len(errors) == 1, errors
+    err = errors[0]
+    assert err["type"] == ray_constants.RAYLET_DIED_ERROR
+    assert "Termination is unexpected." in err["error_message"], err["error_message"]
+    assert "Raylet logs:" in err["error_message"], err["error_message"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…38909)

Previously the dashboard agent listens on raylet death and exits. Porting this feature to runtime env agent also.

Closes #39092
Signed-off-by: Ruiyang Wang <rywang014@gmail.com>
