### PR TITLE
[train] Fix error propagation for `Checkpoint.as_directory` if downloading fails

### DIFF
--- a/python/ray/train/_checkpoint.py
+++ b/python/ray/train/_checkpoint.py
@@ -265,8 +265,8 @@ class Checkpoint(metaclass=_CheckpointMetaClass):
             del_lock_path = _get_del_lock_path(self._get_temporary_checkpoint_dir())
             open(del_lock_path, "a").close()
 
+            temp_dir = self.to_directory()
             try:
-                temp_dir = self.to_directory()
                 yield temp_dir
             finally:
                 # Always cleanup the del lock after we're done with the directory.
@@ -280,6 +280,8 @@ class Checkpoint(metaclass=_CheckpointMetaClass):
                         f"Traceback:\n{traceback.format_exc()}"
                     )
 
+                # If there are no more lock files, that means there are no more
+                # readers of this directory, and we can safely delete it.
                 # In the edge case (process crash before del lock file is removed),
                 # we do not remove the directory at all.
                 # Since it's in /tmp, this is not that big of a deal.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`Checkpoint.as_directory` currently downloads the checkpoint to the local filesystem if the checkpoint is remote. It uses `to_directory` to do so. If this fails, `as_directory` will raise a strange error during its `finally` clause that is unrelated to the actual error that occurred during downloading. This PR fixes the issue by only wrapping the user's code in the `try` block. This way, any exceptions during downloading get raised immediately.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
