### PR TITLE
[Data] Add support for shuffling input files

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass, field
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 from .common import NodeIdStr
 from ray.data._internal.execution.util import memory_string
@@ -101,6 +101,10 @@ class ExecutionOptions:
         verbose_progress: Whether to report progress individually per operator. By
             default, only AllToAll operators and global progress is reported. This
             option is useful for performance debugging. Off by default.
+        shuffle_input: Set this to shuffle input before execution. The shuffle seed
+            (as an integer) can also be set. Note current implementation only shuffles
+            the order of input files, but does not shuffle the order of rows inside
+            each file. Off by default.
     """
 
     resource_limits: ExecutionResources = field(default_factory=ExecutionResources)
@@ -112,3 +116,5 @@ class ExecutionOptions:
     actor_locality_enabled: bool = True
 
     verbose_progress: bool = bool(int(os.environ.get("RAY_DATA_VERBOSE_PROGRESS", "0")))
+
+    shuffle_input: Union[bool, Tuple[bool, int]] = False

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Union
 
 from .common import NodeIdStr
 from ray.data._internal.execution.util import memory_string
@@ -101,10 +101,6 @@ class ExecutionOptions:
         verbose_progress: Whether to report progress individually per operator. By
             default, only AllToAll operators and global progress is reported. This
             option is useful for performance debugging. Off by default.
-        shuffle_input: Set this to shuffle input before execution. The shuffle seed
-            (as an integer) can also be set. Note current implementation only shuffles
-            the order of input files, but does not shuffle the order of rows inside
-            each file. Off by default.
     """
 
     resource_limits: ExecutionResources = field(default_factory=ExecutionResources)
@@ -116,5 +112,3 @@ class ExecutionOptions:
     actor_locality_enabled: bool = True
 
     verbose_progress: bool = bool(int(os.environ.get("RAY_DATA_VERBOSE_PROGRESS", "0")))
-
-    shuffle_input: Union[bool, Tuple[bool, int]] = False

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -511,7 +511,9 @@ class _FileBasedDatasourceReader(Reader):
                     "No input files found to read. Please double check that "
                     "'partition_filter' field is set properly."
                 )
-        self._file_metadata_shuffler = FileMetadataShuffler()
+        self._file_metadata_shuffler = FileMetadataShuffler(
+            reader_args.get("shuffle", None)
+        )
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
         total_size = 0

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -284,6 +284,7 @@ class DefaultParquetMetadataProvider(ParquetMetadataProvider):
         if (
             prefetched_metadata is not None
             and len(prefetched_metadata) == num_fragments
+            and all(m is not None for m in prefetched_metadata)
         ):
             # Fragment metadata was available, construct a normal
             # BlockMetadata.

--- a/python/ray/data/datasource/file_metadata_shuffler.py
+++ b/python/ray/data/datasource/file_metadata_shuffler.py
@@ -1,29 +1,24 @@
-from typing import Any, List
+import sys
+from typing import Any, List, Union
 
 import numpy as np
 
-from ray.data.context import DataContext
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class FileMetadataShuffler:
-    """Random shuffle file metadata when the `DataContext` enables it.
+    """Random shuffle file metadata when the `shuffle` parameter enables it.
     Otherwise returns file metadata in its original order.
     """
 
-    def __init__(self):
-        ctx = DataContext.get_current()
-        shuffle_input = ctx.execution_options.shuffle_input
-        is_shuffle_enabled = False
-        shuffle_seed = None
-        if isinstance(shuffle_input, bool):
-            is_shuffle_enabled = shuffle_input
-        else:
-            assert isinstance(shuffle_input, tuple) and len(shuffle_input) == 2
-            is_shuffle_enabled, shuffle_seed = shuffle_input
-
-        self._is_shuffle_enabled = is_shuffle_enabled
-        if self._is_shuffle_enabled:
-            self._generator = np.random.default_rng(shuffle_seed)
+    def __init__(self, shuffle: Union[Literal["files"], None]):
+        self._is_shuffle_enabled = False
+        if shuffle == "files":
+            self._is_shuffle_enabled = True
+            self._generator = np.random.default_rng()
 
     def shuffle_files(
         self,

--- a/python/ray/data/datasource/file_metadata_shuffler.py
+++ b/python/ray/data/datasource/file_metadata_shuffler.py
@@ -1,34 +1,38 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, List
+
+import numpy as np
+
+from ray.data.context import DataContext
 
 
 class FileMetadataShuffler:
-    """Abstract class for file metadata shuffler.
-
-    Shufflers live on the driver side of the Dataset only.
+    """Random shuffle file metadata when the `DataContext` enables it.
+    Otherwise returns file metadata in its original order.
     """
 
-    def __init__(self, reader_args: Dict[str, Any]):
-        self._reader_args = reader_args
+    def __init__(self):
+        ctx = DataContext.get_current()
+        shuffle_input = ctx.execution_options.shuffle_input
+        is_shuffle_enabled = False
+        shuffle_seed = None
+        if isinstance(shuffle_input, bool):
+            is_shuffle_enabled = shuffle_input
+        else:
+            assert isinstance(shuffle_input, tuple) and len(shuffle_input) == 2
+            is_shuffle_enabled, shuffle_seed = shuffle_input
+
+        self._is_shuffle_enabled = is_shuffle_enabled
+        if self._is_shuffle_enabled:
+            self._generator = np.random.default_rng(shuffle_seed)
 
     def shuffle_files(
         self,
-        paths_and_sizes: List[Tuple[str, int]],
-    ) -> List[Tuple[str, int]]:
-        """Shuffle files in the given paths and sizes.
-
-        Args:
-            paths_and_sizes: The file paths and file sizes to shuffle.
-
-        Returns:
-            The file paths and their sizes after shuffling.
-        """
-        raise NotImplementedError
-
-
-class SequentialFileMetadataShuffler(FileMetadataShuffler):
-    def shuffle_files(
-        self,
-        paths_and_sizes: List[Tuple[str, int]],
-    ) -> List[Tuple[str, int]]:
-        """Return files in the given paths and sizes sequentially."""
-        return paths_and_sizes
+        files_metadata: List[Any],
+    ) -> List[Any]:
+        if self._is_shuffle_enabled:
+            return [
+                files_metadata[i]
+                for i in self._generator.permutation(len(files_metadata))
+            ]
+        else:
+            return files_metadata

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -276,7 +276,9 @@ class _ParquetDatasourceReader(Reader):
         self._columns = columns
         self._schema = schema
         self._encoding_ratio = self._estimate_files_encoding_ratio()
-        self._file_metadata_shuffler = FileMetadataShuffler()
+        self._file_metadata_shuffler = FileMetadataShuffler(
+            reader_args.get("shuffle", None)
+        )
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
         total_size = 0

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2,6 +2,7 @@ import collections
 import logging
 import math
 import os
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -85,6 +86,11 @@ from ray.types import ObjectRef
 from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 if TYPE_CHECKING:
     import dask
@@ -632,6 +638,7 @@ def read_parquet(
     tensor_column_schema: Optional[Dict[str, Tuple[np.dtype, Tuple[int, ...]]]] = None,
     meta_provider: Optional[ParquetMetadataProvider] = None,
     partition_filter: Optional[PathPartitionFilter] = None,
+    shuffle: Union[Literal["files"], None] = None,
     **arrow_parquet_args,
 ) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from parquet files.
@@ -738,6 +745,8 @@ def read_parquet(
         partition_filter: A
             :class:`~ray.data.datasource.partitioning.PathPartitionFilter`. Use
             with a custom callback to read only selected partitions of a dataset.
+        shuffle: If setting to "files", randomly shuffle input files order before read.
+            Defaults to not shuffle with ``None``.
         arrow_parquet_args: Other parquet read options to pass to PyArrow. For the full
             set of arguments, see the`PyArrow API <https://arrow.apache.org/docs/\
                 python/generated/pyarrow.dataset.Scanner.html\
@@ -783,6 +792,7 @@ def read_images(
     mode: Optional[str] = None,
     include_paths: bool = False,
     ignore_missing_paths: bool = False,
+    shuffle: Union[Literal["files"], None] = None,
 ) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from image files.
 
@@ -875,6 +885,8 @@ def read_images(
             stored in the ``'path'`` column.
         ignore_missing_paths: If True, ignores any file/directory paths in ``paths``
             that are not found. Defaults to False.
+        shuffle: If setting to "files", randomly shuffle input files order before read.
+            Defaults to not shuffle with ``None``.
 
     Returns:
         A :class:`~ray.data.Dataset` producing tensors that represent the images at
@@ -901,6 +913,7 @@ def read_images(
         mode=mode,
         include_paths=include_paths,
         ignore_missing_paths=ignore_missing_paths,
+        shuffle=shuffle,
     )
 
 
@@ -918,6 +931,7 @@ def read_parquet_bulk(
     partition_filter: Optional[PathPartitionFilter] = (
         ParquetBaseDatasource.file_extension_filter()
     ),
+    shuffle: Union[Literal["files"], None] = None,
     **arrow_parquet_args,
 ) -> Dataset:
     """Create :class:`~ray.data.Dataset` from parquet files without reading metadata.
@@ -986,6 +1000,8 @@ def read_parquet_bulk(
             with a custom callback to read only selected partitions of a dataset.
             By default, this filters out any file paths whose file extension does not
             match "*.parquet*".
+        shuffle: If setting to "files", randomly shuffle input files order before read.
+            Defaults to not shuffle with ``None``.
         arrow_parquet_args: Other parquet read options to pass to PyArrow. For the full
             set of arguments, see
             the `PyArrow API <https://arrow.apache.org/docs/python/generated/\
@@ -1028,6 +1044,7 @@ def read_json(
     ] = JSONDatasource.file_extension_filter(),
     partitioning: Partitioning = Partitioning("hive"),
     ignore_missing_paths: bool = False,
+    shuffle: Union[Literal["files"], None] = None,
     **arrow_json_args,
 ) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from JSON and JSONL files.
@@ -1113,6 +1130,8 @@ def read_json(
                 hive-style-partitioning/>`_.
         ignore_missing_paths: If True, ignores any file paths in ``paths`` that are not
             found. Defaults to False.
+        shuffle: If setting to "files", randomly shuffle input files order before read.
+            Defaults to not shuffle with ``None``.
         arrow_json_args: JSON read options to pass to `pyarrow.json.read_json <https://\
             arrow.apache.org/docs/python/generated/pyarrow.json.read_json.html#pyarrow.\
             json.read_json>`_.
@@ -1149,6 +1168,7 @@ def read_csv(
     partition_filter: Optional[PathPartitionFilter] = None,
     partitioning: Partitioning = Partitioning("hive"),
     ignore_missing_paths: bool = False,
+    shuffle: Union[Literal["files"], None] = None,
     **arrow_csv_args,
 ) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from CSV files.
@@ -1262,6 +1282,8 @@ def read_csv(
                 hive-style-partitioning/>`_.
         ignore_missing_paths: If True, ignores any file paths in ``paths`` that are not
             found. Defaults to False.
+        shuffle: If setting to "files", randomly shuffle input files order before read.
+            Defaults to not shuffle with ``None``.
         arrow_csv_args: CSV read options to pass to
             `pyarrow.csv.open_csv <https://arrow.apache.org/docs/python/generated/\
             pyarrow.csv.open_csv.html#pyarrow.csv.open_csv>`_
@@ -1302,6 +1324,7 @@ def read_text(
     partition_filter: Optional[PathPartitionFilter] = None,
     partitioning: Partitioning = None,
     ignore_missing_paths: bool = False,
+    shuffle: Union[Literal["files"], None] = None,
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from lines stored in text files.
 
@@ -1360,6 +1383,8 @@ def read_text(
             that describes how paths are organized. Defaults to ``None``.
         ignore_missing_paths: If True, ignores any file paths in ``paths`` that are not
             found. Defaults to False.
+        shuffle: If setting to "files", randomly shuffle input files order before read.
+            Defaults to not shuffle with ``None``.
 
     Returns:
         :class:`~ray.data.Dataset` producing lines of text read from the specified
@@ -1396,6 +1421,7 @@ def read_numpy(
     ] = NumpyDatasource.file_extension_filter(),
     partitioning: Partitioning = None,
     ignore_missing_paths: bool = False,
+    shuffle: Union[Literal["files"], None] = None,
     **numpy_load_args,
 ) -> Dataset:
     """Create an Arrow dataset from numpy files.
@@ -1435,6 +1461,8 @@ def read_numpy(
             that describes how paths are organized. Defaults to ``None``.
         ignore_missing_paths: If True, ignores any file paths in ``paths`` that are not
             found. Defaults to False.
+        shuffle: If setting to "files", randomly shuffle input files order before read.
+            Defaults to not shuffle with ``None``.
 
     Returns:
         Dataset holding Tensor records read from the specified paths.
@@ -1466,6 +1494,7 @@ def read_tfrecords(
     partition_filter: Optional[PathPartitionFilter] = None,
     ignore_missing_paths: bool = False,
     tf_schema: Optional["schema_pb2.Schema"] = None,
+    shuffle: Union[Literal["files"], None] = None,
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from TFRecord files that contain
     `tf.train.Example <https://www.tensorflow.org/api_docs/python/tf/train/Example>`_
@@ -1537,6 +1566,8 @@ def read_tfrecords(
             found. Defaults to False.
         tf_schema: Optional TensorFlow Schema which is used to explicitly set the schema
             of the underlying Dataset.
+        shuffle: If setting to "files", randomly shuffle input files order before read.
+            Defaults to not shuffle with ``None``.
 
     Returns:
         A :class:`~ray.data.Dataset` that contains the example features.
@@ -1575,6 +1606,7 @@ def read_webdataset(
     filerename: Optional[Union[list, callable]] = None,
     suffixes: Optional[Union[list, callable]] = None,
     verbose_open: bool = False,
+    shuffle: Union[Literal["files"], None] = None,
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from
     `WebDataset <https://webdataset.github.io/webdataset/>`_ files.
@@ -1600,6 +1632,8 @@ def read_webdataset(
         filerename: A function or list of tuples to rename files prior to grouping.
         suffixes: A function or list of suffixes to select for creating samples.
         verbose_open: Whether to print the file names as they are opened.
+        shuffle: If setting to "files", randomly shuffle input files order before read.
+            Defaults to not shuffle with ``None``.
 
     Returns:
         A :class:`~ray.data.Dataset` that contains the example features.
@@ -1642,6 +1676,7 @@ def read_binary_files(
     partition_filter: Optional[PathPartitionFilter] = None,
     partitioning: Partitioning = None,
     ignore_missing_paths: bool = False,
+    shuffle: Union[Literal["files"], None] = None,
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from binary files of arbitrary contents.
 
@@ -1706,6 +1741,8 @@ def read_binary_files(
             that describes how paths are organized. Defaults to ``None``.
         ignore_missing_paths: If True, ignores any file paths in ``paths`` that are not
             found. Defaults to False.
+        shuffle: If setting to "files", randomly shuffle input files order before read.
+            Defaults to not shuffle with ``None``.
 
     Returns:
         :class:`~ray.data.Dataset` producing rows read from the specified paths.

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -771,6 +771,7 @@ def read_parquet(
         ray_remote_args=ray_remote_args,
         meta_provider=meta_provider,
         partition_filter=partition_filter,
+        shuffle=shuffle,
         **arrow_parquet_args,
     )
 
@@ -1026,6 +1027,7 @@ def read_parquet_bulk(
         open_stream_args=arrow_open_file_args,
         meta_provider=meta_provider,
         partition_filter=partition_filter,
+        shuffle=shuffle,
         **arrow_parquet_args,
     )
 
@@ -1152,6 +1154,7 @@ def read_json(
         partition_filter=partition_filter,
         partitioning=partitioning,
         ignore_missing_paths=ignore_missing_paths,
+        shuffle=shuffle,
         **arrow_json_args,
     )
 
@@ -1306,6 +1309,7 @@ def read_csv(
         partition_filter=partition_filter,
         partitioning=partitioning,
         ignore_missing_paths=ignore_missing_paths,
+        shuffle=shuffle,
         **arrow_csv_args,
     )
 
@@ -1405,6 +1409,7 @@ def read_text(
         drop_empty_lines=drop_empty_lines,
         encoding=encoding,
         ignore_missing_paths=ignore_missing_paths,
+        shuffle=shuffle,
     )
 
 
@@ -1479,6 +1484,7 @@ def read_numpy(
         partition_filter=partition_filter,
         partitioning=partitioning,
         ignore_missing_paths=ignore_missing_paths,
+        shuffle=shuffle,
         **numpy_load_args,
     )
 
@@ -1589,6 +1595,7 @@ def read_tfrecords(
         partition_filter=partition_filter,
         ignore_missing_paths=ignore_missing_paths,
         tf_schema=tf_schema,
+        shuffle=shuffle,
     )
 
 
@@ -1660,6 +1667,7 @@ def read_webdataset(
         filerename=filerename,
         suffixes=suffixes,
         verbose_open=verbose_open,
+        shuffle=shuffle,
     )
 
 
@@ -1762,6 +1770,7 @@ def read_binary_files(
         partition_filter=partition_filter,
         partitioning=partitioning,
         ignore_missing_paths=ignore_missing_paths,
+        shuffle=shuffle,
         output_arrow_format=output_arrow_format,
     )
 

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -168,54 +168,37 @@ class TestReadImages:
             "image-datasets/simple/image3.jpg",
         ]
 
-    def test_random_shuffle(self, ray_start_regular_shared):
+    def test_random_shuffle(self, ray_start_regular_shared, restore_data_context):
         # NOTE: set preserve_order to True to allow consistent output behavior.
         context = ray.data.DataContext.get_current()
-        preserve_order = context.execution_options.preserve_order
+        context.execution_options.preserve_order = True
 
-        try:
-            dir_path = "s3://anonymous@air-example-data/mnist"
-            file_paths = [
-                "00000.png",
-                "00001.png",
-                "00002.png",
-                "00003.png",
-                "00004.png",
-                "00005.png",
-                "00006.png",
-                "00007.png",
-                "00008.png",
-                "00009.png",
-            ]
-            input_uris = [f"{dir_path}/{file_path}" for file_path in file_paths]
+        dir_path = "s3://anonymous@air-example-data/mnist"
+        file_paths = [f"{i:05d}.png" for i in range(10)]
+        input_uris = [f"{dir_path}/{file_path}" for file_path in file_paths]
 
-            ds = ray.data.read_images(
-                paths=input_uris,
-                include_paths=True,
-                shuffle="files",
-            )
+        ds = ray.data.read_images(
+            paths=input_uris,
+            include_paths=True,
+            shuffle="files",
+        )
 
-            # Execute 10 times to get a set of output paths.
-            output_paths_list = []
-            for _ in range(10):
-                uris = [row["path"][-len(file_paths[0]) :] for row in ds.take_all()]
-                output_paths_list.append(uris)
-            all_paths_matched = [
-                file_paths == output_paths for output_paths in output_paths_list
-            ]
+        # Execute 10 times to get a set of output paths.
+        output_paths_list = []
+        for _ in range(10):
+            paths = [row["path"][-len(file_paths[0]) :] for row in ds.take_all()]
+            output_paths_list.append(paths)
+        all_paths_matched = [
+            file_paths == output_paths for output_paths in output_paths_list
+        ]
 
-            # Check when shuffle is enabled, output order has at least one different
-            # case.
-            assert not all(all_paths_matched)
-            # Check all files are output properly without missing one.
-            assert all(
-                [
-                    file_paths == sorted(output_paths)
-                    for output_paths in output_paths_list
-                ]
-            )
-        finally:
-            context.preserve_order = preserve_order
+        # Check when shuffle is enabled, output order has at least one different
+        # case.
+        assert not all(all_paths_matched)
+        # Check all files are output properly without missing one.
+        assert all(
+            [file_paths == sorted(output_paths) for output_paths in output_paths_list]
+        )
 
     def test_e2e_prediction(self, shutdown_only):
         import torch

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -305,6 +305,7 @@ class TestReadImages:
             "mode": "foo",
             "include_paths": True,
             "ignore_missing_paths": True,
+            "shuffle": None,
         }
         with patch("ray.data.read_api.read_datasource") as mock:
             ray.data.read_images(**kwargs)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to add support for shuffling input files ordering, for all file-based data sources. The interface for controlling the behavior is through `shuffle` argument in all read APIs for file-based data sources:

```py
# Enable input files shuffling with default seed
ds = ray.data.read_parquet(..., shuffle="files")
ds = ray.data.read_images(..., shuffle="files")
```

Several different interfaces considered but not chosen:

1. Add to `DataContext`. It has drawback that `DataContext` config controlling the subtle semantics difference for operators, which could introduce bugs later, and not consistent with rest of APIs.

2. Optimizer rule to push down `randomize_block_order` to data source: `read_xxx().randomize_block_order()`. This has the benefit of not introducing any new interface. But it has drawback: (1).`randomize_block_order()` API is exposing block concept, and hard for users to understand and use based on feedback in the past. (2).Pushdown can only happen when `randomize_block_order()` applied immediately after `read_xxx()`, and it's not safe to push down if there's more operation in between: `read_xxx().map_batches().randomize_block_order()`. This behavior will be hard for users to understand, and will cause issue when user code gets more complicated.

3. Introduce new argument into `random_shuffle(file=True)`, and optimizer rule to push down to data source: `read_xxx().random_shuffle(file=True)`. It has drawback similar to above 2.(2)., and I get a hard time to choose the name of new argument. `file` is not a good name here, because `random_shuffle()` should not care about whether data is coming form file or not (it's part of data source concepts). and I don't want to name it `random_shuffle(block=True)`, so this exposes block concept, and make it even more confusing given we already have `randomize_block_order()`.

Note:
The seed would be always using the default one, and not supported to change from users. After 2.8, we shall iterate on how to expose the seed option for users. One option is to have a `Dataset.manual/set_seed()` API to control the global seed of random number generator, but it's a bit too early to introduce now without users feedback. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
