### PR TITLE
[data] put get_object_locations behind metrics flag

### DIFF
--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -25,7 +25,7 @@ def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
     locations."""
     current_node_id = ray.get_runtime_context().get_node_id()
 
-    locs = ray.experimental.get_object_locations(refs)
+    locs = ray.experimental.get_object_locations(refs, for_metrics=True)
     nodes: List[List[str]] = [loc["node_ids"] for loc in locs.values()]
     hits = sum(current_node_id in node_ids for node_ids in nodes)
     unknowns = sum(1 for node_ids in nodes if not node_ids)

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -277,7 +277,7 @@ class MapOperator(OneToOneOperator, ABC):
             # Otherwise, if the task crashes in the middle, we can't rerun it.
             blocks = [input[0] for input in inputs.blocks]
             metadata = [input[1] for input in inputs.blocks]
-            locations = ray.experimental.get_object_locations(blocks)
+            locations = ray.experimental.get_object_locations(blocks, for_metrics=True)
             for block, meta in zip(blocks, metadata):
                 if locations[block]["did_spill"]:
                     self._metrics.spilled += meta.size_bytes

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -133,6 +133,9 @@ DEFAULT_ENABLE_PROGRESS_BARS = not bool(
     env_integer("RAY_DATA_DISABLE_PROGRESS_BARS", 0)
 )
 
+# Whether to enable metric collection
+DEFAULT_ENABLE_METRIC_COLLECTION = False
+
 
 @DeveloperAPI
 class DataContext:
@@ -173,6 +176,7 @@ class DataContext:
         use_legacy_iter_batches: bool,
         enable_progress_bars: bool,
         file_metadata_shuffler: str,
+        enable_metric_collection: bool,
     ):
         """Private constructor (use get_current() instead)."""
         self.target_max_block_size = target_max_block_size
@@ -207,6 +211,7 @@ class DataContext:
         self.use_legacy_iter_batches = use_legacy_iter_batches
         self.enable_progress_bars = enable_progress_bars
         self.file_metadata_shuffler = file_metadata_shuffler
+        self.enable_metric_collection = enable_metric_collection
 
     @staticmethod
     def get_current() -> "DataContext":
@@ -257,6 +262,7 @@ class DataContext:
                     use_legacy_iter_batches=DEFAULT_USE_LEGACY_ITER_BATCHES,
                     enable_progress_bars=DEFAULT_ENABLE_PROGRESS_BARS,
                     file_metadata_shuffler=DEFAULT_FILE_METADATA_SHUFFLER,
+                    enable_metric_collection=DEFAULT_ENABLE_METRIC_COLLECTION,
                 )
 
             return _default_context

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1353,6 +1353,21 @@ Dataset memory:
     assert ds._plan.stats().dataset_bytes_spilled == 0
 
 
+def test_metrics_flag(shutdown_only):
+    ctx = ray.data.DataContext.get_current()
+
+    ref = ray.put("123")
+    locations = ray.experimental.get_object_locations([ref], for_metrics=True)
+    assert locations[ref]["node_ids"] == []
+
+    locations = ray.experimental.get_object_locations([ref])
+    assert len(locations[ref]["node_ids"]) > 0
+
+    ctx.enable_metric_collection = True
+    locations = ray.experimental.get_object_locations([ref], for_metrics=True)
+    assert len(locations[ref]["node_ids"]) > 0
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds the flag `ENABLE_METRIC_COLLECTION` to `DataContext`.

If set, this flag skips the `get_object_locations` call if the result is used only for metrics.

TODO:
Update some of the other tests

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #39596

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
