### PR TITLE
[serve] add back missing update_actor_details call

### DIFF
--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -492,6 +492,11 @@ class ProxyState:
                 ready_call_status = self._actor_proxy_wrapper.is_ready()
                 if ready_call_status == ProxyWrapperCallStatus.FINISHED_SUCCEED:
                     self.try_update_status(ProxyStatus.HEALTHY)
+                    self.update_actor_details(
+                        worker_id=self._actor_proxy_wrapper.worker_id,
+                        log_file_path=self._actor_proxy_wrapper.log_file_path,
+                        status=self._status,
+                    )
                 elif ready_call_status == ProxyWrapperCallStatus.FINISHED_FAILED:
                     self.set_status(ProxyStatus.UNHEALTHY)
                     logger.warning(

--- a/python/ray/serve/tests/test_proxy_state.py
+++ b/python/ray/serve/tests/test_proxy_state.py
@@ -294,12 +294,22 @@ def test_proxy_state_update_starting_ready_succeed():
     # Ensure the proxy status before update is STARTING.
     assert proxy_state.status == ProxyStatus.STARTING
 
+    # Ensure actor_details are set to the initial state when the proxy_state is created.
+    assert proxy_state._actor_details.worker_id is None
+    assert proxy_state._actor_details.log_file_path is None
+    assert proxy_state._actor_details.status == ProxyStatus.STARTING.value
+
     # Continuously trigger update and wait for status to be changed.
     wait_for_condition(
         condition_predictor=_update_and_check_proxy_status,
         state=proxy_state,
         status=ProxyStatus.HEALTHY,
     )
+
+    # Ensure actor_details are updated.
+    assert proxy_state._actor_details.worker_id == "mock_worker_id"
+    assert proxy_state._actor_details.log_file_path == "mock_log_file_path"
+    assert proxy_state._actor_details.status == ProxyStatus.HEALTHY.value
 
 
 def test_proxy_state_update_starting_ready_failed_once():

--- a/python/ray/serve/tests/test_proxy_state.py
+++ b/python/ray/serve/tests/test_proxy_state.py
@@ -295,9 +295,9 @@ def test_proxy_state_update_starting_ready_succeed():
     assert proxy_state.status == ProxyStatus.STARTING
 
     # Ensure actor_details are set to the initial state when the proxy_state is created.
-    assert proxy_state._actor_details.worker_id is None
-    assert proxy_state._actor_details.log_file_path is None
-    assert proxy_state._actor_details.status == ProxyStatus.STARTING.value
+    assert proxy_state.actor_details.worker_id is None
+    assert proxy_state.actor_details.log_file_path is None
+    assert proxy_state.actor_details.status == ProxyStatus.STARTING.value
 
     # Continuously trigger update and wait for status to be changed.
     wait_for_condition(
@@ -307,9 +307,9 @@ def test_proxy_state_update_starting_ready_succeed():
     )
 
     # Ensure actor_details are updated.
-    assert proxy_state._actor_details.worker_id == "mock_worker_id"
-    assert proxy_state._actor_details.log_file_path == "mock_log_file_path"
-    assert proxy_state._actor_details.status == ProxyStatus.HEALTHY.value
+    assert proxy_state.actor_details.worker_id == "mock_worker_id"
+    assert proxy_state.actor_details.log_file_path == "mock_log_file_path"
+    assert proxy_state.actor_details.status == ProxyStatus.HEALTHY.value
 
 
 def test_proxy_state_update_starting_ready_failed_once():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Re: https://github.com/ray-project/ray/pull/40000/files#diff-501cd0c3028a2d026eafd94a7b13830b2865df94d9f2ef05e088443670dfab8eL226 Accidentantlly dropped `update_actor_details` call. Add it back and add a test to ensure coverage.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
