### PR TITLE
[data] Normalize upstream blocks for zip/map/reduce/etc. operations using inferred block accessors

### DIFF
--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -7,6 +7,7 @@ from ray.data._internal.execution.interfaces import PhysicalOperator, RefBundle
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.split import _split_at_indices
 from ray.data._internal.stats import StatsDict
+from ray.data._internal.util import normalize_blocks
 from ray.data.block import (
     Block,
     BlockAccessor,
@@ -235,6 +236,10 @@ def _zip_one_block(
     if inverted:
         # Swap blocks if ordering was inverted during block alignment splitting.
         block, other_block = other_block, block
+
+    if not isinstance(other_block, type(block)):
+        block, other_block = normalize_blocks([block, other_block])
+
     # Zip block and other blocks.
     result = BlockAccessor.for_block(block).zip(other_block)
     br = BlockAccessor.for_block(result)

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -237,7 +237,7 @@ def _zip_one_block(
         # Swap blocks if ordering was inverted during block alignment splitting.
         block, other_block = other_block, block
 
-    # Normailze blocks if they're not of the same type
+    # Normalize blocks if they're not of the same type
     if not isinstance(other_block, type(block)):
         block, other_block = normalize_blocks([block, other_block])
 

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -237,6 +237,7 @@ def _zip_one_block(
         # Swap blocks if ordering was inverted during block alignment splitting.
         block, other_block = other_block, block
 
+    # Normailze blocks if they're not of the same type
     if not isinstance(other_block, type(block)):
         block, other_block = normalize_blocks([block, other_block])
 

--- a/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
@@ -75,7 +75,7 @@ class SortAggregateTaskSpec(ExchangeTaskSpec):
         except AttributeError:
             # mapper_outputs might contain heterogeneous block types
             # normalize all blocks from mapper outputs and retry
-            normalized_blocks = normalize_blocks(mapper_outputs)
+            normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
             return BlockAccessor.for_block(
                 normalized_blocks[0]
             ).aggregate_combined_blocks(

--- a/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
@@ -68,7 +68,7 @@ class SortAggregateTaskSpec(ExchangeTaskSpec):
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
     ) -> Tuple[Block, BlockMetadata]:
-        normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
+        normalized_blocks = normalize_blocks(mapper_outputs)
         return BlockAccessor.for_block(normalized_blocks[0]).aggregate_combined_blocks(
             normalized_blocks, key, aggs, finalize=not partial_reduce
         )

--- a/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
@@ -68,19 +68,10 @@ class SortAggregateTaskSpec(ExchangeTaskSpec):
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
     ) -> Tuple[Block, BlockMetadata]:
-        try:
-            return BlockAccessor.for_block(mapper_outputs[0]).aggregate_combined_blocks(
-                list(mapper_outputs), key, aggs, finalize=not partial_reduce
-            )
-        except AttributeError:
-            # mapper_outputs might contain heterogeneous block types
-            # normalize all blocks from mapper outputs and retry
-            normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
-            return BlockAccessor.for_block(
-                normalized_blocks[0]
-            ).aggregate_combined_blocks(
-                normalized_blocks, key, aggs, finalize=not partial_reduce
-            )
+        normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
+        return BlockAccessor.for_block(normalized_blocks[0]).aggregate_combined_blocks(
+            normalized_blocks, key, aggs, finalize=not partial_reduce
+        )
 
     @staticmethod
     def _prune_unused_columns(

--- a/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
@@ -41,7 +41,7 @@ class ShuffleTaskSpec(ExchangeTaskSpec):
         # TODO: Support fusion with other upstream operators.
         stats = BlockExecStats.builder()
         if upstream_map_fn:
-            mapped_blocks = list(upstream_map_fn([block]))
+            mapped_blocks = normalize_blocks(list(upstream_map_fn([block])))
             if len(mapped_blocks) > 1:
                 builder = BlockAccessor.for_block(mapped_blocks[0]).builder()
                 for b in mapped_blocks:

--- a/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.planner.exchange.interfaces import ExchangeTaskSpec
+from ray.data._internal.util import normalize_blocks
 from ray.data.block import Block, BlockAccessor, BlockExecStats, BlockMetadata
 
 
@@ -82,7 +83,7 @@ class ShuffleTaskSpec(ExchangeTaskSpec):
         # TODO: Support fusion with other downstream operators.
         stats = BlockExecStats.builder()
         builder = DelegatingBlockBuilder()
-        for block in mapper_outputs:
+        for block in normalize_blocks(mapper_outputs):
             builder.add_block(block)
         new_block = builder.build()
         accessor = BlockAccessor.for_block(new_block)

--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -76,7 +76,7 @@ class SortTaskSpec(ExchangeTaskSpec):
         except AttributeError:
             # mapper_outputs might contain heterogeneous block types
             # normalize blocks in mapper_outputs and retry
-            normalized_blocks = normalize_blocks(mapper_outputs)
+            normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
             return BlockAccessor.for_block(normalized_blocks[0]).merge_sorted_blocks(
                 normalized_blocks, sort_key
             )

--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -69,17 +69,10 @@ class SortTaskSpec(ExchangeTaskSpec):
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
     ) -> Tuple[Block, BlockMetadata]:
-        try:
-            return BlockAccessor.for_block(mapper_outputs[0]).merge_sorted_blocks(
-                mapper_outputs, sort_key
-            )
-        except AttributeError:
-            # mapper_outputs might contain heterogeneous block types
-            # normalize blocks in mapper_outputs and retry
-            normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
-            return BlockAccessor.for_block(normalized_blocks[0]).merge_sorted_blocks(
-                normalized_blocks, sort_key
-            )
+        normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
+        return BlockAccessor.for_block(normalized_blocks[0]).merge_sorted_blocks(
+            normalized_blocks, sort_key
+        )
 
     @staticmethod
     def sample_boundaries(

--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -97,7 +97,7 @@ class SortTaskSpec(ExchangeTaskSpec):
         samples = sample_bar.fetch_until_complete(sample_results)
         sample_bar.close()
         del sample_results
-        samples = [s for s in samples if len(s) > 0]
+        samples = normalize_blocks([s for s in samples if len(s) > 0])
         # The dataset is empty
         if len(samples) == 0:
             return [None] * (num_reducers - 1)

--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -69,7 +69,7 @@ class SortTaskSpec(ExchangeTaskSpec):
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
     ) -> Tuple[Block, BlockMetadata]:
-        normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
+        normalized_blocks = normalize_blocks(mapper_outputs)
         return BlockAccessor.for_block(normalized_blocks[0]).merge_sorted_blocks(
             normalized_blocks, sort_key
         )

--- a/python/ray/data/_internal/shuffle_and_partition.py
+++ b/python/ray/data/_internal/shuffle_and_partition.py
@@ -3,6 +3,8 @@ from typing import Callable, Iterable, List, Optional, Union
 
 import numpy as np
 
+from python.ray.data._internal.util import normalize_blocks
+
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.push_based_shuffle import PushBasedShufflePlan
@@ -80,7 +82,7 @@ class _ShufflePartitionOp(ShuffleOp):
     ) -> (Block, BlockMetadata):
         stats = BlockExecStats.builder()
         builder = DelegatingBlockBuilder()
-        for block in mapper_outputs:
+        for block in normalize_blocks(mapper_outputs):
             builder.add_block(block)
         new_block = builder.build()
         accessor = BlockAccessor.for_block(new_block)

--- a/python/ray/data/_internal/shuffle_and_partition.py
+++ b/python/ray/data/_internal/shuffle_and_partition.py
@@ -40,7 +40,7 @@ class _ShufflePartitionOp(ShuffleOp):
         if block_udf:
             ctx = TaskContext(task_idx=idx)
             # TODO(ekl) note that this effectively disables block splitting.
-            blocks = list(block_udf([block], ctx))
+            blocks = normalize_blocks(list(block_udf([block], ctx)))
             if len(blocks) > 1:
                 builder = BlockAccessor.for_block(blocks[0]).builder()
                 for b in blocks:

--- a/python/ray/data/_internal/shuffle_and_partition.py
+++ b/python/ray/data/_internal/shuffle_and_partition.py
@@ -3,12 +3,11 @@ from typing import Callable, Iterable, List, Optional, Union
 
 import numpy as np
 
-from python.ray.data._internal.util import normalize_blocks
-
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.push_based_shuffle import PushBasedShufflePlan
 from ray.data._internal.shuffle import ShuffleOp, SimpleShufflePlan
+from ray.data._internal.util import normalize_blocks
 from ray.data.block import Block, BlockAccessor, BlockExecStats, BlockMetadata
 
 

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -125,7 +125,7 @@ class _SortOp(ShuffleOp):
         except AttributeError:
             # mapper_outputs might contain heterogeneous block types
             # normalize blocks in mapper_outputs and retry
-            normalized_blocks = normalize_blocks(mapper_outputs)
+            normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
             return BlockAccessor.for_block(normalized_blocks[0]).merge_sorted_blocks(
                 normalized_blocks, sort_key
             )

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -118,7 +118,7 @@ class _SortOp(ShuffleOp):
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
     ) -> (Block, BlockMetadata):
-        normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
+        normalized_blocks = normalize_blocks(mapper_outputs)
         return BlockAccessor.for_block(normalized_blocks[0]).merge_sorted_blocks(
             normalized_blocks, sort_key
         )

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -118,17 +118,10 @@ class _SortOp(ShuffleOp):
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
     ) -> (Block, BlockMetadata):
-        try:
-            return BlockAccessor.for_block(mapper_outputs[0]).merge_sorted_blocks(
-                mapper_outputs, sort_key
-            )
-        except AttributeError:
-            # mapper_outputs might contain heterogeneous block types
-            # normalize blocks in mapper_outputs and retry
-            normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
-            return BlockAccessor.for_block(normalized_blocks[0]).merge_sorted_blocks(
-                normalized_blocks, sort_key
-            )
+        normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
+        return BlockAccessor.for_block(normalized_blocks[0]).merge_sorted_blocks(
+            normalized_blocks, sort_key
+        )
 
 
 class SimpleSortOp(_SortOp, SimpleShufflePlan):

--- a/python/ray/data/_internal/sort.py
+++ b/python/ray/data/_internal/sort.py
@@ -167,7 +167,7 @@ def sample_boundaries(
     if should_close_bar:
         sample_bar.close()
     del sample_results
-    samples = [s for s in samples if len(s) > 0]
+    samples = normalize_blocks([s for s in samples if len(s) > 0])
     # The dataset is empty
     if len(samples) == 0:
         return [None] * (num_reducers - 1)

--- a/python/ray/data/_internal/stage_impl.py
+++ b/python/ray/data/_internal/stage_impl.py
@@ -14,6 +14,7 @@ from ray.data._internal.shuffle_and_partition import (
 )
 from ray.data._internal.sort import SortKey, sort_impl
 from ray.data._internal.split import _split_at_index, _split_at_indices
+from ray.data._internal.util import normalize_blocks
 from ray.data.block import (
     Block,
     BlockAccessor,
@@ -302,6 +303,11 @@ def _do_zip(
     if inverted:
         # Swap blocks if ordering was inverted during block alignment splitting.
         block, other_block = other_block, block
+
+    # Normailze blocks if they're not of the same type
+    if not isinstance(other_block, type(block)):
+        block, other_block = normalize_blocks([block, other_block])
+
     # Zip block and other blocks.
     result = BlockAccessor.for_block(block).zip(other_block)
     br = BlockAccessor.for_block(result)

--- a/python/ray/data/_internal/stage_impl.py
+++ b/python/ray/data/_internal/stage_impl.py
@@ -304,7 +304,7 @@ def _do_zip(
         # Swap blocks if ordering was inverted during block alignment splitting.
         block, other_block = other_block, block
 
-    # Normailze blocks if they're not of the same type
+    # Normalize blocks if they're not of the same type
     if not isinstance(other_block, type(block)):
         block, other_block = normalize_blocks([block, other_block])
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -491,11 +491,12 @@ def pandas_df_to_arrow_block(df: "pandas.DataFrame") -> "Block":
     )
 
 
-def normalize_blocks(blocks: Iterable[Block]) -> Iterable[Block]:
-    seen = set()
-    # Check if all blocks are homogenous
-    if not any(len(seen) > 1 or seen.add(type(block)) for block in blocks):
-        return blocks
+def normalize_blocks(blocks: Iterable[Block], check_types=True) -> Iterable[Block]:
+    if check_types:  # Check if all blocks are homogenous
+        seen = set()
+        if not any(len(seen) > 1 or seen.add(type(block)) for block in blocks):
+            # All blocks have the same type, return as-is
+            return blocks
 
     # Convert heterogeneous block types to arrow blocks
     return [BlockAccessor.for_block(block).to_arrow() for block in blocks]

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -491,9 +491,13 @@ def pandas_df_to_arrow_block(df: "pandas.DataFrame") -> "Block":
 
 
 def normalize_blocks(blocks: Iterable["Block"]) -> Iterable["Block"]:
-    seen = set()
+    """Normalize blocks checking if input blocks have more than one type.
+    If only one type exist return blocks as-is, otherwise convert blocks to
+    arrow blocks.
+    """
+    seen_types = set()
     # Check if blocks types are homogeneous
-    if all(seen.add(type(block)) or len(seen) == 1 for block in blocks):
+    if all(seen_types.add(type(block)) or len(seen_types) == 1 for block in blocks):
         # All blocks have the same type, return as-is
         return blocks
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -490,12 +490,12 @@ def pandas_df_to_arrow_block(df: "pandas.DataFrame") -> "Block":
     )
 
 
-def normalize_blocks(blocks: Iterable["Block"], check_types=True) -> Iterable["Block"]:
-    if check_types:  # Check if all blocks are homogenous
-        seen = set()
-        if not any(len(seen) > 1 or seen.add(type(block)) for block in blocks):
-            # All blocks have the same type, return as-is
-            return blocks
+def normalize_blocks(blocks: Iterable["Block"]) -> Iterable["Block"]:
+    seen = set()
+    # Check if blocks are homogenous
+    if not any(len(seen) > 1 or seen.add(type(block)) for block in blocks):
+        # All blocks have the same type, return as-is
+        return blocks
 
     from ray.data.block import BlockAccessor
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -490,16 +490,16 @@ def pandas_df_to_arrow_block(df: "pandas.DataFrame") -> "Block":
     )
 
 
-def normalize_blocks(blocks: Iterable["Block"]) -> List["Block"]:
+def normalize_blocks(blocks: Iterable["Block"]) -> Iterable["Block"]:
     seen = set()
-    # Check if blocks are homogenous
+    # Check if blocks types are homogeneous
     if all(seen.add(type(block)) or len(seen) == 1 for block in blocks):
         # All blocks have the same type, return as-is
         return blocks
 
     from ray.data.block import BlockAccessor
 
-    # Convert heterogeneous block types to arrow blocks
+    # Convert any heterogeneous block types to arrow blocks
     return [BlockAccessor.for_block(block).to_arrow() for block in blocks]
 
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -490,10 +490,10 @@ def pandas_df_to_arrow_block(df: "pandas.DataFrame") -> "Block":
     )
 
 
-def normalize_blocks(blocks: Iterable["Block"]) -> Iterable["Block"]:
+def normalize_blocks(blocks: Iterable["Block"]) -> List["Block"]:
     seen = set()
     # Check if blocks are homogenous
-    if not any(len(seen) > 1 or seen.add(type(block)) for block in blocks):
+    if all(seen.add(type(block)) or len(seen) == 1 for block in blocks):
         # All blocks have the same type, return as-is
         return blocks
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -24,7 +24,6 @@ import numpy as np
 import ray
 from ray._private.utils import _get_pyarrow_version
 from ray.data._internal.arrow_ops.transform_pyarrow import unify_schemas
-from ray.data.block import BlockAccessor
 from ray.data.context import DataContext
 
 if TYPE_CHECKING:
@@ -491,12 +490,14 @@ def pandas_df_to_arrow_block(df: "pandas.DataFrame") -> "Block":
     )
 
 
-def normalize_blocks(blocks: Iterable[Block], check_types=True) -> Iterable[Block]:
+def normalize_blocks(blocks: Iterable["Block"], check_types=True) -> Iterable["Block"]:
     if check_types:  # Check if all blocks are homogenous
         seen = set()
         if not any(len(seen) > 1 or seen.add(type(block)) for block in blocks):
             # All blocks have the same type, return as-is
             return blocks
+
+    from ray.data.block import BlockAccessor
 
     # Convert heterogeneous block types to arrow blocks
     return [BlockAccessor.for_block(block).to_arrow() for block in blocks]

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -1,5 +1,4 @@
 from typing import List, Optional, Tuple, Union
-from weakref import finalize
 
 from ._internal.table_block import TableBlockAccessor
 from ray.data._internal import sort
@@ -71,7 +70,7 @@ class _GroupbyOp(ShuffleOp):
         except AttributeError:
             # mapper_outputs might contain heterogeneous block types
             # normalize blocks in mapper_outputs and retry
-            normalized_blocks = normalize_blocks(mapper_outputs)
+            normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
             return BlockAccessor.for_block(
                 normalized_blocks[0]
             ).aggregate_combined_blocks(

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -63,7 +63,7 @@ class _GroupbyOp(ShuffleOp):
         partial_reduce: bool = False,
     ) -> (Block, BlockMetadata):
         """Aggregate sorted and partially combined blocks."""
-        normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
+        normalized_blocks = normalize_blocks(mapper_outputs)
         return BlockAccessor.for_block(normalized_blocks[0]).aggregate_combined_blocks(
             normalized_blocks, key, aggs, finalize=not partial_reduce
         )

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -63,19 +63,10 @@ class _GroupbyOp(ShuffleOp):
         partial_reduce: bool = False,
     ) -> (Block, BlockMetadata):
         """Aggregate sorted and partially combined blocks."""
-        try:
-            return BlockAccessor.for_block(mapper_outputs[0]).aggregate_combined_blocks(
-                list(mapper_outputs), key, aggs, finalize=not partial_reduce
-            )
-        except AttributeError:
-            # mapper_outputs might contain heterogeneous block types
-            # normalize blocks in mapper_outputs and retry
-            normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
-            return BlockAccessor.for_block(
-                normalized_blocks[0]
-            ).aggregate_combined_blocks(
-                normalized_blocks, key, aggs, finalize=not partial_reduce
-            )
+        normalized_blocks = normalize_blocks(mapper_outputs, check_types=False)
+        return BlockAccessor.for_block(normalized_blocks[0]).aggregate_combined_blocks(
+            normalized_blocks, key, aggs, finalize=not partial_reduce
+        )
 
     @staticmethod
     def _prune_unused_columns(

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -47,6 +47,19 @@ def test_zip_different_num_blocks_combinations(
     )
 
 
+def test_zip_different_types(ray_start_regular_shared):
+    df = pd.DataFrame({"spam": [0]})  # Reproducing issue #31550
+    ds1 = ray.data.from_pandas(df)
+    ds2 = ray.data.from_items([{"ham": [0]}])
+    zipped_ds = ds1.zip(ds2)
+    assert zipped_ds.schema().names == ["spam", "ham"]
+    assert zipped_ds.take() == [{"ham": [0], "spam": 0}]
+
+    zipped_ds = ds2.zip(ds1)
+    assert zipped_ds.schema().names == ["ham", "spam"]
+    assert zipped_ds.take() == [{"ham": [0], "spam": 0}]
+
+
 @pytest.mark.parametrize(
     "num_cols1,num_cols2,should_invert",
     [

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -48,16 +48,17 @@ def test_zip_different_num_blocks_combinations(
 
 
 def test_zip_different_types(ray_start_regular_shared):
-    df = pd.DataFrame({"spam": [0]})  # Reproducing issue #31550
+    # Reproducing issue #31550
+    df = pd.DataFrame({"spam": [0]})
     ds1 = ray.data.from_pandas(df)
     ds2 = ray.data.from_items([{"ham": [0]}])
+
     zipped_ds = ds1.zip(ds2)
     assert zipped_ds.schema().names == ["spam", "ham"]
-    assert zipped_ds.take() == [{"ham": [0], "spam": 0}]
-
+    assert zipped_ds.take() == named_values(["spam", "ham"], [(0, [0])])
     zipped_ds = ds2.zip(ds1)
     assert zipped_ds.schema().names == ["ham", "spam"]
-    assert zipped_ds.take() == [{"ham": [0], "spam": 0}]
+    assert zipped_ds.take() == named_values(["ham", "spam"], [([0], 0)])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: Michael Huang <michaelhly@gmail.com><!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When reducing mapped outputs (or zipping datasets), BlockAccessors are inferred based on the first block of `mapper_outputs`. However, `mapper_outputs` can contain heterogeneous block types inadvertently due to
- user setting inconsistent batch format in task graph 
- internal fallback conversion when encountering data types not supported by pyarrow
a.) https://github.com/ray-project/ray/blob/3135323aa1f6eb5861c331b24a9209419106c0ed/python/ray/data/block.py#L366-L373
b.) https://github.com/ray-project/ray/blob/08aa1384e8c25f8898a20fd1d647012d1f020400/python/ray/data/_internal/delegating_block_builder.py#L20-L28

We want to normalize heterogeneous blocks in `mapper_output` to arrow blocks before using the BlockAccessor for the first block to compute reduced results.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #39155 
Closes https://github.com/ray-project/ray/issues/39206
Closes https://github.com/ray-project/ray/issues/39291
Closes https://github.com/ray-project/ray/issues/31550
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
