### PR TITLE
[train][doc] Remove preprocessor reference in tune+train user guide

### DIFF
--- a/doc/source/train/doc_code/tuner.py
+++ b/doc/source/train/doc_code/tuner.py
@@ -118,30 +118,24 @@ result_grid = tuner.fit()
 # __torch_end__
 
 
-# __tune_preprocess_start__
-from ray.data.preprocessors import StandardScaler
-from ray.tune import Tuner
-
-prep_v1 = StandardScaler(["worst radius", "worst area"])
-prep_v2 = StandardScaler(["worst concavity", "worst smoothness"])
-tuner = Tuner(
-    trainer,
-    param_space={
-        "preprocessor": tune.grid_search([prep_v1, prep_v2]),
-        # Your other parameters go here
-    },
-)
-# __tune_preprocess_end__
-
-
 # __tune_dataset_start__
+from ray.data.preprocessors import StandardScaler
+
+
 def get_dataset():
-    return ray.data.read_csv("s3://anonymous@air-example-data/breast_cancer.csv")
+    ds1 = ray.data.read_csv("s3://anonymous@air-example-data/breast_cancer.csv")
+    prep_v1 = StandardScaler(["worst radius", "worst area"])
+    ds1 = prep_v1.fit_transform(ds1)
+    return ds1
 
 
 def get_another_dataset():
-    # imagine this is a different dataset
-    return ray.data.read_csv("s3://anonymous@air-example-data/breast_cancer.csv")
+    ds2 = ray.data.read_csv(
+        "s3://anonymous@air-example-data/breast_cancer_with_categorical.csv"
+    )
+    prep_v2 = StandardScaler(["worst concavity", "worst smoothness"])
+    ds2 = prep_v2.fit_transform(ds2)
+    return ds2
 
 
 dataset_1 = get_dataset()

--- a/doc/source/train/user-guides/hyperparameter-optimization.rst
+++ b/doc/source/train/user-guides/hyperparameter-optimization.rst
@@ -16,12 +16,12 @@ Hyperparameter tuning with :ref:`Ray Tune <tune-main>` is natively supported wit
 Key Concepts
 ------------
 
-There are a number of key concepts Tuner:
+There are a number of key concepts when doing hyperparameter optimization with a :class:`~ray.tune.Tuner`:
 
 * A set of hyperparameters you want to tune in a *search space*.
 * A *search algorithm* to effectively optimize your parameters and optionally use a
   *scheduler* to stop searches early and speed up your experiments.
-* The *search space*, *search algorithm*, *scheduler*, and *Trainer* are passed to a :class:`~ray.tune.Tuner`,
+* The *search space*, *search algorithm*, *scheduler*, and *Trainer* are passed to a Tuner,
   which runs the hyperparameter tuning workload by evaluating multiple hyperparameters in parallel.
 * Each individual hyperparameter evaluation run is called a *trial*.
 * The Tuner returns its results as a :class:`~ray.tune.ResultGrid`.

--- a/doc/source/train/user-guides/hyperparameter-optimization.rst
+++ b/doc/source/train/user-guides/hyperparameter-optimization.rst
@@ -3,8 +3,7 @@
 Hyperparameter Tuning with Ray Tune
 ===================================
 
-Hyperparameter tuning with :ref:`Ray Tune <tune-main>` is natively supported
-with Ray Train. 
+Hyperparameter tuning with :ref:`Ray Tune <tune-main>` is natively supported with Ray Train.
 
 
 .. https://docs.google.com/drawings/d/1yMd12iMkyo6DGrFoET1TIlKfFnXX9dfh2u3GSdTz6W4/edit
@@ -17,15 +16,15 @@ with Ray Train.
 Key Concepts
 ------------
 
-There are a number of key concepts that dictate proper use of a Tuner:
+There are a number of key concepts Tuner:
 
-* A set of hyperparameters you want to tune in a `search space`.
-* A `search algorithm` to effectively optimize your parameters and optionally use a
-  `scheduler` to stop searches early and speed up your experiments.
-* The `search space`, `search algorithm`, `scheduler`, and `Trainer` are passed to a `Tuner`,
+* A set of hyperparameters you want to tune in a *search space*.
+* A *search algorithm* to effectively optimize your parameters and optionally use a
+  *scheduler* to stop searches early and speed up your experiments.
+* The *search space*, *search algorithm*, *scheduler*, and *Trainer* are passed to a :class:`~ray.tune.Tuner`,
   which runs the hyperparameter tuning workload by evaluating multiple hyperparameters in parallel.
-* Each individual hyperparameter evaluation run is called a `trial`.
-* The `Tuner` returns its results in a `ResultGrid`.
+* Each individual hyperparameter evaluation run is called a *trial*.
+* The Tuner returns its results as a :class:`~ray.tune.ResultGrid`.
 
 .. note::
    Tuners can also be used to launch hyperparameter tuning without using Ray Train. See
@@ -34,8 +33,8 @@ There are a number of key concepts that dictate proper use of a Tuner:
 Basic usage
 -----------
 
-Specifically, you can take an existing ``Trainer`` and simply
-pass it into a :py:class:`~ray.tune.tuner.Tuner`.
+You can take an existing :class:`Trainer <ray.train.base_trainer.BaseTrainer>` and simply
+pass it into a :class:`~ray.tune.Tuner`.
 
 .. literalinclude:: ../doc_code/tuner.py
     :language: python
@@ -49,7 +48,7 @@ How to configure a Tuner?
 
 There are two main configuration objects that can be passed into a Tuner: the :class:`TuneConfig <ray.tune.tune_config.TuneConfig>` and the :class:`RunConfig <ray.train.RunConfig>`.
 
-The :class:`TuneConfig <ray.tune.tune_config.TuneConfig>` contains tuning specific settings, including:
+The :class:`TuneConfig <ray.tune.TuneConfig>` contains tuning specific settings, including:
 
 - the tuning algorithm to use
 - the metric and mode to rank results
@@ -65,7 +64,7 @@ Here are some common configurations for `TuneConfig`:
 See the :class:`TuneConfig API reference <ray.tune.tune_config.TuneConfig>` for more details.
 
 The :class:`RunConfig <ray.train.RunConfig>` contains configurations that are more generic than tuning specific settings.
-This may include:
+This includes:
 
 - failure/retry configurations
 - verbosity levels
@@ -100,9 +99,8 @@ Depending on the model and dataset, you may want to tune:
 You can use a Tuner to tune most arguments and configurations for Ray Train, including but
 not limited to:
 
-- Ray Data
-- Preprocessors
-- Scaling configurations
+- Ray :class:`Datasets <ray.data.Dataset>`
+- :class:`~ray.train.ScalingConfig`
 - and other hyperparameters.
 
 
@@ -122,14 +120,8 @@ See :doc:`/tune/tutorials/tune_get_data_in_and_out` for an example.
 Advanced Tuning
 ---------------
 
-Tuners also offer the ability to tune different data preprocessing steps, as shown in the following snippet.
-
-.. literalinclude:: ../doc_code/tuner.py
-    :language: python
-    :start-after: __tune_preprocess_start__
-    :end-before: __tune_preprocess_end__
-
-Additionally, you can sample different train/validation datasets:
+Tuners also offer the ability to tune over different data preprocessing steps and
+different training/validation datasets, as shown in the following snippet.
 
 .. literalinclude:: ../doc_code/tuner.py
     :language: python


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This removes the deprecated preprocessor usage in the tune+train user guide.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
