### PR TITLE
[core] Default actor object's callable method to ActorMethod.remote

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1198,10 +1198,22 @@ class ActorHandle:
         return object_refs
 
     def __getattr__(self, item):
+        if item in ["remote"] and "__call__" in self._ray_method_signatures:
+            method_name = (
+                "__call__"  # Default to actor's callable method registered at __init__
+            )
+            return ActorMethod(
+                self,
+                method_name,
+                self._ray_method_num_returns[method_name],
+                decorator=self._ray_method_decorators.get(method_name),
+            ).remote
+
         if not self._ray_is_cross_language:
             raise AttributeError(
                 f"'{type(self).__name__}' object has " f"no attribute '{item}'"
             )
+
         if item in ["__ray_terminate__"]:
 
             class FakeActorMethod(object):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Better API for actors' with callable methods. 

## Related issue number
Closes #6163

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
