### PR TITLE
[RLlib] Adding action space scaling to Gaussian noise in exploration

### DIFF
--- a/rllib/utils/exploration/tests/test_explorations.py
+++ b/rllib/utils/exploration/tests/test_explorations.py
@@ -240,17 +240,17 @@ class TestExplorations(unittest.TestCase):
                 }
             )
         )
-        stddev1 = do_test_explorations(
+        stddev_normal = do_test_explorations(
             config_normal,
             np.array([0.0, 0.1, 0.0]),
             expected_mean_action=0.0,
         )
-        stddev2 = do_test_explorations(
+        stddev_scaled = do_test_explorations(
             config_scaled,
             np.array([0.0, 0.1, 0.0]),
             expected_mean_action=0.0,
         )
-        check(stddev1 < stddev2, True)
+        check(stddev_normal < stddev_scaled, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Exploration noise is not well calibrated to the action space if the action space itself is multidimensional and has varying ranges. A constant stddev here is not well suited.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#40002 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
