### PR TITLE
[tune] Raise an error if `Tuner.restore()` is called on an instance

### DIFF
--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -517,6 +517,21 @@ def test_invalid_param_space(shutdown_only):
     tune.run(trainable, config=CustomConfig())
 
 
+def test_tuner_restore_classmethod():
+    tuner = Tuner("PPO")
+
+    # Calling `tuner.restore()` on an instance should raise an AttributeError
+    with pytest.raises(AttributeError):
+        tuner.restore("/", "PPO")
+
+    # Calling `Tuner.restore()` on the class should work. This will throw a
+    # FileNotFoundError because no checkpoint exists at that location. Since
+    # this happens in the downstream restoration code, this means that the
+    # classmethod check successfully passed.
+    with pytest.raises(FileNotFoundError):
+        tuner = Tuner.restore("/invalid", "PPO")
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -432,3 +432,12 @@ class Tuner:
                 string_queue,
             )
             return ray.get(get_results_future)
+
+    def __getattribute__(self, item):
+        if item == "restore":
+            raise AttributeError(
+                "`Tuner.restore()` is a classmethod and cannot be called on an "
+                "instance. Use `tuner = Tuner.restore(...)` to instantiate the "
+                "Tuner instead."
+            )
+        return super().__getattribute__(item)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`Tuner.restore()` is used to construct a `Tuner` object from an existing experiment. However, calling `tuner = Tuner(...); tuner.restore()` is a common misuse of the API and does not throw an error.

This PR updates the `Tuner` class to only allow `restore()` to be called on the class, not on an instance of the class.

## Related issue number

Closes #39674

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
