### PR TITLE
[core] Releases mmap sections in plasma client when releasing objects

### DIFF
--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -569,6 +569,15 @@ Status PlasmaClient::Impl::MarkObjectUnused(const ObjectID &object_id) {
   RAY_CHECK(object_entry != objects_in_use_.end());
   RAY_CHECK(object_entry->second->count == 0);
 
+  // TODO:  hypothesis: each object has its own unique map section, so I just need to
+  // unmap here.
+  // If the hypothesis does not hold, we need to instead do ref counts on the mmap:
+  // - on mmap creation (and mmap Lookup???), increment the refcnt
+  // - here, decrement the refcnt, and release if refcnt == 0.
+  auto mmap_entry = mmap_table_.find(object_entry->second->object.store_fd);
+  RAY_CHECK(mmap_entry != mmap_table_.end());
+  mmap_table_.erase(mmap_entry);
+
   // Remove the entry from the hash table of objects currently in use.
   objects_in_use_.erase(object_id);
   return Status::OK();

--- a/src/ray/object_manager/plasma/shared_memory.cc
+++ b/src/ray/object_manager/plasma/shared_memory.cc
@@ -62,6 +62,11 @@ void ClientMmapTableEntry::MaybeMadviseDontdump() {
 }
 
 ClientMmapTableEntry::~ClientMmapTableEntry() {
+  if (!SafeToUnmap()) {
+    RAY_LOG(WARNING) << "Unmapping ClientMmapTableEntry while ref count is not zero. You "
+                        "may see segfault on read/write access to the memory. addr: "
+                     << pointer_ << ", size: " << length_;
+  }
   // At this point it is safe to unmap the memory, as the PlasmaBuffer
   // keeps the PlasmaClient (and therefore the ClientMmapTableEntry)
   // alive until it is destroyed.
@@ -75,6 +80,8 @@ ClientMmapTableEntry::~ClientMmapTableEntry() {
 #endif
   if (r != 0) {
     RAY_LOG(ERROR) << "munmap returned " << r << ", errno = " << errno;
+  } else {
+    RAY_LOG(DEBUG) << "munmap successfully for " << pointer_ << ", " << length_;
   }
 }
 

--- a/src/ray/object_manager/plasma/shared_memory.cc
+++ b/src/ray/object_manager/plasma/shared_memory.cc
@@ -61,6 +61,13 @@ void ClientMmapTableEntry::MaybeMadviseDontdump() {
 #endif
 }
 
+void ClientMmapTableEntry::IncrementRefCount() { ref_count_++; }
+void ClientMmapTableEntry::DecrementRefCount() {
+  RAY_CHECK(ref_count_ > 0);
+  ref_count_--;
+}
+bool ClientMmapTableEntry::SafeToUnmap() { return ref_count_ == 0; }
+
 ClientMmapTableEntry::~ClientMmapTableEntry() {
   if (!SafeToUnmap()) {
     RAY_LOG(WARNING) << "Unmapping ClientMmapTableEntry while ref count is not zero. You "

--- a/src/ray/object_manager/plasma/shared_memory.h
+++ b/src/ray/object_manager/plasma/shared_memory.h
@@ -19,12 +19,9 @@ class ClientMmapTableEntry {
 
   MEMFD_TYPE fd() { return fd_; }
 
-  void IncrementRefCount() { ref_count_++; }
-  void DecrementRefCount() {
-    RAY_CHECK(ref_count_ > 0);
-    ref_count_--;
-  }
-  bool SafeToUnmap() { return ref_count_ == 0; }
+  void IncrementRefCount();
+  void DecrementRefCount();
+  bool SafeToUnmap();
 
  private:
   /// The associated file descriptor on the client.

--- a/src/ray/object_manager/plasma/shared_memory.h
+++ b/src/ray/object_manager/plasma/shared_memory.h
@@ -19,6 +19,13 @@ class ClientMmapTableEntry {
 
   MEMFD_TYPE fd() { return fd_; }
 
+  void IncrementRefCount() { ref_count_++; }
+  void DecrementRefCount() {
+    RAY_CHECK(ref_count_ > 0);
+    ref_count_--;
+  }
+  bool SafeToUnmap() { return ref_count_ == 0; }
+
  private:
   /// The associated file descriptor on the client.
   MEMFD_TYPE fd_;
@@ -26,6 +33,8 @@ class ClientMmapTableEntry {
   uint8_t *pointer_;
   /// The length of the memory-mapped file.
   size_t length_;
+  /// Reference count to this mmap section. If it's zero, it can be safely unmapped.
+  size_t ref_count_ = 0;
 
   void MaybeMadviseDontdump();
 


### PR DESCRIPTION
PlasmaClient mmaps memory sections for each object `Get`-or-`Create`d, but never releases those mmaps. It was a good hope that when PlasmaClient itself is deallocated the mmaps are freed, and since each `PlasmaBuffer` holds a shared ptr to the PlasmaClient we can count on that to auto munmap. However this does not work because a PlasmaClient is also held by `CoreWorkerPlasmaStoreProvider` which never releases.

This PR releases each mmap when its corresponding Object is marked unused. It does reference counting of the n-to-1 relationship `objects -> mmap sections`. If there's 0 object pointing to a mmap section, unmap the section.

Note that for the shared memory, the number of refcount == the number of objects which can be big. For the fallback objects, the number of refcount == 1 or 0 and is unmapped right after object released.