### PR TITLE
[Serve] Make sure Ray installs uvloop to be used as event-loop implementation for asyncio

### DIFF
--- a/python/ray/_private/async_compat.py
+++ b/python/ray/_private/async_compat.py
@@ -19,6 +19,14 @@ def get_new_event_loop():
         return asyncio.new_event_loop()
 
 
+def try_install_uvloop():
+    """Installs uvloop as event-loop implementation for asyncio (if available)"""
+    if uvloop:
+        uvloop.install()
+    else:
+        pass
+
+
 def is_async_func(func):
     """Return True if the function is an async or async generator method."""
     return inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func)

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -2204,4 +2204,3 @@ def try_install_uvloop() -> None:
         logger.warning(
             "No uvloop found, falling back to default asyncio event-loop implementation"
         )
-        pass

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -2194,13 +2194,14 @@ def load_class(path):
 
 
 def try_install_uvloop() -> None:
-    """Installs uvloop as event-loop implementation for asyncio (if available)
-    """
+    """Installs uvloop as event-loop implementation for asyncio (if available)"""
     try:
         import uvloop
+
         uvloop.install()
         logger.info("Installing uvloop as event-loop implementation for asyncio")
     except ImportError:
-        logger.warning("No uvloop found, falling back to default asyncio event-loop implementation")
+        logger.warning(
+            "No uvloop found, falling back to default asyncio event-loop implementation"
+        )
         pass
-

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -2191,3 +2191,16 @@ def load_class(path):
     class_str = class_data[-1]
     module = importlib.import_module(module_path)
     return getattr(module, class_str)
+
+
+def try_install_uvloop() -> None:
+    """Installs uvloop as event-loop implementation for asyncio (if available)
+    """
+    try:
+        import uvloop
+        uvloop.install()
+        logger.info("Installing uvloop as event-loop implementation for asyncio")
+    except ImportError:
+        logger.warning("No uvloop found, falling back to default asyncio event-loop implementation")
+        pass
+

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -2191,16 +2191,3 @@ def load_class(path):
     class_str = class_data[-1]
     module = importlib.import_module(module_path)
     return getattr(module, class_str)
-
-
-def try_install_uvloop() -> None:
-    """Installs uvloop as event-loop implementation for asyncio (if available)"""
-    try:
-        import uvloop
-
-        uvloop.install()
-        logger.info("Installing uvloop as event-loop implementation for asyncio")
-    except ImportError:
-        logger.warning(
-            "No uvloop found, falling back to default asyncio event-loop implementation"
-        )

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -12,7 +12,7 @@ import ray.actor
 from ray._private.parameter import RayParams
 from ray._private.ray_logging import configure_log_file, get_worker_log_file_name
 from ray._private.runtime_env.setup_hook import load_and_execute_setup_hook
-
+from ray._private.utils import try_install_uvloop
 
 parser = argparse.ArgumentParser(
     description=("Parse addresses for the worker to connect to.")
@@ -193,6 +193,10 @@ if __name__ == "__main__":
         mode = ray.RESTORE_WORKER_MODE
     else:
         raise ValueError("Unknown worker type: " + args.worker_type)
+
+    # Try installing uvloop as default event-loop implementation
+    # for asyncio
+    try_install_uvloop()
 
     raylet_ip_address = args.raylet_ip_address
     if raylet_ip_address is None:

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -9,10 +9,10 @@ import ray._private.node
 import ray._private.ray_constants as ray_constants
 import ray._private.utils
 import ray.actor
+from ray._private.async_compat import try_install_uvloop
 from ray._private.parameter import RayParams
 from ray._private.ray_logging import configure_log_file, get_worker_log_file_name
 from ray._private.runtime_env.setup_hook import load_and_execute_setup_hook
-from ray._private.utils import try_install_uvloop
 
 parser = argparse.ArgumentParser(
     description=("Parse addresses for the worker to connect to.")

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -8,7 +8,18 @@ import pickle
 import socket
 import time
 import grpc
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, Union, Literal
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    Literal,
+)
 import uuid
 
 import uvicorn
@@ -114,9 +125,7 @@ RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S = (
 )
 # Controls whether Ray Serve is operating in debug-mode switching off some
 # of the performance optimizations to make troubleshooting easier
-RAY_SERVE_DEBUG_MODE = bool(
-    os.environ.get("RAY_SERVE_DEBUG_MODE", 0)
-)
+RAY_SERVE_DEBUG_MODE = bool(os.environ.get("RAY_SERVE_DEBUG_MODE", 0))
 
 if os.environ.get("SERVE_REQUEST_PROCESSING_TIMEOUT_S") is not None:
     logger.warning(
@@ -1726,12 +1735,12 @@ class HTTPProxyActor:
 def _determine_target_loop() -> Literal["uvloop", "asyncio"]:
     """We determine target loop based on whether RAY_SERVE_DEBUG_MODE is enabled:
 
-      - RAY_SERVE_DEBUG_MODE=0 (default): we use "uvloop" (Cython) providing high-performance,
-                                native implementation of the event-loop,
+    - RAY_SERVE_DEBUG_MODE=0 (default): we use "uvloop" (Cython) providing high-performance,
+                              native implementation of the event-loop,
 
-      - RAY_SERVE_DEBUG_MODE=1: we fall back to "asyncio" (pure Python) event-loop implementation
-                                that is considerably slower than "uvloop", but provides for easy
-                                access to the source implementation
+    - RAY_SERVE_DEBUG_MODE=1: we fall back to "asyncio" (pure Python) event-loop implementation
+                              that is considerably slower than "uvloop", but provides for easy
+                              access to the source implementation
     """
     if RAY_SERVE_DEBUG_MODE:
         return "asyncio"

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -1598,6 +1598,7 @@ class HTTPProxyActor:
             self.wrapped_http_proxy,
             host=self.host,
             port=self.port,
+            loop="uvloop",
             root_path=self.root_path,
             lifespan="off",
             access_log=False,

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -1735,12 +1735,12 @@ class HTTPProxyActor:
 def _determine_target_loop() -> Literal["uvloop", "asyncio"]:
     """We determine target loop based on whether RAY_SERVE_DEBUG_MODE is enabled:
 
-    - RAY_SERVE_DEBUG_MODE=0 (default): we use "uvloop" (Cython) providing high-performance,
-                              native implementation of the event-loop,
+    - RAY_SERVE_DEBUG_MODE=0 (default): we use "uvloop" (Cython) providing
+                              high-performance, native implementation of the event-loop
 
-    - RAY_SERVE_DEBUG_MODE=1: we fall back to "asyncio" (pure Python) event-loop implementation
-                              that is considerably slower than "uvloop", but provides for easy
-                              access to the source implementation
+    - RAY_SERVE_DEBUG_MODE=1: we fall back to "asyncio" (pure Python) event-loop
+                              implementation that is considerably slower than "uvloop",
+                              but provides for easy access to the source implementation
     """
     if RAY_SERVE_DEBUG_MODE:
         return "asyncio"

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -8,7 +8,7 @@ import pickle
 import socket
 import time
 import grpc
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, Union, Literal
 import uuid
 
 import uvicorn
@@ -111,6 +111,11 @@ RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S = (
     float(os.environ.get("RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S", 0))
     or float(os.environ.get("SERVE_REQUEST_PROCESSING_TIMEOUT_S", 0))
     or None
+)
+# Controls whether Ray Serve is operating in debug-mode switching off some
+# of the performance optimizations to make troubleshooting easier
+RAY_SERVE_DEBUG_MODE = bool(
+    os.environ.get("RAY_SERVE_DEBUG_MODE", 0)
 )
 
 if os.environ.get("SERVE_REQUEST_PROCESSING_TIMEOUT_S") is not None:
@@ -1591,14 +1596,14 @@ class HTTPProxyActor:
                 "Please make sure your http-host and http-port are specified correctly."
             )
 
-        # Note(simon): we have to use lower level uvicorn Config and Server
+        # NOTE: We have to use lower level uvicorn Config and Server
         # class because we want to run the server as a coroutine. The only
         # alternative is to call uvicorn.run which is blocking.
         config = uvicorn.Config(
             self.wrapped_http_proxy,
             host=self.host,
             port=self.port,
-            loop="uvloop",
+            loop=_determine_target_loop(),
             root_path=self.root_path,
             lifespan="off",
             access_log=False,
@@ -1716,3 +1721,19 @@ class HTTPProxyActor:
         """
         if self._uvicorn_server:
             return self._uvicorn_server.config.timeout_keep_alive
+
+
+def _determine_target_loop() -> Literal["uvloop", "asyncio"]:
+    """We determine target loop based on whether RAY_SERVE_DEBUG_MODE is enabled:
+
+      - RAY_SERVE_DEBUG_MODE=0 (default): we use "uvloop" (Cython) providing high-performance,
+                                native implementation of the event-loop,
+
+      - RAY_SERVE_DEBUG_MODE=1: we fall back to "asyncio" (pure Python) event-loop implementation
+                                that is considerably slower than "uvloop", but provides for easy
+                                access to the source implementation
+    """
+    if RAY_SERVE_DEBUG_MODE:
+        return "asyncio"
+    else:
+        return "uvloop"

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -18,7 +18,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    Literal,
 )
 import uuid
 
@@ -1732,7 +1731,7 @@ class HTTPProxyActor:
             return self._uvicorn_server.config.timeout_keep_alive
 
 
-def _determine_target_loop() -> Literal["uvloop", "asyncio"]:
+def _determine_target_loop():
     """We determine target loop based on whether RAY_SERVE_DEBUG_MODE is enabled:
 
     - RAY_SERVE_DEBUG_MODE=0 (default): we use "uvloop" (Cython) providing

--- a/python/setup.py
+++ b/python/setup.py
@@ -275,7 +275,7 @@ if setup_spec.type == SetupType.RAY:
             else "grpcio",
         ],
         "serve": [
-            "uvicorn",
+            "uvicorn[standard]",
             "requests",
             "starlette",
             "fastapi",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, `HTTPProxy` is configured with `loop="auto"` which will prefer uvloop iff it's present in the runtime env, which from my recent profiling (see flame-graph attached) indicates that it's not.

This change makes it explicit requirement to use "uvloop" in production, w/ an optional fallback to asyncio when debugging (`DEBUG_MODE=1`).

Running Serve micro benchmarks (`microbenchmark.py`) following results were obtained:


Benchmark | asyncio (RPS) | uvloop (RPS) | increase
-- | -- | -- | --
num_client:1/replica:1/batch_size:1/concurrent_queries:1/data_size:small/intermediate_handle:False | 419.26 | 477.14 | 13.81%
num_client:1/replica:1/batch_size:1/concurrent_queries:1/data_size:small/intermediate_handle:True | 240.25 | 253.7 | 5.60%
num_client:1/replica:1/batch_size:1/concurrent_queries:10000/data_size:small/intermediate_handle:False | 419.2 | 479.02 | 14.27%
num_client:1/replica:1/batch_size:1/concurrent_queries:10000/data_size:small/intermediate_handle:True | 218.37 | 264.84 | 21.28%
num_client:1/replica:1/batch_size:10000/concurrent_queries:10000/data_size:small/intermediate_handle:False | 370.01 | 457.36 | 23.61%
num_client:1/replica:1/batch_size:10000/concurrent_queries:10000/data_size:small/intermediate_handle:True | 233.16 | 257.02 | 10.23%
num_client:1/replica:8/batch_size:1/concurrent_queries:1/data_size:small/intermediate_handle:False | 365.49 | 399.59 | 9.33%
num_client:1/replica:8/batch_size:1/concurrent_queries:1/data_size:small/intermediate_handle:True | 219.5 | 241.55 | 10.05%
num_client:1/replica:8/batch_size:1/concurrent_queries:10000/data_size:small/intermediate_handle:False | 359.04 | 400.67 | 11.59%
num_client:1/replica:8/batch_size:1/concurrent_queries:10000/data_size:small/intermediate_handle:True | 220.66 | 238.57 | 8.12%
num_client:1/replica:8/batch_size:10000/concurrent_queries:10000/data_size:small/intermediate_handle:False | 354.05 | 373.93 | 5.62%
num_client:1/replica:8/batch_size:10000/concurrent_queries:10000/data_size:small/intermediate_handle:True | 210.43 | 234.68 | 11.52%
num_client:8/replica:1/batch_size:1/concurrent_queries:1/data_size:small/intermediate_handle:False | 106.82 | 57.88 | -45.82%
num_client:8/replica:1/batch_size:1/concurrent_queries:1/data_size:small/intermediate_handle:True | 470.21 | 544.04 | 15.70%
num_client:8/replica:1/batch_size:1/concurrent_queries:10000/data_size:small/intermediate_handle:False | 723.65 | 869.66 | 20.18%
num_client:8/replica:1/batch_size:1/concurrent_queries:10000/data_size:small/intermediate_handle:True | 551.9 | 632.91 | 14.68%
num_client:8/replica:1/batch_size:10000/concurrent_queries:10000/data_size:small/intermediate_handle:False | 737.23 | 809.28 | 9.77%
num_client:8/replica:1/batch_size:10000/concurrent_queries:10000/data_size:small/intermediate_handle:True | 540.38 | 617.39 | 14.25%
num_client:8/replica:8/batch_size:1/concurrent_queries:1/data_size:small/intermediate_handle:False | 660.34 | 720.91 | 9.17%
num_client:8/replica:8/batch_size:1/concurrent_queries:1/data_size:small/intermediate_handle:True | 523.58 | 590.37 | 12.76%
num_client:8/replica:8/batch_size:1/concurrent_queries:10000/data_size:small/intermediate_handle:False | 690.91 | 792.34 | 14.68%
num_client:8/replica:8/batch_size:1/concurrent_queries:10000/data_size:small/intermediate_handle:True | 525.47 | 608.2 | 15.74%
num_client:8/replica:8/batch_size:10000/concurrent_queries:10000/data_size:small/intermediate_handle:False | 687.46 | 804.69 | 17.05%
num_client:8/replica:8/batch_size:10000/concurrent_queries:10000/data_size:small/intermediate_handle:True | 516.37 | 599.71 | 16.14%



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
