### PR TITLE
[civ2][4] fix include/exclude tag ordering

### DIFF
--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -1,4 +1,5 @@
 flaky_tests:
+  - //python/ray/tests:test_actor_advanced
   - //python/ray/tests:test_actor_cancel
   - //python/ray/tests:test_gcs_fault_tolerance
   - //python/ray/tests:test_object_manager

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -70,8 +70,8 @@ def test_get_all_test_query() -> None:
     )
     assert _get_all_test_query(["a"], "core", except_tags="tag1", only_tags="tag2") == (
         "attr(tags, 'team:core\\\\b', tests(a)) "
-        "except (attr(tags, tag1, tests(a))) "
-        "intersect (attr(tags, tag2, tests(a)))"
+        "intersect (attr(tags, tag2, tests(a))) "
+        "except (attr(tags, tag1, tests(a)))"
     )
 
 

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -129,17 +129,17 @@ def _get_all_test_query(
     test_query = " union ".join([f"tests({target})" for target in targets])
     query = f"attr(tags, 'team:{team}\\\\b', {test_query})"
 
-    if except_tags:
-        except_query = " union ".join(
-            [f"attr(tags, {t}, {test_query})" for t in except_tags.split(",")]
-        )
-        query = f"{query} except ({except_query})"
-
     if only_tags:
         only_query = " union ".join(
             [f"attr(tags, {t}, {test_query})" for t in only_tags.split(",")]
         )
         query = f"{query} intersect ({only_query})"
+
+    if except_tags:
+        except_query = " union ".join(
+            [f"attr(tags, {t}, {test_query})" for t in except_tags.split(",")]
+        )
+        query = f"{query} except ({except_query})"
 
     return query
 


### PR DESCRIPTION
In rayci, we always include tags first before exclude tags. Fix the ordering logic.

Test:
- CI