### PR TITLE
[deps] pin uvicorn==0.22.0 in test-requirements.txt

### DIFF
--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -71,6 +71,7 @@ smart_open[s3]==6.2.0
 tqdm==4.64.1
 trustme==0.9.0
 testfixtures==7.0.0
+uvicorn==0.22.0
 vsphere-automation-sdk @ git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.1.0
 werkzeug==2.1.2
 xlrd==2.0.1

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -118,7 +118,7 @@ dnspython==2.4.2
 docker==6.1.3
 docker-pycreds==0.4.0
 docutils==0.17.1
-dopamine-rl==4.0.5
+dopamine-rl==4.0.5 ; (sys_platform != "darwin" or platform_machine != "arm64") and python_version >= "3.8"
 dragonfly-opt==0.1.7
 dulwich==0.21.6
 ecdsa==0.18.0
@@ -549,7 +549,7 @@ ujson==5.8.0
 uri-template==1.3.0
 uritemplate==4.1.1
 urllib3==1.26.16
-uvicorn==0.23.2
+uvicorn==0.22.0
 uvloop==0.17.0
 virtualenv==20.21.0
 vsphere-automation-sdk @ git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.1.0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`uvicorn==0.23.2` caused `test_websockets.py::test_server_disconnect` to fail. Pinning this in the test requirements since it's not clear whether or not this is required as a global requirement.

Generated `requirements_compiled.txt` by running `./ci/ci.sh compile_pip_dependencies` 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
