### PR TITLE
[data] drop columns before grouping by in Dataset.unique()

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1909,7 +1909,7 @@ class Dataset:
         Returns:
             A list with unique elements in the given column.
         """  # noqa: E501
-        ds = self.groupby(column).count().select_columns([column])
+        ds = self.select_columns([column]).groupby(column).count()
         return [item[column] for item in ds.take_all()]
 
     @ConsumptionAPI

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -2,6 +2,7 @@ import itertools
 import math
 import random
 import time
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -228,7 +229,11 @@ def test_unique(ray_start_regular_shared):
         ]
     )
     assert set(ds.unique("a")) == {1}
-    assert set(ds.unique("b")) == {1, 2}
+
+    with patch("ray.data.aggregate.AggregateFn._validate") as mock_validate:
+        assert set(ds.unique("b")) == {1, 2}
+        # check that column 'a' was dropped before aggregation
+        assert mock_validate.call_args_list[0].args[0].names == ["b"]
 
 
 def test_grouped_dataset_repr(ray_start_regular_shared):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Drops non-group-by columns before aggregation for `Dataset.unique` so that we do not have to shuffle with extra columns that will get dropped later anyways.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

First part of #38764

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
