### PR TITLE
[civ2] Fix data test setup

### DIFF
--- a/ci/docker/data.build.Dockerfile
+++ b/ci/docker/data.build.Dockerfile
@@ -1,6 +1,7 @@
 ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml
-ARG ARROW_VERSION
 FROM $DOCKER_IMAGE_BASE_BUILD
+
+ARG ARROW_VERSION
 
 # Unset dind settings; we are using the host's docker daemon.
 ENV DOCKER_TLS_CERTDIR=


### PR DESCRIPTION
ARROW_VERSION is currently declared before the FROM keyword so it is not read in properly into the docker image. As a result, all data tests are currently running pyarrow=12 (which is part of requirement files).

Fix by moving the arg to below the FROM keyword

Test:
- CI