### PR TITLE
[data] Record dataset spill stats for map_batches

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -563,6 +563,8 @@ cdef CObjectLocationPtrToDict(CObjectLocation* c_object_location):
             The hex IDs of the nodes that have a copy of this object.
         - object_size:
             The size of data + metadata in bytes.
+        - times_spilled:
+            The number of times this object was spilled.
     """
     object_size = c_object_location.GetObjectSize()
     times_spilled = c_object_location.GetTimesSpilled()

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -565,6 +565,7 @@ cdef CObjectLocationPtrToDict(CObjectLocation* c_object_location):
             The size of data + metadata in bytes.
     """
     object_size = c_object_location.GetObjectSize()
+    times_spilled = c_object_location.GetTimesSpilled()
 
     node_ids = set()
     c_node_ids = c_object_location.GetNodeIDs()
@@ -585,6 +586,7 @@ cdef CObjectLocationPtrToDict(CObjectLocation* c_object_location):
     return {
         "node_ids": list(node_ids),
         "object_size": object_size,
+        "times_spilled": times_spilled,
     }
 
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -563,11 +563,11 @@ cdef CObjectLocationPtrToDict(CObjectLocation* c_object_location):
             The hex IDs of the nodes that have a copy of this object.
         - object_size:
             The size of data + metadata in bytes.
-        - times_spilled:
-            The number of times this object was spilled.
+        - did_spill:
+            Whether or not this object was spilled.
     """
     object_size = c_object_location.GetObjectSize()
-    times_spilled = c_object_location.GetTimesSpilled()
+    did_spill = c_object_location.GetDidSpill()
 
     node_ids = set()
     c_node_ids = c_object_location.GetNodeIDs()
@@ -588,7 +588,7 @@ cdef CObjectLocationPtrToDict(CObjectLocation* c_object_location):
     return {
         "node_ids": list(node_ids),
         "object_size": object_size,
-        "times_spilled": times_spilled,
+        "did_spill": did_spill,
     }
 
 

--- a/python/ray/core/generated/pubsub_pb2.py
+++ b/python/ray/core/generated/pubsub_pb2.py
@@ -19,7 +19,7 @@ from . import gcs_pb2 as src_dot_ray_dot_protobuf_dot_gcs__pb2
 from . import logging_pb2 as src_dot_ray_dot_protobuf_dot_logging__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1dsrc/ray/protobuf/pubsub.proto\x12\x07ray.rpc\x1a\x1dsrc/ray/protobuf/common.proto\x1a!src/ray/protobuf/dependency.proto\x1a\x1asrc/ray/protobuf/gcs.proto\x1a\x1esrc/ray/protobuf/logging.proto\"\x80\x07\n\nPubMessage\x12*\n\x0c\x63hannel_type\x18\x01 \x01(\x0e\x32\x14.ray.rpc.ChannelType\x12\x0e\n\x06key_id\x18\x02 \x01(\x0c\x12N\n\x1eworker_object_eviction_message\x18\x03 \x01(\x0b\x32$.ray.rpc.WorkerObjectEvictionMessageH\x00\x12\x46\n\x1aworker_ref_removed_message\x18\x04 \x01(\x0b\x32 .ray.rpc.WorkerRefRemovedMessageH\x00\x12S\n\x1fworker_object_locations_message\x18\x05 \x01(\x0b\x32(.ray.rpc.WorkerObjectLocationsPubMessageH\x00\x12\x30\n\ractor_message\x18\x07 \x01(\x0b\x32\x17.ray.rpc.ActorTableDataH\x00\x12,\n\x0bjob_message\x18\x08 \x01(\x0b\x32\x15.ray.rpc.JobTableDataH\x00\x12\x31\n\x11node_info_message\x18\t \x01(\x0b\x32\x14.ray.rpc.GcsNodeInfoH\x00\x12<\n\x15node_resource_message\x18\n \x01(\x0b\x32\x1b.ray.rpc.NodeResourceChangeH\x00\x12\x38\n\x14worker_delta_message\x18\x0b \x01(\x0b\x32\x18.ray.rpc.WorkerDeltaDataH\x00\x12\x35\n\x12\x65rror_info_message\x18\x0c \x01(\x0b\x32\x17.ray.rpc.ErrorTableDataH\x00\x12.\n\x11log_batch_message\x18\r \x01(\x0b\x32\x11.ray.rpc.LogBatchH\x00\x12:\n\x17python_function_message\x18\x0e \x01(\x0b\x32\x17.ray.rpc.PythonFunctionH\x00\x12\x41\n\x1bnode_resource_usage_message\x18\x0f \x01(\x0b\x32\x1a.ray.rpc.NodeResourceUsageH\x00\x12\x32\n\x0f\x66\x61ilure_message\x18\x06 \x01(\x0b\x32\x17.ray.rpc.FailureMessageH\x00\x12\x13\n\x0bsequence_id\x18\x10 \x01(\x03\x42\x0f\n\rinner_message\"0\n\x1bWorkerObjectEvictionMessage\x12\x11\n\tobject_id\x18\x01 \x01(\x0c\"O\n\x17WorkerRefRemovedMessage\x12\x34\n\rborrowed_refs\x18\x01 \x03(\x0b\x32\x1d.ray.rpc.ObjectReferenceCount\"\xbe\x01\n\x1fWorkerObjectLocationsPubMessage\x12\x10\n\x08node_ids\x18\x01 \x03(\x0c\x12\x13\n\x0bobject_size\x18\x02 \x01(\x04\x12\x13\n\x0bspilled_url\x18\x03 \x01(\t\x12\x17\n\x0fspilled_node_id\x18\x04 \x01(\x0c\x12\x17\n\x0fprimary_node_id\x18\x06 \x01(\x0c\x12\x13\n\x0bref_removed\x18\x07 \x01(\x08\x12\x18\n\x10pending_creation\x18\x08 \x01(\x08\"\x10\n\x0e\x46\x61ilureMessage\"\xcd\x01\n\x07\x43ommand\x12*\n\x0c\x63hannel_type\x18\x01 \x01(\x0e\x32\x14.ray.rpc.ChannelType\x12\x0e\n\x06key_id\x18\x02 \x01(\x0c\x12:\n\x13unsubscribe_message\x18\x03 \x01(\x0b\x32\x1b.ray.rpc.UnsubscribeMessageH\x00\x12\x30\n\x11subscribe_message\x18\x04 \x01(\x0b\x32\x13.ray.rpc.SubMessageH\x00\x42\x18\n\x16\x63ommand_message_one_of\"\x14\n\x12UnsubscribeMessage\"\x95\x02\n\nSubMessage\x12Q\n\x1eworker_object_eviction_message\x18\x01 \x01(\x0b\x32\'.ray.rpc.WorkerObjectEvictionSubMessageH\x00\x12I\n\x1aworker_ref_removed_message\x18\x02 \x01(\x0b\x32#.ray.rpc.WorkerRefRemovedSubMessageH\x00\x12S\n\x1fworker_object_locations_message\x18\x03 \x01(\x0b\x32(.ray.rpc.WorkerObjectLocationsSubMessageH\x00\x42\x14\n\x12sub_message_one_of\"\xa9\x01\n\x1eWorkerObjectEvictionSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12\x11\n\tobject_id\x18\x02 \x01(\x0c\x12,\n\x12subscriber_address\x18\x03 \x01(\x0b\x32\x10.ray.rpc.Address\x12\x19\n\x0cgenerator_id\x18\x04 \x01(\x0cH\x00\x88\x01\x01\x42\x0f\n\r_generator_id\"\x9c\x01\n\x1aWorkerRefRemovedSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12+\n\treference\x18\x02 \x01(\x0b\x32\x18.ray.rpc.ObjectReference\x12\x17\n\x0f\x63ontained_in_id\x18\x03 \x01(\x0c\x12\x1c\n\x14subscriber_worker_id\x18\x04 \x01(\x0c\"P\n\x1fWorkerObjectLocationsSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12\x11\n\tobject_id\x18\x02 \x01(\x0c\"j\n\x18PubsubLongPollingRequest\x12\x15\n\rsubscriber_id\x18\x01 \x01(\x0c\x12!\n\x19max_processed_sequence_id\x18\x02 \x01(\x03\x12\x14\n\x0cpublisher_id\x18\x03 \x01(\x0c\"Y\n\x16PubsubLongPollingReply\x12)\n\x0cpub_messages\x18\x01 \x03(\x0b\x32\x13.ray.rpc.PubMessage\x12\x14\n\x0cpublisher_id\x18\x02 \x01(\x0c\"V\n\x19PubsubCommandBatchRequest\x12\x15\n\rsubscriber_id\x18\x01 \x01(\x0c\x12\"\n\x08\x63ommands\x18\x02 \x03(\x0b\x32\x10.ray.rpc.Command\"\x19\n\x17PubsubCommandBatchReply*\xca\x02\n\x0b\x43hannelType\x12\x1a\n\x16WORKER_OBJECT_EVICTION\x10\x00\x12\x1e\n\x1aWORKER_REF_REMOVED_CHANNEL\x10\x01\x12#\n\x1fWORKER_OBJECT_LOCATIONS_CHANNEL\x10\x02\x12\x15\n\x11GCS_ACTOR_CHANNEL\x10\x03\x12\x13\n\x0fGCS_JOB_CHANNEL\x10\x04\x12\x19\n\x15GCS_NODE_INFO_CHANNEL\x10\x05\x12\x1c\n\x18GCS_WORKER_DELTA_CHANNEL\x10\x06\x12\x1a\n\x16RAY_ERROR_INFO_CHANNEL\x10\x07\x12\x13\n\x0fRAY_LOG_CHANNEL\x10\x08\x12\x1f\n\x1bRAY_PYTHON_FUNCTION_CHANNEL\x10\t\x12#\n\x1fRAY_NODE_RESOURCE_USAGE_CHANNEL\x10\n2\xc8\x01\n\x11SubscriberService\x12W\n\x11PubsubLongPolling\x12!.ray.rpc.PubsubLongPollingRequest\x1a\x1f.ray.rpc.PubsubLongPollingReply\x12Z\n\x12PubsubCommandBatch\x12\".ray.rpc.PubsubCommandBatchRequest\x1a .ray.rpc.PubsubCommandBatchReplyB\x03\xf8\x01\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1dsrc/ray/protobuf/pubsub.proto\x12\x07ray.rpc\x1a\x1dsrc/ray/protobuf/common.proto\x1a!src/ray/protobuf/dependency.proto\x1a\x1asrc/ray/protobuf/gcs.proto\x1a\x1esrc/ray/protobuf/logging.proto\"\x80\x07\n\nPubMessage\x12*\n\x0c\x63hannel_type\x18\x01 \x01(\x0e\x32\x14.ray.rpc.ChannelType\x12\x0e\n\x06key_id\x18\x02 \x01(\x0c\x12N\n\x1eworker_object_eviction_message\x18\x03 \x01(\x0b\x32$.ray.rpc.WorkerObjectEvictionMessageH\x00\x12\x46\n\x1aworker_ref_removed_message\x18\x04 \x01(\x0b\x32 .ray.rpc.WorkerRefRemovedMessageH\x00\x12S\n\x1fworker_object_locations_message\x18\x05 \x01(\x0b\x32(.ray.rpc.WorkerObjectLocationsPubMessageH\x00\x12\x30\n\ractor_message\x18\x07 \x01(\x0b\x32\x17.ray.rpc.ActorTableDataH\x00\x12,\n\x0bjob_message\x18\x08 \x01(\x0b\x32\x15.ray.rpc.JobTableDataH\x00\x12\x31\n\x11node_info_message\x18\t \x01(\x0b\x32\x14.ray.rpc.GcsNodeInfoH\x00\x12<\n\x15node_resource_message\x18\n \x01(\x0b\x32\x1b.ray.rpc.NodeResourceChangeH\x00\x12\x38\n\x14worker_delta_message\x18\x0b \x01(\x0b\x32\x18.ray.rpc.WorkerDeltaDataH\x00\x12\x35\n\x12\x65rror_info_message\x18\x0c \x01(\x0b\x32\x17.ray.rpc.ErrorTableDataH\x00\x12.\n\x11log_batch_message\x18\r \x01(\x0b\x32\x11.ray.rpc.LogBatchH\x00\x12:\n\x17python_function_message\x18\x0e \x01(\x0b\x32\x17.ray.rpc.PythonFunctionH\x00\x12\x41\n\x1bnode_resource_usage_message\x18\x0f \x01(\x0b\x32\x1a.ray.rpc.NodeResourceUsageH\x00\x12\x32\n\x0f\x66\x61ilure_message\x18\x06 \x01(\x0b\x32\x17.ray.rpc.FailureMessageH\x00\x12\x13\n\x0bsequence_id\x18\x10 \x01(\x03\x42\x0f\n\rinner_message\"0\n\x1bWorkerObjectEvictionMessage\x12\x11\n\tobject_id\x18\x01 \x01(\x0c\"O\n\x17WorkerRefRemovedMessage\x12\x34\n\rborrowed_refs\x18\x01 \x03(\x0b\x32\x1d.ray.rpc.ObjectReferenceCount\"\xd5\x01\n\x1fWorkerObjectLocationsPubMessage\x12\x10\n\x08node_ids\x18\x01 \x03(\x0c\x12\x13\n\x0bobject_size\x18\x02 \x01(\x04\x12\x13\n\x0bspilled_url\x18\x03 \x01(\t\x12\x17\n\x0fspilled_node_id\x18\x04 \x01(\x0c\x12\x17\n\x0fprimary_node_id\x18\x06 \x01(\x0c\x12\x13\n\x0bref_removed\x18\x07 \x01(\x08\x12\x18\n\x10pending_creation\x18\x08 \x01(\x08\x12\x15\n\rtimes_spilled\x18\t \x01(\x04\"\x10\n\x0e\x46\x61ilureMessage\"\xcd\x01\n\x07\x43ommand\x12*\n\x0c\x63hannel_type\x18\x01 \x01(\x0e\x32\x14.ray.rpc.ChannelType\x12\x0e\n\x06key_id\x18\x02 \x01(\x0c\x12:\n\x13unsubscribe_message\x18\x03 \x01(\x0b\x32\x1b.ray.rpc.UnsubscribeMessageH\x00\x12\x30\n\x11subscribe_message\x18\x04 \x01(\x0b\x32\x13.ray.rpc.SubMessageH\x00\x42\x18\n\x16\x63ommand_message_one_of\"\x14\n\x12UnsubscribeMessage\"\x95\x02\n\nSubMessage\x12Q\n\x1eworker_object_eviction_message\x18\x01 \x01(\x0b\x32\'.ray.rpc.WorkerObjectEvictionSubMessageH\x00\x12I\n\x1aworker_ref_removed_message\x18\x02 \x01(\x0b\x32#.ray.rpc.WorkerRefRemovedSubMessageH\x00\x12S\n\x1fworker_object_locations_message\x18\x03 \x01(\x0b\x32(.ray.rpc.WorkerObjectLocationsSubMessageH\x00\x42\x14\n\x12sub_message_one_of\"\xa9\x01\n\x1eWorkerObjectEvictionSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12\x11\n\tobject_id\x18\x02 \x01(\x0c\x12,\n\x12subscriber_address\x18\x03 \x01(\x0b\x32\x10.ray.rpc.Address\x12\x19\n\x0cgenerator_id\x18\x04 \x01(\x0cH\x00\x88\x01\x01\x42\x0f\n\r_generator_id\"\x9c\x01\n\x1aWorkerRefRemovedSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12+\n\treference\x18\x02 \x01(\x0b\x32\x18.ray.rpc.ObjectReference\x12\x17\n\x0f\x63ontained_in_id\x18\x03 \x01(\x0c\x12\x1c\n\x14subscriber_worker_id\x18\x04 \x01(\x0c\"P\n\x1fWorkerObjectLocationsSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12\x11\n\tobject_id\x18\x02 \x01(\x0c\"j\n\x18PubsubLongPollingRequest\x12\x15\n\rsubscriber_id\x18\x01 \x01(\x0c\x12!\n\x19max_processed_sequence_id\x18\x02 \x01(\x03\x12\x14\n\x0cpublisher_id\x18\x03 \x01(\x0c\"Y\n\x16PubsubLongPollingReply\x12)\n\x0cpub_messages\x18\x01 \x03(\x0b\x32\x13.ray.rpc.PubMessage\x12\x14\n\x0cpublisher_id\x18\x02 \x01(\x0c\"V\n\x19PubsubCommandBatchRequest\x12\x15\n\rsubscriber_id\x18\x01 \x01(\x0c\x12\"\n\x08\x63ommands\x18\x02 \x03(\x0b\x32\x10.ray.rpc.Command\"\x19\n\x17PubsubCommandBatchReply*\xca\x02\n\x0b\x43hannelType\x12\x1a\n\x16WORKER_OBJECT_EVICTION\x10\x00\x12\x1e\n\x1aWORKER_REF_REMOVED_CHANNEL\x10\x01\x12#\n\x1fWORKER_OBJECT_LOCATIONS_CHANNEL\x10\x02\x12\x15\n\x11GCS_ACTOR_CHANNEL\x10\x03\x12\x13\n\x0fGCS_JOB_CHANNEL\x10\x04\x12\x19\n\x15GCS_NODE_INFO_CHANNEL\x10\x05\x12\x1c\n\x18GCS_WORKER_DELTA_CHANNEL\x10\x06\x12\x1a\n\x16RAY_ERROR_INFO_CHANNEL\x10\x07\x12\x13\n\x0fRAY_LOG_CHANNEL\x10\x08\x12\x1f\n\x1bRAY_PYTHON_FUNCTION_CHANNEL\x10\t\x12#\n\x1fRAY_NODE_RESOURCE_USAGE_CHANNEL\x10\n2\xc8\x01\n\x11SubscriberService\x12W\n\x11PubsubLongPolling\x12!.ray.rpc.PubsubLongPollingRequest\x1a\x1f.ray.rpc.PubsubLongPollingReply\x12Z\n\x12PubsubCommandBatch\x12\".ray.rpc.PubsubCommandBatchRequest\x1a .ray.rpc.PubsubCommandBatchReplyB\x03\xf8\x01\x01\x62\x06proto3')
 
 _CHANNELTYPE = DESCRIPTOR.enum_types_by_name['ChannelType']
 ChannelType = enum_type_wrapper.EnumTypeWrapper(_CHANNELTYPE)
@@ -161,8 +161,8 @@ if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'\370\001\001'
-  _CHANNELTYPE._serialized_start=2647
-  _CHANNELTYPE._serialized_end=2977
+  _CHANNELTYPE._serialized_start=2670
+  _CHANNELTYPE._serialized_end=3000
   _PUBMESSAGE._serialized_start=169
   _PUBMESSAGE._serialized_end=1065
   _WORKEROBJECTEVICTIONMESSAGE._serialized_start=1067
@@ -170,29 +170,29 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _WORKERREFREMOVEDMESSAGE._serialized_start=1117
   _WORKERREFREMOVEDMESSAGE._serialized_end=1196
   _WORKEROBJECTLOCATIONSPUBMESSAGE._serialized_start=1199
-  _WORKEROBJECTLOCATIONSPUBMESSAGE._serialized_end=1389
-  _FAILUREMESSAGE._serialized_start=1391
-  _FAILUREMESSAGE._serialized_end=1407
-  _COMMAND._serialized_start=1410
-  _COMMAND._serialized_end=1615
-  _UNSUBSCRIBEMESSAGE._serialized_start=1617
-  _UNSUBSCRIBEMESSAGE._serialized_end=1637
-  _SUBMESSAGE._serialized_start=1640
-  _SUBMESSAGE._serialized_end=1917
-  _WORKEROBJECTEVICTIONSUBMESSAGE._serialized_start=1920
-  _WORKEROBJECTEVICTIONSUBMESSAGE._serialized_end=2089
-  _WORKERREFREMOVEDSUBMESSAGE._serialized_start=2092
-  _WORKERREFREMOVEDSUBMESSAGE._serialized_end=2248
-  _WORKEROBJECTLOCATIONSSUBMESSAGE._serialized_start=2250
-  _WORKEROBJECTLOCATIONSSUBMESSAGE._serialized_end=2330
-  _PUBSUBLONGPOLLINGREQUEST._serialized_start=2332
-  _PUBSUBLONGPOLLINGREQUEST._serialized_end=2438
-  _PUBSUBLONGPOLLINGREPLY._serialized_start=2440
-  _PUBSUBLONGPOLLINGREPLY._serialized_end=2529
-  _PUBSUBCOMMANDBATCHREQUEST._serialized_start=2531
-  _PUBSUBCOMMANDBATCHREQUEST._serialized_end=2617
-  _PUBSUBCOMMANDBATCHREPLY._serialized_start=2619
-  _PUBSUBCOMMANDBATCHREPLY._serialized_end=2644
-  _SUBSCRIBERSERVICE._serialized_start=2980
-  _SUBSCRIBERSERVICE._serialized_end=3180
+  _WORKEROBJECTLOCATIONSPUBMESSAGE._serialized_end=1412
+  _FAILUREMESSAGE._serialized_start=1414
+  _FAILUREMESSAGE._serialized_end=1430
+  _COMMAND._serialized_start=1433
+  _COMMAND._serialized_end=1638
+  _UNSUBSCRIBEMESSAGE._serialized_start=1640
+  _UNSUBSCRIBEMESSAGE._serialized_end=1660
+  _SUBMESSAGE._serialized_start=1663
+  _SUBMESSAGE._serialized_end=1940
+  _WORKEROBJECTEVICTIONSUBMESSAGE._serialized_start=1943
+  _WORKEROBJECTEVICTIONSUBMESSAGE._serialized_end=2112
+  _WORKERREFREMOVEDSUBMESSAGE._serialized_start=2115
+  _WORKERREFREMOVEDSUBMESSAGE._serialized_end=2271
+  _WORKEROBJECTLOCATIONSSUBMESSAGE._serialized_start=2273
+  _WORKEROBJECTLOCATIONSSUBMESSAGE._serialized_end=2353
+  _PUBSUBLONGPOLLINGREQUEST._serialized_start=2355
+  _PUBSUBLONGPOLLINGREQUEST._serialized_end=2461
+  _PUBSUBLONGPOLLINGREPLY._serialized_start=2463
+  _PUBSUBLONGPOLLINGREPLY._serialized_end=2552
+  _PUBSUBCOMMANDBATCHREQUEST._serialized_start=2554
+  _PUBSUBCOMMANDBATCHREQUEST._serialized_end=2640
+  _PUBSUBCOMMANDBATCHREPLY._serialized_start=2642
+  _PUBSUBCOMMANDBATCHREPLY._serialized_end=2667
+  _SUBSCRIBERSERVICE._serialized_start=3003
+  _SUBSCRIBERSERVICE._serialized_end=3203
 # @@protoc_insertion_point(module_scope)

--- a/python/ray/core/generated/pubsub_pb2.py
+++ b/python/ray/core/generated/pubsub_pb2.py
@@ -19,7 +19,7 @@ from . import gcs_pb2 as src_dot_ray_dot_protobuf_dot_gcs__pb2
 from . import logging_pb2 as src_dot_ray_dot_protobuf_dot_logging__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1dsrc/ray/protobuf/pubsub.proto\x12\x07ray.rpc\x1a\x1dsrc/ray/protobuf/common.proto\x1a!src/ray/protobuf/dependency.proto\x1a\x1asrc/ray/protobuf/gcs.proto\x1a\x1esrc/ray/protobuf/logging.proto\"\x80\x07\n\nPubMessage\x12*\n\x0c\x63hannel_type\x18\x01 \x01(\x0e\x32\x14.ray.rpc.ChannelType\x12\x0e\n\x06key_id\x18\x02 \x01(\x0c\x12N\n\x1eworker_object_eviction_message\x18\x03 \x01(\x0b\x32$.ray.rpc.WorkerObjectEvictionMessageH\x00\x12\x46\n\x1aworker_ref_removed_message\x18\x04 \x01(\x0b\x32 .ray.rpc.WorkerRefRemovedMessageH\x00\x12S\n\x1fworker_object_locations_message\x18\x05 \x01(\x0b\x32(.ray.rpc.WorkerObjectLocationsPubMessageH\x00\x12\x30\n\ractor_message\x18\x07 \x01(\x0b\x32\x17.ray.rpc.ActorTableDataH\x00\x12,\n\x0bjob_message\x18\x08 \x01(\x0b\x32\x15.ray.rpc.JobTableDataH\x00\x12\x31\n\x11node_info_message\x18\t \x01(\x0b\x32\x14.ray.rpc.GcsNodeInfoH\x00\x12<\n\x15node_resource_message\x18\n \x01(\x0b\x32\x1b.ray.rpc.NodeResourceChangeH\x00\x12\x38\n\x14worker_delta_message\x18\x0b \x01(\x0b\x32\x18.ray.rpc.WorkerDeltaDataH\x00\x12\x35\n\x12\x65rror_info_message\x18\x0c \x01(\x0b\x32\x17.ray.rpc.ErrorTableDataH\x00\x12.\n\x11log_batch_message\x18\r \x01(\x0b\x32\x11.ray.rpc.LogBatchH\x00\x12:\n\x17python_function_message\x18\x0e \x01(\x0b\x32\x17.ray.rpc.PythonFunctionH\x00\x12\x41\n\x1bnode_resource_usage_message\x18\x0f \x01(\x0b\x32\x1a.ray.rpc.NodeResourceUsageH\x00\x12\x32\n\x0f\x66\x61ilure_message\x18\x06 \x01(\x0b\x32\x17.ray.rpc.FailureMessageH\x00\x12\x13\n\x0bsequence_id\x18\x10 \x01(\x03\x42\x0f\n\rinner_message\"0\n\x1bWorkerObjectEvictionMessage\x12\x11\n\tobject_id\x18\x01 \x01(\x0c\"O\n\x17WorkerRefRemovedMessage\x12\x34\n\rborrowed_refs\x18\x01 \x03(\x0b\x32\x1d.ray.rpc.ObjectReferenceCount\"\xd5\x01\n\x1fWorkerObjectLocationsPubMessage\x12\x10\n\x08node_ids\x18\x01 \x03(\x0c\x12\x13\n\x0bobject_size\x18\x02 \x01(\x04\x12\x13\n\x0bspilled_url\x18\x03 \x01(\t\x12\x17\n\x0fspilled_node_id\x18\x04 \x01(\x0c\x12\x17\n\x0fprimary_node_id\x18\x06 \x01(\x0c\x12\x13\n\x0bref_removed\x18\x07 \x01(\x08\x12\x18\n\x10pending_creation\x18\x08 \x01(\x08\x12\x15\n\rtimes_spilled\x18\t \x01(\x04\"\x10\n\x0e\x46\x61ilureMessage\"\xcd\x01\n\x07\x43ommand\x12*\n\x0c\x63hannel_type\x18\x01 \x01(\x0e\x32\x14.ray.rpc.ChannelType\x12\x0e\n\x06key_id\x18\x02 \x01(\x0c\x12:\n\x13unsubscribe_message\x18\x03 \x01(\x0b\x32\x1b.ray.rpc.UnsubscribeMessageH\x00\x12\x30\n\x11subscribe_message\x18\x04 \x01(\x0b\x32\x13.ray.rpc.SubMessageH\x00\x42\x18\n\x16\x63ommand_message_one_of\"\x14\n\x12UnsubscribeMessage\"\x95\x02\n\nSubMessage\x12Q\n\x1eworker_object_eviction_message\x18\x01 \x01(\x0b\x32\'.ray.rpc.WorkerObjectEvictionSubMessageH\x00\x12I\n\x1aworker_ref_removed_message\x18\x02 \x01(\x0b\x32#.ray.rpc.WorkerRefRemovedSubMessageH\x00\x12S\n\x1fworker_object_locations_message\x18\x03 \x01(\x0b\x32(.ray.rpc.WorkerObjectLocationsSubMessageH\x00\x42\x14\n\x12sub_message_one_of\"\xa9\x01\n\x1eWorkerObjectEvictionSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12\x11\n\tobject_id\x18\x02 \x01(\x0c\x12,\n\x12subscriber_address\x18\x03 \x01(\x0b\x32\x10.ray.rpc.Address\x12\x19\n\x0cgenerator_id\x18\x04 \x01(\x0cH\x00\x88\x01\x01\x42\x0f\n\r_generator_id\"\x9c\x01\n\x1aWorkerRefRemovedSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12+\n\treference\x18\x02 \x01(\x0b\x32\x18.ray.rpc.ObjectReference\x12\x17\n\x0f\x63ontained_in_id\x18\x03 \x01(\x0c\x12\x1c\n\x14subscriber_worker_id\x18\x04 \x01(\x0c\"P\n\x1fWorkerObjectLocationsSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12\x11\n\tobject_id\x18\x02 \x01(\x0c\"j\n\x18PubsubLongPollingRequest\x12\x15\n\rsubscriber_id\x18\x01 \x01(\x0c\x12!\n\x19max_processed_sequence_id\x18\x02 \x01(\x03\x12\x14\n\x0cpublisher_id\x18\x03 \x01(\x0c\"Y\n\x16PubsubLongPollingReply\x12)\n\x0cpub_messages\x18\x01 \x03(\x0b\x32\x13.ray.rpc.PubMessage\x12\x14\n\x0cpublisher_id\x18\x02 \x01(\x0c\"V\n\x19PubsubCommandBatchRequest\x12\x15\n\rsubscriber_id\x18\x01 \x01(\x0c\x12\"\n\x08\x63ommands\x18\x02 \x03(\x0b\x32\x10.ray.rpc.Command\"\x19\n\x17PubsubCommandBatchReply*\xca\x02\n\x0b\x43hannelType\x12\x1a\n\x16WORKER_OBJECT_EVICTION\x10\x00\x12\x1e\n\x1aWORKER_REF_REMOVED_CHANNEL\x10\x01\x12#\n\x1fWORKER_OBJECT_LOCATIONS_CHANNEL\x10\x02\x12\x15\n\x11GCS_ACTOR_CHANNEL\x10\x03\x12\x13\n\x0fGCS_JOB_CHANNEL\x10\x04\x12\x19\n\x15GCS_NODE_INFO_CHANNEL\x10\x05\x12\x1c\n\x18GCS_WORKER_DELTA_CHANNEL\x10\x06\x12\x1a\n\x16RAY_ERROR_INFO_CHANNEL\x10\x07\x12\x13\n\x0fRAY_LOG_CHANNEL\x10\x08\x12\x1f\n\x1bRAY_PYTHON_FUNCTION_CHANNEL\x10\t\x12#\n\x1fRAY_NODE_RESOURCE_USAGE_CHANNEL\x10\n2\xc8\x01\n\x11SubscriberService\x12W\n\x11PubsubLongPolling\x12!.ray.rpc.PubsubLongPollingRequest\x1a\x1f.ray.rpc.PubsubLongPollingReply\x12Z\n\x12PubsubCommandBatch\x12\".ray.rpc.PubsubCommandBatchRequest\x1a .ray.rpc.PubsubCommandBatchReplyB\x03\xf8\x01\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1dsrc/ray/protobuf/pubsub.proto\x12\x07ray.rpc\x1a\x1dsrc/ray/protobuf/common.proto\x1a!src/ray/protobuf/dependency.proto\x1a\x1asrc/ray/protobuf/gcs.proto\x1a\x1esrc/ray/protobuf/logging.proto\"\x80\x07\n\nPubMessage\x12*\n\x0c\x63hannel_type\x18\x01 \x01(\x0e\x32\x14.ray.rpc.ChannelType\x12\x0e\n\x06key_id\x18\x02 \x01(\x0c\x12N\n\x1eworker_object_eviction_message\x18\x03 \x01(\x0b\x32$.ray.rpc.WorkerObjectEvictionMessageH\x00\x12\x46\n\x1aworker_ref_removed_message\x18\x04 \x01(\x0b\x32 .ray.rpc.WorkerRefRemovedMessageH\x00\x12S\n\x1fworker_object_locations_message\x18\x05 \x01(\x0b\x32(.ray.rpc.WorkerObjectLocationsPubMessageH\x00\x12\x30\n\ractor_message\x18\x07 \x01(\x0b\x32\x17.ray.rpc.ActorTableDataH\x00\x12,\n\x0bjob_message\x18\x08 \x01(\x0b\x32\x15.ray.rpc.JobTableDataH\x00\x12\x31\n\x11node_info_message\x18\t \x01(\x0b\x32\x14.ray.rpc.GcsNodeInfoH\x00\x12<\n\x15node_resource_message\x18\n \x01(\x0b\x32\x1b.ray.rpc.NodeResourceChangeH\x00\x12\x38\n\x14worker_delta_message\x18\x0b \x01(\x0b\x32\x18.ray.rpc.WorkerDeltaDataH\x00\x12\x35\n\x12\x65rror_info_message\x18\x0c \x01(\x0b\x32\x17.ray.rpc.ErrorTableDataH\x00\x12.\n\x11log_batch_message\x18\r \x01(\x0b\x32\x11.ray.rpc.LogBatchH\x00\x12:\n\x17python_function_message\x18\x0e \x01(\x0b\x32\x17.ray.rpc.PythonFunctionH\x00\x12\x41\n\x1bnode_resource_usage_message\x18\x0f \x01(\x0b\x32\x1a.ray.rpc.NodeResourceUsageH\x00\x12\x32\n\x0f\x66\x61ilure_message\x18\x06 \x01(\x0b\x32\x17.ray.rpc.FailureMessageH\x00\x12\x13\n\x0bsequence_id\x18\x10 \x01(\x03\x42\x0f\n\rinner_message\"0\n\x1bWorkerObjectEvictionMessage\x12\x11\n\tobject_id\x18\x01 \x01(\x0c\"O\n\x17WorkerRefRemovedMessage\x12\x34\n\rborrowed_refs\x18\x01 \x03(\x0b\x32\x1d.ray.rpc.ObjectReferenceCount\"\xd1\x01\n\x1fWorkerObjectLocationsPubMessage\x12\x10\n\x08node_ids\x18\x01 \x03(\x0c\x12\x13\n\x0bobject_size\x18\x02 \x01(\x04\x12\x13\n\x0bspilled_url\x18\x03 \x01(\t\x12\x17\n\x0fspilled_node_id\x18\x04 \x01(\x0c\x12\x17\n\x0fprimary_node_id\x18\x06 \x01(\x0c\x12\x13\n\x0bref_removed\x18\x07 \x01(\x08\x12\x18\n\x10pending_creation\x18\x08 \x01(\x08\x12\x11\n\tdid_spill\x18\t \x01(\x08\"\x10\n\x0e\x46\x61ilureMessage\"\xcd\x01\n\x07\x43ommand\x12*\n\x0c\x63hannel_type\x18\x01 \x01(\x0e\x32\x14.ray.rpc.ChannelType\x12\x0e\n\x06key_id\x18\x02 \x01(\x0c\x12:\n\x13unsubscribe_message\x18\x03 \x01(\x0b\x32\x1b.ray.rpc.UnsubscribeMessageH\x00\x12\x30\n\x11subscribe_message\x18\x04 \x01(\x0b\x32\x13.ray.rpc.SubMessageH\x00\x42\x18\n\x16\x63ommand_message_one_of\"\x14\n\x12UnsubscribeMessage\"\x95\x02\n\nSubMessage\x12Q\n\x1eworker_object_eviction_message\x18\x01 \x01(\x0b\x32\'.ray.rpc.WorkerObjectEvictionSubMessageH\x00\x12I\n\x1aworker_ref_removed_message\x18\x02 \x01(\x0b\x32#.ray.rpc.WorkerRefRemovedSubMessageH\x00\x12S\n\x1fworker_object_locations_message\x18\x03 \x01(\x0b\x32(.ray.rpc.WorkerObjectLocationsSubMessageH\x00\x42\x14\n\x12sub_message_one_of\"\xa9\x01\n\x1eWorkerObjectEvictionSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12\x11\n\tobject_id\x18\x02 \x01(\x0c\x12,\n\x12subscriber_address\x18\x03 \x01(\x0b\x32\x10.ray.rpc.Address\x12\x19\n\x0cgenerator_id\x18\x04 \x01(\x0cH\x00\x88\x01\x01\x42\x0f\n\r_generator_id\"\x9c\x01\n\x1aWorkerRefRemovedSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12+\n\treference\x18\x02 \x01(\x0b\x32\x18.ray.rpc.ObjectReference\x12\x17\n\x0f\x63ontained_in_id\x18\x03 \x01(\x0c\x12\x1c\n\x14subscriber_worker_id\x18\x04 \x01(\x0c\"P\n\x1fWorkerObjectLocationsSubMessage\x12\x1a\n\x12intended_worker_id\x18\x01 \x01(\x0c\x12\x11\n\tobject_id\x18\x02 \x01(\x0c\"j\n\x18PubsubLongPollingRequest\x12\x15\n\rsubscriber_id\x18\x01 \x01(\x0c\x12!\n\x19max_processed_sequence_id\x18\x02 \x01(\x03\x12\x14\n\x0cpublisher_id\x18\x03 \x01(\x0c\"Y\n\x16PubsubLongPollingReply\x12)\n\x0cpub_messages\x18\x01 \x03(\x0b\x32\x13.ray.rpc.PubMessage\x12\x14\n\x0cpublisher_id\x18\x02 \x01(\x0c\"V\n\x19PubsubCommandBatchRequest\x12\x15\n\rsubscriber_id\x18\x01 \x01(\x0c\x12\"\n\x08\x63ommands\x18\x02 \x03(\x0b\x32\x10.ray.rpc.Command\"\x19\n\x17PubsubCommandBatchReply*\xca\x02\n\x0b\x43hannelType\x12\x1a\n\x16WORKER_OBJECT_EVICTION\x10\x00\x12\x1e\n\x1aWORKER_REF_REMOVED_CHANNEL\x10\x01\x12#\n\x1fWORKER_OBJECT_LOCATIONS_CHANNEL\x10\x02\x12\x15\n\x11GCS_ACTOR_CHANNEL\x10\x03\x12\x13\n\x0fGCS_JOB_CHANNEL\x10\x04\x12\x19\n\x15GCS_NODE_INFO_CHANNEL\x10\x05\x12\x1c\n\x18GCS_WORKER_DELTA_CHANNEL\x10\x06\x12\x1a\n\x16RAY_ERROR_INFO_CHANNEL\x10\x07\x12\x13\n\x0fRAY_LOG_CHANNEL\x10\x08\x12\x1f\n\x1bRAY_PYTHON_FUNCTION_CHANNEL\x10\t\x12#\n\x1fRAY_NODE_RESOURCE_USAGE_CHANNEL\x10\n2\xc8\x01\n\x11SubscriberService\x12W\n\x11PubsubLongPolling\x12!.ray.rpc.PubsubLongPollingRequest\x1a\x1f.ray.rpc.PubsubLongPollingReply\x12Z\n\x12PubsubCommandBatch\x12\".ray.rpc.PubsubCommandBatchRequest\x1a .ray.rpc.PubsubCommandBatchReplyB\x03\xf8\x01\x01\x62\x06proto3')
 
 _CHANNELTYPE = DESCRIPTOR.enum_types_by_name['ChannelType']
 ChannelType = enum_type_wrapper.EnumTypeWrapper(_CHANNELTYPE)
@@ -161,8 +161,8 @@ if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'\370\001\001'
-  _CHANNELTYPE._serialized_start=2670
-  _CHANNELTYPE._serialized_end=3000
+  _CHANNELTYPE._serialized_start=2666
+  _CHANNELTYPE._serialized_end=2996
   _PUBMESSAGE._serialized_start=169
   _PUBMESSAGE._serialized_end=1065
   _WORKEROBJECTEVICTIONMESSAGE._serialized_start=1067
@@ -170,29 +170,29 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _WORKERREFREMOVEDMESSAGE._serialized_start=1117
   _WORKERREFREMOVEDMESSAGE._serialized_end=1196
   _WORKEROBJECTLOCATIONSPUBMESSAGE._serialized_start=1199
-  _WORKEROBJECTLOCATIONSPUBMESSAGE._serialized_end=1412
-  _FAILUREMESSAGE._serialized_start=1414
-  _FAILUREMESSAGE._serialized_end=1430
-  _COMMAND._serialized_start=1433
-  _COMMAND._serialized_end=1638
-  _UNSUBSCRIBEMESSAGE._serialized_start=1640
-  _UNSUBSCRIBEMESSAGE._serialized_end=1660
-  _SUBMESSAGE._serialized_start=1663
-  _SUBMESSAGE._serialized_end=1940
-  _WORKEROBJECTEVICTIONSUBMESSAGE._serialized_start=1943
-  _WORKEROBJECTEVICTIONSUBMESSAGE._serialized_end=2112
-  _WORKERREFREMOVEDSUBMESSAGE._serialized_start=2115
-  _WORKERREFREMOVEDSUBMESSAGE._serialized_end=2271
-  _WORKEROBJECTLOCATIONSSUBMESSAGE._serialized_start=2273
-  _WORKEROBJECTLOCATIONSSUBMESSAGE._serialized_end=2353
-  _PUBSUBLONGPOLLINGREQUEST._serialized_start=2355
-  _PUBSUBLONGPOLLINGREQUEST._serialized_end=2461
-  _PUBSUBLONGPOLLINGREPLY._serialized_start=2463
-  _PUBSUBLONGPOLLINGREPLY._serialized_end=2552
-  _PUBSUBCOMMANDBATCHREQUEST._serialized_start=2554
-  _PUBSUBCOMMANDBATCHREQUEST._serialized_end=2640
-  _PUBSUBCOMMANDBATCHREPLY._serialized_start=2642
-  _PUBSUBCOMMANDBATCHREPLY._serialized_end=2667
-  _SUBSCRIBERSERVICE._serialized_start=3003
-  _SUBSCRIBERSERVICE._serialized_end=3203
+  _WORKEROBJECTLOCATIONSPUBMESSAGE._serialized_end=1408
+  _FAILUREMESSAGE._serialized_start=1410
+  _FAILUREMESSAGE._serialized_end=1426
+  _COMMAND._serialized_start=1429
+  _COMMAND._serialized_end=1634
+  _UNSUBSCRIBEMESSAGE._serialized_start=1636
+  _UNSUBSCRIBEMESSAGE._serialized_end=1656
+  _SUBMESSAGE._serialized_start=1659
+  _SUBMESSAGE._serialized_end=1936
+  _WORKEROBJECTEVICTIONSUBMESSAGE._serialized_start=1939
+  _WORKEROBJECTEVICTIONSUBMESSAGE._serialized_end=2108
+  _WORKERREFREMOVEDSUBMESSAGE._serialized_start=2111
+  _WORKERREFREMOVEDSUBMESSAGE._serialized_end=2267
+  _WORKEROBJECTLOCATIONSSUBMESSAGE._serialized_start=2269
+  _WORKEROBJECTLOCATIONSSUBMESSAGE._serialized_end=2349
+  _PUBSUBLONGPOLLINGREQUEST._serialized_start=2351
+  _PUBSUBLONGPOLLINGREQUEST._serialized_end=2457
+  _PUBSUBLONGPOLLINGREPLY._serialized_start=2459
+  _PUBSUBLONGPOLLINGREPLY._serialized_end=2548
+  _PUBSUBCOMMANDBATCHREQUEST._serialized_start=2550
+  _PUBSUBCOMMANDBATCHREQUEST._serialized_end=2636
+  _PUBSUBCOMMANDBATCHREPLY._serialized_start=2638
+  _PUBSUBCOMMANDBATCHREPLY._serialized_end=2663
+  _SUBSCRIBERSERVICE._serialized_start=2999
+  _SUBSCRIBERSERVICE._serialized_end=3199
 # @@protoc_insertion_point(module_scope)

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -275,11 +275,12 @@ class MapOperator(OneToOneOperator, ABC):
         def _task_done_callback(task_index, inputs):
             # We should only destroy the input bundle when the whole task is done.
             # Otherwise, if the task crashes in the middle, we can't rerun it.
-            refs = [input[0] for input in inputs.blocks]
-            locations = ray.experimental.get_object_locations(refs)
-            for ref in inputs.blocks:
+            blocks = [input[0] for input in inputs.blocks]
+            metadata = [input[1] for input in inputs.blocks]
+            locations = ray.experimental.get_object_locations(blocks)
+            for block, meta in zip(blocks, metadata):
                 self._metrics.spilled += (
-                    ref[1].size_bytes * locations[ref[0]]["times_spilled"]
+                    meta.size_bytes * locations[block]["times_spilled"]
                 )
 
             inputs.destroy_if_owned()

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -63,7 +63,7 @@ class MapOperator(OneToOneOperator, ABC):
         # Bundles block references up to the min_rows_per_bundle target.
         self._block_ref_bundler = _BlockRefBundler(min_rows_per_bundle)
         # Object store allocation stats.
-        self._metrics = _ObjectStoreMetrics(alloc=0, freed=0, cur=0, peak=0)
+        self._metrics = _ObjectStoreMetrics(alloc=0, freed=0, cur=0, peak=0, spilled=0)
 
         # Queue for task outputs, either ordered or unordered (this is set by start()).
         self._output_queue: _OutputQueue = None
@@ -275,6 +275,13 @@ class MapOperator(OneToOneOperator, ABC):
         def _task_done_callback(task_index, inputs):
             # We should only destroy the input bundle when the whole task is done.
             # Otherwise, if the task crashes in the middle, we can't rerun it.
+            refs = [input[0] for input in inputs.blocks]
+            locations = ray.experimental.get_object_locations(refs)
+            for ref in inputs.blocks:
+                self._metrics.spilled += (
+                    ref[1].size_bytes * locations[ref[0]]["times_spilled"]
+                )
+
             inputs.destroy_if_owned()
             freed = inputs.size_bytes()
             self._metrics.freed += freed
@@ -374,12 +381,14 @@ class _ObjectStoreMetrics:
     freed: int
     cur: int
     peak: int
+    spilled: int
 
     def to_metrics_dict(self) -> Dict[str, int]:
         return {
             "obj_store_mem_alloc": self.alloc,
             "obj_store_mem_freed": self.freed,
             "obj_store_mem_peak": self.peak,
+            "obj_store_mem_spilled": self.spilled,
         }
 
 

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -279,9 +279,8 @@ class MapOperator(OneToOneOperator, ABC):
             metadata = [input[1] for input in inputs.blocks]
             locations = ray.experimental.get_object_locations(blocks)
             for block, meta in zip(blocks, metadata):
-                self._metrics.spilled += (
-                    meta.size_bytes * locations[block]["times_spilled"]
-                )
+                if locations[block]["did_spill"]:
+                    self._metrics.spilled += meta.size_bytes
 
             inputs.destroy_if_owned()
             freed = inputs.size_bytes()

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -647,6 +647,17 @@ class ExecutionPlan:
                     reply.store_stats.restored_bytes_total
                 )
 
+            stats.dataset_bytes_spilled = 0
+
+            def collect_stats(cur_stats):
+                stats.dataset_bytes_spilled += cur_stats.extra_metrics.get(
+                    "obj_store_mem_spilled", 0
+                )
+                for parent in cur_stats.parents:
+                    collect_stats(parent)
+
+            collect_stats(stats)
+
             # Set the snapshot to the output of the final stage.
             self._snapshot_blocks = blocks
             self._snapshot_stats = stats

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -268,6 +268,7 @@ class DatasetStats:
         # Memory usage stats
         self.global_bytes_spilled: int = 0
         self.global_bytes_restored: int = 0
+        self.dataset_bytes_spilled: int = 0
 
     @property
     def stats_actor(self):
@@ -342,6 +343,7 @@ class DatasetStats:
             self.extra_metrics,
             self.global_bytes_spilled,
             self.global_bytes_restored,
+            self.dataset_bytes_spilled,
         )
 
 
@@ -358,6 +360,7 @@ class DatasetStatsSummary:
     extra_metrics: Dict[str, Any]
     global_bytes_spilled: int
     global_bytes_restored: int
+    dataset_bytes_spilled: int
 
     def to_string(
         self,
@@ -419,16 +422,18 @@ class DatasetStatsSummary:
             out += "* Extra metrics: " + str(self.extra_metrics) + "\n"
         out += str(self.iter_stats)
 
-        mb_spilled = round(self.global_bytes_spilled / 1e6)
-        mb_restored = round(self.global_bytes_restored / 1e6)
-        if (
-            len(self.stages_stats) > 0
-            and add_global_stats
-            and (mb_spilled or mb_restored)
-        ):
-            out += "\nCluster memory:\n"
-            out += "* Spilled to disk: {}MB\n".format(mb_spilled)
-            out += "* Restored from disk: {}MB\n".format(mb_restored)
+        if len(self.stages_stats) > 0 and add_global_stats:
+            mb_spilled = round(self.global_bytes_spilled / 1e6)
+            mb_restored = round(self.global_bytes_restored / 1e6)
+            if mb_spilled or mb_restored:
+                out += "\nCluster memory:\n"
+                out += "* Spilled to disk: {}MB\n".format(mb_spilled)
+                out += "* Restored from disk: {}MB\n".format(mb_restored)
+
+            dataset_mb_spilled = round(self.dataset_bytes_spilled / 1e6)
+            if dataset_mb_spilled:
+                out += "\nDataset memory:\n"
+                out += "* Spilled to disk: {}MB\n".format(dataset_mb_spilled)
 
         return out
 
@@ -455,6 +460,7 @@ class DatasetStatsSummary:
             f"{indent}   iter_stats={self.iter_stats.__repr__(level+1)},\n"
             f"{indent}   global_bytes_spilled={self.global_bytes_spilled / 1e6}MB,\n"
             f"{indent}   global_bytes_restored={self.global_bytes_restored / 1e6}MB,\n"
+            f"{indent}   dataset_bytes_spilled={self.dataset_bytes_spilled / 1e6}MB,\n"
             f"{indent}   parents=[{parent_stats}],\n"
             f"{indent})"
         )

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -375,6 +375,7 @@ class DatasetStatsSummary:
             out.
             include_parent: If true, also include parent stats summary; otherwise, only
             log stats of the latest stage.
+            add_global_stats: If true, includes global stats to this summary.
         Returns:
             String with summary statistics for executing the Dataset.
         """

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1343,6 +1343,15 @@ Dataset memory:
     # two map_batches operators, twice the spillage
     assert ds._plan.stats().dataset_bytes_spilled > 200e6
 
+    # The size of dataset is around 50MB, there should be no spillage
+    ds = (
+        ray.data.range_tensor(250, shape=(80, 80, 4), parallelism=100)
+        .map_batches(lambda x: x)
+        .materialize()
+    )
+
+    assert ds._plan.stats().dataset_bytes_spilled == 0
+
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -16,13 +16,21 @@ from ray.data.tests.util import column_udf
 from ray.tests.conftest import *  # noqa
 
 STANDARD_EXTRA_METRICS = (
-    "{'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, 'obj_store_mem_peak': N, "
+    "{'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, "
+    "'obj_store_mem_peak': N, 'obj_store_mem_spilled': Z, "
     "'ray_remote_args': {'num_cpus': N, 'scheduling_strategy': 'SPREAD'}}"
 )
 
 LARGE_ARGS_EXTRA_METRICS = (
-    "{'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, 'obj_store_mem_peak': N, "
+    "{'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, "
+    "'obj_store_mem_peak': N, 'obj_store_mem_spilled': Z, "
     "'ray_remote_args': {'num_cpus': Z.N, 'scheduling_strategy': 'DEFAULT'}}"
+)
+
+MEM_SPILLED_EXTRA_METRICS = (
+    "{'obj_store_mem_alloc': N, 'obj_store_mem_freed': N, "
+    "'obj_store_mem_peak': N, 'obj_store_mem_spilled': N, "
+    "'ray_remote_args': {'num_cpus': N, 'scheduling_strategy': 'SPREAD'}}"
 )
 
 
@@ -420,6 +428,7 @@ def test_dataset__repr__(ray_start_regular_shared):
         "   ),\n"
         "   global_bytes_spilled=M,\n"
         "   global_bytes_restored=M,\n"
+        "   dataset_bytes_spilled=M,\n"
         "   parents=[],\n"
         ")"
     )
@@ -451,6 +460,7 @@ def test_dataset__repr__(ray_start_regular_shared):
         "      obj_store_mem_alloc: N,\n"
         "      obj_store_mem_freed: N,\n"
         "      obj_store_mem_peak: N,\n"
+        "      obj_store_mem_spilled: Z,\n"
         "      ray_remote_args: {'num_cpus': N, 'scheduling_strategy': 'SPREAD'},\n"
         "   },\n"
         "   stage_stats=[\n"
@@ -480,6 +490,7 @@ def test_dataset__repr__(ray_start_regular_shared):
         "   ),\n"
         "   global_bytes_spilled=M,\n"
         "   global_bytes_restored=M,\n"
+        "   dataset_bytes_spilled=M,\n"
         "   parents=[\n"
         "      DatasetStatsSummary(\n"
         "         dataset_uuid=U,\n"
@@ -513,6 +524,7 @@ def test_dataset__repr__(ray_start_regular_shared):
         "         ),\n"
         "         global_bytes_spilled=M,\n"
         "         global_bytes_restored=M,\n"
+        "         dataset_bytes_spilled=M,\n"
         "         parents=[],\n"
         "      ),\n"
         "   ],\n"
@@ -1286,6 +1298,40 @@ def test_stats_actor_cap_num_stats(ray_start_cluster):
     assert ray.get(actor.get.remote(0))[0] == {}
     # The start_time has 3 entries because we just added it above with record_start().
     assert ray.get(actor._get_stats_dict_size.remote()) == (3, 2, 2)
+
+
+def test_spilled_stats(shutdown_only):
+    # The object store is about 100MB.
+    ray.init(object_store_memory=100e6)
+    # The size of dataset is 1000*(80*80*4)*8B, about 200MB.
+    ds = (
+        ray.data.range_tensor(1000, shape=(80, 80, 4), parallelism=100)
+        .map_batches(lambda x: x)
+        .materialize()
+    )
+
+    assert (
+        canonicalize(ds.stats())
+        == f"""Stage N ReadRange->MapBatches(<lambda>): N/N blocks executed in T
+* Remote wall time: T min, T max, T mean, T total
+* Remote cpu time: T min, T max, T mean, T total
+* Peak heap memory usage (MiB): N min, N max, N mean
+* Output num rows: N min, N max, N mean, N total
+* Output size bytes: N min, N max, N mean, N total
+* Tasks per node: N min, N max, N mean; N nodes used
+* Extra metrics: {MEM_SPILLED_EXTRA_METRICS}
+
+Cluster memory:
+* Spilled to disk: M
+* Restored from disk: M
+
+Dataset memory:
+* Spilled to disk: M
+"""
+    )
+
+    # Around 100MB should be spilled (200MB - 100MB)
+    assert ds._plan.stats().dataset_bytes_spilled > 100e6
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1333,6 +1333,16 @@ Dataset memory:
     # Around 100MB should be spilled (200MB - 100MB)
     assert ds._plan.stats().dataset_bytes_spilled > 100e6
 
+    ds = (
+        ray.data.range_tensor(1000, shape=(80, 80, 4), parallelism=100)
+        .map_batches(lambda x: x)
+        .limit(1000)
+        .map_batches(lambda x: x)
+        .materialize()
+    )
+    # two map_batches operators, twice the spillage
+    assert ds._plan.stats().dataset_bytes_spilled > 200e6
+
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -359,6 +359,7 @@ cdef extern from "ray/core_worker/common.h" nogil:
         c_bool IsSpilled() const
         const c_string &GetSpilledURL() const
         const CNodeID &GetSpilledNodeID() const
+        const uint64_t GetTimesSpilled() const
 
 cdef extern from "ray/gcs/gcs_client/gcs_client.h" nogil:
     cdef enum CGrpcStatusCode "grpc::StatusCode":

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -359,7 +359,7 @@ cdef extern from "ray/core_worker/common.h" nogil:
         c_bool IsSpilled() const
         const c_string &GetSpilledURL() const
         const CNodeID &GetSpilledNodeID() const
-        const uint64_t GetTimesSpilled() const
+        const c_bool GetDidSpill() const
 
 cdef extern from "ray/gcs/gcs_client/gcs_client.h" nogil:
     cdef enum CGrpcStatusCode "grpc::StatusCode":

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -199,13 +199,15 @@ class ObjectLocation {
                  std::vector<NodeID> node_ids,
                  bool is_spilled,
                  std::string spilled_url,
-                 NodeID spilled_node_id)
+                 NodeID spilled_node_id,
+                 uint64_t times_spilled)
       : primary_node_id_(primary_node_id),
         object_size_(object_size),
         node_ids_(std::move(node_ids)),
         is_spilled_(is_spilled),
         spilled_url_(std::move(spilled_url)),
-        spilled_node_id_(spilled_node_id) {}
+        spilled_node_id_(spilled_node_id),
+        times_spilled_(times_spilled) {}
 
   const NodeID &GetPrimaryNodeID() const { return primary_node_id_; }
 
@@ -218,6 +220,8 @@ class ObjectLocation {
   const std::string &GetSpilledURL() const { return spilled_url_; }
 
   const NodeID &GetSpilledNodeID() const { return spilled_node_id_; }
+
+  const uint64_t GetTimesSpilled() const { return times_spilled_; }
 
  private:
   /// The ID of the node has the primary copy of the object.
@@ -234,6 +238,8 @@ class ObjectLocation {
   /// If spilled, the ID of the node that spilled the object. Nil if the object was
   /// spilled to distributed external storage.
   const NodeID spilled_node_id_;
+  /// Number of times this object was spilled.
+  const uint64_t times_spilled_;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -200,14 +200,14 @@ class ObjectLocation {
                  bool is_spilled,
                  std::string spilled_url,
                  NodeID spilled_node_id,
-                 uint64_t times_spilled)
+                 bool did_spill)
       : primary_node_id_(primary_node_id),
         object_size_(object_size),
         node_ids_(std::move(node_ids)),
         is_spilled_(is_spilled),
         spilled_url_(std::move(spilled_url)),
         spilled_node_id_(spilled_node_id),
-        times_spilled_(times_spilled) {}
+        did_spill_(did_spill) {}
 
   const NodeID &GetPrimaryNodeID() const { return primary_node_id_; }
 
@@ -221,7 +221,7 @@ class ObjectLocation {
 
   const NodeID &GetSpilledNodeID() const { return spilled_node_id_; }
 
-  const uint64_t GetTimesSpilled() const { return times_spilled_; }
+  const bool GetDidSpill() const { return did_spill_; }
 
  private:
   /// The ID of the node has the primary copy of the object.
@@ -238,8 +238,8 @@ class ObjectLocation {
   /// If spilled, the ID of the node that spilled the object. Nil if the object was
   /// spilled to distributed external storage.
   const NodeID spilled_node_id_;
-  /// Number of times this object was spilled.
-  const uint64_t times_spilled_;
+  /// Whether or not this object was spilled.
+  const bool did_spill_;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -102,7 +102,8 @@ ObjectLocation CreateObjectLocation(const rpc::GetObjectLocationsOwnerReply &rep
                         std::move(node_ids),
                         is_spilled,
                         object_info.spilled_url(),
-                        NodeID::FromBinary(object_info.spilled_node_id()));
+                        NodeID::FromBinary(object_info.spilled_node_id()),
+                        object_info.times_spilled());
 }
 }  // namespace
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -103,7 +103,7 @@ ObjectLocation CreateObjectLocation(const rpc::GetObjectLocationsOwnerReply &rep
                         is_spilled,
                         object_info.spilled_url(),
                         NodeID::FromBinary(object_info.spilled_node_id()),
-                        object_info.times_spilled());
+                        object_info.did_spill());
 }
 }  // namespace
 

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1369,6 +1369,7 @@ bool ReferenceCounter::HandleObjectSpilled(const ObjectID &object_id,
   }
 
   it->second.spilled = true;
+  it->second.times_spilled++;
   bool spilled_location_alive =
       spilled_node_id.IsNil() || check_node_alive_(spilled_node_id);
   if (spilled_location_alive) {
@@ -1551,6 +1552,7 @@ void ReferenceCounter::FillObjectInformationInternal(
   auto primary_node_id = it->second.pinned_at_raylet_id.value_or(NodeID::Nil());
   object_info->set_primary_node_id(primary_node_id.Binary());
   object_info->set_pending_creation(it->second.pending_creation);
+  object_info->set_times_spilled(it->second.times_spilled);
 }
 
 void ReferenceCounter::PublishObjectLocationSnapshot(const ObjectID &object_id) {

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1369,7 +1369,7 @@ bool ReferenceCounter::HandleObjectSpilled(const ObjectID &object_id,
   }
 
   it->second.spilled = true;
-  it->second.times_spilled++;
+  it->second.did_spill = true;
   bool spilled_location_alive =
       spilled_node_id.IsNil() || check_node_alive_(spilled_node_id);
   if (spilled_location_alive) {
@@ -1552,7 +1552,7 @@ void ReferenceCounter::FillObjectInformationInternal(
   auto primary_node_id = it->second.pinned_at_raylet_id.value_or(NodeID::Nil());
   object_info->set_primary_node_id(primary_node_id.Binary());
   object_info->set_pending_creation(it->second.pending_creation);
-  object_info->set_times_spilled(it->second.times_spilled);
+  object_info->set_did_spill(it->second.did_spill);
 }
 
 void ReferenceCounter::PublishObjectLocationSnapshot(const ObjectID &object_id) {

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -786,8 +786,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// Whether the task that creates this object is scheduled/executing.
     bool pending_creation = false;
 
-    /// Number of times this object is spilled.
-    int64_t times_spilled = 0;
+    /// Whether or not this object was spilled.
+    bool did_spill = false;
   };
 
   using ReferenceTable = absl::flat_hash_map<ObjectID, Reference>;

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -785,6 +785,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
     /// Whether the task that creates this object is scheduled/executing.
     bool pending_creation = false;
+
+    /// Number of times this object is spilled.
+    int64_t times_spilled = 0;
   };
 
   using ReferenceTable = absl::flat_hash_map<ObjectID, Reference>;

--- a/src/ray/protobuf/pubsub.proto
+++ b/src/ray/protobuf/pubsub.proto
@@ -116,8 +116,8 @@ message WorkerObjectLocationsPubMessage {
   // there are no locations and this is set, the subscriber should wait for the
   // new location to appear.
   bool pending_creation = 8;
-  // Number of times this object was spilled.
-  uint64 times_spilled = 9;
+  // Whether or not this object was spilled.
+  bool did_spill = 9;
 }
 
 /// Indicating the subscriber needs to handle failure callback.

--- a/src/ray/protobuf/pubsub.proto
+++ b/src/ray/protobuf/pubsub.proto
@@ -116,6 +116,8 @@ message WorkerObjectLocationsPubMessage {
   // there are no locations and this is set, the subscriber should wait for the
   // new location to appear.
   bool pending_creation = 8;
+  // Number of times this object was spilled.
+  uint64 times_spilled = 9;
 }
 
 /// Indicating the subscriber needs to handle failure callback.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Records spill stats for individual datasets.

For now only recorded for `MapOperator` since it is the only operator that deletes blocks after it's done.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #38847

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
