### PR TITLE
Fix get_wheel_filename being out of date

### DIFF
--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -138,7 +138,7 @@ You can install the nightly Ray wheels via the following links. These daily rele
 
 .. note::
 
-  .. If changes are made to the list of wheel links below, ensure `get_wheel_filename()` in  `https://github.com/ray-project/ray/blob/master/python/ray/_private/utils.py` are up to date.
+  .. If you change the list of wheel links below, remember to update `get_wheel_filename()` in  `https://github.com/ray-project/ray/blob/master/python/ray/_private/utils.py`.
   
   Python 3.11 support is experimental.
 

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -138,6 +138,8 @@ You can install the nightly Ray wheels via the following links. These daily rele
 
 .. note::
 
+  .. If changes are made to the list of wheel links below, ensure `get_wheel_filename()` in  `https://github.com/ray-project/ray/blob/master/python/ray/_private/utils.py` are up to date.
+  
   Python 3.11 support is experimental.
 
 .. _`Linux Python 3.11 (x86_64) (EXPERIMENTAL)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-manylinux2014_x86_64.whl

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1406,12 +1406,13 @@ def get_wheel_filename(
     assert py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS, py_version
 
     py_version_str = "".join(map(str, py_version))
-    if py_version_str in ["37", "38", "39"]:
-        darwin_os_string = "macosx_10_15_x86_64"
-    else:
-        darwin_os_string = "macosx_10_15_universal2"
-
+    
     architecture = architecture or platform.processor()
+
+    if py_version_str in ["311", "310", "39", "38"] and architecture == "arm64":
+        darwin_os_string = "macosx_11_0_arm64"
+    else:
+        darwin_os_string = "macosx_10_15_x86_64"
 
     if architecture == "aarch64":
         linux_os_string = "manylinux2014_aarch64"

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1406,7 +1406,7 @@ def get_wheel_filename(
     assert py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS, py_version
 
     py_version_str = "".join(map(str, py_version))
-    
+
     architecture = architecture or platform.processor()
 
     if py_version_str in ["311", "310", "39", "38"] and architecture == "arm64":

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -129,7 +129,7 @@ def test_get_master_wheel_url():
     # This should be a commit for which wheels have already been built for
     # all platforms and python versions at
     # `s3://ray-wheels/master/<test_commit>/`.
-    test_commit = "cf23cd6810dbfd7b1ac3016fba02ff4594f24b7f"
+    test_commit = "904dbce085bc542b93fbe06d75f3b02a65d3a2b4"
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             # TODO(https://github.com/ray-project/ray/issues/31362)
@@ -147,7 +147,7 @@ def test_get_release_wheel_url():
     # This should be a commit for which wheels have already been built for
     # all platforms and python versions at
     # `s3://ray-wheels/releases/2.2.0/<commit>/`.
-    test_commits = {"2.5.0": "ddf0ccab7aa87be5cf6cf7df9d6e24a3611fb345"}
+    test_commits = {"2.7.0": "904dbce085bc542b93fbe06d75f3b02a65d3a2b4"}
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             for version, commit in test_commits.items():

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -129,13 +129,9 @@ def test_get_master_wheel_url():
     # This should be a commit for which wheels have already been built for
     # all platforms and python versions at
     # `s3://ray-wheels/master/<test_commit>/`.
-    test_commit = "904dbce085bc542b93fbe06d75f3b02a65d3a2b4"
+    test_commit = "0910639b6eba1b77b9a36b9f3350c5aa274578dd"
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
-            # TODO(https://github.com/ray-project/ray/issues/31362)
-            if py_version == (3, 11) and sys_platform != "linux":
-                continue
-
             url = get_master_wheel_url(
                 test_commit, sys_platform, ray_version, py_version
             )
@@ -151,10 +147,6 @@ def test_get_release_wheel_url():
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             for version, commit in test_commits.items():
-                # TODO(https://github.com/ray-project/ray/issues/31362)
-                if py_version == (3, 11) and sys_platform != "linux":
-                    continue
-
                 url = get_release_wheel_url(commit, sys_platform, version, py_version)
                 assert requests.head(url).status_code == 200, url
 

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -114,10 +114,6 @@ def test_get_wheel_filename():
     ray_version = "3.0.0.dev0"
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
-            # TODO(https://github.com/ray-project/ray/issues/31362)
-            if py_version == (3) and sys_platform != "linux":
-                continue
-
             filename = get_wheel_filename(sys_platform, ray_version, py_version)
             prefix = "https://s3-us-west-2.amazonaws.com/ray-wheels/latest/"
             url = f"{prefix}{filename}"
@@ -323,7 +319,7 @@ def test_no_spurious_worker_startup(shutdown_only, runtime_env_class):
             for line in f.readlines():
                 num_workers_prefix = "- num PYTHON workers: "
                 if num_workers_prefix in line:
-                    return int(line[len(num_workers_prefix) :])
+                    return int(line[len(num_workers_prefix):])
         return None
 
     # Wait for "debug_state.txt" to be updated to reflect the started worker.

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -112,12 +112,14 @@ def test_get_wheel_filename():
     """Test the code that generates the filenames of the `latest` wheels."""
     # NOTE: These should not be changed for releases.
     ray_version = "3.0.0.dev0"
-    for sys_platform in ["darwin", "linux", "win32"]:
-        for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
-            filename = get_wheel_filename(sys_platform, ray_version, py_version)
-            prefix = "https://s3-us-west-2.amazonaws.com/ray-wheels/latest/"
-            url = f"{prefix}{filename}"
-            assert requests.head(url).status_code == 200, url
+    for arch in ["x86_64", "aarch64", "arm64"]:
+        for sys_platform in ["darwin", "linux", "win32"]:
+            for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
+                filename = get_wheel_filename(
+                    sys_platform, ray_version, py_version, arch)
+                prefix = "https://s3-us-west-2.amazonaws.com/ray-wheels/latest/"
+                url = f"{prefix}{filename}"
+                assert requests.head(url).status_code == 200, url
 
 
 def test_get_master_wheel_url():

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -115,7 +115,7 @@ def test_get_wheel_filename():
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             # TODO(https://github.com/ray-project/ray/issues/31362)
-            if py_version == (3, 11) and sys_platform != "linux":
+            if py_version == (3) and sys_platform != "linux":
                 continue
 
             filename = get_wheel_filename(sys_platform, ray_version, py_version)

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -116,7 +116,8 @@ def test_get_wheel_filename():
         for sys_platform in ["darwin", "linux", "win32"]:
             for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
                 filename = get_wheel_filename(
-                    sys_platform, ray_version, py_version, arch)
+                    sys_platform, ray_version, py_version, arch
+                )
                 prefix = "https://s3-us-west-2.amazonaws.com/ray-wheels/latest/"
                 url = f"{prefix}{filename}"
                 assert requests.head(url).status_code == 200, url
@@ -313,7 +314,7 @@ def test_no_spurious_worker_startup(shutdown_only, runtime_env_class):
             for line in f.readlines():
                 num_workers_prefix = "- num PYTHON workers: "
                 if num_workers_prefix in line:
-                    return int(line[len(num_workers_prefix):])
+                    return int(line[len(num_workers_prefix) :])
         return None
 
     # Wait for "debug_state.txt" to be updated to reflect the started worker.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `get_wheel_filename` method was not returning the proper filename of the current wheels.
This pr fixes this issue

## Related issue number
<!-- For example: "Closes #1234" -->
Fixes #39842

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
