### PR TITLE
[Train][Telemetry] Limit the usage of `ray.train.torch.get_device`.

### DIFF
--- a/python/ray/air/util/torch_dist.py
+++ b/python/ray/air/util/torch_dist.py
@@ -17,8 +17,7 @@ import ray
 from ray.actor import ActorHandle
 from ray.train._internal.utils import get_address_and_port
 from ray.train.constants import DEFAULT_NCCL_SOCKET_IFNAME
-from ray.train.torch.train_loop_utils import get_device
-
+from ray.air._internal.torch_utils import get_device
 
 class TorchDistributedWorker(ABC):
     """Defines the interfaces required by the init_torch_dist_process_group().

--- a/python/ray/air/util/torch_dist.py
+++ b/python/ray/air/util/torch_dist.py
@@ -19,6 +19,7 @@ from ray.train._internal.utils import get_address_and_port
 from ray.train.constants import DEFAULT_NCCL_SOCKET_IFNAME
 from ray.air._internal.torch_utils import get_device
 
+
 class TorchDistributedWorker(ABC):
     """Defines the interfaces required by the init_torch_dist_process_group().
 

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -114,7 +114,7 @@ def _setup_torch_process_group(
 
 
 def _shutdown_torch(destroy_process_group=False):
-    from ray.train.torch.train_loop_utils import get_device
+    from ray.air._internal.torch_utils import get_device
 
     devices = get_device()
     if not isinstance(devices, list):
@@ -130,7 +130,7 @@ def _shutdown_torch(destroy_process_group=False):
 def _set_torch_distributed_env_vars():
     # Same env vars as in
     # https://pytorch.org/docs/stable/elastic/run.html#environment-variables
-    from ray.train.torch.train_loop_utils import get_device
+    from ray.air._internal.torch_utils import get_device
 
     context = ray.train.get_context()
     os.environ["LOCAL_RANK"] = str(context.get_local_rank())

--- a/rllib/core/learner/torch/torch_learner.py
+++ b/rllib/core/learner/torch/torch_learner.py
@@ -44,7 +44,7 @@ from ray.rllib.utils.typing import Optimizer, Param, ParamDict, TensorType
 torch, nn = try_import_torch()
 
 if torch:
-    from ray.train.torch.train_loop_utils import get_device
+    from ray.air._internal.torch_utils import get_device
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In Ray 2.7, we added a series of TagKey for TorchTrainer utilities. We are using `ray.train.torch.get_device` in multiple places internally. To avoid report inaccurate telemetry metrics, we want to expose this API only for user code. 

This PR limits the usage of this API, and converted all internal calls with `ray.air._internal.torch_utils.get_device`.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
