### PR TITLE
[ci] Fix aws_cluster_launcher and friend tests

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -6634,7 +6634,7 @@
 
   run:
     timeout: 2400
-    script: python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10
+    script: sudo python launch_and_verify_cluster.py aws/tests/aws_cluster.yaml --num-expected-nodes 2 --retries 10
 
 
 - name: aws_cluster_launcher_nightly_image


### PR DESCRIPTION
The existing code creates the local_key_path as a directory, which causes s3 to fail when trying to download it as a file.

Test:
- CI