### PR TITLE
[civ2][5] support tag filtering when running flaky tests

### DIFF
--- a/ci/ray_ci/serve.tests.yml
+++ b/ci/ray_ci/serve.tests.yml
@@ -1,1 +1,2 @@
-flaky_tests: []
+flaky_tests:
+  - //python/ray/serve/tests:test_standalone_3

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -37,7 +37,6 @@ def test_get_test_targets() -> None:
             "//python/ray/tests:good_test_02",
             "//python/ray/tests:good_test_03",
             "//python/ray/tests:flaky_test_01",
-            "",
         ]
         with mock.patch(
             "subprocess.check_output",
@@ -46,15 +45,27 @@ def test_get_test_targets() -> None:
             "ci.ray_ci.tester_container.TesterContainer.install_ray",
             return_value=None,
         ):
+            assert set(
+                _get_test_targets(
+                    TesterContainer("core"),
+                    "targets",
+                    "core",
+                    yaml_dir=tmp,
+                )
+            ) == {
+                "//python/ray/tests:good_test_01",
+                "//python/ray/tests:good_test_02",
+                "//python/ray/tests:good_test_03",
+            }
+
             assert _get_test_targets(
                 TesterContainer("core"),
                 "targets",
                 "core",
                 yaml_dir=tmp,
+                get_flaky_tests=True,
             ) == [
-                "//python/ray/tests:good_test_01",
-                "//python/ray/tests:good_test_02",
-                "//python/ray/tests:good_test_03",
+                "//python/ray/tests:flaky_test_01",
             ]
 
 

--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -51,6 +51,23 @@ def test_run_script_in_docker() -> None:
         container.run_script_with_output(["run command"])
 
 
+def test_skip_ray_installation() -> None:
+    install_ray_called = []
+
+    def _mock_install_ray() -> None:
+        install_ray_called.append(True)
+
+    with mock.patch(
+        "ci.ray_ci.tester_container.TesterContainer.install_ray",
+        side_effect=_mock_install_ray,
+    ):
+        assert len(install_ray_called) == 0
+        TesterContainer("team", skip_ray_installation=False)
+        assert len(install_ray_called) == 1
+        TesterContainer("team", skip_ray_installation=True)
+        assert len(install_ray_called) == 1
+
+
 def test_run_tests() -> None:
     def _mock_run_tests_in_docker(
         test_targets: List[str],

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -54,6 +54,13 @@ bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
     help=("Run flaky tests."),
 )
 @click.option(
+    "--skip-ray-installation",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help=("Skip ray installation."),
+)
+@click.option(
     "--test-env",
     multiple=True,
     type=str,
@@ -73,6 +80,7 @@ def main(
     except_tags: str,
     only_tags: str,
     run_flaky_tests: bool,
+    skip_ray_installation: bool,
     test_env: List[str],
     build_name: Optional[str],
 ) -> None:
@@ -82,7 +90,12 @@ def main(
     docker_login(_DOCKER_ECR_REPO.split("/")[0])
 
     container = _get_container(
-        team, workers, worker_id, parallelism_per_worker, build_name
+        team,
+        workers,
+        worker_id,
+        parallelism_per_worker,
+        build_name,
+        skip_ray_installation,
     )
     test_targets = _get_test_targets(
         container,
@@ -102,6 +115,7 @@ def _get_container(
     worker_id: int,
     parallelism_per_worker: int,
     build_name: Optional[str] = None,
+    skip_ray_installation: bool = False,
 ) -> TesterContainer:
     shard_count = workers * parallelism_per_worker
     shard_start = worker_id * parallelism_per_worker
@@ -111,6 +125,7 @@ def _get_container(
         build_name or f"{team}build",
         shard_count=shard_count,
         shard_ids=list(range(shard_start, shard_end)),
+        skip_ray_installation=skip_ray_installation,
     )
 
 

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -17,6 +17,7 @@ class TesterContainer(Container):
         docker_tag: str,
         shard_count: int = 1,
         shard_ids: Optional[List[int]] = None,
+        skip_ray_installation: bool = False,
     ) -> None:
         """
         :param docker_tag: Name of the wanda build to be used as test container.
@@ -28,7 +29,8 @@ class TesterContainer(Container):
         self.shard_count = shard_count
         self.shard_ids = shard_ids or []
 
-        self.install_ray()
+        if not skip_ray_installation:
+            self.install_ray()
 
     def run_tests(
         self,


### PR DESCRIPTION
Currently when we run flaky tests on civ2, it doesn't respect the tag filtering arguments. This make it possible to filter flaky tests using tags.

Test:
- CI