### PR TITLE
[data] fix test_spilled_stats

### DIFF
--- a/ci/ray_ci/data.tests.yml
+++ b/ci/ray_ci/data.tests.yml
@@ -2,4 +2,3 @@ flaky_tests:
   - //python/ray/data:test_streaming_executor
   - //python/ray/data:test_split
   - //python/ray/data:test_object_gc
-  - //python/ray/data:test_stats

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1309,12 +1309,8 @@ def test_stats_actor_cap_num_stats(ray_start_cluster):
 def test_spilled_stats(shutdown_only):
     # The object store is about 100MB.
     ray.init(object_store_memory=100e6)
-    # The size of dataset is 1000*(80*80*4)*8B, about 200MB.
-    ds = (
-        ray.data.range_tensor(1000, shape=(80, 80, 4))
-        .map_batches(lambda x: x)
-        .materialize()
-    )
+    # The size of dataset is 1000*80*80*4*8B, about 200MB.
+    ds = ray.data.range(1000 * 80 * 80 * 4).map_batches(lambda x: x).materialize()
 
     assert (
         canonicalize(ds.stats())
@@ -1340,7 +1336,7 @@ Dataset memory:
     assert ds._plan.stats().dataset_bytes_spilled > 100e6
 
     ds = (
-        ray.data.range_tensor(1000, shape=(80, 80, 4))
+        ray.data.range(1000 * 80 * 80 * 4)
         .map_batches(lambda x: x)
         .random_shuffle()
         .map_batches(lambda x: x)
@@ -1351,7 +1347,7 @@ Dataset memory:
 
     # The size of dataset is around 50MB, there should be no spillage
     ds = (
-        ray.data.range_tensor(250, shape=(80, 80, 4), parallelism=1)
+        ray.data.range(250 * 80 * 80 * 4, parallelism=1)
         .map_batches(lambda x: x)
         .materialize()
     )

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1311,7 +1311,7 @@ def test_spilled_stats(shutdown_only):
     ray.init(object_store_memory=100e6)
     # The size of dataset is 1000*(80*80*4)*8B, about 200MB.
     ds = (
-        ray.data.range_tensor(1000, shape=(80, 80, 4), parallelism=100)
+        ray.data.range_tensor(1000, shape=(80, 80, 4))
         .map_batches(lambda x: x)
         .materialize()
     )
@@ -1340,9 +1340,9 @@ Dataset memory:
     assert ds._plan.stats().dataset_bytes_spilled > 100e6
 
     ds = (
-        ray.data.range_tensor(1000, shape=(80, 80, 4), parallelism=100)
+        ray.data.range_tensor(1000, shape=(80, 80, 4))
         .map_batches(lambda x: x)
-        .limit(1000)
+        .random_shuffle()
         .map_batches(lambda x: x)
         .materialize()
     )
@@ -1351,7 +1351,7 @@ Dataset memory:
 
     # The size of dataset is around 50MB, there should be no spillage
     ds = (
-        ray.data.range_tensor(250, shape=(80, 80, 4), parallelism=100)
+        ray.data.range_tensor(250, shape=(80, 80, 4), parallelism=1)
         .map_batches(lambda x: x)
         .materialize()
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Use `range` instead of `range_tensor`, `shuffle` instead of `limit`, and remove parallelism. It's not clear why the tests failed.

This has passed the last 8 times run.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
