### PR TITLE
[tune] New persistence mode cleanup: Fix broken Tune tests

### DIFF
--- a/python/ray/tune/tests/execution/test_actor_caching.py
+++ b/python/ray/tune/tests/execution/test_actor_caching.py
@@ -13,11 +13,7 @@ def test_actor_cached(tmpdir):
 
     assert not actor_manger.added_actors
 
-    tune_controller.add_trial(
-        TestingTrial(
-            "trainable1", stub=True, trial_id="trial1", experiment_path=str(tmpdir)
-        )
-    )
+    tune_controller.add_trial(TestingTrial("trainable1", stub=True, trial_id="trial1"))
     tune_controller.step()
 
     tracked_actor, cls_name, kwargs = actor_manger.added_actors[0]
@@ -47,7 +43,6 @@ def test_actor_reuse_unstaged(tmpdir):
         "trainable1",
         stub=True,
         trial_id="trialA1",
-        experiment_path=str(tmpdir),
         placement_group_factory=PlacementGroupFactory([{"CPU": 1}]),
     )
     tune_controller.add_trial(trialA1)
@@ -55,7 +50,6 @@ def test_actor_reuse_unstaged(tmpdir):
         "trainable1",
         stub=True,
         trial_id="trialB1",
-        experiment_path=str(tmpdir),
         placement_group_factory=PlacementGroupFactory([{"CPU": 5}]),
     )
     tune_controller.add_trial(trialB1)
@@ -63,7 +57,6 @@ def test_actor_reuse_unstaged(tmpdir):
         "trainable1",
         stub=True,
         trial_id="trialA2",
-        experiment_path=str(tmpdir),
         placement_group_factory=PlacementGroupFactory([{"CPU": 1}]),
     )
     tune_controller.add_trial(trialA2)
@@ -77,7 +70,6 @@ def test_actor_reuse_unstaged(tmpdir):
         "trainable1",
         stub=True,
         trial_id="trialA3",
-        experiment_path=str(tmpdir),
         placement_group_factory=PlacementGroupFactory([{"CPU": 1}]),
     )
     tune_controller.add_trial(trialA3)

--- a/python/ray/tune/tests/test_logger.py
+++ b/python/ray/tune/tests/test_logger.py
@@ -38,7 +38,7 @@ class Trial:
     logdir: str
     experiment_path: Optional[str] = None
     experiment_dir_name: Optional[str] = None
-    remote_checkpoint_dir: Optional[str] = None
+    path: Optional[str] = None
     checkpoint: Optional[Checkpoint] = None
 
     @property
@@ -59,10 +59,6 @@ class Trial:
     @property
     def local_experiment_path(self):
         return self.experiment_path
-
-    @property
-    def remote_path(self):
-        return self.remote_checkpoint_dir
 
     def __hash__(self):
         return hash(self.trial_id)
@@ -336,7 +332,7 @@ class AimLoggerSuite(unittest.TestCase):
                 experiment_path=self.test_dir,
                 logdir=trial_logdir,
                 experiment_dir_name="aim_test",
-                remote_checkpoint_dir="s3://bucket/aim_test/trial_0_logdir",
+                path="bucket/aim_test/trial_0_logdir",
             ),
             Trial(
                 evaluated_params=self.config,
@@ -344,7 +340,7 @@ class AimLoggerSuite(unittest.TestCase):
                 experiment_path=self.test_dir,
                 logdir=trial_logdir,
                 experiment_dir_name="aim_test",
-                remote_checkpoint_dir="s3://bucket/aim_test/trial_1_logdir",
+                path="bucket/aim_test/trial_1_logdir",
             ),
         ]
 
@@ -380,7 +376,7 @@ class AimLoggerSuite(unittest.TestCase):
 
         for i, run in enumerate(runs):
             assert set(run["hparams"]) == expected_logged_hparams
-            assert run.get("trial_remote_log_dir")
+            assert run.get("trial_log_dir")
             assert run.get("trial_ip")
 
             results = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
https://github.com/ray-project/ray/pull/40175 broke some Tune tests (some broken attributes and outdated mock classes referenced in tests), and this PR fixes them.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
