### PR TITLE
[serve] gRPC proxy to handle internal errors (#39144)

### DIFF
--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -693,6 +693,14 @@ class gRPCProxy(GenericProxy):
             response=response_proto.SerializeToString(),
         )
 
+    def _set_internal_error_response(
+        self, proxy_request: ProxyRequest, error: Exception
+    ) -> ProxyResponse:
+        status_code = grpc.StatusCode.INTERNAL
+        proxy_request.send_status_code(status_code=status_code)
+        proxy_request.send_details(message=str(error))
+        return ProxyResponse(status_code=str(status_code))
+
     def service_handler_factory(self, service_method: str, stream: bool) -> Callable:
         async def unary_unary(
             request_proto: Any, context: grpc._cython.cygrpc._ServicerContext
@@ -811,6 +819,9 @@ class gRPCProxy(GenericProxy):
 
             except StopAsyncIteration:
                 break
+            except Exception as e:
+                self._set_internal_error_response(proxy_request, e)
+                break
 
     async def _consume_generator_stream(
         self,
@@ -898,7 +909,7 @@ class gRPCProxy(GenericProxy):
 
         except Exception as e:
             logger.exception(e)
-            return ProxyResponse(status_code=str(grpc.StatusCode.INTERNAL))
+            return self._set_internal_error_response(proxy_request, e)
 
 
 class HTTPProxy(GenericProxy):

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -230,7 +230,7 @@ def test_proxy_metrics(serve_start_shutdown):
     serve.run(A.bind(), name=app_name)
     requests.get("http://127.0.0.1:8000/A/")
     requests.get("http://127.0.0.1:8000/A/")
-    with pytest.raises(AssertionError):
+    with pytest.raises(grpc.RpcError):
         ping_grpc_call_method(channel=channel, app_name=app_name)
     try:
         wait_for_condition(
@@ -339,7 +339,7 @@ def test_proxy_metrics_fields(serve_start_shutdown):
     print("Sent requests to correct URL.")
 
     # Ping gPRC proxy for broken app
-    with pytest.raises(AssertionError):
+    with pytest.raises(grpc.RpcError):
         ping_grpc_call_method(channel=channel, app_name=real_app_name)
 
     num_deployment_errors = get_metric_dictionaries(
@@ -679,7 +679,7 @@ class TestRequestContextMetrics:
         channel = grpc.insecure_channel("localhost:9000")
         ping_grpc_call_method(channel, app_name1)
         ping_fruit_stand(channel, app_name2)
-        with pytest.raises(AssertionError):
+        with pytest.raises(grpc.RpcError):
             ping_grpc_call_method(channel, app_name3)
 
         # app1 has 1 deployment, app2 has 3 deployments, and app3 has 1 deployment.


### PR DESCRIPTION
Found this unhandled case when writing the doc. The current behavior did not send gRPC "INTERNAL" status back to the client. For unary requests, it will just fail silently without the client getting the error. For streaming requests, although the errors are returned, the status code are not properly propagated to the client. This PR ensure the RPC calls set the expected status code and error messages when there are internal error raised. Also added a test case for it to ensure it's caught moving forward.
Signed-off-by: Gene Su <e870252314@gmail.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Picks of https://github.com/ray-project/ray/pull/39144

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
