### PR TITLE
[Doc] Update miscellaneous.rst to reflect deletion of feature flag 'use_ray_syncer'

### DIFF
--- a/doc/source/ray-core/miscellaneous.rst
+++ b/doc/source/ray-core/miscellaneous.rst
@@ -256,15 +256,6 @@ Tuning Ray Settings
 
 To run a large cluster, several parameters need to be tuned in Ray.
 
-Resource broadcasting
-*********************
-
-In Ray 2.3+, lightweight resource broadcasting is supported as an experimental feature.
-Turning it on can significantly reduce GCS load and thus
-improve its overall stability and scalability. To turn it on, this OS environment
-should be set: ``RAY_use_ray_syncer=true``. This feature will be turned on by
-default in 2.4+.
-
 Benchmark
 ~~~~~~~~~
 
@@ -284,7 +275,6 @@ The OS setup:
 
 The Ray setup:
 
-- ``RAY_use_ray_syncer=true``
 - ``RAY_event_stats=false``
 
 Test workload:


### PR DESCRIPTION
Feature flag 'use_ray_syncer' has been deleted in 'src/ray/common/ray_config_def.h' ([PR #38489](https://github.com/ray-project/ray/pull/38489)), so update the doc accordingly.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
