### PR TITLE
[Data] Remove unhelpful actor pool warning

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -257,20 +257,7 @@ class ActorPoolMapOperator(MapOperator):
         total_rows = sum([m.num_rows for m in self._output_metadata])
         min_workers = self._autoscaling_policy.min_workers
         max_desired_batch_size = total_rows // min_workers
-        if (
-            self._min_rows_per_bundle is not None
-            and self._min_rows_per_bundle > max_desired_batch_size
-        ):
-            # The user specified a batch size, but it was probably too large.
-            logger.get_logger().warning(
-                f"Your batch size is too large. Currently, your batch size is "
-                f"{self._min_rows_per_bundle}. Your dataset contains {total_rows}, and "
-                f"Ray Data tried to parallelize it across {min_workers} actors. To "
-                f"parallelize this fully across all {min_workers} actors, set batch "
-                f"size to not exceed `{total_rows} / {min_workers} = "
-                f"{max_desired_batch_size}`."
-            )
-        elif len(self._output_metadata) < min_workers:
+        if len(self._output_metadata) < min_workers:
             # The user created a stream that has too few blocks to begin with.
             logger.get_logger().warning(
                 "To ensure full parallelization across an actor pool of size "

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -254,7 +254,6 @@ class ActorPoolMapOperator(MapOperator):
         # Warn if the user specified a batch or block size that prevents full
         # parallelization across the actor pool. We only know this information after
         # execution has completed.
-        total_rows = sum([m.num_rows for m in self._output_metadata])
         min_workers = self._autoscaling_policy.min_workers
         if len(self._output_metadata) < min_workers:
             # The user created a stream that has too few blocks to begin with.

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -256,7 +256,6 @@ class ActorPoolMapOperator(MapOperator):
         # execution has completed.
         total_rows = sum([m.num_rows for m in self._output_metadata])
         min_workers = self._autoscaling_policy.min_workers
-        max_desired_batch_size = total_rows // min_workers
         if len(self._output_metadata) < min_workers:
             # The user created a stream that has too few blocks to begin with.
             logger.get_logger().warning(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This warning message assumes that `ActorPoolMapOperator._min_rows_per_bundle` represents the batch size, but sometime it isn't accurate. As a result, you can get confusing warnings like this:
> Your batch size is too large. Currently, your batch size is 0. Your dataset contains 1000, and Ray Data tried to parallelize it across 8 actors. To parallelize this fully across all 8 actors, set batch size to not exceed `1000 / 8 = 125`.

To avoid confusion, this PR removes the warning.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
