### PR TITLE
[Data] Fix streaming ingest benchmark

### DIFF
--- a/release/nightly_tests/dataset/data_ingest_benchmark.py
+++ b/release/nightly_tests/dataset/data_ingest_benchmark.py
@@ -239,24 +239,24 @@ if __name__ == "__main__":
         benchmark.run_fn(
             "streaming-ingest",
             run_ingest_streaming,
-            fn_args=(
-                args.dataset_size_gb,
-                args.num_workers,
-                args.use_gpu,
-                args.early_stop,
-            ),
+            args.dataset_size_gb,
+            args.num_workers,
+            args.use_gpu,
+            args.early_stop,
         )
     elif args.streaming:
         benchmark.run_fn(
             "pipeline-ingest",
             run_ingest_dataset_pipeline,
-            fn_args=(args.dataset_size_gb, args.num_workers),
+            args.dataset_size_gb,
+            args.num_workers,
         )
     else:
         benchmark.run_fn(
             "bulk-ingest",
             run_ingest_bulk,
-            fn_args=(args.dataset_size_gb, args.num_workers),
+            args.dataset_size_gb,
+            args.num_workers,
         )
 
     benchmark.write_result()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `streaming_data_ingest_benchmark` is failing with an error like this:

> TypeError: run_ingest_streaming() got an unexpected keyword argument 'fn_args'

This is because we pass in the positional arguments as a keyword argument, when we should just pass them in as normal positional arguments.

https://github.com/ray-project/ray/blob/3fb4e19ad84c862f37930909894c0a4aaee115df/release/nightly_tests/dataset/benchmark.py#L130-L133

https://github.com/ray-project/ray/blob/3fb4e19ad84c862f37930909894c0a4aaee115df/release/nightly_tests/dataset/data_ingest_benchmark.py#L242-L248

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/pull/40264, fixes https://github.com/ray-project/ray/issues/40258, fixes https://github.com/ray-project/ray/issues/40257

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
