### PR TITLE
[ci] use pinned and compiled dependencies to run the release test runner

### DIFF
--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -50,9 +50,8 @@ if [ -n "${RAY_COMMIT_OF_WHEEL-}" ]; then
 fi
 
 if [ -z "${NO_INSTALL}" ]; then
-  pip install --use-deprecated=legacy-resolver -q -r requirements.txt
-  pip install -q -U boto3 botocore bazel-runfiles
-  pip install --use-deprecated=legacy-resolver -c requirements.txt -e .
+  pip install -r ./requirements_buildkite.txt
+  pip install --no-deps -e .
 fi
 
 RETRY_NUM=0

--- a/release/setup.py
+++ b/release/setup.py
@@ -12,5 +12,22 @@ setup(
     author="Ray Team",
     description="The Ray OSS release testing package",
     url="https://github.com/ray-project/ray",
-    install_requires=["ray>=1.9", "click", "anyscale", "boto3", "freezegun", "retry"],
+    install_requires=[
+        # Keep this in sync with requirements_buildkite.in
+        "anyscale",
+        "bazel-runfiles",
+        "boto3",
+        "click",
+        "freezegun",
+        "google-cloud-storage",
+        "jinja2",
+        "protobuf",
+        "pydantic",
+        "pytest",
+        "pyyaml",
+        "pybuildkite",
+        "PyGithub",
+        "requests",
+        "retry",
+    ],
 )


### PR DESCRIPTION
don't install other misc, unrelated deps.