### PR TITLE
[data] Read data with multi-threading for FileBasedDataSource

### DIFF
--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -12,11 +12,11 @@ from ray.data._internal.block_batching.util import (
     extract_data_from_batch,
     finalize_batches,
     format_batches,
-    make_async_gen,
     resolve_block_refs,
 )
 from ray.data._internal.memory_tracing import trace_deallocation
 from ray.data._internal.stats import DatasetStats
+from ray.data._internal.util import make_async_gen
 from ray.data.block import Block, BlockMetadata, DataBatch
 from ray.data.context import DataContext
 from ray.types import ObjectRef

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -1,8 +1,7 @@
 import logging
 import threading
-from collections import deque
 from contextlib import nullcontext
-from typing import Any, Callable, Iterator, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Iterator, List, Optional, Tuple, Union
 
 import ray
 from ray.actor import ActorHandle
@@ -16,9 +15,6 @@ from ray.data._internal.stats import DatasetPipelineStats, DatasetStats
 from ray.data.block import Block, BlockAccessor, DataBatch
 from ray.types import ObjectRef
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
-
-T = TypeVar("T")
-U = TypeVar("U")
 
 logger = logging.getLogger(__name__)
 
@@ -211,99 +207,6 @@ def extract_data_from_batch(batch_iter: Iterator[Batch]) -> Iterator[Any]:
         yield batch.data
 
 
-def make_async_gen(
-    base_iterator: Iterator[T],
-    fn: Callable[[Iterator[T]], Iterator[U]],
-    num_workers: int = 1,
-) -> Iterator[U]:
-    """Returns a new iterator with elements fetched from the base_iterator
-    in an async fashion using a threadpool.
-
-    Each thread in the threadpool will fetch data from the base_iterator in a
-    thread-safe fashion, and apply the provided `fn` computation concurrently.
-
-    Args:
-        base_iterator: The iterator to asynchronously fetch from.
-        fn: The function to run on the input iterator.
-        num_workers: The number of threads to use in the threadpool. Defaults to 1.
-
-    Returns:
-        An iterator with the same elements as outputted from `fn`.
-    """
-
-    if num_workers < 1:
-        raise ValueError("Size of threadpool must be at least 1.")
-
-    # Use a lock to fetch from the base_iterator in a thread-safe fashion.
-    def convert_to_threadsafe_iterator(base_iterator: Iterator[T]) -> Iterator[T]:
-        class ThreadSafeIterator:
-            def __init__(self, it):
-                self.lock = threading.Lock()
-                self.it = it
-
-            def __next__(self):
-                with self.lock:
-                    return next(self.it)
-
-            def __iter__(self):
-                return self
-
-        return ThreadSafeIterator(base_iterator)
-
-    thread_safe_generator = convert_to_threadsafe_iterator(base_iterator)
-
-    class Sentinel:
-        def __init__(self, thread_index: int):
-            self.thread_index = thread_index
-
-    output_queue = Queue(1)
-
-    # Because pulling from the base iterator cannot happen concurrently,
-    # we must execute the expensive computation in a separate step which
-    # can be parallelized via a threadpool.
-    def execute_computation(thread_index: int):
-        try:
-            for item in fn(thread_safe_generator):
-                if output_queue.put(item):
-                    # Return early when it's instructed to do so.
-                    return
-            output_queue.put(Sentinel(thread_index))
-        except Exception as e:
-            output_queue.put(e)
-
-    # Use separate threads to produce output batches.
-    threads = [
-        threading.Thread(target=execute_computation, args=(i,), daemon=True)
-        for i in range(num_workers)
-    ]
-
-    for thread in threads:
-        thread.start()
-
-    # Use main thread to consume output batches.
-    num_threads_finished = 0
-    try:
-        while True:
-            next_item = output_queue.get()
-            if isinstance(next_item, Exception):
-                raise next_item
-            if isinstance(next_item, Sentinel):
-                logger.debug(f"Thread {next_item.thread_index} finished.")
-                num_threads_finished += 1
-            else:
-                yield next_item
-            if num_threads_finished >= num_workers:
-                break
-    finally:
-        # Cooperatively exit all producer threads.
-        # This is to avoid these daemon threads hanging there with holding batches in
-        # memory, which can cause GRAM OOM easily. This can happen when caller breaks
-        # in the middle of iteration.
-        num_threads_alive = num_workers - num_threads_finished
-        if num_threads_alive > 0:
-            output_queue.release(num_threads_alive)
-
-
 PREFETCHER_ACTOR_NAMESPACE = "ray.dataset"
 
 
@@ -383,66 +286,3 @@ class _BlockPretcher:
 
     def prefetch(self, *blocks) -> None:
         pass
-
-
-class Queue:
-    """A thread-safe queue implementation for multiple producers and consumers.
-
-    Provide `release()` to exit producer threads cooperatively for resource release.
-    """
-
-    def __init__(self, queue_size: int):
-        # The queue shared across multiple producer threads.
-        self._queue = deque()
-        # The boolean varilable to indicate whether producer threads should exit.
-        self._threads_exit = False
-        # The semaphore for producer threads to put item into queue.
-        self._producer_semaphore = threading.Semaphore(queue_size)
-        # The semaphore for consumer threads to get item from queue.
-        self._consumer_semaphore = threading.Semaphore(0)
-        # The mutex lock to guard access of `self._queue` and `self._threads_exit`.
-        self._mutex = threading.Lock()
-
-    def put(self, item: Any) -> bool:
-        """Put an item into the queue.
-
-        Block if necessary until a free slot is available in queue.
-        This method is called by producer threads.
-
-        Returns:
-            True if the caller thread should exit immediately.
-        """
-        self._producer_semaphore.acquire()
-        with self._mutex:
-            if self._threads_exit:
-                return True
-            else:
-                self._queue.append(item)
-        self._consumer_semaphore.release()
-        return False
-
-    def get(self) -> Any:
-        """Remove and return an item from the queue.
-
-        Block if necessary until an item is available in queue.
-        This method is called by consumer threads.
-        """
-        self._consumer_semaphore.acquire()
-        with self._mutex:
-            next_item = self._queue.popleft()
-        self._producer_semaphore.release()
-        return next_item
-
-    def release(self, num_threads: int):
-        """Release `num_threads` of producers so they would exit cooperatively."""
-        with self._mutex:
-            self._threads_exit = True
-        for _ in range(num_threads):
-            # NOTE: After Python 3.9+, Semaphore.release(n) can be used to
-            # release all threads at once.
-            self._producer_semaphore.release()
-
-    def qsize(self):
-        """Return the size of the queue."""
-        with self._mutex:
-            return len(self._queue)

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -30,6 +30,7 @@ from ray.data._internal.util import (
     _check_pyarrow_version,
     _resolve_custom_scheme,
     get_attribute_from_class_name,
+    make_async_gen,
 )
 from ray.data.block import Block, BlockAccessor
 from ray.data.context import DataContext
@@ -226,6 +227,9 @@ class FileBasedDatasource(Datasource):
     # each block to a file.
     _WRITE_FILE_PER_ROW = False
     _FILE_EXTENSION: Optional[Union[str, List[str]]] = None
+    # Number of threads for concurrent reading within each read task.
+    # If zero or negative, reading will be performed in the main thread.
+    _NUM_THREADS_PER_TASK = 0
 
     def _open_input_source(
         self,
@@ -541,11 +545,11 @@ class _FileBasedDatasourceReader(Reader):
         open_input_source = self._delegate._open_input_source
 
         def read_files(
-            read_paths: List[str],
-            fs: Union["pyarrow.fs.FileSystem", _S3FileSystemWrapper],
+            read_paths: Iterable[str],
         ) -> Iterable[Block]:
+            nonlocal filesystem, open_stream_args, reader_args, partitioning
+
             DataContext._set_current(ctx)
-            logger.get_logger().debug(f"Reading {len(read_paths)} files.")
             fs = _unwrap_s3_serialization_workaround(filesystem)
             for read_path in read_paths:
                 compression = open_stream_args.pop("compression", None)
@@ -591,6 +595,29 @@ class _FileBasedDatasourceReader(Reader):
                             data = _add_partitions(data, partitions)
                         yield data
 
+        def create_read_task_fn(read_paths, num_threads):
+            def read_task_fn():
+                nonlocal num_threads, read_paths
+
+                if num_threads > 0:
+                    if len(read_paths) < num_threads:
+                        num_threads = len(read_paths)
+
+                    logger.get_logger().debug(
+                        f"Reading {len(read_paths)} files with {num_threads} threads."
+                    )
+
+                    yield from make_async_gen(
+                        iter(read_paths),
+                        read_files,
+                        num_workers=num_threads,
+                    )
+                else:
+                    logger.get_logger().debug(f"Reading {len(read_paths)} files.")
+                    yield from read_files(read_paths)
+
+            return read_task_fn
+
         # fix https://github.com/ray-project/ray/issues/24296
         parallelism = min(parallelism, len(paths))
 
@@ -607,9 +634,13 @@ class _FileBasedDatasourceReader(Reader):
                 rows_per_file=self._delegate._rows_per_file(),
                 file_sizes=file_sizes,
             )
-            read_task = ReadTask(
-                lambda read_paths=read_paths: read_files(read_paths, filesystem), meta
+
+            read_task_fn = create_read_task_fn(
+                read_paths, self._delegate._NUM_THREADS_PER_TASK
             )
+
+            read_task = ReadTask(read_task_fn, meta)
+
             read_tasks.append(read_task)
 
         return read_tasks
@@ -894,7 +925,6 @@ def _unwrap_arrow_serialization_workaround(kwargs: dict) -> dict:
 def _resolve_kwargs(
     kwargs_fn: Callable[[], Dict[str, Any]], **kwargs
 ) -> Dict[str, Any]:
-
     if kwargs_fn:
         kwarg_overrides = kwargs_fn()
         kwargs.update(kwarg_overrides)

--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -43,6 +43,8 @@ class ImageDatasource(FileBasedDatasource):
 
     _WRITE_FILE_PER_ROW = True
     _FILE_EXTENSION = ["png", "jpg", "jpeg", "tif", "tiff", "bmp", "gif"]
+    # Use 8 threads per task to read image files.
+    _NUM_THREADS_PER_TASK = 8
 
     def create_reader(
         self,

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -15,9 +15,9 @@ from ray.data._internal.block_batching.util import (
     collate,
     finalize_batches,
     format_batches,
-    make_async_gen,
     resolve_block_refs,
 )
+from ray.data._internal.util import make_async_gen
 
 
 def block_generator(num_rows: int, num_blocks: int):

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -32,15 +32,24 @@ class TestReadImages:
         assert isinstance(column_type, ArrowTensorType)
         assert all(record["image"].shape == (32, 32, 3) for record in ds.take())
 
-    @pytest.mark.parametrize("num_shards", [-1, 0, 1, 2, 4])
+    @pytest.mark.parametrize("num_threads", [-1, 0, 1, 2, 4])
     def test_multi_threading(self, ray_start_regular_shared, num_threads, monkeypatch):
         monkeypatch.setattr(
             ray.data.datasource.image_datasource.ImageDatasource,
             "_NUM_THREADS_PER_TASK",
             num_threads,
         )
-        ds = ray.data.read_images("example://image-datasets/simple")
-        print(ds.take_all())
+        ds = ray.data.read_images(
+            "example://image-datasets/simple",
+            parallelism=1,
+            include_paths=True,
+        )
+        paths = [item["path"][-len("image1.jpg"):] for item in ds.take_all()]
+        if num_threads > 1:
+            # If there are more than 1 threads, the order is not guaranteed.
+            paths = sorted(paths)
+        expected_paths = ["image1.jpg", "image2.jpg", "image3.jpg"]
+        assert paths == expected_paths
 
     def test_multiple_paths(self, ray_start_regular_shared):
         ds = ray.data.read_images(

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -44,7 +44,7 @@ class TestReadImages:
             parallelism=1,
             include_paths=True,
         )
-        paths = [item["path"][-len("image1.jpg"):] for item in ds.take_all()]
+        paths = [item["path"][-len("image1.jpg") :] for item in ds.take_all()]
         if num_threads > 1:
             # If there are more than 1 threads, the order is not guaranteed.
             paths = sorted(paths)

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -32,6 +32,16 @@ class TestReadImages:
         assert isinstance(column_type, ArrowTensorType)
         assert all(record["image"].shape == (32, 32, 3) for record in ds.take())
 
+    @pytest.mark.parametrize("num_shards", [-1, 0, 1, 2, 4])
+    def test_multi_threading(self, ray_start_regular_shared, num_threads, monkeypatch):
+        monkeypatch.setattr(
+            ray.data.datasource.image_datasource.ImageDatasource,
+            "_NUM_THREADS_PER_TASK",
+            num_threads,
+        )
+        ds = ray.data.read_images("example://image-datasets/simple")
+        print(ds.take_all())
+
     def test_multiple_paths(self, ray_start_regular_shared):
         ds = ray.data.read_images(
             paths=[


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously we sequentially read files in read tasks. This turns out to be a bottleneck in our benchmark. 
This PR makes reading files multi-threaded. 
Also move `make_async_gen` from `python/ray/data/_internal/block_batching/util.py` to `python/ray/data/_internal/util.py`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
