### PR TITLE
[core] `check_health` address not handling names with ":"

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2921,7 +2921,10 @@ def check_health(address: str, timeout=2, skip_version_check=False):
         Raises an exception otherwise.
     """
 
-    gcs_address, gcs_port = address.split(":")
+    tokens = address.rsplit(":", 1)
+    if len(tokens) != 2:
+        raise ValueError("Invalid address: {}. Expect 'ip:port'".format(address))
+    gcs_address, gcs_port = tokens
 
     cdef:
         c_string c_gcs_address = gcs_address

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -122,7 +122,6 @@ def test_check_health(shutdown_only):
     with pytest.raises(ValueError):
         check_health("bad_address_no_port")
 
-
     conn = ray.init()
     addr = conn.address_info["address"]
     assert check_health(addr)

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -116,6 +116,12 @@ def test_jemalloc_env_var_propagate():
 
 def test_check_health(shutdown_only):
     assert not check_health("127.0.0.1:8888")
+    # Should not raise error: https://github.com/ray-project/ray/issues/38785
+    assert not check_health("ip:address:with:colon:name:8265")
+
+    with pytest.raises(ValueError):
+        check_health("bad_address_no_port")
+
 
     conn = ray.init()
     addr = conn.address_info["address"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We could also pass in address names with ":" for ray address, thus allowing ":" to split it into more than 2 parts. 



<!-- Please give a short summary of the change and the problem this solves. -->

Related, but we won't close https://github.com/ray-project/ray/issues/38785

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
