### PR TITLE
[civ2][doc/2] move install_ray into container parent class

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -8,7 +8,7 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --except-tags debug_tests,asan_tests,post_wheel_build,xcommit
     depends_on: corebuild
-    job_env: corebuild
+    job_env: forge
 
   - label: ":ray: core: redis tests"
     instance_type: large
@@ -27,4 +27,4 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //... core --run-flaky-tests --parallelism-per-worker 3
     depends_on: corebuild
-    job_env: corebuild
+    job_env: forge

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -11,7 +11,7 @@ steps:
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
         --except-tags data_integration,doctest
     depends_on: data6build
-    job_env: data6build
+    job_env: forge
 
   - label: ":database: data: arrow 12 tests"
     instance_type: medium
@@ -24,7 +24,7 @@ steps:
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
         --except-tags data_integration,doctest
     depends_on: data12build
-    job_env: data12build
+    job_env: forge
 
   - label: ":database: data: arrow nightly tests"
     instance_type: medium
@@ -37,7 +37,7 @@ steps:
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
         --except-tags data_integration,doctest
     depends_on: datanbuild
-    job_env: datanbuild
+    job_env: forge
 
   - label: ":database: data: bulk executor tests"
     instance_type: medium
@@ -50,7 +50,7 @@ steps:
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
         --except-tags data_integration,doctest
     depends_on: databbuild
-    job_env: databbuild
+    job_env: forge
 
   - label: ":database: data: flaky tests"
     instance_type: medium
@@ -60,4 +60,4 @@ steps:
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1 --parallelism-per-worker 3
         --build-name data12build
     depends_on: data12build
-    job_env: data12build
+    job_env: forge

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -5,7 +5,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serve --except-tags worker-container
     depends_on: servebuild
-    job_env: servebuild
+    job_env: forge
 
   - label: ":ray-serve: serve: serve tests"
     parallelism: 3
@@ -14,7 +14,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve --except-tags post_wheel_build,gpu,xcommit
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
     depends_on: servebuild
-    job_env: servebuild
+    job_env: forge
 
   - label: ":ray-serve: serve: serve tests (streaming ff off)"
     parallelism: 3
@@ -24,7 +24,7 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --test-env=RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=0
     depends_on: servebuild
-    job_env: servebuild
+    job_env: forge
 
   - label: ":ray-serve: serve: serve tests (streaming and routing ff off)"
     parallelism: 3
@@ -35,7 +35,7 @@ steps:
         --test-env=RAY_SERVE_ENABLE_NEW_ROUTING=0
         --test-env=RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=0
     depends_on: servebuild
-    job_env: servebuild
+    job_env: forge
 
   - label: ":ray-serve: serve: flaky tests"
     instance_type: medium
@@ -43,4 +43,4 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //... serve --run-flaky-tests --parallelism-per-worker 3
     depends_on: servebuild
-    job_env: servebuild
+    job_env: forge

--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -8,7 +8,7 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --except-tags manual,kuberay_operator,spark_plugin_tests
     depends_on: serverlessbuild
-    job_env: serverlessbuild
+    job_env: forge
 
   - label: ":serverless: serverless: flaky tests"
     instance_type: medium
@@ -16,4 +16,4 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //... serverless --run-flaky-tests  --parallelism-per-worker 3
     depends_on: serverlessbuild
-    job_env: serverlessbuild
+    job_env: forge

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -49,6 +49,27 @@ class Container:
             stderr=sys.stderr,
         )
 
+    def install_ray(self) -> None:
+        env = os.environ.copy()
+        env["DOCKER_BUILDKIT"] = "1"
+        subprocess.check_call(
+            [
+                "docker",
+                "build",
+                "--pull",
+                "--build-arg",
+                f"BASE_IMAGE={self._get_docker_image()}",
+                "-t",
+                self._get_docker_image(),
+                "-f",
+                "/ray/ci/ray_ci/tests.env.Dockerfile",
+                "/ray",
+            ],
+            env=env,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+
     def _get_run_command(self, script: List[str]) -> List[str]:
         command = [
             "docker",

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -38,6 +38,9 @@ def test_get_test_targets() -> None:
         ), mock.patch(
             "subprocess.check_output",
             return_value="\n".join(test_targets).encode("utf-8"),
+        ), mock.patch(
+            "ci.ray_ci.tester_container.TesterContainer.install_ray",
+            return_value=None,
         ):
             assert _get_all_test_targets(
                 TesterContainer("core"),

--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -28,7 +28,10 @@ def test_run_tests_in_docker() -> None:
             "--test_env v=k t1 t2" in input_str
         )
 
-    with mock.patch("subprocess.Popen", side_effect=_mock_popen):
+    with mock.patch("subprocess.Popen", side_effect=_mock_popen), mock.patch(
+        "ci.ray_ci.tester_container.TesterContainer.install_ray",
+        return_value=None,
+    ):
         container = TesterContainer("team")
         container._run_tests_in_docker(["t1", "t2"], ["v=k"])
 
@@ -38,7 +41,12 @@ def test_run_script_in_docker() -> None:
         input_str = " ".join(input)
         assert "/bin/bash -iecuo pipefail -- run command" in input_str
 
-    with mock.patch("subprocess.check_output", side_effect=_mock_check_output):
+    with mock.patch(
+        "subprocess.check_output", side_effect=_mock_check_output
+    ), mock.patch(
+        "ci.ray_ci.tester_container.TesterContainer.install_ray",
+        return_value=None,
+    ):
         container = TesterContainer("team")
         container.run_script_with_output(["run command"])
 
@@ -58,6 +66,9 @@ def test_run_tests() -> None:
         side_effect=_mock_run_tests_in_docker,
     ), mock.patch(
         "ci.ray_ci.tester_container.shard_tests", side_effect=_mock_shard_tests
+    ), mock.patch(
+        "ci.ray_ci.tester_container.TesterContainer.install_ray",
+        return_value=None,
     ):
         container = TesterContainer("team")
         # test_targets are not empty

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -5,8 +5,9 @@ from typing import List, Optional
 import yaml
 import click
 
+from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.tester_container import TesterContainer
-from ci.ray_ci.utils import shard_tests
+from ci.ray_ci.utils import shard_tests, docker_login
 
 # Gets the path of product/tools/docker (i.e. the parent of 'common')
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
@@ -71,11 +72,11 @@ def main(
     if not bazel_workspace_dir:
         raise Exception("Please use `bazelisk run //ci/ray_ci`")
     os.chdir(bazel_workspace_dir)
+    docker_login(_DOCKER_ECR_REPO.split("/")[0])
 
     if not build_name:
         build_name = f"{team}build"
     container = TesterContainer(build_name)
-    container.setup_test_environment()
     if run_flaky_tests:
         test_targets = _get_flaky_test_targets(team)
     else:

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import sys
 from typing import List
 
 from ci.ray_ci.utils import shard_tests
@@ -12,6 +11,10 @@ class TesterContainer(Container):
     """
     A wrapper for running tests in ray ci docker container
     """
+
+    def __init__(self, docker_tag: str) -> None:
+        super().__init__(docker_tag)
+        self.install_ray()
 
     def run_tests(
         self,
@@ -28,29 +31,6 @@ class TesterContainer(Container):
         ]
         exits = [run.wait() for run in runs]
         return all(exit == 0 for exit in exits)
-
-    def setup_test_environment(self) -> None:
-        """
-        Build the docker image for running tests
-        """
-        env = os.environ.copy()
-        env["DOCKER_BUILDKIT"] = "1"
-        subprocess.check_call(
-            [
-                "docker",
-                "build",
-                "--build-arg",
-                f"BASE_IMAGE={self._get_docker_image()}",
-                "-t",
-                self._get_docker_image(),
-                "-f",
-                "/ray/ci/ray_ci/tests.env.Dockerfile",
-                "/ray",
-            ],
-            env=env,
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-        )
 
     def _run_tests_in_docker(
         self,


### PR DESCRIPTION
Currently the tester_container install ray into itself before running test. Move this capability to the container parent class. doc also requires this ability

Test:
- CI