### PR TITLE
[civ2] fix job env for core redis test

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -19,7 +19,7 @@ steps:
         --test-env=TEST_EXTERNAL_REDIS=1
         --except-tags debug_tests,asan_tests,post_wheel_build,xcommit
     depends_on: corebuild
-    job_env: corebuild
+    job_env: forge
 
   - label: ":ray: core: flaky tests"
     instance_type: large


### PR DESCRIPTION
Use forge as the base for core redis test. The current setting doesn't break, but using forge will make the job 5 minutes faster.  This bug is due to a merge conflict.

Test:
- CI