### PR TITLE
[Core][Observability]Add job_id and state filters for "get all actor info" api

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -2191,3 +2191,21 @@ def load_class(path):
     class_str = class_data[-1]
     module = importlib.import_module(module_path)
     return getattr(module, class_str)
+
+
+def validate_actor_state_name(actor_state_name):
+    if actor_state_name is None:
+        return
+    actor_state_names = [
+        "DEPENDENCIES_UNREADY",
+        "PENDING_CREATION",
+        "ALIVE",
+        "RESTARTING",
+        "DEAD",
+    ]
+    if actor_state_name not in actor_state_names:
+        raise ValueError(
+            f'"{actor_state_name}" is not a valid actor state name, '
+            'it must be one of the following: "DEPENDENCIES_UNREADY", '
+            '"PENDING_CREATION", "ALIVE", "RESTARTING", or "DEAD"'
+        )

--- a/python/ray/includes/global_state_accessor.pxd
+++ b/python/ray/includes/global_state_accessor.pxd
@@ -15,6 +15,9 @@ from ray.includes.common cimport (
     CRayStatus,
     CGcsClientOptions,
 )
+from ray.includes.optional cimport (
+    optional
+)
 
 cdef extern from "ray/gcs/gcs_client/global_state_accessor.h" nogil:
     cdef cppclass CGlobalStateAccessor "ray::gcs::GlobalStateAccessor":
@@ -29,7 +32,8 @@ cdef extern from "ray/gcs/gcs_client/global_state_accessor.h" nogil:
         c_vector[c_string] GetAllTaskEvents()
         unique_ptr[c_string] GetObjectInfo(const CObjectID &object_id)
         unique_ptr[c_string] GetAllResourceUsage()
-        c_vector[c_string] GetAllActorInfo()
+        c_vector[c_string] GetAllActorInfo(
+            optional[CActorID], optional[CJobID], optional[c_string])
         unique_ptr[c_string] GetActorInfo(const CActorID &actor_id)
         unique_ptr[c_string] GetWorkerInfo(const CWorkerID &worker_id)
         c_vector[c_string] GetAllWorkerInfo()

--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -26,8 +26,11 @@ class MockActorInfoAccessor : public ActorInfoAccessor {
                const OptionalItemCallback<rpc::ActorTableData> &callback),
               (override));
   MOCK_METHOD(Status,
-              AsyncGetAll,
-              (const MultiItemCallback<rpc::ActorTableData> &callback),
+              AsyncGetAllByFilter,
+              (const std::optional<ActorID> &actor_id,
+               const std::optional<JobID> &job_id,
+               const std::optional<std::string> &actor_state_name,
+               const MultiItemCallback<rpc::ActorTableData> &callback),
               (override));
   MOCK_METHOD(Status,
               AsyncGetByName,

--- a/src/ray/common/BUILD
+++ b/src/ray/common/BUILD
@@ -132,6 +132,7 @@ ray_cc_library(
         ":constants",
         ":status",
         "//src/ray/protobuf:common_cc_proto",
+        "//src/ray/protobuf:gcs_cc_proto",
         "//src/ray/util",
         "@com_github_google_flatbuffers//:flatbuffers",
         "@msgpack",

--- a/src/ray/common/common_protocol.h
+++ b/src/ray/common/common_protocol.h
@@ -21,6 +21,7 @@
 #include "ray/common/id.h"
 #include "ray/util/logging.h"
 #include "src/ray/protobuf/common.pb.h"
+#include "src/ray/protobuf/gcs.pb.h"
 
 /// Convert an unique ID to a flatbuffer string.
 ///
@@ -222,4 +223,22 @@ static inline std::vector<ray::ObjectID> ObjectRefsToIds(
     object_ids.push_back(ObjectRefToId(ref));
   }
   return object_ids;
+}
+
+static inline ray::rpc::ActorTableData::ActorState StringToActorState(
+    const std::string &actor_state_name) {
+  if (actor_state_name == "DEPENDENCIES_UNREADY") {
+    return ray::rpc::ActorTableData::DEPENDENCIES_UNREADY;
+  } else if (actor_state_name == "PENDING_CREATION") {
+    return ray::rpc::ActorTableData::PENDING_CREATION;
+  } else if (actor_state_name == "ALIVE") {
+    return ray::rpc::ActorTableData::ALIVE;
+  } else if (actor_state_name == "RESTARTING") {
+    return ray::rpc::ActorTableData::RESTARTING;
+  } else if (actor_state_name == "DEAD") {
+    return ray::rpc::ActorTableData::DEAD;
+  } else {
+    RAY_CHECK(false) << "Invalid actor state name:" << actor_state_name;
+    return {};
+  }
 }

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -52,9 +52,16 @@ class ActorInfoAccessor {
 
   /// Get all actor specification from the GCS asynchronously.
   ///
+  /// \param  actor_id To filter actors by actor_id.
+  /// \param  job_id To filter actors by job_id.
+  /// \param  actor_state_name To filter actors based on actor state.
   /// \param callback Callback that will be called after lookup finishes.
   /// \return Status
-  virtual Status AsyncGetAll(const MultiItemCallback<rpc::ActorTableData> &callback);
+  virtual Status AsyncGetAllByFilter(
+      const std::optional<ActorID> &actor_id,
+      const std::optional<JobID> &job_id,
+      const std::optional<std::string> &actor_state_name,
+      const MultiItemCallback<rpc::ActorTableData> &callback);
 
   /// Get actor specification for a named actor from the GCS asynchronously.
   ///

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -168,12 +168,18 @@ std::unique_ptr<std::string> GlobalStateAccessor::GetAllResourceUsage() {
   return resource_batch_data;
 }
 
-std::vector<std::string> GlobalStateAccessor::GetAllActorInfo() {
+std::vector<std::string> GlobalStateAccessor::GetAllActorInfo(
+    const std::optional<ActorID> &actor_id,
+    const std::optional<JobID> &job_id,
+    const std::optional<std::string> &actor_state_name) {
   std::vector<std::string> actor_table_data;
   std::promise<bool> promise;
   {
     absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Actors().AsyncGetAll(
+    RAY_CHECK_OK(gcs_client_->Actors().AsyncGetAllByFilter(
+        actor_id,
+        job_id,
+        actor_state_name,
         TransformForMultiItemCallback<rpc::ActorTableData>(actor_table_data, promise)));
   }
   promise.get_future().get();

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -96,10 +96,17 @@ class GlobalStateAccessor {
 
   /// Get information of all actors from GCS Service.
   ///
+  /// \param  actor_id To filter actors by actor_id.
+  /// \param  job_id To filter actors by job_id.
+  /// \param  actor_state_name To filter actors based on actor state.
   /// \return All actor info. To support multi-language, we serialize each ActorTableData
   /// and return the serialized string. Where used, it needs to be deserialized with
   /// protobuf function.
-  std::vector<std::string> GetAllActorInfo() ABSL_LOCKS_EXCLUDED(mutex_);
+  std::vector<std::string> GetAllActorInfo(
+      const std::optional<ActorID> &actor_id = std::nullopt,
+      const std::optional<JobID> &job_id = std::nullopt,
+      const std::optional<std::string> &actor_state_name = std::nullopt)
+      ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Get information of an actor from GCS Service.
   ///

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -287,7 +287,10 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
   std::vector<rpc::ActorTableData> GetAllActors(bool filter_non_dead_actor = false) {
     std::promise<bool> promise;
     std::vector<rpc::ActorTableData> actors;
-    RAY_CHECK_OK(gcs_client_->Actors().AsyncGetAll(
+    RAY_CHECK_OK(gcs_client_->Actors().AsyncGetAllByFilter(
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
         [filter_non_dead_actor, &actors, &promise](
             Status status, std::vector<rpc::ActorTableData> &&result) {
           if (!result.empty()) {


### PR DESCRIPTION

## Why are these changes needed?

1. We both have many jobs in a ray cluster, so a job's manager role want to get this job's actors. Use ray.state.actors to fetching all actors in the cluster can lead to performance degradation.
2. We only want to get alive actors.

```
 # To filter actors by job id
job_id = ray.get_runtime_context().job_id
actors_info = ray.state.actors(job_id=job_id)
assert len(actors_info) == 2

# To filter actors by state
ray.state.actors(actor_state_name="PENDING_CREATION")
```
## Related issue number
[Core] [Observability]Add job_id and state filters for "get all actor info" api  #39245

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
