### PR TITLE
[Data] Backwards compatibility for Preprocessor that have been fit in older versions

### DIFF
--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -66,7 +66,10 @@ class Preprocessor(abc.ABC):
     def _check_has_fitted_state(self):
         """Checks if the Preprocessor has fitted state.
 
-        This is also used as an indiciation if the Preprocessor has been fit.
+        This is also used as an indiciation if the Preprocessor has been fit, following
+        convention from Ray versions prior to 2.6.
+        This allows preprocessors that have been fit in older versions of Ray to be
+        used to transform data in newer versions.
         """
 
         fitted_vars = [v for v in vars(self) if v.endswith("_")]

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -63,10 +63,21 @@ class Preprocessor(abc.ABC):
     # Preprocessors that do not need to be fitted must override this.
     _is_fittable = True
 
+    def _check_has_fitted_state(self):
+        """Checks if the Preprocessor has fitted state.
+
+        This is also used as an indiciation if the Preprocessor has been fit.
+        """
+
+        fitted_vars = [v for v in vars(self) if v.endswith("_")]
+        return bool(fitted_vars)
+
     def fit_status(self) -> "Preprocessor.FitStatus":
         if not self._is_fittable:
             return Preprocessor.FitStatus.NOT_FITTABLE
-        elif hasattr(self, "_fitted") and self._fitted:
+        elif (
+            hasattr(self, "_fitted") and self._fitted
+        ) or self._check_has_fitted_state():
             return Preprocessor.FitStatus.FITTED
         else:
             return Preprocessor.FitStatus.NOT_FITTED

--- a/python/ray/data/tests/preprocessors/test_preprocessors.py
+++ b/python/ray/data/tests/preprocessors/test_preprocessors.py
@@ -127,6 +127,18 @@ def test_fitted_preprocessor_without_stats():
     assert preprocessor.fit_status() == Preprocessor.FitStatus.FITTED
 
 
+def test_fitted_preprocessor_with_stats():
+    """Tests that Preprocessors can be fitted by setting an attribute that ends
+    with _."""
+
+    class FittablePreprocessor(Preprocessor):
+        ...
+
+    preprocessor = FittablePreprocessor()
+    preprocessor.stats_ = True
+    assert preprocessor.fit_status() == Preprocessor.FitStatus.FITTED
+
+
 @patch.object(warnings, "warn")
 def test_fit_twice(mocked_warn):
     """Tests that a warning msg should be printed."""


### PR DESCRIPTION
This is a cherry pick of #39173

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Per user ask, support transforming with Preprocessors that have been fit in an older version of Ray.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
