### PR TITLE
[civ2][docker/3] build multiple ray docker per python version

### DIFF
--- a/.buildkite/_forge.rayci.yml
+++ b/.buildkite/_forge.rayci.yml
@@ -30,6 +30,21 @@ steps:
       PYTHON_VERSION: "{{matrix.python}}"
       CUDA_VERSION: "{{matrix.cuda}}"
 
+  - name: raycpubase
+    label: "wanda: ray.py{{matrix}}.cpu.base"
+    tags:
+      - python_dependencies
+      - docker
+      - core_cpp
+    wanda: ci/docker/ray.cpu.base.wanda.yaml
+    matrix:
+      - "3.8"
+      - "3.9"
+      - "3.10"
+      - "3.11"
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+
   - name: ray-mlcudabase
     label: "wanda: ray-ml.py{{matrix.python}}.cu{{matrix.cuda}}.base"
     tags:
@@ -49,6 +64,21 @@ steps:
     env:
       PYTHON_VERSION: "{{matrix.python}}"
       CUDA_VERSION: "{{matrix.cuda}}"
+
+  - name: ray-mlcpubase
+    label: "wanda: ray-ml.py{{matrix}}.cpu.base"
+    tags:
+      - python_dependencies
+      - docker
+      - core_cpp
+    wanda: ci/docker/ray-ml.cpu.base.wanda.yaml
+    depends_on: raycpubase
+    matrix:
+      - "3.8"
+      - "3.9"
+      - "3.10"
+    env:
+      PYTHON_VERSION: "{{matrix}}"
   
   - name: oss-ci-base_test
     wanda: ci/docker/base.test.wanda.yaml

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -39,12 +39,13 @@ steps:
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
         --platform cu11.5.2 --platform cu11.6.2 --platform cu11.7.1 
-        --platform cu11.8.0 --platform cu12.1.1
+        --platform cu11.8.0 --platform cu12.1.1 --platform cpu
         --image-type ray
     depends_on:
       - manylinux
       - forge
       - raycudabase
+      - raycpubase
     job_env: forge
     matrix:
       - "3.8"
@@ -60,11 +61,12 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
-        --platform cu11.8.0 --image-type ray-ml
+        --platform cu11.8.0 --platform cpu --image-type ray-ml
     depends_on:
       - manylinux
       - forge
       - ray-mlcudabase
+      - ray-mlcpubase
     job_env: forge
     matrix:
       - "3.8"

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -30,56 +30,46 @@ steps:
     depends_on: docbuild
     job_env: forge
 
-  - label: ":tapioca: build: ray py{{matrix.python}} cu{{matrix.cuda}} docker"
+  - label: ":tapioca: build: ray py{{matrix}} docker"
     tags:
       - python_dependencies
       - docker
       - core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix.python}}
-        --platform cu{{matrix.cuda}} --image-type ray
+      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
+        --platform cu11.5.2 --platform cu11.6.2 --platform cu11.7.1 
+        --platform cu11.8.0 --platform cu12.1.1
+        --image-type ray
     depends_on:
       - manylinux
       - forge
       - raycudabase
     job_env: forge
     matrix:
-      setup:
-        python:
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-        cuda:
-          - "11.5.2"
-          - "11.6.2"
-          - "11.7.1"
-          - "11.8.0"
-          - "12.1.1"
+      - "3.8"
+      - "3.9"
+      - "3.10"
+      - "3.11"
 
-  - label: ":tapioca: build: ray-ml py{{matrix.python}} cu{{matrix.cuda}} docker"
+  - label: ":tapioca: build: ray-ml py{{matrix}} docker"
     tags:
       - python_dependencies
       - docker
       - core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix.python}}
-        --platform cu{{matrix.cuda}} --image-type ray-ml
+      - bazel run //ci/ray_ci:build_in_docker -- docker --python-version {{matrix}}
+        --platform cu11.8.0 --image-type ray-ml
     depends_on:
       - manylinux
       - forge
       - ray-mlcudabase
     job_env: forge
     matrix:
-      setup:
-        python:
-          - "3.8"
-          - "3.9"
-          - "3.10"
-        cuda:
-          - "11.8.0"
+      - "3.8"
+      - "3.9"
+      - "3.10"
 
   - label: ":tapioca: build: pip-compile dependencies"
     instance_type: small

--- a/.buildkite/pipeline.build_release.yml
+++ b/.buildkite/pipeline.build_release.yml
@@ -37,18 +37,3 @@
     - python .buildkite/copy_files.py --destination branch_wheels --path ./.whl
     # Upload to latest directory.
     - if [ "$BUILDKITE_BRANCH" == "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
-
-- label: ":docker: Build Images: {{matrix}} - cpu"
-  conditions: ["RAY_CI_PYTHON_DEPENDENCIES_AFFECTED", "RAY_CI_DOCKER_AFFECTED", "RAY_CI_CORE_CPP_AFFECTED"]
-  instance_size: medium
-  commands:
-    - LINUX_WHEELS=1 BUILD_ONE_PYTHON_ONLY={{matrix}} ./ci/ci.sh build
-    - pip install -q docker aws_requests_auth boto3
-    - ./ci/env/env_info.sh
-    - if [[ "${BUILDKITE_PULL_REQUEST}" == "false" ]]; then python .buildkite/copy_files.py --destination docker_login; fi
-    - python ./ci/build/build-docker-images.py --py-versions {{matrix}} -T cpu --build-type BUILDKITE --build-base
-  matrix:
-    - py38
-    - py39
-    - py310
-    - py311

--- a/ci/docker/ray-ml.cpu.base.wanda.yaml
+++ b/ci/docker/ray-ml.cpu.base.wanda.yaml
@@ -1,0 +1,22 @@
+name: "ray-ml-py$PYTHON_VERSION-cpu-base"
+froms: ["cr.ray.io/rayproject/ray-py$PYTHON_VERSION-cpu-base"]
+dockerfile: docker/ray-ml/Dockerfile
+srcs:
+  - python/requirements.txt
+  - python/requirements_compiled.txt
+  - python/requirements/ml/dl-cpu-requirements.txt
+  - python/requirements/ml/dl-gpu-requirements.txt
+  - python/requirements/ml/core-requirements.txt
+  - python/requirements/ml/data-requirements.txt
+  - python/requirements/ml/rllib-requirements.txt
+  - python/requirements/ml/rllib-test-requirements.txt
+  - python/requirements/ml/train-requirements.txt
+  - python/requirements/ml/train-test-requirements.txt
+  - python/requirements/ml/tune-requirements.txt
+  - python/requirements/ml/tune-test-requirements.txt
+  - python/requirements/docker/ray-docker-requirements.txt
+  - docker/ray-ml/install-ml-docker-requirements.sh
+build_args:
+  - FULL_BASE_IMAGE=cr.ray.io/rayproject/ray-py$PYTHON_VERSION-cpu-base
+tags:
+  - cr.ray.io/rayproject/ray-ml-py$PYTHON_VERSION-cpu-base

--- a/ci/docker/ray.cpu.base.wanda.yaml
+++ b/ci/docker/ray.cpu.base.wanda.yaml
@@ -1,0 +1,8 @@
+name: "ray-py$PYTHON_VERSION-cpu-base"
+froms: ["ubuntu:focal"]
+dockerfile: docker/base-deps/Dockerfile
+build_args:
+  - PYTHON_VERSION
+  - BASE_IMAGE=ubuntu:focal
+tags:
+  - cr.ray.io/rayproject/ray-py$PYTHON_VERSION-cpu-base

--- a/ci/ray_ci/builder.py
+++ b/ci/ray_ci/builder.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import click
 
 from ci.ray_ci.builder_container import PYTHON_VERSIONS, BuilderContainer
@@ -17,6 +19,11 @@ from ci.ray_ci.utils import logger, docker_login
     type=click.Choice(["wheel", "doc", "docker", "anyscale"]),
 )
 @click.option(
+    "--image-type",
+    default="ray",
+    type=click.Choice(["ray", "ray-ml"]),
+)
+@click.option(
     "--python-version",
     default="3.8",
     type=click.Choice(list(PYTHON_VERSIONS.keys())),
@@ -24,20 +31,15 @@ from ci.ray_ci.utils import logger, docker_login
 )
 @click.option(
     "--platform",
-    default="cu11.8.0",
+    multiple=True,
     type=click.Choice(list(PLATFORM)),
     help=("Platform to build the docker with"),
 )
-@click.option(
-    "--image-type",
-    default="ray",
-    type=click.Choice(["ray", "ray-ml"]),
-)
 def main(
     artifact_type: str,
-    python_version: str,
-    platform: str,
     image_type: str,
+    python_version: str,
+    platform: List[str],
 ) -> None:
     """
     Build a wheel or jar artifact
@@ -50,14 +52,14 @@ def main(
 
     if artifact_type == "docker":
         logger.info(f"Building {image_type} docker for {python_version} on {platform}")
-        build_docker(python_version, platform, image_type)
+        build_docker(image_type, python_version, platform)
         return
 
     if artifact_type == "anyscale":
         logger.info(
             f"Building {image_type} anyscale for {python_version} on {platform}"
         )
-        build_anyscale(python_version, platform, image_type)
+        build_anyscale(image_type, python_version, platform)
         return
 
     if artifact_type == "doc":
@@ -76,21 +78,23 @@ def build_wheel(python_version: str) -> None:
     ForgeContainer().upload_wheel()
 
 
-def build_docker(python_version: str, platform: str, image_type: str) -> None:
+def build_docker(image_type: str, python_version: str, platform: List[str]) -> None:
     """
     Build a container artifact.
     """
     BuilderContainer(python_version).run()
-    RayDockerContainer(python_version, platform, image_type).run()
+    for p in platform:
+        RayDockerContainer(python_version, p, image_type).run()
 
 
-def build_anyscale(python_version: str, platform: str, image_type: str) -> None:
+def build_anyscale(image_type: str, python_version: str, platform: List[str]) -> None:
     """
     Build an anyscale container artifact.
     """
     BuilderContainer(python_version).run()
-    RayDockerContainer(python_version, platform, image_type).run()
-    AnyscaleDockerContainer(python_version, platform, image_type).run()
+    for p in platform:
+        RayDockerContainer(python_version, p, image_type).run()
+        AnyscaleDockerContainer(python_version, p, image_type).run()
 
 
 def build_doc() -> None:


### PR DESCRIPTION
Add supports for building multiple ray docker images for one python version in a single job. This save ray build time, reduces the number of machines required.

Test:
- CI