### PR TITLE
[CI] [Doc] Add reminder to install setup hooks for linter

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -10,6 +10,8 @@ steps:
     commands:
       - pip install -c python/requirements_compiled.txt -r python/requirements/lint-requirements.txt
       - FORMAT_SH_PRINT_DIFF=1 ./ci/lint/format.sh --all-scripts
+      - echo -e "\e[93mReminder: Run './ci/setup_hooks.sh' to install a pre-push hook that automatically runs the linter before you push.\e[39m"
+
     depends_on: forge
 
   - label: ":lint-roller: lint: untested code snippet"

--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -9,10 +9,7 @@ steps:
   - label: ":lint-roller: lint: code format"
     commands:
       - pip install -c python/requirements_compiled.txt -r python/requirements/lint-requirements.txt
-      - FORMAT_SH_PRINT_DIFF=1 ./ci/lint/format.sh --all-scripts || \
-        (echo "~~~ Reminder" && \
-        buildkite-agent annotate "Run './ci/setup_hooks.sh' to install a pre-push hook \
-        that automatically runs the linter before you push." --style "warning" && false)
+      - FORMAT_SH_PRINT_DIFF=1 ./ci/lint/format.sh --all-scripts || (echo "~~~ Reminder" && buildkite-agent annotate "Run './ci/setup_hooks.sh' to install a pre-push hook that automatically runs the linter before you push." --style "warning" && false)
     depends_on: forge
 
   - label: ":lint-roller: lint: untested code snippet"

--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -9,9 +9,10 @@ steps:
   - label: ":lint-roller: lint: code format"
     commands:
       - pip install -c python/requirements_compiled.txt -r python/requirements/lint-requirements.txt
-      - FORMAT_SH_PRINT_DIFF=1 ./ci/lint/format.sh --all-scripts
-      - echo -e "\e[93mReminder: Run './ci/setup_hooks.sh' to install a pre-push hook that automatically runs the linter before you push.\e[39m"
-
+      - FORMAT_SH_PRINT_DIFF=1 ./ci/lint/format.sh --all-scripts || \
+        (echo "~~~ Reminder" && \
+        buildkite-agent annotate "Run './ci/setup_hooks.sh' to install a pre-push hook \
+        that automatically runs the linter before you push." --style "warning" && false)
     depends_on: forge
 
   - label: ":lint-roller: lint: untested code snippet"

--- a/doc/source/ray-contribute/getting-involved.rst
+++ b/doc/source/ray-contribute/getting-involved.rst
@@ -65,17 +65,17 @@ There are a couple steps to merge a contribution.
      git remote add upstream https://github.com/ray-project/ray.git
      git pull . upstream/master
 
-2. Make sure all existing `tests <getting-involved.html#testing>`__ and `linters <getting-involved.html#lint-and-formatting>`__ pass.
-   Run ``setup_hooks.sh`` to create a git hook that will run the linter before you push your changes.
-3. If introducing a new feature or patching a bug, be sure to add new test cases
+2. Run ``setup_hooks.sh`` to create a git hook that will automatically run the `linters <getting-involved.html#lint-and-formatting>`__ before you push your changes. (You only need to do this once.) 
+3. Make sure all existing `tests <getting-involved.html#testing>`__ pass.  
+4. If introducing a new feature or patching a bug, be sure to add new test cases
    in the relevant file in ``ray/python/ray/tests/``.
-4. Document the code. Public functions need to be documented, and remember to provide an usage
+5. Document the code. Public functions need to be documented, and remember to provide an usage
    example if applicable. See ``doc/README.md`` for instructions on editing and building public documentation.
-5. Address comments on your PR. During the review
+6. Address comments on your PR. During the review
    process you may need to address merge conflicts with other changes. To resolve merge conflicts,
    run ``git pull . upstream/master`` on your branch (please do not use rebase, as it is less
    friendly to the GitHub review tool. All commits will be squashed on merge.)
-6. Reviewers will merge and approve the pull request; be sure to ping them if
+7. Reviewers will merge and approve the pull request; be sure to ping them if
    the pull request is getting stale.
 
 PR Review Process
@@ -232,7 +232,8 @@ See :ref:`this <writing-code-snippets_ref>` for more details about how to write 
 Lint and Formatting
 ~~~~~~~~~~~~~~~~~~~
 
-We also have tests for code formatting and linting that need to pass before merge.
+We also have tests for code formatting and linting that need to pass before merge. You can run ``setup_hooks.sh`` to create a git hook that will run the linters before you push your changes.
+
 
 * For Python formatting, install the `required dependencies <https://github.com/ray-project/ray/blob/master/python/requirements/lint-requirements.txt>`_ first with:
 
@@ -284,7 +285,6 @@ In addition, there are other formatting and semantic checkers for components lik
 
     ./ci/lint/check-git-clang-tidy-output.sh
 
-You can run ``setup_hooks.sh`` to create a git hook that will run the linter before you push your changes.
 
 Understanding CI test jobs
 --------------------------

--- a/python/ray/autoscaler/sdk/sdk.py
+++ b/python/ray/autoscaler/sdk/sdk.py
@@ -100,7 +100,7 @@ def run_on_cluster(
         no_config_cache: Whether to disable the config cache and fully
             resolve all environment settings from the Cloud provider again.
         port_forward ( (int,int) or list[(int,int)]): port(s) to forward.
-        with_output: Whether to capture command output.
+        with_output: Whether to capture command output. Let me just mess up the lint real bad with a long line....................................................
 
     Returns:
         The output of the command as a string.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
