### PR TITLE
[Serve] Skip test_max_replicas_per_node on Windows

### DIFF
--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -10,6 +10,7 @@ import ray
 from ray import serve
 from ray._private.test_utils import wait_for_condition
 from ray._private.usage import usage_lib
+from ray.cluster_utils import AutoscalingCluster, Cluster
 from ray.serve.context import _get_global_client
 from ray.serve.tests.utils import TELEMETRY_ROUTE_PREFIX, check_ray_stopped
 from ray.tests.conftest import propagate_logs, pytest_runtest_makereport  # noqa
@@ -27,6 +28,25 @@ def ray_shutdown():
     yield
     serve.shutdown()
     ray.shutdown()
+
+
+@pytest.fixture
+def ray_cluster():
+    cluster = Cluster()
+    yield Cluster()
+    serve.shutdown()
+    ray.shutdown()
+    cluster.shutdown()
+
+
+@pytest.fixture
+def ray_autoscaling_cluster(request):
+    cluster = AutoscalingCluster(**request.param)
+    cluster.start()
+    yield
+    serve.shutdown()
+    ray.shutdown()
+    cluster.shutdown()
 
 
 @pytest.fixture

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -19,15 +19,6 @@ from ray.serve.context import _get_global_client
 from ray.serve.handle import RayServeHandle
 
 
-@pytest.fixture
-def ray_cluster():
-    cluster = Cluster()
-    yield cluster
-    serve.shutdown()
-    ray.shutdown()
-    cluster.shutdown()
-
-
 def get_pids(expected, deployment_name="D", app_name="default", timeout=30):
     handle = serve.get_deployment_handle(deployment_name, app_name)
     refs = []

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -26,15 +26,6 @@ from ray.serve.tests.utils import (
 )
 
 
-@pytest.fixture
-def ray_cluster():
-    cluster = Cluster()
-    yield Cluster()
-    serve.shutdown()
-    ray.shutdown()
-    cluster.shutdown()
-
-
 def test_serving_request_through_grpc_proxy(ray_cluster):
     """Test serving request through gRPC proxy.
 

--- a/python/ray/serve/tests/test_max_replicas_per_node.py
+++ b/python/ray/serve/tests/test_max_replicas_per_node.py
@@ -5,7 +5,6 @@ import pytest
 
 import ray
 from ray import serve
-from ray.cluster_utils import AutoscalingCluster
 from ray.serve.drivers import DAGDriver
 from ray.util.state import list_actors
 
@@ -36,13 +35,12 @@ def get_node_to_deployment_to_num_replicas():
     sys.platform == "win32",
     reason="Flaky on Windows due to https://github.com/ray-project/ray/issues/36926.",
 )
-def test_basic():
-    """Test that max_replicas_per_node is honored."""
-
-    try:
-        cluster = AutoscalingCluster(
-            head_resources={"CPU": 0},
-            worker_node_types={
+@pytest.mark.parametrize(
+    "ray_autoscaling_cluster",
+    [
+        {
+            "head_resources": {"CPU": 0},
+            "worker_node_types": {
                 "cpu_node": {
                     "resources": {
                         "CPU": 9999,
@@ -52,54 +50,52 @@ def test_basic():
                     "max_workers": 100,
                 },
             },
-        )
-
-        cluster.start()
-        ray.init()
-
-        @serve.deployment
-        class D:
-            def __call__(self):
-                return "hello"
-
-        deployments = {
-            "/deploy1": D.options(
-                num_replicas=6, max_replicas_per_node=3, name="deploy1"
-            ).bind(),
-            "/deploy2": D.options(
-                num_replicas=2, max_replicas_per_node=1, name="deploy2"
-            ).bind(),
         }
-        serve.run(DAGDriver.bind(deployments), name="app")
+    ],
+    indirect=True,
+)
+def test_basic(ray_autoscaling_cluster):
+    """Test that max_replicas_per_node is honored."""
 
-        # 2 worker nodes should be started.
-        # Each worker node should run 3 deploy1 replicas
-        # and 1 deploy2 replicas.
-        assert len(ray.nodes()) == 3
-        node_to_deployment_to_num_replicas = get_node_to_deployment_to_num_replicas()
+    ray.init()
 
-        assert len(node_to_deployment_to_num_replicas) == 2
-        for _, deployment_to_num_replicas in node_to_deployment_to_num_replicas.items():
-            assert deployment_to_num_replicas["deploy1"] == 3
-            assert deployment_to_num_replicas["deploy2"] == 1
+    @serve.deployment
+    class D:
+        def __call__(self):
+            return "hello"
 
-    finally:
-        serve.shutdown()
-        ray.shutdown()
-        cluster.shutdown()
+    deployments = {
+        "/deploy1": D.options(
+            num_replicas=6, max_replicas_per_node=3, name="deploy1"
+        ).bind(),
+        "/deploy2": D.options(
+            num_replicas=2, max_replicas_per_node=1, name="deploy2"
+        ).bind(),
+    }
+    serve.run(DAGDriver.bind(deployments), name="app")
+
+    # 2 worker nodes should be started.
+    # Each worker node should run 3 deploy1 replicas
+    # and 1 deploy2 replicas.
+    assert len(ray.nodes()) == 3
+    node_to_deployment_to_num_replicas = get_node_to_deployment_to_num_replicas()
+
+    assert len(node_to_deployment_to_num_replicas) == 2
+    for _, deployment_to_num_replicas in node_to_deployment_to_num_replicas.items():
+        assert deployment_to_num_replicas["deploy1"] == 3
+        assert deployment_to_num_replicas["deploy2"] == 1
 
 
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="Flaky on Windows due to https://github.com/ray-project/ray/issues/36926.",
 )
-def test_update_max_replicas_per_node():
-    """Test re-deploying a deployment with different max_replicas_per_node."""
-
-    try:
-        cluster = AutoscalingCluster(
-            head_resources={"CPU": 0},
-            worker_node_types={
+@pytest.mark.parametrize(
+    "ray_autoscaling_cluster",
+    [
+        {
+            "head_resources": {"CPU": 0},
+            "worker_node_types": {
                 "cpu_node": {
                     "resources": {
                         "CPU": 9999,
@@ -109,48 +105,47 @@ def test_update_max_replicas_per_node():
                     "max_workers": 100,
                 },
             },
-        )
+        }
+    ],
+    indirect=True,
+)
+def test_update_max_replicas_per_node(ray_autoscaling_cluster):
+    """Test re-deploying a deployment with different max_replicas_per_node."""
 
-        cluster.start()
-        ray.init()
+    ray.init()
 
-        @serve.deployment
-        class D:
-            def __call__(self):
-                return "hello"
+    @serve.deployment
+    class D:
+        def __call__(self):
+            return "hello"
 
-        # Requires 2 worker nodes.
-        serve.run(
-            D.options(num_replicas=3, max_replicas_per_node=2, name="deploy1").bind(),
-            name="app",
-        )
+    # Requires 2 worker nodes.
+    serve.run(
+        D.options(num_replicas=3, max_replicas_per_node=2, name="deploy1").bind(),
+        name="app",
+    )
 
-        assert len(ray.nodes()) == 3
-        node_to_deployment_to_num_replicas = get_node_to_deployment_to_num_replicas()
+    assert len(ray.nodes()) == 3
+    node_to_deployment_to_num_replicas = get_node_to_deployment_to_num_replicas()
 
-        assert len(node_to_deployment_to_num_replicas) == 2
-        # One node has 2 replicas and the other has 1 replica.
-        for _, deployment_to_num_replicas in node_to_deployment_to_num_replicas.items():
-            assert deployment_to_num_replicas["deploy1"] in {1, 2}
+    assert len(node_to_deployment_to_num_replicas) == 2
+    # One node has 2 replicas and the other has 1 replica.
+    for _, deployment_to_num_replicas in node_to_deployment_to_num_replicas.items():
+        assert deployment_to_num_replicas["deploy1"] in {1, 2}
 
-        # Redeploy, requires 3 worker nodes.
-        serve.run(
-            D.options(num_replicas=3, max_replicas_per_node=1, name="deploy1").bind(),
-            name="app",
-        )
+    # Redeploy, requires 3 worker nodes.
+    serve.run(
+        D.options(num_replicas=3, max_replicas_per_node=1, name="deploy1").bind(),
+        name="app",
+    )
 
-        assert len(ray.nodes()) == 4
-        node_to_deployment_to_num_replicas = get_node_to_deployment_to_num_replicas()
+    assert len(ray.nodes()) == 4
+    node_to_deployment_to_num_replicas = get_node_to_deployment_to_num_replicas()
 
-        assert len(node_to_deployment_to_num_replicas) == 3
-        for _, deployment_to_num_replicas in node_to_deployment_to_num_replicas.items():
-            # Every node has 1 replica.
-            assert deployment_to_num_replicas["deploy1"] == 1
-
-    finally:
-        serve.shutdown()
-        ray.shutdown()
-        cluster.shutdown()
+    assert len(node_to_deployment_to_num_replicas) == 3
+    for _, deployment_to_num_replicas in node_to_deployment_to_num_replicas.items():
+        # Every node has 1 replica.
+        assert deployment_to_num_replicas["deploy1"] == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
#36926 makes the test flaky by launching extra worker nodes than needed. Seems it's more flaky on Windows so disabling the test on Windows for now until the underlying issue is fixed.

Also make sure we clean up everything even when tests fail.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
