### PR TITLE
[KubeRay][Autoscaler] Make KubeRay CRD version configurable

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -33,7 +33,7 @@ KUBERAY_LABEL_KEY_TYPE = "ray.io/group"
 KUBERAY_KIND_HEAD = "head"
 # Group name (node type) to use for the head.
 KUBERAY_TYPE_HEAD = "head-group"
-# KubeRay CRD version: KubeRay bumps the CRD version from v1alpha1 to v1 in the KubeRay v1.0.0-rc.1 release.
+# KubeRay CRD version
 KUBERAY_CRD_VER = os.getenv("KUBERAY_CRD_VER", "v1alpha1")
 
 RAY_HEAD_POD_NAME = os.getenv("RAY_HEAD_POD_NAME")

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -31,8 +31,10 @@ KUBERAY_LABEL_KEY_KIND = "ray.io/node-type"
 KUBERAY_LABEL_KEY_TYPE = "ray.io/group"
 # Kind label value indicating the pod is the head.
 KUBERAY_KIND_HEAD = "head"
-# Group name (node type) to use for the  head.
+# Group name (node type) to use for the head.
 KUBERAY_TYPE_HEAD = "head-group"
+# KubeRay CRD version: KubeRay bumps the CRD version from v1alpha1 to v1 in the KubeRay v1.0.0-rc.1 release.
+KUBERAY_CRD_VER = os.getenv("KUBERAY_CRD_VER", "v1alpha1")
 
 RAY_HEAD_POD_NAME = os.getenv("RAY_HEAD_POD_NAME")
 
@@ -162,7 +164,7 @@ def url_from_resource(namespace: str, path: str) -> str:
     if path.startswith("pods"):
         api_group = "/api/v1"
     elif path.startswith("rayclusters"):
-        api_group = "/apis/ray.io/v1alpha1"
+        api_group = "/apis/ray.io/" + KUBERAY_CRD_VER
     else:
         raise NotImplementedError("Tried to access unknown entity at {}".format(path))
     return (
@@ -398,7 +400,7 @@ class KuberayNodeProvider(BatchingNodeProvider):  # type: ignore
         if path.startswith("pods"):
             api_group = "/api/v1"
         elif path.startswith("rayclusters"):
-            api_group = "/apis/ray.io/v1alpha1"
+            api_group = "/apis/ray.io/" + KUBERAY_CRD_VER
         else:
             raise NotImplementedError(
                 "Tried to access unknown entity at {}".format(path)


### PR DESCRIPTION
## Why are these changes needed?

The KubeRay community has decided to bump the CRD version from v1alpha1 to v1 in the KubeRay v1.0.0-rc.1 release. Initially, I also planned to delete CRD v1alpha1 in v1.0.0-rc.1. However, the Ray Autoscaler has hard-coded the CRD version to v1alpha1. As a result, the Autoscaler will throw an exception when attempting to fetch data from the Kubernetes API server, given that CRD v1alpha1 no longer exists. See https://github.com/ray-project/kuberay/pull/1492#issuecomment-1762309656 for more details.

This PR makes the CRD version configurable, and KubeRay v1.0.0-rc.1 will automatically inject the environment variable `KUBERAY_CRD_VER` (https://github.com/ray-project/kuberay/pull/1496).

* Compatibility between KubeRay and Ray
  * KubeRay v0.6.0: Support all Ray versions
    * KubeRay v0.6.0 only has CRD v1alpha1. It won't inject the KUBERAY_CRD_VER environment variable into the Autoscaler sidecar container. Therefore, Ray 2.8.0 (including this PR) will fall back to CRD v1alpha1. This ensures that KubeRay v0.6.0 remains compatible with Ray versions that incorporate this PR.
  * KubeRay v1.0.0: Support all Ray versions
    * KubeRay v1.0.0 supports both CRD v1alpha1 and v1, with v1 being the storage version. It automatically injects the `KUBERAY_CRD_VER` environment variable set to `v1`. If users are on KubeRay v1.0.0, the Autoscaler in Ray 2.8.0 and later versions (including this PR) will use CRD v1. For Ray versions older than 2.8.0, the Autoscaler will use CRD v1alpha1 since those versions don't include this PR.
  * KubeRay v1.1.0: Support Ray 2.8.0 and later
    * In KubeRay v1.1.0, I plan to remove CRD v1alpha1, leaving only CRD v1. Ray versions without this PR will no longer be supported. As a result, KubeRay v1.1.0 might be released concurrently with Ray 2.10.0.
    * [Update: May 10, 2024]: I won't remove the CRD v1alpha1 in KubeRay v1.1.0 due to compatibility issues with Kueue. Instead, I will remove it in KubeRay v1.2.0.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

* KubeRay v0.6.0: CI

* KubeRay v1.0.0 (including CRD v1alpha1 and v1): Try to fetch both CRD v1alpha1 and CRD v1 from Kubernetes API server in the Autoscaler sidecar container, and both results are the same.
  <img width="1438" alt="Screen Shot 2023-10-15 at 11 46 07 PM" src="https://github.com/ray-project/ray/assets/20109646/9f1fd79b-3ea1-4bf9-a28b-caed57e4f22c">

* KubeRay v1.1.0 (only has CRD v1): Try to fetch both CRD v1alpha1 and CRD v1 from Kubernetes API server in the Autoscaler sidecar container. Fail to fetch data when I use CRD v1alpha1.
  <img width="1439" alt="Screen Shot 2023-10-15 at 11 27 09 PM" src="https://github.com/ray-project/ray/assets/20109646/3e2fe0e0-1c17-4892-b00b-a22e743c6ea9">
