### PR TITLE
[ci][core][cluster] Capture outputs for ray up/down commands to understand why it failed

### DIFF
--- a/python/ray/autoscaler/launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/launch_and_verify_cluster.py
@@ -169,7 +169,11 @@ def cleanup_cluster(cluster_config):
     """
     print("======================================")
     print("Cleaning up cluster...")
-    subprocess.run(["ray", "down", "-v", "-y", str(cluster_config)], check=True)
+    subprocess.run(
+        ["ray", "down", "-v", "-y", str(cluster_config)],
+        check=True,
+        capture_output=True,
+    )
 
 
 def run_ray_commands(cluster_config, retries, no_config_cache, num_expected_nodes=1):
@@ -192,7 +196,7 @@ def run_ray_commands(cluster_config, retries, no_config_cache, num_expected_node
     if no_config_cache:
         cmd.append("--no-config-cache")
     cmd.append(str(cluster_config))
-    subprocess.run(cmd, check=True)
+    subprocess.run(cmd, check=True, capture_output=True)
 
     print("======================================")
     print("Verifying Ray is running...")

--- a/python/ray/autoscaler/launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/launch_and_verify_cluster.py
@@ -169,11 +169,15 @@ def cleanup_cluster(cluster_config):
     """
     print("======================================")
     print("Cleaning up cluster...")
-    subprocess.run(
-        ["ray", "down", "-v", "-y", str(cluster_config)],
-        check=True,
-        capture_output=True,
-    )
+    try:
+        subprocess.run(
+            ["ray", "down", "-v", "-y", str(cluster_config)],
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        raise e
 
 
 def run_ray_commands(cluster_config, retries, no_config_cache, num_expected_nodes=1):
@@ -196,7 +200,12 @@ def run_ray_commands(cluster_config, retries, no_config_cache, num_expected_node
     if no_config_cache:
         cmd.append("--no-config-cache")
     cmd.append(str(cluster_config))
-    subprocess.run(cmd, check=True, capture_output=True)
+
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        raise e
 
     print("======================================")
     print("Verifying Ray is running...")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There's currently no easy way of figuring out why ray/up/ down fails in the cluster launcher test script. 

Capturing output of the subprocess to allow debugging. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
