### PR TITLE
[civ2][docker/1] change python version format

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -5,10 +5,10 @@ steps:
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- wheel --python-version {{matrix}}
     matrix:
-      - py38
-      - py39
-      - py310
-      - py311
+      - "3.8"
+      - "3.9"
+      - "3.10"
+      - "3.11"
     depends_on:
       - manylinux
       - forge
@@ -33,7 +33,7 @@ steps:
   - label: ":tapioca: build: ray py38 cu118 docker"
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version py38
+      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version 3.8
         --platform cu118 --image-type ray
     depends_on:
       - manylinux
@@ -44,7 +44,7 @@ steps:
   - label: ":tapioca: build: ray-ml py38 cu118 docker"
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version py38
+      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version 3.8
         --platform cu118 --image-type ray-ml
     depends_on:
       - manylinux

--- a/ci/ray_ci/builder.py
+++ b/ci/ray_ci/builder.py
@@ -18,7 +18,7 @@ from ci.ray_ci.utils import logger, docker_login
 )
 @click.option(
     "--python-version",
-    default="py38",
+    default="3.8",
     type=click.Choice(list(PYTHON_VERSIONS.keys())),
     help=("Python version to build the wheel with"),
 )

--- a/ci/ray_ci/builder_container.py
+++ b/ci/ray_ci/builder_container.py
@@ -10,10 +10,10 @@ class PythonVersionInfo(TypedDict):
 
 
 PYTHON_VERSIONS = {
-    "py38": PythonVersionInfo(bin_path="cp38-cp38", numpy_version="1.19.3"),
-    "py39": PythonVersionInfo(bin_path="cp39-cp39", numpy_version="1.19.3"),
-    "py310": PythonVersionInfo(bin_path="cp310-cp310", numpy_version="1.22.0"),
-    "py311": PythonVersionInfo(bin_path="cp311-cp311", numpy_version="1.22.0"),
+    "3.8": PythonVersionInfo(bin_path="cp38-cp38", numpy_version="1.19.3"),
+    "3.9": PythonVersionInfo(bin_path="cp39-cp39", numpy_version="1.19.3"),
+    "3.10": PythonVersionInfo(bin_path="cp310-cp310", numpy_version="1.22.0"),
+    "3.11": PythonVersionInfo(bin_path="cp311-cp311", numpy_version="1.22.0"),
 }
 
 

--- a/ci/ray_ci/docker_container.py
+++ b/ci/ray_ci/docker_container.py
@@ -17,7 +17,7 @@ class DockerContainer(Container):
     def __init__(self, python_version: str, platform: str, image_type: str) -> None:
         assert "RAYCI_CHECKOUT_DIR" in os.environ, "RAYCI_CHECKOUT_DIR not set"
         rayci_checkout_dir = os.environ["RAYCI_CHECKOUT_DIR"]
-        self.python_version = python_version
+        self.python_version = f"py{python_version.replace('.', '')}"  # 3.8 -> py38
         self.platform = platform
         self.image_type = image_type
 

--- a/ci/ray_ci/ray_docker_container.py
+++ b/ci/ray_ci/ray_docker_container.py
@@ -25,7 +25,8 @@ class RayDockerContainer(DockerContainer):
         )
         docker_pull(base_image)
 
-        bin_path = PYTHON_VERSIONS[self.python_version]["bin_path"]
+        bin_path_py_version = f"3.{self.python_version[3:]}"  # py38 -> 3.8
+        bin_path = PYTHON_VERSIONS[bin_path_py_version]["bin_path"]
         wheel_name = f"ray-{RAY_VERSION}-{bin_path}-manylinux2014_x86_64.whl"
 
         constraints_file = "requirements_compiled.txt"

--- a/ci/ray_ci/test_anyscale_docker_container.py
+++ b/ci/ray_ci/test_anyscale_docker_container.py
@@ -19,7 +19,7 @@ class TestAnyscaleDockerContainer(RayCITestBase):
             "ci.ray_ci.docker_container.Container.run_script",
             side_effect=_mock_run_script,
         ):
-            container = AnyscaleDockerContainer("py38", "cu118", "ray")
+            container = AnyscaleDockerContainer("3.8", "cu118", "ray")
             container.run()
             cmd = self.cmds[-1]
             assert cmd == (

--- a/ci/ray_ci/test_ray_docker_container.py
+++ b/ci/ray_ci/test_ray_docker_container.py
@@ -24,7 +24,7 @@ class TestRayDockerContainer(RayCITestBase):
             "ci.ray_ci.docker_container.Container.run_script",
             side_effect=_mock_run_script,
         ):
-            container = RayDockerContainer("py38", "cu118", "ray")
+            container = RayDockerContainer("3.8", "cu118", "ray")
             container.run()
             cmd = self.cmds[-1]
             assert cmd == (
@@ -35,7 +35,7 @@ class TestRayDockerContainer(RayCITestBase):
                 "rayproject/ray:123456-py38-cu118"
             )
 
-            container = RayDockerContainer("py39", "cpu", "ray-ml")
+            container = RayDockerContainer("3.9", "cpu", "ray-ml")
             container.run()
             cmd = self.cmds[-1]
             assert cmd == (
@@ -47,20 +47,20 @@ class TestRayDockerContainer(RayCITestBase):
             )
 
     def test_canonical_tag(self) -> None:
-        container = RayDockerContainer("py38", "cpu", "ray")
+        container = RayDockerContainer("3.8", "cpu", "ray")
         assert container._get_canonical_tag() == "123456-py38-cpu"
 
-        container = RayDockerContainer("py38", "cu118", "ray-ml")
+        container = RayDockerContainer("3.8", "cu118", "ray-ml")
         assert container._get_canonical_tag() == "123456-py38-cu118"
 
         with mock.patch.dict(os.environ, {"BUILDKITE_BRANCH": "releases/1.0.0"}):
-            container = RayDockerContainer("py38", "cpu", "ray")
+            container = RayDockerContainer("3.8", "cpu", "ray")
             assert container._get_canonical_tag() == "1.0.0.123456-py38-cpu"
 
     def test_get_image_tags(self) -> None:
         # bulk logic of _get_image_tags is tested in its callers (get_image_name and
         # get_canonical_tag), so we only test the basic cases here
-        container = RayDockerContainer("py38", "cpu", "ray")
+        container = RayDockerContainer("3.8", "cpu", "ray")
         assert container._get_image_tags() == [
             "123456-py38-cpu",
             "123456-cpu",
@@ -73,7 +73,7 @@ class TestRayDockerContainer(RayCITestBase):
         ]
 
     def test_get_image_name(self) -> None:
-        container = RayDockerContainer("py38", "cpu", "ray")
+        container = RayDockerContainer("3.8", "cpu", "ray")
         assert container._get_image_names() == [
             "rayproject/ray:123456-py38-cpu",
             "rayproject/ray:123456-cpu",
@@ -85,7 +85,7 @@ class TestRayDockerContainer(RayCITestBase):
             "rayproject/ray:nightly",
         ]
 
-        container = RayDockerContainer("py39", "cu118", "ray-ml")
+        container = RayDockerContainer("3.9", "cu118", "ray-ml")
         assert container._get_image_names() == [
             "rayproject/ray-ml:123456-py39-cu118",
             "rayproject/ray-ml:123456-py39-gpu",
@@ -96,7 +96,7 @@ class TestRayDockerContainer(RayCITestBase):
         ]
 
         with mock.patch.dict(os.environ, {"BUILDKITE_BRANCH": "releases/1.0.0"}):
-            container = RayDockerContainer("py38", "cpu", "ray")
+            container = RayDockerContainer("3.8", "cpu", "ray")
             assert container._get_image_names() == [
                 "rayproject/ray:1.0.0.123456-py38-cpu",
                 "rayproject/ray:1.0.0.123456-cpu",


### PR DESCRIPTION
Use a different python version format (py38 --> 3.8) for //rayci:build. This is necessary to align the format used by docker and wheel images.

Test:
- CI