### PR TITLE
[train] Re-introduce `local_dir` API to match the new persistence implementation semantics

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -622,8 +622,6 @@ class RunConfig:
     callbacks: Optional[List["Callback"]] = None
     progress_reporter: Optional["ProgressReporter"] = None
     log_to_file: Union[bool, str, Tuple[str, str]] = False
-
-    # Deprecated
     local_dir: Optional[str] = None
 
     def __post_init__(self):

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -425,6 +425,7 @@ class StorageContext:
         self,
         storage_path: Optional[Union[str, os.PathLike]],
         experiment_dir_name: str,
+        storage_local_path: Optional[Union[str, os.PathLike]] = None,
         sync_config: Optional[SyncConfig] = None,
         storage_filesystem: Optional[pyarrow.fs.FileSystem] = None,
         trial_dir_name: Optional[str] = None,
@@ -432,7 +433,7 @@ class StorageContext:
     ):
         self.custom_fs_provided = storage_filesystem is not None
 
-        self.storage_local_path = _get_defaults_results_dir()
+        self.storage_local_path = storage_local_path or _get_defaults_results_dir()
 
         # If no remote path is set, try to get Ray Storage URI
         ray_storage_uri: Optional[str] = _get_storage_uri()

--- a/python/ray/tune/experiment/experiment.py
+++ b/python/ray/tune/experiment/experiment.py
@@ -118,6 +118,7 @@ class Experiment:
         num_samples: int = 1,
         storage_path: Optional[str] = None,
         storage_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+        local_dir: Optional[str] = None,
         _experiment_checkpoint_dir: Optional[str] = None,
         sync_config: Optional[Union[SyncConfig, dict]] = None,
         checkpoint_config: Optional[Union[CheckpointConfig, dict]] = None,
@@ -127,8 +128,6 @@ class Experiment:
         export_formats: Optional[Sequence] = None,
         max_failures: int = 0,
         restore: Optional[str] = None,
-        # Deprecated
-        local_dir: Optional[str] = None,
     ):
         if isinstance(checkpoint_config, dict):
             checkpoint_config = CheckpointConfig(**checkpoint_config)
@@ -172,6 +171,7 @@ class Experiment:
         self.storage = self._storage_context_cls(
             storage_path=storage_path,
             storage_filesystem=storage_filesystem,
+            storage_local_path=local_dir,
             sync_config=sync_config,
             experiment_dir_name=name,
         )

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -619,8 +619,6 @@ class TunerInternal:
             trial_name_creator=self._tune_config.trial_name_creator,
             trial_dirname_creator=self._tune_config.trial_dirname_creator,
             _entrypoint=self._entrypoint,
-            # TODO(justinvyu): Finalize the local_dir vs. env var API in 2.8.
-            # For now, keep accepting both options.
             local_dir=self._run_config.local_dir,
             # Deprecated
             chdir_to_trial_dir=self._tune_config.chdir_to_trial_dir,

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -247,6 +247,7 @@ def run(
     num_samples: int = 1,
     storage_path: Optional[str] = None,
     storage_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    local_dir: Optional[str] = None,
     search_alg: Optional[Union[Searcher, SearchAlgorithm, str]] = None,
     scheduler: Optional[Union[TrialScheduler, str]] = None,
     checkpoint_config: Optional[CheckpointConfig] = None,
@@ -272,7 +273,6 @@ def run(
     checkpoint_freq: int = 0,  # Deprecated (2.7)
     checkpoint_at_end: bool = False,  # Deprecated (2.7)
     chdir_to_trial_dir: bool = _DEPRECATED_VALUE,  # Deprecated (2.8)
-    local_dir: Optional[str] = None,
     # == internal only ==
     _experiment_checkpoint_dir: Optional[str] = None,
     _remote: Optional[bool] = None,
@@ -618,11 +618,6 @@ def run(
 
     sync_config = sync_config or SyncConfig()
 
-    # TODO(justinvyu): Finalize the local_dir vs. env var API in 2.8.
-    # For now, keep accepting both options.
-    if local_dir is not None:
-        os.environ["RAY_AIR_LOCAL_CACHE_DIR"] = local_dir
-
     checkpoint_config = checkpoint_config or CheckpointConfig()
 
     # For backward compatibility
@@ -783,6 +778,7 @@ def run(
                 num_samples=num_samples,
                 storage_path=storage_path,
                 storage_filesystem=storage_filesystem,
+                local_dir=local_dir,
                 _experiment_checkpoint_dir=_experiment_checkpoint_dir,
                 sync_config=sync_config,
                 checkpoint_config=checkpoint_config,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

[This REP](https://github.com/ray-project/enhancements/blob/c3dcbe8cd31358344cd55bd59cdf1a18c1e9d1f4/reps/2023-06-06-simplify-sync.md#faq) aimed to simplify the system by treating all paths the same: storage_path is now always the path to upload to. This means for NFS, you’ll still save files locally at ~/ray_results then “upload” them to the NFS storage path. This results in 2 copies of the directory, which a few users are already confused about. ([1](https://ray-distributed.slack.com/archives/CNECXMW22/p1694712269714009), [2](https://discuss.ray.io/t/auto-generated-local-copy-in-home-directory-ray-2-7-0/12266), [3](https://ray-distributed.slack.com/archives/CNECXMW22/p1696532512789169))

The workaround right now is to set an environment variable, rather than use the public API:

```python
os.environ["RAY_AIR_LOCAL_CACHE_DIR"] = "/mnt/cluster_storage"

RunConfig(storage_path=None)
```

Having an env variable as the main API is not good, and the env variable also references Ray AIR which is no longer a thing.

Requirements:
* The user needs to be able to specify where their results and checkpoints end up.
* (Optionally) If the user wants their results to end up in cloud storage, they need to be able to configure the intermediate location on the local filesystem where results are saved before being uploaded.

Proposal: Introduce local_dir + rename storage_path → upload_dir

```python
# NFS
RunConfig(local_dir="/mnt/cluster_storage", upload_dir=None)

# Local path
RunConfig(local_dir="/other/local/path", upload_dir=None)

# S3 with default local dir (~/ray_results)
RunConfig(local_dir=None, upload_dir="s3://bucket")

# S3 with custom local dir
RunConfig(local_dir="/tmp/local", upload_dir="s3://bucket")
```

Pros:
* Renaming storage_path to upload_dir makes the uploading behavior more explicit.
* It is clear when syncing is happening.
* In line with the REP
Cons:
* There are now two settings that users need to think about when setting the storage

## TODO

- [ ] corresponding docs changes

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
