### PR TITLE
[Data] Make empty block returned by BlocksToBatchesMapTransformFn in …

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -281,7 +281,9 @@ class BlocksToBatchesMapTransformFn(MapTransformFn):
         if first is None:
             # If the input blocks are all empty, then yield an empty block with same
             # format as the input blocks.
-            return [empty_block]
+            return [
+                BlockAccessor.for_block(empty_block).to_batch_format(self._batch_format)
+            ]
         else:
             return itertools.chain([first], formatted_batch_iter)
 


### PR DESCRIPTION
…the given format

BlocksToBatchesMapTransformFn's __call__ method either returns a list of one empty block or a batch blocks with given format. Prior to this PR, when it returns an empty block, it always returns a pyarrow.Table rather than `batch_format` specified by user. This PR fixes this so this method now always returns blocks in the given format.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Prior to this PR, if all input blocks are all empty, BlocksToBatchesMapTransformFn will create an empty block with the same format as the first block. However, user may specify a specific batch_format, whereas the returned empty block isn't converted to that format.

This causes problems such as #39206. Later in this function
```
    @staticmethod
    def reduce(
        key: Optional[str],
        aggs: List[AggregateFn],
        *mapper_outputs: List[Block],
        partial_reduce: bool = False,
    ) -> Tuple[Block, BlockMetadata]:
        return BlockAccessor.for_block(mapper_outputs[0]).aggregate_combined_blocks(
            list(mapper_outputs), key, aggs, finalize=not partial_reduce
        )
```
It will determine type of blocks only using the first block. However, as due to the issue mentioned above, the input could contain both pyarrow.Table object (empty block generated) and pandas.DataFrame object (non-empty blocks), which triggers the error shown in that issue.

We should also convert the empty block to the specified format, so all blocks are in the same format.


## Related issue number

Closes #39206 
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
