### PR TITLE
[core] Fix the `maximum_startup_concurrency` incorrect use.

### DIFF
--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -88,23 +88,20 @@ WorkerPool::WorkerPool(instrumented_io_context &io_service,
       node_id_(node_id),
       node_address_(node_address),
       get_num_cpus_available_(get_num_cpus_available),
-      maximum_startup_concurrency_(maximum_startup_concurrency),
+      maximum_startup_concurrency_(
+          RayConfig::instance().worker_maximum_startup_concurrency() > 0 ?
+          // Overwrite the maximum concurrency.
+          RayConfig::instance().worker_maximum_startup_concurrency() : maximum_startup_concurrency),
       gcs_client_(std::move(gcs_client)),
       native_library_path_(native_library_path),
       starting_worker_timeout_callback_(starting_worker_timeout_callback),
       ray_debugger_external(ray_debugger_external),
       first_job_registered_python_worker_count_(0),
       first_job_driver_wait_num_python_workers_(
-          std::min(num_prestarted_python_workers, maximum_startup_concurrency)),
+          std::min(num_prestarted_python_workers, maximum_startup_concurrency_)),
       num_prestart_python_workers(num_prestarted_python_workers),
       periodical_runner_(io_service),
       get_time_(get_time) {
-  if (RayConfig::instance().worker_maximum_startup_concurrency() > 0) {
-    // Overwrite the maximum concurrency.
-    maximum_startup_concurrency_ =
-        RayConfig::instance().worker_maximum_startup_concurrency();
-  }
-
   RAY_CHECK(maximum_startup_concurrency_ > 0);
   // We need to record so that the metric exists. This way, we report that 0
   // processes have started before a task runs on the node (as opposed to the

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -89,9 +89,11 @@ WorkerPool::WorkerPool(instrumented_io_context &io_service,
       node_address_(node_address),
       get_num_cpus_available_(get_num_cpus_available),
       maximum_startup_concurrency_(
-          RayConfig::instance().worker_maximum_startup_concurrency() > 0 ?
-          // Overwrite the maximum concurrency.
-          RayConfig::instance().worker_maximum_startup_concurrency() : maximum_startup_concurrency),
+          RayConfig::instance().worker_maximum_startup_concurrency() > 0
+              ?
+              // Overwrite the maximum concurrency.
+              RayConfig::instance().worker_maximum_startup_concurrency()
+              : maximum_startup_concurrency),
       gcs_client_(std::move(gcs_client)),
       native_library_path_(native_library_path),
       starting_worker_timeout_callback_(starting_worker_timeout_callback),

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -105,7 +105,7 @@ WorkerPool::WorkerPool(instrumented_io_context &io_service,
         RayConfig::instance().worker_maximum_startup_concurrency();
   }
 
-  RAY_CHECK(maximum_startup_concurrency > 0);
+  RAY_CHECK(maximum_startup_concurrency_ > 0);
   // We need to record so that the metric exists. This way, we report that 0
   // processes have started before a task runs on the node (as opposed to the
   // metric not existing at all).
@@ -122,7 +122,7 @@ WorkerPool::WorkerPool(instrumented_io_context &io_service,
   for (const auto &entry : worker_commands) {
     // Initialize the pool state for this language.
     auto &state = states_by_lang_[entry.first];
-    state.multiple_for_warning = maximum_startup_concurrency;
+    state.multiple_for_warning = maximum_startup_concurrency_;
     // Set worker command for this language.
     state.worker_command = entry.second;
     RAY_CHECK(!state.worker_command.empty()) << "Worker command must not be empty.";


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In the code, this parameter is overwritten, but in later steps, it's still being used. This PR fixes it.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
