### PR TITLE
[data] Convert mismatched table blocks at runtime when initializing ArrowBlockAccessor/PandasBlockAccessor 

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -24,7 +24,11 @@ from ray.data._internal.numpy_support import (
     is_valid_udf_return,
 )
 from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
-from ray.data._internal.util import _truncated_repr, find_partitions, _lazy_import_pandas
+from ray.data._internal.util import (
+    _lazy_import_pandas,
+    _truncated_repr,
+    find_partitions,
+)
 from ray.data.block import (
     Block,
     BlockAccessor,

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -149,9 +149,12 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
         pd = _lazy_import_pandas()
         if pd and isinstance(table, pd.DataFrame):
-            # Python types do not get checked at runtime,
-            # if the user explicity specifies batch_format='pandas'
-            # batches can be interleaved with both pandas and arrow blocks
+            # Python types are not checked at runtime.
+            # If the user explicity force batches to be
+            # be created with Pandas DataFrame blocks by specifying
+            # batch_format='pandas' in the task graph, then
+            # ArrowBlockAccessor(block) can be initalized with a
+            # table of type pandas.DataFrame.
             table = pyarrow.Table.from_pandas(table)
 
         super().__init__(table)

--- a/python/ray/data/_internal/null_aggregate.py
+++ b/python/ray/data/_internal/null_aggregate.py
@@ -1,10 +1,9 @@
-from types import ModuleType
-from typing import Any, Callable, Tuple, Union
+from typing import Any, Callable, Tuple
 
 import numpy as np
 
-from ray.data.block import AggType, Block, KeyType, T, U
 from ray.data._internal.util import _lazy_import_pandas
+from ray.data.block import AggType, Block, KeyType, T, U
 
 WrappedAggType = Tuple[AggType, int]
 

--- a/python/ray/data/_internal/null_aggregate.py
+++ b/python/ray/data/_internal/null_aggregate.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Tuple, Union
 import numpy as np
 
 from ray.data.block import AggType, Block, KeyType, T, U
+from ray.data._internal.util import _lazy_import_pandas
 
 WrappedAggType = Tuple[AggType, int]
 
@@ -248,22 +249,6 @@ def _null_wrap_finalize(
         return finalize(a)
 
     return _finalize
-
-
-LazyModule = Union[None, bool, ModuleType]
-_pandas: LazyModule = None
-
-
-def _lazy_import_pandas() -> LazyModule:
-    global _pandas
-    if _pandas is None:
-        try:
-            import pandas as _pandas
-        except ModuleNotFoundError:
-            # If module is not found, set _pandas to False so we won't
-            # keep trying to import it on every _lazy_import_pandas() call.
-            _pandas = False
-    return _pandas
 
 
 def _is_null(r: Any):

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
-from ray.data._internal.util import find_partitions
+from ray.data._internal.util import _lazy_import_pyarrow_table, find_partitions
 from ray.data.block import (
     Block,
     BlockAccessor,
@@ -135,9 +135,9 @@ class PandasBlockAccessor(TableBlockAccessor):
     ROW_TYPE = PandasRow
 
     def __init__(self, table: Union["pandas.DataFrame", "pyarrow.Table"]):
-        from pyarrow import Table
+        pyarrow_table = _lazy_import_pyarrow_table()
 
-        if isinstance(table, Table):
+        if pyarrow_table and isinstance(table, pyarrow_table):
             # Python types do not get checked at runtime,
             # if the user explicity specifies batch_format='arrow'
             # batches can be interleaved with both pandas and arrow blocks

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -138,9 +138,12 @@ class PandasBlockAccessor(TableBlockAccessor):
         pyarrow_table = _lazy_import_pyarrow_table()
 
         if pyarrow_table and isinstance(table, pyarrow_table):
-            # Python types do not get checked at runtime,
-            # if the user explicity specifies batch_format='arrow'
-            # batches can be interleaved with both pandas and arrow blocks
+            # Python types are not checked at runtime.
+            # If the user explicity force batches to be
+            # be created with Arrow Table blocks by specifying
+            # batch_format='arrow' in the task graph, then
+            # PandasBlockAccessor(block) can be initalized with a
+            # table of type pyarrow.Table.
             table = table.to_pandas()
 
         super().__init__(table)

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -134,7 +134,15 @@ PandasBlockSchema = collections.namedtuple("PandasBlockSchema", ["names", "types
 class PandasBlockAccessor(TableBlockAccessor):
     ROW_TYPE = PandasRow
 
-    def __init__(self, table: "pandas.DataFrame"):
+    def __init__(self, table: Union["pandas.DataFrame", "pyarrow.Table"]):
+        from pyarrow import Table
+
+        if isinstance(table, Table):
+            # Python types do not get checked at runtime,
+            # if the user explicity specifies batch_format='arrow'
+            # batches can be interleaved with both pandas and arrow blocks
+            table = table.to_pandas()
+
         super().__init__(table)
 
     def column_names(self) -> List[str]:

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -49,8 +49,19 @@ _EXAMPLE_SCHEME = "example"
 
 
 LazyModule = Union[None, bool, ModuleType]
+_pandas: LazyModule = None
 _pyarrow_dataset: LazyModule = None
 
+def _lazy_import_pandas() -> LazyModule:
+    global _pandas
+    if _pandas is None:
+        try:
+            import pandas as _pandas
+        except ModuleNotFoundError:
+            # If module is not found, set _pandas to False so we won't
+            # keep trying to import it on every _lazy_import_pandas() call.
+            _pandas = False
+    return _pandas
 
 def _lazy_import_pyarrow_dataset() -> LazyModule:
     global _pyarrow_dataset

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -52,6 +52,7 @@ LazyModule = Union[None, bool, ModuleType]
 _pandas: LazyModule = None
 _pyarrow_dataset: LazyModule = None
 
+
 def _lazy_import_pandas() -> LazyModule:
     global _pandas
     if _pandas is None:
@@ -62,6 +63,7 @@ def _lazy_import_pandas() -> LazyModule:
             # keep trying to import it on every _lazy_import_pandas() call.
             _pandas = False
     return _pandas
+
 
 def _lazy_import_pyarrow_dataset() -> LazyModule:
     global _pyarrow_dataset

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -51,6 +51,7 @@ _EXAMPLE_SCHEME = "example"
 LazyModule = Union[None, bool, ModuleType]
 _pandas: LazyModule = None
 _pyarrow_dataset: LazyModule = None
+_pyarrow_table: LazyModule = None
 
 
 def _lazy_import_pandas() -> LazyModule:
@@ -75,6 +76,18 @@ def _lazy_import_pyarrow_dataset() -> LazyModule:
             # keep trying to import it on every _lazy_import_pyarrow() call.
             _pyarrow_dataset = False
     return _pyarrow_dataset
+
+
+def _lazy_import_pyarrow_table() -> LazyModule:
+    global _pyarrow_table
+    if _pyarrow_table is None:
+        try:
+            from pyarrow import Table as _pyarrow_table
+        except ModuleNotFoundError:
+            # If module is not found, set _pandas to False so we won't
+            # keep trying to import it on every _lazy_import_pyarrow() call.
+            _pyarrow_table = False
+    return _pyarrow_table
 
 
 def _check_pyarrow_version():


### PR DESCRIPTION
Signed-off-by: Michael Huang <michaelhly@gmail.com><!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Python types do not get checked at runtime. If the user explicitly specifies `batch_format='pandas'` batches can be interleaved with both pandas and arrow blocks. We must convert the table from `pandas.DataFrame` to `pyarrow.Table` to properly initialize an `ArrowBlockAccessor`.

Prior to this patch:
```python3
>>> import ray
>>> import pandas as pd
>>> table = pd.DataFrame({"spam": [0]})
>>> acc = ray.data._internal.arrow_block.ArrowBlockAccessor(table)
>>> type(acc)
<class 'ray.data._internal.arrow_block.ArrowBlockAccessor'>
>>> type(acc._table)
<class 'pandas.core.frame.DataFrame'>
```
We fix to guarantee that `ArrowBlockAccessor` has a `table` of type `<class 'pyarrow.lib.Table'>`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #39206
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
