### PR TITLE
[data] add rows outputted to data metrics

### DIFF
--- a/dashboard/client/src/components/DataOverviewTable.tsx
+++ b/dashboard/client/src/components/DataOverviewTable.tsx
@@ -33,7 +33,7 @@ const columns = [
     helpInfo: <Typography>Blocks outputted by output operator.</Typography>,
   },
   { label: "State", align: "center" },
-  { label: "Bytes Outputted" },
+  { label: "Rows Outputted" },
   {
     label: "Memory Usage (Current / Max)",
     helpInfo: (
@@ -52,6 +52,12 @@ const columns = [
         = True" to collect spill stats.
       </Typography>
     ),
+  },
+  {
+    label: "CPU Usage (Current / Max)",
+  },
+  {
+    label: "GPU Usage (Current / Max)",
   },
   { label: "Start Time", align: "center" },
   { label: "End Time", align: "center" },
@@ -123,7 +129,7 @@ const DataOverviewTable = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {list.map((dataset, index) => (
+            {list.map((dataset) => (
               <DatasetTable
                 datasetMetrics={dataset}
                 isExpanded={expandedDatasets[dataset.dataset]}
@@ -212,15 +218,21 @@ const DataRow = ({
       <TableCell align="center">
         <StatusChip type="task" status={data.state} />
       </TableCell>
-      <TableCell align="right">
-        {memoryConverter(Number(data.ray_data_output_bytes.max))}
-      </TableCell>
+      <TableCell align="right">{data.ray_data_output_rows.max}</TableCell>
       <TableCell align="right">
         {memoryConverter(Number(data.ray_data_current_bytes.value))}/
         {memoryConverter(Number(data.ray_data_current_bytes.max))}
       </TableCell>
       <TableCell align="right">
         {memoryConverter(Number(data.ray_data_spilled_bytes.max))}
+      </TableCell>
+      <TableCell align="right">
+        {data.ray_data_cpu_usage_cores.value}/
+        {data.ray_data_cpu_usage_cores.max}
+      </TableCell>
+      <TableCell align="right">
+        {data.ray_data_gpu_usage_cores.value}/
+        {data.ray_data_gpu_usage_cores.max}
       </TableCell>
       <TableCell align="center">
         {isDatasetRow && formatDateFromTimeMs(datasetMetrics.start_time * 1000)}

--- a/dashboard/client/src/components/DataOverviewTable.tsx
+++ b/dashboard/client/src/components/DataOverviewTable.tsx
@@ -5,6 +5,7 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableContainer,
   TableHead,
   TableRow,
   TextField,
@@ -35,7 +36,7 @@ const columns = [
   { label: "State", align: "center" },
   { label: "Rows Outputted" },
   {
-    label: "Memory Usage (Current / Max)",
+    label: "Memory Usage (current / max)",
     helpInfo: (
       <Typography>
         Amount of object store memory used by a dataset. Includes spilled
@@ -54,12 +55,12 @@ const columns = [
     ),
   },
   {
-    label: "CPU Usage (Current / Max)",
-    helpInfo: <Typography>Logical CPU usage in cores.</Typography>,
+    label: "Logical CPU Cores (current / max)",
+    align: "center",
   },
   {
-    label: "GPU Usage (Current / Max)",
-    helpInfo: <Typography>Logical GPU usage in cores.</Typography>,
+    label: "Logical GPU Cores (current / max)",
+    align: "center",
   },
   { label: "Start Time", align: "center" },
   { label: "End Time", align: "center" },
@@ -108,7 +109,7 @@ const DataOverviewTable = ({
           <StateCounter type="task" list={datasetList} />
         </div>
       </div>
-      <div className={classes.tableContainer}>
+      <TableContainer>
         <Table>
           <TableHead>
             <TableRow>
@@ -147,7 +148,7 @@ const DataOverviewTable = ({
             ))}
           </TableBody>
         </Table>
-      </div>
+      </TableContainer>
     </div>
   );
 };
@@ -204,7 +205,7 @@ const DataRow = ({
         {isDatasetRow && datasetMetrics.dataset}
         {isOperatorRow && operatorMetrics.operator}
       </TableCell>
-      <TableCell align="right" size={"small"}>
+      <TableCell align="right" style={{ width: 200 }}>
         <TaskProgressBar
           showLegend={false}
           numFinished={data.progress}
@@ -228,11 +229,11 @@ const DataRow = ({
       <TableCell align="right">
         {memoryConverter(Number(data.ray_data_spilled_bytes.max))}
       </TableCell>
-      <TableCell align="right">
+      <TableCell align="center" style={{ width: 200 }}>
         {data.ray_data_cpu_usage_cores.value}/
         {data.ray_data_cpu_usage_cores.max}
       </TableCell>
-      <TableCell align="right">
+      <TableCell align="center" style={{ width: 200 }}>
         {data.ray_data_gpu_usage_cores.value}/
         {data.ray_data_gpu_usage_cores.max}
       </TableCell>

--- a/dashboard/client/src/components/DataOverviewTable.tsx
+++ b/dashboard/client/src/components/DataOverviewTable.tsx
@@ -55,9 +55,11 @@ const columns = [
   },
   {
     label: "CPU Usage (Current / Max)",
+    helpInfo: <Typography>Logical CPU usage in cores.</Typography>,
   },
   {
     label: "GPU Usage (Current / Max)",
+    helpInfo: <Typography>Logical GPU usage in cores.</Typography>,
   },
   { label: "Start Time", align: "center" },
   { label: "End Time", align: "center" },

--- a/dashboard/client/src/pages/data/DataOverview.component.test.tsx
+++ b/dashboard/client/src/pages/data/DataOverview.component.test.tsx
@@ -14,7 +14,7 @@ describe("DataOverview", () => {
         total: 100,
         start_time: 0,
         end_time: undefined,
-        ray_data_output_bytes: {
+        ray_data_output_rows: {
           max: 10,
         },
         ray_data_spilled_bytes: {
@@ -24,13 +24,21 @@ describe("DataOverview", () => {
           value: 30,
           max: 40,
         },
+        ray_data_cpu_usage_cores: {
+          value: 50,
+          max: 60,
+        },
+        ray_data_gpu_usage_cores: {
+          value: 70,
+          max: 80,
+        },
         operators: [
           {
             operator: "test_ds1_op1",
             state: "RUNNING",
             progress: 99,
             total: 101,
-            ray_data_output_bytes: {
+            ray_data_output_rows: {
               max: 11,
             },
             ray_data_spilled_bytes: {
@@ -39,6 +47,14 @@ describe("DataOverview", () => {
             ray_data_current_bytes: {
               value: 31,
               max: 41,
+            },
+            ray_data_cpu_usage_cores: {
+              value: 51,
+              max: 61,
+            },
+            ray_data_gpu_usage_cores: {
+              value: 71,
+              max: 81,
             },
           },
         ],
@@ -50,7 +66,7 @@ describe("DataOverview", () => {
         total: 200,
         start_time: 1,
         end_time: 2,
-        ray_data_output_bytes: {
+        ray_data_output_rows: {
           max: 50,
         },
         ray_data_spilled_bytes: {
@@ -59,6 +75,14 @@ describe("DataOverview", () => {
         ray_data_current_bytes: {
           value: 70,
           max: 80,
+        },
+        ray_data_cpu_usage_cores: {
+          value: 90,
+          max: 100,
+        },
+        ray_data_gpu_usage_cores: {
+          value: 110,
+          max: 120,
         },
         operators: [],
       },
@@ -71,9 +95,11 @@ describe("DataOverview", () => {
     expect(screen.getByText("test_ds1")).toBeVisible();
     expect(screen.getByText("50 / 100")).toBeVisible();
     expect(screen.getByText("1969/12/31 16:00:00")).toBeVisible();
-    expect(screen.getByText("10.0000B")).toBeVisible();
+    expect(screen.getByText("10")).toBeVisible();
     expect(screen.getByText("20.0000B")).toBeVisible();
     expect(screen.getByText("30.0000B/40.0000B")).toBeVisible();
+    expect(screen.getByText("50/60")).toBeVisible();
+    expect(screen.getByText("70/80")).toBeVisible();
 
     // Operator dropdown
     expect(screen.queryByText("test_ds1_op1")).toBeNull();
@@ -87,8 +113,10 @@ describe("DataOverview", () => {
     expect(screen.getByText("200 / 200")).toBeVisible();
     expect(screen.getByText("1969/12/31 16:00:01")).toBeVisible();
     expect(screen.getByText("1969/12/31 16:00:02")).toBeVisible();
-    expect(screen.getByText("50.0000B")).toBeVisible();
+    expect(screen.getByText("50")).toBeVisible();
     expect(screen.getByText("60.0000B")).toBeVisible();
     expect(screen.getByText("70.0000B/80.0000B")).toBeVisible();
+    expect(screen.getByText("90/100")).toBeVisible();
+    expect(screen.getByText("110/120")).toBeVisible();
   });
 });

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -205,16 +205,20 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
         pathParams: "orgId=1&theme=light&panelId=7",
       },
       {
-        title: "Block Generation Time",
+        title: "Rows Outputted",
         pathParams: "orgId=1&theme=light&panelId=8",
       },
       {
-        title: "Iteration Blocked Time",
+        title: "Block Generation Time",
         pathParams: "orgId=1&theme=light&panelId=9",
       },
       {
-        title: "Iteration User Time",
+        title: "Iteration Blocked Time",
         pathParams: "orgId=1&theme=light&panelId=10",
+      },
+      {
+        title: "Iteration User Time",
+        pathParams: "orgId=1&theme=light&panelId=11",
       },
     ],
   },

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -206,19 +206,19 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
       },
       {
         title: "Rows Outputted",
-        pathParams: "orgId=1&theme=light&panelId=8",
+        pathParams: "orgId=1&theme=light&panelId=11",
       },
       {
         title: "Block Generation Time",
-        pathParams: "orgId=1&theme=light&panelId=9",
+        pathParams: "orgId=1&theme=light&panelId=8",
       },
       {
         title: "Iteration Blocked Time",
-        pathParams: "orgId=1&theme=light&panelId=10",
+        pathParams: "orgId=1&theme=light&panelId=9",
       },
       {
         title: "Iteration User Time",
-        pathParams: "orgId=1&theme=light&panelId=11",
+        pathParams: "orgId=1&theme=light&panelId=10",
       },
     ],
   },

--- a/dashboard/client/src/type/data.ts
+++ b/dashboard/client/src/type/data.ts
@@ -19,10 +19,18 @@ export type DataMetrics = {
     value: number;
     max: number;
   };
-  ray_data_output_bytes: {
+  ray_data_output_rows: {
     max: number;
   };
   ray_data_spilled_bytes: {
+    max: number;
+  };
+  ray_data_cpu_usage_cores: {
+    value: number;
+    max: number;
+  };
+  ray_data_gpu_usage_cores: {
+    value: number;
     max: number;
   };
   progress: number;

--- a/dashboard/modules/data/data_head.py
+++ b/dashboard/modules/data/data_head.py
@@ -31,9 +31,11 @@ class PrometheusQuery(Enum):
 
 
 DATASET_METRICS = {
-    "ray_data_output_bytes": (PrometheusQuery.MAX,),
+    "ray_data_output_rows": (PrometheusQuery.MAX,),
     "ray_data_spilled_bytes": (PrometheusQuery.MAX,),
     "ray_data_current_bytes": (PrometheusQuery.VALUE, PrometheusQuery.MAX),
+    "ray_data_cpu_usage_cores": (PrometheusQuery.VALUE, PrometheusQuery.MAX),
+    "ray_data_gpu_usage_cores": (PrometheusQuery.VALUE, PrometheusQuery.MAX),
 }
 
 

--- a/dashboard/modules/data/tests/test_data_head.py
+++ b/dashboard/modules/data/tests/test_data_head.py
@@ -9,9 +9,11 @@ DATA_SCHEMA = [
     "state",
     "progress",
     "total",
-    "ray_data_output_bytes",
+    "ray_data_output_rows",
     "ray_data_spilled_bytes",
     "ray_data_current_bytes",
+    "ray_data_cpu_usage_cores",
+    "ray_data_gpu_usage_cores",
 ]
 
 RESPONSE_SCHEMA = [

--- a/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -92,7 +92,7 @@ DATA_GRAFANA_PANELS = [
         ],
     ),
     Panel(
-        id=8,
+        id=11,
         title="Rows Outputted",
         description="Total rows outputted by dataset operators.",
         unit="rows",
@@ -104,7 +104,7 @@ DATA_GRAFANA_PANELS = [
         ],
     ),
     Panel(
-        id=9,
+        id=8,
         title="Block Generation Time",
         description="Time spent generating blocks.",
         unit="seconds",
@@ -116,7 +116,7 @@ DATA_GRAFANA_PANELS = [
         ],
     ),
     Panel(
-        id=10,
+        id=9,
         title="Iteration Blocked Time",
         description="Seconds user thread is blocked by iter_batches()",
         unit="seconds",
@@ -128,7 +128,7 @@ DATA_GRAFANA_PANELS = [
         ],
     ),
     Panel(
-        id=11,
+        id=10,
         title="Iteration User Time",
         description="Seconds spent in user code",
         unit="seconds",

--- a/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -93,6 +93,18 @@ DATA_GRAFANA_PANELS = [
     ),
     Panel(
         id=8,
+        title="Rows Outputted",
+        description="Total rows outputted by dataset operators.",
+        unit="rows",
+        targets=[
+            Target(
+                expr="sum(ray_data_output_rows{{{global_filters}}}) by (dataset, operator)",
+                legend="Rows Outputted: {{dataset}}",
+            )
+        ],
+    ),
+    Panel(
+        id=9,
         title="Block Generation Time",
         description="Time spent generating blocks.",
         unit="seconds",
@@ -104,7 +116,7 @@ DATA_GRAFANA_PANELS = [
         ],
     ),
     Panel(
-        id=9,
+        id=10,
         title="Iteration Blocked Time",
         description="Seconds user thread is blocked by iter_batches()",
         unit="seconds",
@@ -116,7 +128,7 @@ DATA_GRAFANA_PANELS = [
         ],
     ),
     Panel(
-        id=10,
+        id=11,
         title="Iteration User Time",
         description="Seconds spent in user code",
         unit="seconds",

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -51,6 +51,10 @@ class OpRuntimeMetrics:
     bytes_outputs_generated: int = field(
         default=0, metadata={"map_only": True, "export_metric": True}
     )
+    # Number of rows of generated output blocks that are from finished tasks.
+    rows_outputs_generated: int = field(
+        default=0, metadata={"map_only": True, "export_metric": True}
+    )
 
     # Number of output blocks that are already taken by the downstream.
     num_outputs_taken: int = 0
@@ -218,6 +222,8 @@ class OpRuntimeMetrics:
         for block_ref, meta in output.blocks:
             assert meta.exec_stats and meta.exec_stats.wall_time_s
             self.block_generation_time += meta.exec_stats.wall_time_s
+            assert meta.num_rows is not None
+            self.rows_outputs_generated += meta.num_rows
             trace_allocation(block_ref, "operator_output")
 
     def on_task_finished(self, task_index: int):

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -190,6 +190,11 @@ class _StatsActor:
             description="Bytes outputted by dataset operators",
             tag_keys=op_tags_keys,
         )
+        self.rows_outputted = Gauge(
+            "data_output_rows",
+            description="Rows outputted by dataset operators",
+            tag_keys=op_tags_keys,
+        )
         self.block_generation_time = Gauge(
             "data_block_generation_seconds",
             description="Time spent generating blocks.",
@@ -260,6 +265,7 @@ class _StatsActor:
             self.bytes_freed.set(stats.get("obj_store_mem_freed", 0), tags)
             self.bytes_current.set(stats.get("obj_store_mem_cur", 0), tags)
             self.bytes_outputted.set(stats.get("bytes_outputs_generated", 0), tags)
+            self.rows_outputted.set(stats.get("rows_outputs_generated", 0), tags)
             self.cpu_usage.set(stats.get("cpu_usage", 0), tags)
             self.gpu_usage.set(stats.get("gpu_usage", 0), tags)
             self.block_generation_time.set(stats.get("block_generation_time", 0), tags)
@@ -279,6 +285,7 @@ class _StatsActor:
             self.bytes_freed.set(0, tags)
             self.bytes_current.set(0, tags)
             self.bytes_outputted.set(0, tags)
+            self.rows_outputted.set(0, tags)
             self.cpu_usage.set(0, tags)
             self.gpu_usage.set(0, tags)
             self.block_generation_time.set(0, tags)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -35,6 +35,7 @@ def gen_expected_metrics(
             "'bytes_inputs_processed': N",
             "'num_outputs_generated': N",
             "'bytes_outputs_generated': N",
+            "'rows_outputs_generated': N",
             "'num_outputs_taken': N",
             "'bytes_outputs_taken': N",
             "'num_outputs_of_finished_tasks': N",
@@ -564,6 +565,7 @@ def test_dataset__repr__(ray_start_regular_shared):
         "      bytes_inputs_processed: N,\n"
         "      num_outputs_generated: N,\n"
         "      bytes_outputs_generated: N,\n"
+        "      rows_outputs_generated: N,\n"
         "      num_outputs_taken: N,\n"
         "      bytes_outputs_taken: N,\n"
         "      num_outputs_of_finished_tasks: N,\n"
@@ -1193,6 +1195,7 @@ def test_stats_actor_metrics():
         == ds._plan.stats().extra_metrics["obj_store_mem_freed"]
     )
     assert final_metric.bytes_outputs_generated == 1000 * 80 * 80 * 4 * 8  # 8B per int
+    assert final_metric.rows_outputs_generated == 1000 * 80 * 80 * 4
     # There should be nothing in object store at the end of execution.
     assert final_metric.obj_store_mem_cur == 0
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Exports rows outputted as a data metric to the ray dashboard.
<img width="585" alt="Screenshot 2023-10-19 at 9 25 18 AM" src="https://github.com/ray-project/ray/assets/39287272/c96d6592-05f7-4829-bf75-819ade0940ad">
Adds it to the ray data overview, replacing bytes outputted in the table.
Also adds CPU/GPU usage to the ray data overview
<img width="1667" alt="Screenshot 2023-11-16 at 10 18 32 AM" src="https://github.com/ray-project/ray/assets/39287272/d0a01ea7-f027-4303-80bf-342e64126d93">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
