### PR TITLE
[Core][Java Worker]Add get all actors info api in java worker

### DIFF
--- a/java/api/src/main/java/io/ray/api/runtimecontext/ActorInfo.java
+++ b/java/api/src/main/java/io/ray/api/runtimecontext/ActorInfo.java
@@ -1,0 +1,24 @@
+package io.ray.api.runtimecontext;
+
+import io.ray.api.id.ActorId;
+
+public class ActorInfo {
+  public final ActorId actorId;
+
+  public final ActorState state;
+
+  public final long numRestarts;
+
+  public final Address address;
+
+  public final String name;
+
+  public ActorInfo(
+      ActorId actorId, ActorState state, long numRestarts, Address address, String name) {
+    this.actorId = actorId;
+    this.state = state;
+    this.numRestarts = numRestarts;
+    this.address = address;
+    this.name = name;
+  }
+}

--- a/java/api/src/main/java/io/ray/api/runtimecontext/ActorState.java
+++ b/java/api/src/main/java/io/ray/api/runtimecontext/ActorState.java
@@ -1,0 +1,44 @@
+package io.ray.api.runtimecontext;
+
+/** The state of an actor. Note, this class should be aligned with the actor state of proto. */
+public enum ActorState {
+  DEPENDENCIES_UNREADY("DEPENDENCIES_UNREADY", 0),
+  PENDING_CREATION("PENDING_CREATION", 1),
+  ALIVE("ALIVE", 2),
+  RESTARTING("RESTARTING", 3),
+  DEAD("DEAD", 4);
+
+  private String name;
+
+  private int value;
+
+  private ActorState(String name, int value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  public static ActorState fromValue(int value) {
+    switch (value) {
+      case 0:
+        return DEPENDENCIES_UNREADY;
+      case 1:
+        return PENDING_CREATION;
+      case 2:
+        return ALIVE;
+      case 3:
+        return RESTARTING;
+      case 4:
+        return DEAD;
+      default:
+        throw new RuntimeException("Value out of range.");
+    }
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getValue() {
+    return value;
+  }
+}

--- a/java/api/src/main/java/io/ray/api/runtimecontext/Address.java
+++ b/java/api/src/main/java/io/ray/api/runtimecontext/Address.java
@@ -1,0 +1,35 @@
+package io.ray.api.runtimecontext;
+
+import io.ray.api.id.UniqueId;
+import java.util.Objects;
+
+public class Address {
+  public final UniqueId nodeId;
+  public final String ip;
+  public final int port;
+
+  public Address(UniqueId nodeId, String ip, int port) {
+    this.nodeId = nodeId;
+    this.ip = ip;
+    this.port = port;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+
+    if (!this.getClass().equals(obj.getClass())) {
+      return false;
+    }
+
+    Address other = (Address) obj;
+    return this.nodeId.equals(other.nodeId) && this.ip.equals(other.ip) && this.port == other.port;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nodeId, ip, port);
+  }
+}

--- a/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
+++ b/java/api/src/main/java/io/ray/api/runtimecontext/RuntimeContext.java
@@ -34,6 +34,12 @@ public interface RuntimeContext {
   List<NodeInfo> getAllNodeInfo();
 
   /**
+   * Get all actor information of Ray cluster. Note that this will return all actor information of
+   * all jobs in this Ray cluster.
+   */
+  List<ActorInfo> getAllActorInfo();
+
+  /**
    * Get the handle to the current actor itself. Note that this method must be invoked in an actor.
    */
   <T extends BaseActorHandle> T getCurrentActorHandle();

--- a/java/runtime/src/main/java/io/ray/runtime/context/RuntimeContextImpl.java
+++ b/java/runtime/src/main/java/io/ray/runtime/context/RuntimeContextImpl.java
@@ -6,6 +6,7 @@ import io.ray.api.id.ActorId;
 import io.ray.api.id.JobId;
 import io.ray.api.id.TaskId;
 import io.ray.api.id.UniqueId;
+import io.ray.api.runtimecontext.ActorInfo;
 import io.ray.api.runtimecontext.NodeInfo;
 import io.ray.api.runtimecontext.ResourceValue;
 import io.ray.api.runtimecontext.RuntimeContext;
@@ -63,6 +64,11 @@ public class RuntimeContextImpl implements RuntimeContext {
   @Override
   public List<NodeInfo> getAllNodeInfo() {
     return runtime.getGcsClient().getAllNodeInfo();
+  }
+
+  @Override
+  public List<ActorInfo> getAllActorInfo() {
+    return runtime.getGcsClient().getAllActorInfo();
   }
 
   @Override

--- a/java/test/src/main/java/io/ray/test/GetActorInfoTest.java
+++ b/java/test/src/main/java/io/ray/test/GetActorInfoTest.java
@@ -1,0 +1,55 @@
+package io.ray.test;
+
+import io.ray.api.ActorHandle;
+import io.ray.api.ObjectRef;
+import io.ray.api.Ray;
+import io.ray.api.runtimecontext.ActorInfo;
+import io.ray.api.runtimecontext.Address;
+import io.ray.api.runtimecontext.NodeInfo;
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test(groups = {"cluster"})
+public class GetActorInfoTest extends BaseTest {
+
+  private static class Echo {
+
+    public String echo(String str) {
+      return str;
+    }
+  }
+
+  public void testGetAllActorInfo() {
+    List<NodeInfo> nodes = Ray.getRuntimeContext().getAllNodeInfo();
+    Assert.assertEquals(nodes.size(), 1);
+    final NodeInfo thisNode = nodes.get(0);
+    final Address thisAddress =
+        new Address(thisNode.nodeId, thisNode.nodeAddress, thisNode.nodeManagerPort);
+
+    final int numActors = 5;
+    ArrayList<ActorHandle<Echo>> echos = new ArrayList<>(numActors);
+    for (int i = 0; i < numActors; ++i) {
+      ActorHandle<Echo> echo = Ray.actor(Echo::new).remote();
+      echos.add(echo);
+    }
+
+    ArrayList<ObjectRef<String>> objs = new ArrayList<>();
+    echos.forEach(echo -> objs.add(echo.task(Echo::echo, "hello").remote()));
+    Ray.wait(objs);
+
+    List<ActorInfo> actorInfo = Ray.getRuntimeContext().getAllActorInfo();
+    Assert.assertEquals(actorInfo.size(), 5);
+    actorInfo.forEach(
+        info -> {
+          Assert.assertEquals(info.name, "");
+          Assert.assertTrue(echos.stream().anyMatch(echo -> echo.getId().equals(info.actorId)));
+          Assert.assertEquals(info.numRestarts, 0);
+          /// Because `node.nodeManagerPort` is not `actorInfo.address.port`, we should
+          /// not just equal them.
+          Assert.assertEquals(info.address.nodeId, thisAddress.nodeId);
+          Assert.assertEquals(info.address.ip, thisAddress.ip);
+        });
+  }
+}


### PR DESCRIPTION
## Why are these changes needed?
1. Add get all actors info api in java worker, like python `ray.state.state.actor_table` api.
```
    List<ActorInfo> actorInfo = Ray.getRuntimeContext().getAllActorInfo();
    Assert.assertEquals(actorInfo.size(), 5);
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
