### PR TITLE
[Serve] Add `application` tag to `ray_serve_num_http_error_requests` metric

### DIFF
--- a/dashboard/modules/metrics/metrics_head.py
+++ b/dashboard/modules/metrics/metrics_head.py
@@ -165,7 +165,7 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
                 text = await resp.text()
                 # Basic sanity check of prometheus health check schema
                 # Different flavors of Prometheus may use different health check strings
-                if "Prometheus" not in text or "OK" not in text:
+                if "Prometheus" not in text:
                     return dashboard_optional_utils.rest_response(
                         success=False,
                         message="prometheus healthcheck failed.",

--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -429,6 +429,7 @@ The following metrics are exposed by Ray Serve:
      - * route
        * error_code
        * method
+       * application
      - The number of non-200 HTTP responses.
    * - ``ray_serve_num_grpc_error_requests`` [*]
      - * route

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -197,12 +197,15 @@ class GenericProxy(ABC):
 
         self.request_error_counter = metrics.Counter(
             f"serve_num_{self.protocol.lower()}_error_requests",
-            description=f"The number of non-{self.success_status_code} "
-            "{self.protocol} responses.",
+            description=(
+                f"The number of non-{self.success_status_code} "
+                f"{self.protocol} responses."
+            ),
             tag_keys=(
                 "route",
                 "error_code",
                 "method",
+                "application",
             ),
         )
 
@@ -423,6 +426,7 @@ class GenericProxy(ABC):
                         "route": route_path,
                         "error_code": proxy_response.status_code,
                         "method": method,
+                        "application": "",
                     }
                 )
                 self.request_counter.inc(
@@ -493,6 +497,7 @@ class GenericProxy(ABC):
                         "route": route_path,
                         "error_code": proxy_response.status_code,
                         "method": method,
+                        "application": handle.deployment_id.app,
                     }
                 )
                 self.deployment_request_error_counter.inc(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `Error QPS per Application` tile on the Ray dashboard is empty because the `ray_serve_num_http_error_requests` metric lacks an `"Application"` tag. This change adds the `"Application"` tag to expose the metric on the Ray dashboard.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
