### PR TITLE
[tune] Make Trainable.save/restore developer APIs

### DIFF
--- a/python/ray/tune/trainable/trainable.py
+++ b/python/ray/tune/trainable/trainable.py
@@ -59,7 +59,7 @@ from ray.tune.execution.placement_groups import PlacementGroupFactory
 from ray.train._internal.syncer import SyncConfig, get_node_to_storage_syncer
 from ray.tune.trainable.util import TrainableUtil
 from ray.tune.utils.util import Tee, _get_checkpoint_from_remote_node
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
     from ray.tune.logger import Logger
@@ -495,6 +495,7 @@ class Trainable:
         )
         return checkpoint_dir
 
+    @DeveloperAPI
     def save(
         self, checkpoint_dir: Optional[str] = None, prevent_upload: bool = False
     ) -> str:
@@ -871,6 +872,7 @@ class Trainable:
 
         return True
 
+    @Deprecated
     def save_to_object(self):
         raise DeprecationWarning(
             "Trainable.save_to_object() has been removed. "
@@ -884,6 +886,7 @@ class Trainable:
                 checkpoint_node_ip=None,
             )
 
+    @DeveloperAPI
     def restore(
         self,
         checkpoint_path: Union[str, Checkpoint],
@@ -1072,12 +1075,14 @@ class Trainable:
         }
         logger.info("Current state after restoring: %s", state)
 
+    @Deprecated
     def restore_from_object(self, obj):
         raise DeprecationWarning(
             "Trainable.restore_from_object() has been removed. "
             "Use Trainable.restore() instead."
         )
 
+    @Deprecated
     def delete_checkpoint(self, checkpoint_path: Union[str, Checkpoint]):
         """Deletes local copy of checkpoint.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the future, we will want to change the API. They are internal/developer-facing right now, so we mark the accordingly. The PR also adds three deprecation annotations.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
