### PR TITLE
[Logging] Fix Deduplication URL

### DIFF
--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -339,7 +339,8 @@ def _warn_once() -> str:
         return (
             " (Ray deduplicates logs by default. Set RAY_DEDUP_LOGS=0 to "
             "disable log deduplication, or see https://docs.ray.io/en/master/"
-            "ray-observability/ray-logging.html#log-deduplication for more options.)"
+            "ray-observability/user-guides/configure-logging.html#log-deduplication"
+            " for more options.)"
         )
     else:
         return ""


### PR DESCRIPTION
## Why are these changes needed?
The current URL does not work (https://docs.ray.io/en/master/ray-observability/ray-logging.html#log-deduplication). Switch to the correct URL (https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#log-deduplication).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
