### PR TITLE
[train/tune] Separate storage checkpoint index bookkeeping

### DIFF
--- a/python/ray/train/_internal/session.py
+++ b/python/ray/train/_internal/session.py
@@ -558,7 +558,7 @@ class _TrainSession:
 
             # NOTE: This is where the coordinator AND workers increment their
             # checkpoint index.
-            self.storage.current_checkpoint_index += 1
+            self.storage._increase_checkpoint_index(training_result.metrics)
 
         # Add result to a thread-safe queue.
         self.result_queue.put(training_result, block=True)

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -511,6 +511,11 @@ class StorageContext:
                 "to the configured storage path."
             )
 
+    def _increase_checkpoint_index(self, metrics: Dict):
+        # Per default, increase by 1. This can be overwritten to customize checkpoint
+        # directories.
+        self.current_checkpoint_index += 1
+
     def persist_current_checkpoint(self, checkpoint: "Checkpoint") -> "Checkpoint":
         """Persists a given checkpoint to the current checkpoint path on the filesystem.
 

--- a/python/ray/tune/experiment/experiment.py
+++ b/python/ray/tune/experiment/experiment.py
@@ -133,6 +133,7 @@ class Experiment:
 
     # Keys that will be present in `public_spec` dict.
     PUBLIC_KEYS = {"stop", "num_samples", "time_budget_s"}
+    _storage_context_cls = StorageContext
 
     def __init__(
         self,
@@ -201,7 +202,7 @@ class Experiment:
             if not name:
                 name = StorageContext.get_experiment_dir_name(run)
 
-            self.storage = StorageContext(
+            self.storage = self._storage_context_cls(
                 storage_path=storage_path,
                 storage_filesystem=storage_filesystem,
                 sync_config=sync_config,

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -1104,7 +1104,7 @@ class Trial:
             # Increment the checkpoint index to keep the checkpoint index in sync.
             # This index will get restored when the trial is restored and will
             # be passed to the Trainable as the starting checkpoint index.
-            self.storage.current_checkpoint_index += 1
+            self.storage._increase_checkpoint_index(checkpoint_result.metrics)
         else:
             self.run_metadata.checkpoint_manager.on_checkpoint(checkpoint)
         self.invalidate_json_state()

--- a/python/ray/tune/trainable/trainable.py
+++ b/python/ray/tune/trainable/trainable.py
@@ -552,7 +552,7 @@ class Trainable:
                     # The checkpoint index needs to be incremented.
                     # NOTE: This is no longer using "iteration" as the folder indexing
                     # to be consistent with fn trainables.
-                    self._storage.current_checkpoint_index += 1
+                    self._storage._increase_checkpoint_index(metrics)
 
                     checkpoint_result = _TrainingResult(
                         checkpoint=persisted_checkpoint, metrics=metrics


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Checkpoint IDs are incremented in three different places: The `Trainable` (for class trainables), the `session` (for function trainables), and the `Trial` (on the driver). These are currently implicitly kept in sync. In the future, we may want to synchronize driver and trainable state via other means, or customize the checkpoint directory name to be populated by other metrics. In preparation for this, we separate out the checkpoint ID mutation into a subfunction that can be overwritten or (in a follow-up) provided or otherwise modified.


```
from ray.train import Checkpoint, CheckpointConfig, RunConfig, ScalingConfig
from ray.train._internal.storage import StorageContext
from ray.tune import Tuner
from ray.tune.experiment import Experiment
from ray.tune.trainable import Trainable


class CustomStorageContext(StorageContext):
    def _increase_checkpoint_index(self, metrics):
        self.current_checkpoint_index = metrics.get(
            "training_iteration", self.current_checkpoint_index + 1
        )


class MyTrainable(Trainable):
    def step(self):
        return {"metric": self.iteration + 100}

    def save_checkpoint(self, checkpoint_dir):
        return {"test": "data"}

    def load_checkpoint(self, checkpoint_dir):
        pass


# monkey patch
Experiment._storage_context_cls = CustomStorageContext


tuner = Tuner(
    MyTrainable,
    run_config=RunConfig(
        checkpoint_config=CheckpointConfig(checkpoint_frequency=5),
        stop={"training_iteration": 100},
    ),
)
tuner.fit()
```

Result:

```
...
(MyTrainable pid=56464) Checkpoint successfully created at: Checkpoint(filesystem=local, path=/Users/kai/ray_results/MyTrainable_2023-09-27_14-37-02/MyTrainable_270ba_00000_0_2023-09-27_14-37-07/checkpoint_000080)
(MyTrainable pid=56464) Checkpoint successfully created at: Checkpoint(filesystem=local, path=/Users/kai/ray_results/MyTrainable_2023-09-27_14-37-02/MyTrainable_270ba_00000_0_2023-09-27_14-37-07/checkpoint_000085)
(MyTrainable pid=56464) Checkpoint successfully created at: Checkpoint(filesystem=local, path=/Users/kai/ray_results/MyTrainable_2023-09-27_14-37-02/MyTrainable_270ba_00000_0_2023-09-27_14-37-07/checkpoint_000090)
...
```



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
