### PR TITLE
[core][RFC] http based pure external client

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -63,6 +63,7 @@ py_test_module_list(
     "test_memstat.py",
     "test_node_label_scheduling_strategy.py",
     "test_protobuf_compatibility.py"
+    "test_client2.py",
   ],
   size = "medium",
   tags = ["exclusive", "medium_size_python_tests_a_to_j", "team:core"],

--- a/python/ray/tests/test_client2.py
+++ b/python/ray/tests/test_client2.py
@@ -1,0 +1,97 @@
+import ray
+import pytest
+from ray.util.client2.session import start_session
+from ray._private.test_utils import (
+    format_web_url,
+    get_current_unused_port,
+)
+
+# Goals:
+# - [x] can start actors, run tasks
+# - [x] if client dies, the job does not die (can reconnect)
+#     - via job submission + detached actor
+# - [x] can IO with local desktop files
+# - [x] "purely external" to ray core, low maintainence
+#       - the whole code should be <1000 LoC.
+# - [x] only expose a limited subset of ray
+#      - when client is on, ray (as of worker and raylet) is NOT CONNECTED#
+#
+# Design: use job submission API to spin up a actor that runs http server,
+# proxying ray get and put.
+#
+# Dependant feature: allow to set job metadata from within the job (so that we can tell
+# back the http addr) https://github.com/ray-project/ray/issues/36638
+
+
+######################### usage #####################################################
+
+
+@ray.remote(num_cpus=0.01)
+def fib(j):
+    if j < 2:
+        return 1
+    return sum(ray.get([fib.remote(j - 1), fib.remote(j - 2)]))
+
+
+class MyDataType:
+    def __init__(self, i: int, s: str) -> None:
+        self.i = i
+        self.s = s
+
+    def pprint(self):
+        return f"MyDataType: {self.i}, {self.s}"
+
+
+@pytest.fixture
+def call_ray_start_with_webui_addr():
+    import subprocess
+
+    port = get_current_unused_port()
+    cmd = "ray start --head " f"--dashboard-port {port}"
+    subprocess.check_output(cmd, shell=True)
+    webui = format_web_url(f"http://127.0.0.1:{port}")  # TODO: fix this ip
+    yield webui
+    # Disconnect from the Ray cluster.
+    ray.shutdown()
+    # Kill the Ray cluster.
+    subprocess.check_call(["ray", "stop"])
+    # Delete the cluster address just in case.
+    ray._private.utils.reset_ray_address()
+
+
+# TODO: pickle does not work now. It worked in standalone script,
+# but now I get:
+# ModuleNotFoundError: No module named 'test_client2'
+#
+@pytest.mark.skip(reason="does not work")
+def test_client2_get_put(call_ray_start_with_webui_addr):  # noqa: F811
+    webui = call_ray_start_with_webui_addr
+    client2_session = start_session(webui, "name")
+    with client2_session:
+        my_data = MyDataType(42, "some serializable python object")
+        ref = ray.put(my_data)
+        print(f"put {my_data.pprint()} as ref: {ref}")
+        # but within a task/method, it's all in the worker, ofc
+        got = ray.get(ref)
+        print(f"got {got.pprint()} as ref: {ref}")
+        assert type(got) == type(my_data)
+        assert got.i == my_data.i
+        assert got.s == my_data.s
+
+
+def test_client2_task_remote(call_ray_start_with_webui_addr):  # noqa: F811
+    webui = call_ray_start_with_webui_addr
+    client2_session = start_session(webui, "name")
+    with client2_session:
+        remote_task_call = fib.remote(5)
+        print(f"fib.remote(5) = {remote_task_call}")
+        got = ray.get(remote_task_call)
+        print(f"which evaluates to {got}")
+        assert got == 8
+
+
+if __name__ == "__main__":
+    import sys
+
+    print(ray.__file__)
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/util/client2/driver.py
+++ b/python/ray/util/client2/driver.py
@@ -1,0 +1,84 @@
+import ray
+import asyncio
+from aiohttp import web
+import ray.cloudpickle as cloudpickle
+
+"""
+A script that spins up a detached actor and exits.
+TODO: now there's no way for a driver to send back info to the job submission client. So
+we have no way to tell the client our http address. let's add
+change-job-metadata-within-job or return-value feature to the job submission. Before
+that I will use fixed http addr.
+"""
+
+
+@ray.remote
+class DriverActor:
+    def __init__(self, name) -> None:
+
+        # if client died and restarted, it can reconnect via this name as actor name
+        self.client_session_name = name
+        # TODO: how to do gc?
+        self.put_objects = []
+        self.running_jobs = []
+        self.actors = []
+
+        asyncio.get_running_loop().create_task(self.run_http_server())
+
+    async def run_http_server(self):
+        app = web.Application()
+        app.add_routes(
+            [
+                web.post("/get", self.get),
+                web.post("/put", self.put),
+                web.post("/remotefunction/remote", self.remotefunction_remote),
+            ]
+        )
+        runner = web.AppRunner(app)
+        await runner.setup()
+        # TODO: properly set ip address + port
+        # TODO: how to send this addr back to the client?
+        site = web.TCPSite(runner, "127.0.0.1", 25001)
+        print("running http server!")
+        await site.start()
+
+    async def get(self, request):
+        body = await request.read()
+        obj_ref = ray.ObjectRef(body)
+        print(f"get ref {obj_ref}")
+        obj = await obj_ref
+        print(f"got {obj} from {obj_ref}")
+        data = cloudpickle.dumps(obj)
+        return web.Response(body=data)
+
+    async def put(self, request):
+        body = await request.read()
+        obj = cloudpickle.loads(body)
+        obj_ref = ray.put(obj)
+        self.put_objects.append(obj_ref)  # keeping the obj refs...
+        print(f"put {body} to {obj_ref}")
+        return web.Response(body=obj_ref.binary())
+
+    async def remotefunction_remote(self, request):
+        body = await request.read()
+        func, args, kwargs, task_options = cloudpickle.loads(body)
+        print(f"remote: {(func, args, kwargs, task_options)}")
+        obj_ref = ray.remote(func)._remote(args, kwargs, **task_options)
+        self.put_objects.append(obj_ref)  # keeping the obj refs...
+        print(f"remotefunction_remote {func} to {obj_ref}")
+        return web.Response(body=obj_ref.binary())
+
+
+import time
+
+if __name__ == "__main__":
+    ray.init()
+    # TODO: args: client_session_name
+    # TODO: only create if actor not already exists
+    # TODO: make "detach" configurable by job submission args
+    DriverActor.options(name="client_session_name", lifetime="detached").remote(
+        "client_session_name"
+    )
+    # TODO: if detach, make health check ping and return
+    while True:
+        time.sleep(1000)

--- a/python/ray/util/client2/session.py
+++ b/python/ray/util/client2/session.py
@@ -1,0 +1,104 @@
+import aiohttp
+import asyncio
+import ray
+from typing import Any
+from ray.job_submission import JobSubmissionClient
+import ray.cloudpickle as cloudpickle
+import os
+
+# TODO: change cloudpickle.dumps to pickle_dumps
+
+
+class ClientSession:
+    def __init__(self, server_addr: str) -> None:
+        self.server_addr = server_addr
+        self.old_ray_get = None
+        self.old_ray_put = None
+        self.old_ray_remotefunction_remote = None
+
+    def __enter__(self):
+        # object_refs, timeout
+        self.old_ray_get = ray.get
+        self.old_ray_put = ray.put
+        self.old_ray_remotefunction_remote = ray.remote_function.RemoteFunction._remote
+        ray.get = self.ray_get
+        ray.put = self.ray_put
+
+        def remote(func, args, kwargs, **task_options):
+            return self.ray_remotefunction_remote(func, args, kwargs, **task_options)
+
+        ray.remote_function.RemoteFunction._remote = remote
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # TODO: exc handling
+        ray.get = self.old_ray_get
+        ray.put = self.old_ray_put
+        ray.remote_function.RemoteFunction._remote = self.old_ray_remotefunction_remote
+        self.old_ray_get = None
+        self.old_ray_put = None
+        self.old_ray_remotefunction_remote = None
+
+    async def ray_get_async(self, object_refs, timeout=None):
+        # TODO: long connection
+        async with aiohttp.ClientSession(read_timeout=timeout) as session:
+            # TODO: support more than 1 object ref
+            async with session.post(
+                f"{self.server_addr}/get", data=object_refs.binary()
+            ) as resp:
+                # TODO: error handling
+                data = await resp.read()
+                obj = cloudpickle.loads(data)
+                return obj
+
+    def ray_get(self, object_refs, timeout=None):
+        # TODO: support those overloads
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(self.ray_get_async(object_refs, timeout))
+
+    async def ray_put_async(self, value: Any):
+        # TODO: long connection
+        async with aiohttp.ClientSession(read_timeout=None) as session:
+            async with session.post(
+                f"{self.server_addr}/put", data=cloudpickle.dumps(value)
+            ) as resp:
+                # TODO: error handling
+                ref_data = await resp.read()
+                return ray.ObjectRef(ref_data)
+
+    def ray_put(self, value):
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(self.ray_put_async(value))
+
+    async def ray_remotefunction_remote_async(self, func, args, kwargs, **task_options):
+        data = cloudpickle.dumps((func._function, args, kwargs, task_options))
+        async with aiohttp.ClientSession(read_timeout=None) as session:
+            async with session.post(
+                f"{self.server_addr}/remotefunction/remote", data=data
+            ) as resp:
+                # TODO: error handling
+                ref_data = await resp.read()
+                print(ref_data)
+                # TODO: support more than 1 refs
+                return ray.ObjectRef(ref_data)
+
+    def ray_remotefunction_remote(self, func, args, kwargs, **task_options):
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(
+            self.ray_remotefunction_remote_async(func, args, kwargs, **task_options)
+        )
+
+
+def start_session(cluster_address: str, name: str) -> ClientSession:
+    job_client = JobSubmissionClient(cluster_address)
+    # TODO: pass the name.
+    # TODO: first list jobs. if the job by name already exists, return the http address in metadata.
+    job_client.submit_job(
+        entrypoint="python -m ray.util.client2.driver", runtime_env={"pip": ["aiohttp"]}
+    )
+    import time
+
+    # wait for actor and http server to be on.
+    # TODO: instead, wait for notification
+    time.sleep(5)
+    # TODO: somehow let the driver to pass back the http address
+    return ClientSession("http://127.0.0.1:25001")


### PR DESCRIPTION
This is a prototype of a http based rewrite of Ray Client. Some thoughts:

- Ray Client is very useful and we can't lose the chance to easily run a local jupyter that has access to customer's macbook's 1 MiB toy data sets and scratch codes
- current ray client is bad.
  - it's too entangled into Ray Core and duplicate every code 2 times (worker mode, client mode; hooks; stuff)
  - if client script crashes, we lose any work in progress
- in Ray Client, we don't need *all* ray features; we only need what's Ray exposed in `__init__.py`, or even a subset of it.
- Absolute must is: `ray.get, ray.put, RemoteFunction.remote, Actor.remote`, and that's it
- no local raylet, no local gcs
- can be not performance-optimized

This is a prototype based on that thought. Features:

- simple, purely external to ray core
- client can crash and reconnect to an existing session
- limited support set (as mentioned before)

Design:
- starting a session: submits a job. The job spins up an actor as http server that proxies `get, put, remote` calls.
- reconnect: the driver is the submitted job, so it can outlive the client script. Script will be able to reconnect via http
- just pickle everything and pass to http server actor

Limitations:
- need https://github.com/ray-project/ray/issues/36638 to be able to set job metadata, to enable the actor tell client script its http address
- performance is not optimized. this is fine because "the real work" is within the ray cluster, and this cost is only paid when crossing the ray cluster border to client script