### PR TITLE
[cherry-pick] [core] Fix the GCS crash when using LD_PRELOAD and make jemalloc work with worker as well (#39192)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,8 +14,8 @@ build:clang-cl --cxxopt="-std=c++17"
 build:msvc-cl --cxxopt="/std:c++17"
 build:windows --cxxopt="/std:c++17"
 # This workaround is needed to prevent Bazel from compiling the same file twice (once PIC and once not).
-build:linux --force_pic
-build:macos --force_pic
+build:linux --copt="-fPIC"
+build:macos --copt="-fPIC"
 build:clang-cl --compiler=clang-cl
 build:msvc-cl --compiler=msvc-cl
 # `LC_ALL` and `LANG` is needed for cpp worker tests, because they will call "ray start".

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,11 +9,11 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:defs.bzl", "py_library", "py_runtime", "py_runtime_pair")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_github_grpc_grpc//bazel:cython_library.bzl", "pyx_library")
 load("@com_github_google_flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
-load("//bazel:ray.bzl", "COPTS", "PYX_COPTS", "PYX_SRCS", "copy_to_workspace")
+load("//bazel:ray.bzl", "COPTS", "PYX_COPTS", "PYX_SRCS", "copy_to_workspace", "ray_cc_binary", "ray_cc_test", "ray_cc_library")
 load("@python3_9//:defs.bzl", python39 = "interpreter")
 
 package(
@@ -41,7 +41,6 @@ constraint_setting(name = "hermetic")
 constraint_value(
     name = "hermetic_python",
     constraint_setting = ":hermetic",
-    visibility = ["//visibility:public"],
 )
 
 toolchain(
@@ -91,17 +90,9 @@ config_setting(
     }
 )
 
-malloc_deps = select({
-    ":jemalloc": [
-         "@jemalloc//:libjemalloc",
-    ],
-    "//conditions:default": [],
-})
-
-
 # === Begin of rpc definitions ===
 # GRPC common lib.
-cc_library(
+ray_cc_library(
     name = "grpc_common_lib",
     srcs = [
         "src/ray/rpc/common.cc",
@@ -118,8 +109,6 @@ cc_library(
         "src/ray/rpc/grpc_util.h",
         "src/ray/raylet_client/*.h",
     ]),
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":stats_metric",
         "//src/ray/common:asio",
@@ -143,7 +132,7 @@ cc_grpc_library(
 )
 
 # Node manager server and client.
-cc_library(
+ray_cc_library(
     name = "node_manager_rpc",
     srcs = glob([
         "src/ray/rpc/node_manager/*.cc",
@@ -151,8 +140,6 @@ cc_library(
     hdrs = glob([
         "src/ray/rpc/node_manager/*.h",
     ]),
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":grpc_common_lib",
         ":node_manager_cc_grpc",
@@ -179,14 +166,12 @@ cc_grpc_library(
 )
 
 # gcs rpc server and client.
-cc_library(
+ray_cc_library(
     name = "gcs_service_rpc",
     hdrs = [
         "src/ray/rpc/gcs_server/gcs_rpc_client.h",
         "src/ray/rpc/gcs_server/gcs_rpc_server.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":autoscaler_cc_grpc",
         ":gcs_service_cc_grpc",
@@ -208,13 +193,11 @@ cc_grpc_library(
 )
 
 # Object manager rpc server and client.
-cc_library(
+ray_cc_library(
     name = "object_manager_rpc",
     hdrs = glob([
         "src/ray/rpc/object_manager/*.h",
     ]),
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":grpc_common_lib",
         ":object_manager_cc_grpc",
@@ -233,7 +216,7 @@ cc_grpc_library(
 )
 
 # worker server and client.
-cc_library(
+ray_cc_library(
     name = "worker_rpc",
     srcs = glob([
         "src/ray/rpc/worker/*.cc",
@@ -241,8 +224,6 @@ cc_library(
     hdrs = glob([
         "src/ray/rpc/worker/*.h",
     ]),
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":grpc_common_lib",
         ":pubsub_lib",
@@ -263,13 +244,11 @@ cc_grpc_library(
 )
 
 # Metrics Agent client.
-cc_library(
+ray_cc_library(
     name = "reporter_rpc",
     hdrs = glob([
         "src/ray/rpc/metrics_agent_client.h",
     ]),
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":grpc_common_lib",
         ":reporter_cc_grpc",
@@ -292,9 +271,8 @@ cc_grpc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "pubsub_rpc",
-    copts = COPTS,
     deps = [
         "pubsub_cc_grpc",
         ":grpc_common_lib",
@@ -310,10 +288,8 @@ cc_grpc_library(
     deps = ["//src/ray/protobuf:monitor_cc_proto"],
 )
 
-cc_library(
+ray_cc_library(
     name = "monitor_rpc",
-    copts = COPTS,
-    visibility = ["//visibility:public"],
     deps = [
         ":monitor_cc_grpc",
     ],
@@ -328,10 +304,8 @@ cc_grpc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "autoscaler_rpc",
-    copts = COPTS,
-    visibility = ["//visibility:public"],
     deps = [
         ":autoscaler_cc_grpc",
     ],
@@ -360,7 +334,7 @@ PLASMA_LINKOPTS = [] + select({
     ],
 })
 
-cc_library(
+ray_cc_library(
     name = "plasma_client",
     srcs = [
         "src/ray/object_manager/plasma/client.cc",
@@ -400,7 +374,6 @@ cc_library(
         "//conditions:default": [],
     }),
     linkopts = PLASMA_LINKOPTS,
-    strip_include_prefix = "src",
     deps = [
         ":plasma_fbs",
         ":ray_common",
@@ -410,7 +383,7 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "plasma_store_server_lib",
     srcs = [
         "src/ray/object_manager/plasma/create_request_queue.cc",
@@ -440,7 +413,6 @@ cc_library(
     ],
     copts = PLASMA_COPTS,
     linkopts = PLASMA_LINKOPTS,
-    strip_include_prefix = "src",
     deps = [
         ":plasma_client",
         ":stats_lib",
@@ -462,14 +434,11 @@ flatbuffer_cc_library(
 
 # === End of plasma definitions ===
 
-cc_library(
+ray_cc_library(
     name = "ray_mock",
     hdrs = glob(
         ["src/mock/**/*.h"],
     ),
-    copts = COPTS,
-    strip_include_prefix = "src",
-    visibility = ["//visibility:public"],
 )
 
 cc_grpc_library(
@@ -479,11 +448,8 @@ cc_grpc_library(
     deps = ["//src/ray/protobuf:ray_syncer_cc_proto"],
 )
 
-cc_library(
+ray_cc_library(
     name = "ray_common",
-    copts = COPTS,
-    strip_include_prefix = "src",
-    visibility = ["//visibility:public"],
     deps = [
         ":stats_metric",
         "//src/ray/common:asio",
@@ -504,19 +470,18 @@ cc_library(
     ],
 )
 
-cc_binary(
+ray_cc_binary(
     name = "raylet",
     srcs = ["src/ray/raylet/main.cc"],
-    copts = COPTS,
     visibility = ["//java:__subpackages__"],
     deps = [
         ":raylet_lib",
         "//src/ray/util",
         "@com_github_gflags_gflags//:gflags",
-    ] + malloc_deps,
+    ],
 )
 
-cc_library(
+ray_cc_library(
     name = "gcs_pub_sub_lib",
     srcs = [
         "src/ray/gcs/pubsub/gcs_pub_sub.cc",
@@ -524,8 +489,6 @@ cc_library(
     hdrs = [
         "src/ray/gcs/pubsub/gcs_pub_sub.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":gcs",
         ":gcs_service_rpc",
@@ -535,7 +498,7 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "gcs_server_lib",
     srcs = glob(
         [
@@ -551,8 +514,6 @@ cc_library(
             "src/ray/gcs/gcs_server/*.h",
         ],
     ),
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":autoscaler_rpc",
         ":gcs",
@@ -574,22 +535,21 @@ cc_library(
     ],
 )
 
-cc_binary(
+ray_cc_binary(
     name = "gcs_server",
     srcs = [
         "src/ray/gcs/gcs_server/gcs_server_main.cc",
     ],
-    copts = COPTS,
     visibility = ["//java:__subpackages__"],
     deps = [
         ":gcs_server_lib",
         ":stats_lib",
         "@com_github_gflags_gflags//:gflags",
-    ] + malloc_deps,
+    ],
 )
 
 # Ray native pubsub module.
-cc_library(
+ray_cc_library(
     name = "pubsub_lib",
     srcs = glob([
         "src/ray/pubsub/*.cc",
@@ -597,9 +557,6 @@ cc_library(
     hdrs = glob([
         "src/ray/pubsub/*.h",
     ]),
-    copts = COPTS,
-    strip_include_prefix = "src",
-    visibility = ["//visibility:public"],
     deps = [
         ":pubsub_rpc",
         "@boost//:any",
@@ -609,7 +566,7 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "stats_metric",
     srcs = [
         "src/ray/stats/metric.cc",
@@ -621,8 +578,6 @@ cc_library(
         "src/ray/stats/metric_defs.h",
         "src/ray/stats/tag_defs.h",
     ],
-    strip_include_prefix = "src",
-    visibility = ["//visibility:public"],
     deps = [
         "//src/ray/util",
         "@com_github_jupp0r_prometheus_cpp//pull",
@@ -638,7 +593,7 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "stats_lib",
     srcs = [
         "src/ray/stats/metric_exporter.cc",
@@ -651,7 +606,6 @@ cc_library(
         "src/ray/stats/stats.h",
         "src/ray/stats/tag_defs.h",
     ],
-    copts = COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [
         ],
@@ -659,15 +613,13 @@ cc_library(
             "-lpthread",
         ],
     }),
-    strip_include_prefix = "src",
-    visibility = ["//visibility:public"],
     deps = [
         ":reporter_rpc",
         ":stats_metric",
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "scheduler",
     srcs = glob(
         [
@@ -684,7 +636,6 @@ cc_library(
             "src/ray/core_worker/common.h",
         ],
     ),
-    copts = COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [
         ],
@@ -692,8 +643,6 @@ cc_library(
             "-lpthread",
         ],
     }),
-    strip_include_prefix = "src",
-    visibility = ["//visibility:public"],
     deps = [
         ":gcs_client_lib",
         ":ray_common",
@@ -716,7 +665,7 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "raylet_lib",
     srcs = glob(
         [
@@ -737,7 +686,6 @@ cc_library(
             "src/ray/raylet/main.cc",
         ],
     ),
-    copts = COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [
         ],
@@ -745,8 +693,6 @@ cc_library(
             "-lpthread",
         ],
     }),
-    strip_include_prefix = "src",
-    visibility = ["//visibility:public"],
     deps = [
         ":gcs",
         ":gcs_client_lib",
@@ -778,7 +724,7 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "raylet_client_lib",
     srcs = glob([
         "src/ray/raylet_client/*.cc",
@@ -786,7 +732,6 @@ cc_library(
     hdrs = glob([
         "src/ray/raylet_client/*.h",
     ]),
-    copts = COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [
         ],
@@ -794,8 +739,6 @@ cc_library(
             "-lpthread",
         ],
     }),
-    strip_include_prefix = "src",
-    visibility = ["//visibility:public"],
     deps = [
         ":node_manager_fbs",
         ":node_manager_rpc",
@@ -806,7 +749,7 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "core_worker_lib",
     srcs = glob(
         [
@@ -826,9 +769,6 @@ cc_library(
         "src/ray/core_worker/store_provider/memory_store/*.h",
         "src/ray/core_worker/transport/*.h",
     ]),
-    copts = COPTS,
-    strip_include_prefix = "src",
-    visibility = ["//visibility:public"],
     deps = [
         ":gcs",
         ":gcs_client_lib",
@@ -849,28 +789,25 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "mock_worker_lib",
     srcs = ["src/ray/core_worker/test/mock_worker.cc"],
     hdrs = glob([
         "src/ray/core_worker/test/*.h",
     ]),
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":core_worker_lib",
     ],
 )
 
-cc_binary(
+ray_cc_binary(
     name = "mock_worker",
-    copts = COPTS,
     deps = [
         ":mock_worker_lib",
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "core_worker_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/core_worker_test.cc"],
@@ -881,7 +818,6 @@ cc_test(
         "$(location redis-cli)",
         "$(location redis-server)",
     ],
-    copts = COPTS,
     data = [
         "//:gcs_server",
         "//:mock_worker",
@@ -900,11 +836,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "core_worker_resubmit_queue_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/core_worker_resubmit_queue_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -912,11 +847,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "memory_store_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/memory_store_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -924,10 +858,9 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "direct_actor_transport_test",
     srcs = ["src/ray/core_worker/test/direct_actor_transport_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -936,10 +869,9 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "direct_actor_transport_mock_test",
     srcs = ["src/ray/core_worker/test/direct_actor_transport_mock_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -948,10 +880,9 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_function_manager_test",
     srcs = ["src/ray/gcs/gcs_server/test/gcs_function_manager_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -960,11 +891,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "dependency_resolver_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/dependency_resolver_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -973,11 +903,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "direct_task_transport_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/direct_task_transport_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -986,11 +915,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "direct_task_transport_mock_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/direct_task_transport_mock_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -999,11 +927,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "reference_count_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/reference_count_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -1011,11 +938,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "object_recovery_manager_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/object_recovery_manager_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -1023,10 +949,9 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "scheduling_queue_test",
     srcs = ["src/ray/core_worker/test/scheduling_queue_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -1034,10 +959,9 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "concurrency_group_manager_test",
     srcs = ["src/ray/core_worker/test/concurrency_group_manager_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -1045,10 +969,9 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "fiber_state_test",
     srcs = ["src/ray/core_worker/test/fiber_state_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -1056,11 +979,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "actor_submit_queue_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/actor_submit_queue_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -1068,11 +990,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "task_manager_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/task_manager_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -1081,11 +1002,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "task_event_buffer_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/task_event_buffer_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -1094,11 +1014,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "actor_creator_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/actor_creator_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -1109,11 +1028,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "actor_manager_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/actor_manager_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -1121,11 +1039,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "lease_policy_test",
     size = "small",
     srcs = ["src/ray/core_worker/test/lease_policy_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",
@@ -1133,13 +1050,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "cluster_resource_scheduler_test",
     size = "small",
     srcs = [
         "src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":ray_mock",
@@ -1148,13 +1064,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "local_resource_manager_test",
     size = "small",
     srcs = [
         "src/ray/raylet/scheduling/local_resource_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":ray_mock",
@@ -1163,13 +1078,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "cluster_resource_scheduler_2_test",
     size = "small",
     srcs = [
         "src/ray/raylet/scheduling/cluster_resource_scheduler_2_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":raylet_lib",
@@ -1177,13 +1091,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "scheduling_policy_test",
     size = "small",
     srcs = [
         "src/ray/raylet/scheduling/policy/scheduling_policy_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":raylet_lib",
@@ -1191,13 +1104,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "hybrid_scheduling_policy_test",
     size = "small",
     srcs = [
         "src/ray/raylet/scheduling/policy/hybrid_scheduling_policy_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":scheduler",
@@ -1206,13 +1118,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "cluster_task_manager_test",
     size = "small",
     srcs = [
         "src/ray/raylet/scheduling/cluster_task_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":ray_mock",
@@ -1221,13 +1132,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "cluster_resource_manager_test",
     size = "small",
     srcs = [
         "src/ray/raylet/scheduling/cluster_resource_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":raylet_lib",
@@ -1235,13 +1145,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "local_object_manager_test",
     size = "small",
     srcs = [
         "src/ray/raylet/test/local_object_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":raylet_lib",
@@ -1249,13 +1158,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "pull_manager_test",
     size = "small",
     srcs = [
         "src/ray/object_manager/test/pull_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":object_manager",
@@ -1263,13 +1171,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "object_buffer_pool_test",
     size = "small",
     srcs = [
         "src/ray/object_manager/test/object_buffer_pool_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":object_manager",
@@ -1277,13 +1184,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "ownership_based_object_directory_test",
     size = "small",
     srcs = [
         "src/ray/object_manager/test/ownership_based_object_directory_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":object_manager",
@@ -1292,13 +1198,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "push_manager_test",
     size = "small",
     srcs = [
         "src/ray/object_manager/test/push_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":raylet_lib",
@@ -1306,13 +1211,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "spilled_object_test",
     size = "small",
     srcs = [
         "src/ray/object_manager/test/spilled_object_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":raylet_lib",
@@ -1322,12 +1226,11 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "fallback_allocator_test",
     srcs = [
         "src/ray/object_manager/plasma/test/fallback_allocator_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":plasma_store_server_lib",
@@ -1336,12 +1239,11 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "object_store_test",
     srcs = [
         "src/ray/object_manager/plasma/test/object_store_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":plasma_store_server_lib",
@@ -1351,13 +1253,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "object_lifecycle_manager_test",
     srcs = [
         "src/ray/object_manager/plasma/test/object_lifecycle_manager_test.cc",
         "src/ray/object_manager/plasma/test/stats_collector_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":plasma_store_server_lib",
@@ -1367,12 +1268,11 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "eviction_policy_test",
     srcs = [
         "src/ray/object_manager/plasma/test/eviction_policy_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":plasma_store_server_lib",
@@ -1380,13 +1280,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "create_request_queue_test",
     size = "small",
     srcs = [
         "src/ray/object_manager/test/create_request_queue_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":plasma_store_server_lib",
@@ -1395,13 +1294,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "get_request_queue_test",
     size = "small",
     srcs = [
         "src/ray/object_manager/test/get_request_queue_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":plasma_store_server_lib",
@@ -1410,11 +1308,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "worker_pool_test",
     size = "small",
     srcs = ["src/ray/raylet/worker_pool_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":raylet_lib",
@@ -1422,13 +1319,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_placement_group_manager_mock_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_placement_group_manager_mock_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1438,11 +1334,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "placement_group_resource_manager_test",
     size = "small",
     srcs = ["src/ray/raylet/placement_group_resource_manager_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         "gcs_test_util_lib",
@@ -1453,11 +1348,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "runtime_env_agent_client_test",
     size = "small",
     srcs = ["src/ray/raylet/runtime_env_agent_client_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         "gcs_test_util_lib",
@@ -1468,11 +1362,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "dependency_manager_test",
     size = "small",
     srcs = ["src/ray/raylet/dependency_manager_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":raylet_lib",
@@ -1480,11 +1373,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "wait_manager_test",
     size = "small",
     srcs = ["src/ray/raylet/wait_manager_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":raylet_lib",
@@ -1492,13 +1384,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "worker_killing_policy_test",
     size = "small",
     srcs = [
         "src/ray/raylet/worker_killing_policy_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":ray_common",
@@ -1507,13 +1398,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "worker_killing_policy_group_by_owner_test",
     size = "small",
     srcs = [
         "src/ray/raylet/worker_killing_policy_group_by_owner_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":ray_common",
@@ -1522,13 +1412,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "worker_killing_policy_retriable_fifo_test",
     size = "small",
     srcs = [
         "src/ray/raylet/worker_killing_policy_retriable_fifo_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":ray_common",
@@ -1537,11 +1426,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "pubsub_integration_test",
     size = "small",
     srcs = ["src/ray/pubsub/test/integration_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":pubsub_cc_grpc",
@@ -1553,11 +1441,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "publisher_test",
     size = "small",
     srcs = ["src/ray/pubsub/test/publisher_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":pubsub_lib",
@@ -1565,13 +1452,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "subscriber_test",
     size = "small",
     srcs = [
         "src/ray/pubsub/test/subscriber_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":pubsub_lib",
@@ -1579,11 +1465,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "stats_test",
     size = "small",
     srcs = ["src/ray/stats/stats_test.cc"],
-    copts = COPTS,
     tags = [
         "stats",
         "team:core",
@@ -1594,11 +1479,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "metric_exporter_client_test",
     size = "small",
     srcs = ["src/ray/stats/metric_exporter_client_test.cc"],
-    copts = COPTS,
     tags = [
         "stats",
         "team:core",
@@ -1609,26 +1493,23 @@ cc_test(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "gcs_test_util_lib",
     hdrs = [
         "src/ray/gcs/test/gcs_test_util.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":gcs",
         ":gcs_service_rpc",
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "grpc_server_client_test",
     size = "small",
     srcs = [
         "src/ray/rpc/test/grpc_server_client_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":grpc_common_lib",
@@ -1636,7 +1517,7 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_server_rpc_test",
     size = "small",
     srcs = [
@@ -1646,7 +1527,6 @@ cc_test(
         "$(location redis-server)",
         "$(location redis-cli)",
     ],
-    copts = COPTS,
     data = [
         "//:redis-cli",
         "//:redis-server",
@@ -1659,7 +1539,7 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_kv_manager_test",
     size = "small",
     srcs = [
@@ -1669,7 +1549,6 @@ cc_test(
         "$(location redis-server)",
         "$(location redis-cli)",
     ],
-    copts = COPTS,
     data = [
         "//:redis-cli",
         "//:redis-server",
@@ -1682,25 +1561,22 @@ cc_test(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "gcs_server_test_util",
     hdrs = [
         "src/ray/gcs/gcs_server/test/gcs_server_test_util.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":gcs_client_lib",
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_health_check_manager_test",
     size = "medium",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1708,13 +1584,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_node_manager_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1725,13 +1600,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_job_manager_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1742,13 +1616,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_task_manager_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1759,13 +1632,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_placement_group_manager_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1776,13 +1648,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_placement_group_scheduler_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1793,13 +1664,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_actor_scheduler_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_client_lib",
@@ -1811,13 +1681,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_actor_scheduler_mock_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_actor_scheduler_mock_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1826,13 +1695,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_actor_manager_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1843,13 +1711,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_worker_manager_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_worker_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1860,13 +1727,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_monitor_server_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_monitor_server_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:serverless"],
     deps = [
         ":gcs_server_lib",
@@ -1877,7 +1743,7 @@ cc_test(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "gcs_table_storage_lib",
     srcs = glob(
         [
@@ -1889,8 +1755,6 @@ cc_library(
             "src/ray/gcs/gcs_server/gcs_table_storage.h",
         ],
     ),
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":gcs",
         ":gcs_in_memory_store_client",
@@ -1901,19 +1765,17 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "gcs_table_storage_test_lib",
     hdrs = [
         "src/ray/gcs/gcs_server/test/gcs_table_storage_test_base.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         "redis_store_client",
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "redis_gcs_table_storage_test",
     size = "small",
     srcs = [
@@ -1923,7 +1785,6 @@ cc_test(
         "$(location redis-server)",
         "$(location redis-cli)",
     ],
-    copts = COPTS,
     data = [
         "//:redis-cli",
         "//:redis-server",
@@ -1938,13 +1799,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "in_memory_gcs_table_storage_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/in_memory_gcs_table_storage_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_table_storage_lib",
@@ -1955,13 +1815,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_autoscaler_state_manager_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1972,13 +1831,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_resource_manager_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -1987,13 +1845,12 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "grpc_based_resource_broadcaster_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_server/test/grpc_based_resource_broadcaster_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_server_lib",
@@ -2002,7 +1859,7 @@ cc_test(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "gcs_client_lib",
     srcs = [
         "src/ray/gcs/gcs_client/accessor.cc",
@@ -2014,8 +1871,6 @@ cc_library(
         "src/ray/gcs/gcs_client/gcs_client.h",
         "src/ray/gcs/gcs_client/usage_stats_client.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":gcs",
         ":gcs_pub_sub_lib",
@@ -2027,7 +1882,7 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "global_state_accessor_lib",
     srcs = glob(
         [
@@ -2039,21 +1894,17 @@ cc_library(
             "src/ray/gcs/gcs_client/global_state_accessor.h",
         ],
     ),
-    copts = COPTS,
-    strip_include_prefix = "src",
-    visibility = ["//visibility:public"],
     deps = [
         ":gcs_client_lib",
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "accessor_test",
     size = "small",
     srcs = [
         "src/ray/gcs/gcs_client/test/accessor_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_client_lib",
@@ -2062,7 +1913,7 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "global_state_accessor_test",
     size = "small",
     srcs = [
@@ -2072,7 +1923,6 @@ cc_test(
         "$(location redis-server)",
         "$(location redis-cli)",
     ],
-    copts = COPTS,
     data = [
         "//:redis-cli",
         "//:redis-server",
@@ -2087,7 +1937,7 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_client_test",
     size = "medium",
     srcs = [
@@ -2097,7 +1947,6 @@ cc_test(
         "$(location redis-server)",
         "$(location redis-cli)",
     ],
-    copts = COPTS,
     data = [
         "//:redis-cli",
         "//:redis-server",
@@ -2111,7 +1960,7 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "gcs_client_reconnection_test",
     srcs = [
         "src/ray/gcs/gcs_client/test/gcs_client_reconnection_test.cc",
@@ -2120,7 +1969,6 @@ cc_test(
         "$(location redis-server)",
         "$(location redis-cli)",
     ],
-    copts = COPTS,
     data = [
         "//:redis-cli",
         "//:redis-server",
@@ -2134,12 +1982,11 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "usage_stats_client_test",
     srcs = [
         "src/ray/gcs/gcs_client/test/usage_stats_client_test.cc",
     ],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_client_lib",
@@ -2149,7 +1996,7 @@ cc_test(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "object_manager",
     srcs = glob([
         "src/ray/object_manager/*.cc",
@@ -2159,8 +2006,6 @@ cc_library(
         "src/ray/object_manager/*.h",
         "src/ray/object_manager/notification/*.h",
     ]),
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":core_worker_lib",
         ":gcs",
@@ -2172,7 +2017,7 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "platform_shims",
     srcs = [] + select({
         "@bazel_tools//src/conditions:windows": glob([
@@ -2188,12 +2033,10 @@ cc_library(
         ]),
         "//conditions:default": [],
     }),
-    copts = COPTS,
     strip_include_prefix = select({
         "@bazel_tools//src/conditions:windows": "src/shims/windows",
         "//conditions:default": "",
     }),
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
@@ -2237,7 +2080,7 @@ extra_action(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "sha256",
     srcs = [
         "src/ray/thirdparty/sha256.c",
@@ -2245,11 +2088,9 @@ cc_library(
     hdrs = [
         "src/ray/thirdparty/sha256.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
 )
 
-cc_library(
+ray_cc_library(
     name = "aligned_alloc",
     srcs = [
         "src/ray/thirdparty/aligned_alloc.c",
@@ -2257,8 +2098,6 @@ cc_library(
     hdrs = [
         "src/ray/thirdparty/aligned_alloc.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
 )
 
 alias(
@@ -2266,7 +2105,7 @@ alias(
     actual = "@com_github_redis_hiredis//:hiredis",
 )
 
-cc_library(
+ray_cc_library(
     name = "redis_client",
     srcs = [
         "src/ray/gcs/asio.cc",
@@ -2280,8 +2119,6 @@ cc_library(
         "src/ray/gcs/redis_client.h",
         "src/ray/gcs/redis_context.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":hiredis",
         ":ray_common",
@@ -2291,7 +2128,7 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "redis_store_client",
     srcs = [
         "src/ray/gcs/store_client/redis_store_client.cc",
@@ -2301,8 +2138,6 @@ cc_library(
         "src/ray/gcs/store_client/redis_store_client.h",
         "src/ray/gcs/store_client/store_client.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         "redis_client",
         "@com_google_absl//absl/strings:str_format",
@@ -2310,7 +2145,7 @@ cc_library(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "gcs_in_memory_store_client",
     srcs = [
         "src/ray/gcs/store_client/in_memory_store_client.cc",
@@ -2320,15 +2155,13 @@ cc_library(
         "src/ray/gcs/store_client/in_memory_store_client.h",
         "src/ray/gcs/store_client/store_client.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":ray_common",
         "//src/ray/util",
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "observable_store_client",
     srcs = [
         "src/ray/gcs/store_client/observable_store_client.cc",
@@ -2338,27 +2171,23 @@ cc_library(
         "src/ray/gcs/store_client/observable_store_client.h",
         "src/ray/gcs/store_client/store_client.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":ray_common",
         "//src/ray/util",
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "store_client_test_lib",
     hdrs = [
         "src/ray/gcs/store_client/test/store_client_test_base.h",
     ],
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         "redis_store_client",
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "redis_store_client_test",
     size = "small",
     srcs = ["src/ray/gcs/store_client/test/redis_store_client_test.cc"],
@@ -2366,7 +2195,6 @@ cc_test(
         "$(location redis-server)",
         "$(location redis-cli)",
     ],
-    copts = COPTS,
     data = [
         "//:redis-cli",
         "//:redis-server",
@@ -2379,7 +2207,7 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "chaos_redis_store_client_test",
     size = "small",
     srcs = ["src/ray/gcs/store_client/test/redis_store_client_test.cc"],
@@ -2387,7 +2215,6 @@ cc_test(
         "$(location redis-server)",
         "$(location redis-cli)",
     ],
-    copts = COPTS,
     data = [
         "//:redis-cli",
         "//:redis-server",
@@ -2404,11 +2231,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "in_memory_store_client_test",
     size = "small",
     srcs = ["src/ray/gcs/store_client/test/in_memory_store_client_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_in_memory_store_client",
@@ -2417,11 +2243,10 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "observable_store_client_test",
     size = "small",
     srcs = ["src/ray/gcs/store_client/test/in_memory_store_client_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs_in_memory_store_client",
@@ -2431,7 +2256,7 @@ cc_test(
     ],
 )
 
-cc_library(
+ray_cc_library(
     name = "gcs",
     srcs = glob(
         [
@@ -2444,8 +2269,6 @@ cc_library(
     hdrs = glob([
         "src/ray/gcs/*.h",
     ]),
-    copts = COPTS,
-    strip_include_prefix = "src",
     deps = [
         ":hiredis",
         ":node_manager_fbs",
@@ -2460,11 +2283,10 @@ cc_library(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "callback_reply_test",
     size = "small",
     srcs = ["src/ray/gcs/test/callback_reply_test.cc"],
-    copts = COPTS,
     tags = ["team:core"],
     deps = [
         ":gcs",
@@ -2472,7 +2294,7 @@ cc_test(
     ],
 )
 
-cc_test(
+ray_cc_test(
     name = "asio_test",
     size = "small",
     srcs = ["src/ray/gcs/test/asio_test.cc"],
@@ -2480,7 +2302,6 @@ cc_test(
         "$(location redis-server)",
         "$(location redis-cli)",
     ],
-    copts = COPTS,
     data = [
         "//:redis-cli",
         "//:redis-server",
@@ -2541,13 +2362,12 @@ pyx_library(
     ],
 )
 
-cc_binary(
+ray_cc_binary(
     name = "libcore_worker_library_java.so",
     srcs = glob([
         "src/ray/core_worker/lib/java/*.h",
         "src/ray/core_worker/lib/java/*.cc",
     ]),
-    copts = COPTS,
     # Export ray ABI symbols, which can then be used by libstreaming_java.so. see `//:_raylet`
     linkopts = select({
         "@bazel_tools//src/conditions:darwin": [
@@ -2602,7 +2422,6 @@ alias(
         "@bazel_tools//src/conditions:windows": "@com_github_tporadowski_redis_bin//:redis-server.exe",
         "//conditions:default": "@com_github_antirez_redis//:redis-server",
     }),
-    visibility = ["//visibility:public"],
 )
 
 alias(
@@ -2611,7 +2430,6 @@ alias(
         "@bazel_tools//src/conditions:windows": "@com_github_tporadowski_redis_bin//:redis-cli.exe",
         "//conditions:default": "@com_github_antirez_redis//:redis-cli",
     }),
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
@@ -2693,6 +2511,13 @@ copy_to_workspace(
     dstdir = "python/ray/core/src/ray/gcs",
 )
 
+copy_to_workspace(
+    name = "cp_jemalloc",
+    srcs = ["@jemalloc//:shared"],
+    dstdir = "python/ray/core/",
+)
+
+
 genrule(
     name = "install_py_proto",
     srcs = [
@@ -2734,7 +2559,12 @@ genrule(
         ":cp_redis",
         ":cp_raylet",
         ":cp_gcs_server",
-    ],
+    ] + select({
+        ":jemalloc": [
+            ":cp_jemalloc",
+        ],
+        "//conditions:default": [],
+    }),
     outs = ["ray_pkg.out"],
     cmd = """
         if [ "$${OSTYPE-}" = "msys" ]; then
@@ -2744,3 +2574,4 @@ genrule(
     """,
     local = 1,
 )
+

--- a/bazel/BUILD.jemalloc
+++ b/bazel/BUILD.jemalloc
@@ -1,5 +1,5 @@
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
-
+load("@com_github_ray_project_ray//bazel:ray.bzl", "filter_files_with_suffix")
 
 filegroup(
     name = "all",
@@ -12,6 +12,15 @@ configure_make(
     linkopts = ["-ldl"],
     copts = ["-fPIC"],
     args = ["-j"],
-    configure_options = ["--disable-shared", "--enable-prof"],
+    out_shared_libs = ["libjemalloc.so"],
+    configure_options = ["--disable-static", "--enable-prof"],
+    visibility = ["//visibility:public"],
+)
+
+
+filter_files_with_suffix(
+    name = "shared",
+    srcs = ["@jemalloc//:libjemalloc"],
+    suffix = ".so",
     visibility = ["//visibility:public"],
 )

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -373,9 +373,7 @@ check_sphinx_links() {
 _bazel_build_before_install() {
   local target
   if [ "${OSTYPE}" = msys ]; then
-    # On Windows, we perform as full of a build as possible, to ensure the repository always remains buildable on Windows.
-    # (Pip install will not perform a full build.)
-    target="//:*"
+    target="//:ray_pkg"
   else
     # Just build Python on other platforms.
     # This because pip install captures & suppresses the build output, which causes a timeout on CI.

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -51,6 +51,10 @@ GCS_SERVER_EXECUTABLE = os.path.join(
     RAY_PATH, "core", "src", "ray", "gcs", "gcs_server" + EXE_SUFFIX
 )
 
+JEMALLOC_SO = os.path.join(RAY_PATH, "core", "libjemalloc.so")
+
+JEMALLOC_SO = JEMALLOC_SO if os.path.exists(JEMALLOC_SO) else None
+
 # Location of the cpp default worker executables.
 DEFAULT_WORKER_EXECUTABLE = os.path.join(RAY_PATH, "cpp", "default_worker" + EXE_SUFFIX)
 
@@ -211,13 +215,13 @@ def propagate_jemalloc_env_var(
     assert isinstance(jemalloc_comps, list)
     assert process_type is not None
     process_type = process_type.lower()
-    if not jemalloc_path or process_type not in jemalloc_comps:
+    if not jemalloc_path:
         return {}
 
     env_vars = {
         "LD_PRELOAD": jemalloc_path,
     }
-    if jemalloc_conf:
+    if process_type in jemalloc_comps and jemalloc_conf:
         env_vars.update({"MALLOC_CONF": jemalloc_conf})
     return env_vars
 
@@ -771,17 +775,21 @@ def start_ray_process(
         logger.info("Detected environment variable '%s'.", gdb_env_var)
         use_gdb = True
     # Jemalloc memory profiling.
-    jemalloc_lib_path = os.environ.get(RAY_JEMALLOC_LIB_PATH)
-    jemalloc_conf = os.environ.get(RAY_JEMALLOC_CONF)
-    jemalloc_comps = os.environ.get(RAY_JEMALLOC_PROFILE)
-    jemalloc_comps = [] if not jemalloc_comps else jemalloc_comps.split(",")
-    jemalloc_env_vars = propagate_jemalloc_env_var(
-        jemalloc_path=jemalloc_lib_path,
-        jemalloc_conf=jemalloc_conf,
-        jemalloc_comps=jemalloc_comps,
-        process_type=process_type,
-    )
-    use_jemalloc_mem_profiler = len(jemalloc_env_vars) > 0
+    if os.environ.get("LD_PRELOAD") is None:
+        jemalloc_lib_path = os.environ.get(RAY_JEMALLOC_LIB_PATH, JEMALLOC_SO)
+        jemalloc_conf = os.environ.get(RAY_JEMALLOC_CONF)
+        jemalloc_comps = os.environ.get(RAY_JEMALLOC_PROFILE)
+        jemalloc_comps = [] if not jemalloc_comps else jemalloc_comps.split(",")
+        jemalloc_env_vars = propagate_jemalloc_env_var(
+            jemalloc_path=jemalloc_lib_path,
+            jemalloc_conf=jemalloc_conf,
+            jemalloc_comps=jemalloc_comps,
+            process_type=process_type,
+        )
+    else:
+        jemalloc_env_vars = {}
+
+    use_jemalloc_mem_profiler = "MALLOC_CONF" in jemalloc_env_vars
 
     if (
         sum(
@@ -844,12 +852,7 @@ def start_ray_process(
         modified_env["LD_PRELOAD"] = os.environ["PERFTOOLS_PATH"]
         modified_env["CPUPROFILE"] = os.environ["PERFTOOLS_LOGFILE"]
 
-    if use_jemalloc_mem_profiler:
-        logger.info(
-            f"Jemalloc profiling will be used for {process_type}. "
-            f"env vars: {jemalloc_env_vars}"
-        )
-        modified_env.update(jemalloc_env_vars)
+    modified_env.update(jemalloc_env_vars)
 
     if use_tmux:
         # The command has to be created exactly as below to ensure that it

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -185,7 +185,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     ray._private.ray_logging.setup_logger(args.logging_level, args.logging_format)
     worker_launched_time_ms = time.time_ns() // 1e6
-
     if args.worker_type == "WORKER":
         mode = ray.WORKER_MODE
     elif args.worker_type == "SPILL_WORKER":


### PR DESCRIPTION
cherry-pick (#39192)

## Why are these changes needed?
`libjemalloc` was built into gcs and raylet in [this](https://github.com/ray-project/ray/pull/38644) PR. While it fixed the memory issues it brings some issues.

It'll break the workload if the user start ray with tcmalloc.

It doesn't work with core worker and for some workload, we need this.

This PR make the jemalloc a shared library and if there is LD_PRELOAD, it won't load jemalloc.so automatically.

## Related issue number
Closes #39135

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
