### PR TITLE
[RLlib] Don't call deprecated `Dataset.repeat`  in `DatasetReader`

### DIFF
--- a/rllib/offline/dataset_reader.py
+++ b/rllib/offline/dataset_reader.py
@@ -231,13 +231,10 @@ class DatasetReader(InputReader):
             print(
                 f"DatasetReader {self._ioctx.worker_index} has {ds.count()}, samples."
             )
-            # TODO: @avnishn make this call seeded.
-            # calling random_shuffle_each_window shuffles the dataset after
-            # each time the whole dataset has been read.
 
             def iterator():
                 while True:
-                    ds = self._dataset.random_shuffle()
+                    ds = self._dataset.random_shuffle(seed=seed)
                     yield from ds.iter_rows()
 
             self._iter = iterator()

--- a/rllib/offline/dataset_reader.py
+++ b/rllib/offline/dataset_reader.py
@@ -228,14 +228,19 @@ class DatasetReader(InputReader):
                     if not self._ioctx.config.get("_disable_preprocessors", False)
                     else None
                 )
-            self._dataset.random_shuffle(seed=seed)
             print(
                 f"DatasetReader {self._ioctx.worker_index} has {ds.count()}, samples."
             )
             # TODO: @avnishn make this call seeded.
             # calling random_shuffle_each_window shuffles the dataset after
             # each time the whole dataset has been read.
-            self._iter = self._dataset.repeat().random_shuffle_each_window().iter_rows()
+
+            def iterator():
+                while True:
+                    ds = self._dataset.random_shuffle()
+                    yield from ds.iter_rows()
+
+            self._iter = iterator()
         else:
             self._iter = None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`DatasetPipeline` (and `Dataset.repeat()`) are being hard deprecated in Ray 2.8. This PR updates `DatasetReader` to use updated APIs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
