### PR TITLE
[Core] Bugfix/runtime agent binding (#40092)

### DIFF
--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -205,7 +205,9 @@ if __name__ == "__main__":
         check_raylet_task = create_check_raylet_task(
             args.log_dir, args.gcs_address, parent_dead_callback, loop
         )
-    runtime_env_agent_ip = "127.0.0.1" if args.node_ip_address == "127.0.0.1" else "0.0.0.0"
+    runtime_env_agent_ip = (
+        "127.0.0.1" if args.node_ip_address == "127.0.0.1" else "0.0.0.0"
+    )
     try:
         web.run_app(
             app,

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -205,10 +205,11 @@ if __name__ == "__main__":
         check_raylet_task = create_check_raylet_task(
             args.log_dir, args.gcs_address, parent_dead_callback, loop
         )
+    runtime_env_agent_ip = "127.0.0.1" if args.node_ip_address == "127.0.0.1" else "0.0.0.0"
     try:
         web.run_app(
             app,
-            host=args.node_ip_address,
+            host=runtime_env_agent_ip,
             port=args.runtime_env_agent_port,
             loop=loop,
         )


### PR DESCRIPTION

## Why are these changes needed?

This PR makes the RuntimeEnvAgent process bind on 0.0.0.0 when `--node-ip-address` is set, rather than trying to bind on the node IP address itself. 

This behaviour is consistent with other processes such as the dashboard agent:
https://github.com/ray-project/ray/blob/67593a914a7d2e5dd703a27bad9959a1ceb94bf9/dashboard/agent.py#L116

## Related issue number
Closes #40092 

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
