### PR TITLE
[serve] Remove routing and streaming FF CI builds

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -4,12 +4,6 @@
   commands:
     - ./java/test.sh
 
-- label: ":java: Java (streaming and routing FFs off)"
-  conditions: ["RAY_CI_JAVA_AFFECTED"]
-  instance_size: medium
-  commands:
-    - export RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=0 RAY_SERVE_ENABLE_NEW_ROUTING=0 && ./java/test.sh
-
 - label: ":serverless: Dashboard Tests"
   conditions:
     [

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -16,27 +16,6 @@ steps:
     depends_on: servebuild
     job_env: forge
 
-  - label: ":ray-serve: serve: serve tests (streaming ff off)"
-    parallelism: 3
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve --except-tags post_wheel_build,gpu,xcommit
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --test-env=RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=0
-    depends_on: servebuild
-    job_env: forge
-
-  - label: ":ray-serve: serve: serve tests (streaming and routing ff off)"
-    parallelism: 3
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve --except-tags post_wheel_build,gpu,xcommit
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --test-env=RAY_SERVE_ENABLE_NEW_ROUTING=0
-        --test-env=RAY_SERVE_ENABLE_EXPERIMENTAL_STREAMING=0
-    depends_on: servebuild
-    job_env: forge
-
   - label: ":ray-serve: serve: flaky tests"
     instance_type: medium
     soft_fail: true


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Routing FF is removed, so setting that takes no effect anymore, and streaming flag will soon be removed as well.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
