### PR TITLE
[ci][coverage] turn off core + serverless tests for non-core changes

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -1,6 +1,7 @@
 group: core tests
 steps:
   - label: ":ray: core: python tests"
+    tags: [RAY_CI_PYTHON_AFFECTED]
     instance_type: large
     parallelism: 4
     commands:
@@ -11,6 +12,7 @@ steps:
     job_env: forge
 
   - label: ":ray: core: redis tests"
+    tags: [RAY_CI_PYTHON_AFFECTED]
     instance_type: large
     parallelism: 4
     commands:
@@ -22,6 +24,7 @@ steps:
     job_env: forge
 
   - label: ":ray: core: flaky tests"
+    tags: [RAY_CI_PYTHON_AFFECTED]
     instance_type: large
     soft_fail: true
     commands:

--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -1,6 +1,7 @@
 group: serverless tests
 steps:
   - label: ":serverless: serverless: python tests"
+    tags: [RAY_CI_PYTHON_AFFECTED]
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless 
@@ -10,6 +11,7 @@ steps:
     job_env: forge
 
   - label: ":serverless: serverless: flaky tests"
+    tags: [RAY_CI_PYTHON_AFFECTED]
     instance_type: medium
     soft_fail: true
     commands:

--- a/ci/ci_tags_from_change.sh
+++ b/ci/ci_tags_from_change.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec python ci/pipeline/determine_tests_to_run.py --output rayci_tags

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -72,7 +72,9 @@ def get_commit_range():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--output", type=str, help="json or envvars", default="envvars")
+    parser.add_argument(
+        "--output", type=str, help="json, rayci_tags or envvars", default="envvars"
+    )
     args = parser.parse_args()
 
     RAY_CI_BRANCH_BUILD = int(
@@ -366,9 +368,11 @@ if __name__ == "__main__":
     print(output_string, file=sys.stderr)
 
     # Used by buildkite log format
+    pairs = [item.split("=") for item in output_string.split(" ")]
+    affected_vars = [key for key, affected in pairs if affected == "1"]
     if args.output.lower() == "json":
-        pairs = [item.split("=") for item in output_string.split(" ")]
-        affected_vars = [key for key, affected in pairs if affected == "1"]
         print(json.dumps(affected_vars))
+    elif args.output.lower() == "rayci_tags":
+        print(" ".join(affected_vars))
     else:
         print(output_string)


### PR DESCRIPTION
Compute coverage info for ray/python changes, so that we can turn off core + serverless tests for non-core changes. These tests deem to be quite flaky, and we should let core fix them without affecting other team.

Test:

- CI
- core + serverless are correctly turned off: https://buildkite.com/ray-project/dev/builds/74