### PR TITLE
[civ2][docker] copy docker pip freeze to artifact mount

### DIFF
--- a/ci/build/build-ray-docker.sh
+++ b/ci/build/build-ray-docker.sh
@@ -5,6 +5,7 @@ WHEEL_NAME="$1"
 SOURCE_IMAGE="$2"
 CONSTRAINTS_FILE="$3"
 DEST_IMAGE="$4"
+PIP_FREEZE_FILE="$5"
 
 CPU_TMP="$(mktemp -d)"
 
@@ -14,6 +15,7 @@ cp .whl/"$WHEEL_NAME" "${CPU_TMP}/.whl/${WHEEL_NAME}"
 cp docker/ray/Dockerfile "${CPU_TMP}/Dockerfile"
 cp python/requirements_compiled.txt "${CPU_TMP}/."
 
+# Build the image.
 cd "${CPU_TMP}"
 tar --mtime="UTC 2020-01-01" -c -f - . \
     | docker build --progress=plain \
@@ -21,3 +23,9 @@ tar --mtime="UTC 2020-01-01" -c -f - . \
         --build-arg WHEEL_PATH=".whl/${WHEEL_NAME}" \
         --build-arg CONSTRAINTS_FILE="$CONSTRAINTS_FILE" \
         -t "$DEST_IMAGE" -f Dockerfile -
+
+# Copy the pip freeze file to the artifact mount.
+mkdir -p /artifact-mount/.image-info
+CONTAINER="$(docker create "$DEST_IMAGE")"
+docker cp "$CONTAINER":/home/ray/pip-freeze.txt \
+    /artifact-mount/.image-info/"$PIP_FREEZE_FILE"

--- a/ci/ray_ci/ray_docker_container.py
+++ b/ci/ray_ci/ray_docker_container.py
@@ -28,13 +28,14 @@ class RayDockerContainer(DockerContainer):
 
         bin_path = PYTHON_VERSIONS[self.python_version]["bin_path"]
         wheel_name = f"ray-{RAY_VERSION}-{bin_path}-manylinux2014_x86_64.whl"
-
         constraints_file = "requirements_compiled.txt"
+        tag = self._get_canonical_tag()
+        ray_image = f"rayproject/{self.image_type}:{tag}"
+        pip_freeze = f"{self.image_type}:{tag}_pip-freeze.txt"
 
-        ray_image = f"rayproject/{self.image_type}:{self._get_canonical_tag()}"
         cmds = [
             "./ci/build/build-ray-docker.sh "
-            f"{wheel_name} {base_image} {constraints_file} {ray_image}"
+            f"{wheel_name} {base_image} {constraints_file} {ray_image} {pip_freeze}"
         ]
         if self._should_upload():
             cmds += [

--- a/ci/ray_ci/test_ray_docker_container.py
+++ b/ci/ray_ci/test_ray_docker_container.py
@@ -32,7 +32,8 @@ class TestRayDockerContainer(RayCITestBase):
                 f"ray-{RAY_VERSION}-cp38-cp38-manylinux2014_x86_64.whl "
                 f"{_DOCKER_ECR_REPO}:123-ray-py3.8-cu11.8.0-base "
                 "requirements_compiled.txt "
-                "rayproject/ray:123456-py38-cu118"
+                "rayproject/ray:123456-py38-cu118 "
+                "ray:123456-py38-cu118_pip-freeze.txt"
             )
 
             container = RayDockerContainer("3.9", "cpu", "ray-ml")
@@ -43,7 +44,8 @@ class TestRayDockerContainer(RayCITestBase):
                 f"ray-{RAY_VERSION}-cp39-cp39-manylinux2014_x86_64.whl "
                 f"{_DOCKER_ECR_REPO}:123-ray-ml-py3.9-cpu-base "
                 "requirements_compiled.txt "
-                "rayproject/ray-ml:123456-py39-cpu"
+                "rayproject/ray-ml:123456-py39-cpu "
+                "ray-ml:123456-py39-cpu_pip-freeze.txt"
             )
 
     def test_canonical_tag(self) -> None:


### PR DESCRIPTION
Since docker build is migrated to civ2, pip freeze is not longer copied to buildkite artifact mount. This PR fixes it.

Test:
- CI
- Freeze files on artifact: https://buildkite.com/ray-project/premerge/builds/8110#018b1b79-1b40-4c13-bc3e-761f6c3fda43