### PR TITLE
[ci][release] fix release tests, upgrade typepy

### DIFF
--- a/release/ray_release/byod/requirements_ml_byod_3.9.in
+++ b/release/ray_release/byod/requirements_ml_byod_3.9.in
@@ -25,4 +25,5 @@ torchmetrics
 torchtext
 torchvision
 transformers>=4.31.0
+typepy>=1.3.2
 wandb

--- a/release/ray_release/byod/requirements_ml_byod_3.9.txt
+++ b/release/ray_release/byod/requirements_ml_byod_3.9.txt
@@ -2558,10 +2558,11 @@ triton==2.0.0 \
     # via
     #   openai-whisper
     #   torch
-typepy[datetime]==1.3.1 \
-    --hash=sha256:892566bff279368d63f02901aba0a3ce78cd7a319ec1f2bf6c8baab3520207a3 \
-    --hash=sha256:dfc37b888d6eed8542208389efa60ec8454e06fd84b276b45b2e33897f9d7825
+typepy[datetime]==1.3.2 \
+    --hash=sha256:b69fd48b9f50cdb3809906eef36b855b3134ff66c8893a4f8580abddb0b39517 \
+    --hash=sha256:d5d1022a424132622993800f1d2cd16cfdb691ac4e3b9c325f0fcb37799db1ae
     # via
+    #   -r release/ray_release/byod/requirements_ml_byod_3.9.in
     #   dataproperty
     #   pytablewriter
     #   tabledata


### PR DESCRIPTION
Upgrade typepy, typepy 1.3.1 is broken

https://buildkite.com/ray-project/release-tests-branch/builds/2225#018afbb2-428e-4364-b26c-7c49052edd26

```
#14 80.99 ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
--
  | 2023-10-05 07:42:44 PDT | #14 80.99     typepy<2,>=1.2.0 from https://files.pythonhosted.org/packages/f1/10/0d6dc654bb4e0eca017bbaf43a315b464c888576a68a2883cd4a74bd1b6b/typepy-1.3.2-py3-none-any.whl (from tabledata==1.3.1->-r requirements_ml_byod_3.9.txt (line 2259))
```

Test:
- CI
- Install requirements_ml_byod_3.9.txt locally

