### PR TITLE
[Serve] [Docs] Update `route_prefix` usage in docs

### DIFF
--- a/doc/source/serve/advanced-guides/migration.md
+++ b/doc/source/serve/advanced-guides/migration.md
@@ -87,7 +87,7 @@ Sometimes, you have a customized route prefix for each deployment:
 :language: python
 ```
 
-With the 2.0 deployment API, you can use the following code to update the above one.
+With the 2.0 deployment API, use the following code to update the above one.
 
 ```{literalinclude} ../doc_code/migration_example.py
 :start-after: __customized_route_old_api_1_start__
@@ -95,7 +95,7 @@ With the 2.0 deployment API, you can use the following code to update the above 
 :language: python
 ```
 
-Or if you have multiple deployments and want to customize the HTTP route prefix for each model, you can use the following code:
+Or to customize the route prefix for multiple deployments, split the deployments into separate apps with the following code:
 
 ```{literalinclude} ../doc_code/migration_example.py
 :start-after: __customized_route_old_api_2_start__

--- a/doc/source/serve/configure-serve-deployment.md
+++ b/doc/source/serve/configure-serve-deployment.md
@@ -8,7 +8,7 @@ Configure the following parameters either in the Serve config file, or on the `@
 
 - `name` - Name uniquely identifying this deployment within the application. If not provided, the name of the class or function is used.
 - `num_replicas` - Number of replicas to run that handle requests to this deployment. Defaults to 1.
-- `route_prefix` - Requests to paths under this HTTP path prefix are routed to this deployment. Defaults to ‘/{name}’. This can only be set for the ingress (top-level) deployment of an application.
+- `route_prefix` - Requests to paths under this HTTP path prefix are routed to this deployment. Defaults to `/{name}`. This can only be set for the ingress (top-level) deployment of an application.
 - `ray_actor_options` - Options to pass to the Ray Actor decorator, such as resource requirements. Valid options are: `accelerator_type`, `memory`, `num_cpus`, `num_gpus`, `object_store_memory`, `resources`, and `runtime_env` For more details - [Resource management in Serve](serve-cpus-gpus)
 - `max_concurrent_queries` - Maximum number of queries that are sent to a replica of this deployment without receiving a response. Defaults to 100. This may be an important parameter to configure for [performance tuning](serve-perf-tuning).
 - `autoscaling_config` - Parameters to configure autoscaling behavior. If this is set, num_replicas cannot be set. For more details on configurable parameters for autoscaling - [Ray Serve Autoscaling](ray-serve-autoscaling). 

--- a/doc/source/serve/configure-serve-deployment.md
+++ b/doc/source/serve/configure-serve-deployment.md
@@ -8,7 +8,7 @@ Configure the following parameters either in the Serve config file, or on the `@
 
 - `name` - Name uniquely identifying this deployment within the application. If not provided, the name of the class or function is used.
 - `num_replicas` - Number of replicas to run that handle requests to this deployment. Defaults to 1.
-- `route_prefix` - Requests to paths under this HTTP path prefix are routed to this deployment. Defaults to `/{name}`. This can only be set for the ingress (top-level) deployment of an application.
+- `route_prefix` - Requests to paths under this HTTP path prefix are routed to this deployment. Defaults to ‘/{name}’. This can only be set for the ingress (top-level) deployment of an application.
 - `ray_actor_options` - Options to pass to the Ray Actor decorator, such as resource requirements. Valid options are: `accelerator_type`, `memory`, `num_cpus`, `num_gpus`, `object_store_memory`, `resources`, and `runtime_env` For more details - [Resource management in Serve](serve-cpus-gpus)
 - `max_concurrent_queries` - Maximum number of queries that are sent to a replica of this deployment without receiving a response. Defaults to 100. This may be an important parameter to configure for [performance tuning](serve-perf-tuning).
 - `autoscaling_config` - Parameters to configure autoscaling behavior. If this is set, num_replicas cannot be set. For more details on configurable parameters for autoscaling - [Ray Serve Autoscaling](ray-serve-autoscaling). 

--- a/doc/source/serve/doc_code/http_guide/http_guide.py
+++ b/doc/source/serve/doc_code/http_guide/http_guide.py
@@ -46,7 +46,7 @@ from ray import serve
 app = FastAPI()
 
 
-@serve.deployment(route_prefix="/hello")
+@serve.deployment
 @serve.ingress(app)
 class MyFastAPIDeployment:
     @app.get("/")
@@ -54,7 +54,7 @@ class MyFastAPIDeployment:
         return "Hello, world!"
 
 
-serve.run(MyFastAPIDeployment.bind())
+serve.run(MyFastAPIDeployment.bind(), route_prefix="/hello")
 resp = requests.get("http://localhost:8000/hello")
 assert resp.json() == "Hello, world!"
 # __end_fastapi__
@@ -69,7 +69,7 @@ from ray import serve
 app = FastAPI()
 
 
-@serve.deployment(route_prefix="/hello")
+@serve.deployment
 @serve.ingress(app)
 class MyFastAPIDeployment:
     @app.get("/")
@@ -81,7 +81,7 @@ class MyFastAPIDeployment:
         return f"Hello from {subpath}!"
 
 
-serve.run(MyFastAPIDeployment.bind())
+serve.run(MyFastAPIDeployment.bind(), route_prefix="/hello")
 resp = requests.post("http://localhost:8000/hello/Serve")
 assert resp.json() == "Hello from Serve!"
 # __end_fastapi_multi_routes__
@@ -100,13 +100,13 @@ def f():
     return "Hello from the root!"
 
 
-@serve.deployment(route_prefix="/")
+@serve.deployment
 @serve.ingress(app)
 class FastAPIWrapper:
     pass
 
 
-serve.run(FastAPIWrapper.bind())
+serve.run(FastAPIWrapper.bind(), route_prefix="/")
 resp = requests.get("http://localhost:8000/")
 assert resp.json() == "Hello from the root!"
 # __end_byo_fastapi__

--- a/doc/source/serve/doc_code/migration_example.py
+++ b/doc/source/serve/doc_code/migration_example.py
@@ -162,8 +162,8 @@ class Model:
         return "done"
 
 
-d = DAGDriver.options(route_prefix="/my_model1").bind(Model.bind())
-handle = serve.run(d)
+d = DAGDriver.bind(Model.bind())
+handle = serve.run(d, route_prefix="/my_model1")
 resp = requests.get("http://localhost:8000/my_model1", data="321")
 # __customized_route_old_api_1_end__
 
@@ -185,8 +185,10 @@ class Model2:
         return "done"
 
 
-d = DAGDriver.bind({"/my_model1": Model.bind(), "/my_model2": Model2.bind()})
-handle = serve.run(d)
+app1 = DAGDriver.bind(Model.bind())
+app2 = DAGDriver.bind(Model2.bind())
+handle1 = serve.run(app1, name="app1", route_prefix="/my_model1")
+handle2 = serve.run(app1, name="app2", route_prefix="/my_model2")
 resp = requests.get("http://localhost:8000/my_model1", data="321")
 resp = requests.get("http://localhost:8000/my_model2", data="321")
 # __customized_route_old_api_2_end__

--- a/doc/source/serve/http-guide.md
+++ b/doc/source/serve/http-guide.md
@@ -27,7 +27,7 @@ When you deploy a Serve application, the [ingress deployment](serve-key-concepts
 :language: python
 ```
 
-Requests to the Serve HTTP server at `/` are routed to the deployment's `__call__` method with a [Starlette Request object](https://www.starlette.io/requests/) as the sole argument. The `__call__` method can return any JSON-serializable object or a [Starlette Response object](https://www.starlette.io/responses/) (e.g., to return a custom status code or custom headers).
+Requests to the Serve HTTP server at `/` are routed to the deployment's `__call__` method with a [Starlette Request object](https://www.starlette.io/requests/) as the sole argument. The `__call__` method can return any JSON-serializable object or a [Starlette Response object](https://www.starlette.io/responses/) (e.g., to return a custom status code or custom headers). A Serve app's route prefix can be changed from `/` to another string by setting `route_prefix` in `serve.run()` or the Serve config file.
 
 Often for ML models, you just need the API to accept a `numpy` array. You can use Serve's `DAGDriver` to simplify the request parsing.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change makes the docs explain how to set `route_prefix`. It also updates examples in the docs where `route_prefix` was set in the `@serve.deployment` decorator.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #39133.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
