### PR TITLE
[core] loosen the check on release object (#39570)

### DIFF
--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -278,9 +278,10 @@ int PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
 void PlasmaStore::ReleaseObject(const ObjectID &object_id,
                                 const std::shared_ptr<Client> &client) {
   auto entry = object_lifecycle_mgr_.GetObject(object_id);
-  RAY_CHECK(entry != nullptr);
-  // Remove the client from the object's array of clients.
-  RAY_CHECK(RemoveFromClientObjectIds(object_id, client) == 1);
+  if (entry != nullptr) {
+    // Remove the client from the object's array of clients.
+    RemoveFromClientObjectIds(object_id, client);
+  }
 }
 
 void PlasmaStore::SealObjects(const std::vector<ObjectID> &object_ids) {

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -175,6 +175,7 @@ class PlasmaStore {
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Record the fact that a particular client is no longer using an object.
+  /// This function is idempotent thus can be called multiple times.
   ///
   /// \param object_id The object ID of the object that is being released.
   /// \param client The client making this request.


### PR DESCRIPTION
This check is probably too strict, as the same client might call release object multiple times. This is a benign behavior and we shouldn't crash.

Cherry-pick to fix user issues.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
