### PR TITLE
[Serve] [Docs] Correct tags for scheduling task metrics

### DIFF
--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -529,8 +529,9 @@ The following metrics are exposed by Ray Serve:
        * application
      - The number of calls to get a multiplexed model.
 ```
-[*] - only available when using proxy calls
-[**] - only available when using Python `DeploymentHandle` calls
+
+[*] - only available when using proxy calls</br>
+[**] - only available when using Python `DeploymentHandle` calls</br>
 [†] - developer metrics for advanced usage; may change in future releases
 
 To see this in action, first run the following command to start Ray and set up the metrics export port:

--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -448,11 +448,11 @@ The following metrics are exposed by Ray Serve:
        * route
        * application
      - The number of requests processed by the router.
-   * - ``ray_serve_num_scheduling_tasks`` [*]
+   * - ``ray_serve_num_scheduling_tasks`` [*][†]
      - * deployment
        * actor_id
      - The number of request scheduling tasks in the router.
-   * - ``ray_serve_num_scheduling_tasks_in_backoff`` [*]
+   * - ``ray_serve_num_scheduling_tasks_in_backoff`` [*][†]
      - * deployment
        * actor_id
      - The number of request scheduling tasks in the router that are undergoing backoff.
@@ -531,6 +531,7 @@ The following metrics are exposed by Ray Serve:
 ```
 [*] - only available when using proxy calls
 [**] - only available when using Python `DeploymentHandle` calls
+[†] - developer metrics for advanced usage; may change in future releases
 
 To see this in action, first run the following command to start Ray and set up the metrics export port:
 

--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -450,11 +450,11 @@ The following metrics are exposed by Ray Serve:
      - The number of requests processed by the router.
    * - ``ray_serve_num_scheduling_tasks`` [*]
      - * deployment
-       * actor_name
+       * actor_id
      - The number of request scheduling tasks in the router.
    * - ``ray_serve_num_scheduling_tasks_in_backoff`` [*]
      - * deployment
-       * actor_name
+       * actor_id
      - The number of request scheduling tasks in the router that are undergoing backoff.
    * - ``ray_serve_handle_request_counter`` [**]
      - * handle


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The scheduling task metrics introduced in #38199 have an `actor_id` tag. However, the tag is listed as `actor_name` in the docs.

This change corrects the tag in the docs.

Link to the updated docs: https://anyscale-ray--39549.com.readthedocs.build/en/39549/serve/monitoring.html#built-in-ray-serve-metrics

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This is a pure docs change.
