### PR TITLE
[Data] Fix documentation link for local shuffle

### DIFF
--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -328,7 +328,7 @@ To randomly shuffle all rows, call :meth:`~ray.data.Dataset.random_shuffle`.
 .. tip::
 
     :meth:`~ray.data.Dataset.random_shuffle` is slow. For better performance, try
-    `Iterating over batches with shuffling <iterating-over-data#iterating-over-batches-with-shuffling>`_.
+    `Iterating over batches with shuffling <iterating-over-batches-with-shuffling>`_.
 
 Repartitioning data
 ===================

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -328,7 +328,7 @@ To randomly shuffle all rows, call :meth:`~ray.data.Dataset.random_shuffle`.
 .. tip::
 
     :meth:`~ray.data.Dataset.random_shuffle` is slow. For better performance, try
-    `Iterating over batches with shuffling <iterating-over-batches-with-shuffling>`_.
+    :ref:`Iterating over batches with shuffling <iterating-over-batches-with-shuffling>`.
 
 Repartitioning data
 ===================

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1016,7 +1016,7 @@ class Dataset:
         .. tip::
 
             This method can be slow. For better performance, try
-            `Iterating over batches with shuffling <iterating-over-data#iterating-over-batches-with-shuffling>`_.
+            `Iterating over batches with shuffling <iterating-over-batches-with-shuffling>`_.
             Also, see :ref:`Optimizing shuffles <optimizing_shuffles>`.
 
         Examples:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1016,7 +1016,7 @@ class Dataset:
         .. tip::
 
             This method can be slow. For better performance, try
-            `Iterating over batches with shuffling <iterating-over-batches-with-shuffling>`_.
+            :ref:`Iterating over batches with shuffling <iterating-over-batches-with-shuffling>`.
             Also, see :ref:`Optimizing shuffles <optimizing_shuffles>`.
 
         Examples:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This link for local shuffle from followed places are broken:
* https://docs.ray.io/en/master/data/transforming-data.html#shuffling-rows
* https://docs.ray.io/en/master/data/api/doc/ray.data.Dataset.random_shuffle.html

This PR fixs the issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
