### PR TITLE
[core] Dashboard agent no longer uses grpc server in minimal. #39409

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -218,7 +218,11 @@ class DashboardAgent:
             tasks.append(check_parent_task)
         await asyncio.gather(*tasks)
 
-        await self.server.wait_for_termination()
+        if self.server:
+            await self.server.wait_for_termination()
+        else:
+            while True:
+                await asyncio.sleep(3600)  # waits forever
 
         if self.http_server:
             await self.http_server.cleanup()


### PR DESCRIPTION
Previously dashboard agent always has a grpc server, even in Ray minimal. The code assumes this (self.server being non null), and listens on it for completion. Now dashboard agent no longer has a grpc server in minimal, so we instead simply waits forever.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
