### PR TITLE
[docs] [train] copy edits to E2E ingest example

### DIFF
--- a/doc/source/_toc.yml
+++ b/doc/source/_toc.yml
@@ -110,6 +110,8 @@ parts:
                 title: "PyTorch Finetuning ResNet Example"
               - file: train/examples/lightning/vicuna_13b_lightning_deepspeed_finetune
                 title: "Fine-tune Vicuna-13B with DeepSpeed and PyTorch Lightning"
+              - file: ray-air/examples/training_ingest_object_classification
+                title: "Training Ingest Object Classification"
           - file: train/internals/index
             title: "Internals"
             sections:

--- a/doc/source/ray-air/examples/training_ingest_object_classification.ipynb
+++ b/doc/source/ray-air/examples/training_ingest_object_classification.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This example demonstrates how to work with image training datasets using [Ray Data](data) on a single node.\n",
     "\n",
-    "In this example, we'll use Ray Data to:\n",
+    "This example uses Ray Data to:\n",
     "1. Load and preprocess raw images for training.\n",
     "2. Load preprocessed images into PyTorch using [Ray Train](train) to train and validate an object classification model.\n",
     "\n",
@@ -78,9 +78,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's first download an image dataset to use. If you already have an image dataset on local disk or in S3, you can skip the rest of this section.\n",
+    "First download an image dataset to use. If you already have an image dataset on local disk or in S3, you can skip the rest of this section.\n",
     "Otherwise, follow on to download a dataset from Kaggle.\n",
-    "For this example, we'll use bash to download a [4GB subset of the ImageNet dataset](https://www.kaggle.com/datasets/ifigotin/imagenetmini-1000) and (optionally) upload it to an S3 bucket.\n",
+    "This example, uses bash to download a [4GB subset of the ImageNet dataset](https://www.kaggle.com/datasets/ifigotin/imagenetmini-1000) and (optionally) upload it to an S3 bucket.\n",
     "\n",
     "```bash\n",
     "$ pip install kaggle awscli\n",
@@ -127,37 +127,28 @@
    "source": [
     "## Loading the training dataset\n",
     "\n",
-    "Let's start by loading the training dataset and examining the data.\n",
-    "To speed things up, we'll first download the dataset from S3 to local disk.\n",
+    "Start by loading the training dataset and examining the data.\n",
+    "To speed things up, first download the dataset from S3 to local disk.\n",
     "If you're using a multi-node cluster, you can also just read directly from S3.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "^C\n",
-      "fatal error: \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!aws s3 sync s3://imagenetmini-1000/ /tmp/imagenetmini-1000"
+    "! aws s3 sync s3://imagenetmini-1000/ /tmp/imagenetmini-1000"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use {meth}`~ray.data.Dataset.take_batch` to produce a single batch of data.\n",
-    "Later, we'll apply preprocessing transforms to the images, one batch at a time."
+    "You can use {meth}`~ray.data.Dataset.take_batch` to produce a single batch of data.\n",
+    "A later step applies preprocessing transforms to the images, one batch at a time."
    ]
   },
   {
@@ -214,7 +205,7 @@
     "TRAIN_DATASET_URL = \"/tmp/imagenetmini-1000/train\"\n",
     "\n",
     "# Uncomment to read directly from S3.\n",
-    "# This is recommended if you are using multiple nodes for training\n",
+    "# This approach is recommended if you are using multiple nodes for training\n",
     "# or if you do not have enough disk space to hold the entire dataset.\n",
     "# TRAIN_DATASET_URL = \"s3://imagenetmini-1000/train\"\n",
     "\n",
@@ -239,9 +230,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When we pass the `Dataset` to Ray Train, we will receive a {class}`ray.data.DataIterator` on each training worker.\n",
-    "Let's use that API to iterate through the dataset here.\n",
-    "We'll limit the dataset to 1000 rows to shorten the execution and we'll use {meth}`ray.data.DataIterator.iter_torch_batches` since we'll be using a PyTorch model later on.\n",
+    "When you pass the `Dataset` to Ray Train, you receive a {class}`ray.data.DataIterator` on each training worker.\n",
+    "Use that API to iterate through the dataset.\n",
+    "Limit the dataset to 1000 rows to shorten the execution and use {meth}`ray.data.DataIterator.iter_torch_batches` since you are using a PyTorch model later on.\n",
     "\n",
     "Try commenting back in the code below and see what happens."
    ]
@@ -254,7 +245,7 @@
    },
    "outputs": [],
    "source": [
-    "# This is the interface that will be used by Ray Train workers.\n",
+    "# This is the interface that Ray Train workers use.\n",
     "it = ds.limit(1000).iterator()\n",
     "\n",
     "# for torch_batch in it.iter_torch_batches(batch_size=32):\n",
@@ -265,14 +256,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Uh-oh, did you get an error above?\n",
+    "Did you get an error above?\n",
     "\n",
-    "You should have seen an error like this:\n",
+    "You should have seen an error like this output:\n",
     "```python\n",
     "RuntimeError: Numpy array of object dtype cannot be converted to a Torch Tensor. This may because the numpy array is a ragged tensor--it contains items of different sizes. If using `iter_torch_batches()` API, you can pass in a `collate_fn` argument to specify custom logic to convert the Numpy array batch to a Torch tensor batch.\n",
     "```\n",
     "\n",
-    "This happens because each of our images is a different size. Later we'll crop all of the images to the same size, so we can revisit this then."
+    "This error happens because each of the images is a different size. In a later step, when you crop all of the images to the same size, you can revisit the sizing."
    ]
   },
   {
@@ -281,8 +272,8 @@
    "source": [
     "## Extracting labels from the pathname\n",
     "\n",
-    "We also want our dataset to include the label for each image.\n",
-    "For images where the subdirectory name is also the class name, we can use a {class}`~ray.data.datasource.Partitioning` to extract the class name from each filename and attach it as an additional field to each row."
+    "You also want the dataset to include the label for each image.\n",
+    "For images where the subdirectory name is also the class name, use a {class}`~ray.data.datasource.Partitioning` to extract the class name from each filename and attach it as an additional field to each row."
    ]
   },
   {
@@ -336,7 +327,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have a different directory structure, then you can instead attach each image's filename using `include_paths=True` and add a custom {meth}`~ray.data.Dataset.map_batches` call to extract the class label."
+    "If you have a different directory structure, you can attach each image's filename using `include_paths=True` and add a custom {meth}`~ray.data.Dataset.map_batches` call to extract the class label instead."
    ]
   },
   {
@@ -489,9 +480,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To extract the class as an integer, we can do another `map_batches` call to convert the string to an integer.\n",
+    "To extract the class as an integer, you can do another `map_batches` call to convert the string to an integer.\n",
     "\n",
-    "If your class names don't already have an integer in them, we can also assign each class name an integer. To do this, we first call {meth}`~ray.data.Dataset.unique` to get the unique label values and assign each value an integer."
+    "If your class names don't already have an integer in them, you can also assign each class name an integer. To do this, first call {meth}`~ray.data.Dataset.unique` to get the unique label values and assign each value an integer."
    ]
   },
   {
@@ -592,7 +583,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we call `map_batches` again to convert each image's class from a string to an integer."
+    "Next, call `map_batches` again to convert each image's class from a string to an integer."
    ]
   },
   {
@@ -652,8 +643,8 @@
    "source": [
     "## Preprocessing images\n",
     "\n",
-    "Next we'll apply some preprocessing transforms to our images.\n",
-    "Let's use [torchvision](https://pytorch.org/vision/stable/index.html) to define a preprocessor function that randomly crops and flips a batch of images, then returns the image as a `torch.Tensor`.\n",
+    "Next apply some preprocessing transforms to the images.\n",
+    "Use [torchvision](https://pytorch.org/vision/stable/index.html) to define a preprocessor function that randomly crops and flips a batch of images, then returns the image as a `torch.Tensor`.\n",
     "This code matches the spec for the [MLPerf image classification benchmark](https://github.com/mlcommons/training/tree/master/image_classification)."
    ]
   },
@@ -702,14 +693,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we can try the function out manually on one of the batches that we produced earlier."
+    "First, try the function out manually on one of the batches that you produced earlier."
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -729,7 +722,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's apply the preprocessor to the entire dataset."
+    "Now apply the preprocessor to the entire dataset."
    ]
   },
   {
@@ -751,10 +744,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that all of the images have the same dimensions, we're ready to iterate using {meth}`ray.data.DataIterator.iter_torch_batches`.\n",
+    "Now that all of the images have the same dimensions, you're ready to iterate using {meth}`ray.data.DataIterator.iter_torch_batches`.\n",
     "\n",
-    "Note that because we're using a randomized preprocessor, each time we call `DataIterator.iter_torch_batches`, it will produce different results.\n",
-    "This can be helpful during training, if you want to randomly apply transforms during each epoch."
+    "Note that because you're using a randomized preprocessor, each time you call `DataIterator.iter_torch_batches`, it produces different results.\n",
+    "This behavior can be helpful during training, if you want to randomly apply transforms during each epoch."
    ]
   },
   {
@@ -794,7 +787,7 @@
     }
    ],
    "source": [
-    "# This is the interface that will be used by Ray Train workers.\n",
+    "# This is the interface that Ray Train workers use.\n",
     "ds = get_training_dataset(TRAIN_DATASET_URL)\n",
     "it = ds.limit(1000).iterator()\n",
     "\n",
@@ -806,13 +799,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Training a model on the dataset\n",
     "\n",
-    "Now we're ready to build an end-to-end example with Ray AIR.\n",
-    "First, let's define the code for the training worker.\n",
-    "This code uses the {class}`ray.data.DataIterator` that we defined earlier to load batches of data into a training worker."
+    "Now you're ready to build an end-to-end example.\n",
+    "First, define the code for the training worker.\n",
+    "This code uses the {class}`ray.data.DataIterator` that you defined earlier to load batches of data into a training worker."
    ]
   },
   {
@@ -862,7 +857,7 @@
     "        )\n",
     "\n",
     "\n",
-    "def train_loop_per_worker(config):\n",
+    "def train_func(config):\n",
     "    model = models.resnet50()\n",
     "    model = ray.train.torch.prepare_model(model)\n",
     "    parameters = [p for p in model.parameters() if p.requires_grad]\n",
@@ -897,10 +892,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we can go ahead and run the training loop.\n",
-    "We'll define our training dataset (and limit it a smaller number of rows) and pass it to the {class}`ray.train.torch.TorchTrainer`.\n",
-    "If we were using multiple training workers, the dataset would get split into one iterator per training worker, and each worker would see a disjoint subset of the data.\n",
-    "But for now, we'll just use 1 training worker and a CPU model."
+    "Next, run the training loop.\n",
+    "Define the training dataset (limit it to a smaller number of rows) and pass it to the {class}`ray.train.torch.TorchTrainer`.\n",
+    "If you're using multiple training workers, Ray Train splits the dataset into one iterator per training worker, and each worker sees a disjoint subset of the data.\n",
+    "But for now, just use 1 training worker and a CPU model."
    ]
   },
   {
@@ -1026,7 +1021,7 @@
     "train_dataset = get_training_dataset(TRAIN_DATASET_URL).limit(32)\n",
     "\n",
     "trainer = TorchTrainer(\n",
-    "    train_loop_per_worker=train_loop_per_worker,\n",
+    "    train_loop_per_worker=train_func,\n",
     "    train_loop_config={\n",
     "        \"batch_size\": 4,\n",
     "        \"lr\": 0.02,\n",
@@ -1050,9 +1045,9 @@
     "tags": []
    },
    "source": [
-    "Let's check the results of our training job.\n",
+    "Check the results of the training job.\n",
     "\n",
-    "First, let's define a validation dataset. This will look very similar to our training dataset, except without the random transforms."
+    "First, define a validation dataset. This validation dataset looks very similar to the training dataset, but it doesn't have the random transforms."
    ]
   },
   {
@@ -1086,7 +1081,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we'll define a `Predict` class that we can use to load a copy of the model and make predictions on batches of the validation dataset."
+    "Next define a `Predict` class that you can use to load a copy of the model and make predictions on batches of the validation dataset."
    ]
   },
   {
@@ -1125,7 +1120,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we can use `ray.data` to run batch prediction."
+    "Finally, use `ray.data` to run batch prediction."
    ]
   },
   {
@@ -1194,7 +1189,7 @@
    "source": [
     "## What next?\n",
     "\n",
-    "Now that we've gotten ingest working on a single node, check out the [Ray AIR ingest guide](air-ingest) for more advanced features including:\n",
+    "Now that ingest works on a single node, see [Ray AIR ingest guide](air-ingest) for more advanced features including:\n",
     "- Scaling out to multiple GPU workers\n",
     "- Configuring Datasets for shuffling data\n",
     "- Improving Datasets performance"


### PR DESCRIPTION
Trying to add copy edits as a commit. @stephanie-wang, sorry if this didn't work!

The code examples still need to be updated to the new Train GA APIs. References to AIR are now out of date.

## Why are these changes needed?

Copy edits to make the style more consistent with the style guide we follow.

## Related issue number

https://github.com/ray-project/ray/pull/38082

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
