### PR TITLE
[Data] Increase timeouts for Data+Train benchmarks after adding caching variants

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5941,7 +5941,7 @@
     cluster_compute: multi_node_train_4_workers.yaml
 
   run:
-    timeout: 1800
+    timeout: 5400
     script: python multi_node_train_benchmark.py --num-workers 4 --file-type image
 
   variations:
@@ -5965,7 +5965,7 @@
     cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_4x4_aws.yaml
 
   run:
-    timeout: 1800
+    timeout: 5400
     script: python multi_node_train_benchmark.py --num-workers 16 --file-type image
 
   variations:
@@ -5989,7 +5989,7 @@
     cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_4x4_aws.yaml
 
   run:
-    timeout: 1800
+    timeout: 5400
     script: python multi_node_train_benchmark.py --num-workers 16 --file-type image --preserve-order
 
   variations:
@@ -6013,7 +6013,7 @@
     cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_2x2_aws.yaml
 
   run:
-    timeout: 1800
+    timeout: 5400
     script: python multi_node_train_benchmark.py --num-workers 4 --file-type parquet
 
   variations:
@@ -6037,7 +6037,7 @@
     cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_4x4_aws.yaml
 
   run:
-    timeout: 1800
+    timeout: 5400
     script: python multi_node_train_benchmark.py --num-workers 16 --file-type parquet
 
   variations:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5942,7 +5942,7 @@
 
   run:
     timeout: 5400
-    script: python multi_node_train_benchmark.py --num-workers 4 --file-type image
+    script: python multi_node_train_benchmark.py --num-workers 4 --use-gpu --file-type image
 
   variations:
     - __suffix__: aws
@@ -5966,7 +5966,7 @@
 
   run:
     timeout: 5400
-    script: python multi_node_train_benchmark.py --num-workers 16 --file-type image
+    script: python multi_node_train_benchmark.py --num-workers 16 --use-gpu --file-type image
 
   variations:
     - __suffix__: aws
@@ -5990,7 +5990,7 @@
 
   run:
     timeout: 5400
-    script: python multi_node_train_benchmark.py --num-workers 16 --file-type image --preserve-order
+    script: python multi_node_train_benchmark.py --num-workers 16 --use-gpu --file-type image --preserve-order
 
   variations:
     - __suffix__: aws
@@ -6014,7 +6014,7 @@
 
   run:
     timeout: 5400
-    script: python multi_node_train_benchmark.py --num-workers 4 --file-type parquet
+    script: python multi_node_train_benchmark.py --num-workers 4 --use-gpu --file-type parquet
 
   variations:
     - __suffix__: aws
@@ -6038,7 +6038,7 @@
 
   run:
     timeout: 5400
-    script: python multi_node_train_benchmark.py --num-workers 16 --file-type parquet
+    script: python multi_node_train_benchmark.py --num-workers 16 --use-gpu --file-type parquet
 
   variations:
     - __suffix__: aws


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/pull/38917 adds caching variants for the Data+Train benchmarks, but did not increase the timeouts for the tests. We increase the timeout by a factor of 3, since we now run the benchmark code 3 times (once for each variant).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
