### PR TITLE
[serve] Try not to explicitly cancel websocket handlers

### DIFF
--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -1171,6 +1171,7 @@ class HTTPProxy(GenericProxy):
         response_done = False
         response_started = False
         expecting_trailers = False
+        is_websocket_connection = False
         while True:
             try:
                 next_obj_ref_task = asyncio.ensure_future(
@@ -1217,7 +1218,11 @@ class HTTPProxy(GenericProxy):
                         "during execution, cancelling request."
                     )
                     next_obj_ref_task.cancel()
-                    ray.cancel(obj_ref_generator)
+                    if not is_websocket_connection:
+                        # Websocket code explicitly handles client disconnects,
+                        # so let the ASGI disconnect message propagate instead of
+                        # cancelling the handler.
+                        ray.cancel(obj_ref_generator)
                     return DISCONNECT_ERROR_CODE
 
                 obj_ref = next_obj_ref_task.result()
@@ -1231,6 +1236,8 @@ class HTTPProxy(GenericProxy):
                         # field. Other response types (e.g., WebSockets) may not.
                         status_code = str(asgi_message["status"])
                         expecting_trailers = asgi_message.get("trailers", False)
+                    elif asgi_message["type"] == "websocket.connect":
+                        is_websocket_connection = True
                     elif (
                         asgi_message["type"] == "http.response.body"
                         and not asgi_message.get("more_body", False)

--- a/python/ray/serve/tests/test_websockets.py
+++ b/python/ray/serve/tests/test_websockets.py
@@ -57,10 +57,6 @@ def test_send_recv_text_and_binary(serve_instance, route_prefix: str):
     not RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING,
     reason="Streaming feature flag is disabled.",
 )
-@pytest.mark.skipif(
-    sys.version_info.major >= 3 and sys.version_info.minor <= 7,
-    reason="Different disconnect behavior on 3.7.",
-)
 def test_client_disconnect(serve_instance):
     app = FastAPI()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

WebSocket handlers already handle disconnects in their own way (a `WebSocketDisconnect` exception is raised). Avoid conflicting with this behavior.

This should fix the flakiness of `test_websockets.py`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
