### PR TITLE
[cherry-pick][core] Ship the libjemalloc.so with wheel (#39241)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -83,7 +83,6 @@ config_setting(
     name = "jemalloc",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
     ],
     flag_values = {
         ":jemalloc_flag": "true",

--- a/python/setup.py
+++ b/python/setup.py
@@ -168,6 +168,9 @@ ray_files = [
     "ray/core/src/ray/raylet/raylet" + exe_suffix,
 ]
 
+if sys.platform == "linux":
+    ray_files.append("ray/core/libjemalloc.so")
+
 if BUILD_JAVA or os.path.exists(os.path.join(ROOT_DIR, "ray/jars/ray_dist.jar")):
     ray_files.append("ray/jars/ray_dist.jar")
 


### PR DESCRIPTION
## Why are these changes needed?
In [PR](https://github.com/ray-project/ray/pull/39192), jemalloc is added, but it's not delivered with the wheel. This PR fixed it.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
