### PR TITLE
[Core] Tmp_dir is incorrectly set from the driver when `ray start --t…

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -112,7 +112,6 @@ class Node:
         ray_params.update_if_absent(
             include_log_monitor=True,
             resources={},
-            temp_dir=ray._private.utils.get_ray_temp_dir(),
             worker_path=os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),
                 "workers",
@@ -410,6 +409,9 @@ class Node:
         self._incremental_dict = collections.defaultdict(lambda: 0)
 
         if self.head:
+            self._ray_params.update_if_absent(
+                temp_dir=ray._private.utils.get_ray_temp_dir()
+            )
             self._temp_dir = self._ray_params.temp_dir
         else:
             if self._ray_params.temp_dir is None:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -920,6 +920,7 @@ def start(
         node = ray._private.node.Node(
             ray_params, head=False, shutdown_at_exit=block, spawn_reaper=block
         )
+        temp_dir = node.get_temp_dir_path()
 
         # Ray and Python versions should probably be checked before
         # initializing Node.

--- a/python/ray/tests/test_gcs_ha_e2e_2.py
+++ b/python/ray/tests/test_gcs_ha_e2e_2.py
@@ -5,6 +5,7 @@ from ray._private.test_utils import wait_for_condition
 from ray.tests.conftest_docker import *  # noqa
 
 
+# TODO(sang): Also check temp dir
 @pytest.mark.skip(reason="Currently flaky.")
 def test_ray_session_name_preserved(docker_cluster):
     get_nodes_script = """

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -2,6 +2,8 @@ import logging
 import os
 import sys
 import unittest.mock
+import tempfile
+import shutil
 from unittest.mock import patch
 
 import pytest
@@ -374,6 +376,20 @@ def test_driver_node_ip_address_auto_configuration(monkeypatch, ray_start_cluste
                 _get_node_id_from_node_ip(get_node_ip_address())
                 == ray.get_runtime_context().get_node_id()
             )
+
+
+@pytest.fixture
+def short_tmp_path():
+    path = tempfile.mkdtemp(dir="/tmp")
+    yield path
+    shutil.rmtree(path)
+
+
+def test_temp_dir_with_node_ip_address(ray_start_cluster, short_tmp_path):
+    cluster = ray_start_cluster
+    cluster.add_node(temp_dir=short_tmp_path)
+    ray.init(address=cluster.address)
+    assert short_tmp_path == ray._private.worker._global_node.get_temp_dir_path()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

This was the issue that always existed, but it actually breaks the ray.init after merging the automatic node ip address setup PR. 


…emp-dir` is given (#39443)

Looks like the temp dir was never set correctly when ray.init is called after it is set from ray start.

It is because we always eagerly set the temp dir before we obtain it from GCS (via internal_kv_get("temp_dir")).

This PR defers the temp_dir detection to the later part of the code to fix the issue

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
