### PR TITLE
[Core] Fix GCS check failure due to autoscaler V2

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -135,15 +135,17 @@ void GcsAutoscalerStateManager::GetPendingGangResourceRequests(
   // Iterate through each placement group load.
   for (const auto &pg_data : placement_group_load->placement_group_data()) {
     auto gang_resource_req = state->add_pending_gang_resource_requests();
+    auto pg_state = pg_data.state();
+    auto pg_id = PlacementGroupID::FromBinary(pg_data.placement_group_id());
     // For each placement group, if it's not pending/rescheduling, skip it since.
     // it's not part of the load.
-    RAY_CHECK(pg_data.state() == rpc::PlacementGroupTableData::PENDING ||
-              pg_data.state() == rpc::PlacementGroupTableData::RESCHEDULING)
-        << "Placement group load should only include pending/rescheduling PGs. ";
+    RAY_CHECK(pg_state == rpc::PlacementGroupTableData::PENDING ||
+              pg_state == rpc::PlacementGroupTableData::RESCHEDULING)
+        << "Placement group load should only include pending/rescheduling PGs. "
+        << "PG id: " << pg_id << ", state: " << pg_state;
 
-    const auto pg_constraint = GenPlacementConstraintForPlacementGroup(
-        PlacementGroupID::FromBinary(pg_data.placement_group_id()).Hex(),
-        pg_data.strategy());
+    const auto pg_constraint =
+        GenPlacementConstraintForPlacementGroup(pg_id.Hex(), pg_data.strategy());
 
     // Add the strategy as detail info for the gang resource request.
     gang_resource_req->set_details(FormatPlacementGroupDetails(pg_data));
@@ -154,7 +156,7 @@ void GcsAutoscalerStateManager::GetPendingGangResourceRequests(
         // We will be skipping **placed** bundle (which has node id associated with it).
         // This is to avoid double counting the bundles that are already placed when
         // reporting PG related load.
-        RAY_CHECK(pg_data.state() == rpc::PlacementGroupTableData::RESCHEDULING);
+        RAY_CHECK(pg_state == rpc::PlacementGroupTableData::RESCHEDULING);
         // NOTE: This bundle is placed in a PG, this must be a bundle that was lost due
         // to node crashed.
         continue;

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -139,10 +139,10 @@ void GcsAutoscalerStateManager::GetPendingGangResourceRequests(
     auto pg_id = PlacementGroupID::FromBinary(pg_data.placement_group_id());
     // For each placement group, if it's not pending/rescheduling, skip it since.
     // it's not part of the load.
-    RAY_CHECK(pg_state == rpc::PlacementGroupTableData::PENDING ||
-              pg_state == rpc::PlacementGroupTableData::RESCHEDULING)
-        << "Placement group load should only include pending/rescheduling PGs. "
-        << "PG id: " << pg_id << ", state: " << pg_state;
+    if (pg_state != rpc::PlacementGroupTableData::PENDING &&
+        pg_state != rpc::PlacementGroupTableData::RESCHEDULING) {
+      continue;
+    }
 
     const auto pg_constraint =
         GenPlacementConstraintForPlacementGroup(pg_id.Hex(), pg_data.strategy());

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -880,9 +880,18 @@ std::shared_ptr<rpc::PlacementGroupLoad> GcsPlacementGroupManager::GetPlacementG
   int total_cnt = 0;
   for (const auto &elem : pending_placement_groups_) {
     const auto pending_pg_spec = elem.second.second;
-    auto placement_group_data = placement_group_load->add_placement_group_data();
     auto placement_group_table_data = pending_pg_spec->GetPlacementGroupTableData();
+
+    auto pg_state = placement_group_table_data.state();
+    if (pg_state != rpc::PlacementGroupTableData::PENDING &&
+        pg_state != rpc::PlacementGroupTableData::RESCHEDULING) {
+      // REMOVED or CREATED pgs are not considered as load.
+      continue;
+    }
+
+    auto placement_group_data = placement_group_load->add_placement_group_data();
     placement_group_data->Swap(&placement_group_table_data);
+
     total_cnt += 1;
     if (total_cnt >= RayConfig::instance().max_placement_group_load_report_size()) {
       break;
@@ -891,9 +900,18 @@ std::shared_ptr<rpc::PlacementGroupLoad> GcsPlacementGroupManager::GetPlacementG
   // NOTE: Infeasible placement groups also belong to the pending queue when report
   // metrics.
   for (const auto &pending_pg_spec : infeasible_placement_groups_) {
-    auto placement_group_data = placement_group_load->add_placement_group_data();
     auto placement_group_table_data = pending_pg_spec->GetPlacementGroupTableData();
+
+    auto pg_state = placement_group_table_data.state();
+    if (pg_state != rpc::PlacementGroupTableData::PENDING &&
+        pg_state != rpc::PlacementGroupTableData::RESCHEDULING) {
+      // REMOVED or CREATED pgs are not considered as load.
+      continue;
+    }
+
+    auto placement_group_data = placement_group_load->add_placement_group_data();
     placement_group_data->Swap(&placement_group_table_data);
+
     total_cnt += 1;
     if (total_cnt >= RayConfig::instance().max_placement_group_load_report_size()) {
       break;

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -395,6 +395,9 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
 
   /// Get the placement group load information.
   ///
+  /// The API guarantees the returned placement groups' states
+  /// are either PENDING or RESCHEDULING.
+  ///
   /// \return Placement group load information. Users should check if
   /// the returned rpc has any placement_group_data.
   virtual std::shared_ptr<rpc::PlacementGroupLoad> GetPlacementGroupLoad() const;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, `GetPlacementGroupLoad` can include REMOVED placement group states when the placement group is just removed and failed to schedule (https://github.com/ray-project/ray/blob/8a434b4ee7cd48e60fa1531315d39901fac5d79e/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc#L306). The removed pgs will be cleaned when it is scheduled next time.

If we call `GetPlacementGroupLoad` at this time, it triggers the check failure because the downstream consumer (autoscaler v2) assumes this should be only in PENDING & RESCHEDULING state. I fixed the issue by

- making the API `GetPlacementGroupLoad` have stronger guarantee (it now only returns PENDING & RESCHEDULING).
- making the downstream consumer to be more graceful (instead of check, we just add if). 

## Related issue number

Closes https://github.com/ray-project/ray/issues/39249

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
