### PR TITLE
[core] fix runtime_context.get_resource_ids docstring

### DIFF
--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -399,7 +399,7 @@ class RuntimeContext(object):
         Returns:
             A dictionary keyed by the resource name. The values are list
             of ids `{'GPU': ['0', '1'], 'neuron_cores': ['0', '1'],
-                     'TPU': ['0', '1']}`.
+            'TPU': ['0', '1']}`.
         """
         worker = self.worker
         worker.check_connected()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fixes https://github.com/ray-project/ray/pull/38669#issuecomment-1709244367

Rendered here: [RuntimeContext.get_resource_ids](https://anyscale-ray--39365.com.readthedocs.build/en/39365/ray-core/api/doc/ray.runtime_context.RuntimeContext.get_resource_ids.html#ray.runtime_context.RuntimeContext.get_resource_ids)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
