### PR TITLE
[data] fix test_spilled_stats and incr size of test_streaming_executor to medium

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -460,7 +460,7 @@ py_test(
 
 py_test(
     name = "test_streaming_executor",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_streaming_executor.py"],
     tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],

--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -452,7 +452,7 @@ py_test(
 
 py_test(
     name = "test_stats",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_stats.py"],
     tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],

--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -452,7 +452,7 @@ py_test(
 
 py_test(
     name = "test_stats",
-    size = "medium",
+    size = "small",
     srcs = ["tests/test_stats.py"],
     tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1354,7 +1354,7 @@ Dataset memory:
     ds = (
         ray.data.range(1000 * 80 * 80 * 4)
         .map_batches(lambda x: x)
-        .random_shuffle()
+        .materialize()
         .map_batches(lambda x: x)
         .materialize()
     )

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -34,7 +34,19 @@ MEM_SPILLED_EXTRA_METRICS = (
 )
 
 
-def canonicalize(stats: str) -> str:
+CLUSTER_MEMORY_STATS = """
+Cluster memory:
+* Spilled to disk: M
+* Restored from disk: M
+"""
+
+DATASET_MEMORY_STATS = """
+Dataset memory:
+* Spilled to disk: M
+"""
+
+
+def canonicalize(stats: str, filter_global_stats: bool = True) -> str:
     # Dataset UUID expression.
     s0 = re.sub("([a-f\d]{32})", "U", stats)
     # Time expressions.
@@ -47,6 +59,10 @@ def canonicalize(stats: str) -> str:
     s4 = re.sub("[0-9]+(\.[0-9]+)?", "N", s3)
     # Replace tabs with spaces.
     s5 = re.sub("\t", "    ", s4)
+    if filter_global_stats:
+        s6 = s5.replace(CLUSTER_MEMORY_STATS, "")
+        s7 = s6.replace(DATASET_MEMORY_STATS, "")
+        return s7
     return s5
 
 
@@ -1309,15 +1325,11 @@ def test_stats_actor_cap_num_stats(ray_start_cluster):
 def test_spilled_stats(shutdown_only):
     # The object store is about 100MB.
     ray.init(object_store_memory=100e6)
-    # The size of dataset is 1000*(80*80*4)*8B, about 200MB.
-    ds = (
-        ray.data.range_tensor(1000, shape=(80, 80, 4), parallelism=100)
-        .map_batches(lambda x: x)
-        .materialize()
-    )
+    # The size of dataset is 1000*80*80*4*8B, about 200MB.
+    ds = ray.data.range(1000 * 80 * 80 * 4).map_batches(lambda x: x).materialize()
 
     assert (
-        canonicalize(ds.stats())
+        canonicalize(ds.stats(), filter_global_stats=False)
         == f"""Stage N ReadRange->MapBatches(<lambda>): N/N blocks executed in T
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
@@ -1340,9 +1352,9 @@ Dataset memory:
     assert ds._plan.stats().dataset_bytes_spilled > 100e6
 
     ds = (
-        ray.data.range_tensor(1000, shape=(80, 80, 4), parallelism=100)
+        ray.data.range(1000 * 80 * 80 * 4)
         .map_batches(lambda x: x)
-        .limit(1000)
+        .random_shuffle()
         .map_batches(lambda x: x)
         .materialize()
     )
@@ -1351,7 +1363,7 @@ Dataset memory:
 
     # The size of dataset is around 50MB, there should be no spillage
     ds = (
-        ray.data.range_tensor(250, shape=(80, 80, 4), parallelism=100)
+        ray.data.range(250 * 80 * 80 * 4, parallelism=1)
         .map_batches(lambda x: x)
         .materialize()
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`map_batches -> shuffle` was getting fused into an `AllToAllOperator`, which we don't collect spill stats for. Replace `shuffle` with `materialize` to keep `MapOperator`.

`test_streaming_executor.py::test_resource_constrained_triggers_autoscaling` cannot run after any test that executes a dataset. Increased the size of this test to medium as a workaround to retain the original ordering.

E.g. running `python -m pytest test_stats.py::test_spilled_stats test_streaming_executor.py::test_resource_constrained_triggers_autoscaling` will fail.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
