### PR TITLE
[ci] jail rllib tests

### DIFF
--- a/ci/ray_ci/rllib.tests.yml
+++ b/ci/ray_ci/rllib.tests.yml
@@ -3,5 +3,6 @@ flaky_tests:
   - //rllib:learning_tests_multi_agent_cartpole_impala 
   - //rllib:learning_tests_stateless_cartpole_r2d2
   - //rllib:learning_tests_cartpole_appo_fake_gpus
+  - //rllib:learning_tests_cartpole_ddppo
   - //rllib:learning_tests_two_step_game_qmix
   - //rllib:learning_tests_pendulum_cql


### PR DESCRIPTION
Jail linux://rllib:learning_tests_cartpole_ddppo, the test has became flaky

Test:
- CI