### PR TITLE
[serve] Fix serve agent 501 response

### DIFF
--- a/dashboard/modules/serve/serve_agent.py
+++ b/dashboard/modules/serve/serve_agent.py
@@ -23,7 +23,7 @@ routes = optional_utils.ClassMethodRouteTable
 
 def gracefully_handle_missing_serve_dependencies(func):
     @wraps(func)
-    def check(self, *args, **kwargs):
+    async def check(self, *args, **kwargs):
         try:
             from ray import serve  # noqa: F401
         except ImportError:
@@ -34,7 +34,7 @@ def gracefully_handle_missing_serve_dependencies(func):
                     '"ray[serve]"`.'
                 ),
             )
-        return func(self, *args, **kwargs)
+        return await func(self, *args, **kwargs)
 
     return check
 

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -904,8 +904,8 @@ def test_dashboard_does_not_depend_on_serve():
     """Check that the dashboard can start without Serve."""
     ray.shutdown()
 
-    with pytest.raises(ImportError):
-        from ray import serve  # noqa: F401
+    # with pytest.raises(ImportError):
+    #     from ray import serve  # noqa: F401
 
     ctx = ray.init()
 
@@ -925,12 +925,11 @@ def test_dashboard_does_not_depend_on_serve():
     # Check that Serve-dependent features fail
     try:
         response = requests.get(f"http://{agent_url}/api/serve/deployments/")
-    except Exception as e:
-        # Fail to connect to service is fine.
-        print(e)
-    else:
         print(f"response status code: {response.status_code}, expected: 501")
         assert response.status_code == 501
+    except requests.ConnectionError as e:
+        # Fail to connect to service is fine.
+        print(e)
 
 
 @pytest.mark.skipif(
@@ -964,12 +963,11 @@ def test_agent_does_not_depend_on_serve(shutdown_only):
     # Check that Serve-dependent features fail
     try:
         response = requests.get(f"http://{agent_url}/api/serve/deployments/")
-    except Exception as e:
-        # Fail to connect to service is fine.
-        print(e)
-    else:
         print(f"response status code: {response.status_code}, expected: 501")
         assert response.status_code == 501
+    except requests.ConnectionError as e:
+        # Fail to connect to service is fine.
+        print(e)
 
     # The agent should be dead if raylet exits.
     raylet_proc.kill()

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -925,11 +925,12 @@ def test_dashboard_does_not_depend_on_serve():
     # Check that Serve-dependent features fail
     try:
         response = requests.get(f"http://{agent_url}/api/serve/deployments/")
-        assert response.status_code == 501
     except Exception as e:
         # Fail to connect to service is fine.
         print(e)
-        assert True
+    else:
+        print(f"response status code: {response.status_code}, expected: 501")
+        assert response.status_code == 501
 
 
 @pytest.mark.skipif(
@@ -963,11 +964,12 @@ def test_agent_does_not_depend_on_serve(shutdown_only):
     # Check that Serve-dependent features fail
     try:
         response = requests.get(f"http://{agent_url}/api/serve/deployments/")
-        assert response.status_code == 501
     except Exception as e:
         # Fail to connect to service is fine.
         print(e)
-        assert True
+    else:
+        print(f"response status code: {response.status_code}, expected: 501")
+        assert response.status_code == 501
 
     # The agent should be dead if raylet exits.
     raylet_proc.kill()

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -904,8 +904,8 @@ def test_dashboard_does_not_depend_on_serve():
     """Check that the dashboard can start without Serve."""
     ray.shutdown()
 
-    # with pytest.raises(ImportError):
-    #     from ray import serve  # noqa: F401
+    with pytest.raises(ImportError):
+        from ray import serve  # noqa: F401
 
     ctx = ray.init()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

TL;DR: the optimization added in https://github.com/ray-project/ray/pull/38836, which returns 501 if Serve dependencies aren't installed, doesn't work. Instead of returning a 501 response like it should, the serve agent returns a mysterious `TypeError: object Response can't be used in 'await' expression`

The decorator `gracefully_handle_missing_serve_dependencies` doesn't return an async function, and the second decorator `init_ray_and_catch_exceptions` runs `await f`, `f` being the result of the first decorator.
- Normally this works fine since `f` returns a coroutine (the original async function)
- But when serve dependencies are not installed and `f` returns a 501 Response, await on the 501 Response fails.

The tests `test_dashboard_does_not_depend_on_serve` and `test_agent_does_not_depend_on_serve` didn't catch this because it includes the assert statement inside a try-except block, so the assert statement was actually failing but it was being ignored by the except block :facepalm:

Fixed the test and also verified manually this time that the optimization works.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
