### PR TITLE
Fix Cluster UI #39924

### DIFF
--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -141,7 +141,12 @@ export const NodeRow = ({
       </TableCell>
       <TableCell>
         {raylet.state !== "DEAD" && (
-          <Link to={`/logs/${encodeURIComponent(logUrl)}`}>Log</Link>
+          <Link
+            to={`/logs/${encodeURIComponent(logUrl)}`}
+            style={{ textDecoration: "none" }}
+          >
+            Log
+          </Link>
         )}
       </TableCell>
       <TableCell>
@@ -254,11 +259,16 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
       </TableCell>
       <TableCell align="center">{pid}</TableCell>
       <TableCell>
-        <Link to={workerLogUrl} target="_blank">
-          Logs
+        <Link
+          to={workerLogUrl}
+          target="_blank"
+          style={{ textDecoration: "none" }}
+        >
+          Log
         </Link>
         <br />
         <CpuStackTraceLink pid={pid} ip={ip} type="" />
+        <br />
         <CpuProfilingLink pid={pid} ip={ip} type="" />
         <br />
       </TableCell>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

1. Unify the text in NodeRow "Log" and WorkerRow "Logs"
2. There is an underline under "Logs," but not under "CPU Flame Graph" and "Stack Trace."
3. Add a line break between "CPU Flame Graph" and "Stack Trace."

These revisions should help maintain a more consistent and clear user interface on the cluster page. 

| after| before |
|----------|----------|
| <img width="642" alt="Screenshot 2023-09-27 at 3 39 50 PM" src="https://github.com/ray-project/ray/assets/125417081/2426c27e-414e-40ec-9a0f-e1ddbd8bc7ff"> | <img width="827" alt="Screenshot 2023-09-27 at 3 43 13 PM" src="https://github.com/ray-project/ray/assets/125417081/2a7a69ea-118d-48b1-b5b8-2c61fa73e69a"> |


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
