### PR TITLE
[CI] Skip getting logs for long running jobs (#39146)

### DIFF
--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -45,6 +45,7 @@ class AnyscaleJobManager:
         self._last_job_result = None
         self._last_logs = None
         self.cluster_startup_timeout = 600
+        self._duration = None
 
     def _run_job(
         self,
@@ -248,8 +249,8 @@ class AnyscaleJobManager:
             retcode = -4
         else:
             retcode = job_status_to_return_code[status]
-        duration = time.time() - self.start_time
-        return retcode, duration
+        self._duration = time.time() - self.start_time
+        return retcode, self._duration
 
     def run_and_wait(
         self,
@@ -274,25 +275,25 @@ class AnyscaleJobManager:
         Obtain any ray logs that contain keywords that indicate a crash, such as
         ERROR or Traceback
         """
-        tmpdir = tempfile.mktemp()
-        try:
-            subprocess.check_output(
-                [
-                    "anyscale",
-                    "logs",
-                    "cluster",
-                    "--id",
-                    self.cluster_manager.cluster_id,
-                    "--head-only",
-                    "--download",
-                    "--download-dir",
-                    tmpdir,
-                ]
-            )
-        except Exception as e:
-            logger.log(f"Failed to download logs from anyscale {e}")
-            return None
-        return AnyscaleJobManager._find_job_driver_and_ray_error_logs(tmpdir)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                subprocess.check_output(
+                    [
+                        "anyscale",
+                        "logs",
+                        "cluster",
+                        "--id",
+                        self.cluster_manager.cluster_id,
+                        "--head-only",
+                        "--download",
+                        "--download-dir",
+                        tmpdir,
+                    ]
+                )
+            except Exception as e:
+                logger.exception(f"Failed to download logs from anyscale {e}")
+                return None, None
+            return AnyscaleJobManager._find_job_driver_and_ray_error_logs(tmpdir)
 
     @staticmethod
     def _find_job_driver_and_ray_error_logs(
@@ -336,6 +337,10 @@ class AnyscaleJobManager:
 
         if self._last_logs:
             return self._last_logs
+
+        # Skip loading logs when the job ran for too long and collected too much logs.
+        if self._duration is not None and self._duration > 4 * 3_600:
+            return None
 
         def _get_logs():
             job_driver_log, ray_error_log = self._get_ray_logs()

--- a/release/ray_release/tests/test_anyscale_job_manager.py
+++ b/release/ray_release/tests/test_anyscale_job_manager.py
@@ -7,6 +7,11 @@ from ray_release.util import ERROR_LOG_PATTERNS
 from ray_release.job_manager.anyscale_job_manager import AnyscaleJobManager
 
 
+class FakeJobResult:
+    def __init__(self, _id: str):
+        self.id = _id
+
+
 def test_get_ray_error_logs():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "log01"), "w") as f:
@@ -21,6 +26,18 @@ def test_get_ray_error_logs():
         ) = AnyscaleJobManager._find_job_driver_and_ray_error_logs(tmpdir)
         assert ray_error_log == "".join(ERROR_LOG_PATTERNS + ["haha"])
         assert job_driver_log == "w00t"
+
+
+def test_get_last_logs_long_running_job():
+    """Test calling get_last_logs() on long-running jobs.
+
+    When the job is running longer than 4 hours, get_last_logs() should skip
+    downloading the logs and return None.
+    """
+    anyscale_job_manager = AnyscaleJobManager(cluster_manager=None)
+    anyscale_job_manager._duration = 4 * 3_600 + 1
+    anyscale_job_manager._last_job_result = FakeJobResult(_id="foo")
+    assert anyscale_job_manager.get_last_logs() is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For long running jobs (over ~4 hours) we are getting Exited with status -1 (agent lost) during Fetching Results step due to we are collecting and downloading too many logs. Buildkite agent seems to be exited automatically during this process. This PR skips downloading ray logs for those long running jobs so the test can finish successfully.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is to fix all the failing long running release tests

## Related issue number

Pick of https://github.com/ray-project/ray/pull/39146#event-10286627118

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
