### PR TITLE
fix: add cython async detection

### DIFF
--- a/python/ray/_private/async_compat.py
+++ b/python/ray/_private/async_compat.py
@@ -28,8 +28,28 @@ def try_install_uvloop():
 
 
 def is_async_func(func):
-    """Return True if the function is an async or async generator method."""
-    return inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func)
+    """
+    Returns True if the passed function is a coroutine or an async generator.
+
+    note: we prefer this version as Python Coroutines != Cython Coroutines and Cython Coroutines
+    are not detected properly by the inspect module
+
+    this is the optimized version from the links below, using the flag as defined by the inspect module
+    - https://github.com/cython/cython/blob/master/tests/run/test_coroutines_pep492.pyx#L889
+    - https://github.com/hugapi/hug/blob/develop/hug/introspect.py#L33
+
+    The issues above outline the PR where this was added to ensure async flag support on Cython
+    - https://github.com/cython/cython/pull/4902
+    """
+    is_async_cython = func.__code__.co_flags & 0x80 or getattr(
+        func, "_is_coroutine", False
+    )
+
+    return (
+        is_async_cython
+        or inspect.iscoroutinefunction(func)
+        or inspect.isasyncgenfunction(func)
+    )
 
 
 def sync_to_async(func):

--- a/python/ray/_private/async_compat.py
+++ b/python/ray/_private/async_compat.py
@@ -31,15 +31,17 @@ def is_async_func(func):
     """
     Returns True if the passed function is a coroutine or an async generator.
 
-    note: we prefer this version as Python Coroutines != Cython Coroutines and Cython Coroutines
-    are not detected properly by the inspect module
+    note: we prefer this version as Python Coroutines != Cython Coroutines
+    and Cython Coroutines are not detected properly by the inspect module
 
-    this is the optimized version from the links below, using the flag as defined by the inspect module
-    - https://github.com/cython/cython/blob/master/tests/run/test_coroutines_pep492.pyx#L889
-    - https://github.com/hugapi/hug/blob/develop/hug/introspect.py#L33
+    this is the optimized version from the links below, using the flag as defined by
+    the inspect module
+    https://github.com/cython/cython/blob/master/tests/run/test_coroutines_pep492.pyx#L889
+    https://github.com/hugapi/hug/blob/develop/hug/introspect.py#L33
 
-    The issues above outline the PR where this was added to ensure async flag support on Cython
-    - https://github.com/cython/cython/pull/4902
+    The issues above outline the PR where this was added to ensure async flag support
+    on Cython
+    https://github.com/cython/cython/pull/4902
     """
     is_async_cython = func.__code__.co_flags & 0x80 or getattr(
         func, "_is_coroutine", False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fix introduces a check for Async marked functions through Cython as `inspect` fails to do this on certain Python versions.

> Note: I could use some help in testing this in Ray since it's Cython specific

## Related issue number

Closes #39736

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
