### PR TITLE
[Docs] Fix DOC_LIB Env Var for `ray-<>` Directories

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -217,7 +217,9 @@ exclude_patterns = [
 # If "DOC_LIB" is found, only build that top-level navigation item.
 build_one_lib = os.getenv("DOC_LIB")
 
-all_toc_libs = [f.path for f in os.scandir(".") if f.is_dir() and "ray-" in f.path]
+all_toc_libs = [
+    f.path.strip("./") for f in os.scandir(".") if f.is_dir() and "ray-" in f.path
+]
 all_toc_libs += [
     "cluster",
     "tune",


### PR DESCRIPTION
## Why are these changes needed?

* Currently `DOC_LIB=./ray-observability`, which feels ergonomically weird. It should really just be `ray-observability`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
