### PR TITLE
[serve] Remove unused `get_deployment_import_path` util

### DIFF
--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -14,7 +14,6 @@ from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
-import __main__
 import fastapi.encoders
 import numpy as np
 import pydantic
@@ -205,50 +204,6 @@ def merge_dict(dict1, dict2):
     for key in dict1.keys() | dict2.keys():
         result[key] = sum([e.get(key, 0) for e in (dict1, dict2)])
     return result
-
-
-def get_deployment_import_path(
-    deployment, replace_main=False, enforce_importable=False
-):
-    """
-    Gets the import path for deployment's func_or_class.
-
-    deployment: A deployment object whose import path should be returned
-    replace_main: If this is True, the function will try to replace __main__
-        with __main__'s file name if the deployment's module is __main__
-    """
-
-    body = deployment.func_or_class
-
-    if isinstance(body, str):
-        # deployment's func_or_class is already an import path
-        return body
-    elif hasattr(body, "__ray_actor_class__"):
-        # If ActorClass, get the class or function inside
-        body = body.__ray_actor_class__
-
-    import_path = f"{body.__module__}.{body.__qualname__}"
-
-    if enforce_importable and "<locals>" in body.__qualname__:
-        raise RuntimeError(
-            "Deployment definitions must be importable to build the Serve app, "
-            f"but deployment '{deployment.name}' is inline defined or returned "
-            "from another function. Please restructure your code so that "
-            f"'{import_path}' can be imported (i.e., put it in a module)."
-        )
-
-    if replace_main:
-        # Replaces __main__ with its file name. E.g. suppose the import path
-        # is __main__.classname and classname is defined in filename.py.
-        # Its import path becomes filename.classname.
-
-        if import_path.split(".")[0] == "__main__" and hasattr(__main__, "__file__"):
-            file_name = os.path.basename(__main__.__file__)
-            extensionless_file_name = file_name.split(".")[0]
-            attribute_name = import_path.split(".")[-1]
-            import_path = f"{extensionless_file_name}.{attribute_name}"
-
-    return import_path
 
 
 def parse_import_path(import_path: str):

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -1,9 +1,6 @@
 import asyncio
 import json
 import os
-import subprocess
-import sys
-import tempfile
 import time
 from copy import deepcopy
 from unittest.mock import patch
@@ -21,7 +18,6 @@ from ray.serve._private.utils import (
     dict_keys_snake_to_camel_case,
     get_all_live_placement_group_names,
     get_current_actor_id,
-    get_deployment_import_path,
     get_head_node_id,
     is_running_in_asyncio_loop,
     merge_dict,
@@ -112,70 +108,6 @@ def gen_class():
         pass
 
     return A
-
-
-class TestGetDeploymentImportPath:
-    def test_invalid_inline_defined(self):
-        @serve.deployment
-        def inline_f():
-            pass
-
-        with pytest.raises(RuntimeError, match="must be importable"):
-            get_deployment_import_path(inline_f, enforce_importable=True)
-
-        with pytest.raises(RuntimeError, match="must be importable"):
-            get_deployment_import_path(gen_func(), enforce_importable=True)
-
-        @serve.deployment
-        class InlineCls:
-            pass
-
-        with pytest.raises(RuntimeError, match="must be importable"):
-            get_deployment_import_path(InlineCls, enforce_importable=True)
-
-        with pytest.raises(RuntimeError, match="must be importable"):
-            get_deployment_import_path(gen_class(), enforce_importable=True)
-
-    def test_get_import_path_basic(self):
-        d = decorated_f.options()
-
-        # CI may change the parent path, so check only that the suffix matches.
-        assert get_deployment_import_path(d).endswith(
-            "ray.serve.tests.test_util.decorated_f"
-        )
-
-    def test_get_import_path_nested_actor(self):
-        d = DecoratedActor.options(name="actor")
-
-        # CI may change the parent path, so check only that the suffix matches.
-        assert get_deployment_import_path(d).endswith(
-            "ray.serve.tests.test_util.DecoratedActor"
-        )
-
-    @pytest.mark.skipif(
-        sys.platform == "win32", reason="File path incorrect on Windows."
-    )
-    def test_replace_main(self):
-        temp_fname = "testcase.py"
-        expected_import_path = "testcase.main_f"
-
-        code = (
-            "from ray import serve\n"
-            "from ray.serve._private.utils import get_deployment_import_path\n"
-            "@serve.deployment\n"
-            "def main_f(*args):\n"
-            "\treturn 'reached main_f'\n"
-            "assert get_deployment_import_path(main_f, replace_main=True) == "
-            f"'{expected_import_path}'"
-        )
-
-        with tempfile.TemporaryDirectory() as dirpath:
-            full_fname = os.path.join(dirpath, temp_fname)
-
-            with open(full_fname, "w+") as f:
-                f.write(code)
-
-            subprocess.check_output(["python", full_fname])
 
 
 class TestOverrideRuntimeEnvsExceptEnvVars:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
