### PR TITLE
[civ2][gpu/2] migrate ml gpu tests to civ2

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -1,6 +1,6 @@
 group: ml tests
 steps:
-  - label: ":train: ml: train tests and examples"
+  - label: ":train: ml: train tests"
     tags: train
     instance_type: large
     parallelism: 2
@@ -9,4 +9,18 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --except-tags gpu_only,gpu,minimal,tune,doctest,needs_credentials 
     depends_on: mlbuild
+    job_env: forge
+
+  - label: ":train: ml: train gpu tests"
+    tags: 
+      - train
+      - gpu
+    instance_type: gpu-large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... //python/ray/air/... //doc/... ml
+        --parallelism-per-worker 2
+        --build-name mlgpubuild
+        --only-tags gpu,gpu_only
+        --except-tags doctest
+    depends_on: mlgpubuild
     job_env: forge

--- a/.buildkite/pipeline.gpu_large.yml
+++ b/.buildkite/pipeline.gpu_large.yml
@@ -1,26 +1,5 @@
 #ci:group=Large GPU tests
 
-- label: ":tv: :steam_locomotive: Train GPU tests "
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh
-    - pip install -Ur ./python/requirements/ml/dl-gpu-requirements.txt
-    - ./ci/env/install-horovod.sh
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=gpu,gpu_only,-ray_air 
-      python/ray/train/...
-
-- label: ":tv: :database: :steam_locomotive: Datasets Train Integration GPU Tests and Examples (Python 3.7)"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - TRAIN_TESTING=1 DATA_PROCESSING_TESTING=1 ./ci/env/install-dependencies.sh
-    - pip install -Ur ./python/requirements/ml/dl-gpu-requirements.txt
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=datasets_train,-doctest 
-      doc/...
-
 - label: ":tv: :brain: RLlib: Multi-GPU Tests"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
   parallelism: 2
@@ -39,17 +18,6 @@
       --test_env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 
       rllib/...
 
-- label: ":tv: :airplane: AIR GPU tests (ray/air)"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_ML_AFFECTED"]
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - DATA_PROCESSING_TESTING=1 TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh
-    - pip install -Ur ./python/requirements/ml/dl-gpu-requirements.txt
-    - ./ci/env/install-horovod.sh
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=gpu 
-      python/ray/air/... python/ray/train/...
-
 - label: ":tv: :book: Doc GPU tests and examples"
   conditions:
     ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_TUNE_AFFECTED", "RAY_CI_DOC_AFFECTED"]
@@ -62,7 +30,7 @@
     # TODO(amogkam): Remove when https://github.com/ray-project/ray/issues/36011
     # is resolved.
     - pip install -U transformers
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=gpu,-timeseries_libs,-post_wheel_build,-doctest 
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=gpu,-timeseries_libs,-post_wheel_build,-doctest,-team:ml 
       doc/...
 
 - label: ":book: Doctest (GPU)"

--- a/ci/docker/ml.build.Dockerfile
+++ b/ci/docker/ml.build.Dockerfile
@@ -1,5 +1,7 @@
-ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml
-FROM $DOCKER_IMAGE_BASE_BUILD
+ARG BASE_BUILD
+FROM cr.ray.io/rayproject/$BASE_BUILD
+
+ARG BASE_BUILD
 
 ARG IS_GPU_BUILD
 

--- a/ci/docker/ml.build.Dockerfile
+++ b/ci/docker/ml.build.Dockerfile
@@ -1,7 +1,5 @@
-ARG BASE_BUILD
-FROM cr.ray.io/rayproject/$BASE_BUILD
-
-ARG BASE_BUILD
+ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml
+FROM $DOCKER_IMAGE_BASE_BUILD
 
 ARG IS_GPU_BUILD
 

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -9,6 +9,22 @@ from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.tester_container import TesterContainer
 from ci.ray_ci.utils import docker_login
 
+CUDA_COPYRIGHT = """
+==========
+== CUDA ==
+==========
+
+CUDA Version 11.8.0
+
+Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+This container image and its contents are governed by the NVIDIA Deep Learning Container License.
+By pulling and using the container, you accept the terms and conditions of this license:
+https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license
+
+A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.
+"""  # noqa: E501
+
 # Gets the path of product/tools/docker (i.e. the parent of 'common')
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 
@@ -183,6 +199,8 @@ def _get_test_targets(
             ]
         )
         .decode("utf-8")
+        # CUDA image comes with a license header that we need to remove
+        .replace(CUDA_COPYRIGHT, "")
         .strip()
         .split("\n")
     )

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -25,7 +25,7 @@ py_test(
     name = "datasets_train",
     size = "medium",
     srcs = ["source/ray-core/_examples/datasets_train/datasets_train.py"],
-    tags = ["exclusive", "team:ml", "datasets_train"],
+    tags = ["exclusive", "team:ml", "datasets_train", "gpu"],
     args = ["--smoke-test", "--num-workers=2", "--use-gpu"]
 )
 


### PR DESCRIPTION
Migrate ml gpu tests to civ2. Merge train, air and example tests into one job. This reduces 2.5x of total job time.

Caveat:
- CUDA image prints licence header in every docker run, need to trim it to correctly parse the output

Test:
- CI