### PR TITLE
[serve] Fix small bugs

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -352,7 +352,7 @@ class ApplicationState:
             except Exception:
                 self._set_target_state_deployment_infos(None)
                 self._update_status(
-                    BuildAppStatus.FAILED,
+                    ApplicationStatus.DEPLOY_FAILED,
                     (
                         f"Unexpected error occured while applying config for "
                         f"application '{self._name}': \n{traceback.format_exc()}"
@@ -845,6 +845,8 @@ class ApplicationStateManager:
     def shutdown(self) -> None:
         for app_state in self._application_states.values():
             app_state.delete()
+
+        self._kv_store.delete(CHECKPOINT_KEY)
 
     def is_ready_for_shutdown(self) -> bool:
         """Return whether all applications have shut down.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix two bugs:
1. Application target state checkpoint is not deleted when Serve is shutdown, so you will see `Recovering target state for application 'default' from checkpoint` each time you start Serve again. It "recovers" the default target state so there is no actual difference, but this is still a bug and the confusing log is printed to console + log files.
<img width="1202" alt="Screen Shot 2023-09-20 at 3 35 19 PM" src="https://github.com/ray-project/ray/assets/15851518/85a63678-6c99-4e3c-a2fd-9b795b0e10dd">

2. Typo in `deploy_config`. We have a generic catch block in case unexpected errors are thrown, had a typo in that block (which is untested since it's for unexpected errors).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
