### PR TITLE
[train] Do not raise warning when no results were reported

### DIFF
--- a/python/ray/tune/analysis/experiment_analysis.py
+++ b/python/ray/tune/analysis/experiment_analysis.py
@@ -163,10 +163,10 @@ class ExperimentAnalysis:
         # Prefer reading the JSON if it exists.
         if _exists_at_fs_path(trial.storage.storage_filesystem, json_fs_path):
             with trial.storage.storage_filesystem.open_input_stream(json_fs_path) as f:
-                json_list = [
-                    json.loads(json_row)
-                    for json_row in f.readall().decode("utf-8").rstrip("\n").split("\n")
-                ]
+                content = f.readall().decode("utf-8").rstrip("\n")
+                if not content:
+                    return DataFrame()
+                json_list = [json.loads(row) for row in content.split("\n")]
             df = pd.json_normalize(json_list, sep="/")
         # Fallback to reading the CSV.
         elif _exists_at_fs_path(trial.storage.storage_filesystem, csv_fs_path):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When no result is reported, a training run will print this message at the end of training:

```
2023-09-07 18:53:20,003 WARNING experiment_analysis.py:205 -- Failed to fetch metrics for 1 trial(s):
- TorchTrainer_78aea_00000: JSONDecodeError('Expecting value: line 1 column 1 (char 0)')
```

This is due to the results json file being empty. Instead, we should identify empty files early and return an empty dataframe, avoiding the error message.

## Related issue number

Closes #39430

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
