### PR TITLE
[data] estimate blocks for limit and union operator

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Union
 
 import ray
 from .ref_bundle import RefBundle
@@ -200,16 +200,17 @@ class PhysicalOperator(Operator):
         """
         return ""
 
-    def num_outputs_total(self) -> Optional[int]:
-        """Returns the total number of output bundles of this operator, if known.
+    def num_outputs_total(self) -> int:
+        """Returns the total number of output bundles of this operator.
 
+        The value returned may be an estimate.
         This is useful for reporting progress.
         """
         if self._estimated_output_blocks is not None:
             return self._estimated_output_blocks
         if len(self.input_dependencies) == 1:
             return self.input_dependencies[0].num_outputs_total()
-        return None
+        raise NotImplementedError
 
     def start(self, options: ExecutionOptions) -> None:
         """Called by the executor when execution starts for an operator.

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -203,14 +203,14 @@ class PhysicalOperator(Operator):
     def num_outputs_total(self) -> int:
         """Returns the total number of output bundles of this operator.
 
-        The value returned may be an estimate.
+        The value returned may be an estimate based off the consumption so far.
         This is useful for reporting progress.
         """
         if self._estimated_output_blocks is not None:
             return self._estimated_output_blocks
         if len(self.input_dependencies) == 1:
             return self.input_dependencies[0].num_outputs_total()
-        raise NotImplementedError
+        raise AttributeError
 
     def start(self, options: ExecutionOptions) -> None:
         """Called by the executor when execution starts for an operator.

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -68,7 +68,7 @@ class AllToAllOperator(PhysicalOperator):
         self._stats: StatsDict = {}
         super().__init__(name, [input_op])
 
-    def num_outputs_total(self) -> Optional[int]:
+    def num_outputs_total(self) -> int:
         return (
             self._num_outputs
             if self._num_outputs

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -56,7 +56,7 @@ class InputDataBuffer(PhysicalOperator):
     def get_next(self) -> RefBundle:
         return self._input_data.pop(0)
 
-    def num_outputs_total(self) -> Optional[int]:
+    def num_outputs_total(self) -> int:
         return self._num_output_blocks or self._num_output_bundles
 
     def get_stats(self) -> StatsDict:

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -1,6 +1,6 @@
 import copy
 from collections import deque
-from typing import Deque, List, Optional, Tuple
+from typing import Deque, List, Tuple
 
 import ray
 from ray.data._internal.execution.interfaces import PhysicalOperator, RefBundle
@@ -81,6 +81,17 @@ class LimitOperator(OneToOneOperator):
         if self._limit_reached():
             self.all_inputs_done()
 
+        # Estimate number of output bundles
+        # Check the case where _limit > # of input rows
+        num_inputs = self.input_dependencies[0].num_outputs_total()
+        estimated_total_output_rows = min(
+            self._limit, self._consumed_rows / self._cur_output_bundles * num_inputs
+        )
+        # _consumed_rows / _limit is roughly _cur_output_bundles / total output blocks
+        self._estimated_output_blocks = round(
+            estimated_total_output_rows / self._consumed_rows * self._cur_output_bundles
+        )
+
     def has_next(self) -> bool:
         return len(self._buffer) > 0
 
@@ -90,11 +101,13 @@ class LimitOperator(OneToOneOperator):
     def get_stats(self) -> StatsDict:
         return {self._name: self._output_metadata}
 
-    def num_outputs_total(self) -> Optional[int]:
+    def num_outputs_total(self) -> int:
         # Before inputs are completed (either because the limit is reached or
         # because the inputs operators are done), we don't know how many output
-        # bundles we will have.
+        # bundles we will have. We estimate based off the consumption so far.
         if self._inputs_complete:
             return self._cur_output_bundles
+        elif self._estimated_output_blocks is not None:
+            return self._estimated_output_blocks
         else:
-            return None
+            return self.input_dependencies[0].num_outputs_total()

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -81,16 +81,21 @@ class LimitOperator(OneToOneOperator):
         if self._limit_reached():
             self.all_inputs_done()
 
-        # Estimate number of output bundles
-        # Check the case where _limit > # of input rows
-        num_inputs = self.input_dependencies[0].num_outputs_total()
-        estimated_total_output_rows = min(
-            self._limit, self._consumed_rows / self._cur_output_bundles * num_inputs
-        )
-        # _consumed_rows / _limit is roughly _cur_output_bundles / total output blocks
-        self._estimated_output_blocks = round(
-            estimated_total_output_rows / self._consumed_rows * self._cur_output_bundles
-        )
+        # We cannot estimate if we have only consumed empty blocks
+        if self._consumed_rows > 0:
+            # Estimate number of output bundles
+            # Check the case where _limit > # of input rows
+            num_inputs = self.input_dependencies[0].num_outputs_total()
+            estimated_total_output_rows = min(
+                self._limit, self._consumed_rows / self._cur_output_bundles * num_inputs
+            )
+            # _consumed_rows / _limit is roughly equal to
+            # _cur_output_bundles / total output blocks
+            self._estimated_output_blocks = round(
+                estimated_total_output_rows
+                / self._consumed_rows
+                * self._cur_output_bundles
+            )
 
     def has_next(self) -> bool:
         return len(self._buffer) > 0

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 from ray.data._internal.execution.interfaces import (
     ExecutionOptions,
@@ -46,15 +46,10 @@ class UnionOperator(NAryOperator):
         self._preserve_order = options.preserve_order
         super().start(options)
 
-    def num_outputs_total(self) -> Optional[int]:
+    def num_outputs_total(self) -> int:
         num_outputs = 0
         for input_op in self.input_dependencies:
-            op_num_outputs = input_op.num_outputs_total()
-            # If at least one of the input ops has an unknown number of outputs,
-            # the number of outputs of the union operator is unknown.
-            if op_num_outputs is None:
-                return None
-            num_outputs += op_num_outputs
+            num_outputs += input_op.num_outputs_total()
         return num_outputs
 
     def add_input(self, refs: RefBundle, input_index: int) -> None:

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import ray
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
@@ -41,7 +41,7 @@ class ZipOperator(PhysicalOperator):
         self._stats: StatsDict = {}
         super().__init__("Zip", [left_input_op, right_input_op])
 
-    def num_outputs_total(self) -> Optional[int]:
+    def num_outputs_total(self) -> int:
         left_num_outputs = self.input_dependencies[0].num_outputs_total()
         right_num_outputs = self.input_dependencies[1].num_outputs_total()
         if left_num_outputs is not None and right_num_outputs is not None:

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -104,7 +104,7 @@ class StreamingExecutor(Executor, threading.Thread):
 
         if not isinstance(dag, InputDataBuffer):
             # Note: DAG must be initialized in order to query num_outputs_total.
-            self._global_info = ProgressBar("Running", dag.num_outputs_total() or 1)
+            self._global_info = ProgressBar("Running", dag.num_outputs_total())
 
         self._output_node: OpState = self._topology[dag]
         self.start()

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -138,7 +138,7 @@ class OpState:
         enabled = verbose_progress or is_all_to_all
         self.progress_bar = ProgressBar(
             "- " + self.op.name,
-            self.op.num_outputs_total() or 1,
+            self.op.num_outputs_total(),
             index,
             enabled=enabled,
         )

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -108,7 +108,7 @@ class ProgressBar:
     def update(self, i: int = 0, total: Optional[int] = None) -> None:
         if self._bar and (i != 0 or self._bar.total != total):
             self._progress += i
-            if total is not None and total > self._bar.total:
+            if total is not None:
                 self._bar.total = total
             if self._bar.total is not None and self._progress > self._bar.total:
                 # If the progress goes over 100%, update the total.

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -809,7 +809,7 @@ def test_block_ref_bundler_uniform(
     assert flat_out == list(range(n))
 
 
-def test_estimated_output_blocks():
+def test_map_estimated_output_blocks():
     # Test map operator estimation
     input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
 
@@ -838,6 +838,8 @@ def test_estimated_output_blocks():
     # 100 inputs -> 100 / 10 = 10 tasks -> 10 * 5 = 50 output blocks
     assert op._estimated_output_blocks == 50
 
+
+def test_limit_estimated_output_blocks():
     # Test limit operator estimation
     input_op = InputDataBuffer(make_ref_bundles([[i, i] for i in range(100)]))
     op = LimitOperator(100, input_op)
@@ -866,6 +868,8 @@ def test_estimated_output_blocks():
     # all blocks are outputted
     assert op._estimated_output_blocks == 100
 
+
+def test_all_to_all_estimated_output_blocks():
     # Test all to all operator
     input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
 

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -612,10 +612,6 @@ def test_limit_operator(ray_start_regular_shared):
             # If the limit is 0, the operator should be completed immediately.
             assert limit_op.completed()
             assert limit_op._limit_reached()
-        else:
-            # The number of output bundles is unknown until
-            # inputs are completed.
-            assert limit_op.num_outputs_total() is None, limit
         cur_rows = 0
         loop_count = 0
         while input_op.has_next() and not limit_op._limit_reached():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We estimate # of blocks outputted for `MapOperator`, but it depends on the `num_outputs_total` of it's input dependency. If this method is allowed to return `None`, then the output blocks of any operator following it cannot be estimated. 

This pr estimates the number of blocks outputted from a `LimitOperator` using the rule: `_consumed_rows / _limit = _cur_output_bundles / *total_output_bundles*`. This and `UnionOperator` were the only other operators that returned `None`, so now `num_outputs_total` will always return an int.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
