### PR TITLE
[civ2][2] deprecate data_integration bazel tags

### DIFF
--- a/.buildkite/_forge.rayci.yml
+++ b/.buildkite/_forge.rayci.yml
@@ -24,6 +24,10 @@ steps:
     wanda: ci/docker/base.ml.wanda.yaml
     depends_on: oss-ci-base_test
 
+  - name: docbuild
+    wanda: ci/docker/doc.build.wanda.yaml
+    depends_on: oss-ci-base_build
+
   - name: corebuild
     wanda: ci/docker/core.build.wanda.yaml
     depends_on: oss-ci-base_build

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -24,6 +24,13 @@ steps:
     depends_on: manylinux
     job_env: manylinux
 
+  - label: ":tapioca: build: doc"
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:build_in_docker -- doc 
+    depends_on: docbuild
+    job_env: docbuild
+
   - label: ":tapioca: build: ray py38 cu118 docker"
     instance_type: medium
     commands:

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -9,7 +9,7 @@ steps:
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name data6build
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
-        --except-tags data_integration,doctest
+        --except-tags doctest
     depends_on: data6build
     job_env: forge
 
@@ -22,7 +22,7 @@ steps:
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name data12build
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
-        --except-tags data_integration,doctest
+        --except-tags doctest
     depends_on: data12build
     job_env: forge
 
@@ -35,7 +35,7 @@ steps:
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name datanbuild
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
-        --except-tags data_integration,doctest
+        --except-tags doctest
     depends_on: datanbuild
     job_env: forge
 
@@ -48,7 +48,7 @@ steps:
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name databbuild
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
-        --except-tags data_integration,doctest
+        --except-tags doctest
     depends_on: databbuild
     job_env: forge
 

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -420,26 +420,6 @@
     - echo "--- Running the script with fault of networking delay"
     - ray job submit --address http://localhost:8265 --runtime-env python/ray/tests/chaos/streaming_llm.yaml --working-dir python/ray/tests/chaos -- python streaming_llm.py --num_queries_per_task=100 --num_tasks=2 --num_words_per_query=100
     
-
-- label: ":book: Documentation"
-  commands:
-    - export LINT=1
-    - ./ci/env/install-dependencies.sh
-    # Specifying above somehow messes up the Ray install.
-    # Uninstall and re-install Ray so that we can use Ray Client
-    # (remove thirdparty_files to sidestep an issue with psutil).
-    - pip uninstall -y ray && rm -rf /ray/python/ray/thirdparty_files
-    - pushd /ray && git clean -f -f -x -d -e .whl -e python/ray/dashboard/client && popd
-    - bazel clean --expunge
-    - export WANDB_MODE=offline
-    # Horovod needs to be installed separately (needed for API ref imports)
-    - ./ci/env/install-horovod.sh
-    # See https://stackoverflow.com/questions/63383400/error-cannot-uninstall-ruamel-yaml-while-creating-docker-image-for-azure-ml-a
-    # Pin urllib to avoid downstream ssl incompatibility issues. This matches requirements-doc.txt.
-    - pip install "mosaicml==0.12.1" "urllib3<1.27" "typing-extensions==4.5.0" --ignore-installed
-    - ./ci/env/env_info.sh
-    - ./ci/ci.sh build_sphinx_docs
-
 - label: ":octopus: Tune multinode tests"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TUNE_AFFECTED"]
   instance_size: medium

--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -387,21 +387,6 @@
     # Dask tests and examples.
     - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-client python/ray/util/dask/...
 
-- label: ":potable_water: Dataset datasource integration tests"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - ./ci/env/install-java.sh
-    - DATA_PROCESSING_TESTING=1 ARROW_VERSION=9.* ARROW_MONGO_VERSION=0.5.* ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - sudo apt-get purge -y mongodb*
-    - sudo apt-get install -y mongodb
-    - sudo rm -rf /var/lib/mongodb/mongod.lock
-    - sudo service mongodb start
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=data_integration,-doctest python/ray/data/...
-    - sudo service mongodb stop
-    - sudo apt-get purge -y mongodb*
-
 - label: "Workflow tests"
   conditions: ["RAY_CI_PYTHON_AFFECTED", "RAY_CI_WORKFLOW_AFFECTED"]
   instance_size: medium

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -128,7 +128,8 @@ compile_pip_dependencies() {
     "${WORKSPACE_DIR}/python/requirements/ml/train-requirements.txt" \
     "${WORKSPACE_DIR}/python/requirements/ml/train-test-requirements.txt" \
     "${WORKSPACE_DIR}/python/requirements/ml/tune-requirements.txt" \
-    "${WORKSPACE_DIR}/python/requirements/ml/tune-test-requirements.txt"
+    "${WORKSPACE_DIR}/python/requirements/ml/tune-test-requirements.txt" \
+    "${WORKSPACE_DIR}/doc/requirements-doc.txt"
 
   # Remove some pins from upstream dependencies:
   # ray, xgboost-ray, lightgbm-ray, tune-sklearn

--- a/ci/docker/data.build.Dockerfile
+++ b/ci/docker/data.build.Dockerfile
@@ -2,6 +2,7 @@ ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml
 FROM $DOCKER_IMAGE_BASE_BUILD
 
 ARG ARROW_VERSION
+ARG ARROW_MONGO_VERSION
 
 # Unset dind settings; we are using the host's docker daemon.
 ENV DOCKER_TLS_CERTDIR=
@@ -13,5 +14,10 @@ SHELL ["/bin/bash", "-ice"]
 
 COPY . .
 
-RUN DATA_PROCESSING_TESTING=1 ARROW_VERSION=$ARROW_VERSION ./ci/env/install-dependencies.sh
+RUN DATA_PROCESSING_TESTING=1 ARROW_VERSION=$ARROW_VERSION ARROW_MONGO_VERSION=$ARROW_MONGO_VERSION ./ci/env/install-dependencies.sh
 RUN pip install "datasets==2.14.0"
+
+# Install MongoDB
+RUN sudo apt-get install -y mongodb
+RUN sudo rm -rf /var/lib/mongodb/mongod.lock
+RUN sudo service mongodb start

--- a/ci/docker/data12.build.wanda.yaml
+++ b/ci/docker/data12.build.wanda.yaml
@@ -11,5 +11,6 @@ srcs:
   - python/requirements/ml/data-test-requirements.txt
 build_args:
   - ARROW_VERSION=12
+  - ARROW_MONGO_VERSION=1.0.2
 tags:
   - cr.ray.io/rayproject/data12build

--- a/ci/docker/datab.build.wanda.yaml
+++ b/ci/docker/datab.build.wanda.yaml
@@ -11,5 +11,6 @@ srcs:
   - python/requirements/ml/data-test-requirements.txt
 build_args:
   - ARROW_VERSION=12.*
+  - ARROW_MONGO_VERSION=1.0.2
 tags:
   - cr.ray.io/rayproject/databbuild

--- a/ci/docker/doc.build.Dockerfile
+++ b/ci/docker/doc.build.Dockerfile
@@ -1,0 +1,22 @@
+ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build
+FROM $DOCKER_IMAGE_BASE_BUILD
+
+# Unset dind settings; we are using the host's docker daemon.
+ENV DOCKER_TLS_CERTDIR=
+ENV DOCKER_HOST=
+ENV DOCKER_TLS_VERIFY=
+ENV DOCKER_CERT_PATH=
+
+SHELL ["/bin/bash", "-ice"]
+
+COPY . .
+
+RUN pip install -U --ignore-installed  \
+  -c python/requirements_compiled.txt \
+  -r python/requirements.txt \
+  -r python/requirements/test-requirements.txt \
+  -r python/requirements/lint-requirements.txt \
+  -r doc/requirements-doc.txt 
+
+RUN HOROVOD_WITH_GLOO=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_MXNET=1 \
+  pip install -U --ignore-installed  -c python/requirements_compiled.txt horovod

--- a/ci/docker/doc.build.wanda.yaml
+++ b/ci/docker/doc.build.wanda.yaml
@@ -1,0 +1,11 @@
+name: "docbuild"
+froms: ["cr.ray.io/rayproject/oss-ci-base_build"]
+dockerfile: ci/docker/doc.build.Dockerfile
+srcs:
+  - python/requirements.txt
+  - python/requirements_compiled.txt
+  - python/requirements/test-requirements.txt
+  - python/requirements/lint-requirements.txt
+  - doc/requirements-doc.txt
+tags:
+  - cr.ray.io/rayproject/docbuild

--- a/ci/ray_ci/builder.py
+++ b/ci/ray_ci/builder.py
@@ -1,6 +1,7 @@
 import click
 
 from ci.ray_ci.builder_container import PYTHON_VERSIONS, BuilderContainer
+from ci.ray_ci.doc_builder_container import DocBuilderContainer
 from ci.ray_ci.forge_container import ForgeContainer
 from ci.ray_ci.docker_container import PLATFORM, DockerContainer
 from ci.ray_ci.container import _DOCKER_ECR_REPO
@@ -11,7 +12,7 @@ from ci.ray_ci.utils import logger, docker_login
 @click.argument(
     "artifact_type",
     required=True,
-    type=click.Choice(["wheel", "docker"]),
+    type=click.Choice(["wheel", "doc", "docker"]),
 )
 @click.option(
     "--python-version",
@@ -50,12 +51,17 @@ def main(
         build_docker(python_version, platform, image_type)
         return
 
+    if artifact_type == "doc":
+        logger.info("Building ray docs")
+        build_doc()
+        return
+
     raise ValueError(f"Invalid artifact type {artifact_type}")
 
 
 def build_wheel(python_version: str) -> None:
     """
-    Build a wheel artifact
+    Build a wheel artifact.
     """
     BuilderContainer(python_version).run()
     ForgeContainer().upload_wheel()
@@ -63,7 +69,14 @@ def build_wheel(python_version: str) -> None:
 
 def build_docker(python_version: str, platform: str, image_type: str) -> None:
     """
-    Build a container artifact
+    Build a container artifact.
     """
     BuilderContainer(python_version).run()
     DockerContainer(python_version, platform, image_type).run()
+
+
+def build_doc() -> None:
+    """
+    Build a doc artifact.
+    """
+    DocBuilderContainer().run()

--- a/ci/ray_ci/doc_builder_container.py
+++ b/ci/ray_ci/doc_builder_container.py
@@ -1,0 +1,15 @@
+from ci.ray_ci.container import Container
+
+
+class DocBuilderContainer(Container):
+    def __init__(self) -> None:
+        super().__init__("docbuild")
+        self.install_ray()
+
+    def run(self) -> None:
+        self.run_script(
+            [
+                "cd doc",
+                "FAST=True make html",
+            ]
+        )

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -2,24 +2,30 @@ import os
 import sys
 from tempfile import TemporaryDirectory
 from unittest import mock
-from typing import List
 
 import pytest
 
 from ci.ray_ci.tester_container import TesterContainer
 from ci.ray_ci.tester import (
-    _get_all_test_targets,
+    _get_container,
     _get_all_test_query,
     _get_test_targets,
     _get_flaky_test_targets,
 )
-from ci.ray_ci.utils import chunk_into_n
+
+
+def test_get_container() -> None:
+    with mock.patch(
+        "ci.ray_ci.tester_container.TesterContainer.install_ray",
+        return_value=None,
+    ):
+        container = _get_container("core", 3, 1, 2)
+        assert container.docker_tag == "corebuild"
+        assert container.shard_count == 6
+        assert container.shard_ids == [2, 3]
 
 
 def test_get_test_targets() -> None:
-    def _mock_shard_tests(tests: List[str], workers: int, worker_id: int) -> List[str]:
-        return chunk_into_n(tests, workers)[worker_id]
-
     _TEST_YAML = "flaky_tests: [//python/ray/tests:flaky_test_01]"
 
     with TemporaryDirectory() as tmp:
@@ -34,15 +40,13 @@ def test_get_test_targets() -> None:
             "",
         ]
         with mock.patch(
-            "ci.ray_ci.tester.shard_tests", side_effect=_mock_shard_tests
-        ), mock.patch(
             "subprocess.check_output",
             return_value="\n".join(test_targets).encode("utf-8"),
         ), mock.patch(
             "ci.ray_ci.tester_container.TesterContainer.install_ray",
             return_value=None,
         ):
-            assert _get_all_test_targets(
+            assert _get_test_targets(
                 TesterContainer("core"),
                 "targets",
                 "core",
@@ -51,17 +55,6 @@ def test_get_test_targets() -> None:
                 "//python/ray/tests:good_test_01",
                 "//python/ray/tests:good_test_02",
                 "//python/ray/tests:good_test_03",
-            ]
-            assert _get_test_targets(
-                TesterContainer("core"),
-                "targets",
-                "core",
-                2,
-                0,
-                yaml_dir=tmp,
-            ) == [
-                "//python/ray/tests:good_test_01",
-                "//python/ray/tests:good_test_02",
             ]
 
 

--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -70,14 +70,14 @@ def test_run_tests() -> None:
         "ci.ray_ci.tester_container.TesterContainer.install_ray",
         return_value=None,
     ):
-        container = TesterContainer("team")
+        container = TesterContainer("team", shard_count=2, shard_ids=[0, 1])
         # test_targets are not empty
-        assert container.run_tests(["t1", "t2"], [], 2)
+        assert container.run_tests(["t1", "t2"], [])
         # test_targets is empty after chunking, but not creating popen
-        assert container.run_tests(["t1"], [], 2)
-        assert container.run_tests([], [], 2)
+        assert container.run_tests(["t1"], [])
+        assert container.run_tests([], [])
         # test targets contain bad_test
-        assert not container.run_tests(["bad_test"], [], 2)
+        assert not container.run_tests(["bad_test"], [])
 
 
 if __name__ == "__main__":

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -37,3 +37,7 @@ urllib3 < 1.27
 # For the API docs
 fastapi==0.99.1
 grpcio==1.57.0
+
+# Build dependencies
+mosaicml
+typing-extensions

--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -69,7 +69,7 @@ py_test(
     name = "test_mongo",
     size = "large",
     srcs = ["tests/test_mongo.py"],
-    tags = ["team:data", "exclusive", "data_integration"],
+    tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -422,7 +422,7 @@ py_test(
     name = "test_raydp",
     size = "medium",
     srcs = ["tests/test_raydp.py"],
-    tags = ["team:data", "exclusive", "data_integration"],
+    tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],
 )
 

--- a/python/ray/data/tests/test_mongo.py
+++ b/python/ray/data/tests/test_mongo.py
@@ -12,10 +12,15 @@ from ray.tests.conftest import *  # noqa
 # and start a local service:
 # sudo apt-get install -y mongodb
 # sudo service mongodb start
+#
 
 
 @pytest.fixture
 def start_mongo():
+    # This test has only been tested for the following versions:
+    pytest.importorskip("pyarrow", minversion="12.0.0")
+    pytest.importorskip("pymongoarrow", minversion="1.0.0")
+
     import pymongo
 
     mongo_url = "mongodb://localhost:27017"

--- a/python/ray/data/tests/test_raydp.py
+++ b/python/ray/data/tests/test_raydp.py
@@ -7,10 +7,19 @@ import ray
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.test_execution_optimizer import _check_usage_record
 
+# To run tests locally, make sure you install mongodb
+# and start a local service:
+# sudo apt-get install -y mongodb
+# sudo service mongodb start
+
 
 # RayDP tests require Ray Java. Make sure ray jar is built before running this test.
 @pytest.fixture(scope="function")
 def spark(request):
+    # This test has only been tested for the following versions:
+    pytest.importorskip("pyarrow", minversion="12.0.0")
+    pytest.importorskip("pymongoarrow", minversion="1.0.0")
+
     ray.init(num_cpus=2, include_dashboard=False)
     spark_session = raydp.init_spark("test", 1, 1, "500M")
 

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -28,6 +28,7 @@ applicationinsights==0.11.10
 argcomplete==1.12.3
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
+argparse==1.4.0
 array-record==0.4.0
 arrow==1.2.3
 asttokens==2.4.0
@@ -37,6 +38,7 @@ async-generator==1.10
 async-timeout==4.0.3
 asyncmock==0.4.2
 attrs==21.4.0
+autodoc-pydantic==1.6.1
 autograd==1.6.2
 autorom==0.6.1 ; platform_machine != "arm64"
 autorom-accept-rom-license==0.6.1
@@ -117,6 +119,7 @@ dm-tree==0.1.8
 dnspython==2.4.2
 docker==6.1.3
 docker-pycreds==0.4.0
+docstring-parser==0.15
 docutils==0.17.1
 dopamine-rl==4.0.5 ; (sys_platform != "darwin" or platform_machine != "arm64") and python_version >= "3.8"
 dragonfly-opt==0.1.7
@@ -194,6 +197,7 @@ h5py==3.7.0
 hebo @ git+https://github.com/huawei-noah/HEBO@9a2a674c22518eed35a8b98e5134576741a95410#subdirectory=HEBO
 higher==0.2.1
 hjson==3.1.0
+horovod==0.28.1
 hpbandster==0.7.4
 httpcore==0.15.0
 httplib2==0.20.4
@@ -281,6 +285,7 @@ mock==5.1.0
 modin==0.22.2 ; python_version >= "3.8"
 monotonic==1.6
 more-itertools==10.1.0
+mosaicml==0.3.1
 moto==4.0.7
 mpmath==1.3.0
 msal==1.18.0b1
@@ -384,6 +389,7 @@ pycodestyle==2.7.0
 pycparser==2.21
 pycryptodome==3.18.0
 pydantic==1.10.12
+pydata-sphinx-theme==0.8.1
 pydeprecate==0.3.2
 pydot==1.4.2
 pydub==0.25.1
@@ -430,6 +436,7 @@ python-lsp-jsonrpc==1.0.0
 python-multipart==0.0.6
 python-snappy==0.6.1
 pytorch-lightning==1.6.5
+pytorch-ranger==0.1.1
 pytz==2022.7.1
 pyu2f==0.1.5
 pyvmomi==8.0.1.0.2
@@ -481,13 +488,25 @@ snowballstemmer==2.2.0
 sortedcontainers==2.4.0
 soupsieve==2.5
 sphinx==4.3.2
+sphinx-book-theme==0.3.3
+sphinx-click==3.0.2
+sphinx-copybutton==0.4.0
+sphinx-design==0.4.1
+sphinx-external-toc==0.2.4
+sphinx-jsonschema==1.17.2
+sphinx-remove-toctrees==0.0.3
+sphinx-sitemap==2.2.0
+sphinx-tabs==3.4.0
 sphinx-togglebutton==0.2.3
+sphinx-version-warning==1.1.2
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-redoc==1.6.0
 sphinxcontrib-serializinghtml==1.1.5
+sphinxemoji==0.2.0
 sqlalchemy==1.4.17
 sqlparse==0.4.4
 sshpubkeys==3.3.1
@@ -528,6 +547,7 @@ toolz==0.12.0
 torch==2.0.1 ; python_version > "3.7"
 torch-cluster==1.6.1
 torch-geometric==2.3.1
+torch-optimizer==0.1.0
 torch-scatter==2.1.1
 torch-sparse==0.6.17
 torch-spline-conv==1.2.2
@@ -540,6 +560,7 @@ tqdm==4.64.1
 traitlets==5.9.0
 transformers==4.19.1
 trustme==0.9.0
+tune-sklearn @ git+https://github.com/ray-project/tune-sklearn@master
 typeguard==2.13.3
 typer==0.9.0
 types-pyyaml==6.0.12.2
@@ -571,6 +592,7 @@ xlrd==2.0.1
 xmltodict==0.13.0
 xxhash==3.3.0
 y-py==0.6.0
+yahp==0.1.1
 yarl==1.9.2
 ypy-websocket==0.8.4
 yq==3.2.2


### PR DESCRIPTION
As an effort to make ray ci simpler, this PR deprecates the  bazel`data_integration` tag. This tag is used for data tests that require mongodb. By deprecating this tag, we can merge these tests into the normal data test job.

One of the tricky part here is that the data_integration tests do not run with pyarrow 6 and nightly, so we skip the tests in these settings.

Test:
- CI