### PR TITLE
Log raw exception data in case of bad pickle

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -45,7 +45,10 @@ class RayError(Exception):
             try:
                 return pickle.loads(ray_exception.serialized_exception)
             except Exception as e:
-                msg = "Failed to unpickle serialized exception. Raw exception data:\n" + str(ray_exception.serialized_exception)
+                msg = (
+                    "Failed to unpickle serialized exception. Raw exception data:\n"
+                    + str(ray_exception.serialized_exception)
+                )
                 raise RuntimeError(msg) from e
         else:
             return CrossLanguageError(ray_exception)

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -45,7 +45,7 @@ class RayError(Exception):
             try:
                 return pickle.loads(ray_exception.serialized_exception)
             except Exception as e:
-                msg = "Failed to unpickle serialized exception"
+                msg = "Failed to unpickle serialized exception. Raw exception data:\n" + str(ray_exception.serialized_exception)
                 raise RuntimeError(msg) from e
         else:
             return CrossLanguageError(ray_exception)


### PR DESCRIPTION
When an exception is raised that cannot be unpickled for various reasons (e.g. missing __reduce__ method in exception class) it is useful to be able to see the raw pickled message for diagnostic purposes.