### PR TITLE
[serve] allow dictionary grpc_options for serve.start

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -70,7 +70,7 @@ def start(
     proxy_location: Union[None, str, ProxyLocation] = None,
     http_options: Union[None, dict, HTTPOptions] = None,
     dedicated_cpu: bool = False,
-    grpc_options: Optional[gRPCOptions] = None,
+    grpc_options: Union[None, dict, gRPCOptions] = None,
     **kwargs,
 ):
     """Start Serve on the cluster.
@@ -97,8 +97,9 @@ def start(
           `HTTPOptions` for supported options.
         dedicated_cpu: [DEPRECATED] Whether to reserve a CPU core for the
           Serve controller actor.
-        grpc_options: [EXPERIMENTAL] gRPC config options for the proxies. See
-          `gRPCOptions` for supported options.
+        grpc_options: [EXPERIMENTAL] gRPC config options for the proxies. These can
+          be passed as an unstructured dictionary or the structured `gRPCOptions`
+          class See `gRPCOptions` for supported options.
     """
     if not detached:
         warnings.warn(

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -313,6 +313,38 @@ def test_serving_request_through_grpc_proxy(ray_cluster):
     ping_fruit_stand(channel, app_name)
 
 
+def test_serve_start_dictionary_grpc_options(ray_cluster):
+    """Test serve able to start with dictionary grpc_options.
+
+    When Serve starts with dictionary grpc_options, it should not throw errors and able
+    to serve health check and list applications gRPC requests.
+    """
+    cluster = ray_cluster
+    cluster.add_node(num_cpus=2)
+    cluster.connect(namespace=SERVE_NAMESPACE)
+
+    grpc_port = 9000
+    grpc_servicer_functions = [
+        "ray.serve.generated.serve_pb2_grpc.add_UserDefinedServiceServicer_to_server",
+        "ray.serve.generated.serve_pb2_grpc.add_FruitServiceServicer_to_server",
+    ]
+
+    serve.start(
+        grpc_options={
+            "port": grpc_port,
+            "grpc_servicer_functions": grpc_servicer_functions,
+        },
+    )
+
+    channel = grpc.insecure_channel("localhost:9000")
+
+    # Ensures ListApplications method succeeding.
+    ping_grpc_list_applications(channel, [])
+
+    # Ensures Healthz method succeeding.
+    ping_grpc_healthz(channel)
+
+
 def test_grpc_proxy_routing_without_metadata(ray_cluster):
     """Test metadata are not required when calling gRPC proxy with only one app.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Update the typing for `grpc_options` to include dict. Also added a test to ensure passing dictionary `grpc_options` works as expected

## Related issue number

Closes https://github.com/ray-project/ray/issues/39160

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
