### PR TITLE
[Docs] Remove unnecessary testoutputs (#39141)

### DIFF
--- a/doc/source/data/batch_inference.rst
+++ b/doc/source/data/batch_inference.rst
@@ -454,10 +454,6 @@ Models that have been trained with :ref:`Ray Train <train-docs>` can then be use
     )
     result = trainer.fit()
 
-.. testoutput::
-    :hide:
-
-    ...
 
 **Step 2:** Extract the :class:`Checkpoint <ray.train.Checkpoint>` from the training :class:`Result <ray.train.Result>`.
 

--- a/doc/source/data/working-with-pytorch.rst
+++ b/doc/source/data/working-with-pytorch.rst
@@ -77,10 +77,6 @@ Ray Data integrates with :ref:`Ray Train <train-docs>` for easy data ingest for 
     )
     trainer.fit()
 
-.. testoutput::
-    :hide:
-
-    ...
 
 For more details, see the :ref:`Ray Train user guide <data-ingest-torch>`.
 

--- a/doc/source/ray-contribute/writing-code-snippets.rst
+++ b/doc/source/ray-contribute/writing-code-snippets.rst
@@ -269,17 +269,13 @@ If your output is nondeterministic and you want to display a sample output, add
 
         0.969461416250246
 
-If your output is hard to test and you don't want to display a sample output, use
-ellipses and `:hide:`. ::
+If your output is hard to test and you don't want to display a sample output, exclude
+the ``testoutput``. ::
 
     .. testcode::
 
         print("This output is hidden and untested")
 
-    .. testoutput::
-        :hide:
-
-        ...
 
 ------------------------------
 How to test examples with GPUs

--- a/doc/source/ray-observability/user-guides/debug-apps/general-debugging.rst
+++ b/doc/source/ray-observability/user-guides/debug-apps/general-debugging.rst
@@ -68,10 +68,6 @@ And I have this code:
 
   print(ray.get(futures))
 
-.. testoutput::
-    :hide:
-
-    ...
 
 then you will get a mix of True and False. If
 ``check_file()`` runs on the Head Node, or we're running

--- a/doc/source/train/user-guides/data-loading-preprocessing.rst
+++ b/doc/source/train/user-guides/data-loading-preprocessing.rst
@@ -342,10 +342,6 @@ For example, to split only the training dataset, do the following:
     )
     my_trainer.fit()
 
-.. testoutput::
-    :hide:
-
-    ...
 
 Full customization (advanced)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -408,10 +404,6 @@ For use cases not covered by the default config class, you can also fully custom
     )
     my_trainer.fit()
 
-.. testoutput::
-    :hide:
-
-    ... 
 
 The subclass must be serializable, since Ray Train copies it from the driver script to the driving actor of the Trainer. Ray Train calls its :meth:`configure <ray.train.DataConfig.configure>` method on the main actor of the Trainer group to create the data iterators for each worker.
 
@@ -459,11 +451,6 @@ First, randomize each :ref:`block <dataset_concept>` of your dataset via :meth:`
         datasets={"train": ds},
     )
     my_trainer.fit()
-
-.. testoutput::
-    :hide:
-
-    ...
 
 
 If your model is sensitive to shuffle quality, call :meth:`Dataset.random_shuffle <ray.data.Dataset.random_shuffle>` to perform a global shuffle.
@@ -576,11 +563,6 @@ You can use this with Ray Train Trainers by applying them on the dataset before 
     print(StandardScaler.deserialize(metadata["preprocessor_pkl"]))
 
 
-.. testoutput::
-    :hide:
-
-    ...
-
 In this example, we persist the fitted preprocessor using the ``Trainer(metadata={...})`` constructor argument. This arg specifies a dict that will available from ``TrainContext.get_metadata()`` and ``checkpoint.get_metadata()`` for checkpoints saved from the Trainer. This enables recreation of the fitted preprocessor for use for inference.
 
 Performance tips
@@ -620,10 +602,6 @@ For example, the following code prefetches 10 batches at a time for each trainin
     )
     my_trainer.fit()
 
-.. testoutput::
-    :hide:
-
-    ...
 
 .. _dataset_cache_performance:
 
@@ -669,10 +647,6 @@ Transformations that you want run per-epoch, such as randomization, should go af
 
     # Pass train_ds to the Trainer
 
-.. testoutput::
-    :hide:
-
-    ...
 
 Adding CPU-only nodes to your cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
ray-project/pytest-sphinx#5 changed our tooling to only check outputs if you provide a testoutput (previously, if you didn't provide a testoutput, then our tooling would expect your testcode to produce no output). As a follow up, this PR removes unnecessary testoutput blocks.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes the OSS test failure on the release branch https://buildkite.com/ray-project/oss-ci-build-branch/builds/5897#018a691b-2cff-4fc5-acb3-9b36f5c71f09/1641-1925

## Related issue number

Pick of https://github.com/ray-project/ray/pull/39141

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
