### PR TITLE
[train] New persistence mode: Deprecate experimental distributed checkpointing configs

### DIFF
--- a/doc/source/train/user-guides/checkpoints.rst
+++ b/doc/source/train/user-guides/checkpoints.rst
@@ -324,12 +324,6 @@ checkpoints to disk), a :py:class:`~ray.train.CheckpointConfig` can be passed in
     :py:class:`~ray.train.CheckpointConfig`,
     please ensure that the metric is always reported together with the checkpoints.
 
-**[Experimental] Distributed Checkpoints**: For model parallel workloads where the models do not fit in a single GPU worker,
-it will be important to save and upload the model that is partitioned across different workers. You
-can enable this by setting `_checkpoint_keep_all_ranks=True` to retain the model checkpoints across workers,
-and `_checkpoint_upload_from_workers=True` to upload their checkpoints to cloud directly in :class:`~ray.train.CheckpointConfig`. This functionality works for any trainer that inherits from :class:`~ray.train.data_parallel_trainer.DataParallelTrainer`.
-
-
 
 .. _train-dl-loading-checkpoints:
 

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -45,6 +45,7 @@ SampleRange = Union["Domain", Dict[str, List]]
 
 MAX = "max"
 MIN = "min"
+_DEPRECATED_VALUE = "DEPRECATED"
 
 
 logger = logging.getLogger(__name__)
@@ -608,15 +609,15 @@ class CheckpointConfig:
             This attribute is only supported by trainers that don't take in
             custom training loops. Defaults to True for trainers that support it
             and False for generic function trainables.
-        _checkpoint_keep_all_ranks: If True, will save checkpoints from all ranked
-            training workers. If False, only checkpoint from rank 0 worker is kept.
-            NOTE: This API is experimental and subject to change between minor
-            releases.
-        _checkpoint_upload_from_workers: If True, distributed workers
-            will upload their checkpoints to cloud directly. This is to avoid the
-            need for transferring large checkpoint files to the training worker
-            group coordinator for persistence. NOTE: This API is experimental and
-            subject to change between minor releases.
+        _checkpoint_keep_all_ranks: This experimental config is deprecated.
+            This behavior is now controlled by reporting `checkpoint=None`
+            in the workers that shouldn't persist a checkpoint.
+            For example, if you only want the rank 0 worker to persist a checkpoint
+            (e.g., in standard data parallel training), then you should save and
+            report a checkpoint if `ray.train.get_context().get_world_rank() == 0`
+            and `None` otherwise.
+        _checkpoint_upload_from_workers: This experimental config is deprecated.
+            Uploading checkpoint directly from the worker is now the default behavior.
     """
 
     num_to_keep: Optional[int] = None
@@ -624,10 +625,29 @@ class CheckpointConfig:
     checkpoint_score_order: Optional[str] = MAX
     checkpoint_frequency: Optional[int] = 0
     checkpoint_at_end: Optional[bool] = None
-    _checkpoint_keep_all_ranks: Optional[bool] = False
-    _checkpoint_upload_from_workers: Optional[bool] = False
+    _checkpoint_keep_all_ranks: Optional[bool] = _DEPRECATED_VALUE
+    _checkpoint_upload_from_workers: Optional[bool] = _DEPRECATED_VALUE
 
     def __post_init__(self):
+        if self._checkpoint_keep_all_ranks != _DEPRECATED_VALUE:
+            raise DeprecationWarning(
+                "The experimental `_checkpoint_keep_all_ranks` config is deprecated. "
+                "This behavior is now controlled by reporting `checkpoint=None` "
+                "in the workers that shouldn't persist a checkpoint. "
+                "For example, if you only want the rank 0 worker to persist a "
+                "checkpoint (e.g., in standard data parallel training), "
+                "then you should save and report a checkpoint if "
+                "`ray.train.get_context().get_world_rank() == 0` "
+                "and `None` otherwise."
+            )
+
+        if self._checkpoint_upload_from_workers != _DEPRECATED_VALUE:
+            raise DeprecationWarning(
+                "The experimental `_checkpoint_upload_from_workers` config is "
+                "deprecated. Uploading checkpoint directly from the worker is "
+                "now the default behavior."
+            )
+
         if self.num_to_keep is not None and self.num_to_keep <= 0:
             raise ValueError(
                 f"Received invalid num_to_keep: "

--- a/python/ray/train/tests/test_lightning_deepspeed.py
+++ b/python/ray/train/tests/test_lightning_deepspeed.py
@@ -59,7 +59,6 @@ def test_deepspeed_stages(ray_start_6_cpus_4_gpus, tmpdir, stage, test_restore):
                 num_to_keep=3,
                 checkpoint_score_attribute="val_loss",
                 checkpoint_score_order="min",
-                _checkpoint_keep_all_ranks=True,
             ),
         ),
     )

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -329,8 +329,6 @@ def run(
     checkpoint_score_attr: Optional[str] = None,  # Deprecated (2.7)
     checkpoint_freq: int = 0,  # Deprecated (2.7)
     checkpoint_at_end: bool = False,  # Deprecated (2.7)
-    checkpoint_keep_all_ranks: bool = False,  # Deprecated (2.7)
-    checkpoint_upload_from_workers: bool = False,  # Deprecated (2.7)
     chdir_to_trial_dir: bool = _DEPRECATED_VALUE,  # Deprecated (2.8)
     local_dir: Optional[str] = None,
     # == internal only ==
@@ -740,22 +738,6 @@ def run(
             DeprecationWarning,
         )
         checkpoint_config.checkpoint_at_end = checkpoint_at_end
-    if checkpoint_keep_all_ranks:
-        warnings.warn(
-            "checkpoint_keep_all_ranks is deprecated and will be removed. "
-            "use checkpoint_config._checkpoint_keep_all_ranks instead.",
-            DeprecationWarning,
-        )
-        checkpoint_config._checkpoint_keep_all_ranks = checkpoint_keep_all_ranks
-    if checkpoint_upload_from_workers:
-        warnings.warn(
-            "checkpoint_upload_from_workers is deprecated and will be removed. "
-            "use checkpoint_config._checkpoint_upload_from_workers instead.",
-            DeprecationWarning,
-        )
-        checkpoint_config._checkpoint_upload_from_workers = (
-            checkpoint_upload_from_workers
-        )
 
     if chdir_to_trial_dir != _DEPRECATED_VALUE:
         warnings.warn(

--- a/release/jobs_tests/workloads/jobs_basic.py
+++ b/release/jobs_tests/workloads/jobs_basic.py
@@ -15,7 +15,6 @@ from typing import Optional
 from ray.dashboard.modules.job.common import JobStatus
 
 from ray.job_submission import JobSubmissionClient
-from ray.train.constants import RAY_AIR_NEW_PERSISTENCE_MODE
 
 
 def wait_until_finish(
@@ -62,7 +61,6 @@ if __name__ == "__main__":
         runtime_env={
             "pip": ["ray[tune]"],
             "working_dir": args.working_dir,
-            "env_vars": {RAY_AIR_NEW_PERSISTENCE_MODE: "1"},
         },
     )
     timeout_s = 10 * 60

--- a/release/jobs_tests/workloads/jobs_basic.py
+++ b/release/jobs_tests/workloads/jobs_basic.py
@@ -15,6 +15,7 @@ from typing import Optional
 from ray.dashboard.modules.job.common import JobStatus
 
 from ray.job_submission import JobSubmissionClient
+from ray.train.constants import RAY_AIR_NEW_PERSISTENCE_MODE
 
 
 def wait_until_finish(
@@ -61,6 +62,7 @@ if __name__ == "__main__":
         runtime_env={
             "pip": ["ray[tune]"],
             "working_dir": args.working_dir,
+            "env_vars": {RAY_AIR_NEW_PERSISTENCE_MODE: "1"},
         },
     )
     timeout_s = 10 * 60


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR deprecates some distributed checkpointing configs that are no longer used and suggests the new way to configure the behavior if applicable.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/38957

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
