### PR TITLE
Clarify default scheduling strategy used by Ray Data

### DIFF
--- a/doc/source/data/data-internals.rst
+++ b/doc/source/data/data-internals.rst
@@ -77,10 +77,13 @@ For an in-depth guide on shuffle performance, see :ref:`Performance Tips and Tun
 Scheduling
 ==========
 
-Ray Data uses Ray Core for execution, and is subject to the same scheduling considerations as normal Ray Tasks and Actors. Ray Data uses the following custom scheduling settings by default for improved performance:
+Ray Data uses Ray Core for execution. Below is a summary of the scheduling strategy for Ray Data:
 
-* The ``SPREAD`` scheduling strategy ensures that data blocks and map tasks are evenly balanced across the cluster.
-* Dataset tasks ignore placement groups by default, see :ref:`Ray Data and Placement Groups <datasets_pg>`.
+* Read operations use the ``SPREAD`` scheduling strategy if the file isn't located locally; otherwise, they're scheduled on the current node.
+* Map operations use the ``SPREAD`` scheduling strategy if the total argument size is less than 50MB.
+* The ``SPREAD`` scheduling strategy ensures an even distribution of data blocks and map tasks across the cluster.
+* All other operations use ``DEFAULT`` scheduling strategy.
+* Dataset tasks bypass placement groups by default. For more details, see :ref:`Ray Data and Placement Groups <datasets_pg>`.
 
 .. _datasets_pg:
 

--- a/doc/source/data/data-internals.rst
+++ b/doc/source/data/data-internals.rst
@@ -79,11 +79,11 @@ Scheduling
 
 Ray Data uses Ray Core for execution. Below is a summary of the scheduling strategy for Ray Data:
 
+* The ``SPREAD`` scheduling strategy ensures an even distribution of data blocks and map tasks across the cluster.
+* Dataset tasks bypass placement groups by default. For more details, see :ref:`Ray Data and Placement Groups <datasets_pg>`.
 * Read operations use the ``SPREAD`` scheduling strategy if the file isn't located locally; otherwise, they're scheduled on the current node.
 * Map operations use the ``SPREAD`` scheduling strategy if the total argument size is less than 50 MB.
-* The ``SPREAD`` scheduling strategy ensures an even distribution of data blocks and map tasks across the cluster.
 * All other operations use ``DEFAULT`` scheduling strategy.
-* Dataset tasks bypass placement groups by default. For more details, see :ref:`Ray Data and Placement Groups <datasets_pg>`.
 
 .. _datasets_pg:
 

--- a/doc/source/data/data-internals.rst
+++ b/doc/source/data/data-internals.rst
@@ -79,8 +79,8 @@ Scheduling
 
 Ray Data uses Ray Core for execution. Below is a summary of the scheduling strategy for Ray Data:
 
-* The ``SPREAD`` scheduling strategy ensures an even distribution of data blocks and map tasks across the cluster.
-* Dataset tasks bypass placement groups by default. For more details, see :ref:`Ray Data and Placement Groups <datasets_pg>`.
+* The ``SPREAD`` scheduling strategy ensures that data blocks and map tasks are evenly balanced across the cluster.
+* Dataset tasks ignore placement groups by default, see :ref:`Ray Data and Placement Groups <datasets_pg>`.
 * Read operations use the ``SPREAD`` scheduling strategy if the file isn't located locally; otherwise, they're scheduled on the current node.
 * Map operations use the ``SPREAD`` scheduling strategy if the total argument size is less than 50 MB.
 * All other operations use ``DEFAULT`` scheduling strategy.

--- a/doc/source/data/data-internals.rst
+++ b/doc/source/data/data-internals.rst
@@ -77,13 +77,13 @@ For an in-depth guide on shuffle performance, see :ref:`Performance Tips and Tun
 Scheduling
 ==========
 
-Ray Data uses Ray Core for execution. Below is a summary of the scheduling strategy for Ray Data:
+Ray Data uses Ray Core for execution. Below is a summary of the :ref:`scheduling strategy <ray-scheduling-strategies>` for Ray Data:
 
 * The ``SPREAD`` scheduling strategy ensures that data blocks and map tasks are evenly balanced across the cluster.
 * Dataset tasks ignore placement groups by default, see :ref:`Ray Data and Placement Groups <datasets_pg>`.
-* Read operations use the ``SPREAD`` scheduling strategy if the file isn't located locally; otherwise, they're scheduled on the current node.
-* Map operations use the ``SPREAD`` scheduling strategy if the total argument size is less than 50 MB.
-* All other operations use ``DEFAULT`` scheduling strategy.
+* Map operations use the ``SPREAD`` scheduling strategy if the total argument size is less than 50 MB; otherwise, they use the ``DEFAULT`` scheduling strategy.
+* Read operations use the ``SPREAD`` scheduling strategy.
+* All other operations, such as split, sort, and shuffle, use the ``DEFAULT`` scheduling strategy.
 
 .. _datasets_pg:
 

--- a/doc/source/data/data-internals.rst
+++ b/doc/source/data/data-internals.rst
@@ -80,7 +80,7 @@ Scheduling
 Ray Data uses Ray Core for execution. Below is a summary of the scheduling strategy for Ray Data:
 
 * Read operations use the ``SPREAD`` scheduling strategy if the file isn't located locally; otherwise, they're scheduled on the current node.
-* Map operations use the ``SPREAD`` scheduling strategy if the total argument size is less than 50MB.
+* Map operations use the ``SPREAD`` scheduling strategy if the total argument size is less than 50 MB.
 * The ``SPREAD`` scheduling strategy ensures an even distribution of data blocks and map tasks across the cluster.
 * All other operations use ``DEFAULT`` scheduling strategy.
 * Dataset tasks bypass placement groups by default. For more details, see :ref:`Ray Data and Placement Groups <datasets_pg>`.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As https://github.com/ray-project/ray/issues/39871 indicated, The [current Data Internals page](https://docs.ray.io/en/latest/data/data-internals.html#scheduling) has a section on Scheduling, which confusingly states that both SPREAD and DEFAULT are the default scheduling strategies used.  This PR summarized the scheduling strategy used by Ray Data as follows:

1. By default, the scheduling strategy is set to Default Hybrid Policy([code](https://github.com/ray-project/ray/blob/9c143f63233d5cbde8a6943db31b91fb3b05f017/python/ray/data/_internal/remote_fn.py#L26), [related PR](https://github.com/ray-project/ray/pull/36722)).
2. Read operation overrides the scheduling strategy to Spread Policy if the file is not located locally; otherwise, it is scheduled to the current node([code](https://github.com/Yicheng-Lu-llll/ray/blob/9c143f63233d5cbde8a6943db31b91fb3b05f017/python/ray/data/read_api.py#L338)).
3. Map operation overrides the scheduling strategy to Spread Policy if total argument size <50MB([code](https://github.com/ray-project/ray/blob/9c143f63233d5cbde8a6943db31b91fb3b05f017/python/ray/data/_internal/execution/operators/map_operator.py#L213), [related PR](https://github.com/ray-project/ray/pull/36290)).

Slack discussion: https://ray-distributed.slack.com/archives/C02PHB3SQHH/p1695756535614819

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #39871
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
