### PR TITLE
[core] Mark stress_test_many_runtime_envs as unstable.

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5125,6 +5125,11 @@
   python: "3.8"
   frequency: nightly
   team: core
+
+  # Marking unstable because it's not working right now beyond ~3000 runtime envs.
+  # Tracking issue: https://github.com/ray-project/ray/issues/38662
+  stable: false
+
   cluster:
     byod: {}
     cluster_compute: stress_tests/smoke_test_compute.yaml


### PR DESCRIPTION
## Why are these changes needed?

Release test stress_test_many_runtime_envs is failing, but we don't have a fix right now. This is ok because the test never passed properly; and in production it's not likely we have 10000 runtime envs. Will fix after the release.

## Related issue number

Unblock release for https://github.com/ray-project/ray/issues/38662.