### PR TITLE
Fix Accelelate typo in deepspeed.rst

### DIFF
--- a/doc/source/train/deepspeed.rst
+++ b/doc/source/train/deepspeed.rst
@@ -89,7 +89,7 @@ Check the below examples for more details:
 
    * - Framework
      - Example
-   * - Accelelate (:ref:`User Guide <train-hf-accelerate>`)
+   * - Accelerate (:ref:`User Guide <train-hf-accelerate>`)
      - `Fine-tune Llama-2 series models with Deepspeed, Accelerate, and Ray Train. <https://github.com/ray-project/ray/tree/master/doc/source/templates/04_finetuning_llms_with_deepspeed>`_
    * - Transformers (:ref:`User Guide <train-pytorch-transformers>`)
      - :ref:`Fine-tune GPT-J-6b with DeepSpeed and Hugging Face Transformers <gptj_deepspeed_finetune>`


### PR DESCRIPTION
typo: Accelelate

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
