### PR TITLE
[core] Dashboard agent no longer uses grpc server in minimal. 

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -218,7 +218,11 @@ class DashboardAgent:
             tasks.append(check_parent_task)
         await asyncio.gather(*tasks)
 
-        await self.server.wait_for_termination()
+        if self.server:
+            await self.server.wait_for_termination()
+        else:
+            while True:
+                await asyncio.sleep(3600)  # waits forever
 
         if self.http_server:
             await self.http_server.cleanup()


### PR DESCRIPTION
Previously dashboard agent always has a grpc server, even in Ray minimal. The code assumes this (self.server being non null), and listens on it for completion. Now dashboard agent no longer has a grpc server in minimal, so we instead simply waits forever.

Fixes https://github.com/ray-project/ray/issues/39236