### PR TITLE
[civ2][3] move rllib benchmark tests to civ2

### DIFF
--- a/.buildkite/_forge.rayci.yml
+++ b/.buildkite/_forge.rayci.yml
@@ -51,3 +51,7 @@ steps:
   - name: serverlessbuild
     wanda: ci/docker/serverless.build.wanda.yaml
     depends_on: oss-ci-base_build
+
+  - name: rllibbuild
+    wanda: ci/docker/rllib.build.wanda.yaml
+    depends_on: oss-ci-base_ml

--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -67,20 +67,6 @@
       --test_env=WANDB_API_KEY --test_env=COMET_API_KEY
       python/ray/train/...
 
-- label: ":brain: RLlib: Benchmarks (Torch 2.x)"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
-  instance_size: medium
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    # Install torch 2.x locally until we move to torch 2.x in the CI.
-    - pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
-    - bazel test --config=ci $(./ci/run/bazel_export_options)
-      --build_tests_only
-      --test_tag_filters=torch_2.x_only_benchmark
-      rllib/...
-
 - label: ":brain: RLlib: Learning tests TF2-static-graph"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
   parallelism: 3

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -1,0 +1,9 @@
+group: rllib tests
+steps:
+  - label: ":brain: rllib: benchmarks"
+    tags: ["RAY_CI_RLLIB_AFFECTED"]
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --only-tags torch_2.x_only_benchmark
+    depends_on: rllibbuild
+    job_env: forge

--- a/ci/docker/rllib.build.Dockerfile
+++ b/ci/docker/rllib.build.Dockerfile
@@ -1,0 +1,14 @@
+ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml
+FROM $DOCKER_IMAGE_BASE_BUILD
+
+# Unset dind settings; we are using the host's docker daemon.
+ENV DOCKER_TLS_CERTDIR=
+ENV DOCKER_HOST=
+ENV DOCKER_TLS_VERIFY=
+ENV DOCKER_CERT_PATH=
+
+SHELL ["/bin/bash", "-ice"]
+
+COPY . .
+
+RUN RLLIB_TESTING=1 ./ci/env/install-dependencies.sh

--- a/ci/docker/rllib.build.wanda.yaml
+++ b/ci/docker/rllib.build.wanda.yaml
@@ -1,0 +1,14 @@
+name: "rllibbuild"
+froms: ["cr.ray.io/rayproject/oss-ci-base_ml"]
+dockerfile: ci/docker/rllib.build.Dockerfile
+srcs:
+  - ci/env/install-dependencies.sh
+  - python/requirements.txt
+  - python/requirements_compiled.txt
+  - python/requirements/test-requirements.txt
+  - python/requirements/ml/core-requirements.txt
+  - python/requirements/ml/dl-cpu-requirements.txt
+  - python/requirements/ml/rllib-requirements.txt
+  - python/requirements/ml/rllib-test-requirements.txt
+tags:
+  - cr.ray.io/rayproject/rllibbuild

--- a/ci/ray_ci/rllib.tests.yml
+++ b/ci/ray_ci/rllib.tests.yml
@@ -1,0 +1,1 @@
+flaky_tests: []


### PR DESCRIPTION
Move one of the rllib torch 2 benchmark tests to civ2. Note that since our CI already uses torch2 (https://github.com/ray-project/ray/blob/master/python/requirements/ml/dl-cpu-requirements.txt#L20), we don't need to reinstall that library any more.

Test:
- CI