### PR TITLE
[core][autoscaler][dashboard] Fix autoscaler sdk accidentally initialize ray worker leading to leaked driver

### DIFF
--- a/dashboard/modules/node/node_head.py
+++ b/dashboard/modules/node/node_head.py
@@ -107,6 +107,7 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
         # head node hasn't been registered.
         self._head_node_registration_time_s = None
         self._gcs_aio_client = dashboard_head.gcs_aio_client
+        self._gcs_address = dashboard_head.gcs_address
 
     async def _update_stubs(self, change):
         if change.old:
@@ -255,7 +256,7 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
             from ray.autoscaler.v2.sdk import get_cluster_status
 
             try:
-                cluster_status = get_cluster_status()
+                cluster_status = get_cluster_status(self._gcs_address)
             except Exception:
                 logger.exception("Error getting cluster status")
                 return {}

--- a/dashboard/modules/reporter/reporter_head.py
+++ b/dashboard/modules/reporter/reporter_head.py
@@ -62,9 +62,11 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
         # will be hang when the ray.state is connected and the GCS is exit.
         # Please refer to: https://github.com/ray-project/ray/issues/16328
         assert dashboard_head.gcs_address or dashboard_head.redis_address
-        gcs_address = dashboard_head.gcs_address
+        self._gcs_address = dashboard_head.gcs_address
         temp_dir = dashboard_head.temp_dir
-        self.service_discovery = PrometheusServiceDiscoveryWriter(gcs_address, temp_dir)
+        self.service_discovery = PrometheusServiceDiscoveryWriter(
+            self._gcs_address, temp_dir
+        )
         self._gcs_aio_client = dashboard_head.gcs_aio_client
         self._state_api = None
 
@@ -138,7 +140,9 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
             return dashboard_optional_utils.rest_response(
                 success=True,
                 message="Got formatted cluster status.",
-                cluster_status=debug_status(formatted_status_string, error),
+                cluster_status=debug_status(
+                    formatted_status_string, error, address=self._gcs_address
+                ),
             )
 
     async def get_task_ids_running_in_a_worker(self, worker_id: str) -> List[str]:

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -70,7 +70,7 @@ from ray.autoscaler.tags import (
     TAG_RAY_NODE_STATUS,
     TAG_RAY_USER_NODE_TYPE,
 )
-from ray.experimental.internal_kv import _internal_kv_put
+from ray.experimental.internal_kv import _internal_kv_put, internal_kv_get_gcs_client
 from ray.util.debug import log_once
 
 try:  # py3
@@ -212,7 +212,8 @@ def request_resources(
     if is_autoscaler_v2():
         from ray.autoscaler.v2.sdk import request_cluster_resources
 
-        request_cluster_resources(to_request)
+        gcs_address = internal_kv_get_gcs_client().address
+        request_cluster_resources(gcs_address, to_request)
 
 
 def create_or_update_cluster(

--- a/python/ray/autoscaler/v2/sdk.py
+++ b/python/ray/autoscaler/v2/sdk.py
@@ -63,7 +63,7 @@ def request_cluster_resources(
 
 
 def get_cluster_status(
-    gcs_address: Optional[str] = None, timeout: int = DEFAULT_RPC_TIMEOUT_S
+    gcs_address: str, timeout: int = DEFAULT_RPC_TIMEOUT_S
 ) -> ClusterStatus:
     """
     Get the cluster status from the autoscaler.

--- a/python/ray/autoscaler/v2/sdk.py
+++ b/python/ray/autoscaler/v2/sdk.py
@@ -1,8 +1,7 @@
 import time
 from collections import defaultdict
-from typing import List, Optional
+from typing import List
 
-import ray
 from ray._raylet import GcsClient
 from ray.autoscaler.v2.schema import ClusterStatus, Stats
 from ray.autoscaler.v2.utils import ClusterStatusParser
@@ -11,19 +10,8 @@ from ray.core.generated.autoscaler_pb2 import GetClusterStatusReply
 DEFAULT_RPC_TIMEOUT_S = 10
 
 
-def get_gcs_client(gcs_address: Optional[str] = None):
-    """Get the GCS client."""
-    if gcs_address is None:
-        gcs_address = ray.get_runtime_context().gcs_address
-    assert gcs_address is not None, (
-        "GCS address should have been detected if getting from runtime context"
-        "or passed in explicitly."
-    )
-    return GcsClient(address=gcs_address)
-
-
 def request_cluster_resources(
-    to_request: List[dict], timeout: int = DEFAULT_RPC_TIMEOUT_S
+    gcs_address: str, to_request: List[dict], timeout: int = DEFAULT_RPC_TIMEOUT_S
 ):
     """Request resources from the autoscaler.
 
@@ -34,16 +22,15 @@ def request_cluster_resources(
     If the cluster already has `to_request` resources, this will be an no-op.
     Future requests submitted through this API will overwrite the previous requests.
 
-    NOTE:
-        This function has to be invoked in a ray worker/driver, i.e., after `ray.init()`
-
     Args:
+        gcs_address: The GCS address to query.
         to_request: A list of resource bundles to request the cluster to have.
             Each bundle is a dict of resource name to resource quantity, e.g:
             [{"CPU": 1}, {"GPU": 1}].
         timeout: Timeout in seconds for the request to be timeout
 
     """
+    assert len(gcs_address) > 0, "GCS address is not specified."
 
     # Aggregate bundle by shape.
     resource_requests_by_count = defaultdict(int)
@@ -57,7 +44,7 @@ def request_cluster_resources(
         bundles.append(dict(bundle))
         counts.append(count)
 
-    get_gcs_client().request_cluster_resource_constraint(
+    GcsClient(gcs_address).request_cluster_resource_constraint(
         bundles, counts, timeout_s=timeout
     )
 
@@ -69,15 +56,15 @@ def get_cluster_status(
     Get the cluster status from the autoscaler.
 
     Args:
-        gcs_address: The GCS address to query. If not specified, will use the
-            GCS address from the runtime context.
+        gcs_address: The GCS address to query.
         timeout: Timeout in seconds for the request to be timeout
 
     Returns:
         A ClusterStatus object.
     """
+    assert len(gcs_address) > 0, "GCS address is not specified."
     req_time = time.time()
-    str_reply = get_gcs_client(gcs_address).get_cluster_status(timeout_s=timeout)
+    str_reply = GcsClient(gcs_address).get_cluster_status(timeout_s=timeout)
     reply_time = time.time()
     reply = GetClusterStatusReply()
     reply.ParseFromString(str_reply)

--- a/python/ray/autoscaler/v2/tests/test_e2e.py
+++ b/python/ray/autoscaler/v2/tests/test_e2e.py
@@ -66,6 +66,7 @@ while True:
     try:
         cluster.start()
         ray.init("auto")
+        gcs_address = ray.get_runtime_context().gcs_address
 
         run_string_as_driver_nonblocking(driver_script)
 
@@ -81,7 +82,7 @@ while True:
 
         for _ in range(30):
             # verify no pending task + with resource used.
-            status = get_cluster_status()
+            status = get_cluster_status(gcs_address)
             has_task_demand = len(status.resource_demands.ray_task_actor_demand) > 0
             has_task_usage = False
 
@@ -139,6 +140,7 @@ while True:
     try:
         cluster.start()
         ray.init("auto")
+        gcs_address = ray.get_runtime_context().gcs_address
 
         run_string_as_driver_nonblocking(driver_script)
 
@@ -152,7 +154,7 @@ while True:
 
         for _ in range(30):
             # verify no pending request + resource used.
-            status = get_cluster_status()
+            status = get_cluster_status(gcs_address)
             has_pg_demand = len(status.resource_demands.placement_group_demand) > 0
             has_pg_usage = False
             for usage in status.cluster_resource_usage:
@@ -181,6 +183,7 @@ def test_placement_group_removal_idle_node():
     try:
         cluster.start()
         ray.init("auto")
+        gcs_address = ray.get_runtime_context().gcs_address
 
         # Schedule a pg on nodes
         pg = placement_group([{"CPU": 2}] * 3, strategy="STRICT_SPREAD")
@@ -192,7 +195,7 @@ def test_placement_group_removal_idle_node():
         from ray.autoscaler.v2.sdk import get_cluster_status
 
         def verify():
-            cluster_state = get_cluster_status()
+            cluster_state = get_cluster_status(gcs_address)
 
             # Verify that nodes are idle.
             assert len((cluster_state.idle_nodes)) == 3
@@ -213,9 +216,10 @@ def test_object_store_memory_idle_node(shutdown_only):
     ray.init()
 
     obj = ray.put("hello")
+    gcs_address = ray.get_runtime_context().gcs_address
 
     def verify():
-        state = get_cluster_status()
+        state = get_cluster_status(gcs_address)
         for node in state.active_nodes:
             assert node.node_status == "RUNNING"
             assert node.used_resources()["object_store_memory"] > 0
@@ -231,7 +235,7 @@ def test_object_store_memory_idle_node(shutdown_only):
     time.sleep(1)
 
     def verify():
-        state = get_cluster_status()
+        state = get_cluster_status(gcs_address)
         for node in state.idle_nodes:
             assert node.node_status == "IDLE"
             assert node.used_resources()["object_store_memory"] == 0
@@ -270,10 +274,11 @@ def test_serve_num_replica_idle_node():
         # = 4 cpus used
         serve.run(Deployment.options(num_replicas=10).bind())
 
+        gcs_address = ray.get_runtime_context().gcs_address
         expected_num_workers = 5
 
         def verify():
-            cluster_state = get_cluster_status()
+            cluster_state = get_cluster_status(gcs_address)
 
             # Verify that nodes are busy.
             assert len(cluster_state.active_nodes) == expected_num_workers + 1
@@ -291,7 +296,7 @@ def test_serve_num_replica_idle_node():
         serve.run(Deployment.options(num_replicas=1).bind())
 
         def verify():
-            cluster_state = get_cluster_status()
+            cluster_state = get_cluster_status(gcs_address)
             # We should only have 1 running worker for the 1 replica, the rest idle.
             expected_idle_workers = expected_num_workers - 1
 
@@ -365,12 +370,13 @@ while True:
                 "raylet_check_gc_period_milliseconds": 10,
             },
         )
-        ray.init("auto")
+        ctx = ray.init("auto")
+        gcs_address = ctx.address_info["gcs_address"]
 
         from ray.autoscaler.v2.sdk import get_cluster_status
 
         def nodes_up():
-            cluster_state = get_cluster_status()
+            cluster_state = get_cluster_status(gcs_address)
             return len(cluster_state.idle_nodes) == num_worker_nodes + 1
 
         wait_for_condition(nodes_up)
@@ -381,7 +387,7 @@ while True:
 
         # Check the cluster state for 10 seconds
         while time.time() - start < 10:
-            cluster_state = get_cluster_status()
+            cluster_state = get_cluster_status(gcs_address)
 
             # Verify total cluster resources never change
             assert (

--- a/python/ray/autoscaler/v2/tests/test_sdk.py
+++ b/python/ray/autoscaler/v2/tests/test_sdk.py
@@ -611,7 +611,7 @@ def test_get_cluster_status_resources(ray_start_cluster):
     actor.loop.remote()
 
     def verify_cpu_resources_all_used():
-        cluster_status = get_cluster_status()
+        cluster_status = get_cluster_status(cluster.address)
         total_cluster_resources = get_total_resources(
             cluster_status.cluster_resource_usage
         )
@@ -629,7 +629,7 @@ def test_get_cluster_status_resources(ray_start_cluster):
     [loop.remote() for _ in range(2)]
 
     def verify_task_demands():
-        resource_demands = get_cluster_status().resource_demands
+        resource_demands = get_cluster_status(cluster.address).resource_demands
         assert len(resource_demands.ray_task_actor_demand) == 1
         assert resource_demands.ray_task_actor_demand[0].bundles_by_count == [
             ResourceRequestByCount(
@@ -645,7 +645,7 @@ def test_get_cluster_status_resources(ray_start_cluster):
     request_cluster_resources(to_request=[{"GPU": 1, "CPU": 2}])
 
     def verify_cluster_constraint_demand():
-        resource_demands = get_cluster_status().resource_demands
+        resource_demands = get_cluster_status(cluster.address).resource_demands
         assert len(resource_demands.cluster_constraint_demand) == 1
         assert resource_demands.cluster_constraint_demand[0].bundles_by_count == [
             ResourceRequestByCount(
@@ -661,7 +661,7 @@ def test_get_cluster_status_resources(ray_start_cluster):
     pg1 = ray.util.placement_group([{"CPU": 1}] * 3)
 
     def verify_pg_demands():
-        resource_demands = get_cluster_status().resource_demands
+        resource_demands = get_cluster_status(cluster.address).resource_demands
         assert len(resource_demands.placement_group_demand) == 1
         assert resource_demands.placement_group_demand[0].bundles_by_count == [
             ResourceRequestByCount(
@@ -691,7 +691,7 @@ def test_get_cluster_status(ray_start_cluster):
     head_node_id, worker_node_ids = get_node_ids()
 
     def verify_nodes():
-        cluster_status = get_cluster_status()
+        cluster_status = get_cluster_status(cluster.address)
         assert_nodes(
             cluster_status.idle_nodes,
             [
@@ -724,7 +724,7 @@ def test_get_cluster_status(ray_start_cluster):
     f.remote()
 
     def verify_nodes_busy():
-        cluster_status = get_cluster_status()
+        cluster_status = get_cluster_status(cluster.address)
         assert_nodes(
             cluster_status.idle_nodes,
             [
@@ -784,7 +784,7 @@ def test_get_cluster_status(ray_start_cluster):
     def verify_autoscaler_state():
         # TODO(rickyx): Add infeasible asserts.
 
-        cluster_status = get_cluster_status()
+        cluster_status = get_cluster_status(cluster.address)
         assert len(cluster_status.pending_launches) == 1
         assert_launches(
             cluster_status,

--- a/python/ray/autoscaler/v2/tests/util.py
+++ b/python/ray/autoscaler/v2/tests/util.py
@@ -3,6 +3,7 @@ import operator
 from abc import abstractmethod
 from typing import Dict, List
 
+import ray
 from ray.autoscaler.v2.schema import ClusterStatus, ResourceUsage
 from ray.autoscaler.v2.sdk import get_cluster_status
 from ray.core.generated import autoscaler_pb2
@@ -122,7 +123,8 @@ class TotalResourceCheck(Check):
 def check_cluster(
     targets: List[Check],
 ) -> bool:
-    cluster_status = get_cluster_status()
+    gcs_address = ray.get_runtime_context().gcs_address
+    cluster_status = get_cluster_status(gcs_address)
 
     for target in targets:
         target.check(cluster_status)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We have code paths in autosclaer v2's sdk which queries GCS for info, however, if the caller doesn't provide a GCS address, the sdk will try to get the address from the runtime context, which would auto init a ray worker if no ray worker has been initialized on the process

This leaks the dashboard process as a driver job, which will show up as an unexpected job in the dashbaord since dashboard process calls the autoscaler sdk for cluster info. 

This PR makes the gcs address a non-optional field, requiring the caller to explicitly pass in the gcs address. This prevents the sdk to accidentally initialize a worker while connecting to GCS. 


Closes #39696

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
