### PR TITLE
[serve] deflake test_http_state

### DIFF
--- a/python/ray/serve/tests/test_http_state.py
+++ b/python/ray/serve/tests/test_http_state.py
@@ -573,7 +573,7 @@ def test_http_proxy_state_update_healthy_check_health_sometimes_fails():
         state.update()
         assert (
             ray.get(state.actor_handle.get_num_health_checks.remote())
-        ) == num_health_checks
+        ) <= num_health_checks
         return True
 
     def incur_health_checks(
@@ -599,7 +599,7 @@ def test_http_proxy_state_update_healthy_check_health_sometimes_fails():
         )
         assert (
             ray.get(proxy_state.actor_handle.get_num_health_checks.remote())
-            == cur_num_health_checks + num_checks
+            <= cur_num_health_checks + num_checks
         )
 
         if expected_final_status:

--- a/python/ray/serve/tests/test_http_state.py
+++ b/python/ray/serve/tests/test_http_state.py
@@ -570,10 +570,12 @@ def test_http_proxy_state_update_healthy_check_health_sometimes_fails():
     def _update_until_num_health_checks_received(
         state: HTTPProxyState, num_health_checks: int
     ):
+        if state.status in {ProxyStatus.DRAINED, ProxyStatus.UNHEALTHY}:
+            num_health_checks -= 1
         state.update()
         assert (
             ray.get(state.actor_handle.get_num_health_checks.remote())
-        ) <= num_health_checks
+        ) == num_health_checks
         return True
 
     def incur_health_checks(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Re: https://github.com/ray-project/ray/pull/39184 fixes the error when calling `update()` from a terminal state. However, in this case, the `update()` on the proxy actor will no longer be called and will not meet the equality that the test is checking. This PR fix the test by checking the actual health checks count is less or equal to the expected health checks count.

## Related issue number

Closes: https://buildkite.com/ray-project/oss-ci-build-branch/builds/5952#018a6f7d-dc95-4ab7-a577-06da77af8ac0/6-285

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
