### PR TITLE
[ci] jail top data flaky tests

### DIFF
--- a/ci/ray_ci/data.tests.yml
+++ b/ci/ray_ci/data.tests.yml
@@ -1,5 +1,6 @@
 flaky_tests:
   - //python/ray/data:test_streaming_executor
+  - //python/ray/data:test_streaming_integration
   - //python/ray/data:test_split
   - //python/ray/data:test_object_gc
   - //python/ray/data:test_stats


### PR DESCRIPTION
Jail another flaky tests. This time from data team.

<img width="1805" alt="Screenshot 2023-10-05 at 2 55 59 PM" src="https://github.com/ray-project/ray/assets/128072568/777f02c6-649f-48f0-bb4e-8ba231763b74">

Test:
- CI
