### PR TITLE
[data] Make exceptions consistent when falling back to pandas

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -15,6 +15,8 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Tuple,
+    Type,
     TypeVar,
     Union,
 )
@@ -782,3 +784,9 @@ def make_async_gen(
         num_threads_alive = num_workers - num_threads_finished
         if num_threads_alive > 0:
             output_queue.release(num_threads_alive)
+
+
+def _fallback_to_pandas_exceptions() -> Tuple[Type[Exception], ...]:
+    import pyarrow as pa
+
+    return (TypeError, pa.ArrowNotImplementedError, pa.ArrowInvalid, pa.ArrowTypeError)

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -789,4 +789,9 @@ def make_async_gen(
 def _fallback_to_pandas_exceptions() -> Tuple[Type[Exception], ...]:
     import pyarrow as pa
 
-    return (TypeError, pa.ArrowNotImplementedError, pa.ArrowInvalid, pa.ArrowTypeError)
+    return (
+        TypeError,
+        pa.lib.ArrowNotImplementedError,
+        pa.lib.ArrowInvalid,
+        pa.lib.ArrowTypeError,
+    )

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -19,7 +19,11 @@ import numpy as np
 
 import ray
 from ray import ObjectRefGenerator
-from ray.data._internal.util import _check_pyarrow_version, _truncated_repr
+from ray.data._internal.util import (
+    _check_pyarrow_version,
+    _fallback_to_pandas_exceptions,
+    _truncated_repr,
+)
 from ray.types import ObjectRef
 from ray.util.annotations import DeveloperAPI
 
@@ -359,13 +363,11 @@ class BlockAccessor:
             )
 
         elif isinstance(batch, collections.abc.Mapping):
-            import pyarrow as pa
-
             from ray.data._internal.arrow_block import ArrowBlockAccessor
 
             try:
                 return ArrowBlockAccessor.numpy_to_block(batch)
-            except (pa.ArrowNotImplementedError, pa.ArrowInvalid, pa.ArrowTypeError):
+            except _fallback_to_pandas_exceptions():
                 import pandas as pd
 
                 # TODO(ekl) once we support Python objects within Arrow blocks, we


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Make these fallback conditions consistent, they both can end up calling `pyarrow.Table.from_pydict`: 

https://github.com/ray-project/ray/blob/3135323aa1f6eb5861c331b24a9209419106c0ed/python/ray/data/block.py#L366-L373

https://github.com/ray-project/ray/blob/08aa1384e8c25f8898a20fd1d647012d1f020400/python/ray/data/_internal/delegating_block_builder.py#L20-L28

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
