### PR TITLE
[Data] Fall back to fetch files info in parallel for multiple directories 

### DIFF
--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -418,12 +418,6 @@ def _expand_paths(
             )
         # 3. Parallelization case.
         else:
-            logger.warning(
-                f"Expanding {len(paths)} path(s). This may be a HIGH LATENCY "
-                f"operation on some cloud storage services. Moving all the "
-                "paths to a common parent directory will lead to faster "
-                "metadata fetching."
-            )
             # Parallelize requests via Ray tasks.
             yield from _get_file_infos_parallel(paths, filesystem, ignore_missing_paths)
 
@@ -449,13 +443,30 @@ def _get_file_infos_common_path_prefix(
     ):
         if path in path_to_size:
             path_to_size[path] = file_size
-    # Iterate over `paths` to yield each path in original order.
-    # NOTE: do not iterate over `path_to_size` because the dictionary skips duplicated
-    # path, while `paths` might contain duplicated path if one wants to read same file
-    # multiple times.
+
+    # Check if all `paths` have file size metadata.
+    # If any of paths has no file size, fall back to get files metadata in parallel.
+    # This can happen when path is a directory, but not a file.
+    have_missing_path = False
     for path in paths:
-        assert path in path_to_size
-        yield path, path_to_size[path]
+        if path not in path_to_size:
+            logger.debug(
+                f"Finding path {path} not have file size metadata. "
+                "Fall back to get files metadata in parallel for all paths."
+            )
+            have_missing_path = True
+            break
+
+    if have_missing_path:
+        # Parallelize requests via Ray tasks.
+        yield from _get_file_infos_parallel(paths, filesystem, ignore_missing_paths)
+    else:
+        # Iterate over `paths` to yield each path in original order.
+        # NOTE: do not iterate over `path_to_size` because the dictionary skips
+        # duplicated path, while `paths` might contain duplicated path if one wants
+        # to read same file multiple times.
+        for path in paths:
+            yield path, path_to_size[path]
 
 
 def _get_file_infos_parallel(
@@ -468,6 +479,13 @@ def _get_file_infos_parallel(
         _fetch_metadata_parallel,
         _unwrap_s3_serialization_workaround,
         _wrap_s3_serialization_workaround,
+    )
+
+    logger.warning(
+        f"Expanding {len(paths)} path(s). This may be a HIGH LATENCY "
+        f"operation on some cloud storage services. Moving all the "
+        "paths to a common parent directory will lead to faster "
+        "metadata fetching."
     )
 
     # Capture the filesystem in the fetcher func closure, but wrap it in our

--- a/python/ray/data/tests/test_metadata_provider.py
+++ b/python/ray/data/tests/test_metadata_provider.py
@@ -423,17 +423,13 @@ def test_default_file_metadata_provider_many_files_diff_dirs(
     assert file_sizes == expected_file_sizes
 
     # Many directories should not trigger error.
-    dir_paths = [dir1, dir2] * num_dfs
-    with caplog.at_level(logging.WARNING), patcher as mock_get:
-        file_paths, file_sizes = map(
-            list, zip(*meta_provider.expand_paths(dir_paths, fs))
-        )
-
-    assert len(file_paths) == len(paths) * num_dfs
-    for i in range(num_dfs):
-        start_idx = max(0, (i - 1) * len(paths))
-        end_idx = start_idx + len(paths)
-        assert file_paths[start_idx:end_idx] == paths
+    if isinstance(fs, LocalFileSystem):
+        dir_paths = [dir1, dir2] * num_dfs
+        with caplog.at_level(logging.WARNING), patcher as mock_get:
+            file_paths, file_sizes = map(
+                list, zip(*meta_provider.expand_paths(dir_paths, fs))
+            )
+        assert len(file_paths) == len(paths) * num_dfs
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_metadata_provider.py
+++ b/python/ray/data/tests/test_metadata_provider.py
@@ -422,6 +422,19 @@ def test_default_file_metadata_provider_many_files_diff_dirs(
     expected_file_sizes = _get_file_sizes_bytes(paths, fs)
     assert file_sizes == expected_file_sizes
 
+    # Many directories should not trigger error.
+    dir_paths = [dir1, dir2] * num_dfs
+    with caplog.at_level(logging.WARNING), patcher as mock_get:
+        file_paths, file_sizes = map(
+            list, zip(*meta_provider.expand_paths(dir_paths, fs))
+        )
+
+    assert len(file_paths) == len(paths) * num_dfs
+    for i in range(num_dfs):
+        start_idx = max(0, (i - 1) * len(paths))
+        end_idx = start_idx + len(paths)
+        assert file_paths[start_idx:end_idx] == paths
+
 
 @pytest.mark.parametrize(
     "fs,data_path,endpoint_url",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
We have a bug in fetching files information/metadata in https://github.com/ray-project/ray/blob/master/python/ray/data/datasource/file_meta_provider.py#L446-L451 , where it assumes all input paths are file paths. For directory paths, it will be omitted and later exception would be thrown. We found this bug during benchmark work.

This PR will fix this issue by falling back to fetch files info in parallel, if there's any directory path.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
