### PR TITLE
[Core][Java Worker]Removing redundant head arguments code in the Java worker

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
+++ b/java/runtime/src/main/java/io/ray/runtime/runner/RunManager.java
@@ -31,31 +31,6 @@ public class RunManager {
     command.add(rayConfig.redisPassword);
     command.addAll(rayConfig.headArgs);
 
-    String numCpus = System.getProperty("num-cpus");
-    if (numCpus != null) {
-      command.add("--num-cpus");
-      command.add(numCpus);
-    }
-
-    String numGpus = System.getProperty("num-gpus");
-    if (numGpus != null) {
-      command.add("--num-gpus");
-      command.add(numGpus);
-    }
-
-    String memory = System.getProperty("memory");
-    if (memory != null) {
-      command.add("--memory");
-      command.add(memory);
-    }
-
-    // Set node labels.
-    String labels = System.getProperty("ray.labels");
-    if (labels != null) {
-      command.add("--labels");
-      command.add(labels);
-    }
-
     String output;
     try {
       output = runCommand(command);

--- a/java/runtime/src/main/resources/ray.default.conf
+++ b/java/runtime/src/main/resources/ray.default.conf
@@ -118,5 +118,9 @@ ray {
 
   // Below args will be appended as parameters of the `ray start` command.
   // It takes effect only if Ray head is started by a driver.
-  head-args: []
+  head-args: [
+//    "--num-cpus=1",
+//    "--num-gpus=1",
+//    "--memory=1073741824"
+  ]
 }

--- a/java/test/src/main/java/io/ray/test/GpuResourceTest.java
+++ b/java/test/src/main/java/io/ray/test/GpuResourceTest.java
@@ -16,7 +16,7 @@ public class GpuResourceTest {
   @Test(groups = "cluster")
   public void testGetResourceId() {
     try {
-      System.setProperty("num-gpus", "3");
+      System.setProperty("ray.head-args.0", "--num-gpus=3");
       Ray.init();
       ActorHandle<GpuActor> gpuActorActorHandle =
           Ray.actor(GpuActor::new).setResource("GPU", 1D).remote();

--- a/java/test/src/main/java/io/ray/test/NodeLabelSchedulingTest.java
+++ b/java/test/src/main/java/io/ray/test/NodeLabelSchedulingTest.java
@@ -24,7 +24,7 @@ public class NodeLabelSchedulingTest {
   }
 
   public void testSetNodeLabels() {
-    System.setProperty("ray.labels", "{\"gpu_type\":\"A100\",\"azone\":\"azone-1\"}");
+    System.setProperty("ray.head-args.0", "--labels={\"gpu_type\":\"A100\",\"azone\":\"azone-1\"}");
     try {
       Ray.init();
       List<NodeInfo> nodeInfos = Ray.getRuntimeContext().getAllNodeInfo();
@@ -35,7 +35,7 @@ public class NodeLabelSchedulingTest {
       labels.put("azone", "azone-1");
       Assert.assertEquals(nodeInfos.get(0).labels, labels);
     } finally {
-      System.clearProperty("ray.labels");
+      System.clearProperty("ray.head-args.0");
       Ray.shutdown();
     }
   }

--- a/java/test/src/main/java/io/ray/test/PlacementGroupWithResourcesTest.java
+++ b/java/test/src/main/java/io/ray/test/PlacementGroupWithResourcesTest.java
@@ -21,15 +21,15 @@ public class PlacementGroupWithResourcesTest extends BaseTest {
 
   @BeforeClass
   public void setUp() {
-    System.setProperty("num-cpus", "1");
+    System.setProperty("ray.head-args.0", "--num-cpus=1");
     // 1GB
-    System.setProperty("memory", "1073741824");
+    System.setProperty("ray.head-args.1", "--memory=1073741824");
   }
 
   @AfterClass
   public void tearDown() {
-    System.clearProperty("num-cpus");
-    System.clearProperty("memory");
+    System.clearProperty("ray.head-args.0");
+    System.clearProperty("ray.head-args.1");
   }
 
   public static int simpleFunction() {


### PR DESCRIPTION
## Why are these changes needed?
There is already a very general method available to address the parameter issue when starting the head node. 
Now, let's remove the redundant code.
```
    System.setProperty("ray.head-args.0", "--num-cpus=1");
    // 1GB
    System.setProperty("ray.head-args.1", "--memory=1073741824");
```
