### PR TITLE
[train] Add `TrainContext.get_storage`

### DIFF
--- a/python/ray/air/_internal/session.py
+++ b/python/ray/air/_internal/session.py
@@ -4,7 +4,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def _get_session(warn: bool = True):
+def _get_session(warn: bool = False):
     from ray.train._internal.session import _session as train_session
     from ray.tune.trainable.session import _session as tune_session
 

--- a/python/ray/train/_internal/session.py
+++ b/python/ray/train/_internal/session.py
@@ -1278,3 +1278,16 @@ def get_dataset_shard(
             "that is passed into `DataParallelTrainer`."
         )
     return session.get_dataset_shard(dataset_name)
+
+
+@DeveloperAPI
+@_warn_session_misuse()
+def get_storage() -> StorageContext:
+    """Returns the :class:`~ray.train._internal.storage.StorageContext` storage
+    context which gives advanced access to the filesystem and paths
+    configured through `RunConfig`.
+
+    NOTE: This is a developer API, and the `StorageContext` interface may change
+    without notice between minor versions.
+    """
+    return get_session().storage

--- a/python/ray/train/context.py
+++ b/python/ray/train/context.py
@@ -2,7 +2,8 @@ import threading
 from typing import TYPE_CHECKING, Optional, Dict, Any
 
 from ray.train._internal import session
-from ray.util.annotations import PublicAPI
+from ray.train._internal.storage import StorageContext
+from ray.util.annotations import DeveloperAPI, PublicAPI
 
 
 if TYPE_CHECKING:
@@ -69,6 +70,11 @@ class TrainContext:
     @_copy_doc(session.get_node_rank)
     def get_node_rank(self) -> int:
         return session.get_node_rank()
+
+    @DeveloperAPI
+    @_copy_doc(session.get_storage)
+    def get_storage(self) -> StorageContext:
+        return session.get_storage()
 
 
 @PublicAPI(stability="beta")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Exposes the `StorageContext` as a developer API for advanced access of storage path and filesystem related attributes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
