### PR TITLE
[data] torch datasource streaming read

### DIFF
--- a/doc/source/data/working-with-pytorch.rst
+++ b/doc/source/data/working-with-pytorch.rst
@@ -342,10 +342,6 @@ Built-in PyTorch Datasets
 
 If you are using built-in PyTorch datasets, for example from ``torchvision``, these can be converted to a Ray Dataset using the :meth:`from_torch() <ray.data.from_torch>` API.
 
-.. caution::
-
-    :meth:`from_torch() <ray.data.from_torch>` requires the PyTorch Dataset to fit in memory. Use this only for small, built-in datasets for prototyping or testing.
-
 .. testcode::
 
     import torchvision

--- a/python/ray/data/_internal/logical/util.py
+++ b/python/ray/data/_internal/logical/util.py
@@ -28,6 +28,7 @@ _op_name_white_list = [
     "ReadTFRecord",
     "ReadBinary",
     "ReadCustom",
+    "ReadTorch",
     # From
     "FromArrow",
     "FromItems",

--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -39,6 +39,7 @@ from ray.data.datasource.partitioning import (
 from ray.data.datasource.sql_datasource import Connection, SQLDatasource
 from ray.data.datasource.text_datasource import TextDatasource
 from ray.data.datasource.tfrecords_datasource import TFRecordDatasource
+from ray.data.datasource.torch_datasource import TorchDatasource
 from ray.data.datasource.webdataset_datasource import WebDatasetDatasource
 
 # Note: HuggingFaceDatasource should NOT be imported here, because
@@ -77,6 +78,7 @@ __all__ = [
     "Reader",
     "TextDatasource",
     "TFRecordDatasource",
+    "TorchDatasource",
     "WebDatasetDatasource",
     "WriteResult",
     "_S3FileSystemWrapper",

--- a/python/ray/data/datasource/torch_datasource.py
+++ b/python/ray/data/datasource/torch_datasource.py
@@ -1,4 +1,3 @@
-import math
 from typing import TYPE_CHECKING
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
@@ -36,7 +35,6 @@ class _TorchDatasourceReader(Reader):
 
     def get_read_tasks(self, parallelism):
         assert parallelism == 1
-        import torch
 
         meta = BlockMetadata(
             num_rows=len(self._dataset),

--- a/python/ray/data/datasource/torch_datasource.py
+++ b/python/ray/data/datasource/torch_datasource.py
@@ -14,8 +14,8 @@ TORCH_DATASOURCE_READER_BATCH_SIZE = 32
 
 @DeveloperAPI
 class TorchDatasource(Datasource):
-    """Torch datasource, for reading from `map-style
-    Torch datasets <https://pytorch.org/docs/stable/data.html#map-style-datasets/>`_.
+    """Torch datasource, for reading from `Torch
+    datasets <https://pytorch.org/docs/stable/data.html/>`_.
     This datasource implements a streaming read using a single read task.
     """
 

--- a/python/ray/data/datasource/torch_datasource.py
+++ b/python/ray/data/datasource/torch_datasource.py
@@ -83,7 +83,11 @@ class _TorchDatasourceReader(Reader):
 
 
 def _read_subset(subset: "torch.utils.data.Subset"):
-    for item in subset:
+    import torch
+
+    loader = torch.utils.data.DataLoader(subset, collate_fn=lambda x: x, batch_size=32)
+
+    for batch in loader:
         builder = DelegatingBlockBuilder()
-        builder.add({"item": item})
+        builder.add_batch({"item": batch})
         yield builder.build()

--- a/python/ray/data/datasource/torch_datasource.py
+++ b/python/ray/data/datasource/torch_datasource.py
@@ -1,0 +1,77 @@
+import math
+
+import cloudpickle
+import torch
+
+from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
+from ray.data.block import BlockMetadata
+from ray.data.datasource.datasource import Datasource, Reader, ReadTask
+
+
+class TorchDatasource(Datasource):
+    def create_reader(
+        self, dataset: torch.utils.data.Dataset, random_split: bool = False
+    ):
+        return _TorchDatasourceReader(dataset, random_split)
+
+
+class _TorchDatasourceReader(Reader):
+    def __init__(self, dataset: torch.utils.data.Dataset, random_split: bool):
+        self._dataset = dataset
+        self._random_split = random_split
+        self._size = len(cloudpickle.dumps(self._dataset))
+
+    def get_read_tasks(self, parallelism):
+        rows = len(self._dataset)
+        subsets = None
+        if self._random_split:
+            subsets = torch.utils.data.random_split(
+                self._dataset, [1 / parallelism] * parallelism
+            )
+        else:
+            rows_per_worker = math.ceil(rows / parallelism)
+            subsets = [
+                torch.utils.data.Subset(
+                    self._dataset,
+                    range(i * rows_per_worker, min((i + 1) * rows_per_worker, rows)),
+                )
+                for i in range(parallelism)
+            ]
+
+        read_tasks = []
+        for i in range(parallelism):
+            num_rows = len(subsets[i])
+            meta = BlockMetadata(
+                num_rows=num_rows,
+                size_bytes=self._size * num_rows / rows,
+                schema=None,
+                input_files=None,
+                exec_stats=None,
+            )
+            read_tasks.append(
+                ReadTask(
+                    lambda subset=subsets[i]: _read_subset(
+                        subset,
+                    ),
+                    metadata=meta,
+                ),
+            )
+
+        return read_tasks
+
+    def estimate_inmemory_data_size(self):
+        return self._size
+
+
+def _read_subset(subset):
+    data_loader = torch.utils.data.DataLoader(
+        # default_collate does not accept `PIL.Image.Image`s
+        subset,
+        collate_fn=lambda x: x,
+        batch_size=5,
+    )
+
+    for batch in data_loader:
+        builder = DelegatingBlockBuilder()
+        builder.add_batch({"item": batch})
+        yield builder.build()

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2286,6 +2286,7 @@ def from_torch(
     dataset: "torch.utils.data.Dataset",
     parallelism: int = -1,
     random_split: bool = False,
+    batch_size: int = 32,
 ) -> MaterializedDataset:
     """Create a :class:`~ray.data.Dataset` from a
     `Torch Dataset <https://pytorch.org/docs/stable/data.html#torch.utils.data.Dataset/>`_.
@@ -2322,6 +2323,7 @@ def from_torch(
         dataset=dataset,
         parallelism=parallelism,
         random_split=random_split,
+        batch_size=batch_size,
     )
 
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2296,7 +2296,10 @@ def from_torch(
         like :meth:`~ray.data.read_images`.
 
     .. note::
-        For iterable-style datasets, This function is not parallelized. It loads the entire dataset into the head
+        This function uses a streaming implementation. The dataset does not need to fit completely into memory.
+
+    .. note::
+        For iterable-style datasets, this function is not parallelized. It loads the entire dataset into the head
         node's memory before moving the data to the distributed object store.
 
     .. note::
@@ -2329,7 +2332,7 @@ def from_torch(
     import torch
 
     # There is no efficient way to read a subset of an iterable-style dataset.
-    # Each task will read all elements up until the last in it's subset.
+    # Each task will read all elements up until the last in its subset.
     if isinstance(dataset, torch.utils.data.IterableDataset):
         parallelism = 1
     return read_datasource(

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2289,7 +2289,8 @@ def from_torch(
     `Torch Dataset <https://pytorch.org/docs/stable/data.html#torch.utils.data.Dataset/>`_.
 
     .. note::
-        The dataset must be serializable.
+        The input dataset can either be map-style or iterable-style, and can have arbitrarily large amount of data.
+        The data will be sequentially streamed with one single read task.
 
     Examples:
         >>> import ray
@@ -2318,6 +2319,7 @@ def from_torch(
     return read_datasource(
         TorchDatasource(),
         dataset=dataset,
+        # Only non-parallel, streaming read is currently supported
         parallelism=1,
         ray_remote_args=ray_remote_args,
     )

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -64,6 +64,7 @@ from ray.data.datasource import (
     SQLDatasource,
     TextDatasource,
     TFRecordDatasource,
+    TorchDatasource,
     WebDatasetDatasource,
 )
 from ray.data.datasource._default_metadata_providers import (
@@ -2283,6 +2284,8 @@ def from_tf(
 @PublicAPI
 def from_torch(
     dataset: "torch.utils.data.Dataset",
+    parallelism: int = -1,
+    random_split: bool = False,
 ) -> MaterializedDataset:
     """Create a :class:`~ray.data.Dataset` from a
     `Torch Dataset <https://pytorch.org/docs/stable/data.html#torch.utils.data.Dataset/>`_.
@@ -2314,7 +2317,12 @@ def from_torch(
     Returns:
         A :class:`MaterializedDataset` containing the Torch dataset samples.
     """  # noqa: E501
-    return from_items(list(dataset))
+    return read_datasource(
+        TorchDatasource(),
+        dataset=dataset,
+        parallelism=parallelism,
+        random_split=random_split,
+    )
 
 
 def _get_reader(

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2286,6 +2286,7 @@ def from_torch(
     dataset: "torch.utils.data.Dataset",
     parallelism: int = -1,
     shuffle: bool = False,
+    batch_size: int = 32,
 ) -> MaterializedDataset:
     """Create a :class:`~ray.data.Dataset` from a
     `Torch Dataset <https://pytorch.org/docs/stable/data.html#torch.utils.data.Dataset/>`_.
@@ -2325,6 +2326,7 @@ def from_torch(
             :ref:`Tuning read parallelism <read_parallelism>`. Parallelism is
             upper bounded by the total number of rows in the Torch dataset.
         shuffle: If True, the dataset will be randomly partitioned for a parallel read. Otherwise, the dataset will be partitioned into contiguous blocks.
+        batch_size: The batch size that each read task will yield.
 
     Returns:
         A :class:`MaterializedDataset` containing the Torch dataset samples.
@@ -2340,6 +2342,7 @@ def from_torch(
         dataset=dataset,
         parallelism=parallelism,
         shuffle=shuffle,
+        batch_size=batch_size,
     )
 
 

--- a/python/ray/data/tests/test.py
+++ b/python/ray/data/tests/test.py
@@ -1,0 +1,7 @@
+import ray
+
+ds = ray.data.range(100, parallelism=100).map_batches(lambda x: x).materialize()
+
+ds.write_parquet("/tmp/test")
+print("stats after", ds.stats())
+print("stats internal", ds._write_ds.stats())

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -1296,10 +1296,11 @@ def test_from_torch_e2e(ray_start_regular_shared, enable_optimizer, tmp_path):
     assert extract_values("item", actual_data) == expected_data
 
     # Check that metadata fetch is included in stats.
-    assert "FromItems" in ray_dataset.stats()
+    assert "ReadTorch" in ray_dataset.stats()
+
     # Underlying implementation uses `FromItems` operator
-    assert ray_dataset._plan._logical_plan.dag.name == "FromItems"
-    _check_usage_record(["FromItems"])
+    assert ray_dataset._plan._logical_plan.dag.name == "ReadTorch"
+    _check_usage_record(["ReadTorch"])
 
 
 @pytest.mark.skip(

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -186,30 +186,10 @@ def test_from_torch(shutdown_only, tmp_path):
     torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
     expected_data = list(torch_dataset)
 
-    ray_dataset = ray.data.from_torch(torch_dataset, parallelism=1)
+    ray_dataset = ray.data.from_torch(torch_dataset)
 
     actual_data = extract_values("item", list(ray_dataset.take_all()))
     assert actual_data == expected_data
-
-
-def test_from_torch_parallel(ray_start_regular_shared, tmp_path):
-    # parallel read may reorder blocks, cannot directly assert equality on outputs
-    torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
-    expected_data = list(torch_dataset)
-
-    ray_dataset = ray.data.from_torch(torch_dataset, use_parallel=True, parallelism=3)
-    actual_data = extract_values("item", list(ray_dataset.take_all()))
-    assert len(actual_data) == len(expected_data)
-    assert Counter([row[1] for row in actual_data]) == Counter(
-        [row[1] for row in expected_data]
-    )
-
-    ray_dataset = ray.data.from_torch(torch_dataset, use_parallel=True, shuffle=True, parallelism=3)
-    actual_data = extract_values("item", list(ray_dataset.take_all()))
-    assert len(actual_data) == len(expected_data)
-    assert Counter([row[1] for row in actual_data]) == Counter(
-        [row[1] for row in expected_data]
-    )
 
 
 class NodeLoggerOutputDatasource(Datasource):

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -197,14 +197,14 @@ def test_from_torch_parallel(ray_start_regular_shared, tmp_path):
     torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
     expected_data = list(torch_dataset)
 
-    ray_dataset = ray.data.from_torch(torch_dataset, parallelism=3)
+    ray_dataset = ray.data.from_torch(torch_dataset, use_parallel=True, parallelism=3)
     actual_data = extract_values("item", list(ray_dataset.take_all()))
     assert len(actual_data) == len(expected_data)
     assert Counter([row[1] for row in actual_data]) == Counter(
         [row[1] for row in expected_data]
     )
 
-    ray_dataset = ray.data.from_torch(torch_dataset, shuffle=True, parallelism=3)
+    ray_dataset = ray.data.from_torch(torch_dataset, use_parallel=True, shuffle=True, parallelism=3)
     actual_data = extract_values("item", list(ray_dataset.take_all()))
     assert len(actual_data) == len(expected_data)
     assert Counter([row[1] for row in actual_data]) == Counter(

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -1,5 +1,4 @@
 import os
-from collections import Counter
 from typing import Iterable, List
 
 import pandas as pd
@@ -187,6 +186,21 @@ def test_from_torch(shutdown_only, tmp_path):
     expected_data = list(torch_dataset)
 
     ray_dataset = ray.data.from_torch(torch_dataset)
+
+    actual_data = extract_values("item", list(ray_dataset.take_all()))
+    assert actual_data == expected_data
+
+    import torch
+
+    class IterMNIST(torch.utils.data.IterableDataset):
+        def __len__(self):
+            return len(torch_dataset)
+
+        def __iter__(self):
+            return iter(torch_dataset)
+
+    iter_torch_dataset = IterMNIST()
+    ray_dataset = ray.data.from_torch(iter_torch_dataset)
 
     actual_data = extract_values("item", list(ray_dataset.take_all()))
     assert actual_data == expected_data

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -197,14 +197,14 @@ def test_from_torch_parallel(ray_start_regular_shared, tmp_path):
     torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
     expected_data = list(torch_dataset)
 
-    ray_dataset = ray.data.from_torch(torch_dataset)
+    ray_dataset = ray.data.from_torch(torch_dataset, parallelism=3)
     actual_data = extract_values("item", list(ray_dataset.take_all()))
     assert len(actual_data) == len(expected_data)
     assert Counter([row[1] for row in actual_data]) == Counter(
         [row[1] for row in expected_data]
     )
 
-    ray_dataset = ray.data.from_torch(torch_dataset, shuffle=True)
+    ray_dataset = ray.data.from_torch(torch_dataset, shuffle=True, parallelism=3)
     actual_data = extract_values("item", list(ray_dataset.take_all()))
     assert len(actual_data) == len(expected_data)
     assert Counter([row[1] for row in actual_data]) == Counter(

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -192,7 +192,7 @@ def test_from_torch(shutdown_only, tmp_path):
     assert actual_data == expected_data
 
 
-def test_from_torch_parallel(shutdown_only, tmp_path):
+def test_from_torch_parallel(ray_start_regular_shared, tmp_path):
     # parallel read may reorder blocks, cannot directly assert equality on outputs
     torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
     expected_data = list(torch_dataset)
@@ -203,11 +203,6 @@ def test_from_torch_parallel(shutdown_only, tmp_path):
     assert Counter([row[1] for row in actual_data]) == Counter(
         [row[1] for row in expected_data]
     )
-
-
-def test_from_torch_parallel_shuffle(shutdown_only, tmp_path):
-    torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
-    expected_data = list(torch_dataset)
 
     ray_dataset = ray.data.from_torch(torch_dataset, shuffle=True)
     actual_data = extract_values("item", list(ray_dataset.take_all()))

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -192,7 +192,7 @@ def test_from_torch(shutdown_only, tmp_path):
     assert actual_data == expected_data
 
 
-def test_from_torch_parallel(ray_start_regular_shared, tmp_path):
+def test_from_torch_parallel(shutdown_only, tmp_path):
     # parallel read may reorder blocks, cannot directly assert equality on outputs
     torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
     expected_data = list(torch_dataset)
@@ -203,6 +203,11 @@ def test_from_torch_parallel(ray_start_regular_shared, tmp_path):
     assert Counter([row[1] for row in actual_data]) == Counter(
         [row[1] for row in expected_data]
     )
+
+
+def test_from_torch_parallel_shuffle(shutdown_only, tmp_path):
+    torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
+    expected_data = list(torch_dataset)
 
     ray_dataset = ray.data.from_torch(torch_dataset, shuffle=True)
     actual_data = extract_values("item", list(ray_dataset.take_all()))

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -192,7 +192,7 @@ def test_from_torch(shutdown_only, tmp_path):
     assert actual_data == expected_data
 
 
-def test_from_torch_parallel(shutdown_only, tmp_path):
+def test_from_torch_parallel(ray_start_regular_shared, tmp_path):
     # parallel read may reorder blocks, cannot directly assert equality on outputs
     torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
     expected_data = list(torch_dataset)

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -197,14 +197,14 @@ def test_from_torch_parallel(shutdown_only, tmp_path):
     torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
     expected_data = list(torch_dataset)
 
-    ray_dataset = ray.data.from_torch(torch_dataset, parallelism=3)
+    ray_dataset = ray.data.from_torch(torch_dataset)
     actual_data = extract_values("item", list(ray_dataset.take_all()))
     assert len(actual_data) == len(expected_data)
     assert Counter([row[1] for row in actual_data]) == Counter(
         [row[1] for row in expected_data]
     )
 
-    ray_dataset = ray.data.from_torch(torch_dataset, parallelism=3, random_split=True)
+    ray_dataset = ray.data.from_torch(torch_dataset, shuffle=True)
     actual_data = extract_values("item", list(ray_dataset.take_all()))
     assert len(actual_data) == len(expected_data)
     assert Counter([row[1] for row in actual_data]) == Counter(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Provides a parallel and streaming implementation for the `from_torch` read api.

In this PR, we set `parallelism=1`, so we only utilize the streaming portion of this api.

Not included in this PR:
- Parallel read across multiple nodes
- Blocks may be reordered because of parallel read tasks. Add option to preserve order. Not an issue here because we use `parallelism=1`.
- Block metadata, there is no good way of getting the size/schema of a torch dataset. We cannot autodetect parallelism well. Also not a problem for now because of `parallelism=1`

## Benchmarks  (For parallel read implementation, not streaming)

### S3 Images
Image data tak`s3://air-example-data-2/20G-image-data-synthetic-raw/` was read with `parallelism=-1` and iterated over with `iter_torch_batches` on `32vCPU`, `128GiB` nodes.

**6 nodes**
time: ~180s
cpu usage: peak ~56 cores
<img width="539" alt="Screenshot 2023-09-22 at 12 26 58 PM" src="https://github.com/ray-project/ray/assets/39287272/8177b770-6258-442b-a32d-f674e54400c1">

**1 node**
time: ~240s
cpu usage: peak ~27 cores
<img width="553" alt="Screenshot 2023-09-22 at 12 27 20 PM" src="https://github.com/ray-project/ray/assets/39287272/b4817506-4758-43cf-93c5-5fc4de7539de">

Speed up between cases: ~1.33x

The bottleneck here is while deserializing the images afterwards on the driver. Parallelism does not help with this.
<img width="1725" alt="Screenshot 2023-09-25 at 3 58 45 PM" src="https://github.com/ray-project/ray/assets/39287272/a0d85ba7-785c-4858-b1e8-027d60a18221">

### Fake Data
We can generate fake data roughly the same size as the S3 images using `torch.randint(...)` and spinning for some time `for i in range(1e7)` to emulate the scenario above but without the need to deserialize the images.

**6 nodes**
time: ~100s
cpu usage: peak ~170 cores

**1 node**
time: ~550s
cpu usage: peak ~27 cores

Speed up between cases: ~5.5x

## Related issue number

<!-- For example: "Closes #1234" -->

Closes torch read #39287

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
