### PR TITLE
[civ2][4] migrate rllib pytorch & TF2-static-graph learning tests

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -67,19 +67,6 @@
       --test_env=WANDB_API_KEY --test_env=COMET_API_KEY
       python/ray/train/...
 
-- label: ":brain: RLlib: Learning tests TF2-static-graph"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
-  parallelism: 3
-  instance_size: large
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - ./ci/run/run_bazel_test_with_sharding.sh --config=ci $(./ci/run/bazel_export_options)
-      --build_tests_only
-      --test_tag_filters=learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous,-fake_gpus,-torch_only,-tf2_only,-no_tf_static_graph
-      --test_arg=--framework=tf rllib/...
-
 - label: ":brain: RLlib: Learning tests TF2-eager-tracing"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
   parallelism: 3
@@ -92,19 +79,6 @@
       --build_tests_only
       --test_tag_filters=learning_tests_discrete,learning_tests_continuous,crashing_cartpole,stateless_cartpole,-fake_gpus,-torch_only,-multi_gpu,-no_tf_eager_tracing
       --test_arg=--framework=tf2 rllib/...
-
-- label: ":brain: RLlib: Learning tests PyTorch"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
-  parallelism: 3
-  instance_size: large
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - ./ci/run/run_bazel_test_with_sharding.sh --config=ci $(./ci/run/bazel_export_options)
-      --build_tests_only
-      --test_tag_filters=learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous,-fake_gpus,-tf_only,-tf2_only,-multi_gpu
-      --test_arg=--framework=torch rllib/...
 
 - label: ":brain: RLlib: Learning tests w/ 2 fake GPUs TF2-static-graph"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_DIRECTLY_AFFECTED"]

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -7,3 +7,48 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --only-tags torch_2.x_only_benchmark
     depends_on: rllibbuild
     job_env: forge
+
+  - label: ":brain: rllib: learning tests TF2-static-graph"
+    tags: rllib
+    parallelism: 2
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --only-tags learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
+        --except-tags fake_gpus,torch_only,tf2_only,no_tf_static_graph
+        --test-arg --framework=tf
+    depends_on: rllibbuild
+    job_env: forge
+
+  - label: ":brain: rllib: learning tests Pytorch"
+    tags: rllib
+    parallelism: 2
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --only-tags learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
+        --except-tags fake_gpus,tf_only,tf2_only,multi_gpu
+        --test-arg --framework=torch
+    depends_on: rllibbuild
+    job_env: forge
+  
+  - label: ":brain: rllib: flaky tests"
+    instance_type: large
+    commands:
+      # torch
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+        --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
+        --except-tags tf_only,tf2_only,multi_gpu
+        --test-arg --framework=torch
+
+      # tf2-static-graph
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+        --only-tags tf_only
+        --except-tags torch_only,tf2_only,no_tf_static_graph,multi_gpu
+        --test-arg --framework=tf
+        --skip-ray-installation # reuse the same docker image as the previous run
+    depends_on: rllibbuild
+    soft_fail: true
+    job_env: forge

--- a/ci/ray_ci/rllib.tests.yml
+++ b/ci/ray_ci/rllib.tests.yml
@@ -1,1 +1,7 @@
-flaky_tests: []
+flaky_tests:
+  # torch, tf2-static-graph, tf2-eager-tracing
+  - //rllib:learning_tests_multi_agent_cartpole_impala 
+  - //rllib:learning_tests_stateless_cartpole_r2d2
+  - //rllib:learning_tests_cartpole_appo_fake_gpus
+  - //rllib:learning_tests_two_step_game_qmix
+  - //rllib:learning_tests_pendulum_cql

--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -1,7 +1,7 @@
 import sys
 import pytest
 from unittest import mock
-from typing import List
+from typing import List, Optional
 
 from ci.ray_ci.tester_container import TesterContainer
 from ci.ray_ci.utils import chunk_into_n
@@ -25,7 +25,7 @@ def test_run_tests_in_docker() -> None:
         input_str = " ".join(input)
         assert (
             "bazel test --config=ci $(./ci/run/bazel_export_options) "
-            "--test_env v=k t1 t2" in input_str
+            "--test_env v=k --test_arg flag t1 t2" in input_str
         )
 
     with mock.patch("subprocess.Popen", side_effect=_mock_popen), mock.patch(
@@ -33,7 +33,7 @@ def test_run_tests_in_docker() -> None:
         return_value=None,
     ):
         container = TesterContainer("team")
-        container._run_tests_in_docker(["t1", "t2"], ["v=k"])
+        container._run_tests_in_docker(["t1", "t2"], ["v=k"], "flag")
 
 
 def test_run_script_in_docker() -> None:
@@ -72,6 +72,7 @@ def test_run_tests() -> None:
     def _mock_run_tests_in_docker(
         test_targets: List[str],
         test_envs: List[str],
+        test_arg: Optional[str] = None,
     ) -> MockPopen:
         return MockPopen(test_targets)
 

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -67,6 +67,11 @@ bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
     help="Environment variables to set for the test.",
 )
 @click.option(
+    "--test-arg",
+    type=str,
+    help=("Arguments to pass to the test."),
+)
+@click.option(
     "--build-name",
     type=str,
     help="Name of the build used to run tests",
@@ -82,6 +87,7 @@ def main(
     run_flaky_tests: bool,
     skip_ray_installation: bool,
     test_env: List[str],
+    test_arg: Optional[str],
     build_name: Optional[str],
 ) -> None:
     if not bazel_workspace_dir:
@@ -105,7 +111,7 @@ def main(
         only_tags=only_tags,
         get_flaky_tests=run_flaky_tests,
     )
-    success = container.run_tests(test_targets, test_env)
+    success = container.run_tests(test_targets, test_env, test_arg)
     sys.exit(0 if success else 1)
 
 

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -299,7 +299,7 @@ py_test(
     name = "learning_tests_multi_agent_cartpole_w_100_policies_appo",
     main = "tests/run_regression_tests.py",
     tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
-    size = "large",
+    size = "enormous",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/multi-agent-cartpole-w-100-policies-appo.py"],
     args = ["--dir=tuned_examples/appo"]
@@ -329,7 +329,7 @@ py_test(
     name = "learning_tests_stateless_cartpole_appo_vtrace",
     main = "tests/run_regression_tests.py",
     tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
-    size = "large",
+    size = "enormous",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/stateless-cartpole-appo-vtrace.py"],
     args = ["--dir=tuned_examples/appo"]
@@ -367,7 +367,7 @@ py_test(
    name = "learning_tests_pendulum_crr",
    main = "tests/run_regression_tests.py",
    tags = ["team:rllib", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "learning_tests_with_ray_data"],
-   size = "large",
+   size = "enormous",
    srcs = ["tests/run_regression_tests.py"],
    # Include an offline json data file as well.
    data = [
@@ -441,7 +441,7 @@ py_test(
     name = "learning_tests_pendulum_ddppo",
     main = "tests/run_regression_tests.py",
     tags = ["team:rllib", "exclusive", "torch_only", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
-    size = "large",
+    size = "enormous",
     srcs = ["tests/run_regression_tests.py"],
     data = glob(["tuned_examples/ddppo/pendulum-ddppo.yaml"]),
     args = ["--dir=tuned_examples/ddppo"]
@@ -787,7 +787,7 @@ py_test(
     name = "learning_tests_stateless_cartpole_r2d2",
     main = "tests/run_regression_tests.py",
     tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "stateless_cartpole"],
-    size = "large",
+    size = "enormous",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/r2d2/stateless-cartpole-r2d2.yaml"],
     args = ["--dir=tuned_examples/r2d2"]
@@ -797,7 +797,7 @@ py_test(
     name = "learning_tests_stateless_cartpole_r2d2_fake_gpus",
     main = "tests/run_regression_tests.py",
     tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "stateless_cartpole", "fake_gpus"],
-    size = "large",
+    size = "enormous",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/r2d2/stateless-cartpole-r2d2-fake-gpus.yaml"],
     args = ["--dir=tuned_examples/r2d2"]


### PR DESCRIPTION
Migrate rllib pytorch & tf2-static-graph learning tests to civ2. I need to declare a few tests as enormous for better test balancing. Theoretically, they are in the large categories, but many medium rllib tests are inflated and declared themselves as large (for some valid reasons), so the typical large tests need to be enourmous.