### PR TITLE
[Serve] Raise exception if deprecated arguments in `Serve.start()` are set

### DIFF
--- a/java/serve/src/main/java/io/ray/serve/api/Serve.java
+++ b/java/serve/src/main/java/io/ray/serve/api/Serve.java
@@ -108,6 +108,26 @@ public class Serve {
     return client;
   }
 
+  public static synchronized ServeControllerClient start(
+      boolean detached, boolean dedicatedCpu, Map<String, String> config) {
+    
+    if (!detached) {
+      throw new IllegalArgumentException(
+        "`detached=false` is no longer supported. "
+        "In a future release, it will be removed altogether."
+      );
+    }
+
+    if (dedicatedCpu) {
+      throw new IllegalArgumentException(
+        "`dedicatedCpu=true` is no longer supported. "
+        "In a future release, it will be removed altogether."
+      );
+    }
+
+    return start(config);
+  }
+
   /**
    * Completely shut down the connected Serve instance.
    *

--- a/java/serve/src/main/java/io/ray/serve/api/Serve.java
+++ b/java/serve/src/main/java/io/ray/serve/api/Serve.java
@@ -110,19 +110,17 @@ public class Serve {
 
   public static synchronized ServeControllerClient start(
       boolean detached, boolean dedicatedCpu, Map<String, String> config) {
-    
+
     if (!detached) {
       throw new IllegalArgumentException(
-        "`detached=false` is no longer supported. "
-        "In a future release, it will be removed altogether."
-      );
+          "`detached=false` is no longer supported. "
+              + "In a future release, it will be removed altogether.");
     }
 
     if (dedicatedCpu) {
       throw new IllegalArgumentException(
-        "`dedicatedCpu=true` is no longer supported. "
-        "In a future release, it will be removed altogether."
-      );
+          "`dedicatedCpu=true` is no longer supported. "
+              + "In a future release, it will be removed altogether.");
     }
 
     return start(config);

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -100,7 +100,7 @@ def start(
 
     if dedicated_cpu is not False:
         raise ValueError(
-            "`dedicated_cpu` is no longer supported. "
+            "`dedicated_cpu=True` is no longer supported. "
             "In a future release, it will be removed altogether."
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change raises and exception if `detached` or `dedicatedCpu` are set to non-default arguments in the Serve Java API.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
