### PR TITLE
[Serve] Ignore cancel request when receving websocket.accept message

### DIFF
--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -1236,10 +1236,7 @@ class HTTPProxy(GenericProxy):
                         # field. Other response types (e.g., WebSockets) may not.
                         status_code = str(asgi_message["status"])
                         expecting_trailers = asgi_message.get("trailers", False)
-                    elif (
-                        asgi_message["type"] == "websocket.connect"
-                        or asgi_message["type"] == "websocket.accept"
-                    ):
+                    elif asgi_message["type"] == "websocket.accept":
                         is_websocket_connection = True
                     elif (
                         asgi_message["type"] == "http.response.body"

--- a/python/ray/serve/_private/http_proxy.py
+++ b/python/ray/serve/_private/http_proxy.py
@@ -1236,7 +1236,10 @@ class HTTPProxy(GenericProxy):
                         # field. Other response types (e.g., WebSockets) may not.
                         status_code = str(asgi_message["status"])
                         expecting_trailers = asgi_message.get("trailers", False)
-                    elif asgi_message["type"] == "websocket.connect":
+                    elif (
+                        asgi_message["type"] == "websocket.connect"
+                        or asgi_message["type"] == "websocket.accept"
+                    ):
                         is_websocket_connection = True
                     elif (
                         asgi_message["type"] == "http.response.body"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

From application to client, it is sending `websocket.accept` message.

https://asgi.readthedocs.io/en/latest/specs/www.html#accept-send-event

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
