### PR TITLE
[cherry-pick][core] Don't preload jemalloc for worker. (#39446)

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -218,9 +218,7 @@ def propagate_jemalloc_env_var(
     if not jemalloc_path:
         return {}
 
-    env_vars = {
-        "LD_PRELOAD": jemalloc_path,
-    }
+    env_vars = {"LD_PRELOAD": jemalloc_path, "RAY_LD_PRELOAD": "1"}
     if process_type in jemalloc_comps and jemalloc_conf:
         env_vars.update({"MALLOC_CONF": jemalloc_conf})
     return env_vars

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -69,7 +69,7 @@ def test_jemalloc_env_var_propagate():
     When the shared library is specified
     """
     library_path = "/abc"
-    expected = {"LD_PRELOAD": library_path}
+    expected = {"LD_PRELOAD": library_path, "RAY_LD_PRELOAD": "1"}
     actual = ray._private.services.propagate_jemalloc_env_var(
         jemalloc_path=library_path,
         jemalloc_conf="",
@@ -100,7 +100,11 @@ def test_jemalloc_env_var_propagate():
     """
     library_path = "/abc"
     malloc_conf = "a,b,c"
-    expected = {"LD_PRELOAD": library_path, "MALLOC_CONF": malloc_conf}
+    expected = {
+        "LD_PRELOAD": library_path,
+        "MALLOC_CONF": malloc_conf,
+        "RAY_LD_PRELOAD": "1",
+    }
     actual = ray._private.services.propagate_jemalloc_env_var(
         jemalloc_path=library_path,
         jemalloc_conf=malloc_conf,

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -387,7 +387,7 @@ def test_jemalloc_ray_start(monkeypatch, ray_start_cluster):
     assert check_jemalloc_enabled(
         node.all_processes[ray_constants.PROCESS_TYPE_RAYLET][0].process.pid
     )
-    assert ray.get(ray.remote(check_jemalloc_enabled).remote())
+    assert not ray.get(ray.remote(check_jemalloc_enabled).remote())
 
     ray.shutdown()
     cluster.shutdown()

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -14,6 +14,10 @@
 
 #include <iostream>
 
+#ifdef __linux__
+#include <stdlib.h>
+#endif
+
 #include "gflags/gflags.h"
 #include "nlohmann/json.hpp"
 #include "ray/common/asio/instrumented_io_context.h"
@@ -120,6 +124,13 @@ int main(int argc, char *argv[]) {
   ray::RayLog::InstallTerminateHandler();
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+#ifdef __linux__
+  // Reset LD_PRELOAD if it's loaded with ray jemalloc
+  auto ray_ld_preload = std::getenv("RAY_LD_PRELOAD");
+  if (ray_ld_preload != nullptr && std::string(ray_ld_preload) == "1") {
+    unsetenv("LD_PRELOAD");
+  }
+#endif
   const std::string raylet_socket_name = FLAGS_raylet_socket_name;
   const std::string store_socket_name = FLAGS_store_socket_name;
   const std::string node_name =


### PR DESCRIPTION
Some library is not compatible with jemalloc. This PR disable jemalloc for python workers.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
