### PR TITLE
[Clusters] Change TPU INFO log to debug and only query TPU endpoint if TPUs are detected

### DIFF
--- a/python/ray/_private/accelerator.py
+++ b/python/ray/_private/accelerator.py
@@ -10,6 +10,7 @@ import ray._private.utils as utils
 import re
 from typing import Callable, Iterable, Optional
 
+logger = logging.getLogger("ray")
 
 def update_resources_with_accelerator_type(resources: dict):
     """Update the resources dictionary with the accelerator type and custom
@@ -169,7 +170,7 @@ def _autodetect_num_tpus() -> int:
         numeric_entries = [int(entry) for entry in vfio_entries if entry.isdigit()]
         return len(numeric_entries)
     except FileNotFoundError as e:
-        logging.info("Failed to detect number of TPUs: %s", e)
+        logger.debug("Failed to detect number of TPUs: %s", e)
         return 0
 
 
@@ -208,7 +209,7 @@ def _autodetect_tpu_version() -> Optional[str]:
     if accelerator_type is not None:
         detected_tpu_version = accelerator_type_to_version(accelerator_type)
         if detected_tpu_version is None:
-            logging.info(
+            logger.debug(
                 "While trying to autodetect a TPU type and "
                 f"parsing {ray_constants.RAY_GKE_TPU_ACCELERATOR_TYPE_ENV_VAR}, "
                 f"received malformed accelerator_type: {accelerator_type}"
@@ -228,27 +229,27 @@ def _autodetect_tpu_version() -> Optional[str]:
                     accelerator_type_request.text
                 )
                 if detected_tpu_version is None:
-                    logging.info(
+                    logger.debug(
                         "While trying to autodetect a TPU type, the TPU GCE metadata "
                         "returned a malformed accelerator type: "
                         f"{accelerator_type_request.text}."
                     )
             else:
-                logging.info(
+                logger.debug(
                     "While trying to autodetect a TPU type, "
                     "unable to poll TPU GCE metadata. Got "
                     f"status code: {accelerator_type_request.status_code} and "
                     f"content: {accelerator_type_request.text}"
                 )
         except requests.RequestException as e:
-            logging.info(
+            logger.debug(
                 "While trying to autodetect a TPU type, "
                 " unable to poll TPU GCE metadata: %s",
                 e,
             )
 
     if detected_tpu_version is None:
-        logging.info("Failed to auto-detect TPU type.")
+        logger.debug("Failed to auto-detect TPU type.")
     return detected_tpu_version
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, a `requests.get()` call is made to a GCE endpoint every time `ray.init()` is called.  It's only supposed to be called when TPUs are detected, but it was in fact being called every time.

This is the main issue that this PR fixes. We now only run the accelerator-specific code if the number of accelerators detected is `> 0`. (Previously we were only checking that it was not `None`.)

Another issue this PR fixes is that a "TPUs not detected" message was being printed to the driver in some cases (e.g. when using Ray Serve, see the linked issue.). We fix this by setting it as a `debug`-level log instead of a `info`-level log.  I don't know a user-friendly way to enable the debug log level, but we can improve this in the future.

This PR also adds a 30s timeout to the `requests.get` call, which is a best practice (otherwise it can silently hang forever.)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/40078
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
