### PR TITLE
[train] New persistence mode: Add backwards compatibility support for `local_dir`

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -787,10 +787,10 @@ class RunConfig:
 
         # Convert Paths to strings
         if isinstance(self.local_dir, Path):
-            self.local_dir = str(self.local_dir)
+            self.local_dir = self.local_dir.as_posix()
 
         if isinstance(self.storage_path, Path):
-            self.storage_path = str(self.storage_path)
+            self.storage_path = self.storage_path.as_posix()
 
         # TODO(justinvyu): [code_removal] Legacy stuff below.
         from ray.tune.utils.util import _resolve_storage_path

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -704,7 +704,6 @@ class TunerInternal:
             stop=self._run_config.stop,
             max_failures=self._run_config.failure_config.max_failures,
             checkpoint_config=checkpoint_config,
-            _experiment_checkpoint_dir=self._legacy_experiment_checkpoint_dir,
             raise_on_failed_trial=False,
             fail_fast=(self._run_config.failure_config.fail_fast),
             progress_reporter=self._run_config.progress_reporter,
@@ -714,8 +713,13 @@ class TunerInternal:
             time_budget_s=self._tune_config.time_budget_s,
             trial_name_creator=self._tune_config.trial_name_creator,
             trial_dirname_creator=self._tune_config.trial_dirname_creator,
-            chdir_to_trial_dir=self._tune_config.chdir_to_trial_dir,
             _entrypoint=self._entrypoint,
+            # TODO(justinvyu): Finalize the local_dir vs. env var API in 2.8.
+            # For now, keep accepting both options.
+            local_dir=self._run_config.local_dir,
+            # Deprecated
+            chdir_to_trial_dir=self._tune_config.chdir_to_trial_dir,
+            _experiment_checkpoint_dir=self._legacy_experiment_checkpoint_dir,
         )
 
     def _fit_internal(

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -680,6 +680,11 @@ def run(
         local_path, remote_path = None, None
         sync_config = sync_config or SyncConfig()
         # TODO(justinvyu): Fix telemetry for the new persistence.
+
+        # TODO(justinvyu): Finalize the local_dir vs. env var API in 2.8.
+        # For now, keep accepting both options.
+        if local_dir is not None:
+            os.environ["RAY_AIR_LOCAL_CACHE_DIR"] = local_path
     else:
         (
             storage_path,

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -684,7 +684,7 @@ def run(
         # TODO(justinvyu): Finalize the local_dir vs. env var API in 2.8.
         # For now, keep accepting both options.
         if local_dir is not None:
-            os.environ["RAY_AIR_LOCAL_CACHE_DIR"] = local_path
+            os.environ["RAY_AIR_LOCAL_CACHE_DIR"] = local_dir
     else:
         (
             storage_path,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Whether or not to re-introduce this `local_dir` config is pushed to Ray 2.8. For now, I'm keeping backwards compatibility by supporting `local_dir` to do the same thing as `RAY_AIR_LOCAL_CACHE_DIR`.

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/38878

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
