### PR TITLE
[Doc][KubeRay] Fix GKE cluster setup instructions

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/gcp-gke-gpu-cluster.md
+++ b/doc/source/cluster/kubernetes/user-guides/gcp-gke-gpu-cluster.md
@@ -14,7 +14,9 @@ gcloud container clusters create kuberay-gpu-cluster \
     --zone=us-west1-b --machine-type e2-standard-4
 ```
 
-> Note: You can also create a cluster from the [Google Cloud Console](https://console.cloud.google.com/kubernetes/list).
+```{admonition} Note
+You can also create a cluster from the [Google Cloud Console](https://console.cloud.google.com/kubernetes/list).
+```
 
 ## Step 2: Create a GPU node pool
 
@@ -22,25 +24,22 @@ Run the following command to create a GPU node pool for Ray GPU workers. You can
 
 ```sh
 gcloud container node-pools create gpu-node-pool \
-  --accelerator type=nvidia-l4-vws,count=1,gpu-driver-version=default \
+  --accelerator type=nvidia-l4-vws,count=1 \
   --zone us-west1-b \
   --cluster kuberay-gpu-cluster \
   --num-nodes 1 \
   --min-nodes 0 \
   --max-nodes 1 \
   --enable-autoscaling \
-  --machine-type g2-standard-4 \
+  --machine-type g2-standard-4
 ```
 
 The `--accelerator` flag specifies the type and number of GPUs for each node in the node pool. This example uses the [NVIDIA L4](https://cloud.google.com/compute/docs/gpus#l4-gpus) GPU. The machine type `g2-standard-4` has 1 GPU, 24 GB GPU Memory, 4 vCPUs and 16 GB RAM.
 
-.. note::
-
-    GKE automatically installs the GPU drivers for you.  For more details, see [GKE documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#create-gpu-pool-auto-drivers).
-
-.. note::
-
-    GKE automatically configures taints and tolerations so that only GPU pods are scheduled on GPU nodes.  For more details, see [GKE documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#create)
+```{admonition} Note
+GKE automatically configures taints and tolerations so that only GPU pods are scheduled on GPU nodes.
+For more details, see [GKE documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#create)
+```
 
 ## Step 3: Configure `kubectl` to connect to the cluster
 
@@ -51,3 +50,20 @@ gcloud container clusters get-credentials kuberay-gpu-cluster --zone us-west1-b
 ```
 
 For more details, see [GKE documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl).
+
+## Step 4: Install GPU drivers (optional)
+
+If you encounter any issues with the GPU drivers installed by GKE, you can manually install the GPU drivers by following the instructions below.
+
+```sh
+# Install NVIDIA GPU device driver
+kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+
+# Verify that your nodes have allocatable GPUs 
+kubectl get nodes "-o=custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu"
+
+# Verify that your nodes have allocatable GPUs 
+# NAME     GPU
+# ......   <none>
+# ......   1
+```


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In theory, specifying `gpu-driver-version=default` in the gcloud command should automatically install the NVIDIA driver. However, there were errors with the driver DaemonSet, as shown in the attachment. As a result, I removed `gpu-driver-version=default` and installed the driver manually. We can reintroduce this option once the feature becomes more stable.

![Screen Shot 2023-10-05 at 11 08 50 PM](https://github.com/ray-project/ray/assets/20109646/6ffcf670-abfa-4e94-84c7-948caec37bd0)

This PR also fixes some formatting issues

* Without this PR
   ![Screen Shot 2023-10-05 at 11 25 50 PM](https://github.com/ray-project/ray/assets/20109646/76a2feb8-1a93-4a5e-8aa7-3ddd9c72290f)

* With this PR
  ![Screen Shot 2023-10-05 at 11 26 22 PM](https://github.com/ray-project/ray/assets/20109646/4d3b3469-dee6-4ddf-ae91-ebe4a3868e50)



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
