### PR TITLE
[Core] Increase the notification timeout to 30 seconds

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -637,7 +637,7 @@ RAY_CONFIG(int64_t, log_rotation_backup_count, 5)
 /// When tasks that can't be sent because of network error. we'll never receive a DEAD
 /// notification, in this case we'll wait for a fixed timeout value and then mark it
 /// as failed.
-RAY_CONFIG(int64_t, timeout_ms_task_wait_for_death_info, 1000)
+RAY_CONFIG(int64_t, timeout_ms_task_wait_for_death_info, 30000)
 
 /// The core worker heartbeat interval. During heartbeat, it'll
 /// report the loads to raylet.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When an actor RPC failed, and if we cannot retry anymore, we consider the actor is dead. At this time, if the actor dead notification is not sent from GCS via pubsub "in 1 second", we mark the actor task is failed without a clear error message.

I observed this in a real cluster. 

This 1 second timeout is too aggressive, especially for an environment that doesn't have fast network. This PR increases the timeout to 30 seconds. The implication of this PR is that if the notification never came from GCS, the actor is marked as failed in 30 seconds, not 1 second. It is already a really bad edge case the notification is not delivered, so increasing failure detection time here is not a big problem.

Note that there are 2 other issues. We should handle it more holistically (maybe in 2.8).

1. When RPC to actor fails, we consider the actor is dead. This is a bad assumption.
2. When the notifcation is not delivered, the error message is bad. While we should improve the error message, this requires some work, so we should do it as a follow-up. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
