### PR TITLE
[templates/04_finetuning_llms_with_deepspeed] pin transformers to 4.31.0

### DIFF
--- a/doc/source/templates/testing/docker/04_finetuning_llms_with_deepspeed/requirements.txt
+++ b/doc/source/templates/testing/docker/04_finetuning_llms_with_deepspeed/requirements.txt
@@ -3,7 +3,7 @@ torchvision==0.15.1
 torchaudio==2.0.1
 deepspeed
 fairscale
-transformers>=4.31.0
+transformers==4.31.0
 dataset
 accelerate
 evaluate


### PR DESCRIPTION
Related to transformers resize_token_embeddings issue https://github.com/huggingface/transformers/issues/25977

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
