### PR TITLE
[civ2][docker/8] build anyscale docker image

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -61,14 +61,3 @@ steps:
       - cp -f ./python/requirements_compiled.txt /artifact-mount/
     depends_on:
       - forge
-
-  - label: ":tapioca: build: anyscale-ml py38 cu118 docker"
-    instance_type: medium
-    commands:
-      - bazel run //ci/ray_ci:build_in_docker -- anyscale --python-version py38 
-        --platform cu118 --image-type ray-ml
-    depends_on: 
-      - manylinux
-      - forge
-      - ray-mlpy38cu118base
-    job_env: forge

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -29,7 +29,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- doc 
     depends_on: docbuild
-    job_env: docbuild
+    job_env: forge
 
   - label: ":tapioca: build: ray py38 cu118 docker"
     instance_type: medium
@@ -61,4 +61,14 @@ steps:
       - cp -f ./python/requirements_compiled.txt /artifact-mount/
     depends_on:
       - forge
+
+  - label: ":tapioca: build: anyscale-ml py38 cu118 docker"
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:build_in_docker -- anyscale --python-version py38 
+        --platform cu118 --image-type ray-ml
+    depends_on: 
+      - manylinux
+      - forge
+      - ray-mlpy38cu118base
     job_env: forge

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,7 +61,7 @@ pip_parse(
 pip_parse(
     name = "py_deps_ray_ci",
     python_interpreter_target = python39,
-    requirements_lock = "//release:requirements_buildkite.txt",
+    requirements_lock = "//ci/ray_ci:requirements.txt",
 )
 
 pip_parse(

--- a/ci/build/build-anyscale-docker.sh
+++ b/ci/build/build-anyscale-docker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+SOURCE_IMAGE="$1"
+DEST_IMAGE="$2"
+
+DATAPLANE_S3_BUCKET="ray-release-automation-results"
+DATAPLANE_FILENAME="dataplane_20230718.tgz"
+DATAPLANE_DIGEST="a3ad426b05f5cf1981fe684ccbffc1dded5e1071a99184d1072b7fc7b4daf8bc"
+
+# download dataplane build file
+aws s3api get-object --bucket "${DATAPLANE_S3_BUCKET}" \
+    --key "${DATAPLANE_FILENAME}" "${DATAPLANE_FILENAME}"
+
+# check dataplane build file digest
+echo "${DATAPLANE_DIGEST}  ${DATAPLANE_FILENAME}" | sha256sum -c
+
+# build anyscale image
+DOCKER_BUILDKIT=1 docker build \
+    --build-arg BASE_IMAGE="$SOURCE_IMAGE" \
+    -t "$DEST_IMAGE" - < "${DATAPLANE_FILENAME}"

--- a/ci/ray_ci/anyscale_docker_container.py
+++ b/ci/ray_ci/anyscale_docker_container.py
@@ -1,0 +1,21 @@
+from ci.ray_ci.docker_container import DockerContainer
+
+
+class AnyscaleDockerContainer(DockerContainer):
+    """
+    Container for building and publishing anyscale docker images
+    """
+
+    def run(self) -> None:
+        """
+        Build and publish anyscale docker images
+        """
+        tag = self._get_canonical_tag()
+        ray_image = f"rayproject/{self.image_type}:{tag}"
+        anyscale_image = f"anyscale/{self.image_type}:{tag}"
+
+        self.run_script(
+            [
+                f"./ci/build/build-anyscale-docker.sh {ray_image} {anyscale_image}",
+            ]
+        )

--- a/ci/ray_ci/builder.py
+++ b/ci/ray_ci/builder.py
@@ -3,7 +3,9 @@ import click
 from ci.ray_ci.builder_container import PYTHON_VERSIONS, BuilderContainer
 from ci.ray_ci.doc_builder_container import DocBuilderContainer
 from ci.ray_ci.forge_container import ForgeContainer
-from ci.ray_ci.docker_container import PLATFORM, DockerContainer
+from ci.ray_ci.docker_container import PLATFORM
+from ci.ray_ci.ray_docker_container import RayDockerContainer
+from ci.ray_ci.anyscale_docker_container import AnyscaleDockerContainer
 from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.utils import logger, docker_login
 
@@ -12,7 +14,7 @@ from ci.ray_ci.utils import logger, docker_login
 @click.argument(
     "artifact_type",
     required=True,
-    type=click.Choice(["wheel", "doc", "docker"]),
+    type=click.Choice(["wheel", "doc", "docker", "anyscale"]),
 )
 @click.option(
     "--python-version",
@@ -51,6 +53,13 @@ def main(
         build_docker(python_version, platform, image_type)
         return
 
+    if artifact_type == "anyscale":
+        logger.info(
+            f"Building {image_type} anyscale for {python_version} on {platform}"
+        )
+        build_anyscale(python_version, platform, image_type)
+        return
+
     if artifact_type == "doc":
         logger.info("Building ray docs")
         build_doc()
@@ -72,7 +81,16 @@ def build_docker(python_version: str, platform: str, image_type: str) -> None:
     Build a container artifact.
     """
     BuilderContainer(python_version).run()
-    DockerContainer(python_version, platform, image_type).run()
+    RayDockerContainer(python_version, platform, image_type).run()
+
+
+def build_anyscale(python_version: str, platform: str, image_type: str) -> None:
+    """
+    Build an anyscale container artifact.
+    """
+    BuilderContainer(python_version).run()
+    RayDockerContainer(python_version, platform, image_type).run()
+    AnyscaleDockerContainer(python_version, platform, image_type).run()
 
 
 def build_doc() -> None:

--- a/ci/ray_ci/docker_container.py
+++ b/ci/ray_ci/docker_container.py
@@ -1,5 +1,6 @@
 import os
 from typing import List
+from datetime import datetime
 
 from ci.ray_ci.container import Container, _DOCKER_ECR_REPO
 from ci.ray_ci.builder_container import PYTHON_VERSIONS

--- a/ci/ray_ci/docker_container.py
+++ b/ci/ray_ci/docker_container.py
@@ -1,10 +1,7 @@
 import os
 from typing import List
-from datetime import datetime
 
-from ci.ray_ci.container import Container, _DOCKER_ECR_REPO
-from ci.ray_ci.builder_container import PYTHON_VERSIONS
-from ci.ray_ci.utils import docker_pull, RAY_VERSION, POSTMERGE_PIPELINE
+from ci.ray_ci.container import Container
 
 
 PLATFORM = ["cu118"]
@@ -32,47 +29,6 @@ class DockerContainer(Container):
             ],
         )
 
-    def run(self) -> None:
-        """
-        Build and publish ray docker images
-        """
-        assert "RAYCI_BUILD_ID" in os.environ, "RAYCI_BUILD_ID not set"
-        rayci_build_id = os.environ["RAYCI_BUILD_ID"]
-
-        base_image = (
-            f"{_DOCKER_ECR_REPO}:{rayci_build_id}"
-            f"-{self.image_type}{self.python_version}{self.platform}base"
-        )
-        docker_pull(base_image)
-
-        bin_path = PYTHON_VERSIONS[self.python_version]["bin_path"]
-        wheel_name = f"ray-{RAY_VERSION}-{bin_path}-manylinux2014_x86_64.whl"
-
-        constraints_file = "requirements_compiled.txt"
-        if self.python_version == "py37":
-            constraints_file = "requirements_compiled_py37.txt"
-
-        ray_images = self._get_image_names()
-        ray_image = ray_images[0]
-        cmds = [
-            "./ci/build/build-ray-docker.sh "
-            f"{wheel_name} {base_image} {constraints_file} {ray_image}"
-        ]
-        if self._should_upload():
-            cmds += [
-                "pip install -q aws_requests_auth boto3",
-                "python .buildkite/copy_files.py --destination docker_login",
-            ]
-            for alias in self._get_image_names():
-                cmds += [
-                    f"docker tag {ray_image} {alias}",
-                    f"docker push {alias}",
-                ]
-        self.run_script(cmds)
-
-    def _should_upload(self) -> bool:
-        return os.environ.get("BUILDKITE_PIPELINE_ID") == POSTMERGE_PIPELINE
-
     def _get_image_version_tags(self) -> List[str]:
         branch = os.environ.get("BUILDKITE_BRANCH")
         sha_tag = os.environ["BUILDKITE_COMMIT"][:6]
@@ -85,8 +41,16 @@ class DockerContainer(Container):
 
         return [sha_tag]
 
-    def _get_image_names(self) -> List[str]:
-        # Image name is composed by ray version tag, python version and platform.
+    def _get_canonical_tag(self) -> str:
+        # The canonical tag is the first tag in the list of tags. The list of tag is
+        # never empty because the image is always tagged with at least the sha tag.
+        #
+        # The canonical tag is the most complete tag with no abbreviation,
+        # e.g. sha-pyversion-platform
+        return self._get_image_tags()[0]
+
+    def _get_image_tags(self) -> List[str]:
+        # An image tag is composed by ray version tag, python version and platform.
         # See https://docs.ray.io/en/latest/ray-overview/installation.html for
         # more information on the image tags.
         versions = self._get_image_version_tags()
@@ -106,12 +70,10 @@ class DockerContainer(Container):
         if self.python_version == DEFAULT_PYTHON_VERSION:
             py_versions.append("")
 
-        alias_images = []
-        ray_repo = f"rayproject/{self.image_type}"
+        tags = []
         for version in versions:
             for platform in platforms:
                 for py_version in py_versions:
-                    alias = f"{ray_repo}:{version}{py_version}{platform}"
-                    alias_images.append(alias)
-
-        return alias_images
+                    tag = f"{version}{py_version}{platform}"
+                    tags.append(tag)
+        return tags

--- a/ci/ray_ci/ray_docker_container.py
+++ b/ci/ray_ci/ray_docker_container.py
@@ -1,0 +1,58 @@
+import os
+from typing import List
+
+from ci.ray_ci.container import _DOCKER_ECR_REPO
+from ci.ray_ci.docker_container import DockerContainer
+from ci.ray_ci.builder_container import PYTHON_VERSIONS
+from ci.ray_ci.utils import docker_pull, RAY_VERSION, POSTMERGE_PIPELINE
+
+
+class RayDockerContainer(DockerContainer):
+    """
+    Container for building and publishing ray docker images
+    """
+
+    def run(self) -> None:
+        """
+        Build and publish ray docker images
+        """
+        assert "RAYCI_BUILD_ID" in os.environ, "RAYCI_BUILD_ID not set"
+        rayci_build_id = os.environ["RAYCI_BUILD_ID"]
+
+        base_image = (
+            f"{_DOCKER_ECR_REPO}:{rayci_build_id}"
+            f"-{self.image_type}{self.python_version}{self.platform}base"
+        )
+        docker_pull(base_image)
+
+        bin_path = PYTHON_VERSIONS[self.python_version]["bin_path"]
+        wheel_name = f"ray-{RAY_VERSION}-{bin_path}-manylinux2014_x86_64.whl"
+
+        constraints_file = "requirements_compiled.txt"
+        if self.python_version == "py37":
+            constraints_file = "requirements_compiled_py37.txt"
+
+        ray_image = f"rayproject/{self.image_type}:{self._get_canonical_tag()}"
+        cmds = [
+            "./ci/build/build-ray-docker.sh "
+            f"{wheel_name} {base_image} {constraints_file} {ray_image}"
+        ]
+        if self._should_upload():
+            cmds += [
+                "pip install -q aws_requests_auth boto3",
+                "python .buildkite/copy_files.py --destination docker_login",
+            ]
+            for alias in self._get_image_names():
+                cmds += [
+                    f"docker tag {ray_image} {alias}",
+                    f"docker push {alias}",
+                ]
+        self.run_script(cmds)
+
+    def _should_upload(self) -> bool:
+        return os.environ.get("BUILDKITE_PIPELINE_ID") == POSTMERGE_PIPELINE
+
+    def _get_image_names(self) -> List[str]:
+        ray_repo = f"rayproject/{self.image_type}"
+
+        return [f"{ray_repo}:{tag}" for tag in self._get_image_tags()]

--- a/ci/ray_ci/test_docker_container.py
+++ b/ci/ray_ci/test_docker_container.py
@@ -2,6 +2,7 @@ import os
 import sys
 from typing import List
 from unittest import mock
+from datetime import datetime
 
 import pytest
 

--- a/ci/ray_ci/test_docker_container.py
+++ b/ci/ray_ci/test_docker_container.py
@@ -2,12 +2,11 @@ import os
 import sys
 from typing import List
 from unittest import mock
-from datetime import datetime
 
 import pytest
 
 from ci.ray_ci.container import _DOCKER_ECR_REPO
-from ci.ray_ci.docker_container import DockerContainer
+from ci.ray_ci.ray_docker_container import RayDockerContainer
 from ci.ray_ci.test_base import RayCITestBase
 from ci.ray_ci.utils import RAY_VERSION
 
@@ -20,12 +19,12 @@ class TestDockerContainer(RayCITestBase):
             self.cmds.append(input[0])
 
         with mock.patch(
-            "ci.ray_ci.docker_container.docker_pull", return_value=None
+            "ci.ray_ci.ray_docker_container.docker_pull", return_value=None
         ), mock.patch(
             "ci.ray_ci.docker_container.Container.run_script",
             side_effect=_mock_run_script,
         ):
-            container = DockerContainer("py38", "cu118", "ray")
+            container = RayDockerContainer("py38", "cu118", "ray")
             container.run()
             cmd = self.cmds[-1]
             assert cmd == (
@@ -36,7 +35,7 @@ class TestDockerContainer(RayCITestBase):
                 "rayproject/ray:123456-py38-cu118"
             )
 
-            container = DockerContainer("py37", "cpu", "ray-ml")
+            container = RayDockerContainer("py37", "cpu", "ray-ml")
             container.run()
             cmd = self.cmds[-1]
             assert cmd == (
@@ -47,8 +46,34 @@ class TestDockerContainer(RayCITestBase):
                 "rayproject/ray-ml:123456-py37-cpu"
             )
 
+    def test_canonical_tag(self) -> None:
+        container = RayDockerContainer("py38", "cpu", "ray")
+        assert container._get_canonical_tag() == "123456-py38-cpu"
+
+        container = RayDockerContainer("py37", "cu118", "ray-ml")
+        assert container._get_canonical_tag() == "123456-py37-cu118"
+
+        with mock.patch.dict(os.environ, {"BUILDKITE_BRANCH": "releases/1.0.0"}):
+            container = RayDockerContainer("py38", "cpu", "ray")
+            assert container._get_canonical_tag() == "1.0.0.123456-py38-cpu"
+
+    def test_get_image_tags(self) -> None:
+        # bulk logic of _get_image_tags is tested in its callers (get_image_name and
+        # get_canonical_tag), so we only test the basic cases here
+        container = RayDockerContainer("py38", "cpu", "ray")
+        assert container._get_image_tags() == [
+            "123456-py38-cpu",
+            "123456-cpu",
+            "123456-py38",
+            "123456",
+            "nightly-py38-cpu",
+            "nightly-cpu",
+            "nightly-py38",
+            "nightly",
+        ]
+
     def test_get_image_name(self) -> None:
-        container = DockerContainer("py38", "cpu", "ray")
+        container = RayDockerContainer("py38", "cpu", "ray")
         assert container._get_image_names() == [
             "rayproject/ray:123456-py38-cpu",
             "rayproject/ray:123456-cpu",
@@ -60,7 +85,7 @@ class TestDockerContainer(RayCITestBase):
             "rayproject/ray:nightly",
         ]
 
-        container = DockerContainer("py37", "cu118", "ray-ml")
+        container = RayDockerContainer("py37", "cu118", "ray-ml")
         assert container._get_image_names() == [
             "rayproject/ray-ml:123456-py37-cu118",
             "rayproject/ray-ml:123456-py37-gpu",
@@ -71,7 +96,7 @@ class TestDockerContainer(RayCITestBase):
         ]
 
         with mock.patch.dict(os.environ, {"BUILDKITE_BRANCH": "releases/1.0.0"}):
-            container = DockerContainer("py38", "cpu", "ray")
+            container = RayDockerContainer("py38", "cpu", "ray")
             assert container._get_image_names() == [
                 "rayproject/ray:1.0.0.123456-py38-cpu",
                 "rayproject/ray:1.0.0.123456-cpu",

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -36,7 +36,6 @@ def docker_login(docker_ecr: str) -> None:
     """
     Login to docker with AWS credentials
     """
-    subprocess.run(["pip", "install", "awscli"])
     password = subprocess.check_output(
         ["aws", "ecr", "get-login-password", "--region", "us-west-2"],
         stderr=sys.stderr,


### PR DESCRIPTION
Add the ability to build anyscale docker image to ray_ci. This will make the logic for building anyscale image self-contained. The only other dependency now is the wanda base images.

- Split docker_container into ray_docker_container and anyscale_docker_container

We don't really need to build anyscale docker image in ray ci, but I'm putting it there for testing. We will move it to release pipeline in the future.

Test:
- CI