### PR TITLE
[train][ci] Fix `tune_hvd_keras` import order

### DIFF
--- a/python/ray/tests/ml_py37_compat/tune_hvd_keras.py
+++ b/python/ray/tests/ml_py37_compat/tune_hvd_keras.py
@@ -9,9 +9,6 @@ from ray.tune import Tuner, TuneConfig
 import numpy as np
 
 
-# TF/Keras-specific
-import horovod.keras as hvd
-
 from ray.air.integrations.keras import ReportCheckpointCallback
 import tensorflow as tf
 
@@ -28,6 +25,8 @@ def create_keras_model(input_features):
 
 
 def keras_train_loop(config):
+    import horovod.keras as hvd
+
     lr = config["lr"]
     epochs = config["epochs"]
     batch_size = config["batch_size"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The test is failing due to the ordering of `horovod` and `tensorboardX.SummaryWriter` imports. This is a known issue: https://github.com/pytorch/pytorch/issues/30651. This PR fixes it by moving the horovod import into the training loop -- to happen after the `tensorboardX` import on the driver.

The tests was passing before the `xgboost_ray` version bump, so there's probably some underlying package that got updated that's the root cause.

### Reproduction of the bug

Horovod first, then tensorboard fails with a segfault:
```
>>> import horovod.keras as hvd
2023-09-01 10:13:20.236734: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
2023-09-01 10:13:20.236757: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
>>> from tensorboardX import SummaryWriter
2023-09-01 10:13:29.194509: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
2023-09-01 10:13:29.194539: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
Segmentation fault
```

Tensorboard first then horovod works:
```
>>> from tensorboardX import SummaryWriter
>>> import horovod.keras as hvd
2023-09-01 10:14:36.773923: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
2023-09-01 10:14:36.773949: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
