### PR TITLE
[docs][serve] De-emphasize DAGDrivers from http guide

### DIFF
--- a/doc/source/serve/advanced-guides/deployment-graphs.md
+++ b/doc/source/serve/advanced-guides/deployment-graphs.md
@@ -145,7 +145,7 @@ $ python arithmetic_client.py
 
 Ray Serve provides the `DAGDriver`, which routes HTTP requests through your call graph. As mentioned in [the call graph section](deployment-graph-call-graph), the `DAGDriver` takes in a `DeploymentNode` and it produces a `ClassNode` that you can run.
 
-The `DAGDriver` also has an optional keyword argument: `http_adapter`. [HTTP adapters](serve-http-adapters) are functions that get run on the HTTP request before it's passed into the graph. Ray Serve provides a handful of these adapters, so you can rely on them to conveniently handle the HTTP parsing while focusing your attention on the graph itself.
+The `DAGDriver` also has an optional keyword argument: `http_adapter`. HTTP adapters are functions that get run on the HTTP request before it's passed into the graph. Ray Serve provides a handful of these adapters, so you can rely on them to conveniently handle the HTTP parsing while focusing your attention on the graph itself.
 
 For instance, you can use the Ray Serve-provided `json_request` adapter to simplify the [arithmetic call graph](deployment-graph-arithmetic-graph) by eliminating the `unpack_request` function. You can replace lines 29 through 38 with this graph:
 
@@ -165,8 +165,6 @@ At runtime:
 3. The `DAGDriver` passes the `http_adapter` output to the same function and methods that the `InputNode` is passed into, kicking off the request's journey through the call graph.
 
 In the example above, the `InputNode` represents the number packaged inside the request's JSON body instead of the HTTP request itself. You can pass the JSON directly into the graph instead of first unpacking it from the request.
-
-See [the guide](serve-http-adapters) on `http_adapters` to learn more.
 
 (deployment-graph-call-graph-testing)=
 ## Testing the Graph with the Python API

--- a/doc/source/serve/doc_code/http_guide/http_guide.py
+++ b/doc/source/serve/doc_code/http_guide/http_guide.py
@@ -17,26 +17,6 @@ resp = requests.get("http://localhost:8000?a=b&c=d")
 assert resp.json() == {"a": "b", "c": "d"}
 # __end_starlette__
 
-# __begin_dagdriver__
-import numpy as np
-import requests
-from ray import serve
-from ray.serve.drivers import DAGDriver
-from ray.serve.http_adapters import json_to_ndarray
-
-
-@serve.deployment
-class Model:
-    def __call__(self, arr: np.ndarray):
-        return arr.sum()
-
-
-serve.run(DAGDriver.bind(Model.bind(), http_adapter=json_to_ndarray))
-resp = requests.post("http://localhost:8000", json={"array": [[1, 2], [2, 3]]})
-assert resp.json() == 8
-
-# __end_dagdriver__
-
 # __begin_fastapi__
 import ray
 import requests


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We want to discourage use of the DAGDriver concept, so remove it from the top-level HTTP guide.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
