### PR TITLE
[ci] drop typings in copy_files.py

### DIFF
--- a/.buildkite/copy_files.py
+++ b/.buildkite/copy_files.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 import time
 from collections import OrderedDict
-from typing import List
 
 import requests
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth

--- a/.buildkite/copy_files.py
+++ b/.buildkite/copy_files.py
@@ -51,7 +51,7 @@ def handle_docker_login(resp):
     )
 
 
-def gather_paths(dir_path) -> List[str]:
+def gather_paths(dir_path):
     dir_path = dir_path.replace("/", os.path.sep)
     assert os.path.exists(dir_path)
     if os.path.isdir(dir_path):


### PR DESCRIPTION
does not work on macs. all other functions do not have typing annotations.
