### PR TITLE
[ci] Fix 0 tests in tester_container

### DIFF
--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -9,15 +9,15 @@ from ci.ray_ci.utils import chunk_into_n
 
 class MockPopen:
     """
-    Mock subprocess.Popen. This process returns 0 if both test_targets and
-    commands are not empty; otherwise return 1.
+    Mock subprocess.Popen. This process returns 1 if test targets is empty or contains
+    bad_test; otherwise return 0.
     """
 
     def __init__(self, test_targets: List[str]):
         self.test_targets = test_targets
 
     def wait(self) -> int:
-        return 0 if self.test_targets else 1
+        return 1 if "bad_test" in self.test_targets or not self.test_targets else 0
 
 
 def test_run_tests_in_docker() -> None:
@@ -62,8 +62,11 @@ def test_run_tests() -> None:
         container = TesterContainer("team")
         # test_targets are not empty
         assert container.run_tests(["t1", "t2"], [], 2)
-        # test_targets is empty after chunking
-        assert not container.run_tests(["t1"], [], 2)
+        # test_targets is empty after chunking, but not creating popen
+        assert container.run_tests(["t1"], [], 2)
+        assert container.run_tests([], [], 2)
+        # test targets contain bad_test
+        assert not container.run_tests(["bad_test"], [], 2)
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import sys
 from typing import List, Optional
@@ -7,7 +6,7 @@ import yaml
 import click
 
 from ci.ray_ci.tester_container import TesterContainer
-from ci.ray_ci.utils import logger, shard_tests
+from ci.ray_ci.utils import shard_tests
 
 # Gets the path of product/tools/docker (i.e. the parent of 'common')
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
@@ -88,10 +87,6 @@ def main(
             worker_id,
             except_tags,
         )
-    if not test_targets:
-        logging.info("No tests to run")
-        return
-    logger.info(f"Running tests: {test_targets}")
     success = container.run_tests(test_targets, test_env, parallelism_per_worker)
     sys.exit(0 if success else 1)
 


### PR DESCRIPTION
Currently test_in_docker will emit errors if there are 0 tests to run (in one of its worker). Fix it by removing workers with 0 tests. Added tests for 0 test case as well.

Test:
- CI