### PR TITLE
[ci] Jail //python/ray/tests:test_redis_tls

### DIFF
--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -7,6 +7,7 @@ flaky_tests:
   - //python/ray/tests:test_placement_group_3
   - //python/ray/tests:test_placement_group_5
   - //python/ray/tests:test_plasma_unlimited
+  - //python/ray/tests:test_redis_tls
   - //python/ray/tests:test_runtime_env_2
   - //python/ray/tests:test_runtime_env_working_dir_3
   - //python/ray/tests:test_scheduling_performance


### PR DESCRIPTION
As title, jail this one test that has became recently flaky

<img width="1795" alt="Screenshot 2023-10-16 at 11 48 36 AM" src="https://github.com/ray-project/ray/assets/128072568/6fb740fc-8cd8-48fc-8d04-78bd5adf02d8">

Test:
- CI