### PR TITLE
[core] Expose Redis getter to Python and use to retrieve session name

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2352,6 +2352,7 @@ pyx_library(
     deps = [
         "//:core_worker_lib",
         "//:global_state_accessor_lib",
+        "//:gcs_server_lib",
         "//:raylet_lib",
         "//:redis_client",
         "//:src/ray/ray_exported_symbols.lds",

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -156,7 +156,7 @@ from ray.includes.libcoreworker cimport (
 
 from ray.includes.ray_config cimport RayConfig
 from ray.includes.global_state_accessor cimport CGlobalStateAccessor
-from ray.includes.global_state_accessor cimport RedisDelKeySync
+from ray.includes.global_state_accessor cimport RedisDelKeySync, RedisGetKeySync
 from ray.includes.optional cimport (
     optional, nullopt
 )
@@ -4574,3 +4574,25 @@ cdef void async_callback(shared_ptr[CRayObject] obj,
 
 def del_key_from_storage(host, port, password, use_ssl, key):
     return RedisDelKeySync(host, port, password, use_ssl, key)
+
+
+def get_session_key_from_storage(host, port, password, use_ssl, config, key):
+    """
+    Get the session key from the storage.
+    Intended to be used for session_name only.
+    Args:
+        host: The address of the owner (caller) of the
+            generator task.
+        port: The task ID of the generator task.
+        password: The redis password.
+        use_ssl: Whether to use SSL.
+        config: The Ray config. Used to get storage namespace.
+        key: The key to retrieve.
+    """
+    cdef:
+        c_string data
+    result = RedisGetKeySync(host, port, password, use_ssl, config, key, &data)
+    if result:
+        return data
+    else:
+        return None

--- a/python/ray/includes/global_state_accessor.pxd
+++ b/python/ray/includes/global_state_accessor.pxd
@@ -49,6 +49,72 @@ cdef extern from "ray/gcs/gcs_client/global_state_accessor.h" nogil:
 cdef extern from * namespace "ray::gcs" nogil:
     """
     #include <thread>
+    #include "ray/gcs/gcs_server/store_client_kv.h"
+    namespace ray {
+    namespace gcs {
+
+    bool RedisGetKeySync(const std::string& host,
+                         int32_t port,
+                         const std::string& password,
+                         bool use_ssl,
+                         const std::string& config,
+                         const std::string& key,
+                         std::string* data) {
+      InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                             ray::RayLog::ShutDownRayLog,
+                                             "ray_init",
+                                             ray::RayLogLevel::WARNING,
+                                             "" /* log_dir */);
+
+      RedisClientOptions options(host, port, password, false, use_ssl);
+
+      std::string config_list;
+      RAY_CHECK(absl::Base64Unescape(config, &config_list));
+      RayConfig::instance().initialize(config_list);
+
+      instrumented_io_context io_service;
+
+      auto redis_client = std::make_shared<RedisClient>(options);
+      auto status = redis_client->Connect(io_service);
+      if(!status.ok()) {
+        RAY_LOG(ERROR) << "Failed to connect to redis: " << status.ToString();
+        return false;
+      }
+
+      auto cli = std::make_unique<StoreClientInternalKV>(
+        std::make_unique<RedisStoreClient>(std::move(redis_client)));
+
+      bool ret_val = false;
+      cli->Get("session", key, [&](std::optional<std::string> result) {
+        if (result.has_value()) {
+          *data = result.value();
+          ret_val = true;
+        } else {
+          RAY_LOG(INFO) << "Failed to retrieve the key " << key
+                        << " from persistent storage.";
+          ret_val = false;
+        }
+      });
+      io_service.run_for(std::chrono::milliseconds(1000));
+
+      return ret_val;
+    }
+
+    }
+    }
+    """
+    c_bool RedisGetKeySync(const c_string& host,
+                           c_int32_t port,
+                           const c_string& password,
+                           c_bool use_ssl,
+                           const c_string& config,
+                           const c_string& key,
+                           c_string* data)
+
+
+cdef extern from * namespace "ray::gcs" nogil:
+    """
+    #include <thread>
     #include "ray/gcs/redis_client.h"
     namespace ray {
     namespace gcs {

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -141,7 +141,6 @@ py_test_module_list(
     "test_multinode_failures_2.py",
     "test_node_manager.py",
     "test_object_assign_owner.py",
-    "test_placement_group.py",
     "test_placement_group_2.py",
     "test_placement_group_4.py",
     "test_placement_group_failover.py",
@@ -224,6 +223,7 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_gcs_ha_e2e.py",
+    "test_gcs_ha_e2e_2.py",
     "test_memory_pressure.py",
     "test_node_labels.py",
   ],
@@ -317,6 +317,7 @@ py_test_module_list(
     "test_reference_counting_2.py",
     "test_exit_observability.py",
     "test_usage_stats.py",
+    "test_placement_group.py",
     "test_placement_group_3.py",
     "test_placement_group_5.py",
     "test_cancel.py",

--- a/python/ray/tests/conftest_docker.py
+++ b/python/ray/tests/conftest_docker.py
@@ -93,7 +93,11 @@ head_node = container(
         "9379",
     ],
     volumes={"{head_node_vol.name}": {"bind": "/tmp", "mode": "rw"}},
-    environment={"RAY_REDIS_ADDRESS": "{redis.ips.primary}:6379"},
+    environment={
+        "RAY_REDIS_ADDRESS": "{redis.ips.primary}:6379",
+        "RAY_raylet_client_num_connect_attempts": "10",
+        "RAY_raylet_client_connect_timeout_milliseconds": "100",
+    },
     wrapper_class=Container,
     ports={
         "8000/tcp": None,
@@ -118,7 +122,11 @@ worker_node = container(
         "9379",
     ],
     volumes={"{worker_node_vol.name}": {"bind": "/tmp", "mode": "rw"}},
-    environment={"RAY_REDIS_ADDRESS": "{redis.ips.primary}:6379"},
+    environment={
+        "RAY_REDIS_ADDRESS": "{redis.ips.primary}:6379",
+        "RAY_raylet_client_num_connect_attempts": "10",
+        "RAY_raylet_client_connect_timeout_milliseconds": "100",
+    },
     wrapper_class=Container,
     ports={
         "8000/tcp": None,

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -355,22 +355,22 @@ print(ray.get([use_gpu.remote(), use_gpu.remote()]))
 
 @pytest.mark.skipif(enable_external_redis(), reason="Only valid in non redis env")
 def test_redis_not_available(monkeypatch, call_ray_stop_only):
-    monkeypatch.setenv("RAY_NUM_REDIS_GET_RETRIES", "2")
+    monkeypatch.setenv("RAY_redis_db_connect_retries", "5")
     monkeypatch.setenv("RAY_REDIS_ADDRESS", "localhost:12345")
+
     p = subprocess.run(
         "ray start --head",
         shell=True,
         capture_output=True,
     )
     assert "Could not establish connection to Redis" in p.stderr.decode()
-    assert "Please check" in p.stderr.decode()
-    assert "gcs_server.out for details" in p.stderr.decode()
-    assert "RuntimeError: Failed to start GCS" in p.stderr.decode()
+    assert "Please check " in p.stderr.decode()
+    assert "redis storage is alive or not." in p.stderr.decode()
 
 
 @pytest.mark.skipif(not enable_external_redis(), reason="Only valid in redis env")
 def test_redis_wrong_password(monkeypatch, external_redis, call_ray_stop_only):
-    monkeypatch.setenv("RAY_NUM_REDIS_GET_RETRIES", "2")
+    monkeypatch.setenv("RAY_redis_db_connect_retries", "5")
     p = subprocess.run(
         "ray start --head  --redis-password=1234",
         shell=True,
@@ -378,8 +378,6 @@ def test_redis_wrong_password(monkeypatch, external_redis, call_ray_stop_only):
     )
 
     assert "RedisError: ERR AUTH <password> called" in p.stderr.decode()
-    assert "Please check /tmp/ray/session" in p.stderr.decode()
-    assert "RuntimeError: Failed to start GCS" in p.stderr.decode()
 
 
 @pytest.mark.skipif(not enable_external_redis(), reason="Only valid in redis env")

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -868,6 +868,36 @@ def test_cluster_id(ray_start_regular):
             sleep(1)
 
 
+def test_session_name(ray_start_cluster):
+    # Kill GCS and check that raylets kill themselves when not backed by Redis,
+    # and stay alive when backed by Redis.
+    # Raylets should kill themselves due to cluster ID mismatch in the
+    # non-persisted case.
+    cluster = ray_start_cluster
+    cluster.add_node()
+    cluster.wait_for_nodes()
+
+    head_node = cluster.head_node
+    session_dir = head_node.get_session_dir_path()
+
+    gcs_server_process = head_node.all_processes["gcs_server"][0].process
+    gcs_server_pid = gcs_server_process.pid
+    cluster.remove_node(head_node, allow_graceful=False)
+    # Wait to prevent the gcs server process becoming zombie.
+    gcs_server_process.wait()
+    wait_for_pid_to_exit(gcs_server_pid, 1000)
+
+    # Add head node back
+    cluster.add_node()
+    head_node = cluster.head_node
+    new_session_dir = head_node.get_session_dir_path()
+
+    if not enable_external_redis():
+        assert session_dir != new_session_dir
+    else:
+        assert session_dir == new_session_dir
+
+
 @pytest.mark.parametrize(
     "ray_start_regular_with_external_redis",
     [
@@ -915,6 +945,34 @@ def test_redis_data_loss_no_leak(ray_start_regular_with_external_redis):
 
     # Waiting for raylet to become unhealthy
     wait_for_condition(lambda: not check_raylet_healthy())
+
+
+def test_redis_logs(external_redis):
+    try:
+        import subprocess
+
+        process = subprocess.Popen(
+            ["ray", "start", "--head"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        stdout, stderr = process.communicate(timeout=30)
+        print(stdout.decode())
+        print(stderr.decode())
+        assert "redis_context.cc" not in stderr.decode()
+        assert "redis_context.cc" not in stdout.decode()
+        assert "Resolve Redis address" not in stderr.decode()
+        assert "Resolve Redis address" not in stdout.decode()
+        # assert "redis_context.cc" not in result.output
+    finally:
+        from click.testing import CliRunner
+        import ray.scripts.scripts as scripts
+
+        runner = CliRunner(env={"RAY_USAGE_STATS_PROMPT_ENABLED": "0"})
+        runner.invoke(
+            scripts.stop,
+            [
+                "--force",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_gcs_ha_e2e.py
+++ b/python/ray/tests/test_gcs_ha_e2e.py
@@ -1,6 +1,8 @@
-import pytest
 import sys
 from time import sleep
+
+import pytest
+
 from ray._private.test_utils import wait_for_condition
 from ray.tests.conftest_docker import *  # noqa
 

--- a/python/ray/tests/test_gcs_ha_e2e_2.py
+++ b/python/ray/tests/test_gcs_ha_e2e_2.py
@@ -1,0 +1,55 @@
+import pytest
+import sys
+from time import sleep
+from ray._private.test_utils import wait_for_condition
+from ray.tests.conftest_docker import *  # noqa
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Only works on linux.")
+def test_ray_session_name_preserved(docker_cluster):
+    get_nodes_script = """
+import ray
+ray.init("auto")
+print(ray._private.worker._global_node.session_name)
+"""
+    head, worker = docker_cluster
+
+    def get_session_name(to_head=True):
+        if to_head:
+            output = head.exec_run(cmd=f"python -c '{get_nodes_script}'")
+        else:
+            output = worker.exec_run(cmd=f"python -c '{get_nodes_script}'")
+        session_name = output.output.decode().strip().split("\n")[-1]
+        print("Output: ", output.output.decode().strip().split("\n"))
+        assert output.exit_code == 0
+        return session_name
+
+    # Make sure two nodes are alive
+    wait_for_condition(get_session_name, to_head=True)
+    session_name_head = get_session_name(to_head=True)
+    wait_for_condition(get_session_name, to_head=False)
+    session_name_worker = get_session_name(to_head=False)
+    assert session_name_head == session_name_worker
+    print("head killed")
+    head.kill()
+
+    sleep(2)
+
+    head.restart()
+
+    wait_for_condition(get_session_name, to_head=True)
+    session_name_head_after_restart = get_session_name(to_head=True)
+    wait_for_condition(get_session_name, to_head=False)
+    session_name_worker_after_restart = get_session_name(to_head=False)
+    assert session_name_worker_after_restart == session_name_head_after_restart
+    assert session_name_head == session_name_head_after_restart
+    assert session_name_worker_after_restart == session_name_worker
+
+
+if __name__ == "__main__":
+    import os
+
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -134,7 +134,7 @@ def test_raylet_tempfiles(shutdown_only):
     assert sum(1 for filename in log_files if filename.startswith("worker")) == 4
 
     socket_files = set(os.listdir(node.get_sockets_dir_path()))
-    assert socket_files == expected_socket_files
+    assert socket_files.issuperset(expected_socket_files)
 
 
 def test_tempdir_privilege(shutdown_only):


### PR DESCRIPTION
… (#39194)

If only GCS communicates with Redis, there is no way to initialize the log directories using persisted values. However, these directories are required to exist before starting GCS. Expose a function to the Python layer specifically to retrieve these keys from Redis and set them. Follow-ups will ensure that these keys are only set and retrieved through this interface.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
