### PR TITLE
[RLlib] Fix MB MPO

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -596,16 +596,18 @@ py_test(
     args = ["--dir=tuned_examples/maddpg", "--framework=tf"]
 )
 
+# Working, but takes a long time to learn (>15min).
+# Removed due to Higher API conflicts with Pytorch-Import tests
 ## MB-MPO
-py_test(
-    name = "learning_tests_pendulum_mbmpo",
-    main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
-    size = "large",
-    srcs = ["tests/run_regression_tests.py"],
-    data = ["tuned_examples/mbmpo/pendulum-mbmpo.yaml"],
-    args = ["--dir=tuned_examples/mbmpo"]
-)
+#py_test(
+#    name = "learning_tests_pendulum_mbmpo",
+#    main = "tests/run_regression_tests.py",
+#    tags = ["team:rllib", "exclusive", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+#    size = "large",
+#    srcs = ["tests/run_regression_tests.py"],
+#    data = ["tuned_examples/mbmpo/pendulum-mbmpo.yaml"],
+#    args = ["--dir=tuned_examples/mbmpo"]
+#)
 
 # PG
 py_test(

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -596,18 +596,16 @@ py_test(
     args = ["--dir=tuned_examples/maddpg", "--framework=tf"]
 )
 
-# Working, but takes a long time to learn (>15min).
-# Removed due to Higher API conflicts with Pytorch-Import tests
 ## MB-MPO
-#py_test(
-#    name = "learning_tests_pendulum_mbmpo",
-#    main = "tests/run_regression_tests.py",
-#    tags = ["team:rllib", "exclusive", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
-#    size = "large",
-#    srcs = ["tests/run_regression_tests.py"],
-#    data = ["tuned_examples/mbmpo/pendulum-mbmpo.yaml"],
-#    args = ["--dir=tuned_examples/mbmpo"]
-#)
+py_test(
+    name = "learning_tests_pendulum_mbmpo",
+    main = "tests/run_regression_tests.py",
+    tags = ["team:rllib", "exclusive", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+    size = "large",
+    srcs = ["tests/run_regression_tests.py"],
+    data = ["tuned_examples/mbmpo/pendulum-mbmpo.yaml"],
+    args = ["--dir=tuned_examples/mbmpo"]
+)
 
 # PG
 py_test(

--- a/rllib/examples/env/mbmpo_env.py
+++ b/rllib/examples/env/mbmpo_env.py
@@ -1,5 +1,5 @@
-from gymnasium.envs.classic_control import PendulumEnv, CartPoleEnv
 import numpy as np
+import gymnasium as gym
 
 # MuJoCo may not be installed.
 HalfCheetahEnv = HopperEnv = None
@@ -10,12 +10,20 @@ except Exception:
     pass
 
 
-class CartPoleWrapper(CartPoleEnv):
+class CartPoleWrapper(gym.Wrapper):
     """Wrapper for the CartPole-v1 environment.
 
     Adds an additional `reward` method for some model-based RL algos (e.g.
     MB-MPO).
     """
+
+    # This is required by MB-MPO's model vector env so that it knows how many
+    # steps to simulate the env for.
+    _max_episode_steps = 500
+
+    def __init__(self, **kwargs):
+        env = gym.make("CartPole-v1", **kwargs)
+        gym.Wrapper.__init__(self, env)
 
     def reward(self, obs, action, obs_next):
         # obs = batch * [pos, vel, angle, rotation_rate]
@@ -34,12 +42,20 @@ class CartPoleWrapper(CartPoleEnv):
         return rew
 
 
-class PendulumWrapper(PendulumEnv):
+class PendulumWrapper(gym.Wrapper):
     """Wrapper for the Pendulum-v1 environment.
 
     Adds an additional `reward` method for some model-based RL algos (e.g.
     MB-MPO).
     """
+
+    # This is required by MB-MPO's model vector env so that it knows how many
+    # steps to simulate the env for.
+    _max_episode_steps = 200
+
+    def __init__(self, **kwargs):
+        env = gym.make("Pendulum-v1", **kwargs)
+        gym.Wrapper.__init__(self, env)
 
     def reward(self, obs, action, obs_next):
         # obs = [cos(theta), sin(theta), dtheta/dt]
@@ -85,6 +101,10 @@ class HopperWrapper(HopperEnv or object):
     Adds an additional `reward` method for some model-based RL algos (e.g.
     MB-MPO).
     """
+
+    # This is required by MB-MPO's model vector env so that it knows how many
+    # steps to simulate the env for.
+    _max_episode_steps = 1000
 
     def reward(self, obs, action, obs_next):
         alive_bonus = 1.0


### PR DESCRIPTION
## Why are these changes needed?

https://github.com/ray-project/ray/issues/38321 raises the issue that the MB MPO example does not work.
This PR fixes multiple issues within MBMPO that have gone undedected in the past:

- When initializing the loss, we use a batch size of 32, which is incompatible with the MAML loss function.
- Since gymnasium has changed with time, the bare Pendulum and CartPole envs that we are wrapping don't have any logic that truncates or terminates by default. Only when you create them with gym.make(...), wrappers are added accordingly. Therefore, our old technique of wrapping causes MBMPO to collect endlessly initially.
- Later, when MBMPO uses a dynamics model to predict future observations, the dynamics model also lacks a truncation or termination mechanism. This PR also adds this to the envs. I'm not sure how this was done in the past.