### PR TITLE
[ci][cluster] Make cluster launcher test termination more graceful

### DIFF
--- a/python/ray/autoscaler/launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/launch_and_verify_cluster.py
@@ -169,15 +169,28 @@ def cleanup_cluster(cluster_config):
     """
     print("======================================")
     print("Cleaning up cluster...")
-    try:
-        subprocess.run(
-            ["ray", "down", "-v", "-y", str(cluster_config)],
-            check=True,
-            capture_output=True,
-        )
-    except subprocess.CalledProcessError as e:
-        print(e.output)
-        raise e
+
+    # We do multiple retries here because sometimes the cluster
+    # fails to clean up properly, resulting in a non-zero exit code (e.g.
+    # when processes have to be killed forcefully).
+
+    last_error = None
+    num_tries = 3
+    for i in range(num_tries):
+        try:
+            subprocess.run(
+                ["ray", "down", "-v", "-y", str(cluster_config)],
+                check=True,
+                capture_output=True,
+            )
+            # Final success
+            return
+        except subprocess.CalledProcessError as e:
+            print(f"ray down fails[{i+1}/{num_tries}]: ")
+            print(e.output)
+            last_error = e
+
+    raise last_error
 
 
 def run_ray_commands(cluster_config, retries, no_config_cache, num_expected_nodes=1):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cluster launcher tests have been failing transiently due to `ray down` not returning exit code 0 when some remote ray processes have to be forcefully killed during the remote `ray stop` 

However, this should not make the test fail. At the same time, we don't want to ignore errors from `ray down` altogether. So as a solution, we try running ray down multiple times (since it is idempotent) and ignore intermediate errors until a retry count (3) 



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/40067
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
