### PR TITLE
avoid to fetch private ip

### DIFF
--- a/python/ray/autoscaler/_private/vsphere/node_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/node_provider.py
@@ -186,11 +186,12 @@ class VsphereNodeProvider(NodeProvider):
             return dict(d1)
 
     def external_ip(self, node_id):
+        # Return the external IP of the VM
         # Fetch vSphere VM object
         vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_moid(
             [vim.VirtualMachine], node_id
         )
-        # Get the ipaddress of this VM
+        # Get the external IP address of this VM
         for ipaddr in vm.guest.net[0].ipAddress:
             if is_ipv4(ipaddr):
                 logger.debug("Fetch IP {} for VM {}".format(ipaddr, vm))

--- a/python/ray/autoscaler/_private/vsphere/node_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/node_provider.py
@@ -186,9 +186,11 @@ class VsphereNodeProvider(NodeProvider):
             return dict(d1)
 
     def external_ip(self, node_id):
+        # Fetch vSphere VM object
         vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_moid(
             [vim.VirtualMachine], node_id
         )
+        # Get the ipaddress of this VM
         for ipaddr in vm.guest.net[0].ipAddress:
             if is_ipv4(ipaddr):
                 logger.debug("Fetch IP {} for VM {}".format(ipaddr, vm))

--- a/python/ray/autoscaler/_private/vsphere/node_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/node_provider.py
@@ -1,5 +1,4 @@
 import copy
-import ipaddress
 import logging
 import threading
 import time
@@ -23,7 +22,7 @@ from pyVmomi import vim
 from ray.autoscaler._private.cli_logger import cli_logger
 from ray.autoscaler._private.vsphere.config import bootstrap_vsphere
 from ray.autoscaler._private.vsphere.sdk_provider import VmwSdkProviderFactory
-from ray.autoscaler._private.vsphere.utils import Constants
+from ray.autoscaler._private.vsphere.utils import Constants, is_ipv4
 from ray.autoscaler.node_provider import NodeProvider
 from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME
 
@@ -90,7 +89,7 @@ class VsphereNodeProvider(NodeProvider):
         existing and in the frozen state. If the frozen VM is existing and off, this
         function will also help to power on the frozen VM and wait until it is frozen.
         """
-        vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
+        vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_name(
             [vim.VirtualMachine], frozen_vm_name
         )
         if vm is None:
@@ -187,19 +186,14 @@ class VsphereNodeProvider(NodeProvider):
             return dict(d1)
 
     def external_ip(self, node_id):
-        # Return the external IP of the VM
-
-        vm = self.vsphere_sdk_client.vcenter.vm.guest.Identity.get(node_id)
-        try:
-            _ = ipaddress.IPv4Address(vm.ip_address)
-            logger.debug("Fetch IP {} for VM {}".format(vm.ip_address, vm))
-        except ipaddress.AddressValueError:
-            # vSphere SDK could return IPv6 address when the VM is just booted. We
-            # just return None in this case because the Ray doesn't support IPv6
-            # address yet When the next time external_ip is called, we could return
-            # the IPv4 address
-            return None
-        return vm.ip_address
+        vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_moid(
+            [vim.VirtualMachine], node_id
+        )
+        for ipaddr in vm.guest.net[0].ipAddress:
+            if is_ipv4(ipaddr):
+                logger.debug("Fetch IP {} for VM {}".format(ipaddr, vm))
+                return ipaddr
+        return None
 
     def internal_ip(self, node_id):
         # Currently vSphere VMs do not show an internal IP. So we just return the
@@ -342,7 +336,7 @@ class VsphereNodeProvider(NodeProvider):
                 break
 
     def get_frozen_vm_obj(self):
-        vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
+        vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_name(
             [vim.VirtualMachine], self.frozen_vm_name
         )
         return vm
@@ -378,7 +372,7 @@ class VsphereNodeProvider(NodeProvider):
         # If resource pool is not provided in the config yaml, then the resource pool
         # of the frozen VM will also be the resource pool of the new VM.
         resource_pool = (
-            self.pyvmomi_sdk_provider.get_pyvmomi_obj(
+            self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_name(
                 [vim.ResourcePool], node_config["resource_pool"]
             )
             if "resource_pool" in node_config and node_config["resource_pool"]
@@ -387,7 +381,7 @@ class VsphereNodeProvider(NodeProvider):
         # If datastore is not provided in the config yaml, then the datastore
         # of the frozen VM will also be the resource pool of the new VM.
         datastore = (
-            self.pyvmomi_sdk_provider.get_pyvmomi_obj(
+            self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_name(
                 [vim.Datastore], node_config["datastore"]
             )
             if "datastore" in node_config and node_config["datastore"]
@@ -416,7 +410,7 @@ class VsphereNodeProvider(NodeProvider):
         threading.Thread(target=self.tag_vm, args=(vm_name_target, tags)).start()
         WaitForTask(parent_vm.InstantClone_Task(spec=instant_clone_spec))
 
-        cloned_vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
+        cloned_vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_name(
             [vim.VirtualMachine], vm_name_target
         )
 
@@ -451,7 +445,7 @@ class VsphereNodeProvider(NodeProvider):
         exception_happened = False
         vm_names = []
 
-        res_pool = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
+        res_pool = self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_name(
             [vim.ResourcePool], node_config["frozen_vm"]["resource_pool"]
         )
         # In vSphere, for any user-created resource pool, the cluster object is the
@@ -509,7 +503,7 @@ class VsphereNodeProvider(NodeProvider):
                 "The datastore name must be provided when deploying frozen"
                 "VM from OVF"
             )
-        datastore_mo = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
+        datastore_mo = self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_name(
             [vim.Datastore], datastore_name
         )
         if not datastore_mo:
@@ -537,7 +531,7 @@ class VsphereNodeProvider(NodeProvider):
                     "The cluster name must be provided when deploying a single frozen"
                     " VM from OVF"
                 )
-            cluster_mo = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
+            cluster_mo = self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_name(
                 [vim.ClusterComputeResource], cluster_name
             )
             if not cluster_mo:
@@ -630,7 +624,9 @@ class VsphereNodeProvider(NodeProvider):
 
         # Get the created vm object
         vm = self.get_vm(result.resource_id.id)
-        vm_mo = self.pyvmomi_sdk_provider.get_pyvmomi_obj([vim.VirtualMachine], vm.name)
+        vm_mo = self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_name(
+            [vim.VirtualMachine], vm.name
+        )
         if wait_until_frozen:
             self.wait_until_vm_is_frozen(vm_mo)
 
@@ -670,8 +666,10 @@ class VsphereNodeProvider(NodeProvider):
             if "schedule_policy" in self.vsphere_config
             else ""
         )
-        self.frozen_vms_resource_pool = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
-            [vim.ResourcePool], self.frozen_vm_resource_pool_name
+        self.frozen_vms_resource_pool = (
+            self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_name(
+                [vim.ResourcePool], self.frozen_vm_resource_pool_name
+            )
         )
 
         if self.frozen_vms_resource_pool is None:

--- a/python/ray/autoscaler/_private/vsphere/pyvmomi_sdk_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/pyvmomi_sdk_provider.py
@@ -31,7 +31,7 @@ class PyvmomiSdkProvider:
             raise ValueError("Must init pyvmomi_sdk_client first.")
 
         container = self.pyvmomi_sdk_client.viewManager.CreateContainerView(
-            self.pyvmomi_sdk_client.content.rootFolder, vimtype, True
+            self.pyvmomi_sdk_client.rootFolder, vimtype, True
         )
 
         for c in container.view:

--- a/python/ray/autoscaler/_private/vsphere/pyvmomi_sdk_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/pyvmomi_sdk_provider.py
@@ -47,6 +47,7 @@ class PyvmomiSdkProvider:
                 f"Unexpected: cannot find vSphere object {vimtype} with moid: {moid}"
             )
         return obj
+
     def get_pyvmomi_obj_by_name(self, vimtype, name):
         """
         This function finds the vSphere object by the object name and the object type.

--- a/python/ray/autoscaler/_private/vsphere/pyvmomi_sdk_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/pyvmomi_sdk_provider.py
@@ -25,7 +25,29 @@ class PyvmomiSdkProvider:
         atexit.register(Disconnect, smart_connect_obj)
         self.pyvmomi_sdk_client = smart_connect_obj.content
 
-    def get_pyvmomi_obj(self, vimtype, name):
+    def get_pyvmomi_obj_by_moid(self, vimtype, moid):
+        obj = None
+        if self.pyvmomi_sdk_client is None:
+            raise ValueError("Must init pyvmomi_sdk_client first.")
+
+        container = self.pyvmomi_sdk_client.viewManager.CreateContainerView(
+            self.pyvmomi_sdk_client.content.rootFolder, vimtype, True
+        )
+
+        for c in container.view:
+            if moid:
+                if moid in str(c):
+                    obj = c
+                    break
+            else:
+                obj = c
+                break
+        if not obj:
+            raise RuntimeError(
+                f"Unexpected: cannot find vSphere object {vimtype} with moid: {moid}"
+            )
+        return obj
+    def get_pyvmomi_obj_by_name(self, vimtype, name):
         """
         This function finds the vSphere object by the object name and the object type.
         The object type can be "VM", "Host", "Datastore", etc.

--- a/python/ray/autoscaler/_private/vsphere/pyvmomi_sdk_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/pyvmomi_sdk_provider.py
@@ -26,6 +26,13 @@ class PyvmomiSdkProvider:
         self.pyvmomi_sdk_client = smart_connect_obj.content
 
     def get_pyvmomi_obj_by_moid(self, vimtype, moid):
+        """
+        This function finds the vSphere object by the object moid and the object type.
+        The object type can be "VM", "Host", "Datastore", etc.
+        The object moid is a unique id for this object type under the vCenter server.
+        To check all such object information, you can go to the managed object board
+        page of your vCenter Server, such as: https://<your_vc_ip/mob
+        """
         obj = None
         if self.pyvmomi_sdk_client is None:
             raise ValueError("Must init pyvmomi_sdk_client first.")

--- a/python/ray/autoscaler/_private/vsphere/utils.py
+++ b/python/ray/autoscaler/_private/vsphere/utils.py
@@ -1,3 +1,4 @@
+import ipaddress
 from enum import Enum
 
 
@@ -18,3 +19,11 @@ class Constants:
     class SessionType(Enum):
         VERIFIED = "verified"
         UNVERIFIED = "unverified"
+
+
+def is_ipv4(ip):
+    try:
+        ipaddress.IPv4Address(ip)
+        return True
+    except ipaddress.AddressValueError:
+        return False

--- a/python/ray/tests/vsphere/test_vsphere_node_provider.py
+++ b/python/ray/tests/vsphere/test_vsphere_node_provider.py
@@ -167,16 +167,6 @@ def test_node_tags():
     assert tags == vnp.tag_cache["test_vm_id_1"]
 
 
-def test_external_ip():
-    vnp = mock_vsphere_node_provider()
-    vm = MagicMock()
-    vm.ip_address = "10.123.234.255"
-    vnp.vsphere_sdk_client.vcenter.vm.guest.Identity.get.return_value = vm
-
-    ip_address = vnp.external_ip("test_id")
-    assert ip_address == "10.123.234.255"
-
-
 def test_create_nodes():
     vnp = mock_vsphere_node_provider()
     vnp.lock = RLock()
@@ -232,7 +222,7 @@ def test_create_instant_clone_node(mock_wait_task, mock_ic_spec, mock_relo_spec)
     VM.InstantCloneSpec = MagicMock(return_value="Clone Spec")
     vnp.vsphere_sdk_client.vcenter.VM.instant_clone.return_value = "test_id_1"
     vnp.vsphere_sdk_client.vcenter.vm.Power.stop.return_value = None
-    vnp.get_pyvmomi_obj = MagicMock(return_value=MagicMock())
+    vnp.get_pyvmomi_obj_by_name = MagicMock(return_value=MagicMock())
     vnp.set_node_tags = MagicMock(return_value=None)
     vnp.vsphere_sdk_client.vcenter.VM.list = MagicMock(
         return_value=[MagicMock(vm="test VM")]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
### Bug fix
Sometimes, an internal ip will appear firstly for a ray node, then break the ray up process
```
<1/1> Setting up head node
  Prepared bootstrap config
  New status: waiting-for-ssh
  [1/7] Waiting for SSH to become available
    Running `uptime` as a test.
    SSH still not available ({messages : [LocalizableMessage(id='com.vmware.api.vcenter.vm.guest.tools_not_running', default_message="VMware Tools are not running in the virtual machine with identifier 'vm-152:95360495-2538-4e6b-8457-69f0a2a38f97'.", args=['vm-152:95360495-2538-4e6b-8457-69f0a2a38f97'], params=None, localized=None)], data : None, error_type : SERVICE_UNAVAILABLE}), retrying in 5 seconds.
    Fetched IP: 172.17.0.1
Warning: Permanently added '172.17.0.1' (ECDSA) to the list of known hosts.
ray@172.17.0.1's password:
```
Check head VM, 172.17.0.1 is ip of docker0.
```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute
       valid_lft forever preferred_lft forever
3: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
    link/ether 02:42:6d:aa:e3:ba brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
       valid_lft forever preferred_lft forever
4: ens192: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 00:50:56:86:dd:c0 brd ff:ff:ff:ff:ff:ff
    altname enp11s0
    inet 10.78.136.144/20 brd 10.78.143.255 scope global dynamic ens192
       valid_lft 7027sec preferred_lft 7027sec
    inet6 fd01:0:106:2:250:56ff:fe86:ddc0/64 scope global dynamic mngtmpaddr
       valid_lft 2591995sec preferred_lft 604795sec
    inet6 fe80::250:56ff:fe86:ddc0/64 scope link
       valid_lft forever preferred_lft forever
```
### Solution
It need time to wait the value of vm.guest.ip_address to changed from private IP to public IP. But vm.guest.net[0].ipAddress is always public IP. Use vm.guest.net[0].ipAddress.

### Test

Create one single frozen VM then do 'ray up'
The yaml snippet:
```
frozen_vm:
        name: frozen-vm
```
Verified that Ray up succeed.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
