### PR TITLE
[Clusters] Change TPU INFO log to debug and only query TPU endpoint if TPUs are detected (#40079)

### DIFF
--- a/python/ray/_private/accelerator.py
+++ b/python/ray/_private/accelerator.py
@@ -107,7 +107,7 @@ def _detect_and_configure_custom_accelerator(
         # Don't use more resources than allowed by the user's pre-set values.
         if accelerator_count is not None and visible_ids is not None:
             accelerator_count = min(accelerator_count, len(visible_ids))
-    if accelerator_count is not None:
+    if accelerator_count is not None and accelerator_count > 0:
         # 4. Update accelerator_type and accelerator_count with
         # number of accelerators detected or configured.
         resources.update(
@@ -169,7 +169,7 @@ def _autodetect_num_tpus() -> int:
         numeric_entries = [int(entry) for entry in vfio_entries if entry.isdigit()]
         return len(numeric_entries)
     except FileNotFoundError as e:
-        logging.info("Failed to detect number of TPUs: %s", e)
+        logging.debug("Failed to detect number of TPUs: %s", e)
         return 0
 
 
@@ -219,6 +219,7 @@ def _autodetect_tpu_version() -> Optional[str]:
             accelerator_type_request = requests.get(
                 ray_constants.RAY_GCE_TPU_ACCELERATOR_ENDPOINT,
                 headers=ray_constants.RAY_GCE_TPU_HEADERS,
+                timeout=30,
             )
             if (
                 accelerator_type_request.status_code == 200


### PR DESCRIPTION
Cherry-pick of #40079 to the release branch. The PR description for that PR is copied below:

---

Currently, a requests.get() call is made to a GCE endpoint every time ray.init() is called. It's only supposed to be called when TPUs are detected, but it was in fact being called every time.

This is the main issue that this PR fixes. We now only run the accelerator-specific code if the number of accelerators detected is > 0. (Previously we were only checking that it was not None.)

Another issue this PR fixes is that a "TPUs not detected" message was being printed to the driver in some cases (e.g. when using Ray Serve, see the linked issue.). We fix this by setting it as a debug-level log instead of a info-level log. I don't know a user-friendly way to enable the debug log level, but we can improve this in the future.

This PR also adds a 30s timeout to the requests.get call, which is a best practice (otherwise it can silently hang forever.)

Related issue number
Closes #40078

---------

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
