### PR TITLE
[civ2] reduce 30% number of workers

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -2,7 +2,7 @@ group: core tests
 steps:
   - label: ":ray: core: python tests"
     instance_type: large
-    parallelism: 6
+    parallelism: 4
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core 
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
@@ -12,7 +12,7 @@ steps:
 
   - label: ":ray: core: redis tests"
     instance_type: large
-    parallelism: 6
+    parallelism: 4
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core 
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -2,7 +2,7 @@ group: data tests
 steps:
   - label: ":database: data: arrow 6 tests"
     instance_type: medium
-    parallelism: 3
+    parallelism: 2
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data 
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" 
@@ -15,7 +15,7 @@ steps:
 
   - label: ":database: data: arrow 12 tests"
     instance_type: medium
-    parallelism: 3
+    parallelism: 2
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" 
@@ -28,7 +28,7 @@ steps:
 
   - label: ":database: data: arrow nightly tests"
     instance_type: medium
-    parallelism: 3
+    parallelism: 2
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data 
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" 

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -8,7 +8,7 @@ steps:
     job_env: forge
 
   - label: ":ray-serve: serve: serve tests"
-    parallelism: 3
+    parallelism: 2
     instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve --except-tags post_wheel_build,gpu,xcommit

--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -2,10 +2,9 @@ group: serverless tests
 steps:
   - label: ":serverless: serverless: python tests"
     instance_type: medium
-    parallelism: 2
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless 
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --parallelism-per-worker 3
         --except-tags manual,kuberay_operator,spark_plugin_tests
     depends_on: serverlessbuild
     job_env: forge


### PR DESCRIPTION
Due to the overhead of setting up a worker for running tests (10 mins of downloading docker + building rays), sharding jobs into too many nodes doesn't really speed things up that much, while due to test parallelism, we can put more tests into one shard. In this PR, I reduced the number of workers by 30%. The overall runtime increases only 5 minutes (from 40 -> 45 minutes)