### PR TITLE
[Core][Observability] Add the scheduling_strategy field to the ActorInfo for the "get actor info" API

### DIFF
--- a/python/ray/_private/scheduling_strategies_util.py
+++ b/python/ray/_private/scheduling_strategies_util.py
@@ -1,0 +1,66 @@
+from ray._private.utils import binary_to_hex
+from ray._raylet import PlacementGroupID
+
+from ray.util.placement_group import PlacementGroup
+from ray.util.scheduling_strategies import (
+    DoesNotExist,
+    Exists,
+    In,
+    NodeAffinitySchedulingStrategy,
+    NodeLabelSchedulingStrategy,
+    NotIn,
+    PlacementGroupSchedulingStrategy,
+    SchedulingStrategyT,
+)
+
+
+def covert_pb_to_label_match_expressions(label_match_expressions_pb):
+    expressions_map = {}
+    for expression in label_match_expressions_pb.expressions:
+        key = expression.key
+        operator = expression.operator
+        if operator.HasField("label_in"):
+            values = []
+            for value in operator.label_in.values:
+                values.append(value)
+            expressions_map[key] = In(*values)
+        elif operator.HasField("label_not_in"):
+            values = []
+            for value in operator.label_in.values:
+                values.append(value)
+            expressions_map[key] = NotIn(*values)
+        elif operator.HasField("label_exists"):
+            expressions_map[key] = Exists()
+        elif operator.HasField("label_does_not_exist"):
+            expressions_map[key] = DoesNotExist()
+    return expressions_map
+
+
+def covert_pb_to_scheduling_strategy(scheduling_strategy_pb) -> SchedulingStrategyT:
+    if scheduling_strategy_pb.HasField("default_scheduling_strategy"):
+        return "DEFAULT"
+    elif scheduling_strategy_pb.HasField("spread_scheduling_strategy"):
+        return "SPREAD"
+    elif scheduling_strategy_pb.HasField("placement_group_scheduling_strategy"):
+        pg_pb = scheduling_strategy_pb.placement_group_scheduling_strategy
+        return PlacementGroupSchedulingStrategy(
+            PlacementGroup(PlacementGroupID(pg_pb.placement_group_id)),
+            pg_pb.placement_group_bundle_index,
+            pg_pb.placement_group_capture_child_tasks,
+        )
+    elif scheduling_strategy_pb.HasField("node_affinity_scheduling_strategy"):
+        node_affinity_pb = scheduling_strategy_pb.node_affinity_scheduling_strategy
+        return NodeAffinitySchedulingStrategy(
+            binary_to_hex(node_affinity_pb.node_id),
+            node_affinity_pb.soft,
+            node_affinity_pb.spill_on_unavailable,
+            node_affinity_pb.fail_on_unavailable,
+        )
+    elif scheduling_strategy_pb.HasField("node_label_scheduling_strategy"):
+        node_label_pb = scheduling_strategy_pb.node_label_scheduling_strategy
+        return NodeLabelSchedulingStrategy(
+            hard=covert_pb_to_label_match_expressions(node_label_pb.hard),
+            soft=covert_pb_to_label_match_expressions(node_label_pb.soft),
+        )
+    else:
+        return None

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -14,6 +14,7 @@ from ray._private.utils import (
     hex_to_binary,
     validate_actor_state_name,
 )
+from ray._private.scheduling_strategies_util import covert_pb_to_scheduling_strategy
 from ray._raylet import GlobalStateAccessor
 from ray.core.generated import common_pb2
 from ray.core.generated import gcs_pb2
@@ -154,6 +155,9 @@ class GlobalState:
             "EndTime": actor_table_data.end_time,
             "DeathCause": actor_table_data.death_cause,
             "Pid": actor_table_data.pid,
+            "SchedulingStrategy": covert_pb_to_scheduling_strategy(
+                actor_table_data.scheduling_strategy
+            ),
         }
         return actor_info
 

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -266,6 +266,7 @@ py_test_module_list(
     "test_mini.py",
     "test_numba.py",
     "test_raylet_output.py",
+    "test_scheduling_strategy_pb.py",
     "test_top_level_api.py",
     "test_unhandled_error.py",
     "test_widgets.py",

--- a/python/ray/tests/test_scheduling_strategy_pb.py
+++ b/python/ray/tests/test_scheduling_strategy_pb.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import pytest
+import ray
+from ray._private.scheduling_strategies_util import covert_pb_to_scheduling_strategy
+from ray.core.generated import common_pb2
+from ray.util.scheduling_strategies import (
+    In,
+    NodeAffinitySchedulingStrategy,
+    NodeLabelSchedulingStrategy,
+    PlacementGroupSchedulingStrategy,
+)
+
+
+def test_default_scheduling_strategy_pb():
+    scheduling_strategy_pb = common_pb2.SchedulingStrategy()
+    scheduling_strategy_pb.default_scheduling_strategy.CopyFrom(
+        common_pb2.DefaultSchedulingStrategy()
+    )
+    assert covert_pb_to_scheduling_strategy(scheduling_strategy_pb) == "DEFAULT"
+
+
+def test_spread_scheduling_strategy_pb():
+    scheduling_strategy_pb = common_pb2.SchedulingStrategy()
+    scheduling_strategy_pb.spread_scheduling_strategy.CopyFrom(
+        common_pb2.SpreadSchedulingStrategy()
+    )
+    assert covert_pb_to_scheduling_strategy(scheduling_strategy_pb) == "SPREAD"
+
+
+def test_placement_scheduling_strategy_pb(ray_start_cluster_head):
+    pg = ray.util.placement_group(bundles=[{"CPU": 1}])
+    scheduling_strategy_pb = common_pb2.SchedulingStrategy()
+    pg_pb = common_pb2.PlacementGroupSchedulingStrategy()
+    pg = ray.util.placement_group(bundles=[{"CPU": 1}])
+    pg_pb.placement_group_id = pg.id.binary()
+    pg_pb.placement_group_bundle_index = 0
+    pg_pb.placement_group_capture_child_tasks = True
+    scheduling_strategy_pb.placement_group_scheduling_strategy.CopyFrom(pg_pb)
+    assert covert_pb_to_scheduling_strategy(
+        scheduling_strategy_pb
+    ) == PlacementGroupSchedulingStrategy(pg, 0, True)
+
+
+def test_node_affinity_scheduling_strategy_pb():
+    scheduling_strategy_pb = common_pb2.SchedulingStrategy()
+    node_affinity_pb = common_pb2.NodeAffinitySchedulingStrategy()
+    node_id = ray.NodeID.from_random()
+    node_affinity_pb.node_id = node_id.binary()
+    node_affinity_pb.soft = True
+    node_affinity_pb.spill_on_unavailable = False
+    node_affinity_pb.fail_on_unavailable = True
+    scheduling_strategy_pb.node_affinity_scheduling_strategy.CopyFrom(node_affinity_pb)
+    assert covert_pb_to_scheduling_strategy(
+        scheduling_strategy_pb
+    ) == NodeAffinitySchedulingStrategy(node_id.hex(), True, False, True)
+
+
+def test_node_label_scheduling_strategy_pb():
+    scheduling_strategy_pb = common_pb2.SchedulingStrategy()
+    node_label_pb = common_pb2.NodeLabelSchedulingStrategy()
+
+    label_in = common_pb2.LabelIn()
+    label_in.values.extend(["value1", "value2"])
+    label_operator = common_pb2.LabelOperator()
+    label_operator.label_in.CopyFrom(label_in)
+
+    label_match_expression = common_pb2.LabelMatchExpression()
+    label_match_expression.key = "label_key"
+    label_match_expression.operator.CopyFrom(label_operator)
+
+    label_match_expressions = common_pb2.LabelMatchExpressions()
+    label_match_expressions.expressions.append(label_match_expression)
+    node_label_pb.hard.CopyFrom(label_match_expressions)
+
+    scheduling_strategy_pb.node_label_scheduling_strategy.CopyFrom(node_label_pb)
+    assert covert_pb_to_scheduling_strategy(
+        scheduling_strategy_pb
+    ) == NodeLabelSchedulingStrategy(hard={"label_key": In("value1", "value2")})
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/util/scheduling_strategies.py
+++ b/python/ray/util/scheduling_strategies.py
@@ -36,6 +36,17 @@ class PlacementGroupSchedulingStrategy:
         self.placement_group_bundle_index = placement_group_bundle_index
         self.placement_group_capture_child_tasks = placement_group_capture_child_tasks
 
+    def __eq__(self, other):
+        if isinstance(other, PlacementGroupSchedulingStrategy):
+            return (
+                self.placement_group == other.placement_group
+                and self.placement_group_bundle_index
+                == other.placement_group_bundle_index
+                and self.placement_group_capture_child_tasks
+                == other.placement_group_capture_child_tasks
+            )
+        return False
+
 
 @PublicAPI(stability="beta")
 class NodeAffinitySchedulingStrategy:
@@ -71,6 +82,16 @@ class NodeAffinitySchedulingStrategy:
         self._spill_on_unavailable = _spill_on_unavailable
         self._fail_on_unavailable = _fail_on_unavailable
 
+    def __eq__(self, other):
+        if isinstance(other, NodeAffinitySchedulingStrategy):
+            return (
+                self.node_id == other.node_id
+                and self.soft == other.soft
+                and self._spill_on_unavailable == other._spill_on_unavailable
+                and self._fail_on_unavailable == other._fail_on_unavailable
+            )
+        return False
+
 
 def _validate_label_match_operator_values(values, operator):
     if not values:
@@ -96,6 +117,11 @@ class In:
         _validate_label_match_operator_values(values, "In")
         self.values = list(values)
 
+    def __eq__(self, other):
+        if isinstance(other, In):
+            return self.values == other.values
+        return False
+
 
 @PublicAPI(stability="alpha")
 class NotIn:
@@ -103,17 +129,32 @@ class NotIn:
         _validate_label_match_operator_values(values, "NotIn")
         self.values = list(values)
 
+    def __eq__(self, other):
+        if isinstance(other, NotIn):
+            return self.values == other.values
+        return False
+
 
 @PublicAPI(stability="alpha")
 class Exists:
     def __init__(self):
         pass
 
+    def __eq__(self, other):
+        if isinstance(other, Exists):
+            return True
+        return False
+
 
 @PublicAPI(stability="alpha")
 class DoesNotExist:
     def __init__(self):
         pass
+
+    def __eq__(self, other):
+        if isinstance(other, DoesNotExist):
+            return True
+        return False
 
 
 class _LabelMatchExpression:
@@ -126,6 +167,11 @@ class _LabelMatchExpression:
     def __init__(self, key: str, operator: Union[In, NotIn, Exists, DoesNotExist]):
         self.key = key
         self.operator = operator
+
+    def __eq__(self, other):
+        if isinstance(other, _LabelMatchExpression):
+            return self.key == other.key and self.operator == other.operator
+        return False
 
 
 LabelMatchExpressionsT = Dict[str, Union[In, NotIn, Exists, DoesNotExist]]
@@ -154,6 +200,11 @@ class NodeLabelSchedulingStrategy:
                 "The `hard` and `soft` parameter "
                 "of NodeLabelSchedulingStrategy cannot both be empty."
             )
+
+    def __eq__(self, other):
+        if isinstance(other, NodeLabelSchedulingStrategy):
+            return self.hard == other.hard and self.soft == other.soft
+        return False
 
 
 def _convert_map_to_expressions(map_expressions: LabelMatchExpressionsT, param: str):

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -111,7 +111,6 @@ class GcsActor {
                                                    .placement_group_scheduling_strategy()
                                                    .placement_group_id());
     }
-
     // Set required resources.
     auto resource_map =
         GetCreationTaskSpecification().GetRequiredResources().GetResourceMap();
@@ -136,6 +135,10 @@ class GcsActor {
 
     actor_table_data_.set_serialized_runtime_env(
         task_spec.runtime_env_info().serialized_runtime_env());
+
+    actor_table_data_.mutable_scheduling_strategy()->CopyFrom(
+        task_spec.scheduling_strategy());
+
     RefreshMetrics();
   }
 

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -162,6 +162,8 @@ message ActorTableData {
   string repr_name = 31;
   // Whether the actor was on a preempted node
   bool preempted = 32;
+  // Strategy about how to schedule this actor.
+  SchedulingStrategy scheduling_strategy = 33;
 }
 
 message ErrorTableData {


### PR DESCRIPTION
## Why are these changes needed?
Now the `scheduling_strategy` can have values like `Default`, `PlacementGroupSchedulingStrategy`, `NodeLabelSchedulingStrategy`,`NodeAffinitySchedulingStrategy` .
Users want to retrieve the scheduling strategy of an actor through the "get actor info" API.

**User  use cases:**
1.  The user has created over a hundred actors for a single task and has used different scheduling strategies. The user wants to visualize the scheduling strategy for the alive actors on the dashboard or `ray status` API.

2. The user has used the NodeAffinitySchedulingStrategy(or others) and wants to verify if the scheduling is correct, i.e., if the specified nodes are being used for scheduling. They want to confirm this on the dashboard or using the "ray status" api.

example:
```
    # SPREAD
    actor = Actor.options(scheduling_strategy="SPREAD").remote()
    ray.get(actor.ping.remote())
    actor_info = ray.state.actors(actor._actor_id.hex())
    assert actor_info["SchedulingStrategy"] == "SPREAD"

    # PlacementGroupSchedulingStrategy
    pg = ray.util.placement_group(bundles=[{"CPU": 1}])
    ray.get(pg.ready(), timeout=5)
    placement_group_scheduling_strategy = PlacementGroupSchedulingStrategy(pg, 0, False)
    actor = Actor.options(
        scheduling_strategy=placement_group_scheduling_strategy
    ).remote()
    ray.get(actor.ping.remote())
    actor_info = ray.state.actors(actor._actor_id.hex())
    assert actor_info["SchedulingStrategy"] == placement_group_scheduling_strategy
```

## Related issue number

[Core] [Observability] Add the scheduling_strategy field to the ActorInfo for the "get actor info" API  #39244

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
