### PR TITLE
[CI] try apt-get update before install java

### DIFF
--- a/ci/env/install-java.sh
+++ b/ci/env/install-java.sh
@@ -8,7 +8,7 @@ set -euxo pipefail
 SCRIPT_DIR=$(builtin cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 WORKSPACE_DIR="${SCRIPT_DIR}/../.."
 
-sudo apt-get install -y maven openjdk-8-jre openjdk-8-jdk
+sudo apt-get update && sudo apt-get install -y maven openjdk-8-jre openjdk-8-jdk
 "${WORKSPACE_DIR}"/java/build-jar-multiplatform.sh linux
 
 # Pop caller's shell options (quietly)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->



## Why are these changes needed?

Somehow the docker image used for the release branch are outdated and can't install java successfully. This PR runs apt-get update before install java to ensure the package index are up to date

## Related issue number

Closes [🚰 Dataset datasource integration tests](https://buildkite.com/ray-project/oss-ci-build-branch/builds/6128#018a96f9-952a-4358-b43d-0034a08ce8ce)

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
