### PR TITLE
[cherry-pick] Fix Overview Page UI will crash Issue

### DIFF
--- a/dashboard/client/src/components/AutoscalerStatusCards.tsx
+++ b/dashboard/client/src/components/AutoscalerStatusCards.tsx
@@ -65,7 +65,7 @@ export const NodeStatusCard = ({ cluster_status }: StatusCardProps) => {
         overflowY: "scroll",
       }}
     >
-      {cluster_status?.data
+      {cluster_status?.data && cluster_status?.data?.clusterStatus
         ? formatNodeStatus(cluster_status?.data.clusterStatus)
         : "No cluster status."}
     </Box>
@@ -80,7 +80,7 @@ export const ResourceStatusCard = ({ cluster_status }: StatusCardProps) => {
         overflowY: "scroll",
       }}
     >
-      {cluster_status?.data
+      {cluster_status?.data && cluster_status?.data?.clusterStatus
         ? formatResourcesStatus(cluster_status?.data.clusterStatus)
         : "No cluster status."}
     </Box>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->


## Why are these changes needed?

Cherry-pick #40063

Fix #39564, for an unknown reason, the backend router 'cluster_status' may return empty data without 'cluster_status'. However, the frontend may need 'cluster_status' to parse information and generate components, potentially leading to a UI crash.

The quick fix in the UI is to add protection for splitting 'cluster_status'.

We are aiming to address this issue and merge it in Ray 2.7.1.

## Results
Now, the UI is available even though cluster_status is undefined.
<img width="1711" alt="Screenshot 2023-10-03 at 3 04 07 PM" src="https://github.com/ray-project/ray/assets/125417081/bdfd7813-1b99-43f0-83f3-62c077a38d1a">

## Reproduce the bug
<img width="1894" alt="Screenshot 2023-10-03 at 2 55 28 PM" src="https://github.com/ray-project/ray/assets/125417081/248b30a8-6747-40fa-a95d-8f6237c41883">

In Component OverviewPage, 

change  `const { cluster_status } = useRayStatus();` to

```
const cluster_status = {
    result: true,
    data: { clusterStatus: undefined },
    message: "",
  };
```







<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
