### PR TITLE
[ci][cov] add coverage info for serve tests

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -1,22 +1,24 @@
 group: serve tests
 steps:
-  - label: ":ray-serve: serve: core tests"
-    instance_type: medium
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serve --except-tags worker-container
-    depends_on: servebuild
-    job_env: forge
-
   - label: ":ray-serve: serve: serve tests"
     parallelism: 2
+    tags: 
+      - serve
+      - ml
+      - python
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve --except-tags post_wheel_build,gpu,xcommit
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... //python/ray/tests/...  serve 
+        --except-tags post_wheel_build,gpu,worker-container,xcommit
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
     depends_on: servebuild
     job_env: forge
 
   - label: ":ray-serve: serve: flaky tests"
+    tags: 
+      - serve
+      - ml
+      - python
     instance_type: medium
     soft_fail: true
     commands:


### PR DESCRIPTION
Add coverage info/tag for serve tests, so that serve tests only run on serve changes. The conditions is obtained from https://github.com/ray-project/ray/blob/9b8e903aa6efc8921ff770c97fbacfcf9847d364/.buildkite/pipeline.build.yml#L102.

Also merge the two existing serve jobs into one. The core job just takes 2 minutes to run tests.

Test:
- CI