### PR TITLE
Don't treat warning as error for external projects

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,16 +42,15 @@ build:windows --enable_runfiles
 # TODO(mehrdadn): Revert the "-\\.(asm|S)$" exclusion when this Bazel bug
 #                 for compiling assembly files is fixed on Windows:
 #                 https://github.com/bazelbuild/bazel/issues/8924
-# Warnings should be errors except for external projects.
-build:linux    --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
-build:macos    --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
-build:clang-cl --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
+# Warnings should be errors
+build:linux    --per_file_copt="-\\.(asm|S)$@-Werror"
+build:macos    --per_file_copt="-\\.(asm|S)$@-Werror"
+build:clang-cl --per_file_copt="-\\.(asm|S)$@-Werror"
 build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 # Ignore warnings for protobuf generated files and external projects.
-build --per_file_copt="\\.pb\\.cc$,external/.*@-w"
-build:macos --per_file_copt="external/.*@-w"
-build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
-build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
+build --per_file_copt="\\.pb\\.cc$@-w"
+build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
+build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
 # Ignore minor warnings for host tools, which we generally can't control
 build:macos --host_copt="-w"
 build:clang-cl --host_copt="-Wno-inconsistent-missing-override"

--- a/.bazelrc
+++ b/.bazelrc
@@ -49,7 +49,7 @@ build:clang-cl --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
 build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 # Ignore warnings for protobuf generated files and external projects.
 build --per_file_copt="\\.pb\\.cc$,external/.*@-w"
-build --per_file_copt=external/.*@-w
+build --per_file_copt="external/.*@-w"
 build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
 build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
 # Ignore minor warnings for host tools, which we generally can't control

--- a/.bazelrc
+++ b/.bazelrc
@@ -50,6 +50,7 @@ build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 # Ignore warnings for protobuf generated files and external projects.
 build --per_file_copt="\\.pb\\.cc$,external/.*@-w"
 build:macos --per_file_copt="external/.*@-w"
+build:macos --host_per_file_copt="external/.*@-w"
 build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
 build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
 # Ignore minor warnings for host tools, which we generally can't control

--- a/.bazelrc
+++ b/.bazelrc
@@ -49,6 +49,7 @@ build:clang-cl --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
 build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 # Ignore warnings for protobuf generated files and external projects.
 build --per_file_copt="\\.pb\\.cc$,external/.*@-w"
+build --per_file_copt=external/.*@-w
 build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
 build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
 # Ignore minor warnings for host tools, which we generally can't control

--- a/.bazelrc
+++ b/.bazelrc
@@ -49,8 +49,8 @@ build:clang-cl --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
 build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 # Ignore warnings for protobuf generated files and external projects.
 build --per_file_copt="\\.pb\\.cc$,external/.*@-w"
-build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
-build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
+build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
+build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
 # Ignore minor warnings for host tools, which we generally can't control
 build:clang-cl --host_copt="-Wno-inconsistent-missing-override"
 build:clang-cl --host_copt="-Wno-microsoft-unqualified-friend"

--- a/.bazelrc
+++ b/.bazelrc
@@ -51,8 +51,10 @@ build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 build --per_file_copt="\\.pb\\.cc$@-w"
 build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
 build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
-# Ignore warnings for host tools, which we generally can't control
-build --host_copt="-w"
+# Ignore warnings for host tools, which we generally can't control.
+# Ideally we only want to ignore warnings for external project
+# but the current bazel version doesn't support host_per_file_copt yet.
+build:macos --host_copt="-w"
 build:clang-cl --host_copt="-Wno-inconsistent-missing-override"
 build:clang-cl --host_copt="-Wno-microsoft-unqualified-friend"
 # This workaround is needed due to https://github.com/bazelbuild/bazel/issues/4341

--- a/.bazelrc
+++ b/.bazelrc
@@ -42,10 +42,10 @@ build:windows --enable_runfiles
 # TODO(mehrdadn): Revert the "-\\.(asm|S)$" exclusion when this Bazel bug
 #                 for compiling assembly files is fixed on Windows:
 #                 https://github.com/bazelbuild/bazel/issues/8924
-# Warnings should be errors
-build:linux    --per_file_copt="-\\.(asm|S)$@-Werror"
-build:macos    --per_file_copt="-\\.(asm|S)$@-Werror"
-build:clang-cl --per_file_copt="-\\.(asm|S)$@-Werror"
+# Warnings should be errors except for external projects.
+build:linux    --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
+build:macos    --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
+build:clang-cl --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
 build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 # Ignore warnings for protobuf generated files and external projects.
 build --per_file_copt="\\.pb\\.cc$@-w"

--- a/.bazelrc
+++ b/.bazelrc
@@ -49,7 +49,7 @@ build:clang-cl --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
 build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 # Ignore warnings for protobuf generated files and external projects.
 build --per_file_copt="\\.pb\\.cc$,external/.*@-w"
-build --per_file_copt="external/.*@-w"
+build:macos --per_file_copt="external/.*@-w"
 build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
 build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
 # Ignore minor warnings for host tools, which we generally can't control

--- a/.bazelrc
+++ b/.bazelrc
@@ -51,8 +51,8 @@ build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 build --per_file_copt="\\.pb\\.cc$@-w"
 build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
 build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
-# Ignore minor warnings for host tools, which we generally can't control
-build:macos --host_copt="-w"
+# Ignore warnings for host tools, which we generally can't control
+build --host_copt="-w"
 build:clang-cl --host_copt="-Wno-inconsistent-missing-override"
 build:clang-cl --host_copt="-Wno-microsoft-unqualified-friend"
 # This workaround is needed due to https://github.com/bazelbuild/bazel/issues/4341

--- a/.bazelrc
+++ b/.bazelrc
@@ -50,10 +50,10 @@ build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 # Ignore warnings for protobuf generated files and external projects.
 build --per_file_copt="\\.pb\\.cc$,external/.*@-w"
 build:macos --per_file_copt="external/.*@-w"
-build:macos --host_per_file_copt="external/.*@-w"
 build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
 build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=range-loop-analysis"
 # Ignore minor warnings for host tools, which we generally can't control
+build:macos --host_copt="-w"
 build:clang-cl --host_copt="-Wno-inconsistent-missing-override"
 build:clang-cl --host_copt="-Wno-microsoft-unqualified-friend"
 # This workaround is needed due to https://github.com/bazelbuild/bazel/issues/4341

--- a/.bazelrc
+++ b/.bazelrc
@@ -48,7 +48,7 @@ build:macos    --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
 build:clang-cl --per_file_copt="-\\.(asm|S)$,-external/.*@-Werror"
 build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 # Ignore warnings for protobuf generated files and external projects.
-build --per_file_copt="\\.pb\\.cc$@-w"
+build --per_file_copt="\\.pb\\.cc$,external/.*@-w"
 build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
 build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
 # Ignore minor warnings for host tools, which we generally can't control


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Mac build is failing with 
```
external/upb/upbc/protoc-gen-upb.cc:1662:19: error: loop variable 'msg' of type 'const upb::EnumDefPtr' creates a copy from type 'const upb::EnumDefPtr' [-Werror,-Wrange-loop-analysis]
--
  | for (const auto msg : SortedEnums(file)) {
  | ^
  | external/upb/upbc/protoc-gen-upb.cc:1662:8: note: use reference type 'const upb::EnumDefPtr &' to prevent copying
  | for (const auto msg : SortedEnums(file)) {
  | ^~~~~~~~~~~~~~~~
  | &
```

We should ignore warnings from external projects.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
