### PR TITLE
[Serve] Fixing coroutines passed to `asyncio.wait` directly 

### DIFF
--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1022,13 +1022,15 @@ class HTTPProxy(GenericProxy):
         while retries < HTTP_REQUEST_MAX_RETRIES + 1:
             should_backoff = False
             result_ref = handle.remote(request)
-            # NOTE: This task will not be completed until response is sent back or client disconnects,
-            #       hence we rely on it to track whether client has disconnected while we're handling
-            #       their requests
+            # NOTE: This task will not be completed until response is sent back or
+            #       client disconnects, hence we rely on it to track whether client
+            #       has disconnected while we're handling their request
             client_disconnection_task = loop.create_task(proxy_request.receive())
-            # Converting response object to `ObjectRef` actually entails assignment of the target replica
-            # that would be handling it
-            replica_assignment_task = loop.create_task(result_ref._to_object_ref(_record_telemetry=False))
+            # Converting response object to `ObjectRef` actually entails assignment
+            # of the target replica that would be handling it
+            replica_assignment_task = loop.create_task(
+                result_ref._to_object_ref(_record_telemetry=False)
+            )
             done, _ = await asyncio.wait(
                 [
                     replica_assignment_task,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Passing coroutines to `asyncio.wait` is deprecated in Python 3.8, and starts dumping following warning in our logs:

```
/home/ray/anaconda3/lib/python3.9/site-packages/ray/serve/handle.py:761: DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
