### PR TITLE
[train] Fix local storage path for windows (#39951)

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -213,6 +213,7 @@ test_python() {
     args+=(
       python/ray/serve/...
       python/ray/tests/...
+      python/ray/train:test_windows
       -python/ray/serve:test_cross_language # Ray java not built on Windows yet.
       -python/ray/serve:test_gcs_failure # Fork not supported in windows
       -python/ray/serve:test_standalone_2 # Multinode not supported on Windows

--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -713,6 +713,14 @@ py_test(
 )
 
 py_test(
+    name = "test_windows",
+    size = "small",
+    srcs = ["tests/test_windows.py"],
+    tags = ["team:ml", "exclusive", "minimal"],
+    deps = [":train_lib"]
+)
+
+py_test(
     name = "test_xgboost_predictor",
     size = "small",
     srcs = ["tests/test_xgboost_predictor.py"],

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -454,6 +454,7 @@ class StorageContext:
         self.storage_filesystem, self.storage_fs_path = get_fs_and_path(
             self.storage_path, storage_filesystem
         )
+        self.storage_fs_path = Path(self.storage_fs_path).as_posix()
 
         # Syncing is always needed if a custom `storage_filesystem` is provided.
         # Otherwise, syncing is only needed if storage_local_path
@@ -603,7 +604,7 @@ class StorageContext:
         by pyarrow.fs.FileSystem.from_uri already. The URI scheme information is
         kept in `storage_filesystem` instead.
         """
-        return os.path.join(self.storage_fs_path, self.experiment_dir_name)
+        return Path(self.storage_fs_path, self.experiment_dir_name).as_posix()
 
     @property
     def experiment_local_path(self) -> str:
@@ -612,7 +613,7 @@ class StorageContext:
         This local "cache" path refers to location where files are dumped before
         syncing them to the `storage_path` on the `storage_filesystem`.
         """
-        return os.path.join(self.storage_local_path, self.experiment_dir_name)
+        return Path(self.storage_local_path, self.experiment_dir_name).as_posix()
 
     @property
     def trial_local_path(self) -> str:
@@ -624,7 +625,7 @@ class StorageContext:
             raise RuntimeError(
                 "Should not access `trial_local_path` without setting `trial_dir_name`"
             )
-        return os.path.join(self.experiment_local_path, self.trial_dir_name)
+        return Path(self.experiment_local_path, self.trial_dir_name).as_posix()
 
     @property
     def trial_fs_path(self) -> str:
@@ -636,7 +637,7 @@ class StorageContext:
             raise RuntimeError(
                 "Should not access `trial_fs_path` without setting `trial_dir_name`"
             )
-        return os.path.join(self.experiment_fs_path, self.trial_dir_name)
+        return Path(self.experiment_fs_path, self.trial_dir_name).as_posix()
 
     @property
     def checkpoint_fs_path(self) -> str:
@@ -646,7 +647,7 @@ class StorageContext:
         The user of this class is responsible for setting the `current_checkpoint_index`
         (e.g., incrementing when needed).
         """
-        return os.path.join(self.trial_fs_path, self.checkpoint_dir_name)
+        return Path(self.trial_fs_path, self.checkpoint_dir_name).as_posix()
 
     @property
     def checkpoint_dir_name(self) -> str:

--- a/python/ray/train/tests/test_minimal.py
+++ b/python/ray/train/tests/test_minimal.py
@@ -41,7 +41,10 @@ def test_run(ray_start_4_cpus):
     def train_func():
         checkpoint = train.get_checkpoint()
         checkpoint_dict = load_dict_checkpoint(checkpoint)
-        train.report(metrics=checkpoint_dict, checkpoint=checkpoint)
+        if train.get_context().get_world_rank() == 0:
+            train.report(metrics=checkpoint_dict, checkpoint=checkpoint)
+        else:
+            train.report(metrics=checkpoint_dict)
         return checkpoint_dict[key]
 
     with create_dict_checkpoint({key: value}) as checkpoint:

--- a/python/ray/train/tests/test_windows.py
+++ b/python/ray/train/tests/test_windows.py
@@ -1,0 +1,56 @@
+"""This is a very minimal set of windows tests for Train/Tune."""
+
+import os
+
+import pytest
+
+import ray
+from ray import train, tune
+from ray.train.data_parallel_trainer import DataParallelTrainer
+
+from ray.train.tests.util import create_dict_checkpoint
+
+
+@pytest.fixture
+def ray_start_4_cpus():
+    address_info = ray.init(num_cpus=4)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
+@pytest.fixture
+def chdir_tmpdir(tmp_path):
+    original_path = os.getcwd()
+    os.chdir(tmp_path)
+    yield
+    os.chdir(original_path)
+
+
+def test_storage_path(ray_start_4_cpus, chdir_tmpdir):
+    """Tests that Train/Tune with a local storage path works on Windows."""
+
+    def train_fn(config):
+        for i in range(5):
+            if train.get_context().get_world_rank() == 0:
+                with create_dict_checkpoint({"dummy": "data"}) as checkpoint:
+                    train.report({"loss": i}, checkpoint=checkpoint)
+            else:
+                train.report({"loss": i})
+
+    tuner = tune.Tuner(train_fn, run_config=train.RunConfig(storage_path=os.getcwd()))
+    results = tuner.fit()
+    assert not results.errors
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        scaling_config=train.ScalingConfig(num_workers=2),
+        run_config=train.RunConfig(storage_path=os.getcwd()),
+    )
+    trainer.fit()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is a cherry-pick of https://github.com/ray-project/ray/pull/39951

This PR fixes setting `storage_path` on windows by using `Path(...).as_posix()` to join paths, so that it's always of the format `C:/a/b/c/exp_dir/trial_dir` rather than a combination of `/` and `\`.

This PR also adds a minimal windows test to make sure it works and doesn't give this error anymore. Ray Tune/Train support for windows is not very comprehensive, since no train/tune CI is ported to windows CI.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
