### PR TITLE
[civ2][6] move examples and rlmodule tests to civ2

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -152,32 +152,6 @@
       --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 
       rllib/...
 
-- label: ":brain: RLlib: RLModule tests"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_DIRECTLY_AFFECTED"]
-  parallelism: 4
-  instance_size: large
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - ./ci/run/run_bazel_test_with_sharding.sh --config=ci $(./ci/run/bazel_export_options)
-      --build_tests_only
-      --test_tag_filters=rlm
-      --test_env=RLLIB_ENABLE_RL_MODULE=1
-      --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 rllib/...
-
-- label: ":brain: RLlib: Examples"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
-  parallelism: 5
-  instance_size: large
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - ./ci/run/run_bazel_test_with_sharding.sh --config=ci $(./ci/run/bazel_export_options) --build_tests_only
-      --test_tag_filters=examples,-multi_gpu,-gpu --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-      rllib/...
-
 - label: ":brain: RLlib: tests/ dir"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_DIRECTLY_AFFECTED"]
   parallelism: 2

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -28,7 +28,7 @@ steps:
 
   - label: ":brain: rllib: learning tests tf2-eager-tracing"
     tags: rllib
-    parallelism: 3
+    parallelism: 2
     instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -28,7 +28,7 @@ steps:
 
   - label: ":brain: rllib: learning tests tf2-eager-tracing"
     tags: rllib
-    parallelism: 2
+    parallelism: 3
     instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -1,6 +1,6 @@
 group: rllib tests
 steps:
-  - label: ":brain: rllib: learning tests TF2-static-graph"
+  - label: ":brain: rllib: learning tests tf2-static-graph"
     tags: rllib
     parallelism: 3
     instance_type: large
@@ -13,7 +13,7 @@ steps:
     depends_on: rllibbuild
     job_env: forge
 
-  - label: ":brain: rllib: learning tests Pytorch"
+  - label: ":brain: rllib: learning tests pytorch"
     tags: rllib
     parallelism: 3
     instance_type: large
@@ -23,6 +23,19 @@ steps:
         --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
         --except-tags tf_only,tf2_only,multi_gpu
         --test-arg --framework=torch
+    depends_on: rllibbuild
+    job_env: forge
+
+  - label: ":brain: rllib: examples"
+    tags: rllib
+    parallelism: 3
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --only-tags examples
+        --except-tags multi_gpu,gpu 
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
     depends_on: rllibbuild
     job_env: forge
 
@@ -36,6 +49,18 @@ steps:
         --only-tags learning_tests_discrete,learning_tests_continuous,crashing_cartpole,stateless_cartpole
         --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
         --test-arg --framework=tf2
+    depends_on: rllibbuild
+    job_env: forge
+
+  - label: ":brain: rllib: rlmodule tests"
+    tags: rllib_directly
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --parallelism-per-worker 3
+        --only-tags rlm
+        --test-env RLLIB_ENABLE_RL_MODULE=1
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
     depends_on: rllibbuild
     job_env: forge
 
@@ -70,13 +95,20 @@ steps:
         --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
         --test-arg --framework=tf2
         --skip-ray-installation # reuse the same docker image as the previous run
+
+      # examples
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib  --run-flaky-tests --parallelism-per-worker 3
+        --only-tags examples
+        --except-tags multi_gpu,gpu 
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+        --skip-ray-installation # reuse the same docker image as the previous run
+
+      # rlmodule tests
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+        --only-tags rlm
+        --test-env RLLIB_ENABLE_RL_MODULE=1
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+        --skip-ray-installation # reuse the same docker image as the previous run
     depends_on: rllibbuild
     soft_fail: true
-    job_env: forge
-
-  - label: ":brain: rllib: benchmarks"
-    instance_type: medium
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --only-tags torch_2.x_only_benchmark
-    depends_on: rllibbuild
     job_env: forge

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -73,3 +73,10 @@ steps:
     depends_on: rllibbuild
     soft_fail: true
     job_env: forge
+
+  - label: ":brain: rllib: benchmarks"
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --only-tags torch_2.x_only_benchmark
+    depends_on: rllibbuild
+    job_env: forge

--- a/ci/ray_ci/rllib.tests.yml
+++ b/ci/ray_ci/rllib.tests.yml
@@ -7,3 +7,26 @@ flaky_tests:
   - //rllib:learning_tests_cartpole_ddppo
   - //rllib:learning_tests_two_step_game_qmix
   - //rllib:learning_tests_pendulum_cql
+  # algorithm, model and other tests
+  - //rllib:test_bc 
+  - //rllib:policy/tests/test_policy
+  - //rllib:env/tests/test_local_inference_cartpole
+  - //rllib:evaluation/tests/test_envs_that_crash
+  - //rllib:test_apex_ddpg
+  - //rllib:test_algorithm_export_checkpoint
+  - //rllib:test_dataset_reader
+  # examples
+  - //rllib:examples/nested_action_spaces_ppo_torch
+  - //rllib:examples/rl_module/mobilenet_rlm
+  - //rllib:examples/action_masking_torch
+  - //rllib:examples/action_masking_tf2
+  - //rllib:examples/learner/train_w_bc_finetune_w_ppo
+  # memory leak tf2-eager-tracing
+  - //rllib:test_memory_leak_ppo
+  - //rllib:test_memory_leak_sac
+  - //rllib:test_memory_leak_impala
+  - //rllib:test_memory_leak_a3c
+  - //rllib:test_memory_leak_dqn
+  - //rllib:test_memory_leak_ddpg
+  # tests/ dir
+  - //rllib:tests/test_io

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -68,6 +68,16 @@ def test_get_test_targets() -> None:
                 "//python/ray/tests:flaky_test_01",
             ]
 
+            assert _get_test_targets(
+                TesterContainer("core"),
+                "targets",
+                "core",
+                yaml_dir=tmp,
+                get_flaky_tests=True,
+            ) == [
+                "//python/ray/tests:flaky_test_01",
+            ]
+
 
 def test_get_all_test_query() -> None:
     assert _get_all_test_query(["a", "b"], "core") == (

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -68,16 +68,6 @@ def test_get_test_targets() -> None:
                 "//python/ray/tests:flaky_test_01",
             ]
 
-            assert _get_test_targets(
-                TesterContainer("core"),
-                "targets",
-                "core",
-                yaml_dir=tmp,
-                get_flaky_tests=True,
-            ) == [
-                "//python/ray/tests:flaky_test_01",
-            ]
-
 
 def test_get_all_test_query() -> None:
     assert _get_all_test_query(["a", "b"], "core") == (


### PR DESCRIPTION
Move examples + rlmodule to civ2. These two jobs require 2x less machine times in civ2.

Test:
- CI