### PR TITLE
[ci] Fix mujoco

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -459,10 +459,10 @@
     - conda activate rllib_contrib
     - sudo apt install libosmesa6-dev libgl1-mesa-glx libglfw3 patchelf -y
     - mkdir -p /root/.mujoco
-    - wget https://mujoco.org/download/mujoco210-linux-x86_64.tar.gz
-    - mv mujoco210-linux-x86_64.tar.gz /root/.mujoco/.
-    - (cd /root/.mujoco && tar -xf /root/.mujoco/mujoco210-linux-x86_64.tar.gz)
-    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mujoco210/bin
+    - wget https://github.com/google-deepmind/mujoco/releases/download/2.1.1/mujoco-2.1.1-linux-x86_64.tar.gz
+    - mv mujoco-2.1.1-linux-x86_64.tar.gz /root/.mujoco/.
+    - (cd /root/.mujoco && tar -xf /root/.mujoco/mujoco-2.1.1-linux-x86_64.tar.gz
+    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mujoco-2.1.1/bin
 
     - (cd rllib_contrib/maml && pip install -r requirements.txt && pip install -e ".[development]")
     - ./ci/env/env_info.sh
@@ -476,10 +476,10 @@
     # Install mujoco necessary for the testing environments
     - sudo apt install libosmesa6-dev libgl1-mesa-glx libglfw3 patchelf -y
     - mkdir -p /root/.mujoco
-    - wget https://mujoco.org/download/mujoco210-linux-x86_64.tar.gz
-    - mv mujoco210-linux-x86_64.tar.gz /root/.mujoco/.
-    - (cd /root/.mujoco && tar -xf /root/.mujoco/mujoco210-linux-x86_64.tar.gz)
-    - echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mujoco210/bin' >> /root/.bashrc
+    - wget https://github.com/google-deepmind/mujoco/releases/download/2.1.1/mujoco-2.1.1-linux-x86_64.tar.gz
+    - mv mujoco-2.1.1-linux-x86_64.tar.gz /root/.mujoco/.
+    - (cd /root/.mujoco && tar -xf /root/.mujoco/mujoco-2.1.1-linux-x86_64.tar.gz
+    - echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mujoco-2.1.1/bin' >> /root/.bashrc
     - source /root/.bashrc
 
     - (cd rllib_contrib/mbmpo && pip install -r requirements.txt && pip install -e ".[development]")

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -354,11 +354,11 @@ install_pip_packages() {
 
     # Install MuJoCo.
     sudo apt install libosmesa6-dev libgl1-mesa-glx libglfw3 patchelf -y
-    wget https://mujoco.org/download/mujoco210-linux-x86_64.tar.gz
+    wget https://github.com/google-deepmind/mujoco/releases/download/2.1.1/mujoco-2.1.1-linux-x86_64.tar.gz
     mkdir -p /root/.mujoco
-    mv mujoco210-linux-x86_64.tar.gz /root/.mujoco/.
-    (cd /root/.mujoco && tar -xf /root/.mujoco/mujoco210-linux-x86_64.tar.gz)
-    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/root/.mujoco/mujoco210/bin
+    mv mujoco-2.1.1-linux-x86_64.tar.gz /root/.mujoco/.
+    (cd /root/.mujoco && tar -xf /root/.mujoco/mujoco-2.1.1-linux-x86_64.tar.gz)
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/root/.mujoco/mujoco-2.1.1/bin
   fi
 
   # Additional Train test dependencies.

--- a/docker/ray-ml/install-ml-docker-requirements.sh
+++ b/docker/ray-ml/install-ml-docker-requirements.sh
@@ -56,9 +56,9 @@ sudo rm ./*requirements*.txt
 
 # MuJoCo Installation.
 export MUJOCO_GL=osmesa
-wget https://mujoco.org/download/mujoco210-linux-x86_64.tar.gz
+wget https://github.com/google-deepmind/mujoco/releases/download/2.1.1/mujoco-2.1.1-linux-x86_64.tar.gz
 mkdir -p ~/.mujoco
-mv mujoco210-linux-x86_64.tar.gz ~/.mujoco/.
+mv mujoco-2.1.1-linux-x86_64.tar.gz ~/.mujoco/.
 cd ~/.mujoco || exit
-tar -xf ~/.mujoco/mujoco210-linux-x86_64.tar.gz
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/root/.mujoco/mujoco210/bin
+tar -xf ~/.mujoco/mujoco-2.1.1-linux-x86_64.tar.gz
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/root/.mujoco/mujoco-2.1.1/bin


### PR DESCRIPTION
Our CI is currently busted due to the disappreanace of the download link of mujoco210: https://buildkite.com/ray-project/postmerge/builds/1106#018b2547-58ec-4c82-bd74-c8a8ecc016ef/160-3749.

mujoco releaes page now points to github and the oldest version they have that we can use is mujoco.2.1.1

Test:
- CI