### PR TITLE
[autoscaler/core][logging] Improve autoscaler logging

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1932,9 +1932,9 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
             return colorama.Fore.YELLOW
         elif data.get("pid") == "autoscaler":
             if "Error:" in line or "Warning:" in line:
-                return colorama.Style.BRIGHT + colorama.Fore.YELLOW
+                return colorama.Fore.YELLOW
             else:
-                return colorama.Style.BRIGHT + colorama.Fore.CYAN
+                return colorama.Fore.CYAN
         elif os.getenv("RAY_COLOR_PREFIX") == "1":
             colors = [
                 # colorama.Fore.BLUE, # Too dark
@@ -1974,8 +1974,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
             else:
                 hide_tqdm()
                 print(
-                    "{}{}({}{}){} {}".format(
-                        colorama.Style.DIM,
+                    "{}({}{}){} {}".format(
                         color_for(data, line),
                         prefix_for(data),
                         pid,
@@ -1991,8 +1990,7 @@ def print_worker_logs(data: Dict[str, str], print_file: Any):
             else:
                 hide_tqdm()
                 print(
-                    "{}{}({}{}, ip={}){} {}".format(
-                        colorama.Style.DIM,
+                    "{}({}{}, ip={}){} {}".format(
                         color_for(data, line),
                         prefix_for(data),
                         pid,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->



<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
See https://github.com/ray-project/ray/issues/26992 for more details. In short, this PR improves the autoscaler logging color to make it look better in different terminals and against different backgrounds (white, dark, grey).

Here's what it looks like:
mac:
<img width="1083" alt="image" src="https://github.com/ray-project/ray/assets/51814063/6f4daffb-d50d-4b84-8c6b-e3b6f2619610">
<img width="1083" alt="image" src="https://github.com/ray-project/ray/assets/51814063/228c7053-67cf-4379-961a-75a5639f1fc5">
<img width="1083" alt="image" src="https://github.com/ray-project/ray/assets/51814063/b7216e02-0fe9-4347-ad2d-6e17010c7b46">

windows:
<img width="1083" alt="image" src="https://github.com/ray-project/ray/assets/51814063/1f7fbf1b-a82d-4d00-be9f-6554f08e2398">
<img width="1083" alt="image" src="https://github.com/ray-project/ray/assets/51814063/7c894f43-9074-48d3-a6f6-ed35073a861a">
<img width="1083" alt="image" src="https://github.com/ray-project/ray/assets/51814063/b3171962-3afe-4b2f-8453-0d0afc819335">

ubuntu:
<img width="1083" alt="image" src="https://github.com/ray-project/ray/assets/51814063/d6483c36-1dee-4798-bd28-bf525130b41b">
<img width="1083" alt="image" src="https://github.com/ray-project/ray/assets/51814063/ad9f73ac-d553-4e16-9a1c-5d3640723679">
<img width="1083" alt="image" src="https://github.com/ray-project/ray/assets/51814063/cf61bac5-6e7e-416a-9eb7-d204486dc919">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #26992 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
