### PR TITLE
[civ2][2] support test types

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -6,7 +6,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core 
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --except-tags debug_tests,asan_tests,post_wheel_build,xcommit
     depends_on: corebuild
     job_env: forge
 
@@ -17,7 +16,6 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core 
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --test-env=TEST_EXTERNAL_REDIS=1
-        --except-tags debug_tests,asan_tests,post_wheel_build,xcommit
     depends_on: corebuild
     job_env: forge
 

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -9,7 +9,6 @@ steps:
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name data6build
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
-        --except-tags data_integration,doctest
     depends_on: data6build
     job_env: forge
 
@@ -22,7 +21,6 @@ steps:
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name data12build
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
-        --except-tags data_integration,doctest
     depends_on: data12build
     job_env: forge
 
@@ -35,7 +33,6 @@ steps:
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name datanbuild
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
-        --except-tags data_integration,doctest
     depends_on: datanbuild
     job_env: forge
 

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -3,7 +3,7 @@ steps:
   - label: ":ray-serve: serve: core tests"
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serve --except-tags worker-container
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serve
     depends_on: servebuild
     job_env: forge
 
@@ -11,7 +11,7 @@ steps:
     parallelism: 3
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve --except-tags post_wheel_build,gpu,xcommit
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
     depends_on: servebuild
     job_env: forge

--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -6,7 +6,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless 
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --except-tags manual,kuberay_operator,spark_plugin_tests
     depends_on: serverlessbuild
     job_env: forge
 

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import List
 from tempfile import TemporaryDirectory
 from unittest import mock
 
@@ -8,9 +9,10 @@ import pytest
 from ci.ray_ci.tester_container import TesterContainer
 from ci.ray_ci.tester import (
     _get_container,
-    _get_all_test_query,
-    _get_test_targets,
-    _get_flaky_test_targets,
+    _get_tests_by_tag_query,
+    _get_tests,
+    _get_flaky_tests,
+    TestType,
 )
 
 
@@ -26,44 +28,57 @@ def test_get_container() -> None:
 
 
 def test_get_test_targets() -> None:
-    _TEST_YAML = "flaky_tests: [//python/ray/tests:flaky_test_01]"
+    _TEST_YAML = "flaky_tests: [//python/ray/tests/team:core_flaky_test_01]"
+
+    def _mock_get_tests_by_tag(
+        _: TesterContainer,
+        targets: List[str],
+        tag: str,
+    ) -> List[str]:
+        return [target for target in targets if tag.replace("\\\\b", "") in target]
 
     with TemporaryDirectory() as tmp:
         with open(os.path.join(tmp, "core.tests.yml"), "w") as f:
             f.write(_TEST_YAML)
 
         test_targets = [
-            "//python/ray/tests:good_test_01",
-            "//python/ray/tests:good_test_02",
-            "//python/ray/tests:good_test_03",
-            "//python/ray/tests:flaky_test_01",
-            "",
+            "//python/ray/tests/team:core_xcommit_test",
+            "//python/ray/tests/team:core_manual_test",
+            "//python/ray/tests/team:core_debug_tests",
+            "//python/ray/tests/team:core_asan_tests",
+            "//python/ray/tests/team:core_test",
+            "//python/ray/tests/team:data_test",
+            "//python/ray/tests/team:core_flaky_test_01",
         ]
         with mock.patch(
-            "subprocess.check_output",
-            return_value="\n".join(test_targets).encode("utf-8"),
+            "ci.ray_ci.tester._get_tests_by_tag",
+            side_effect=_mock_get_tests_by_tag,
         ), mock.patch(
             "ci.ray_ci.tester_container.TesterContainer.install_ray",
             return_value=None,
         ):
-            assert _get_test_targets(
+            # get debug tests
+            assert _get_tests(
                 TesterContainer("core"),
-                "targets",
+                test_targets,
+                "core",
+                test_type=TestType.DEBUG.value,
+                yaml_dir=tmp,
+            ) == ["//python/ray/tests/team:core_debug_tests"]
+
+            # get normal tests
+            assert _get_tests(
+                TesterContainer("core"),
+                test_targets,
                 "core",
                 yaml_dir=tmp,
-            ) == [
-                "//python/ray/tests:good_test_01",
-                "//python/ray/tests:good_test_02",
-                "//python/ray/tests:good_test_03",
-            ]
+            ) == ["//python/ray/tests/team:core_test"]
 
 
-def test_get_all_test_query() -> None:
-    assert _get_all_test_query(["a", "b"], "core", "") == (
+def test_get_tests_by_tag_query() -> None:
+    team = "core"
+    assert _get_tests_by_tag_query(["a", "b"], f"team:{team}\\\\b") == (
         "attr(tags, 'team:core\\\\b', tests(a) union tests(b))"
-    )
-    assert _get_all_test_query(["a"], "core", "tag") == (
-        "attr(tags, 'team:core\\\\b', tests(a)) except (attr(tags, tag, tests(a)))"
     )
 
 
@@ -73,7 +88,7 @@ def test_get_flaky_test_targets() -> None:
     with TemporaryDirectory() as tmp:
         with open(os.path.join(tmp, "core.tests.yml"), "w") as f:
             f.write(_TEST_YAML)
-        assert _get_flaky_test_targets("core", yaml_dir=tmp) == ["//target"]
+        assert _get_flaky_tests("core", yaml_dir=tmp) == ["//target"]
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from typing import List, Optional
+from enum import Enum
 
 import yaml
 import click
@@ -11,6 +12,18 @@ from ci.ray_ci.utils import docker_login
 
 # Gets the path of product/tools/docker (i.e. the parent of 'common')
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
+
+
+class TestType(Enum):
+    ASAN = "asan_tests"
+    DATA_INTEGRATION = "data_integration"
+    DEBUG = "debug_tests"
+    DOC = "doctest"
+    GPU = "gpu"
+    POST_WHEEL = "post_wheel_build"
+    KUBERAY = "kuberay_operator"
+    SPARK_PLUGIN = "spark_plugin_tests"
+    WORKER_CONTAINER = "worker-container"
 
 
 @click.command()
@@ -35,12 +48,6 @@ bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
     help=("Number of concurrent test jobs to run per worker."),
 )
 @click.option(
-    "--except-tags",
-    default="",
-    type=str,
-    help=("Except tests with the given tags."),
-)
-@click.option(
     "--run-flaky-tests",
     is_flag=True,
     show_default=True,
@@ -54,6 +61,11 @@ bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
     help="Environment variables to set for the test.",
 )
 @click.option(
+    "--test-type",
+    default=None,
+    type=click.Choice([t.value for t in TestType]),
+)
+@click.option(
     "--build-name",
     type=str,
     help="Name of the build used to run tests",
@@ -64,9 +76,9 @@ def main(
     workers: int,
     worker_id: int,
     parallelism_per_worker: int,
-    except_tags: str,
     run_flaky_tests: bool,
     test_env: List[str],
+    test_type: Optional[str],
     build_name: Optional[str],
 ) -> None:
     if not bazel_workspace_dir:
@@ -78,13 +90,13 @@ def main(
         team, workers, worker_id, parallelism_per_worker, build_name
     )
     if run_flaky_tests:
-        test_targets = _get_flaky_test_targets(team)
+        test_targets = _get_flaky_tests(team)
     else:
-        test_targets = _get_test_targets(
+        test_targets = _get_tests(
             container,
             targets,
             team,
-            except_tags,
+            test_type,
         )
     success = container.run_tests(test_targets, test_env)
     sys.exit(0 if success else 1)
@@ -108,50 +120,61 @@ def _get_container(
     )
 
 
-def _get_all_test_query(targets: List[str], team: str, except_tags: str) -> str:
-    """
-    Get all test targets that are owned by a particular team, except those that
-    have the given tags
-    """
+def _get_tests_by_tag_query(targets: List[str], tag: str) -> str:
     test_query = " union ".join([f"tests({target})" for target in targets])
-    team_query = f"attr(tags, 'team:{team}\\\\b', {test_query})"
-    if not except_tags:
-        # return all tests owned by the team if no except_tags are given
-        return team_query
-
-    # otherwise exclude tests with the given tags
-    except_query = " union ".join(
-        [f"attr(tags, {t}, {test_query})" for t in except_tags.split(",")]
-    )
-    return f"{team_query} except ({except_query})"
+    return f"attr(tags, '{tag}', {test_query})"
 
 
-def _get_test_targets(
+def _get_tests_by_tag(
     container: TesterContainer,
-    targets: str,
-    team: str,
-    except_tags: Optional[str] = "",
-    yaml_dir: Optional[str] = None,
+    targets: List[str],
+    tag: str,
 ) -> List[str]:
-    """
-    Get all test targets that are not flaky
-    """
-
-    test_targets = (
+    test_query = _get_tests_by_tag_query(targets, tag)
+    return (
         container.run_script_with_output(
             [
-                f'bazel query "{_get_all_test_query(targets, team, except_tags)}"',
+                f'bazel query "{test_query}"',
             ]
         )
         .decode("utf-8")
         .split("\n")
     )
-    flaky_tests = _get_flaky_test_targets(team, yaml_dir)
-
-    return [test for test in test_targets if test and test not in flaky_tests]
 
 
-def _get_flaky_test_targets(team: str, yaml_dir: Optional[str] = None) -> List[str]:
+def _get_tests(
+    container: TesterContainer,
+    targets: str,
+    team: str,
+    test_type: Optional[str] = None,
+    yaml_dir: Optional[str] = None,
+) -> List[str]:
+    """
+    Get all test targets that are not flaky
+    """
+    all_tests = _get_tests_by_tag(container, targets, f"team:{team}\\\\b")
+    # exclude flaky, manual and civ1 tests by default
+    excluded = (
+        _get_flaky_tests(team, yaml_dir)
+        + _get_tests_by_tag(container, targets, "xcommit")
+        + _get_tests_by_tag(container, targets, "manual")
+    )
+
+    if test_type:
+        # if test type is defined, only include tests that particular types (e.g. debug)
+        type_tests = _get_tests_by_tag(container, targets, test_type)
+        included = [test for test in all_tests if test in type_tests]
+    else:
+        # otherwise, exclude all tests of any types (e.g. debug, asan)
+        for test_type in TestType:
+            type_tests = _get_tests_by_tag(container, targets, test_type.value)
+            excluded += type_tests
+        included = all_tests
+
+    return [test for test in included if test not in excluded]
+
+
+def _get_flaky_tests(team: str, yaml_dir: Optional[str] = None) -> List[str]:
     """
     Get all test targets that are flaky
     """


### PR DESCRIPTION
Ray CI currently has a lot of different type of tests: asan, debug, doctest, etc. While I think this list of test type should be much simplified, this PR first natively support test types in ci/ray_ci. This will allow ci/ray_ci to, later, run a test of certain types.

I made an implicit decision to support one single dimension test type instead of multiple dimension of excluding and including bazel tags, so that the usage of bazel tags to manage test types is simpler to understand and can get simpler overtime.

Test:
- CI