### PR TITLE
[docs][clusters]Update text to remove references to Ray Client

### DIFF
--- a/doc/source/cluster/key-concepts.rst
+++ b/doc/source/cluster/key-concepts.rst
@@ -70,11 +70,10 @@ Ray Jobs
 A Ray job is a single application: it is the collection of Ray tasks, objects, and actors that originate from the same script.
 The worker that runs the Python script is known as the *driver* of the job.
 
-There are three ways to run a Ray job on a Ray cluster:
+There are two ways to run a Ray job on a Ray cluster:
 
 1. (Recommended) Submit the job using the :ref:`Ray Jobs API <jobs-overview>`.
 2. Run the driver script directly on any node of the Ray cluster, for interactive development.
-3. (For Experts only) Use :ref:`Ray Client <ray-client-ref>` to connect remotely to the cluster within a driver script.
 
 For details on these workflows, refer to the :ref:`Ray Jobs API guide <jobs-overview>`.
 
@@ -82,4 +81,4 @@ For details on these workflows, refer to the :ref:`Ray Jobs API guide <jobs-over
     :align: center
     :width: 650px
 
-    *Three ways of running a job on a Ray cluster.*
+    *Two ways of running a job on a Ray cluster.*


### PR DESCRIPTION
Because we removed the Ray Client option in the diagram, the text needs to be updated, too.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

(https://github.com/ray-project/ray/pull/38337)

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
