### PR TITLE
[civ2][docker/6] upload ray and ray-ml image in civ2

### DIFF
--- a/.buildkite/pipeline.build_release.yml
+++ b/.buildkite/pipeline.build_release.yml
@@ -65,7 +65,16 @@
     - python ./ci/build/build-docker-images.py --py-versions {{matrix}} -T cu117 -T cu118 -T cu121 --build-type BUILDKITE --build-base
   matrix:
     - py37
-    - py38
     - py39
     - py310
     - py311
+
+- label: ":docker: Build Images: py38 - cu117/cu121"
+  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
+  instance_size: medium
+  commands:
+    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY=py38 ./ci/ci.sh build
+    - pip install -q docker aws_requests_auth boto3
+    - ./ci/env/env_info.sh
+    - if [[ "${BUILDKITE_PULL_REQUEST}" == "false" ]]; then python .buildkite/copy_files.py --destination docker_login; fi
+    - python ./ci/build/build-docker-images.py --py-versions py38 -T cu117 -T cu121 --build-type BUILDKITE --build-base

--- a/ci/ray_ci/test_base.py
+++ b/ci/ray_ci/test_base.py
@@ -10,5 +10,7 @@ class RayCITestBase(unittest.TestCase):
                 "RAYCI_BUILD_ID": "123",
                 "RAYCI_WORK_REPO": "rayproject/citemp",
                 "BUILDKITE_COMMIT": "123456",
+                "BUILDKITE_BRANCH": "master",
+                "BUILDKITE_PIPELINE_ID": "123456",
             }
         )

--- a/ci/ray_ci/test_docker_container.py
+++ b/ci/ray_ci/test_docker_container.py
@@ -4,10 +4,7 @@ from unittest import mock
 
 import pytest
 
-<<<<<<< HEAD
 from ci.ray_ci.container import _DOCKER_ECR_REPO
-=======
->>>>>>> build ml image
 from ci.ray_ci.docker_container import DockerContainer
 from ci.ray_ci.test_base import RayCITestBase
 from ci.ray_ci.utils import RAY_VERSION
@@ -40,7 +37,6 @@ class TestDockerContainer(RayCITestBase):
             container = DockerContainer("py37", "cpu", "ray-ml")
             container.run()
             cmd = self.cmds[-1]
-<<<<<<< HEAD
             assert cmd == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-cp37-cp37m-manylinux2014_x86_64.whl "
@@ -48,12 +44,25 @@ class TestDockerContainer(RayCITestBase):
                 "requirements_compiled_py37.txt "
                 "rayproject/ray-ml:123456-py37-cpu"
             )
-=======
-            assert f"ray-{RAY_VERSION}-cp37-cp37m-manylinux2014_x86_64.whl" in cmd
-            assert "rayproject/citemp:123-ray-mlpy37cpubase" in cmd
-            assert "requirements_compiled_py37.txt" in cmd
-            assert "rayproject/ray-ml:123456-py37-cpu" in cmd
->>>>>>> build ml image
+
+    def test_get_image_name(self) -> None:
+        container = DockerContainer("py38", "cpu", "ray")
+        assert container._get_image_names() == [
+            "rayproject/ray:123456-py38-cpu",
+            "rayproject/ray:123456-py38",
+            "rayproject/ray:nightly-py38-cpu",
+            "rayproject/ray:nightly-py38",
+        ]
+
+        container = DockerContainer("py37", "cu118", "ray-ml")
+        assert container._get_image_names() == [
+            "rayproject/ray-ml:123456-py37-cu118",
+            "rayproject/ray-ml:123456-py37-gpu",
+            "rayproject/ray-ml:123456-py37",
+            "rayproject/ray-ml:nightly-py37-cu118",
+            "rayproject/ray-ml:nightly-py37-gpu",
+            "rayproject/ray-ml:nightly-py37",
+        ]
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/test_docker_container.py
+++ b/ci/ray_ci/test_docker_container.py
@@ -4,7 +4,10 @@ from unittest import mock
 
 import pytest
 
+<<<<<<< HEAD
 from ci.ray_ci.container import _DOCKER_ECR_REPO
+=======
+>>>>>>> build ml image
 from ci.ray_ci.docker_container import DockerContainer
 from ci.ray_ci.test_base import RayCITestBase
 from ci.ray_ci.utils import RAY_VERSION
@@ -37,6 +40,7 @@ class TestDockerContainer(RayCITestBase):
             container = DockerContainer("py37", "cpu", "ray-ml")
             container.run()
             cmd = self.cmds[-1]
+<<<<<<< HEAD
             assert cmd == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-cp37-cp37m-manylinux2014_x86_64.whl "
@@ -44,6 +48,12 @@ class TestDockerContainer(RayCITestBase):
                 "requirements_compiled_py37.txt "
                 "rayproject/ray-ml:123456-py37-cpu"
             )
+=======
+            assert f"ray-{RAY_VERSION}-cp37-cp37m-manylinux2014_x86_64.whl" in cmd
+            assert "rayproject/citemp:123-ray-mlpy37cpubase" in cmd
+            assert "requirements_compiled_py37.txt" in cmd
+            assert "rayproject/ray-ml:123456-py37-cpu" in cmd
+>>>>>>> build ml image
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -9,6 +9,7 @@ from math import ceil
 import ci.ray_ci.bazel_sharding as bazel_sharding
 
 
+POSTMERGE_PIPELINE = "0189e759-8c96-4302-b6b5-b4274406bf89"
 RAY_VERSION = "3.0.0.dev0"
 
 

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -45,7 +45,7 @@ def docker_login(docker_ecr: str) -> None:
         f.flush()
         f.seek(0)
 
-        subprocess.check_run(
+        subprocess.run(
             [
                 "docker",
                 "login",
@@ -71,6 +71,7 @@ def docker_pull(image: str) -> None:
         stderr=sys.stderr,
         check=True,
     )
+
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -45,7 +45,7 @@ def docker_login(docker_ecr: str) -> None:
         f.flush()
         f.seek(0)
 
-        subprocess.run(
+        subprocess.check_run(
             [
                 "docker",
                 "login",
@@ -71,7 +71,6 @@ def docker_pull(image: str) -> None:
         stderr=sys.stderr,
         check=True,
     )
-
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -79,6 +79,22 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
         $(if [[ "$BASE_IMAGE" == "ubuntu:focal" && "$HOSTTYPE" == "x86_64" ]]; then echo \
         g++; fi) \
     && sudo rm -rf /var/lib/apt/lists/* \
-    && sudo apt-get clean
+    && sudo apt-get clean \
+    && (if [ "$AUTOSCALER" = "autoscaler" ]; \
+        then $HOME/anaconda3/bin/pip --no-cache-dir install \
+        "redis>=3.5.0,<4.0.0" \
+        "six==1.13.0" \
+        "boto3==1.26.76" \
+        "pyOpenSSL==22.1.0" \
+        "cryptography==38.0.1" \
+        "google-api-python-client==1.7.8" \
+        "google-oauth" \
+        "azure-cli-core==2.40.0" \
+        "azure-identity==1.10.0" \
+        "azure-mgmt-compute==23.1.0" \
+        "azure-mgmt-network==19.0.0" \
+        "azure-mgmt-resource==20.0.0" \
+        "msrestazure==0.6.4"; \
+    fi;)
 
 WORKDIR $HOME


### PR DESCRIPTION
Upload ray and ray-ml image for py38 and cu118 in civ2. Remove those two flavors in civ1 (which will also removes the uploading of base-deps and ray-deps)

Test:
- CI
- Image is built and pushed: https://hub.docker.com/layers/rayproject/ray-ml/6a4423-py38/images/sha256-6024b8d9b99d58223c58723019fbecc2d89f25044f674cc2a1885f3b83edaad3?context=explore