### PR TITLE
[Core] fix: memory monitor encounters an error in cases where info in /proc/meminfo lacks units.

### DIFF
--- a/src/ray/common/memory_monitor.cc
+++ b/src/ray/common/memory_monitor.cc
@@ -256,8 +256,7 @@ std::tuple<int64_t, int64_t> MemoryMonitor::GetLinuxMemoryBytes() {
   while (std::getline(meminfo_ifs, line)) {
     std::istringstream iss(line);
     iss >> title >> value >> unit;
-    /// Linux reports them as kiB
-    RAY_CHECK(unit == "kB");
+
     value = value * 1024;
     if (title == "MemAvailable:") {
       mem_available_bytes = value;
@@ -269,7 +268,12 @@ std::tuple<int64_t, int64_t> MemoryMonitor::GetLinuxMemoryBytes() {
       buffer_bytes = value;
     } else if (title == "MemTotal:") {
       mem_total_bytes = value;
+    }else{
+      /// Skip other lines
+      continue;
     }
+    /// Linux reports them as kiB
+    RAY_CHECK(unit == "kB");
   }
   if (mem_total_bytes == kNull) {
     RAY_LOG_EVERY_MS(WARNING, kLogIntervalMs)

--- a/src/ray/common/memory_monitor.cc
+++ b/src/ray/common/memory_monitor.cc
@@ -268,7 +268,7 @@ std::tuple<int64_t, int64_t> MemoryMonitor::GetLinuxMemoryBytes() {
       buffer_bytes = value;
     } else if (title == "MemTotal:") {
       mem_total_bytes = value;
-    }else{
+    } else {
       /// Skip other lines
       continue;
     }


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Not all information in /proc/meminfo has a Kb unit. Now we are going to traverse each row, therefore an error will be thrown when encountering rows like the one in the picture.

<img width="280" alt="image" src="https://github.com/ray-project/ray/assets/22362311/f108b011-49c6-4fa1-8be3-944e76637316">

We should only check the fields that are used, and skip the fields that are not used.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
