### PR TITLE
[Data] Optimize sample_boundaries in sort_task_spec.py

### DIFF
--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -107,19 +107,20 @@ class SortTaskSpec(ExchangeTaskSpec):
         sample_dict = BlockAccessor.for_block(samples).to_numpy(columns=columns)
         # Compute sorted indices of the samples. In np.lexsort last key is the
         # primary key hence have to reverse the order.
-        indices = np.lexsort(list(reversed(list(sample_dict.values()))))
+        indices = np.lexsort(list(reversed(sample_dict.values())))
         # Sort each column by indices, and calculate q-ths quantile items.
         # Ignore the 1st item as it's not required for the boundary
         for k, v in sample_dict.items():
             sorted_v = v[indices]
-            sample_dict[k] = [
-                np.quantile(sorted_v, q, interpolation="nearest")
-                for q in np.linspace(0, 1, num_reducers)
-            ][1:]
+            sample_dict[k] = list(np.quantile(
+                sorted_v,
+                np.linspace(0, 1, num_reducers),
+                interpolation="nearest"
+            )[1:])
         # Return the list of boundaries as tuples
         # of a form (col1_value, col2_value, ...)
         return [
-            tuple(sample_dict[k][i] for k in sample_dict)
+            tuple(v[i] for v in sample_dict.values())
             for i in range(num_reducers - 1)
         ]
 


### PR DESCRIPTION
Optimize sample_boundaries in sort_task_spec.py:
- Remove unnecessary list and dict operations.
- Directly use numpy.quantile to get the boundary list for a column, which is much faster when the number of reducers is large (each time numpy.quantile() is called it will sort the input array).

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
