### PR TITLE
[Core] Skip gcs_ha_e2e_2.py

### DIFF
--- a/python/ray/tests/test_gcs_ha_e2e_2.py
+++ b/python/ray/tests/test_gcs_ha_e2e_2.py
@@ -5,7 +5,7 @@ from ray._private.test_utils import wait_for_condition
 from ray.tests.conftest_docker import *  # noqa
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="Only works on linux.")
+@pytest.mark.skip(reason="Currently flaky.")
 def test_ray_session_name_preserved(docker_cluster):
     get_nodes_script = """
 import ray


### PR DESCRIPTION
This test is flaky due to how the test is written. Will fix it after 2.8

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This test is flaky due to test issue. We will reenable it in ray 2.8

## Related issue number

Closes https://github.com/ray-project/ray/issues/39318

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
