### PR TITLE
[serve] Fix flaky `test_replica_scheduler`

### DIFF
--- a/python/ray/serve/tests/test_replica_scheduler.py
+++ b/python/ray/serve/tests/test_replica_scheduler.py
@@ -818,15 +818,16 @@ async def test_prefer_az_off(pow_2_scheduler, fake_query):
 
     async def choose_replicas():
         tasks = []
-        for _ in range(10):
+        for _ in range(30):
             tasks.append(loop.create_task(s.choose_replica_for_query(fake_query)))
-        return await asyncio.gather(*tasks)
+        replicas = await asyncio.gather(*tasks)
+        return {r.replica_id for r in replicas}
 
     # Requests should be spread across all nodes
-    assert set(await choose_replicas()) == {r1, r2, r3}
+    assert await choose_replicas() == {r1.replica_id, r2.replica_id, r3.replica_id}
 
     r1.set_queue_state_response(0, accepted=False)
-    assert set(await choose_replicas()) == {r2, r3}
+    assert await choose_replicas() == {r2.replica_id, r3.replica_id}
 
 
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/test_replica_scheduler.py
+++ b/python/ray/serve/tests/test_replica_scheduler.py
@@ -824,6 +824,8 @@ async def test_prefer_az_off(pow_2_scheduler, fake_query):
         return {r.replica_id for r in replicas}
 
     # Requests should be spread across all nodes
+    # NOTE(zcin): Choose up to 1000 replicas in batches of 10 at a time.
+    # This deflakes the test, but also makes sure the test runs fast on average
     chosen_replicas = set()
     for _ in range(100):
         chosen_replicas = chosen_replicas.union(await choose_replicas())


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_prefer_az_off` fails occasionally because the test chooses a replica 10 times and makes sure all 3 replicas are chosen at the end of the 10 iterations.

However sometimes even though the router logic is correct, only 2 out of the 3 replicas are chosen after 10 iterations. The probability of this happening is (2/3)^10 * 3 = 5%. This makes the test very flaky.
Changing it to run for up to 1000 iterations in batches of 10 at a time. This deflakes the test while still maintaining fast average times.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
