### PR TITLE
[ci] Fix mujoco #40293

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -409,7 +409,7 @@
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
     - DATA_PROCESSING_TESTING=1 ARROW_VERSION=12.* ./ci/env/install-dependencies.sh
-    # TODO(scottjlee): Move datasets to train/data-test-requirements.txt 
+    # TODO(scottjlee): Move datasets to train/data-test-requirements.txt
     # (see https://github.com/ray-project/ray/pull/38432/)
     - pip install "datasets==2.14.0"
     - ./ci/env/env_info.sh
@@ -423,7 +423,7 @@
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
     - DATA_PROCESSING_TESTING=1 ARROW_VERSION=nightly ./ci/env/install-dependencies.sh
-    # TODO(scottjlee): Move datasets to train/data-test-requirements.txt 
+    # TODO(scottjlee): Move datasets to train/data-test-requirements.txt
     # (see https://github.com/ray-project/ray/pull/38432/)
     - pip install "datasets==2.14.0"
     - ./ci/env/env_info.sh
@@ -437,7 +437,7 @@
   commands:
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
     - DATA_PROCESSING_TESTING=1 ARROW_VERSION=12.* ./ci/env/install-dependencies.sh
-    # TODO(scottjlee): Move datasets to train/data-test-requirements.txt 
+    # TODO(scottjlee): Move datasets to train/data-test-requirements.txt
     # (see https://github.com/ray-project/ray/pull/38432/)
     - pip install "datasets==2.14.0"
     - ./ci/env/env_info.sh
@@ -474,7 +474,7 @@
     - DOC_TESTING=1 INSTALL_HOROVOD=1 ./ci/env/install-dependencies.sh
     # TODO (shrekris-anyscale): Remove transformers after core transformer
     # requirement is upgraded
-    # TODO(scottjlee): Move datasets to train/data-test-requirements.txt 
+    # TODO(scottjlee): Move datasets to train/data-test-requirements.txt
     # (see https://github.com/ray-project/ray/pull/38432/)
     - pip install "transformers==4.30.2" "datasets==2.14.0"
     - ./ci/env/env_info.sh

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -354,11 +354,11 @@ install_pip_packages() {
 
     # Install MuJoCo.
     sudo apt install libosmesa6-dev libgl1-mesa-glx libglfw3 patchelf -y
-    wget https://mujoco.org/download/mujoco210-linux-x86_64.tar.gz
+    wget https://github.com/google-deepmind/mujoco/releases/download/2.1.1/mujoco-2.1.1-linux-x86_64.tar.gz
     mkdir -p /root/.mujoco
-    mv mujoco210-linux-x86_64.tar.gz /root/.mujoco/.
-    (cd /root/.mujoco && tar -xf /root/.mujoco/mujoco210-linux-x86_64.tar.gz)
-    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/root/.mujoco/mujoco210/bin
+    mv mujoco-2.1.1-linux-x86_64.tar.gz /root/.mujoco/.
+    (cd /root/.mujoco && tar -xf /root/.mujoco/mujoco-2.1.1-linux-x86_64.tar.gz)
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/root/.mujoco/mujoco-2.1.1/bin
   fi
 
   # Additional Train test dependencies.

--- a/docker/ray-ml/install-ml-docker-requirements.sh
+++ b/docker/ray-ml/install-ml-docker-requirements.sh
@@ -56,9 +56,9 @@ sudo rm ./*requirements*.txt
 
 # MuJoCo Installation.
 export MUJOCO_GL=osmesa
-wget https://mujoco.org/download/mujoco210-linux-x86_64.tar.gz
+wget https://github.com/google-deepmind/mujoco/releases/download/2.1.1/mujoco-2.1.1-linux-x86_64.tar.gz
 mkdir -p ~/.mujoco
-mv mujoco210-linux-x86_64.tar.gz ~/.mujoco/.
+mv mujoco-2.1.1-linux-x86_64.tar.gz ~/.mujoco/.
 cd ~/.mujoco || exit
-tar -xf ~/.mujoco/mujoco210-linux-x86_64.tar.gz
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/root/.mujoco/mujoco210/bin
+tar -xf ~/.mujoco/mujoco-2.1.1-linux-x86_64.tar.gz
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/root/.mujoco/mujoco-2.1.1/bin


### PR DESCRIPTION
Our CI is currently busted due to the disappreanace of the download link of mujoco210: https://buildkite.com/ray-project/postmerge/builds/1106#018b2547-58ec-4c82-bd74-c8a8ecc016ef/160-3749.

mujoco releaes page now points to github and the oldest version they have that we can use is mujoco.2.1.1

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Cherry pick https://github.com/ray-project/ray/pull/40293 to fix CI

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
