### PR TITLE
[Cluster launcher] disable verbose logs by default

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -105,6 +105,7 @@ def cli(logging_level, logging_format):
     default=False,
     help="Disable the local cluster config cache.",
 )
+@add_click_logging_options
 @PublicAPI
 def dashboard(cluster_config_file, cluster_name, port, remote_port, no_config_cache):
     """Port-forward a Ray cluster's dashboard to the local machine."""
@@ -1750,6 +1751,7 @@ def exec(
     type=str,
     help="Override the configured cluster name.",
 )
+@add_click_logging_options
 def get_head_ip(cluster_config_file, cluster_name):
     """Return the head node IP of a Ray cluster."""
     click.echo(get_head_node_ip(cluster_config_file, cluster_name))
@@ -1959,6 +1961,7 @@ def memory(
     hidden=True,
     help="Experimental: Display additional debuggging information.",
 )
+@add_click_logging_options
 @PublicAPI
 def status(address: str, redis_password: str, verbose: bool):
     """Print cluster status, including autoscaling info."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

VINFO and VVINFO logs are expected to only be printed if users specify a verbosity option like -v or -vv to the CLI. But now they are printed by default.

This PR creates the fix for it.

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/ray/issues/35417

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
