### PR TITLE
Revert "[Data] Propagate driver `DataContext` to `RayTrainWorkers`"

### DIFF
--- a/python/ray/train/_internal/worker_group.py
+++ b/python/ray/train/_internal/worker_group.py
@@ -10,7 +10,6 @@ from ray.actor import ActorHandle
 from ray.air._internal.util import skip_exceptions, exception_cause
 from ray.types import ObjectRef
 from ray.util.placement_group import PlacementGroup
-from ray.data.context import DataContext
 
 T = TypeVar("T")
 
@@ -18,16 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class RayTrainWorker:
-    """A class to execute arbitrary functions. Does not hold any state.
-
-    Args:
-        data_context: The DataContext from the driver, to be propagated to this worker.
-            If not specified, default values for DataContext will be used.
-    """
-
-    def __init__(self, data_context: Optional[DataContext] = None):
-        if data_context:
-            DataContext._set_current(data_context)
+    """A class to execute arbitrary functions. Does not hold any state."""
 
     def __execute(self, func: Callable[..., T], *args, **kwargs) -> T:
         """Executes the input function and returns the output.
@@ -190,8 +180,6 @@ class WorkerGroup:
 
         self._actor_cls_args = actor_cls_args or []
         self._actor_cls_kwargs = actor_cls_kwargs or {}
-        # Always propagate the driver's DataContext to each worker.
-        self._actor_cls_kwargs["data_context"] = DataContext.get_current()
 
         self._placement_group = placement_group
 

--- a/python/ray/train/tests/test_base_trainer.py
+++ b/python/ray/train/tests/test_base_trainer.py
@@ -5,7 +5,6 @@ import pytest
 
 import ray
 from ray import train, tune
-from ray.data.context import DataContext
 from ray.train import Checkpoint, ScalingConfig
 from ray.air.constants import MAX_REPR_LENGTH
 from ray.train.gbdt_trainer import GBDTTrainer
@@ -173,24 +172,6 @@ def test_metadata_propagation_data_parallel(ray_start_4_cpus):
     result = trainer.fit()
     meta_out = result.checkpoint.get_metadata()
     assert meta_out == {"a": 1, "b": 2, "c": 3}, meta_out
-
-
-def test_data_context_propagation(ray_start_4_cpus):
-    ctx = DataContext.get_current()
-    # Fake DataContext attribute to propagate to worker.
-    ctx.foo = "bar"
-
-    def training_loop(self):
-        # Dummy train loop that checks that changes in the driver's
-        # DataContext are propagated to the worker.
-        ctx_worker = DataContext.get_current()
-        assert ctx_worker.foo == "bar"
-
-    trainer = DummyTrainer(
-        train_loop=training_loop,
-        datasets={"train": ray.data.range(10)},
-    )
-    trainer.fit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reverts ray-project/ray#39698

This breaks many rllib tests https://flakey-tests.ray.io/?owner=rllib, and is likely blocking rllib team from merging their PRs now that these tests are blocking

Test:
- CI