### PR TITLE
[data] estimate progress bar total

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -154,6 +154,7 @@ class PhysicalOperator(Operator):
         self._inputs_complete = not input_dependencies
         self._dependents_complete = False
         self._started = False
+        self._estimated_output_blocks = None
 
     def __reduce__(self):
         raise ValueError("Operator is not serializable.")

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -59,6 +59,7 @@ class DataOpTask(OpTask):
         self._streaming_gen = streaming_gen
         self._output_ready_callback = output_ready_callback
         self._task_done_callback = task_done_callback
+        self._num_output_blocks = 0
 
     def get_waitable(self) -> StreamingObjectRefGenerator:
         return self._streaming_gen
@@ -91,6 +92,14 @@ class DataOpTask(OpTask):
             self._output_ready_callback(
                 RefBundle([(block_ref, meta)], owns_blocks=True)
             )
+
+    def add_num_output_blocks(self, num_output_blocks):
+        self._num_output_blocks += num_output_blocks
+
+    def get_num_output_blocks(
+        self,
+    ):
+        return self._num_output_blocks
 
 
 class MetadataOpTask(OpTask):
@@ -196,6 +205,8 @@ class PhysicalOperator(Operator):
 
         This is useful for reporting progress.
         """
+        if self._estimated_output_blocks is not None:
+            return self._estimated_output_blocks
         if len(self.input_dependencies) == 1:
             return self.input_dependencies[0].num_outputs_total()
         return None

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -276,7 +276,7 @@ class MapOperator(OneToOneOperator, ABC):
             self._metrics.cur += allocated
             if self._metrics.cur > self._metrics.peak:
                 self._metrics.peak = self._metrics.cur
-            self._task_blocks_outputted[task_index] += 1
+            self._task_blocks_outputted[task_index] += len(output.blocks)
 
         def _task_done_callback(task_index, inputs):
             # We should only destroy the input bundle when the whole task is done.

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -293,8 +293,8 @@ class MapOperator(OneToOneOperator, ABC):
             self._num_output_blocks += task.get_num_output_blocks()
             num_tasks = 1
             if len(self.input_dependencies) == 1:
-                # The number of outputs reported by upstream operator. Do not use
-                # self.num_outputs_total() because we update that value with this estimate
+                # The number of outputs reported by upstream operator. We later
+                #  update self.num_outputs_total() with this estimate
                 num_tasks = self.input_dependencies[0].num_outputs_total()
             self._estimated_output_blocks = round(
                 num_tasks * self._num_output_blocks / self._num_tasks_finished

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -84,6 +84,7 @@ class MapOperator(OneToOneOperator, ABC):
         # Used for estimating the # of output blocks.
         self._num_tasks_finished = 0
         self._num_output_blocks = 0
+        self._num_inputs_received = 0
         super().__init__(name, input_op)
 
     @classmethod
@@ -204,6 +205,7 @@ class MapOperator(OneToOneOperator, ABC):
             # queue.
             bundle = self._block_ref_bundler.get_next_bundle()
             self._add_bundled_input(bundle)
+        self._num_inputs_received += 1
 
     def _get_runtime_ray_remote_args(
         self, input_bundle: Optional[RefBundle] = None
@@ -291,13 +293,14 @@ class MapOperator(OneToOneOperator, ABC):
             # Update estimate for blocks outputted
             self._num_tasks_finished += 1
             self._num_output_blocks += task.get_num_output_blocks()
-            num_tasks = 1
-            if len(self.input_dependencies) == 1:
-                # The number of outputs reported by upstream operator. We later
-                #  update self.num_outputs_total() with this estimate
-                num_tasks = self.input_dependencies[0].num_outputs_total()
+            # Estimate number of tasks from inputs received and tasks submitted so far
+            estimated_num_tasks = (
+                self.input_dependencies[0].num_outputs_total()
+                / self._num_inputs_received
+                * self._next_data_task_idx
+            )
             self._estimated_output_blocks = round(
-                num_tasks * self._num_output_blocks / self._num_tasks_finished
+                estimated_num_tasks * self._num_output_blocks / self._num_tasks_finished
             )
             if task_done_callback:
                 task_done_callback()

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -133,7 +133,7 @@ class StreamingExecutor(Executor, threading.Thread):
                             self._outer._global_info.update(1)
                             if dag._estimated_output_blocks is not None:
                                 self._outer._global_info.update_total(
-                                    dag._estimated_output_blocks, estimate=True
+                                    dag._estimated_output_blocks
                                 )
                         return item
                 # Needs to be BaseException to catch KeyboardInterrupt. Otherwise we

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -131,6 +131,10 @@ class StreamingExecutor(Executor, threading.Thread):
                         # Otherwise return a concrete RefBundle.
                         if self._outer._global_info:
                             self._outer._global_info.update(1)
+                            if dag._estimated_output_blocks is not None:
+                                self._outer._global_info.update_total(
+                                    dag._estimated_output_blocks, estimate=True
+                                )
                         return item
                 # Needs to be BaseException to catch KeyboardInterrupt. Otherwise we
                 # can leave dangling progress bars by skipping shutdown.

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -130,11 +130,9 @@ class StreamingExecutor(Executor, threading.Thread):
                     else:
                         # Otherwise return a concrete RefBundle.
                         if self._outer._global_info:
-                            self._outer._global_info.update(1)
-                            if dag._estimated_output_blocks is not None:
-                                self._outer._global_info.update_total(
-                                    dag._estimated_output_blocks
-                                )
+                            self._outer._global_info.update(
+                                1, dag._estimated_output_blocks
+                            )
                         return item
                 # Needs to be BaseException to catch KeyboardInterrupt. Otherwise we
                 # can leave dangling progress bars by skipping shutdown.

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -171,6 +171,10 @@ class OpState:
         self.num_completed_tasks += 1
         if self.progress_bar:
             self.progress_bar.update(1)
+            if self.op._estimated_output_blocks is not None:
+                self.progress_bar.update_total(
+                    self.op._estimated_output_blocks, estimate=True
+                )
 
     def refresh_progress_bar(self) -> None:
         """Update the console with the latest operator progress."""

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -172,9 +172,7 @@ class OpState:
         if self.progress_bar:
             self.progress_bar.update(1)
             if self.op._estimated_output_blocks is not None:
-                self.progress_bar.update_total(
-                    self.op._estimated_output_blocks, estimate=True
-                )
+                self.progress_bar.update_total(self.op._estimated_output_blocks)
 
     def refresh_progress_bar(self) -> None:
         """Update the console with the latest operator progress."""

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -170,9 +170,7 @@ class OpState:
         self.outqueue.append(ref)
         self.num_completed_tasks += 1
         if self.progress_bar:
-            self.progress_bar.update(1)
-            if self.op._estimated_output_blocks is not None:
-                self.progress_bar.update_total(self.op._estimated_output_blocks)
+            self.progress_bar.update(1, self.op._estimated_output_blocks)
 
     def refresh_progress_bar(self) -> None:
         """Update the console with the latest operator progress."""

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -18,13 +18,6 @@ except ImportError:
 _canceled_threads = set()
 _canceled_threads_lock = threading.Lock()
 
-TQDM_DEFAULT_BAR_FORMAT = (
-    "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]"
-)
-TQDM_ESTIMATE_BAR_FORMAT = TQDM_DEFAULT_BAR_FORMAT.replace(
-    "{total_fmt}", "~{total_fmt}"
-)
-
 
 @PublicAPI
 def set_progress_bars(enabled: bool) -> bool:
@@ -120,12 +113,9 @@ class ProgressBar:
                 self._bar.total = self._progress
             self._bar.update(i)
 
-    def update_total(self, total: int, estimate: bool = False) -> None:
+    def update_total(self, total: int) -> None:
         if self._bar and total != self._bar.total:
             self._bar.total = total
-            self._bar.bar_format = (
-                TQDM_ESTIMATE_BAR_FORMAT if estimate else TQDM_DEFAULT_BAR_FORMAT
-            )
 
     def close(self):
         if self._bar:

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -18,6 +18,13 @@ except ImportError:
 _canceled_threads = set()
 _canceled_threads_lock = threading.Lock()
 
+TQDM_DEFAULT_BAR_FORMAT = (
+    "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]"
+)
+TQDM_ESTIMATE_BAR_FORMAT = TQDM_DEFAULT_BAR_FORMAT.replace(
+    "{total_fmt}", "~{total_fmt}"
+)
+
 
 @PublicAPI
 def set_progress_bars(enabled: bool) -> bool:
@@ -112,6 +119,13 @@ class ProgressBar:
                 # If the progress goes over 100%, update the total.
                 self._bar.total = self._progress
             self._bar.update(i)
+
+    def update_total(self, total: int, estimate: bool = False) -> None:
+        if self._bar and total != self._bar.total:
+            self._bar.total = total
+            self._bar.bar_format = (
+                TQDM_ESTIMATE_BAR_FORMAT if estimate else TQDM_DEFAULT_BAR_FORMAT
+            )
 
     def close(self):
         if self._bar:

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -105,17 +105,15 @@ class ProgressBar:
             self._desc = name
             self._bar.set_description(self._desc)
 
-    def update(self, i: int) -> None:
-        if self._bar and i != 0:
+    def update(self, i: int = 0, total: Optional[int] = None) -> None:
+        if self._bar and (i != 0 or self._bar.total != total):
             self._progress += i
+            if total is not None:
+                self._bar.total = total
             if self._bar.total is not None and self._progress > self._bar.total:
                 # If the progress goes over 100%, update the total.
                 self._bar.total = self._progress
             self._bar.update(i)
-
-    def update_total(self, total: int) -> None:
-        if self._bar and total != self._bar.total:
-            self._bar.total = total
 
     def close(self):
         if self._bar:

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -108,7 +108,7 @@ class ProgressBar:
     def update(self, i: int = 0, total: Optional[int] = None) -> None:
         if self._bar and (i != 0 or self._bar.total != total):
             self._progress += i
-            if total is not None:
+            if total is not None and total > self._bar.total:
                 self._bar.total = total
             if self._bar.total is not None and self._progress > self._bar.total:
                 # If the progress goes over 100%, update the total.

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -813,6 +813,31 @@ def test_block_ref_bundler_uniform(
     assert flat_out == list(range(n))
 
 
+def test_estimated_output_blocks():
+    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
+
+    def yield_five(block_iter: Iterable[Block], ctx) -> Iterable[Block]:
+        for i in range(5):
+            yield pd.DataFrame({"id": [i]})
+
+    op = MapOperator.create(
+        create_map_transformer_from_block_fn(yield_five),
+        input_op=input_op,
+        name="TestEstimatedNumBlocks",
+        min_rows_per_bundle=10,
+    )
+
+    op.start(ExecutionOptions())
+    while input_op.has_next():
+        op.add_input(input_op.get_next(), 0)
+    op.all_inputs_done()
+
+    run_op_tasks_sync(op)
+
+    # 100 inputs -> 100 / 10 = 10 tasks -> 10 * 5 = 50 output blocks
+    assert op._estimated_output_blocks == 50
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_progress_bar.py
+++ b/python/ray/data/tests/test_progress_bar.py
@@ -66,3 +66,18 @@ def test_progress_bar(enable_tqdm_ray):
 
     assert pb._progress == new_total
     assert total_at_close == new_total
+
+    # Test updating the total
+    pb = ProgressBar("", total, enabled=True)
+    assert pb._bar is not None
+    patch_close(pb._bar)
+    new_total = total * 2
+    pb.update_total(new_total, estimate=True)
+
+    assert pb._bar.total == new_total
+    assert "~{total_fmt}" in pb._bar.bar_format
+
+    pb.update_total(total)
+    assert pb._bar.total == total
+    assert "~{total_fmt}" not in pb._bar.bar_format
+    pb.close()

--- a/python/ray/data/tests/test_progress_bar.py
+++ b/python/ray/data/tests/test_progress_bar.py
@@ -72,12 +72,7 @@ def test_progress_bar(enable_tqdm_ray):
     assert pb._bar is not None
     patch_close(pb._bar)
     new_total = total * 2
-    pb.update_total(new_total, estimate=True)
+    pb.update_total(new_total)
 
     assert pb._bar.total == new_total
-    assert "~{total_fmt}" in pb._bar.bar_format
-
-    pb.update_total(total)
-    assert pb._bar.total == total
-    assert "~{total_fmt}" not in pb._bar.bar_format
     pb.close()

--- a/python/ray/data/tests/test_progress_bar.py
+++ b/python/ray/data/tests/test_progress_bar.py
@@ -72,7 +72,9 @@ def test_progress_bar(enable_tqdm_ray):
     assert pb._bar is not None
     patch_close(pb._bar)
     new_total = total * 2
-    pb.update_total(new_total)
+    pb.update(0, new_total)
 
     assert pb._bar.total == new_total
+    pb.update(total + 1, total)
+    assert pb._bar.total == total + 1
     pb.close()

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -66,6 +66,7 @@ class tqdm:
         desc: Optional[str] = None,
         total: Optional[int] = None,
         position: Optional[int] = None,
+        bar_format: Optional[str] = None,
     ):
         import ray._private.services as services
 
@@ -84,6 +85,7 @@ class tqdm:
         self._uuid = uuid.uuid4().hex
         self._x = 0
         self._closed = False
+        self._bar_format = bar_format
 
     def set_description(self, desc):
         """Implements tqdm.tqdm.set_description."""
@@ -114,6 +116,14 @@ class tqdm:
     def total(self, total: int):
         self._total = total
 
+    @property
+    def bar_format(self) -> Optional[str]:
+        return self._bar_format
+
+    @bar_format.setter
+    def bar_format(self, bar_format: str):
+        self._bar_format = bar_format
+
     def _dump_state(self) -> None:
         if ray._private.worker.global_worker.mode == ray.WORKER_MODE:
             # Include newline in payload to avoid split prints.
@@ -133,6 +143,7 @@ class tqdm:
             "pid": self._pid,
             "uuid": self._uuid,
             "closed": self._closed,
+            "bar_format": self._bar_format,
         }
 
     def __iter__(self):
@@ -170,10 +181,16 @@ class _Bar:
 
     def update(self, state: ProgressBarState) -> None:
         """Apply the updated worker progress bar state."""
+        refresh = False
         if state["desc"] != self.state["desc"]:
             self.bar.set_description(state["desc"])
         if state["total"] != self.state["total"]:
             self.bar.total = state["total"]
+            refresh = True
+        if state["bar_format"] != self.state["bar_format"]:
+            self.bar.bar_format = state["bar_format"]
+            refresh = True
+        if refresh:
             self.bar.refresh()
         delta = state["x"] - self.state["x"]
         if delta:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Estimates the number of blocks outputted from the # of finished tasks and # of blocks outputted. `estimated_output_blocks = original_output_blocks * (blocks_outputted / finished_tasks)`.

Before the first task ends, we stick with the original total
<img width="1725" alt="Screenshot 2023-09-25 at 8 05 26 AM" src="https://github.com/ray-project/ray/assets/39287272/a304d0a5-0440-4972-b34d-87d03dd785ed">
And after the first task finishes (and every task after it), we update the estimated total
<img width="1723" alt="Screenshot 2023-09-25 at 8 05 34 AM" src="https://github.com/ray-project/ray/assets/39287272/0d4a0f40-f90b-4e65-a964-e8e4c3be1b46">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #38482 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
