### PR TITLE
[docs] Update KubeRay Ingress Docs

### DIFF
--- a/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
@@ -8,6 +8,13 @@ Three examples show how to use ingress to access your Ray cluster:
   * [GKE Ingress support](kuberay-gke-ingress)
   * [Manually setting up NGINX Ingress on Kind](kuberay-nginx)
 
+
+```{admonition} Warning
+:class: warning
+**Only expose Ingresses to authorized users.** The Ray Dashboard provides read and write access to the Ray Cluster. Anyone with access to this Ingress can execute arbitrary code on the Ray Cluster.
+```
+
+
 (kuberay-aws-alb)=
 ## AWS Application Load Balancer (ALB) Ingress support on AWS EKS
 
@@ -54,7 +61,7 @@ kubectl describe ingress ray-cluster-ingress
 #  ----        ----  --------
 #  *
 #              /   ray-cluster-kuberay-head-svc:8265 (192.168.185.157:8265)
-# Annotations: alb.ingress.kubernetes.io/scheme: internet-facing
+# Annotations: alb.ingress.kubernetes.io/scheme: internal
 #              alb.ingress.kubernetes.io/subnets: ${SUBNET_1},${SUBNET_2}
 #              alb.ingress.kubernetes.io/tags: Environment=dev,Team=test
 #              alb.ingress.kubernetes.io/target-type: ip
@@ -82,6 +89,8 @@ kubectl delete ingress ray-cluster-ingress
 
 * Create a GKE cluster and ensure that you have the kubectl tool installed and authenticated to communicate with your GKE cluster.  See [this tutorial](kuberay-gke-gpu-cluster-setup) for an example of how to create a GKE cluster with GPUs.  (GPUs are not necessary for this section.)
 
+* If you are using a `gce-internal` ingress, create a [Proxy-Only subnet](https://cloud.google.com/load-balancing/docs/proxy-only-subnets#proxy_only_subnet_create) in the same region as your GKE cluster.
+
 * It may be helpful to understand the concepts at <https://cloud.google.com/kubernetes-engine/docs/concepts/ingress>.
 
 ### Instructions
@@ -93,7 +102,7 @@ kind: Ingress
 metadata:
   name: ray-cluster-ingress
   annotations:
-    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.class: "gce-internal"
 spec:
   rules:
     - http:


### PR DESCRIPTION
## Why are these changes needed?
* Incorporates changes made in https://github.com/ray-project/kuberay/pull/1413 about ensuring that Ingresses are not publicly exposed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
