### PR TITLE
[Docs] Change highlighting background

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -145,7 +145,7 @@ nav.bd-links::-webkit-scrollbar {
 }
 
 dt:target, span.highlighted {
-    background-color: #fbe54e;
+    background-color: white;
 }
 
 div.sphx-glr-bigcontainer {


### PR DESCRIPTION
Change span background highlighting from #fbe54e -> white
Before 
<img width="767" alt="Screen Shot 2023-09-29 at 3 34 46 PM" src="https://github.com/ray-project/ray/assets/28913323/319e404b-cfd2-430b-bb40-5125f1d31876">

After
<img width="819" alt="Screen Shot 2023-09-29 at 3 38 06 PM" src="https://github.com/ray-project/ray/assets/28913323/1b401e66-4e79-4ede-89d2-be10917c418f">


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
