### PR TITLE
[Doc] Fix typo in Lightning Getting Start Page

### DIFF
--- a/doc/source/train/doc_code/checkpoints.py
+++ b/doc/source/train/doc_code/checkpoints.py
@@ -205,7 +205,7 @@ class MyLightningModule(pl.LightningModule):
         self.log("mean_accuracy", mean_acc, sync_dist=True)
 
 
-def train_func_per_worker():
+def train_func():
     ...
     model = MyLightningModule(...)
     datamodule = MyLightningDataModule(...)
@@ -218,7 +218,7 @@ def train_func_per_worker():
 
 
 ray_trainer = TorchTrainer(
-    train_func_per_worker,
+    train_func,
     scaling_config=train.ScalingConfig(num_workers=2),
     run_config=train.RunConfig(
         checkpoint_config=train.CheckpointConfig(
@@ -279,7 +279,7 @@ from ray.train.torch import TorchTrainer
 from ray.train.lightning import RayTrainReportCallback
 
 
-def train_func_per_worker():
+def train_func():
     model = MyLightningModule(...)
     datamodule = MyLightningDataModule(...)
     trainer = pl.Trainer(..., callbacks=[RayTrainReportCallback()])
@@ -299,7 +299,7 @@ checkpoint = Checkpoint("s3://bucket/ckpt_dir")
 
 # Resume training from checkpoint file
 ray_trainer = TorchTrainer(
-    train_func_per_worker,
+    train_func,
     scaling_config=train.ScalingConfig(num_workers=2),
     resume_from_checkpoint=checkpoint,
 )

--- a/doc/source/train/getting-started-pytorch-lightning.rst
+++ b/doc/source/train/getting-started-pytorch-lightning.rst
@@ -486,7 +486,7 @@ control over their native Lightning code.
 
             # [5] Explicitly define and run the training function
             ray_trainer = TorchTrainer(
-                train_func_per_worker,
+                train_func,
                 scaling_config=ScalingConfig(num_workers=4, use_gpu=True),
                 run_config=RunConfig(
                     checkpoint_config=CheckpointConfig(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fixed a function name mismatch typo(train_func v.s. train_func_per_worker) in the getting start page.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
