### PR TITLE
[Core] Handle cpu == 0 more gracefully for the dashboard agent report

### DIFF
--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -595,7 +595,6 @@ class ReporterAgent(
         )
 
     def _get_load_avg(self):
-        logger.error("SANG-TODO")
         if sys.platform == "win32":
             cpu_percent = psutil.cpu_percent()
             load = (cpu_percent, cpu_percent, cpu_percent)

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -595,12 +595,16 @@ class ReporterAgent(
         )
 
     def _get_load_avg(self):
+        logger.error("SANG-TODO")
         if sys.platform == "win32":
             cpu_percent = psutil.cpu_percent()
             load = (cpu_percent, cpu_percent, cpu_percent)
         else:
             load = os.getloadavg()
-        per_cpu_load = tuple((round(x / self._cpu_counts[0], 2) for x in load))
+        if self._cpu_counts[0] > 0:
+            per_cpu_load = tuple((round(x / self._cpu_counts[0], 2) for x in load))
+        else:
+            per_cpu_load = None
         return load, per_cpu_load
 
     @staticmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Seems like when logical_cpus == 0 (idk when this can happen, but the user raises a bug), the load_avg calculation doesn't work because of division by zero error. This PR fixes the issue. I also verified if cpus > 0, the issue from the tagged link doesn't happen. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/34895

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
