### PR TITLE
[civ2][ml/1] migrate ml train tests to civ2

### DIFF
--- a/.buildkite/_forge.rayci.yml
+++ b/.buildkite/_forge.rayci.yml
@@ -122,3 +122,7 @@ steps:
   - name: rllibbuild
     wanda: ci/docker/rllib.build.wanda.yaml
     depends_on: oss-ci-base_ml
+
+  - name: mlbuild
+    wanda: ci/docker/ml.build.wanda.yaml
+    depends_on: oss-ci-base_ml

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -1,0 +1,12 @@
+group: ml tests
+steps:
+  - label: ":train: ml: train tests and examples"
+    tags: train
+    instance_type: large
+    parallelism: 2
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --except-tags gpu_only,gpu,minimal,tune,doctest,needs_credentials 
+    depends_on: mlbuild
+    job_env: forge

--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -29,22 +29,6 @@
       --test_tag_filters=team:ml
       release/...
 
-
-- label: ":steam_locomotive: Train tests and examples"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
-  instance_size: large
-  parallelism: 4
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    # Todo (krfricke): Move mosaicml to train-test-requirements.txt
-    - pip install "mosaicml==0.12.1"
-    - TRAIN_TESTING=1 DATA_PROCESSING_TESTING=1 INSTALL_HOROVOD=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - ./ci/run/run_bazel_test_with_sharding.sh
-      --config=ci $(./ci/run/bazel_export_options)
-      --test_tag_filters=-gpu_only,-gpu,-minimal,-tune,-doctest,-needs_credentials
-      python/ray/train/...
-
 - label: ":steam_locomotive: :octopus: Train + Tune tests and examples"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
   instance_size: medium

--- a/ci/docker/ml.build.Dockerfile
+++ b/ci/docker/ml.build.Dockerfile
@@ -1,0 +1,17 @@
+ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml
+FROM $DOCKER_IMAGE_BASE_BUILD
+
+# Unset dind settings; we are using the host's docker daemon.
+ENV DOCKER_TLS_CERTDIR=
+ENV DOCKER_HOST=
+ENV DOCKER_TLS_VERIFY=
+ENV DOCKER_CERT_PATH=
+
+SHELL ["/bin/bash", "-ice"]
+
+COPY . .
+
+# TODO (can): Move mosaicml to train-test-requirements.txt
+RUN pip install "mosaicml==0.12.1"
+RUN TRAIN_TESTING=1 TUNE_TESTING=1 DATA_PROCESSING_TESTING=1 INSTALL_HOROVOD=1 \
+  ./ci/env/install-dependencies.sh

--- a/ci/docker/ml.build.wanda.yaml
+++ b/ci/docker/ml.build.wanda.yaml
@@ -1,0 +1,19 @@
+name: "mlbuild"
+froms: ["cr.ray.io/rayproject/oss-ci-base_ml"]
+dockerfile: ci/docker/ml.build.Dockerfile
+srcs:
+  - ci/env/install-dependencies.sh
+  - ci/env/install-horovod.sh
+  - python/requirements.txt
+  - python/requirements_compiled.txt
+  - python/requirements/test-requirements.txt
+  - python/requirements/ml/core-requirements.txt
+  - python/requirements/ml/dl-cpu-requirements.txt
+  - python/requirements/ml/train-requirements.txt
+  - python/requirements/ml/train-test-requirements.txt
+  - python/requirements/ml/tune-requirements.txt
+  - python/requirements/ml/tune-test-requirements.txt
+  - python/requirements/ml/data-requirements.txt
+  - python/requirements/ml/data-test-requirements.txt
+tags:
+  - cr.ray.io/rayproject/mlbuild

--- a/ci/ray_ci/ml.tests.yml
+++ b/ci/ray_ci/ml.tests.yml
@@ -1,0 +1,1 @@
+flaky_tests: []


### PR DESCRIPTION
Migrate ml train tests to civ2. Need to use only 2 large machines instead of 4 machines w00t.

Test:
- CI