### PR TITLE
[serve] raise error when user provided invalid gRPC servicer functions

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -258,15 +258,17 @@ class gRPCOptions(BaseModel):
                 if callable(imported_func):
                     callables.append(imported_func)
                 else:
-                    logger.warning(
+                    logger.exception(
                         f"{func} is not a callable function! Please make sure "
                         "the function is imported correctly."
                     )
-            except ModuleNotFoundError:
-                logger.warning(
+                    raise ValueError(f"{func} is not a callable function!")
+            except ModuleNotFoundError as e:
+                logger.exception(
                     f"{func} can't be imported! Please make sure there are no typo "
                     "in those functions. Or you might want to rebuild service "
                     "definitions if .proto file is changed."
                 )
+                raise e
 
         return callables

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -258,17 +258,17 @@ class gRPCOptions(BaseModel):
                 if callable(imported_func):
                     callables.append(imported_func)
                 else:
-                    logger.exception(
+                    message = (
                         f"{func} is not a callable function! Please make sure "
                         "the function is imported correctly."
                     )
-                    raise ValueError(f"{func} is not a callable function!")
+                    raise ValueError(message)
             except ModuleNotFoundError as e:
-                logger.exception(
+                message = (
                     f"{func} can't be imported! Please make sure there are no typo "
                     "in those functions. Or you might want to rebuild service "
                     "definitions if .proto file is changed."
                 )
-                raise e
+                raise ModuleNotFoundError(message) from e
 
         return callables

--- a/python/ray/serve/tests/test_config.py
+++ b/python/ray/serve/tests/test_config.py
@@ -497,15 +497,17 @@ def test_grpc_options():
 
     # Import not found should raise ModuleNotFoundError.
     grpc_servicer_functions = ["fake.service.that.does.not.exist"]
-    with pytest.raises(ModuleNotFoundError):
+    with pytest.raises(ModuleNotFoundError) as exception:
         grpc_options = gRPCOptions(grpc_servicer_functions=grpc_servicer_functions)
         grpc_options.grpc_servicer_func_callable
+    assert "can't be imported!" in str(exception)
 
     # Not callable should raise ValueError.
     grpc_servicer_functions = ["ray.serve._private.constants.DEFAULT_HTTP_PORT"]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exception:
         grpc_options = gRPCOptions(grpc_servicer_functions=grpc_servicer_functions)
         grpc_options.grpc_servicer_func_callable
+    assert "is not a callable function!" in str(exception)
 
 
 def test_proxy_location_to_deployment_mode():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Change the behavior to fail on invalid gRPC servicer functions. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/39163

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
