### PR TITLE
[data] add flag to skip get_object_locations for metrics

### DIFF
--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -25,7 +25,7 @@ def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
     locations."""
     current_node_id = ray.get_runtime_context().get_node_id()
 
-    locs = ray.experimental.get_object_locations(refs)
+    locs = ray.experimental.get_object_locations(refs, for_metrics=True)
     nodes: List[List[str]] = [loc["node_ids"] for loc in locs.values()]
     hits = sum(current_node_id in node_ids for node_ids in nodes)
     unknowns = sum(1 for node_ids in nodes if not node_ids)

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -25,7 +25,7 @@ def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
     locations."""
     current_node_id = ray.get_runtime_context().get_node_id()
 
-    locs = ray.experimental.get_object_locations(refs, for_metrics=True)
+    locs = ray.experimental.get_object_locations(refs, skip_get_locations=True)
     nodes: List[List[str]] = [loc["node_ids"] for loc in locs.values()]
     hits = sum(current_node_id in node_ids for node_ids in nodes)
     unknowns = sum(1 for node_ids in nodes if not node_ids)

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -25,7 +25,12 @@ def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
     locations."""
     current_node_id = ray.get_runtime_context().get_node_id()
 
-    locs = ray.experimental.get_object_locations(refs, skip_get_locations=True)
+    if (
+        ray.data.context.DataContext.get_current().enable_get_object_locations_for_metrics
+    ):
+        locs = ray.experimental.get_object_locations(refs)
+    else:
+        locs = {}
     nodes: List[List[str]] = [loc["node_ids"] for loc in locs.values()]
     hits = sum(current_node_id in node_ids for node_ids in nodes)
     unknowns = sum(1 for node_ids in nodes if not node_ids)

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -25,9 +25,8 @@ def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
     locations."""
     current_node_id = ray.get_runtime_context().get_node_id()
 
-    if (
-        ray.data.context.DataContext.get_current().enable_get_object_locations_for_metrics
-    ):
+    ctx = ray.data.context.DataContext.get_current()
+    if ctx.enable_get_object_locations_for_metrics:
         locs = ray.experimental.get_object_locations(refs)
     else:
         locs = {}

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -277,7 +277,7 @@ class MapOperator(OneToOneOperator, ABC):
             # Otherwise, if the task crashes in the middle, we can't rerun it.
             blocks = [input[0] for input in inputs.blocks]
             metadata = [input[1] for input in inputs.blocks]
-            locations = ray.experimental.get_object_locations(blocks)
+            locations = ray.experimental.get_object_locations(blocks, for_metrics=True)
             for block, meta in zip(blocks, metadata):
                 if locations[block]["did_spill"]:
                     self._metrics.spilled += meta.size_bytes

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -277,7 +277,9 @@ class MapOperator(OneToOneOperator, ABC):
             # Otherwise, if the task crashes in the middle, we can't rerun it.
             blocks = [input[0] for input in inputs.blocks]
             metadata = [input[1] for input in inputs.blocks]
-            locations = ray.experimental.get_object_locations(blocks, skip_get_locations=True)
+            locations = ray.experimental.get_object_locations(
+                blocks, skip_get_locations=True
+            )
             for block, meta in zip(blocks, metadata):
                 if locations[block]["did_spill"]:
                     self._metrics.spilled += meta.size_bytes

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -277,7 +277,7 @@ class MapOperator(OneToOneOperator, ABC):
             # Otherwise, if the task crashes in the middle, we can't rerun it.
             blocks = [input[0] for input in inputs.blocks]
             metadata = [input[1] for input in inputs.blocks]
-            locations = ray.experimental.get_object_locations(blocks, for_metrics=True)
+            locations = ray.experimental.get_object_locations(blocks, skip_get_locations=True)
             for block, meta in zip(blocks, metadata):
                 if locations[block]["did_spill"]:
                     self._metrics.spilled += meta.size_bytes

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -277,9 +277,8 @@ class MapOperator(OneToOneOperator, ABC):
             # Otherwise, if the task crashes in the middle, we can't rerun it.
             blocks = [input[0] for input in inputs.blocks]
             metadata = [input[1] for input in inputs.blocks]
-            if (
-                ray.data.context.DataContext.get_current().enable_get_object_locations_for_metrics
-            ):
+            ctx = ray.data.context.DataContext.get_current()
+            if ctx.enable_get_object_locations_for_metrics:
                 locations = ray.experimental.get_object_locations(blocks)
             else:
                 locations = {ref: {"did_spill": False} for ref in blocks}

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -277,9 +277,12 @@ class MapOperator(OneToOneOperator, ABC):
             # Otherwise, if the task crashes in the middle, we can't rerun it.
             blocks = [input[0] for input in inputs.blocks]
             metadata = [input[1] for input in inputs.blocks]
-            locations = ray.experimental.get_object_locations(
-                blocks, skip_get_locations=True
-            )
+            if (
+                ray.data.context.DataContext.get_current().enable_get_object_locations_for_metrics
+            ):
+                locations = ray.experimental.get_object_locations(blocks)
+            else:
+                locations = {ref: {"did_spill": False} for ref in blocks}
             for block, meta in zip(blocks, metadata):
                 if locations[block]["did_spill"]:
                     self._metrics.spilled += meta.size_bytes

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -133,6 +133,9 @@ DEFAULT_ENABLE_PROGRESS_BARS = not bool(
     env_integer("RAY_DATA_DISABLE_PROGRESS_BARS", 0)
 )
 
+# Whether to enable metric collection
+DEFAULT_ENABLE_METRIC_COLLECTION = False
+
 
 @DeveloperAPI
 class DataContext:
@@ -173,6 +176,7 @@ class DataContext:
         use_legacy_iter_batches: bool,
         enable_progress_bars: bool,
         file_metadata_shuffler: str,
+        enable_metric_collection: bool,
     ):
         """Private constructor (use get_current() instead)."""
         self.target_max_block_size = target_max_block_size
@@ -207,6 +211,7 @@ class DataContext:
         self.use_legacy_iter_batches = use_legacy_iter_batches
         self.enable_progress_bars = enable_progress_bars
         self.file_metadata_shuffler = file_metadata_shuffler
+        self.enable_metric_collection = enable_metric_collection
 
     @staticmethod
     def get_current() -> "DataContext":
@@ -257,6 +262,7 @@ class DataContext:
                     use_legacy_iter_batches=DEFAULT_USE_LEGACY_ITER_BATCHES,
                     enable_progress_bars=DEFAULT_ENABLE_PROGRESS_BARS,
                     file_metadata_shuffler=DEFAULT_FILE_METADATA_SHUFFLER,
+                    enable_metric_collection=DEFAULT_ENABLE_METRIC_COLLECTION,
                 )
 
             return _default_context

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -211,7 +211,9 @@ class DataContext:
         self.use_legacy_iter_batches = use_legacy_iter_batches
         self.enable_progress_bars = enable_progress_bars
         self.file_metadata_shuffler = file_metadata_shuffler
-        self.enable_get_object_locations_for_metrics = enable_get_object_locations_for_metrics
+        self.enable_get_object_locations_for_metrics = (
+            enable_get_object_locations_for_metrics
+        )
 
     @staticmethod
     def get_current() -> "DataContext":

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -133,8 +133,8 @@ DEFAULT_ENABLE_PROGRESS_BARS = not bool(
     env_integer("RAY_DATA_DISABLE_PROGRESS_BARS", 0)
 )
 
-# Whether to enable metric collection
-DEFAULT_ENABLE_METRIC_COLLECTION = False
+# Whether to enable get_object_locations for metric
+DEFAULT_ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS = False
 
 
 @DeveloperAPI
@@ -176,7 +176,7 @@ class DataContext:
         use_legacy_iter_batches: bool,
         enable_progress_bars: bool,
         file_metadata_shuffler: str,
-        enable_metric_collection: bool,
+        enable_get_object_locations_for_metrics: bool,
     ):
         """Private constructor (use get_current() instead)."""
         self.target_max_block_size = target_max_block_size
@@ -211,7 +211,7 @@ class DataContext:
         self.use_legacy_iter_batches = use_legacy_iter_batches
         self.enable_progress_bars = enable_progress_bars
         self.file_metadata_shuffler = file_metadata_shuffler
-        self.enable_metric_collection = enable_metric_collection
+        self.enable_get_object_locations_for_metrics = enable_get_object_locations_for_metrics
 
     @staticmethod
     def get_current() -> "DataContext":
@@ -262,7 +262,7 @@ class DataContext:
                     use_legacy_iter_batches=DEFAULT_USE_LEGACY_ITER_BATCHES,
                     enable_progress_bars=DEFAULT_ENABLE_PROGRESS_BARS,
                     file_metadata_shuffler=DEFAULT_FILE_METADATA_SHUFFLER,
-                    enable_metric_collection=DEFAULT_ENABLE_METRIC_COLLECTION,
+                    enable_get_object_locations_for_metrics=DEFAULT_ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS,
                 )
 
             return _default_context

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -264,7 +264,7 @@ class DataContext:
                     use_legacy_iter_batches=DEFAULT_USE_LEGACY_ITER_BATCHES,
                     enable_progress_bars=DEFAULT_ENABLE_PROGRESS_BARS,
                     file_metadata_shuffler=DEFAULT_FILE_METADATA_SHUFFLER,
-                    enable_get_object_locations_for_metrics=DEFAULT_ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS,
+                    enable_get_object_locations_for_metrics=DEFAULT_ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS,  # noqa E501
                 )
 
             return _default_context

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -274,6 +274,13 @@ def test_queue():
 def test_calculate_ref_hits(ray_start_regular_shared):
     refs = [ray.put(0), ray.put(1)]
     hits, misses, unknowns = _calculate_ref_hits(refs)
+    assert hits == 0
+    assert misses == 0
+    assert unknowns == 0
+
+    ctx = ray.data.context.DataContext.get_current()
+    ctx.enable_get_object_locations_for_metrics = True
+    hits, misses, unknowns = _calculate_ref_hits(refs)
     assert hits == 2
     assert misses == 0
     assert unknowns == 0

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1353,18 +1353,18 @@ Dataset memory:
     assert ds._plan.stats().dataset_bytes_spilled == 0
 
 
-def test_metrics_flag(shutdown_only):
+def test_get_object_locations_skip(shutdown_only):
     ctx = ray.data.DataContext.get_current()
 
     ref = ray.put("123")
-    locations = ray.experimental.get_object_locations([ref], for_metrics=True)
+    locations = ray.experimental.get_object_locations([ref], skip_get_locations=True)
     assert locations[ref]["node_ids"] == []
 
     locations = ray.experimental.get_object_locations([ref])
     assert len(locations[ref]["node_ids"]) > 0
 
-    ctx.enable_metric_collection = True
-    locations = ray.experimental.get_object_locations([ref], for_metrics=True)
+    ctx.enable_get_object_locations_for_metrics = True
+    locations = ray.experimental.get_object_locations([ref], skip_get_locations=True)
     assert len(locations[ref]["node_ids"]) > 0
 
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1353,6 +1353,21 @@ Dataset memory:
     assert ds._plan.stats().dataset_bytes_spilled == 0
 
 
+def test_metrics_flag(shutdown_only):
+    ctx = ray.data.DataContext.get_current()
+
+    ref = ray.put("123")
+    locations = ray.experimental.get_object_locations([ref], for_metrics=True)
+    assert locations[ref]["node_ids"] == []
+
+    locations = ray.experimental.get_object_locations([ref])
+    assert len(locations[ref]["node_ids"]) > 0
+
+    ctx.enable_metric_collection = True
+    locations = ray.experimental.get_object_locations([ref], for_metrics=True)
+    assert len(locations[ref]["node_ids"]) > 0
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -62,6 +62,12 @@ def map_batches_sleep(x, n):
     return x
 
 
+@pytest.fixture(autouse=True)
+def enable_get_object_locations_flag():
+    ctx = ray.data.context.DataContext.get_current()
+    ctx.enable_get_object_locations_for_metrics = True
+
+
 def test_streaming_split_stats(ray_start_regular_shared):
     ds = ray.data.range(1000, parallelism=10)
     it = ds.map_batches(dummy_map_batches).streaming_split(1)[0]

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1353,21 +1353,6 @@ Dataset memory:
     assert ds._plan.stats().dataset_bytes_spilled == 0
 
 
-def test_get_object_locations_skip(shutdown_only):
-    ctx = ray.data.DataContext.get_current()
-
-    ref = ray.put("123")
-    locations = ray.experimental.get_object_locations([ref], skip_get_locations=True)
-    assert locations[ref]["node_ids"] == []
-
-    locations = ray.experimental.get_object_locations([ref])
-    assert len(locations[ref]["node_ids"]) > 0
-
-    ctx.enable_get_object_locations_for_metrics = True
-    locations = ray.experimental.get_object_locations([ref], skip_get_locations=True)
-    assert len(locations[ref]["node_ids"]) > 0
-
-
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/experimental/locations.py
+++ b/python/ray/experimental/locations.py
@@ -5,7 +5,7 @@ from ray._raylet import ObjectRef
 
 
 def get_object_locations(
-    obj_refs: List[ObjectRef], timeout_ms: int = -1, for_metrics: bool = False
+    obj_refs: List[ObjectRef], timeout_ms: int = -1, skip_get_locations: bool = False
 ) -> Dict[ObjectRef, Dict[str, Any]]:
     """Lookup the locations for a list of objects.
 
@@ -40,8 +40,8 @@ def get_object_locations(
     # This call can be expensive if not called by the driver.
     # If this is for purely metrics use, we can skip the call for performance.
     if (
-        for_metrics
-        and not ray.data.context.DataContext.get_current().enable_metric_collection
+        skip_get_locations
+        and not ray.data.context.DataContext.get_current().enable_get_object_locations_for_metrics
     ):
         return {
             ref: {"node_ids": [], "object_size": 0, "did_spill": False}

--- a/python/ray/experimental/locations.py
+++ b/python/ray/experimental/locations.py
@@ -16,6 +16,7 @@ def get_object_locations(
         object_refs (List[ObjectRef]): List of object refs.
         timeout_ms: The maximum amount of time in micro seconds to wait
             before returning. Wait infinitely if it's negative.
+        skip_get_locations: Whether or not to skip the get_object_locations call.
 
     Returns:
         A dict maps from an object to its location. The dict excludes those
@@ -27,8 +28,6 @@ def get_object_locations(
           copy of this object.
 
         - object_size (int): The size of data + metadata in bytes.
-
-        - for_metrics (bool): If the use case is purely for metrics.
 
     Raises:
         RuntimeError: if the processes were not started by ray.init().

--- a/python/ray/experimental/locations.py
+++ b/python/ray/experimental/locations.py
@@ -5,7 +5,7 @@ from ray._raylet import ObjectRef
 
 
 def get_object_locations(
-    obj_refs: List[ObjectRef], timeout_ms: int = -1, skip_get_locations: bool = False
+    obj_refs: List[ObjectRef], timeout_ms: int = -1
 ) -> Dict[ObjectRef, Dict[str, Any]]:
     """Lookup the locations for a list of objects.
 
@@ -16,7 +16,6 @@ def get_object_locations(
         object_refs (List[ObjectRef]): List of object refs.
         timeout_ms: The maximum amount of time in micro seconds to wait
             before returning. Wait infinitely if it's negative.
-        skip_get_locations: Whether or not to skip the get_object_locations call.
 
     Returns:
         A dict maps from an object to its location. The dict excludes those
@@ -36,16 +35,6 @@ def get_object_locations(
     """
     if not ray.is_initialized():
         raise RuntimeError("Ray hasn't been initialized.")
-    # This call can be expensive if not called by the driver.
-    # If this is for purely metrics use, we can skip the call for performance.
-    if (
-        skip_get_locations
-        and not ray.data.context.DataContext.get_current().enable_get_object_locations_for_metrics
-    ):
-        return {
-            ref: {"node_ids": [], "object_size": 0, "did_spill": False}
-            for ref in obj_refs
-        }
     return ray._private.worker.global_worker.core_worker.get_object_locations(
         obj_refs, timeout_ms
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds the flag `ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS` to `DataContext`.

If set, this flag skips the `get_object_locations` call if the result is used only for metrics.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #39596
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
