### PR TITLE
[ci] Fix docker image tag in civ2

### DIFF
--- a/ci/ray_ci/docker_container.py
+++ b/ci/ray_ci/docker_container.py
@@ -8,6 +8,7 @@ from ci.ray_ci.utils import docker_pull, RAY_VERSION, POSTMERGE_PIPELINE
 
 PLATFORM = ["cu118"]
 GPU_PLATFORM = "cu118"
+DEFAULT_PYTHON_VERSION = "py38"
 
 
 class DockerContainer(Container):
@@ -100,11 +101,16 @@ class DockerContainer(Container):
                 # no tag is alias to gpu for ray-ml image
                 platforms.append("")
 
+        py_versions = [f"-{self.python_version}"]
+        if self.python_version == DEFAULT_PYTHON_VERSION:
+            py_versions.append("")
+
         alias_images = []
         ray_repo = f"rayproject/{self.image_type}"
         for version in versions:
             for platform in platforms:
-                alias = f"{ray_repo}:{version}-{self.python_version}{platform}"
-                alias_images.append(alias)
+                for py_version in py_versions:
+                    alias = f"{ray_repo}:{version}{py_version}{platform}"
+                    alias_images.append(alias)
 
         return alias_images

--- a/ci/ray_ci/test_docker_container.py
+++ b/ci/ray_ci/test_docker_container.py
@@ -50,9 +50,13 @@ class TestDockerContainer(RayCITestBase):
         container = DockerContainer("py38", "cpu", "ray")
         assert container._get_image_names() == [
             "rayproject/ray:123456-py38-cpu",
+            "rayproject/ray:123456-cpu",
             "rayproject/ray:123456-py38",
+            "rayproject/ray:123456",
             "rayproject/ray:nightly-py38-cpu",
+            "rayproject/ray:nightly-cpu",
             "rayproject/ray:nightly-py38",
+            "rayproject/ray:nightly",
         ]
 
         container = DockerContainer("py37", "cu118", "ray-ml")
@@ -69,7 +73,9 @@ class TestDockerContainer(RayCITestBase):
             container = DockerContainer("py38", "cpu", "ray")
             assert container._get_image_names() == [
                 "rayproject/ray:1.0.0.123456-py38-cpu",
+                "rayproject/ray:1.0.0.123456-cpu",
                 "rayproject/ray:1.0.0.123456-py38",
+                "rayproject/ray:1.0.0.123456",
             ]
 
 


### PR DESCRIPTION
We're missing a few docker tag for default python version in civ2. In particular, this part is missing:

`The optional Python version tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. py37, py38, py39 and py310. If unspecified, the tag points to an image using Python 3.8.`

Test:
- CI