### PR TITLE
[Core] Refactor sigterm to ray.init

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1153,6 +1153,7 @@ def init(
     This method handles two cases; either a Ray cluster already exists and we
     just attach this driver to it or we start all of the processes associated
     with a Ray cluster and attach to the newly started cluster.
+    Note: This method overwrite sigterm handler of the driver process.
 
     In most cases, it is enough to just call this method with no arguments.
     This will autodetect an existing Ray cluster or start a new Ray instance if

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1476,6 +1476,18 @@ def init(
     else:
         driver_mode = SCRIPT_MODE
 
+    # terminate any signal before connecting driver
+    def sigterm_handler(signum, frame):
+        sys.exit(signum)
+
+    try:
+        ray._private.utils.set_sigterm_handler(sigterm_handler)
+    except ValueError:
+        logger.warning(
+            "Failed to set SIGTERM handler, processes might"
+            "not be cleaned up properly on exit."
+        )
+
     global _global_node
 
     if global_worker.connected:
@@ -1647,18 +1659,6 @@ def init(
         )
     else:
         logger.info(info_str)
-
-    # terminate any signal before connecting driver
-    def sigterm_handler(signum, frame):
-        sys.exit(signum)
-
-    try:
-        ray._private.utils.set_sigterm_handler(sigterm_handler)
-    except ValueError:
-        logger.warning(
-            "Failed to set SIGTERM handler, processes might"
-            "not be cleaned up properly on exit."
-        )
 
     connect(
         _global_node,

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1477,18 +1477,6 @@ def init(
     else:
         driver_mode = SCRIPT_MODE
 
-    # terminate any signal before connecting driver
-    def sigterm_handler(signum, frame):
-        sys.exit(signum)
-
-    try:
-        ray._private.utils.set_sigterm_handler(sigterm_handler)
-    except ValueError:
-        logger.warning(
-            "Failed to set SIGTERM handler, processes might"
-            "not be cleaned up properly on exit."
-        )
-
     global _global_node
 
     if global_worker.connected:
@@ -1510,6 +1498,18 @@ def init(
 
     if bootstrap_address is None:
         # In this case, we need to start a new cluster.
+
+        # terminate any signal before connecting driver
+        def sigterm_handler(signum, frame):
+            sys.exit(signum)
+
+        try:
+            ray._private.utils.set_sigterm_handler(sigterm_handler)
+        except ValueError:
+            logger.warning(
+                "Failed to set SIGTERM handler, processes might "
+                "not be cleaned up properly on exit."
+            )
 
         # Don't collect usage stats in ray.init() unless it's a nightly wheel.
         from ray._private.usage import usage_lib
@@ -1754,6 +1754,7 @@ def shutdown(_exiting_interpreter: bool = False):
     # TODO(rkn): Instead of manually resetting some of the worker fields, we
     # should simply set "global_worker" to equal "None" or something like that.
     global_worker.set_mode(None)
+    logger.info("ded")
 
 
 atexit.register(shutdown, True)

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1754,7 +1754,6 @@ def shutdown(_exiting_interpreter: bool = False):
     # TODO(rkn): Instead of manually resetting some of the worker fields, we
     # should simply set "global_worker" to equal "None" or something like that.
     global_worker.set_mode(None)
-    logger.info("ded")
 
 
 atexit.register(shutdown, True)

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -1,8 +1,8 @@
 import os
 import sys
 import unittest.mock
-import subprocess
 import signal
+import subprocess
 
 import grpc
 import pytest
@@ -283,12 +283,12 @@ os.kill(os.getpid(), signal.SIGTERM)
 
     # test if sigterm handler is not overwritten by import ray
     test_child = subprocess.run(["python", "-c", sigterm_handler_cmd()])
-    assert os.path.exists(TEST_FILENAME)
+    assert test_child.returncode == 0 and os.path.exists(TEST_FILENAME)
     os.remove(TEST_FILENAME)
 
     # test if sigterm handler is overwritten by ray.init
     test_child = subprocess.run(["python", "-c", sigterm_handler_cmd(ray_init=True)])
-    assert not os.path.exists(TEST_FILENAME)
+    assert test_child.returncode == signal.SIGTERM and not os.path.exists(TEST_FILENAME)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -263,6 +263,7 @@ def test_new_cluster_new_session_dir(ray_start_cluster):
     cluster.shutdown()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="SIGTERM only on posix")
 def test_ray_init_sigterm_handler():
     TEST_FILENAME = "sigterm.txt"
 

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest.mock
 import subprocess
+import signal
 
 import grpc
 import pytest
@@ -260,6 +261,34 @@ def test_new_cluster_new_session_dir(ray_start_cluster):
         assert ray._private.worker._global_node.get_session_dir_path() != session_dir
     ray.shutdown()
     cluster.shutdown()
+
+
+def test_ray_init_sigterm_handler():
+    TEST_FILENAME = "sigterm.txt"
+
+    def sigterm_handler_cmd(ray_init=False):
+        return f"""
+import os
+import sys
+import signal
+def sigterm_handler(signum, frame):
+    f = open("{TEST_FILENAME}", "w")
+    sys.exit(0)
+signal.signal(signal.SIGTERM, sigterm_handler)
+
+import ray
+{"ray.init()" if ray_init else ""}
+os.kill(os.getpid(), signal.SIGTERM)
+"""
+
+    # test if sigterm handler is not overwritten by import ray
+    test_child = subprocess.run(["python", "-c", sigterm_handler_cmd()])
+    assert os.path.exists(TEST_FILENAME)
+    os.remove(TEST_FILENAME)
+
+    # test if sigterm handler is overwritten by ray.init
+    test_child = subprocess.run(["python", "-c", sigterm_handler_cmd(ray_init=True)])
+    assert not os.path.exists(TEST_FILENAME)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Why are these changes needed?
Resolving issue when importing ray shouldn't affect signal handler, only when we run driver process in main thread

## Related issue number

Closes #17745

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
