### PR TITLE
[Serve] Improve debug info in `test_submit_job`

### DIFF
--- a/dashboard/modules/job/tests/test_http_job_server.py
+++ b/dashboard/modules/job/tests/test_http_job_server.py
@@ -165,7 +165,8 @@ def _check_job_succeeded(client: JobSubmissionClient, job_id: str) -> bool:
         raise RuntimeError(
             f"Job failed\nlogs:\n{logs}, info: {client.get_job_info(job_id)}"
         )
-    return status == JobStatus.SUCCEEDED
+    assert status == JobStatus.SUCCEEDED
+    return True
 
 
 def _check_job_failed(client: JobSubmissionClient, job_id: str) -> bool:

--- a/dashboard/modules/job/tests/test_job_agent.py
+++ b/dashboard/modules/job/tests/test_job_agent.py
@@ -87,7 +87,8 @@ def _check_job(
     client: JobSubmissionClient, job_id: str, status: JobStatus, timeout: int = 10
 ) -> bool:
     res_status = client.get_job_status(job_id)
-    return res_status == status
+    assert res_status == status
+    return True
 
 
 @pytest.fixture(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_job_submit` is failing on `master` due to `wait_for_condition` taking too long:

```console
>       wait_for_condition(
--
  | partial(
  | _check_job, client=head_client, job_id=job_id, status=JobStatus.SUCCEEDED
  | ),
  | timeout=60,
  | )
  |  
  | /private/var/tmp/_bazel_ec2-user/0d934f714279183e590540f553b840ac/execroot/com_github_ray_project_ray/bazel-out/darwin-opt/bin/python/ray/dashboard/modules/job/tests/test_job_agent.runfiles/com_github_ray_project_ray/python/ray/dashboard/modules/job/tests/test_job_agent.py:255:
  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  |  
  | condition_predictor = functools.partial(<function _check_job at 0x7fc830c801f0>, client=<ray.dashboard.modules.job.sdk.JobSubmissionClient object at 0x7fc8501a10d0>, job_id='raysubmit_HCzHEsbfbNFgBZ4Y', status=<JobStatus.SUCCEEDED: 'SUCCEEDED'>)
  | timeout = 60, retry_interval_ms = 100, raise_exceptions = False, kwargs = {}
  | start = 1695672813.8212538, last_ex = None
  | message = "The condition wasn't met before the timeout expired."
  |  
  | def wait_for_condition(
  | condition_predictor,
  | timeout=10,
  | retry_interval_ms=100,
  | raise_exceptions=False,
  | **kwargs: Any,
  | ):
  | """Wait until a condition is met or time out with an exception.
  |  
  | Args:
  | condition_predictor: A function that predicts the condition.
  | timeout: Maximum timeout in seconds.
  | retry_interval_ms: Retry interval in milliseconds.
  | raise_exceptions: If true, exceptions that occur while executing
  | condition_predictor won't be caught and instead will be raised.
  |  
  | Raises:
  | RuntimeError: If the condition is not met before the timeout expires.
  | """
  | start = time.time()
  | last_ex = None
  | while time.time() - start <= timeout:
  | try:
  | if condition_predictor(**kwargs):
  | return
  | except Exception:
  | if raise_exceptions:
  | raise
  | last_ex = ray._private.utils.format_error_message(traceback.format_exc())
  | time.sleep(retry_interval_ms / 1000.0)
  | message = "The condition wasn't met before the timeout expired."
  | if last_ex is not None:
  | message += f" Last exception: {last_ex}"
  | >       raise RuntimeError(message)
  | E       RuntimeError: The condition wasn't met before the timeout expired.
```

No error is raised in `_check_job` though, so the test fails with a `RuntimeError`, and the actual issue is obscured. This change adds an `assert` statement to raise an error inside the `_check_job` function, so the traceback is more informative.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
