### PR TITLE
[serve] Rename http proxies to proxies + add docstrings (#39131)

### DIFF
--- a/dashboard/client/src/pages/serve/ServeApplicationsListPage.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeApplicationsListPage.component.test.tsx
@@ -34,7 +34,7 @@ describe("ServeApplicationsListPage", () => {
     mockGetServeApplications.mockResolvedValue({
       data: {
         http_options: { host: "1.2.3.4", port: 8000 },
-        http_proxies: {
+        proxies: {
           foo: {
             node_id: "node:12345",
             status: ServeSystemActorStatus.STARTING,

--- a/dashboard/client/src/pages/serve/ServeSystemDetailPage.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeSystemDetailPage.component.test.tsx
@@ -35,7 +35,7 @@ describe("ServeSystemDetailPage", () => {
       data: {
         http_options: { host: "1.2.3.4", port: 8000 },
         grpc_options: { port: 9000 },
-        http_proxies: {
+        proxies: {
           foo: {
             node_id: "node:12345",
             status: ServeSystemActorStatus.STARTING,

--- a/dashboard/client/src/pages/serve/hook/useServeApplications.ts
+++ b/dashboard/client/src/pages/serve/hook/useServeApplications.ts
@@ -67,8 +67,8 @@ export const useServeApplications = () => {
     : [];
 
   const httpProxies =
-    data && data.http_proxies
-      ? Object.values(data.http_proxies).sort(
+    data && data.proxies
+      ? Object.values(data.proxies).sort(
           (a, b) =>
             SERVE_HTTP_PROXY_STATUS_SORT_ORDER[b.status] -
             SERVE_HTTP_PROXY_STATUS_SORT_ORDER[a.status],
@@ -211,7 +211,7 @@ export const useServeHTTPProxyDetails = (httpProxyId: string | undefined) => {
     { refreshInterval: API_REFRESH_INTERVAL_MS },
   );
 
-  const httpProxy = httpProxyId ? data?.http_proxies?.[httpProxyId] : undefined;
+  const httpProxy = httpProxyId ? data?.proxies?.[httpProxyId] : undefined;
 
   // Need to expose loading because it's not clear if undefined values
   // for proxies means loading or missing data.

--- a/dashboard/client/src/type/serve.ts
+++ b/dashboard/client/src/type/serve.ts
@@ -119,7 +119,7 @@ export type ServeApplicationsRsp = {
   };
   proxy_location: ServeDeploymentMode;
   controller_info: ServeSystemActor;
-  http_proxies: {
+  proxies: {
     [name: string]: ServeHttpProxy;
   } | null;
   applications: {

--- a/dashboard/modules/serve/tests/test_serve_agent.py
+++ b/dashboard/modules/serve/tests/test_serve_agent.py
@@ -19,7 +19,7 @@ from ray.serve._private.common import (
     ApplicationStatus,
     DeploymentStatus,
     ReplicaState,
-    HTTPProxyStatus,
+    ProxyStatus,
 )
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 
@@ -564,8 +564,8 @@ def test_get_serve_instance_details(ray_start_stop, f_deployment_options):
     )
 
     # Check HTTP Proxy statuses
-    for proxy in serve_details.http_proxies.values():
-        assert proxy.status == HTTPProxyStatus.HEALTHY
+    for proxy in serve_details.proxies.values():
+        assert proxy.status == ProxyStatus.HEALTHY
         assert os.path.exists("/tmp/ray/session_latest/logs" + proxy.log_file_path)
     print("Checked HTTP Proxy details.")
     # Check controller info

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -443,7 +443,7 @@ class ServeDeployMode(str, Enum):
 
 # Keep in sync with ServeSystemActorStatus in
 # python/ray/dashboard/client/src/type/serve.ts
-class HTTPProxyStatus(str, Enum):
+class ProxyStatus(str, Enum):
     STARTING = "STARTING"
     HEALTHY = "HEALTHY"
     UNHEALTHY = "UNHEALTHY"

--- a/python/ray/serve/controller.py
+++ b/python/ray/serve/controller.py
@@ -899,7 +899,7 @@ class ServeController:
             proxy_location=http_config.location,
             http_options=http_options,
             grpc_options=grpc_options,
-            http_proxies=self.http_proxy_state_manager.get_http_proxy_details()
+            proxies=self.http_proxy_state_manager.get_proxy_details()
             if self.http_proxy_state_manager
             else None,
             deploy_mode=self.deploy_mode,

--- a/python/ray/serve/tests/test_callback.py
+++ b/python/ray/serve/tests/test_callback.py
@@ -12,7 +12,7 @@ import ray
 from ray.exceptions import RayActorError
 from ray import serve
 from ray._private.test_utils import wait_for_condition
-from ray.serve._private.common import HTTPProxyStatus
+from ray.serve._private.common import ProxyStatus
 from ray.serve._private.utils import call_function_from_import_path
 from ray.serve.context import get_global_client
 from ray.serve.schema import ServeInstanceDetails
@@ -233,8 +233,8 @@ def test_http_proxy_calllback_failures(ray_instance, capsys):
         prev_actor_id = None
         while True:
             serve_details = ServeInstanceDetails(**client.get_serve_details())
-            for _, proxy_info in serve_details.http_proxies.items():
-                if proxy_info.status != HTTPProxyStatus.STARTING:
+            for _, proxy_info in serve_details.proxies.items():
+                if proxy_info.status != ProxyStatus.STARTING:
                     return False
                 if prev_actor_id is None:
                     prev_actor_id = proxy_info.actor_id


### PR DESCRIPTION
1. Rename `http_proxies` to `proxies` in `ServeInstanceDetails` because the proxy can be both HTTP and gRPC. Note: this is a breaking change, but we are intentionally making it for Ray 2.7 since it has been marked alpha thus far, and it's unlikely anyone is using this right now. Making the change now will save us a lot of headaches in the future.
2. Add docstrings for dataclasses returned from `serve.status()`

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cherry pick https://github.com/ray-project/ray/pull/39131.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
