### PR TITLE
Change code color in sphinx theme

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -391,6 +391,10 @@ pre {
     padding: 5px 0;
 }
 
+.highlight pre {
+    color: green; /* Change to your desired color */
+}
+
 .top-nav-content .menu:hover > ul > li span {
     display: block;
 }
@@ -410,6 +414,10 @@ pre {
     height: 40px;
     border: none;
     white-space: nowrap;
+}
+
+code {
+    color: #ff4d1f; /* Change to your desired color */
 }
 
 @media (max-width: 1000px) {


### PR DESCRIPTION
Change code color in sphinx theme from #e83e8c -> #ff4d1f
Before
<img width="844" alt="Screen Shot 2023-09-29 at 3 32 33 PM" src="https://github.com/ray-project/ray/assets/28913323/be6e0f18-4222-4ea9-a295-c0805eb4a06c">

After
<img width="840" alt="Screen Shot 2023-09-29 at 3 31 43 PM" src="https://github.com/ray-project/ray/assets/28913323/48347328-6a9d-46b8-8c95-df49f0707944">



## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
