### PR TITLE
[civ2][doc/1] add container.run_script function

### DIFF
--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 from typing import List, Optional
 
@@ -32,11 +33,21 @@ class Container:
         self.docker_tag = docker_tag
         self.volumes = volumes or []
 
-    def run_script(self, script: List[str]) -> bytes:
+    def run_script_with_output(self, script: List[str]) -> bytes:
+        """
+        Run a script in container and returns output
+        """
+        return subprocess.check_output(self._get_run_command(script))
+
+    def run_script(self, script: List[str]) -> None:
         """
         Run a script in container
         """
-        return subprocess.check_output(self._get_run_command(script))
+        return subprocess.check_call(
+            self._get_run_command(script),
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
 
     def _get_run_command(self, script: List[str]) -> List[str]:
         command = [

--- a/ci/ray_ci/test_docker_container.py
+++ b/ci/ray_ci/test_docker_container.py
@@ -9,7 +9,7 @@ from ci.ray_ci.test_base import RayCITestBase
 
 class TestDockerContainer(RayCITestBase):
     def test_run(self) -> None:
-        def _mock_check_output(input: List[str]) -> None:
+        def _mock_check_call(input: List[str], stdout, stderr) -> None:
             input_str = " ".join(input)
             assert "ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl" in input_str
             assert "rayproject/citemp:123-raypy38cu118base" in input_str
@@ -18,7 +18,7 @@ class TestDockerContainer(RayCITestBase):
 
         with mock.patch(
             "ci.ray_ci.docker_container.docker_pull", return_value=None
-        ), mock.patch("subprocess.check_output", side_effect=_mock_check_output):
+        ), mock.patch("subprocess.check_call", side_effect=_mock_check_call):
             container = DockerContainer("py38")
             container.run()
 

--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -40,7 +40,7 @@ def test_run_script_in_docker() -> None:
 
     with mock.patch("subprocess.check_output", side_effect=_mock_check_output):
         container = TesterContainer("team")
-        container.run_script(["run command"])
+        container.run_script_with_output(["run command"])
 
 
 def test_run_tests() -> None:

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -140,7 +140,7 @@ def _get_all_test_targets(
     """
 
     test_targets = (
-        container.run_script(
+        container.run_script_with_output(
             [
                 f'bazel query "{_get_all_test_query(targets, team, except_tags)}"',
             ]


### PR DESCRIPTION
Rename existing container.run_script function to container.run_script_with_output. Add container.run_script function that streams output to stdout. This is useful to print debugging information from script to buildkite.

Test:
- CI