### PR TITLE
[Core] Fix get_next_unordered and get_next

### DIFF
--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -199,7 +199,10 @@ def test_get_next_unordered_timeout(init):
 
     pool.submit(lambda a, v: a.f.remote(v), 0)
     with pytest.raises(TimeoutError):
-        pool.get_next_unordered(timeout=0.1)
+        pool.get_next_unordered(timeout=0.1, ignore_if_timedout=False)
+
+    pool.submit(lambda a, v: a.f.remote(v), 0)
+    assert pool.get_next_unordered(timeout=0.1, ignore_if_timedout=True) is None
 
 
 def test_multiple_returns(init):
@@ -215,6 +218,9 @@ def test_multiple_returns(init):
 
     while pool.has_next():
         assert pool.get_next(timeout=None) == [1, 2]
+
+    pool.submit(lambda a, v: a.bar.remote(), None)
+    pool.get_next(timeout=1, ignore_if_timedout=True)
 
 
 def test_pop_idle(init):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This patches makes get_next_unordered return None when ignore_timedout=True, becuase when get unordered, there is no specific future we should ignore. It also fixes get_next and make it correctly handle multiple futures returned by a remote method when timeout is not None.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #38635 #38607 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
