### PR TITLE
[core] Fix performance regression in single_client_tasks_and_get_batc…

### DIFF
--- a/python/ray/tune/tests/test_remote.py
+++ b/python/ray/tune/tests/test_remote.py
@@ -58,7 +58,6 @@ class RemoteTest(unittest.TestCase):
         default_kwargs.pop("run_or_experiment")
         default_kwargs.pop("_remote")
         default_kwargs.pop("progress_reporter")
-        default_kwargs.pop("_ray_trace_ctx")  # automatically added for remote
 
         self.assertDictEqual(kwargs, default_kwargs)
 

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -328,7 +328,9 @@ def _inject_tracing_into_function(function):
     future execution of that function will include tracing.
     Use the provided trace context from kwargs.
     """
-    # Add _ray_trace_ctx to function signature
+    if not _is_tracing_enabled():
+        return function
+
     setattr(
         function,
         "__signature__",
@@ -339,11 +341,6 @@ def _inject_tracing_into_function(function):
             ),
         ),
     )
-
-    # Skip wrapping if tracing is disabled (still add _ray_trace_ctx however to make
-    # sure _ray_trace_ctx could be passed)
-    if not _is_tracing_enabled():
-        return function
 
     @wraps(function)
     def _function_with_tracing(


### PR DESCRIPTION
…h (#39362)

The single_client_tasks_and_get_batch benchmark saw a ~0.5-1k tasks/s average regression (2k tasks/s on a local machine) due to #38323, which changed some tracing logic to unconditionally change the signature of every remote function to accomodate tracing during _inject_tracing_into_function.

Make the signature change conditional again, but move it to the execution portion of RemoteFunction rather than the definition. Also make sure the injection only happens once even when the remote function is executed multiple times.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
