### PR TITLE
[core] Autoscaler consistency fix [2/2]

### DIFF
--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -786,7 +786,8 @@ void NodeResourceInfoAccessor::AsyncResubscribe() {
 Status NodeResourceInfoAccessor::AsyncGetAllResourceUsage(
     const ItemCallback<rpc::ResourceUsageBatchData> &callback) {
   rpc::GetAllResourceUsageRequest request;
-  client_impl_->GetGcsRpcClient().GetAllResourceUsage(
+  // Deviation: we now get this from LegacyAutoscalerService.
+  client_impl_->GetGcsRpcClient().GetAllResourceUsageLegacy(
       request,
       [callback](const Status &status, const rpc::GetAllResourceUsageReply &reply) {
         callback(reply.resource_usage_data());

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -200,7 +200,7 @@ Status PythonGcsClient::Connect(const ClusterID &cluster_id,
   kv_stub_ = rpc::InternalKVGcsService::NewStub(channel_);
   runtime_env_stub_ = rpc::RuntimeEnvGcsService::NewStub(channel_);
   job_info_stub_ = rpc::JobInfoGcsService::NewStub(channel_);
-  node_resource_info_stub_ = rpc::NodeResourceInfoGcsService::NewStub(channel_);
+  legacy_autoscaler_stub_ = rpc::LegacyAutoscalerGcsService::NewStub(channel_);
   autoscaler_stub_ = rpc::autoscaler::AutoscalerStateService::NewStub(channel_);
   return Status::OK();
 }
@@ -467,7 +467,7 @@ Status PythonGcsClient::GetAllResourceUsage(int64_t timeout_ms,
   rpc::GetAllResourceUsageReply reply;
 
   grpc::Status status =
-      node_resource_info_stub_->GetAllResourceUsage(&context, request, &reply);
+      legacy_autoscaler_stub_->GetAllResourceUsageLegacy(&context, request, &reply);
   if (status.ok()) {
     if (reply.status().code() == static_cast<int>(StatusCode::OK)) {
       serialized_reply = reply.SerializeAsString();

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -271,7 +271,7 @@ class RAY_EXPORT PythonGcsClient {
   std::unique_ptr<rpc::InternalKVGcsService::Stub> kv_stub_;
   std::unique_ptr<rpc::RuntimeEnvGcsService::Stub> runtime_env_stub_;
   std::unique_ptr<rpc::NodeInfoGcsService::Stub> node_info_stub_;
-  std::unique_ptr<rpc::NodeResourceInfoGcsService::Stub> node_resource_info_stub_;
+  std::unique_ptr<rpc::LegacyAutoscalerGcsService::Stub> legacy_autoscaler_stub_;
   std::unique_ptr<rpc::JobInfoGcsService::Stub> job_info_stub_;
   std::unique_ptr<rpc::autoscaler::AutoscalerStateService::Stub> autoscaler_stub_;
   std::shared_ptr<grpc::Channel> channel_;

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -198,6 +198,7 @@ void GcsAutoscalerStateManager::UpdateResourceLoadAndUsage(
   if (iter == node_resource_info_.end()) {
     RAY_LOG(WARNING) << "Ignoring resource usage for node that is not alive: "
                      << node_id.Hex() << ".";
+    return;
   }
 
   auto &new_data = iter->second.second;

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -233,10 +233,8 @@ void GcsAutoscalerStateManager::UpdateResourceLoadAndUsage(
 
   auto &new_data = iter->second.second;
 
-  if (data.resource_load_changed()) {
-    (*new_data.mutable_resource_load()) = data.resource_load();
-    (*new_data.mutable_resource_load_by_shape()) = data.resource_load_by_shape();
-  }
+  (*new_data.mutable_resource_load()) = data.resource_load();
+  (*new_data.mutable_resource_load_by_shape()) = data.resource_load_by_shape();
 
   if (data.resources_total_size() > 0) {
     (*new_data.mutable_resources_total()) = data.resources_total();

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h
@@ -25,13 +25,19 @@ class GcsResourceManager;
 class GcsNodeManager;
 class GcsPlacementGroupManager;
 
-class GcsAutoscalerStateManager : public rpc::autoscaler::AutoscalerStateHandler {
+class GcsAutoscalerStateManager : public rpc::autoscaler::AutoscalerStateHandler,
+                                  public rpc::LegacyAutoscalerHandler {
  public:
   GcsAutoscalerStateManager(
       const std::string &session_name,
       const GcsNodeManager &gcs_node_manager,
       const GcsPlacementGroupManager &gcs_placement_group_manager,
       std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool);
+
+  void HandleGetAllResourceUsageLegacy(
+      rpc::GetAllResourceUsageRequest request,
+      rpc::GetAllResourceUsageReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override;
 
   void HandleGetClusterResourceState(
       rpc::autoscaler::GetClusterResourceStateRequest request,
@@ -64,7 +70,8 @@ class GcsAutoscalerStateManager : public rpc::autoscaler::AutoscalerStateHandler
 
   void RemoveNode(const NodeID &node) { node_resource_info_.erase(node); }
 
-  const absl::flat_hash_map<ray::NodeID, std::pair<absl::Time, rpc::ResourcesData>> &GetNodeResourceInfo() const {
+  const absl::flat_hash_map<ray::NodeID, std::pair<absl::Time, rpc::ResourcesData>>
+      &GetNodeResourceInfo() const {
     return node_resource_info_;
   }
 

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -862,7 +862,6 @@ void GcsPlacementGroupManager::CleanPlacementGroupIfNeededWhenActorDead(
 }
 
 void GcsPlacementGroupManager::Tick() {
-  UpdatePlacementGroupLoad();
   // To avoid scheduling exhaution in some race conditions.
   // Note that we don't currently have a known race condition that requires this, but we
   // added as a safety check. https://github.com/ray-project/ray/pull/18419
@@ -919,12 +918,6 @@ std::shared_ptr<rpc::PlacementGroupLoad> GcsPlacementGroupManager::GetPlacementG
   }
 
   return placement_group_load;
-}
-
-void GcsPlacementGroupManager::UpdatePlacementGroupLoad() {
-  // TODO(rickyx): We should remove this, no other callers other than autoscaler
-  // use this info.
-  gcs_resource_manager_.UpdatePlacementGroupLoad(GetPlacementGroupLoad());
 }
 
 void GcsPlacementGroupManager::Initialize(const GcsInitData &gcs_init_data) {

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -62,13 +62,10 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
                            public syncer::ReceiverInterface {
  public:
   /// Create a GcsResourceManager.
-  explicit GcsResourceManager(
-      instrumented_io_context &io_context,
-      ClusterResourceManager &cluster_resource_manager,
-      GcsNodeManager &gcs_node_manager,
-      GcsServer &gcs_server,
-      NodeID local_node_id,
-      std::shared_ptr<ClusterTaskManager> cluster_task_manager = nullptr);
+  explicit GcsResourceManager(instrumented_io_context &io_context,
+                              ClusterResourceManager &cluster_resource_manager,
+                              GcsNodeManager &gcs_node_manager,
+                              NodeID local_node_id);
 
   virtual ~GcsResourceManager() {}
 
@@ -204,9 +201,7 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
 
   ClusterResourceManager &cluster_resource_manager_;
   GcsNodeManager &gcs_node_manager_;
-  GcsServer &gcs_server_;
   NodeID local_node_id_;
-  std::shared_ptr<ClusterTaskManager> cluster_task_manager_;
   /// Num of alive nodes in the cluster.
   size_t num_alive_nodes_ = 0;
 

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -340,9 +340,7 @@ void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
       main_service_,
       cluster_resource_scheduler_->GetClusterResourceManager(),
       *gcs_node_manager_,
-      *this,
-      kGCSNodeID,
-      cluster_task_manager_);
+      kGCSNodeID);
 
   // Initialize by gcs tables data.
   gcs_resource_manager_->Initialize(gcs_init_data);
@@ -681,6 +679,9 @@ void GcsServer::InitGcsAutoscalerStateManager() {
                                                   *gcs_node_manager_,
                                                   *gcs_placement_group_manager_,
                                                   raylet_client_pool_);
+  legacy_autoscaler_service_.reset(new rpc::LegacyAutoscalerGrpcService(
+      main_service_, *gcs_autoscaler_state_manager_));
+  rpc_server_.RegisterService(*legacy_autoscaler_service_);
 
   autoscaler_state_service_.reset(new rpc::autoscaler::AutoscalerStateGrpcService(
       main_service_, *gcs_autoscaler_state_manager_));

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -247,6 +247,8 @@ class GcsServer {
   std::unique_ptr<rpc::JobInfoGrpcService> job_info_service_;
   /// Actor info service.
   std::unique_ptr<rpc::ActorInfoGrpcService> actor_info_service_;
+  /// Legacy autoscaler interface.
+  std::unique_ptr<rpc::LegacyAutoscalerGrpcService> legacy_autoscaler_service_;
   /// Node info handler and service.
   std::unique_ptr<rpc::NodeInfoGrpcService> node_info_service_;
   /// Function table manager.

--- a/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
@@ -85,7 +85,7 @@ class GcsAutoscalerStateManagerTest : public ::testing::Test {
     }
     data.set_node_id(node->node_id());
     data.set_node_manager_address(node->node_manager_address());
-    gcs_autoscaler_state_manager_->OnNodeAdd(NodeID::FromBinary(node->node_id()));
+    gcs_autoscaler_state_manager_->OnNodeAdd(*node);
     gcs_autoscaler_state_manager_->UpdateResourceLoadAndUsage(data);
   }
 

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -612,6 +612,12 @@ message GetDrainingNodesReply {
   repeated bytes node_ids = 2;
 }
 
+// Legacy RPCs that GcsAutoscalerStateManager should also support.
+service LegacyAutoscalerGcsService {
+  // Get resource usage of all nodes from GCS Service.
+  rpc GetAllResourceUsageLegacy(GetAllResourceUsageRequest) returns (GetAllResourceUsageReply);
+}
+
 // Service for node resource info access.
 service NodeResourceInfoGcsService {
   // Get node's resources from GCS Service.

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -477,9 +477,5 @@ size_t ClusterTaskManager::GetPendingQueueSize() const {
   return count;
 }
 
-void ClusterTaskManager::FillPendingActorInfo(rpc::ResourcesData &data) const {
-  scheduler_resource_reporter_.FillPendingActorCountByShape(data);
-}
-
 }  // namespace raylet
 }  // namespace ray

--- a/src/ray/raylet/scheduling/scheduler_resource_reporter.cc
+++ b/src/ray/raylet/scheduling/scheduler_resource_reporter.cc
@@ -175,32 +175,5 @@ void SchedulerResourceReporter::FillResourceUsage(
   }
 }
 
-void SchedulerResourceReporter::FillPendingActorCountByShape(
-    rpc::ResourcesData &data) const {
-  absl::flat_hash_map<SchedulingClass, std::pair<int, int>> pending_count_by_shape;
-  for (const auto &[scheduling_class, queue] : infeasible_tasks_) {
-    pending_count_by_shape[scheduling_class].first = queue.size();
-  }
-  for (const auto &[scheduling_class, queue] : tasks_to_schedule_) {
-    pending_count_by_shape[scheduling_class].second = queue.size();
-  }
-
-  if (!pending_count_by_shape.empty()) {
-    data.set_cluster_full_of_actors_detected(true);
-    auto resource_load_by_shape =
-        data.mutable_resource_load_by_shape()->mutable_resource_demands();
-    for (const auto &shape_entry : pending_count_by_shape) {
-      auto by_shape_entry = resource_load_by_shape->Add();
-      for (const auto &resource_entry :
-           TaskSpecification::GetSchedulingClassDescriptor(shape_entry.first)
-               .resource_set.GetResourceMap()) {
-        (*by_shape_entry->mutable_shape())[resource_entry.first] = resource_entry.second;
-      }
-      by_shape_entry->set_num_infeasible_requests_queued(shape_entry.second.first);
-      by_shape_entry->set_num_ready_requests_queued(shape_entry.second.second);
-    }
-  }
-}
-
 }  // namespace raylet
 }  // namespace ray

--- a/src/ray/raylet/scheduling/scheduler_resource_reporter.h
+++ b/src/ray/raylet/scheduling/scheduler_resource_reporter.h
@@ -49,12 +49,6 @@ class SchedulerResourceReporter {
       rpc::ResourcesData &data,
       const std::shared_ptr<NodeResources> &last_reported_resources) const;
 
-  /// Populate the count of pending and infeasible actor tasks, organized by shape.
-  ///
-  /// \param[out] data: Output parameter. `resource_load_by_shape` is the only field
-  /// filled.
-  void FillPendingActorCountByShape(rpc::ResourcesData &data) const;
-
  private:
   int64_t TotalBacklogSize(SchedulingClass scheduling_class) const;
 

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -240,6 +240,10 @@ class GcsRpcClient {
     task_info_grpc_client_ =
         std::make_unique<GrpcClient<TaskInfoGcsService>>(channel_, client_call_manager);
 
+    legacy_autoscaler_grpc_client_ =
+        std::make_unique<GrpcClient<LegacyAutoscalerGcsService>>(channel_,
+                                                                 client_call_manager);
+
     SetupCheckTimer();
   }
 
@@ -348,6 +352,13 @@ class GcsRpcClient {
   VOID_GCS_RPC_CLIENT_METHOD(NodeInfoGcsService,
                              GetInternalConfig,
                              node_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
+  typedef GetAllResourceUsageRequest GetAllResourceUsageLegacyRequest;
+  typedef GetAllResourceUsageReply GetAllResourceUsageLegacyReply;
+  VOID_GCS_RPC_CLIENT_METHOD(LegacyAutoscalerGcsService,
+                             GetAllResourceUsageLegacy,
+                             legacy_autoscaler_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
   /// Get node's resources from GCS Service.
@@ -605,6 +616,7 @@ class GcsRpcClient {
   std::unique_ptr<GrpcClient<InternalPubSubGcsService>> internal_pubsub_grpc_client_;
 
   std::unique_ptr<GrpcClient<TaskInfoGcsService>> task_info_grpc_client_;
+  std::unique_ptr<GrpcClient<LegacyAutoscalerGcsService>> legacy_autoscaler_grpc_client_;
 
   std::shared_ptr<grpc::Channel> channel_;
   bool gcs_is_down_ = false;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Autoscaler currently does not report a consistent snapshot when polling cluster state. Point-in-time consistency aside, the vast majority of issues show that resources allocated to a task are often double-counted between load (queued for scheduling) and usage (dispatched), which may occur on different nodes when there is spillback. The end result is that autoscaler may provision unnecessary extra nodes for double-counted load (the task has already been dispatched, but the load for the task still exists) before scaling back down, which causes undesirable churn.

While guaranteeing a fix to this issue is complex, one simple change that drastically decreases the probability of an inconsistent snapshot and does not sacrifice performance is to report load and usage for a given node together. By default, node usage changes are pushed at a 100ms cadence by each raylet to every other raylet through Ray Syncer for scheduling purposes. On the other hand, load is reported only to GCS in response to a 1s poll that GCS sends to every node. Even when there is no network error, the potential delta in reporting easily reaches 900ms between load and usage.

Fix this so that load and usage are reported together for autoscaler accounting purposes independently of Ray Syncer. While this still does not guarantee the inconsistency doesn't exist (GCS polls by sending an RPC to all the nodes and collecting the responses, so in theory a task could still be double-counted between nodes if spillback occurs between when two of them respond), it does significantly decrease the chances.

For other approaches to the general consistency problem (as well as autoscaling churn from transient demand), please see:
    https://docs.google.com/document/d/10VhjYQWIGMiOXN7FGw-aUaOn43Y2Z8t5QDqq5n4gBkQ/edit
    https://docs.google.com/document/d/10fy0mSLK5p0EHVzMvSSlSsFXPljsOHWcM7ZU6RWkxGU/edit

Note also that while autoscaler state is now pretty much entirely decoupled from other GCS/scheduling state, it does rely on GcsNodeInfo in GCSNodeManager to provide dead node information at a different cadence than the cadence at which autoscaler information is polled.

This change also adds a repro and enables an existing one that had been disabled.

## Why are these changes needed?

Lots of users have run into this and complained.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/36926
<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/pull/40254

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
