### PR TITLE
[Jobs] [CI] Use lighter dependency in `test_job_driver_inheritance_override`

### DIFF
--- a/dashboard/modules/job/tests/test_job_inheritance.py
+++ b/dashboard/modules/job/tests/test_job_inheritance.py
@@ -138,7 +138,7 @@ def test_job_driver_inheritance_override(monkeypatch):
         # Test conflict resolution regular field
         job_id = client.submit_job(
             entrypoint=f"python {driver_script_path} --conflict=pip",
-            runtime_env={"pip": ["torch"]},
+            runtime_env={"pip": ["scipy==1.11.2"]},
         )
         runtime_env = get_runtime_env_from_logs(client, job_id)
         print(runtime_env)

--- a/dashboard/modules/job/tests/test_job_inheritance.py
+++ b/dashboard/modules/job/tests/test_job_inheritance.py
@@ -138,7 +138,7 @@ def test_job_driver_inheritance_override(monkeypatch):
         # Test conflict resolution regular field
         job_id = client.submit_job(
             entrypoint=f"python {driver_script_path} --conflict=pip",
-            runtime_env={"pip": ["scipy==1.11.2"]},
+            runtime_env={"pip": ["pip-install-test==0.5"]},
         )
         runtime_env = get_runtime_env_from_logs(client, job_id)
         print(runtime_env)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_job_driver_inheritance_override` is flaky on `master`. 

<img width="1328" alt="Screen Shot 2023-09-26 at 1 42 40 PM" src="https://github.com/ray-project/ray/assets/92341594/ce29cc42-308d-4047-b32b-0efb46f5a704">

It looks like [this job](https://github.com/ray-project/ray/blob/6c1c6ac90678461e22115e03566b42dd18443ec1/dashboard/modules/job/tests/test_job_inheritance.py#L139-L142) gets stuck in `PENDING` (example tracebacks: [1](https://buildkite.com/ray-project/oss-ci-build-branch/builds/6189#018acd69-b77e-42b5-bf40-f46703f2c1e9/3614-3693), [2](https://buildkite.com/ray-project/oss-ci-build-branch/builds/6193#018ace2a-1135-4d87-b998-6dd6954fb2f9/3605-3684)). This is likely because PyTorch is a heavy dependency that takes a while to download.

This change makes the test use a lighter dependency instead ([`pip-install-test==0.5`](https://pypi.org/project/pip-install-test/)). That should allow the test to make progress quicker.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change deflakes a test.
