### PR TITLE
[civ2][1] simplify test sharding

### DIFF
--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -2,24 +2,30 @@ import os
 import sys
 from tempfile import TemporaryDirectory
 from unittest import mock
-from typing import List
 
 import pytest
 
 from ci.ray_ci.tester_container import TesterContainer
 from ci.ray_ci.tester import (
-    _get_all_test_targets,
+    _get_container,
     _get_all_test_query,
     _get_test_targets,
     _get_flaky_test_targets,
 )
-from ci.ray_ci.utils import chunk_into_n
+
+
+def test_get_container() -> None:
+    with mock.patch(
+        "ci.ray_ci.tester_container.TesterContainer.install_ray",
+        return_value=None,
+    ):
+        container = _get_container("core", 3, 1, 2)
+        assert container.docker_tag == "corebuild"
+        assert container.shard_count == 6
+        assert container.shard_ids == [2, 3]
 
 
 def test_get_test_targets() -> None:
-    def _mock_shard_tests(tests: List[str], workers: int, worker_id: int) -> List[str]:
-        return chunk_into_n(tests, workers)[worker_id]
-
     _TEST_YAML = "flaky_tests: [//python/ray/tests:flaky_test_01]"
 
     with TemporaryDirectory() as tmp:
@@ -34,15 +40,13 @@ def test_get_test_targets() -> None:
             "",
         ]
         with mock.patch(
-            "ci.ray_ci.tester.shard_tests", side_effect=_mock_shard_tests
-        ), mock.patch(
             "subprocess.check_output",
             return_value="\n".join(test_targets).encode("utf-8"),
         ), mock.patch(
             "ci.ray_ci.tester_container.TesterContainer.install_ray",
             return_value=None,
         ):
-            assert _get_all_test_targets(
+            assert _get_test_targets(
                 TesterContainer("core"),
                 "targets",
                 "core",
@@ -51,17 +55,6 @@ def test_get_test_targets() -> None:
                 "//python/ray/tests:good_test_01",
                 "//python/ray/tests:good_test_02",
                 "//python/ray/tests:good_test_03",
-            ]
-            assert _get_test_targets(
-                TesterContainer("core"),
-                "targets",
-                "core",
-                2,
-                0,
-                yaml_dir=tmp,
-            ) == [
-                "//python/ray/tests:good_test_01",
-                "//python/ray/tests:good_test_02",
             ]
 
 

--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -70,14 +70,14 @@ def test_run_tests() -> None:
         "ci.ray_ci.tester_container.TesterContainer.install_ray",
         return_value=None,
     ):
-        container = TesterContainer("team")
+        container = TesterContainer("team", shard_count=2, shard_ids=[0, 1])
         # test_targets are not empty
-        assert container.run_tests(["t1", "t2"], [], 2)
+        assert container.run_tests(["t1", "t2"], [])
         # test_targets is empty after chunking, but not creating popen
-        assert container.run_tests(["t1"], [], 2)
-        assert container.run_tests([], [], 2)
+        assert container.run_tests(["t1"], [])
+        assert container.run_tests([], [])
         # test targets contain bad_test
-        assert not container.run_tests(["bad_test"], [], 2)
+        assert not container.run_tests(["bad_test"], [])
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -7,7 +7,7 @@ import click
 
 from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.tester_container import TesterContainer
-from ci.ray_ci.utils import shard_tests, docker_login
+from ci.ray_ci.utils import docker_login
 
 # Gets the path of product/tools/docker (i.e. the parent of 'common')
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
@@ -74,9 +74,9 @@ def main(
     os.chdir(bazel_workspace_dir)
     docker_login(_DOCKER_ECR_REPO.split("/")[0])
 
-    if not build_name:
-        build_name = f"{team}build"
-    container = TesterContainer(build_name)
+    container = _get_container(
+        team, workers, worker_id, parallelism_per_worker, build_name
+    )
     if run_flaky_tests:
         test_targets = _get_flaky_test_targets(team)
     else:
@@ -84,30 +84,27 @@ def main(
             container,
             targets,
             team,
-            workers,
-            worker_id,
             except_tags,
         )
-    success = container.run_tests(test_targets, test_env, parallelism_per_worker)
+    success = container.run_tests(test_targets, test_env)
     sys.exit(0 if success else 1)
 
 
-def _get_test_targets(
-    container: TesterContainer,
-    targets: str,
+def _get_container(
     team: str,
     workers: int,
     worker_id: int,
-    except_tags: Optional[str] = "",
-    yaml_dir: Optional[str] = None,
-) -> List[str]:
-    """
-    Get test targets to run for a particular shard
-    """
-    return shard_tests(
-        _get_all_test_targets(container, targets, team, except_tags, yaml_dir=yaml_dir),
-        workers,
-        worker_id,
+    parallelism_per_worker: int,
+    build_name: Optional[str] = None,
+) -> TesterContainer:
+    shard_count = workers * parallelism_per_worker
+    shard_start = worker_id * parallelism_per_worker
+    shard_end = (worker_id + 1) * parallelism_per_worker
+
+    return TesterContainer(
+        build_name or f"{team}build",
+        shard_count=shard_count,
+        shard_ids=list(range(shard_start, shard_end)),
     )
 
 
@@ -129,7 +126,7 @@ def _get_all_test_query(targets: List[str], team: str, except_tags: str) -> str:
     return f"{team_query} except ({except_query})"
 
 
-def _get_all_test_targets(
+def _get_test_targets(
     container: TesterContainer,
     targets: str,
     team: str,

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from typing import List
+from typing import List, Optional
 
 from ci.ray_ci.utils import shard_tests
 from ci.ray_ci.container import Container
@@ -12,20 +12,35 @@ class TesterContainer(Container):
     A wrapper for running tests in ray ci docker container
     """
 
-    def __init__(self, docker_tag: str) -> None:
+    def __init__(
+        self,
+        docker_tag: str,
+        shard_count: int = 1,
+        shard_ids: Optional[List[int]] = None,
+    ) -> None:
+        """
+        :param docker_tag: Name of the wanda build to be used as test container.
+        :param shard_count: The number of shards to split the tests into. This can be
+        used to run tests in a distributed fashion.
+        :param shard_ids: The list of shard ids to run. If none, run no shards.
+        """
         super().__init__(docker_tag)
+        self.shard_count = shard_count
+        self.shard_ids = shard_ids or []
+
         self.install_ray()
 
     def run_tests(
         self,
         test_targets: List[str],
         test_envs: List[str],
-        parallelism: int,
     ) -> bool:
         """
         Run tests parallelly in docker.  Return whether all tests pass.
         """
-        chunks = [shard_tests(test_targets, parallelism, i) for i in range(parallelism)]
+        chunks = [
+            shard_tests(test_targets, self.shard_count, i) for i in self.shard_ids
+        ]
         runs = [
             self._run_tests_in_docker(chunk, test_envs) for chunk in chunks if chunk
         ]


### PR DESCRIPTION
Currently we are calling test shardings twice, once to get test shards for a worker machine, and another to get shard per parallelism on that machine. This PR simplifies that logic and just call sharding once.

CI:
- Test