### PR TITLE
Soften ValueError for TPU autodetection

### DIFF
--- a/python/ray/_private/accelerator.py
+++ b/python/ray/_private/accelerator.py
@@ -8,7 +8,7 @@ import logging
 import ray._private.ray_constants as ray_constants
 import ray._private.utils as utils
 import re
-from typing import Iterable, Optional
+from typing import Callable, Iterable, Optional
 
 
 def update_resources_with_accelerator_type(resources: dict):
@@ -27,18 +27,18 @@ def update_resources_with_accelerator_type(resources: dict):
     _detect_and_configure_custom_accelerator(
         resources=resources,
         accelerator_key=ray_constants.NEURON_CORES,
-        accelerator_type=utils.get_neuron_core_constraint_name(),
-        visible_ids=utils.get_aws_neuron_core_visible_ids(),
-        autodetected_accelerators=_autodetect_aws_neuron_cores(),
+        get_accelerator_type=utils.get_neuron_core_constraint_name,
+        get_visible_ids=utils.get_aws_neuron_core_visible_ids,
+        autodetect_accelerators=_autodetect_aws_neuron_cores,
         visible_devices_env_variable=ray_constants.NEURON_RT_VISIBLE_CORES_ENV_VAR,
     )
     # Autodetect Google Cloud TPUs
     _detect_and_configure_custom_accelerator(
         resources=resources,
         accelerator_key=ray_constants.TPU,
-        accelerator_type=_autodetect_tpu_version(),
-        visible_ids=utils.get_tpu_visible_chips(),
-        autodetected_accelerators=_autodetect_num_tpus(),
+        get_accelerator_type=_autodetect_tpu_version,
+        get_visible_ids=utils.get_tpu_visible_chips,
+        autodetect_accelerators=_autodetect_num_tpus,
         visible_devices_env_variable=ray_constants.TPU_VISIBLE_CHIPS_ENV_VAR,
     )
 
@@ -46,9 +46,9 @@ def update_resources_with_accelerator_type(resources: dict):
 def _detect_and_configure_custom_accelerator(
     resources: dict,
     accelerator_key: str,
-    accelerator_type: str,
-    visible_ids: Optional[Iterable[str]],
-    autodetected_accelerators: int,
+    get_accelerator_type: Callable[[None], str],
+    get_visible_ids: Callable[[None], Optional[Iterable[str]]],
+    autodetect_accelerators: Callable[[None], int],
     visible_devices_env_variable: str,
 ):
     """Configure and autodetect custom accelerators counts and types.
@@ -71,14 +71,14 @@ def _detect_and_configure_custom_accelerator(
         accelerator_key: The key used to access the number of accelerators
             within `resources`. This can be:
             ray_constants.NEURON_CORES or ray_constants.TPU
-        accelerator_type: The name of the accelerator type. This
-            is the unique identifier of the accelerator version, e.g.
+        get_accelerator_type: A function that returns the name of the accelerator
+            type. This is the unique identifier of the accelerator version, e.g.
             ray_constants.AWS_NEURON_CORE or ray_constants.GOOGLE_TPU_V4.
-        visible_ids: The visible IDs specified by the user. This is typically
-            controlled by an environment variable, e.g. NEURON_RT_VISIBLE_CORES
-            or TPU_VISIBLE_CHIPS.
-        autodetected_accelerators: The number of accelerators autodetected
-            on the machine.
+        get_visible_ids: A function that returns the visible IDs specified by the user.
+            This is typically controlled by an environment variable, e.g.
+            NEURON_RT_VISIBLE_CORES or TPU_VISIBLE_CHIPS.
+        autodetected_accelerators: A function that returns the number of
+            accelerators autodetected on the machine.
         visible_devices_env_variable: The environment variable a user uses
             to specify which devices are visible.
 
@@ -90,6 +90,7 @@ def _detect_and_configure_custom_accelerator(
     # 1. Check if the user specified accelerator_count in resources
     accelerator_count = resources.get(accelerator_key, None)
     # 2. Check if the user specified visible cores/chips (within `visible_ids`)
+    visible_ids = get_visible_ids()
     if (
         accelerator_count is not None
         and visible_ids is not None
@@ -102,7 +103,7 @@ def _detect_and_configure_custom_accelerator(
         )
     # 3. Auto-detect accelerator_count if not specified in resources
     if accelerator_count is None:
-        accelerator_count = autodetected_accelerators
+        accelerator_count = autodetect_accelerators()
         # Don't use more resources than allowed by the user's pre-set values.
         if accelerator_count is not None and visible_ids is not None:
             accelerator_count = min(accelerator_count, len(visible_ids))
@@ -112,7 +113,7 @@ def _detect_and_configure_custom_accelerator(
         resources.update(
             {
                 accelerator_key: accelerator_count,
-                accelerator_type: accelerator_count,
+                get_accelerator_type(): accelerator_count,
             }
         )
 

--- a/python/ray/_private/accelerator.py
+++ b/python/ray/_private/accelerator.py
@@ -206,6 +206,12 @@ def _autodetect_tpu_version() -> Optional[str]:
     )
     if accelerator_type is not None:
         detected_tpu_version = accelerator_type_to_version(accelerator_type)
+        if detected_tpu_version is None:
+            logging.info(
+                "While trying to autodetect a TPU type and "
+                f"parsing {ray_constants.RAY_GKE_TPU_ACCELERATOR_TYPE_ENV_VAR}, "
+                f"received malformed accelerator_type: {accelerator_type}"
+            )
     else:
         # GCE-based VM check
         try:
@@ -219,6 +225,19 @@ def _autodetect_tpu_version() -> Optional[str]:
             ):
                 detected_tpu_version = accelerator_type_to_version(
                     accelerator_type_request.text
+                )
+                if detected_tpu_version is None:
+                    logging.info(
+                        "While trying to autodetect a TPU type, the TPU GCE metadata "
+                        "returned a malformed accelerator type: "
+                        f"{accelerator_type_request.text}."
+                    )
+            else:
+                logging.info(
+                    "While trying to autodetect a TPU type, "
+                    "unable to poll TPU GCE metadata. Got "
+                    f"status code: {accelerator_type_request.status_code} and "
+                    f"content: {accelerator_type_request.text}"
                 )
         except requests.RequestException as e:
             logging.info(

--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -65,7 +65,11 @@ def _validate_tpu_config(node: dict):
         )
     if "acceleratorType" in node:
         accelerator_type = node["acceleratorType"]
-        accelerator.assert_tpu_accelerator_type(accelerator_type)
+        if not accelerator.valid_tpu_accelerator_type(accelerator_type):
+            raise ValueError(
+                "`acceleratorType` should match v(generation)-(cores/chips). "
+                f"Got {accelerator_type}."
+            )
     else:  # "acceleratorConfig" in node
         accelerator_config = node["acceleratorConfig"]
         if "type" not in accelerator_config or "topology" not in accelerator_config:

--- a/python/ray/tests/test_accelerator.py
+++ b/python/ray/tests/test_accelerator.py
@@ -158,6 +158,8 @@ def test_autodetect_tpu_version(mock_os, mock_request, accelerator_type_version_
         ("gce", "not-a-valid-version"),
         ("gce", "vNOTVALID-8"),
         ("gce", "230498230948230948"),
+        # From issue #39913
+        ("gce", ""),
         ("gke", "not-a-valid-version"),
         ("gke", "vNOTVALID-8"),
         ("gke", "230498230948230948"),
@@ -175,8 +177,7 @@ def test_autodetect_invalid_type(mock_os, mock_request, test_case):
         mock_os.return_value = None
     else:
         mock_os.return_value = accelerator_type
-    with pytest.raises(ValueError):
-        accelerator._autodetect_tpu_version()
+    assert accelerator._autodetect_tpu_version() is None
 
 
 def test_autodetect_tpu_fails_gracefully():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Softens the assertion for valid TPU type to a log in TPU autodetection.

The original TPU auto detection incorrectly assumed that a GCE call would not return 200, leading to an issue where `ray.init` may fail if it returns status code 200 and an empty string.

This should, however, fail in `gcp/config.py` because we want to assert and fail ASAP if given a malformed accelerator type. We migrate the ValueError there.

We also add a specific test case here to assert that it does not crash.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/39913

<!-- For example: "Closes #1234" -->

## Checks

- [x ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
