### PR TITLE
[Doc] Mock out extra doc dependencies

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -34,10 +34,5 @@ jupytext==1.13.6
 # Pin urllib to avoid downstream ssl incompatibility issues
 urllib3 < 1.27
 
-# For the API docs
-fastapi==0.99.1
-grpcio==1.57.0
-
-# Build dependencies
-mosaicml
-typing-extensions
+# External dependencies such as ML libraries should be mocked out, not added here.
+# See doc/source/conf.py for examples of how to mock out external dependencies.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -439,6 +439,7 @@ autosummary_filename_map = {
 # Mock out external dependencies here.
 autodoc_mock_imports = [
     "aiohttp",
+    "composer",
     "dask",
     "datasets",
     "fastapi",
@@ -490,6 +491,7 @@ for mock_target in autodoc_mock_imports:
 # that are defined in dependencies can link to their respective documentation.
 intersphinx_mapping = {
     "aiohttp": ("https://docs.aiohttp.org/en/stable/", None),
+    "composer": ("https://docs.mosaicml.com/en/latest/", None),
     "dask": ("https://docs.dask.org/en/stable/", None),
     "datasets": ("https://huggingface.co/docs/datasets/main/en/", None),
     "distributed": ("https://distributed.dask.org/en/stable/", None),


### PR DESCRIPTION
## Why are these changes needed?

This PR removes some dependencies that aren't needed from the doc build requriements, and mocks them out.

Tagging @GeneDer and @can-anyscale: can you confirm that mocking out `fastapi`, `grpcio`, `mosaicml`, and `typing-extensions` doesn't break any of the docs you were working on recently?

## Related issue number

Closes #39872.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
