### PR TITLE
[core] set longer gcs connection timeout latency

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -451,8 +451,10 @@ RAY_CONFIG(int32_t, minimum_gcs_reconnect_interval_milliseconds, 5000)
 
 /// gRPC channel reconnection related configs to GCS.
 /// Check https://grpc.github.io/grpc/core/group__grpc__arg__keys.html for details
+/// Note: `gcs_grpc_min_reconnect_backoff_ms` is (mis)used by gRPC as the connection
+/// timeout. If your cluster has a high latency, make it to > 4x the latency.
 RAY_CONFIG(int32_t, gcs_grpc_max_reconnect_backoff_ms, 2000)
-RAY_CONFIG(int32_t, gcs_grpc_min_reconnect_backoff_ms, 100)
+RAY_CONFIG(int32_t, gcs_grpc_min_reconnect_backoff_ms, 1000)
 RAY_CONFIG(int32_t, gcs_grpc_initial_reconnect_backoff_ms, 100)
 
 /// Maximum bytes of request queued when RPC failed due to GCS is down.


### PR DESCRIPTION
In a high latency cluster, Ray GcsClient fails to connect to GCS even though we added many laters of retries. The solution is to set up a longer initial connection timeout. See https://docs.google.com/document/d/1YpE-wbdTzso9ekNMMnL64HQv72eKx15FHcUd9uUJAVY

Fixes #38854 