### PR TITLE
[civ2][2] support --only-tags

### DIFF
--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -59,11 +59,19 @@ def test_get_test_targets() -> None:
 
 
 def test_get_all_test_query() -> None:
-    assert _get_all_test_query(["a", "b"], "core", "") == (
+    assert _get_all_test_query(["a", "b"], "core") == (
         "attr(tags, 'team:core\\\\b', tests(a) union tests(b))"
     )
-    assert _get_all_test_query(["a"], "core", "tag") == (
+    assert _get_all_test_query(["a"], "core", except_tags="tag") == (
         "attr(tags, 'team:core\\\\b', tests(a)) except (attr(tags, tag, tests(a)))"
+    )
+    assert _get_all_test_query(["a"], "core", only_tags="tag") == (
+        "attr(tags, 'team:core\\\\b', tests(a)) intersect (attr(tags, tag, tests(a)))"
+    )
+    assert _get_all_test_query(["a"], "core", except_tags="tag1", only_tags="tag2") == (
+        "attr(tags, 'team:core\\\\b', tests(a)) "
+        "except (attr(tags, tag1, tests(a))) "
+        "intersect (attr(tags, tag2, tests(a)))"
     )
 
 


### PR DESCRIPTION
Support --only-tags in ci/ray_ci. This is a replacement implementation for https://github.com/ray-project/ray/pull/39909. After reviewing the complexity of our tag usages, the former solution won't work.

Test:
- CI