### PR TITLE
[data] store ray dashboard metrics in _StatsActor

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -48,7 +48,9 @@ class OpRuntimeMetrics:
     # Number of generated output blocks.
     num_outputs_generated: int = field(default=0, metadata={"map_only": True})
     # Total size in bytes of generated output blocks.
-    bytes_outputs_generated: int = field(default=0, metadata={"map_only": True})
+    bytes_outputs_generated: int = field(
+        default=0, metadata={"map_only": True, "export_metric": True}
+    )
 
     # Number of output blocks that are already taken by the downstream.
     num_outputs_taken: int = 0
@@ -74,19 +76,28 @@ class OpRuntimeMetrics:
     # === Object store memory metrics ===
 
     # Allocated memory size in the object store.
-    obj_store_mem_alloc: int = field(default=0, metadata={"map_only": True})
+    obj_store_mem_alloc: int = field(
+        default=0, metadata={"map_only": True, "export_metric": True}
+    )
     # Freed memory size in the object store.
-    obj_store_mem_freed: int = field(default=0, metadata={"map_only": True})
+    obj_store_mem_freed: int = field(
+        default=0, metadata={"map_only": True, "export_metric": True}
+    )
     # Current memory size in the object store.
-    obj_store_mem_cur: int = field(default=0, metadata={"map_only": True})
+    obj_store_mem_cur: int = field(
+        default=0, metadata={"map_only": True, "export_metric": True}
+    )
     # Peak memory size in the object store.
     obj_store_mem_peak: int = field(default=0, metadata={"map_only": True})
     # Spilled memory size in the object store.
-    obj_store_mem_spilled: int = field(default=0, metadata={"map_only": True})
+    obj_store_mem_spilled: int = field(
+        default=0, metadata={"map_only": True, "export_metric": True}
+    )
 
     def __init__(self, op: "PhysicalOperator"):
         from ray.data._internal.execution.operators.map_operator import MapOperator
 
+        self._op = op
         self._is_map = isinstance(op, MapOperator)
         self._running_tasks: Dict[int, RunningTaskInfo] = {}
         self._extra_metrics: Dict[str, Any] = {}
@@ -96,17 +107,34 @@ class OpRuntimeMetrics:
         """Return a dict of extra metrics."""
         return self._extra_metrics
 
-    def as_dict(self):
+    def as_dict(self, metrics_only: bool = False):
         """Return a dict representation of the metrics."""
         result = []
         for f in fields(self):
             if f.metadata.get("export", True):
-                if not self._is_map and f.metadata.get("map_only", False):
+                if (not self._is_map and f.metadata.get("map_only", False)) or (
+                    metrics_only and not f.metadata.get("export_metric", False)
+                ):
                     continue
                 value = getattr(self, f.name)
                 result.append((f.name, value))
+
+        resource_usage = self._op.current_resource_usage()
+        result.extend(
+            [
+                ("cpu_usage", resource_usage.cpu or 0),
+                ("gpu_usage", resource_usage.gpu or 0),
+            ]
+        )
         result.extend(self._extra_metrics.items())
         return dict(result)
+
+    @classmethod
+    def get_metric_keys(cls):
+        """Return a list of metric keys."""
+        return [
+            f.name for f in fields(cls) if f.metadata.get("export_metric", False)
+        ] + ["cpu_usage", "gpu_usage"]
 
     @property
     def average_num_outputs_per_task(self) -> Optional[float]:

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -119,13 +119,16 @@ class OpRuntimeMetrics:
                 value = getattr(self, f.name)
                 result.append((f.name, value))
 
-        resource_usage = self._op.current_resource_usage()
-        result.extend(
-            [
-                ("cpu_usage", resource_usage.cpu or 0),
-                ("gpu_usage", resource_usage.gpu or 0),
-            ]
-        )
+        if metrics_only:
+            # TODO: record resource usage in OpRuntimeMetrics,
+            # avoid calling self._op.current_resource_usage()
+            resource_usage = self._op.current_resource_usage()
+            result.extend(
+                [
+                    ("cpu_usage", resource_usage.cpu or 0),
+                    ("gpu_usage", resource_usage.gpu or 0),
+                ]
+            )
         result.extend(self._extra_metrics.items())
         return dict(result)
 

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -119,16 +119,15 @@ class OpRuntimeMetrics:
                 value = getattr(self, f.name)
                 result.append((f.name, value))
 
-        if metrics_only:
-            # TODO: record resource usage in OpRuntimeMetrics,
-            # avoid calling self._op.current_resource_usage()
-            resource_usage = self._op.current_resource_usage()
-            result.extend(
-                [
-                    ("cpu_usage", resource_usage.cpu or 0),
-                    ("gpu_usage", resource_usage.gpu or 0),
-                ]
-            )
+        # TODO: record resource usage in OpRuntimeMetrics,
+        # avoid calling self._op.current_resource_usage()
+        resource_usage = self._op.current_resource_usage()
+        result.extend(
+            [
+                ("cpu_usage", resource_usage.cpu or 0),
+                ("gpu_usage", resource_usage.gpu or 0),
+            ]
+        )
         result.extend(self._extra_metrics.items())
         return dict(result)
 

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -48,6 +48,8 @@ class InputDataBuffer(PhysicalOperator):
             self._input_data = self._input_data_factory()
             self._is_input_initialized = True
             self._initialize_metadata()
+        for bundle in self._input_data:
+            self._metrics.on_input_received(bundle)
         super().start(options)
 
     def has_next(self) -> bool:

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -48,6 +48,8 @@ class InputDataBuffer(PhysicalOperator):
             self._input_data = self._input_data_factory()
             self._is_input_initialized = True
             self._initialize_metadata()
+        # InputDataBuffer does not take inputs from other operators,
+        # so we record input metrics here
         for bundle in self._input_data:
             self._metrics.on_input_received(bundle)
         super().start(options)

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -341,7 +341,6 @@ class StreamingExecutor(Executor, threading.Thread):
             stats[DataMetric.GPU_USAGE] += resource_usage.gpu or 0
 
             # TODO: get these stats from op metrics
-            stats[DataMetric.ROWS_OUTPUTTED] += 0
             stats[DataMetric.BYTES_OUTPUTTED] += 0
             stats[DataMetric.BYTES_CURRENT] += 0
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -59,7 +59,7 @@ class StreamingExecutor(Executor, threading.Thread):
     a way that maximizes throughput under resource constraints.
     """
 
-    def __init__(self, options: ExecutionOptions, dataset_uuid: str = "dataset_uuid"):
+    def __init__(self, options: ExecutionOptions, dataset_uuid: str = "unknown_uuid"):
         self._start_time: Optional[float] = None
         self._initial_stats: Optional[DatasetStats] = None
         self._final_stats: Optional[DatasetStats] = None
@@ -78,7 +78,6 @@ class StreamingExecutor(Executor, threading.Thread):
         self._topology: Optional[Topology] = None
         self._output_node: Optional[OpState] = None
 
-        self._prev_metrics_state = {}
         self._dataset_uuid = dataset_uuid
 
         Executor.__init__(self, options)
@@ -109,10 +108,6 @@ class StreamingExecutor(Executor, threading.Thread):
 
         # Setup the streaming DAG topology and start the runner thread.
         self._topology, _ = build_streaming_topology(dag, self._options)
-
-        # Keep track of previous state to calculate deltas for metrics.
-        for op in self._topology:
-            self._prev_metrics_state[op] = {}
 
         if not isinstance(dag, InputDataBuffer):
             # Note: DAG must be initialized in order to query num_outputs_total.

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -30,7 +30,7 @@ from ray.data._internal.execution.streaming_executor_state import (
     update_operator_states,
 )
 from ray.data._internal.progress_bar import ProgressBar
-from ray.data._internal.stats import DatasetStats
+from ray.data._internal.stats import DatasetStats, _get_or_create_dataset_metrics
 from ray.data.context import DataContext
 
 logger = DatasetLogger(__name__)
@@ -54,7 +54,7 @@ class StreamingExecutor(Executor, threading.Thread):
     a way that maximizes throughput under resource constraints.
     """
 
-    def __init__(self, options: ExecutionOptions):
+    def __init__(self, options: ExecutionOptions, dataset_uuid: Optional[str] = None):
         self._start_time: Optional[float] = None
         self._initial_stats: Optional[DatasetStats] = None
         self._final_stats: Optional[DatasetStats] = None
@@ -72,6 +72,10 @@ class StreamingExecutor(Executor, threading.Thread):
         # generator `yield`s.
         self._topology: Optional[Topology] = None
         self._output_node: Optional[OpState] = None
+
+        self._dataset_metrics = _get_or_create_dataset_metrics()
+        self._prev_metrics_state = {}
+        self._dataset_uuid = dataset_uuid
 
         Executor.__init__(self, options)
         thread_name = f"StreamingExecutor-{self._execution_id}"
@@ -101,6 +105,9 @@ class StreamingExecutor(Executor, threading.Thread):
 
         # Setup the streaming DAG topology and start the runner thread.
         self._topology, _ = build_streaming_topology(dag, self._options)
+
+        for op_state in self._topology.values():
+            self._prev_metrics_state[op_state] = {}
 
         if not isinstance(dag, InputDataBuffer):
             # Note: DAG must be initialized in order to query num_outputs_total.
@@ -271,6 +278,7 @@ class StreamingExecutor(Executor, threading.Thread):
         # Update the progress bar to reflect scheduling decisions.
         for op_state in topology.values():
             op_state.refresh_progress_bar()
+            self._update_dataset_metrics(op_state)
 
         # Keep going until all operators run to completion.
         return not all(op.completed() for op in topology)
@@ -311,6 +319,18 @@ class StreamingExecutor(Executor, threading.Thread):
         )
         if self._global_info:
             self._global_info.set_description(resources_status)
+
+    def _update_dataset_metrics(self, op_state):
+        metrics = op_state.op.get_metrics()
+        self._dataset_metrics.inc_bytes_spilled.remote(
+            metrics.get("obj_store_mem_spilled", 0)
+            - self._prev_metrics_state[op_state].get("bytes_spilled", 0),
+            self._dataset_uuid or "None",
+        )
+
+        self._prev_metrics_state[op_state]["bytes_spilled"] = metrics.get(
+            "obj_store_mem_spilled", 0
+        )
 
 
 def _validate_dag(dag: PhysicalOperator, limits: ExecutionResources) -> None:

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -326,18 +326,16 @@ class StreamingExecutor(Executor, threading.Thread):
         stats = {metric: 0 for metric in DataMetric}
 
         for op in self._topology:
-            metrics = op.get_metrics()
+            metrics = op.metrics
             resource_usage = op.current_resource_usage()
 
-            stats[DataMetric.BYTES_SPILLED] += metrics.get("obj_store_mem_spilled", 0)
-            stats[DataMetric.BYTES_ALLOCATED] += metrics.get("obj_store_mem_alloc", 0)
-            stats[DataMetric.BYTES_FREED] += metrics.get("obj_store_mem_freed", 0)
+            stats[DataMetric.BYTES_SPILLED] += metrics.obj_store_mem_spilled
+            stats[DataMetric.BYTES_ALLOCATED] += metrics.obj_store_mem_alloc
+            stats[DataMetric.BYTES_FREED] += metrics.obj_store_mem_freed
+            stats[DataMetric.BYTES_CURRENT] += metrics.obj_store_mem_cur
+            stats[DataMetric.BYTES_OUTPUTTED] += metrics.bytes_outputs_generated
             stats[DataMetric.CPU_USAGE] += resource_usage.cpu or 0
             stats[DataMetric.GPU_USAGE] += resource_usage.gpu or 0
-
-            # TODO: get these stats from op metrics
-            stats[DataMetric.BYTES_OUTPUTTED] += 0
-            stats[DataMetric.BYTES_CURRENT] += 0
 
         _update_stats_actor_metrics(stats, {"dataset": self._dataset_uuid})
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -201,6 +201,7 @@ class StreamingExecutor(Executor, threading.Thread):
         finally:
             # Signal end of results.
             self._output_node.outqueue.append(None)
+            # Reset dataset metrics so that they do not persist in the grafana dashboard
             _remove_metrics({"dataset": self._dataset_uuid})
 
     def get_stats(self):

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -332,7 +332,10 @@ class StreamingExecutor(Executor, threading.Thread):
             stats[DataMetric.BYTES_SPILLED] += metrics.obj_store_mem_spilled
             stats[DataMetric.BYTES_ALLOCATED] += metrics.obj_store_mem_alloc
             stats[DataMetric.BYTES_FREED] += metrics.obj_store_mem_freed
-            stats[DataMetric.BYTES_CURRENT] += metrics.obj_store_mem_cur
+            # Input operators only produce outputs and do not take inputs, 
+            # so this metric is not properly calculated in these cases
+            if not isinstance(op, InputDataBuffer):
+                stats[DataMetric.BYTES_CURRENT] += metrics.obj_store_mem_cur
             stats[DataMetric.BYTES_OUTPUTTED] += metrics.bytes_outputs_generated
             stats[DataMetric.CPU_USAGE] += resource_usage.cpu or 0
             stats[DataMetric.GPU_USAGE] += resource_usage.gpu or 0

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -33,7 +33,7 @@ from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.stats import (
     DataMetric,
     DatasetStats,
-    _remove_metrics,
+    _clear_metrics,
     _update_stats_actor_metrics,
 )
 from ray.data.context import DataContext
@@ -201,8 +201,8 @@ class StreamingExecutor(Executor, threading.Thread):
         finally:
             # Signal end of results.
             self._output_node.outqueue.append(None)
-            # Reset dataset metrics so that they do not persist in the grafana dashboard
-            _remove_metrics({"dataset": self._dataset_uuid})
+            # Clears metrics for this dataset so that they do not persist in the grafana dashboard
+            _clear_metrics({"dataset": self._dataset_uuid})
 
     def get_stats(self):
         """Return the stats object for the streaming execution.

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -201,7 +201,8 @@ class StreamingExecutor(Executor, threading.Thread):
         finally:
             # Signal end of results.
             self._output_node.outqueue.append(None)
-            # Clears metrics for this dataset so that they do not persist in the grafana dashboard
+            # Clears metrics for this dataset so that they do
+            # not persist in the grafana dashboard after execution
             _clear_metrics({"dataset": self._dataset_uuid})
 
     def get_stats(self):

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -332,7 +332,7 @@ class StreamingExecutor(Executor, threading.Thread):
             stats[DataMetric.BYTES_SPILLED] += metrics.obj_store_mem_spilled
             stats[DataMetric.BYTES_ALLOCATED] += metrics.obj_store_mem_alloc
             stats[DataMetric.BYTES_FREED] += metrics.obj_store_mem_freed
-            # Input operators only produce outputs and do not take inputs, 
+            # Input operators only produce outputs and do not take inputs,
             # so this metric is not properly calculated in these cases
             if not isinstance(op, InputDataBuffer):
                 stats[DataMetric.BYTES_CURRENT] += metrics.obj_store_mem_cur

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -128,7 +128,6 @@ class ExecutionPlan:
         self._last_optimized_stages = None
         # Cached schema.
         self._schema = None
-
         self._dataset_uuid = dataset_uuid or uuid.uuid4().hex
         if not stats.dataset_uuid:
             stats.dataset_uuid = self._dataset_uuid

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -576,7 +576,9 @@ class ExecutionPlan:
                     StreamingExecutor,
                 )
 
-                executor = StreamingExecutor(copy.deepcopy(context.execution_options), self._dataset_uuid)
+                executor = StreamingExecutor(
+                    copy.deepcopy(context.execution_options), self._dataset_uuid
+                )
                 blocks = execute_to_legacy_block_list(
                     executor,
                     self,

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -518,7 +518,9 @@ class ExecutionPlan:
         )
         from ray.data._internal.execution.streaming_executor import StreamingExecutor
 
-        executor = StreamingExecutor(copy.deepcopy(ctx.execution_options))
+        executor = StreamingExecutor(
+            copy.deepcopy(ctx.execution_options), self._dataset_uuid
+        )
         block_iter = execute_to_legacy_block_iterator(
             executor,
             self,
@@ -575,7 +577,7 @@ class ExecutionPlan:
                     StreamingExecutor,
                 )
 
-                executor = StreamingExecutor(copy.deepcopy(context.execution_options))
+                executor = StreamingExecutor(copy.deepcopy(context.execution_options), self._dataset_uuid)
                 blocks = execute_to_legacy_block_list(
                     executor,
                     self,

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -12,6 +12,7 @@ from ray.data._internal.util import capfirst
 from ray.data.block import BlockMetadata
 from ray.data.context import DataContext
 from ray.util.annotations import DeveloperAPI
+from ray.util.metrics import Counter
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 STATS_ACTOR_NAME = "datasets_stats_actor"
@@ -190,6 +191,39 @@ def _get_or_create_stats_actor():
     return _StatsActor.options(
         name=STATS_ACTOR_NAME,
         namespace=STATS_ACTOR_NAMESPACE,
+        get_if_exists=True,
+        lifetime="detached",
+        scheduling_strategy=scheduling_strategy,
+    ).remote()
+
+
+@ray.remote(num_cpus=0)
+class _DatasetMetrics:
+    def __init__(self):
+        self.bytes_spilled = Counter(
+            "ray_data_bytes_spilled",
+            description="Bytes spilled by dataset operators",
+            tag_keys=("dataset",),
+        )
+
+    def inc_bytes_spilled(self, bytes_spilled, dataset):
+        if bytes_spilled > 0:
+            self.bytes_spilled.inc(bytes_spilled, {"dataset": dataset})
+
+
+def _get_or_create_dataset_metrics():
+    ctx = DataContext.get_current()
+    scheduling_strategy = ctx.scheduling_strategy
+    if not ray.util.client.ray.is_connected():
+        # Pin the stats actor to the local node
+        # so it fate-shares with the driver.
+        scheduling_strategy = NodeAffinitySchedulingStrategy(
+            ray.get_runtime_context().get_node_id(),
+            soft=False,
+        )
+    return _DatasetMetrics.options(
+        name="dataset_metrics",
+        namespace="dataset_metrics_namespace",
         get_if_exists=True,
         lifetime="detached",
         scheduling_strategy=scheduling_strategy,

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -275,7 +275,8 @@ We store _cluster_id to check that the stored actor exists in the current cluste
 
 
 def _check_cluster_stats_actor():
-    # Checks if global _stats_actor belongs to current cluster, if not, creates a new one
+    # Checks if global _stats_actor belongs to current cluster,
+    # if not, creates a new one on the current cluster.
     global _stats_actor, _stats_actor_cluster_id
     current_cluster_id = ray._private.worker._global_node.cluster_id
     if _stats_actor is None or _stats_actor_cluster_id != current_cluster_id:

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -129,7 +129,6 @@ class DataMetric(Enum):
     BYTES_CURRENT = "data_current_bytes"
     CPU_USAGE = "data_cpu_usage_cores"
     GPU_USAGE = "data_gpu_usage_cores"
-    ROWS_OUTPUTTED = "data_output_rows"
     BYTES_OUTPUTTED = "data_output_bytes"
 
 
@@ -154,7 +153,7 @@ class _StatsActor:
         self.fifo_queue = []
 
         # Ray Data dashboard metrics
-        # Everything is a gauge because we need to reset all of 
+        # Everything is a gauge because we need to reset all of
         # a dataset's metrics to 0 after each finishing execution.
         tags_keys = ("dataset",)
         self.bytes_spilled = Gauge(
@@ -185,11 +184,6 @@ class _StatsActor:
         self.gpu_usage = Gauge(
             DataMetric.GPU_USAGE.value,
             description="GPU cores used by dataset operators",
-            tag_keys=tags_keys,
-        )
-        self.rows_outputted = Gauge(
-            DataMetric.ROWS_OUTPUTTED.value,
-            description="Rows outputted by dataset operators",
             tag_keys=tags_keys,
         )
         self.bytes_outputted = Gauge(
@@ -230,6 +224,9 @@ class _StatsActor:
             self.last_time[stats_uuid] - self.start_time[stats_uuid],
         )
 
+    def _get_stats_dict_size(self):
+        return len(self.start_time), len(self.last_time), len(self.metadata)
+
     def update_metrics(
         self, stats: Dict[DataMetric, Union[int, float]], tags: Dict[str, str]
     ):
@@ -237,18 +234,15 @@ class _StatsActor:
         self.bytes_allocated.set(stats[DataMetric.BYTES_ALLOCATED], tags)
         self.bytes_freed.set(stats[DataMetric.BYTES_FREED], tags)
         self.bytes_current.set(stats[DataMetric.BYTES_CURRENT], tags)
-        self.rows_outputted.set(stats[DataMetric.ROWS_OUTPUTTED], tags)
         self.bytes_outputted.set(stats[DataMetric.BYTES_OUTPUTTED], tags)
         self.cpu_usage.set(stats[DataMetric.CPU_USAGE], tags)
         self.gpu_usage.set(stats[DataMetric.GPU_USAGE], tags)
 
     def remove_metrics(self, tags):
-        # This doesn't actually delete the metric, just sets it to 0.
         self.bytes_spilled.set(0, tags)
         self.bytes_allocated.set(0, tags)
         self.bytes_freed.set(0, tags)
         self.bytes_current.set(0, tags)
-        self.rows_outputted.set(0, tags)
         self.bytes_outputted.set(0, tags)
         self.cpu_usage.set(0, tags)
         self.gpu_usage.set(0, tags)
@@ -274,20 +268,32 @@ def _get_or_create_stats_actor():
 
 
 _stats_actor = None
+"""This global _stats_actor may be from a previous cluster that was shutdown.
+The below calls try to execute remote calls with the existing actor, and this
+call fails, we create a new StatsActor on the current cluster.
+"""
 
 
 def _update_stats_actor_metrics(stats: Dict[DataMetric, Any], tags: Dict[str, str]):
     global _stats_actor
     if _stats_actor is None:
         _stats_actor = _get_or_create_stats_actor()
-    _stats_actor.update_metrics.remote(stats, tags)
+    try:
+        _stats_actor.update_metrics.remote(stats, tags)
+    except Exception:
+        _stats_actor = _get_or_create_stats_actor()
+        _stats_actor.update_metrics.remote(stats, tags)
 
 
 def _remove_metrics(tags: Dict[str, str]):
     global _stats_actor
     if _stats_actor is None:
         _stats_actor = _get_or_create_stats_actor()
-    _stats_actor.remove_metrics.remote(tags)
+    try:
+        _stats_actor.remove_metrics.remote(tags)
+    except Exception:
+        _stats_actor = _get_or_create_stats_actor()
+        _stats_actor.remove_metrics.remote(tags)
 
 
 class DatasetStats:

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -238,7 +238,7 @@ class _StatsActor:
         self.cpu_usage.set(stats[DataMetric.CPU_USAGE], tags)
         self.gpu_usage.set(stats[DataMetric.GPU_USAGE], tags)
 
-    def remove_metrics(self, tags):
+    def remove_metrics(self, tags: Dict[str, str]):
         self.bytes_spilled.set(0, tags)
         self.bytes_allocated.set(0, tags)
         self.bytes_freed.set(0, tags)
@@ -269,8 +269,8 @@ def _get_or_create_stats_actor():
 
 _stats_actor = None
 """This global _stats_actor may be from a previous cluster that was shutdown.
-The below calls try to execute remote calls with the existing actor, and this
-call fails, we create a new StatsActor on the current cluster.
+The below calls try to execute remote calls with the existing actor, and if this
+call fails, we create a new _StatsActor on the current cluster.
 """
 
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -289,7 +289,7 @@ def _update_stats_actor_metrics(stats: Dict[DataMetric, Any], tags: Dict[str, st
     _stats_actor.update_metrics.remote(stats, tags)
 
 
-def _remove_metrics(tags: Dict[str, str]):
+def _clear_metrics(tags: Dict[str, str]):
     global _stats_actor
     _check_cluster_stats_actor()
     _stats_actor.remove_metrics.remote(tags)

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -125,6 +125,8 @@ class _DatasetStatsBuilder:
 class DataMetric(Enum):
     BYTES_SPILLED = "data_spilled_bytes"
     BYTES_ALLOCATED = "data_allocated_bytes"
+    BYTES_FREED = "data_freed_bytes"
+    BYTES_CURRENT = "data_current_bytes"
     CPU_USAGE = "data_cpu_usage_cores"
     GPU_USAGE = "data_gpu_usage_cores"
     ROWS_OUTPUTTED = "data_output_rows"
@@ -158,9 +160,19 @@ class _StatsActor:
             description="Bytes spilled by dataset operators",
             tag_keys=tags_keys,
         )
-        self.bytes_allocated = Gauge(
+        self.bytes_allocated = Counter(
             DataMetric.BYTES_ALLOCATED.value,
             description="Bytes allocated by dataset operators",
+            tag_keys=tags_keys,
+        )
+        self.bytes_freed = Counter(
+            DataMetric.BYTES_FREED.value,
+            description="Bytes freed by dataset operators",
+            tag_keys=tags_keys,
+        )
+        self.bytes_current = Gauge(
+            DataMetric.BYTES_CURRENT.value,
+            description="Bytes currently in memory store used by dataset operators",
             tag_keys=tags_keys,
         )
         self.cpu_usage = Gauge(
@@ -216,29 +228,16 @@ class _StatsActor:
             self.last_time[stats_uuid] - self.start_time[stats_uuid],
         )
 
-    def _get_stats_dict_size(self):
-        return len(self.start_time), len(self.last_time), len(self.metadata)
-
-    def inc_bytes_spilled(self, bytes_spilled, tags):
-        if bytes_spilled > 0:
-            self.bytes_spilled.inc(bytes_spilled, tags)
-
-    def inc_rows_outputted(self, rows_outputted, tags):
-        if rows_outputted > 0:
-            self.rows_outputted.inc(rows_outputted, tags)
-
-    def inc_bytes_outputted(self, bytes_outputted, tags):
-        if bytes_outputted > 0:
-            self.bytes_outputted.inc(bytes_outputted, tags)
-
-    def set_bytes_allocated(self, bytes_allocated, tags):
-        self.bytes_allocated.set(bytes_allocated, tags)
-
-    def set_cpu_usage(self, cpu_usage, tags):
-        self.cpu_usage.set(cpu_usage, tags)
-
-    def set_gpu_usage(self, gpu_usage, tags):
-        self.gpu_usage.set(gpu_usage, tags)
+    def update_metrics(
+        self, stats: Dict[DataMetric, Union[int, float]], tags: Dict[str, str]
+    ):
+        self.bytes_spilled.inc(stats[DataMetric.BYTES_SPILLED], tags)
+        self.rows_outputted.inc(stats[DataMetric.ROWS_OUTPUTTED], tags)
+        self.bytes_outputted.inc(stats[DataMetric.BYTES_OUTPUTTED], tags)
+        self.bytes_allocated.inc(stats[DataMetric.BYTES_ALLOCATED], tags)
+        self.bytes_current.set(stats[DataMetric.BYTES_CURRENT], tags)
+        self.cpu_usage.set(stats[DataMetric.CPU_USAGE], tags)
+        self.gpu_usage.set(stats[DataMetric.GPU_USAGE], tags)
 
 
 def _get_or_create_stats_actor():
@@ -260,17 +259,13 @@ def _get_or_create_stats_actor():
     ).remote()
 
 
-def _update_stats_actor_metrics(
-    stats_actor: _StatsActor, stats: Dict[DataMetric, Any], dataset: str
-):
-    tags = {"dataset": dataset}
+stats_actor = None
 
-    stats_actor.inc_bytes_spilled.remote(stats[DataMetric.BYTES_SPILLED], tags)
-    stats_actor.inc_rows_outputted.remote(stats[DataMetric.ROWS_OUTPUTTED], tags)
-    stats_actor.inc_bytes_outputted.remote(stats[DataMetric.BYTES_OUTPUTTED], tags)
-    stats_actor.set_bytes_allocated.remote(stats[DataMetric.BYTES_ALLOCATED], tags)
-    stats_actor.set_cpu_usage.remote(stats[DataMetric.CPU_USAGE], tags)
-    stats_actor.set_gpu_usage.remote(stats[DataMetric.GPU_USAGE], tags)
+
+def _update_stats_actor_metrics(stats: Dict[DataMetric, Any], tags: Dict[str, str]):
+    if stats_actor is None:
+        stats_actor = _get_or_create_stats_actor()
+    stats_actor.update_metrics.remote(stats, tags)
 
 
 class DatasetStats:

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -154,7 +154,7 @@ class _StatsActor:
 
         # Ray Data dashboard metrics
         # Everything is a gauge because we need to reset all of
-        # a dataset's metrics to 0 after each finishing execution.
+        # a dataset's metrics to 0 after each finishes execution.
         tags_keys = ("dataset",)
         self.bytes_spilled = Gauge(
             DataMetric.BYTES_SPILLED.value,

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -284,7 +284,7 @@ def update_stats_actor_metrics(
     metric_keys = OpRuntimeMetrics.get_metric_keys()
     stats = {key: 0 for key in metric_keys}
     for op_metric in op_metrics:
-        metric_dict = op_metric.as_dict()
+        metric_dict = op_metric.as_dict(metrics_only=True)
         for key in metric_keys:
             stats[key] += metric_dict.get(key, 0)
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -150,7 +150,7 @@ class _StatsActor:
         self.bytes_spilled = Gauge(
             "data_spilled_bytes",
             description="""Bytes spilled by dataset operators.
-                DataContext.enable_get_object_locations_for_metrics 
+                DataContext.enable_get_object_locations_for_metrics
                 must be set to True to report this metric""",
             tag_keys=tags_keys,
         )
@@ -285,7 +285,8 @@ def update_stats_actor_metrics(
     stats = {key: 0 for key in metric_keys}
     for op_metric in op_metrics:
         metric_dict = op_metric.as_dict()
-        stats = {key: stats[key] + metric_dict.get(key, 0) for key in metric_keys}
+        for key in metric_keys:
+            stats[key] += metric_dict.get(key, 0)
 
     _stats_actor.update_metrics.remote(stats, tags)
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -238,7 +238,7 @@ class _StatsActor:
         self.cpu_usage.set(stats[DataMetric.CPU_USAGE], tags)
         self.gpu_usage.set(stats[DataMetric.GPU_USAGE], tags)
 
-    def remove_metrics(self, tags: Dict[str, str]):
+    def clear_metrics(self, tags: Dict[str, str]):
         self.bytes_spilled.set(0, tags)
         self.bytes_allocated.set(0, tags)
         self.bytes_freed.set(0, tags)
@@ -293,7 +293,7 @@ def update_stats_actor_metrics(stats: Dict[DataMetric, Any], tags: Dict[str, str
 def clear_stats_actor_metrics(tags: Dict[str, str]):
     global _stats_actor
     _check_cluster_stats_actor()
-    _stats_actor.remove_metrics.remote(tags)
+    _stats_actor.clear_metrics.remote(tags)
 
 
 class DatasetStats:

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -12,7 +12,7 @@ from ray.data._internal.util import capfirst
 from ray.data.block import BlockMetadata
 from ray.data.context import DataContext
 from ray.util.annotations import DeveloperAPI
-from ray.util.metrics import Counter
+from ray.util.metrics import Counter, Gauge
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 STATS_ACTOR_NAME = "datasets_stats_actor"
@@ -122,6 +122,15 @@ class _DatasetStatsBuilder:
         return stats
 
 
+class DataMetric(Enum):
+    BYTES_SPILLED = "data_spilled_bytes"
+    BYTES_ALLOCATED = "data_allocated_bytes"
+    CPU_USAGE = "data_cpu_usage_cores"
+    GPU_USAGE = "data_gpu_usage_cores"
+    ROWS_OUTPUTTED = "data_output_rows"
+    BYTES_OUTPUTTED = "data_output_bytes"
+
+
 @ray.remote(num_cpus=0)
 class _StatsActor:
     """Actor holding stats for blocks created by LazyBlockList.
@@ -142,10 +151,37 @@ class _StatsActor:
         self.max_stats = max_stats
         self.fifo_queue = []
 
+        # Ray Data dashboard metrics
+        tags_keys = ("dataset",)
         self.bytes_spilled = Counter(
-            "data_spilled_bytes",
+            DataMetric.BYTES_SPILLED.value,
             description="Bytes spilled by dataset operators",
-            tag_keys=("dataset",),
+            tag_keys=tags_keys,
+        )
+        self.bytes_allocated = Gauge(
+            DataMetric.BYTES_ALLOCATED.value,
+            description="Bytes allocated by dataset operators",
+            tag_keys=tags_keys,
+        )
+        self.cpu_usage = Gauge(
+            DataMetric.CPU_USAGE.value,
+            description="CPU cores used by dataset operators",
+            tag_keys=tags_keys,
+        )
+        self.gpu_usage = Gauge(
+            DataMetric.GPU_USAGE.value,
+            description="GPU cores used by dataset operators",
+            tag_keys=tags_keys,
+        )
+        self.rows_outputted = Counter(
+            DataMetric.ROWS_OUTPUTTED.value,
+            description="Rows outputted by dataset operators",
+            tag_keys=tags_keys,
+        )
+        self.bytes_outputted = Counter(
+            DataMetric.BYTES_OUTPUTTED.value,
+            description="Bytes outputted by dataset operators",
+            tag_keys=tags_keys,
         )
 
     def record_start(self, stats_uuid):
@@ -183,9 +219,26 @@ class _StatsActor:
     def _get_stats_dict_size(self):
         return len(self.start_time), len(self.last_time), len(self.metadata)
 
-    def inc_bytes_spilled(self, bytes_spilled, dataset):
+    def inc_bytes_spilled(self, bytes_spilled, tags):
         if bytes_spilled > 0:
-            self.bytes_spilled.inc(bytes_spilled, {"dataset": dataset})
+            self.bytes_spilled.inc(bytes_spilled, tags)
+
+    def inc_rows_outputted(self, rows_outputted, tags):
+        if rows_outputted > 0:
+            self.rows_outputted.inc(rows_outputted, tags)
+
+    def inc_bytes_outputted(self, bytes_outputted, tags):
+        if bytes_outputted > 0:
+            self.bytes_outputted.inc(bytes_outputted, tags)
+
+    def set_bytes_allocated(self, bytes_allocated, tags):
+        self.bytes_allocated.set(bytes_allocated, tags)
+
+    def set_cpu_usage(self, cpu_usage, tags):
+        self.cpu_usage.set(cpu_usage, tags)
+
+    def set_gpu_usage(self, gpu_usage, tags):
+        self.gpu_usage.set(gpu_usage, tags)
 
 
 def _get_or_create_stats_actor():
@@ -205,6 +258,19 @@ def _get_or_create_stats_actor():
         lifetime="detached",
         scheduling_strategy=scheduling_strategy,
     ).remote()
+
+
+def _update_stats_actor_metrics(
+    stats_actor: _StatsActor, stats: Dict[DataMetric, Any], dataset: str
+):
+    tags = {"dataset": dataset}
+
+    stats_actor.inc_bytes_spilled.remote(stats[DataMetric.BYTES_SPILLED], tags)
+    stats_actor.inc_rows_outputted.remote(stats[DataMetric.ROWS_OUTPUTTED], tags)
+    stats_actor.inc_bytes_outputted.remote(stats[DataMetric.BYTES_OUTPUTTED], tags)
+    stats_actor.set_bytes_allocated.remote(stats[DataMetric.BYTES_ALLOCATED], tags)
+    stats_actor.set_cpu_usage.remote(stats[DataMetric.CPU_USAGE], tags)
+    stats_actor.set_gpu_usage.remote(stats[DataMetric.GPU_USAGE], tags)
 
 
 class DatasetStats:

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -149,7 +149,9 @@ class _StatsActor:
         tags_keys = ("dataset",)
         self.bytes_spilled = Gauge(
             "data_spilled_bytes",
-            description="Bytes spilled by dataset operators",
+            description="""Bytes spilled by dataset operators.
+                DataContext.enable_get_object_locations_for_metrics 
+                must be set to True to report this metric""",
             tag_keys=tags_keys,
         )
         self.bytes_allocated = Gauge(
@@ -169,12 +171,12 @@ class _StatsActor:
         )
         self.cpu_usage = Gauge(
             "data_cpu_usage_cores",
-            description="CPUs used by dataset operators",
+            description="CPUs allocated to dataset operators",
             tag_keys=tags_keys,
         )
         self.gpu_usage = Gauge(
             "data_gpu_usage_cores",
-            description="GPUs used by dataset operators",
+            description="GPUs allocated to dataset operators",
             tag_keys=tags_keys,
         )
         self.bytes_outputted = Gauge(

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -178,12 +178,12 @@ class _StatsActor:
         )
         self.cpu_usage = Gauge(
             DataMetric.CPU_USAGE.value,
-            description="CPU cores used by dataset operators",
+            description="CPUs allocated to dataset operators",
             tag_keys=tags_keys,
         )
         self.gpu_usage = Gauge(
             DataMetric.GPU_USAGE.value,
-            description="GPU cores used by dataset operators",
+            description="GPUs allocated to dataset operators",
             tag_keys=tags_keys,
         )
         self.bytes_outputted = Gauge(

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -284,13 +284,13 @@ def _check_cluster_stats_actor():
         _stats_actor_cluster_id = current_cluster_id
 
 
-def _update_stats_actor_metrics(stats: Dict[DataMetric, Any], tags: Dict[str, str]):
+def update_stats_actor_metrics(stats: Dict[DataMetric, Any], tags: Dict[str, str]):
     global _stats_actor
     _check_cluster_stats_actor()
     _stats_actor.update_metrics.remote(stats, tags)
 
 
-def _clear_metrics(tags: Dict[str, str]):
+def clear_stats_actor_metrics(tags: Dict[str, str]):
     global _stats_actor
     _check_cluster_stats_actor()
     _stats_actor.remove_metrics.remote(tags)

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -12,7 +12,7 @@ from ray.data._internal.util import capfirst
 from ray.data.block import BlockMetadata
 from ray.data.context import DataContext
 from ray.util.annotations import DeveloperAPI
-from ray.util.metrics import Counter, Gauge
+from ray.util.metrics import Gauge
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 STATS_ACTOR_NAME = "datasets_stats_actor"
@@ -154,18 +154,20 @@ class _StatsActor:
         self.fifo_queue = []
 
         # Ray Data dashboard metrics
+        # Everything is a gauge because we need to reset all of 
+        # a dataset's metrics to 0 after each finishing execution.
         tags_keys = ("dataset",)
-        self.bytes_spilled = Counter(
+        self.bytes_spilled = Gauge(
             DataMetric.BYTES_SPILLED.value,
             description="Bytes spilled by dataset operators",
             tag_keys=tags_keys,
         )
-        self.bytes_allocated = Counter(
+        self.bytes_allocated = Gauge(
             DataMetric.BYTES_ALLOCATED.value,
             description="Bytes allocated by dataset operators",
             tag_keys=tags_keys,
         )
-        self.bytes_freed = Counter(
+        self.bytes_freed = Gauge(
             DataMetric.BYTES_FREED.value,
             description="Bytes freed by dataset operators",
             tag_keys=tags_keys,
@@ -185,12 +187,12 @@ class _StatsActor:
             description="GPU cores used by dataset operators",
             tag_keys=tags_keys,
         )
-        self.rows_outputted = Counter(
+        self.rows_outputted = Gauge(
             DataMetric.ROWS_OUTPUTTED.value,
             description="Rows outputted by dataset operators",
             tag_keys=tags_keys,
         )
-        self.bytes_outputted = Counter(
+        self.bytes_outputted = Gauge(
             DataMetric.BYTES_OUTPUTTED.value,
             description="Bytes outputted by dataset operators",
             tag_keys=tags_keys,
@@ -231,13 +233,25 @@ class _StatsActor:
     def update_metrics(
         self, stats: Dict[DataMetric, Union[int, float]], tags: Dict[str, str]
     ):
-        self.bytes_spilled.inc(stats[DataMetric.BYTES_SPILLED], tags)
-        self.rows_outputted.inc(stats[DataMetric.ROWS_OUTPUTTED], tags)
-        self.bytes_outputted.inc(stats[DataMetric.BYTES_OUTPUTTED], tags)
-        self.bytes_allocated.inc(stats[DataMetric.BYTES_ALLOCATED], tags)
+        self.bytes_spilled.set(stats[DataMetric.BYTES_SPILLED], tags)
+        self.bytes_allocated.set(stats[DataMetric.BYTES_ALLOCATED], tags)
+        self.bytes_freed.set(stats[DataMetric.BYTES_FREED], tags)
         self.bytes_current.set(stats[DataMetric.BYTES_CURRENT], tags)
+        self.rows_outputted.set(stats[DataMetric.ROWS_OUTPUTTED], tags)
+        self.bytes_outputted.set(stats[DataMetric.BYTES_OUTPUTTED], tags)
         self.cpu_usage.set(stats[DataMetric.CPU_USAGE], tags)
         self.gpu_usage.set(stats[DataMetric.GPU_USAGE], tags)
+
+    def remove_metrics(self, tags):
+        # This doesn't actually delete the metric, just sets it to 0.
+        self.bytes_spilled.set(0, tags)
+        self.bytes_allocated.set(0, tags)
+        self.bytes_freed.set(0, tags)
+        self.bytes_current.set(0, tags)
+        self.rows_outputted.set(0, tags)
+        self.bytes_outputted.set(0, tags)
+        self.cpu_usage.set(0, tags)
+        self.gpu_usage.set(0, tags)
 
 
 def _get_or_create_stats_actor():
@@ -259,13 +273,21 @@ def _get_or_create_stats_actor():
     ).remote()
 
 
-stats_actor = None
+_stats_actor = None
 
 
 def _update_stats_actor_metrics(stats: Dict[DataMetric, Any], tags: Dict[str, str]):
-    if stats_actor is None:
-        stats_actor = _get_or_create_stats_actor()
-    stats_actor.update_metrics.remote(stats, tags)
+    global _stats_actor
+    if _stats_actor is None:
+        _stats_actor = _get_or_create_stats_actor()
+    _stats_actor.update_metrics.remote(stats, tags)
+
+
+def _remove_metrics(tags: Dict[str, str]):
+    global _stats_actor
+    if _stats_actor is None:
+        _stats_actor = _get_or_create_stats_actor()
+    _stats_actor.remove_metrics.remote(tags)
 
 
 class DatasetStats:

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -10,7 +10,7 @@ import pytest
 import ray
 from ray._private.test_utils import wait_for_condition
 from ray.data._internal.dataset_logger import DatasetLogger
-from ray.data._internal.stats import DatasetStats, _StatsActor
+from ray.data._internal.stats import DataMetric, DatasetStats, _StatsActor
 from ray.data.block import BlockMetadata
 from ray.data.context import DataContext
 from ray.data.tests.util import column_udf
@@ -1138,6 +1138,54 @@ Dataset memory:
     )
 
     assert ds._plan.stats().dataset_bytes_spilled == 0
+
+
+def test_stats_actor_metrics():
+    ray.init(object_store_memory=100e6, num_gpus=1)
+    with patch(
+        "ray.data._internal.execution.streaming_executor._update_stats_actor_metrics"
+    ) as update_fn:
+        ds = ray.data.range(1000 * 80 * 80 * 4).map_batches(lambda x: x).materialize()
+
+    total_bytes_spilled = 0
+    total_bytes_allocated = 0
+    total_bytes_freed = 0
+    sum_cpu_usage = 0
+    sum_gpu_usage = 0
+    for call in update_fn.call_args_list:
+        stats = call.args[0]
+        total_bytes_spilled += stats[DataMetric.BYTES_SPILLED]
+        total_bytes_allocated += stats[DataMetric.BYTES_ALLOCATED]
+        total_bytes_freed += stats[DataMetric.BYTES_FREED]
+        sum_cpu_usage += stats[DataMetric.CPU_USAGE]
+        sum_gpu_usage += stats[DataMetric.GPU_USAGE]
+
+    assert total_bytes_spilled == ds._plan.stats().dataset_bytes_spilled
+    assert (
+        total_bytes_allocated == ds._plan.stats().extra_metrics["obj_store_mem_alloc"]
+    )
+    assert total_bytes_freed == ds._plan.stats().extra_metrics["obj_store_mem_freed"]
+    # There should be nothing in object store at the end of execution.
+    assert update_fn.call_args_list[-1].args[0][DataMetric.BYTES_CURRENT] == 0
+
+    # Check that some CPU was used, and no GPU was used
+    assert sum_cpu_usage > 0
+    assert sum_gpu_usage == 0
+
+    # map_batches with GPU
+    with patch(
+        "ray.data._internal.execution.streaming_executor._update_stats_actor_metrics"
+    ) as update_fn:
+        ds = (
+            ray.data.range(1024)
+            .map_batches(lambda x: x, num_cpus=0, num_gpus=1, batch_size=1024)
+            .materialize()
+        )
+
+    sum_gpu_usage = sum(
+        [call.args[0][DataMetric.GPU_USAGE] for call in update_fn.call_args_list]
+    )
+    assert sum_gpu_usage > 0
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1143,7 +1143,7 @@ Dataset memory:
 def test_stats_actor_metrics():
     ray.init(object_store_memory=100e6, num_gpus=1)
     with patch(
-        "ray.data._internal.execution.streaming_executor._update_stats_actor_metrics"
+        "ray.data._internal.execution.streaming_executor.update_stats_actor_metrics"
     ) as update_fn:
         ds = ray.data.range(1000 * 80 * 80 * 4).map_batches(lambda x: x).materialize()
 
@@ -1175,7 +1175,7 @@ def test_stats_actor_metrics():
 
     # map_batches with GPU
     with patch(
-        "ray.data._internal.execution.streaming_executor._update_stats_actor_metrics"
+        "ray.data._internal.execution.streaming_executor.update_stats_actor_metrics"
     ) as update_fn:
         ds = (
             ray.data.range(1024)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -10,7 +10,6 @@ import pytest
 import ray
 from ray._private.test_utils import wait_for_condition
 from ray.data._internal.dataset_logger import DatasetLogger
-from ray.data._internal.execution.interfaces.op_runtime_metrics import OpRuntimeMetrics
 from ray.data._internal.stats import DatasetStats, _StatsActor
 from ray.data.block import BlockMetadata
 from ray.data.context import DataContext

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1094,8 +1094,29 @@ def test_stats_actor_cap_num_stats(ray_start_cluster):
 def test_spilled_stats(shutdown_only):
     # The object store is about 100MB.
     ray.init(object_store_memory=100e6)
-    # The size of dataset is 1000*80*80*4*8B, about 200MB.
-    ds = ray.data.range(1000 * 80 * 80 * 4).map_batches(lambda x: x).materialize()
+
+    class RemoteCalls:
+        def __init__(self):
+            self.calls = []
+
+        def remote(self, value, dataset):
+            self.calls.append((value, dataset))
+
+    class _MockDatasetMetrics:
+        def __init__(self):
+            self.inc_bytes_spilled = RemoteCalls()
+
+    mock_metrics = _MockDatasetMetrics()
+
+    with patch(
+        "ray.data._internal.execution.streaming_executor._get_or_create_dataset_metrics",
+        lambda: mock_metrics,
+    ):
+        # The size of dataset is 1000*80*80*4*8B, about 200MB.
+        ds = ray.data.range(1000 * 80 * 80 * 4).map_batches(lambda x: x).materialize()
+        total_bytes_spilled = sum(
+            [call[0] for call in mock_metrics.inc_bytes_spilled.calls]
+        )
 
     assert (
         canonicalize(ds.stats(), filter_global_stats=False)
@@ -1119,6 +1140,7 @@ Dataset memory:
 
     # Around 100MB should be spilled (200MB - 100MB)
     assert ds._plan.stats().dataset_bytes_spilled > 100e6
+    assert ds._plan.stats().dataset_bytes_spilled == total_bytes_spilled
 
     ds = (
         ray.data.range(1000 * 80 * 80 * 4)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1147,16 +1147,15 @@ def test_stats_actor_metrics():
     ) as update_fn:
         ds = ray.data.range(1000 * 80 * 80 * 4).map_batches(lambda x: x).materialize()
 
-    total_bytes_spilled = 0
-    total_bytes_allocated = 0
-    total_bytes_freed = 0
+    last_stats = update_fn.call_args_list[-1].args[0]
+
+    total_bytes_spilled = last_stats[DataMetric.BYTES_SPILLED]
+    total_bytes_allocated = last_stats[DataMetric.BYTES_ALLOCATED]
+    total_bytes_freed = last_stats[DataMetric.BYTES_FREED]
     sum_cpu_usage = 0
     sum_gpu_usage = 0
     for call in update_fn.call_args_list:
         stats = call.args[0]
-        total_bytes_spilled += stats[DataMetric.BYTES_SPILLED]
-        total_bytes_allocated += stats[DataMetric.BYTES_ALLOCATED]
-        total_bytes_freed += stats[DataMetric.BYTES_FREED]
         sum_cpu_usage += stats[DataMetric.CPU_USAGE]
         sum_gpu_usage += stats[DataMetric.GPU_USAGE]
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1152,6 +1152,7 @@ def test_stats_actor_metrics():
     total_bytes_spilled = last_stats[DataMetric.BYTES_SPILLED]
     total_bytes_allocated = last_stats[DataMetric.BYTES_ALLOCATED]
     total_bytes_freed = last_stats[DataMetric.BYTES_FREED]
+    total_bytes_outputted = last_stats[DataMetric.BYTES_OUTPUTTED]
     sum_cpu_usage = 0
     sum_gpu_usage = 0
     for call in update_fn.call_args_list:
@@ -1164,6 +1165,7 @@ def test_stats_actor_metrics():
         total_bytes_allocated == ds._plan.stats().extra_metrics["obj_store_mem_alloc"]
     )
     assert total_bytes_freed == ds._plan.stats().extra_metrics["obj_store_mem_freed"]
+    assert total_bytes_outputted == 1000 * 80 * 80 * 4 * 8  # 8B per int
     # There should be nothing in object store at the end of execution.
     assert update_fn.call_args_list[-1].args[0][DataMetric.BYTES_CURRENT] == 0
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -43,6 +43,8 @@ def gen_expected_metrics(
             "'obj_store_mem_cur': Z",
             "'obj_store_mem_peak': N",
             f"""'obj_store_mem_spilled': {"N" if spilled else "Z"}""",
+            "'cpu_usage': Z",
+            "'gpu_usage': Z",
         ]
     else:
         metrics = [
@@ -50,6 +52,8 @@ def gen_expected_metrics(
             "'bytes_inputs_received': N",
             "'num_outputs_taken': N",
             "'bytes_outputs_taken': N",
+            "'cpu_usage': Z",
+            "'gpu_usage': Z",
         ]
     if extra_metrics:
         metrics.extend(extra_metrics)
@@ -549,6 +553,8 @@ def test_dataset__repr__(ray_start_regular_shared):
         "      obj_store_mem_cur: Z,\n"
         "      obj_store_mem_peak: N,\n"
         "      obj_store_mem_spilled: Z,\n"
+        "      cpu_usage: Z,\n"
+        "      gpu_usage: Z,\n"
         "      ray_remote_args: {'num_cpus': N, 'scheduling_strategy': 'SPREAD'},\n"
         "   },\n"
         "   stage_stats=[\n"

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1109,7 +1109,7 @@ def test_spilled_stats(shutdown_only):
     mock_metrics = _MockDatasetMetrics()
 
     with patch(
-        "ray.data._internal.execution.streaming_executor._get_or_create_dataset_metrics",
+        "ray.data._internal.execution.streaming_executor._get_or_create_stats_actor",
         lambda: mock_metrics,
     ):
         # The size of dataset is 1000*80*80*4*8B, about 200MB.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Stores dataset metrics in `_StatsActor`. These stats will be emitted to prometheus and used to create the Ray Data Dashboard. Stats will be collected by `StreamingExecutors` after each `_scheduling_loop_step`.

To be displayed under the "Ray Data Metrics" under metrics tab in ray dashboard

<img width="1727" alt="Screenshot 2023-10-11 at 10 44 23 AM" src="https://github.com/ray-project/ray/assets/39287272/09f409e8-e566-4486-bcc5-96e5b21bd796">
 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
