### PR TITLE
Add `ray start --runtime-env-agent-port`.

### DIFF
--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -98,6 +98,7 @@ class RayParams:
             Defaults to random available port.
         runtime_env_agent_port: The port at which the runtime env agent
             listens to for HTTP.
+            Defaults to random available port.
         plasma_store_socket_name: If provided, it specifies the socket
             name used by the plasma store.
         raylet_socket_name: If provided, it specifies the socket path

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -436,6 +436,12 @@ def debug(address):
     help="The port for the dashboard head to listen for grpc on.",
 )
 @click.option(
+    "--runtime-env-agent-port",
+    type=int,
+    default=None,
+    help="The port for the runtime enviroment agents to listen for http on.",
+)
+@click.option(
     "--block",
     is_flag=True,
     default=False,
@@ -566,6 +572,7 @@ def start(
     dashboard_agent_listen_port,
     dashboard_agent_grpc_port,
     dashboard_grpc_port,
+    runtime_env_agent_port,
     block,
     plasma_directory,
     autoscaling_config,
@@ -664,6 +671,7 @@ def start(
         dashboard_agent_listen_port=dashboard_agent_listen_port,
         metrics_agent_port=dashboard_agent_grpc_port,
         dashboard_grpc_port=dashboard_grpc_port,
+        runtime_env_agent_port=runtime_env_agent_port,
         _system_config=system_config,
         enable_object_reconstruction=enable_object_reconstruction,
         metrics_export_port=metrics_export_port,


### PR DESCRIPTION
Ray 2.7.0 introduced a new runtime env agent that runs on each worker. It has a listening port that is by default randomly assigned. But we need to allow users to specify it.

Fixes #39866.