### PR TITLE
[serve] Migrate v1 api release tests

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -473,6 +473,7 @@ def run(
     Returns:
         RayServeSyncHandle: A handle that can be used to call the application.
     """
+    # trigger tests
     if len(name) == 0:
         raise RayServeException("Application name must a non-empty string.")
 

--- a/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
+++ b/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
@@ -175,9 +175,11 @@ def setup_serve(model, use_gpu: bool = False):
     serve.start(
         http_options={"location": "EveryNode"}
     )  # Start on every node so `predict` can hit localhost.
-    MnistDeployment.options(
-        num_replicas=2, ray_actor_options={"num_gpus": bool(use_gpu)}
-    )._deploy(model)
+    serve.run(
+        MnistDeployment.options(
+            num_replicas=2, ray_actor_options={"num_gpus": bool(use_gpu)}
+        ).bind(model)
+    )
 
 
 @ray.remote

--- a/release/long_running_tests/workloads/serve.py
+++ b/release/long_running_tests/workloads/serve.py
@@ -67,7 +67,7 @@ class Echo:
         return await self.handle_batch(request)
 
 
-Echo._deploy()
+serve.run(Echo.bind(), route_prefix="/echo")
 
 print("Warming up")
 for _ in range(5):

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -13,7 +13,6 @@ from ray import serve
 from ray.serve.context import _get_global_client
 from ray.cluster_utils import Cluster
 from ray._private.test_utils import safe_write_to_results_json
-from ray.serve._private import api as _private_api
 
 # Global variables / constants appear only right after imports.
 # Ray serve deployment setup constants
@@ -83,13 +82,13 @@ class RandomKiller:
             ray.kill(chosen, no_restart=False)
             await asyncio.sleep(self.kill_period_s)
 
-    async def spare(self, deployment_name: str):
-        print(f'Sparing deployment "{deployment_name}" replicas.')
-        self.sanctuary.add(deployment_name)
+    async def spare(self, app_name: str):
+        print(f'Sparing application "{app_name}" replicas.')
+        self.sanctuary.add(app_name)
 
-    async def stop_spare(self, deployment_name: str):
-        print(f'No longer sparing deployment "{deployment_name}" replicas.')
-        self.sanctuary.discard(deployment_name)
+    async def stop_spare(self, app_name: str):
+        print(f'No longer sparing application "{app_name}" replicas.')
+        self.sanctuary.discard(app_name)
 
     def _get_serve_actors(self):
         controller = _get_global_client()._controller
@@ -97,7 +96,7 @@ class RandomKiller:
         all_handles = routers + [controller]
         replica_dict = ray.get(controller._all_running_replicas.remote())
         for deployment_id, replica_info_list in replica_dict.items():
-            if deployment_id.name not in self.sanctuary:
+            if deployment_id.app not in self.sanctuary:
                 for replica_info in replica_info_list:
                     all_handles.append(replica_info.actor_handle)
 
@@ -105,32 +104,32 @@ class RandomKiller:
 
 
 class RandomTest:
-    def __init__(self, random_killer_handle, max_deployments=1):
-        self.max_deployments = max_deployments
+    def __init__(self, random_killer_handle, max_applications=1):
+        self.max_applications = max_applications
         self.weighted_actions = [
-            (self.create_deployment, 1),
-            (self.verify_deployment, 4),
+            (self.create_application, 1),
+            (self.verify_application, 4),
         ]
-        self.deployments = []
+        self.applications = []
 
         self.random_killer = random_killer_handle
 
         # Deploy in parallel to avoid long test startup time.
-        self.wait_for_deployments_ready(
-            [self.create_deployment(blocking=False) for _ in range(max_deployments)]
+        self.wait_for_applications_running(
+            [self.create_application(blocking=False) for _ in range(max_applications)]
         )
 
         self.random_killer.run.remote()
 
-    def wait_for_deployments_ready(self, deployment_names: List[str]):
+    def wait_for_applications_running(self, application_names: List[str]):
         client = _get_global_client()
-        for deployment_name in deployment_names:
-            client._wait_for_deployment_healthy(deployment_name, timeout_s=60)
+        for name in application_names:
+            client._wait_for_application_running(name, timeout_s=60)
 
-    def create_deployment(self, blocking: bool = True) -> str:
-        if len(self.deployments) == self.max_deployments:
-            deployment_to_delete = self.deployments.pop()
-            _private_api.get_deployment(deployment_to_delete)._delete()
+    def create_application(self, blocking: bool = True) -> str:
+        if len(self.applications) == self.max_applications:
+            app_to_delete = self.applications.pop()
+            serve.delete(app_to_delete)
 
         new_name = "".join([random.choice(string.ascii_letters) for _ in range(10)])
 
@@ -141,23 +140,33 @@ class RandomTest:
 
         if blocking:
             ray.get(self.random_killer.spare.remote(new_name))
-            handler._deploy(_blocking=blocking)
-            self.deployments.append(new_name)
+            serve.run(
+                handler.bind(),
+                name=new_name,
+                route_prefix=f"/{new_name}",
+                _blocking=True,
+            )
+            self.applications.append(new_name)
             ray.get(self.random_killer.stop_spare.remote(new_name))
         else:
-            handler._deploy(_blocking=False)
-            self.deployments.append(new_name)
+            serve.run(
+                handler.bind(),
+                name=new_name,
+                route_prefix=f"/{new_name}",
+                _blocking=False,
+            )
+            self.applications.append(new_name)
 
         return new_name
 
-    def verify_deployment(self):
-        deployment = random.choice(self.deployments)
+    def verify_application(self):
+        app = random.choice(self.applications)
         for _ in range(100):
             try:
-                r = requests.get("http://127.0.0.1:8000/" + deployment)
-                assert r.text == deployment
+                r = requests.get("http://127.0.0.1:8000/" + app)
+                assert r.text == app
             except Exception:
-                print("Request to {} failed.".format(deployment))
+                print("Request to {} failed.".format(app))
                 time.sleep(0.1)
 
     def run(self):
@@ -192,5 +201,5 @@ class RandomTest:
 
 
 random_killer = RandomKiller.remote()
-tester = RandomTest(random_killer, max_deployments=NUM_NODES * CPUS_PER_NODE)
+tester = RandomTest(random_killer, max_applications=NUM_NODES * CPUS_PER_NODE)
 tester.run()

--- a/release/serve_tests/workloads/autoscaling_multi_deployment.py
+++ b/release/serve_tests/workloads/autoscaling_multi_deployment.py
@@ -47,7 +47,6 @@ from serve_test_cluster_utils import (
     NUM_CONNECTIONS,
 )
 from typing import Optional
-from ray.serve._private import api as _private_api
 
 logger = logging.getLogger(__file__)
 
@@ -72,8 +71,10 @@ DEFAULT_FULL_TEST_TRIAL_LENGTH = "10m"
 
 
 def setup_multi_deployment_replicas(min_replicas, max_replicas, num_deployments):
+    """Returns: list of application route prefixes."""
+
     max_replicas_per_deployment = max_replicas // num_deployments
-    all_deployment_names = [f"Echo_{i+1}" for i in range(num_deployments)]
+    all_app_names = [f"Echo_{i+1}" for i in range(num_deployments)]
 
     @serve.deployment(
         autoscaling_config={
@@ -88,35 +89,37 @@ def setup_multi_deployment_replicas(min_replicas, max_replicas, num_deployments)
     )
     class Echo:
         def __init__(self):
-            self.all_deployment_async_handles = []
+            self.all_app_async_handles = []
 
-        def get_random_async_handle(self):
+        async def get_random_async_handle(self):
             # sync get_handle() and expected to be called only a few times
             # during deployment warmup so each deployment has reference to
             # all other handles to send recursive inference call
-            if len(self.all_deployment_async_handles) < len(all_deployment_names):
-                deployments = list(_private_api.list_deployments().values())
-                self.all_deployment_async_handles = [
-                    deployment._get_handle(sync=False) for deployment in deployments
+            if len(self.all_app_async_handles) < len(all_app_names):
+                applications = list(serve.status().applications.keys())
+                self.all_app_async_handles = [
+                    serve.get_app_handle(app) for app in applications
                 ]
 
-            return random.choice(self.all_deployment_async_handles)
+            return random.choice(self.all_app_async_handles)
 
         async def handle_request(self, request, depth: int):
             # Max recursive call depth reached
             if depth > 4:
                 return "hi"
 
-            next_async_handle = self.get_random_async_handle()
-            obj_ref = await next_async_handle.handle_request.remote(request, depth + 1)
+            next_async_handle = await self.get_random_async_handle()
+            fut = next_async_handle.handle_request.remote(request, depth + 1)
 
-            return await obj_ref
+            return await fut
 
         async def __call__(self, request):
             return await self.handle_request(request, 0)
 
-    for deployment in all_deployment_names:
-        Echo.options(name=deployment)._deploy()
+    for name in all_app_names:
+        serve.run(Echo.bind(), name=name, route_prefix=f"/{name}")
+
+    return all_app_names
 
 
 @click.command()
@@ -170,11 +173,12 @@ def main(
         f"Deploying with min {min_replicas} and max {max_replicas}"
         f"target replicas ....\n"
     )
-    setup_multi_deployment_replicas(min_replicas, max_replicas, num_deployments)
+    all_endpoints = setup_multi_deployment_replicas(
+        min_replicas, max_replicas, num_deployments
+    )
 
     logger.info("Warming up cluster ....\n")
     endpoint_refs = []
-    all_endpoints = list(_private_api.list_deployments().keys())
     for endpoint in all_endpoints:
         endpoint_refs.append(
             warm_up_one_cluster.options(num_cpus=0).remote(

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -37,7 +37,6 @@ from serve_test_utils import (
     save_test_results,
     is_smoke_test,
 )
-from ray.serve._private import api as _private_api
 from serve_test_cluster_utils import (
     setup_local_single_node_cluster,
     setup_anyscale_cluster,
@@ -73,35 +72,35 @@ def setup_multi_deployment_replicas(num_replicas, num_deployments) -> List[str]:
     @serve.deployment(num_replicas=num_replica_per_deployment)
     class Echo:
         def __init__(self):
-            self.all_deployment_async_handles = []
+            self.all_app_async_handles = []
 
-        def get_random_async_handle(self):
+        async def get_random_async_handle(self):
             # sync get_handle() and expected to be called only a few times
             # during deployment warmup so each deployment has reference to
             # all other handles to send recursive inference call
-            if len(self.all_deployment_async_handles) < len(all_deployment_names):
-                deployments = list(_private_api.list_deployments().values())
-                self.all_deployment_async_handles = [
-                    deployment._get_handle(sync=False) for deployment in deployments
+            if len(self.all_app_async_handles) < len(all_deployment_names):
+                applications = list(serve.status().applications.keys())
+                self.all_app_async_handles = [
+                    serve.get_app_handle(app) for app in applications
                 ]
 
-            return random.choice(self.all_deployment_async_handles)
+            return random.choice(self.all_app_async_handles)
 
         async def handle_request(self, request, depth: int):
             # Max recursive call depth reached
             if depth > 4:
                 return "hi"
 
-            next_async_handle = self.get_random_async_handle()
-            obj_ref = await next_async_handle.handle_request.remote(request, depth + 1)
+            next_async_handle = await self.get_random_async_handle()
+            fut = next_async_handle.handle_request.remote(request, depth + 1)
 
-            return await obj_ref
+            return await fut
 
         async def __call__(self, request):
             return await self.handle_request(request, 0)
 
-    for deployment in all_deployment_names:
-        Echo.options(name=deployment)._deploy()
+    for name in all_deployment_names:
+        serve.run(Echo.bind(), name=name, route_prefix=f"/{name}")
 
     return all_deployment_names
 

--- a/release/serve_tests/workloads/serve_handle_long_chain.py
+++ b/release/serve_tests/workloads/serve_handle_long_chain.py
@@ -19,7 +19,6 @@ from typing import Optional
 
 import ray
 from ray import serve
-from ray.serve.context import _get_global_client
 from serve_test_cluster_utils import (
     setup_local_single_node_cluster,
     setup_anyscale_cluster,
@@ -43,41 +42,31 @@ class Node:
         prev_node=None,
         init_delay_secs=0,
         compute_delay_secs=0,
-        sync_handle=True,
     ):
         time.sleep(init_delay_secs)
         self.id = id
         self.prev_node = prev_node
+        if self.prev_node:
+            self.prev_node = self.prev_node.options(use_new_handle_api=True)
         self.compute_delay_secs = compute_delay_secs
-        self.sync_handle = sync_handle
 
     async def predict(self, input_data: int):
         await asyncio.sleep(self.compute_delay_secs)
         if self.prev_node:
-            if self.sync_handle:
-                return await self.prev_node.predict.remote(input_data) + 1
-            else:
-                return await (await self.prev_node.predict.remote(input_data)) + 1
+            return await self.prev_node.predict.remote(input_data) + 1
         else:
             return input_data + 1
 
 
 def construct_long_chain_graph_with_pure_handle(
-    chain_length, sync_handle: bool, init_delay_secs=0, compute_delay_secs=0
+    chain_length, init_delay_secs=0, compute_delay_secs=0
 ):
-    prev_handle = None
+    prev_node = None
     for id in range(chain_length):
-        Node.options(name=str(id))._deploy(
-            id, prev_handle, init_delay_secs, compute_delay_secs, sync_handle
+        prev_node = Node.options(name=str(id)).bind(
+            id, prev_node, init_delay_secs, compute_delay_secs
         )
-        prev_handle = _get_global_client().get_handle(
-            str(id), app_name="", sync=sync_handle
-        )
-    return prev_handle
-
-
-async def sanity_check_graph_deployment_with_async_handle(handle, expected_result):
-    assert await (await handle.predict.remote(0)) == expected_result
+    return serve.run(prev_node)
 
 
 @click.command()
@@ -96,7 +85,6 @@ async def sanity_check_graph_deployment_with_async_handle(handle, expected_resul
     default=DEFAULT_THROUGHPUT_TRIAL_DURATION_SECS,
 )
 @click.option("--local-test", type=bool, default=True)
-@click.option("--sync-handle", type=bool, default=True)
 def main(
     chain_length: Optional[int],
     init_delay_secs: Optional[int],
@@ -105,7 +93,6 @@ def main(
     num_clients: Optional[int],
     throughput_trial_duration_secs: Optional[int],
     local_test: Optional[bool],
-    sync_handle: Optional[bool],
 ):
     if local_test:
         setup_local_single_node_cluster(1, num_cpu_per_node=8)
@@ -114,14 +101,10 @@ def main(
 
     handle = construct_long_chain_graph_with_pure_handle(
         chain_length,
-        sync_handle,
         init_delay_secs=init_delay_secs,
         compute_delay_secs=compute_delay_secs,
     )
-    if sync_handle:
-        assert ray.get(handle.predict.remote(0)) == chain_length
-    else:
-        sanity_check_graph_deployment_with_async_handle(handle, chain_length)
+    assert ray.get(handle.predict.remote(0)) == chain_length
 
     throughput_mean_tps, throughput_std_tps = asyncio.run(
         benchmark_throughput_tps(
@@ -152,7 +135,6 @@ def main(
         "init_delay_secs": init_delay_secs,
         "compute_delay_secs": compute_delay_secs,
         "local_test": local_test,
-        "sync_handle": sync_handle,
     }
     results["perf_metrics"] = [
         {

--- a/release/serve_tests/workloads/serve_handle_wide_ensemble.py
+++ b/release/serve_tests/workloads/serve_handle_wide_ensemble.py
@@ -25,8 +25,7 @@ from typing import Optional
 
 import ray
 from ray import serve
-from ray.serve.handle import RayServeSyncHandle
-from ray.serve.context import _get_global_client
+from ray.serve.handle import DeploymentHandle, RayServeSyncHandle
 from serve_test_cluster_utils import (
     setup_local_single_node_cluster,
     setup_anyscale_cluster,
@@ -58,42 +57,32 @@ class Node:
 class CombineNode:
     def __init__(
         self,
-        input_nodes: List[RayServeSyncHandle],
+        input_nodes: List[DeploymentHandle],
         compute_delay_secs,
-        sync_handle=True,
     ):
-        assert type(input_nodes) == list
-        self.input_nodes = input_nodes
+        assert isinstance(input_nodes, list)
+        self.handles = [node.options(use_new_handle_api=True) for node in input_nodes]
         self.compute_delay_secs = compute_delay_secs
-        self.sync_handle = sync_handle
 
     async def predict(self, data):
         results = [
-            node.predict.remote(data, self.compute_delay_secs)
-            for node in self.input_nodes
+            handle.predict.remote(data, self.compute_delay_secs)
+            for handle in self.handles
         ]
-        if self.sync_handle:
-            results = await asyncio.gather(*results)
-        else:
-            results = await asyncio.gather(*await asyncio.gather(*results))
+
+        results = await asyncio.gather(*results)
         return sum(results)
 
 
 def construct_wide_fanout_graph_with_pure_handle(
-    fanout_degree, sync_handle: bool, init_delay_secs=0, compute_delay_secs=0
+    fanout_degree, init_delay_secs=0, compute_delay_secs=0
 ) -> RayServeSyncHandle:
     nodes = []
     for id in range(fanout_degree):
-        Node.options(name=str(id))._deploy(id, init_delay_secs=init_delay_secs)
-        nodes.append(_get_global_client().get_handle(str(id), "", sync=sync_handle))
-    CombineNode.options(name="combine")._deploy(
-        nodes, compute_delay_secs, sync_handle=sync_handle
-    )
-    return _get_global_client().get_handle("combine", "", sync=sync_handle)
-
-
-async def sanity_check_graph_deployment_with_async_handle(handle, expected_result):
-    assert await (await handle.predict.remote(0)) == expected_result
+        node = Node.options(name=str(id)).bind(id, init_delay_secs=init_delay_secs)
+        nodes.append(node)
+    app = CombineNode.options(name="combine").bind(nodes, compute_delay_secs)
+    return serve.run(app)
 
 
 @click.command()
@@ -112,7 +101,6 @@ async def sanity_check_graph_deployment_with_async_handle(handle, expected_resul
     default=DEFAULT_THROUGHPUT_TRIAL_DURATION_SECS,
 )
 @click.option("--local-test", type=bool, default=True)
-@click.option("--sync-handle", type=bool, default=True)
 def main(
     fanout_degree: Optional[int],
     init_delay_secs: Optional[int],
@@ -121,7 +109,6 @@ def main(
     num_clients: Optional[int],
     throughput_trial_duration_secs: Optional[int],
     local_test: Optional[bool],
-    sync_handle: Optional[bool],
 ):
     if local_test:
         setup_local_single_node_cluster(1, num_cpu_per_node=8)
@@ -130,17 +117,13 @@ def main(
 
     handle = construct_wide_fanout_graph_with_pure_handle(
         fanout_degree,
-        sync_handle,
         init_delay_secs=init_delay_secs,
         compute_delay_secs=compute_delay_secs,
     )
 
     # 0 + 1 + 2 + 3 + 4 + ... + (fanout_degree - 1)
     expected = ((0 + fanout_degree - 1) * fanout_degree) / 2
-    if sync_handle:
-        assert ray.get(handle.predict.remote(0)) == expected
-    else:
-        sanity_check_graph_deployment_with_async_handle(handle, expected)
+    assert ray.get(handle.predict.remote(0)) == expected
 
     throughput_mean_tps, throughput_std_tps = asyncio.run(
         benchmark_throughput_tps(
@@ -170,7 +153,6 @@ def main(
         "init_delay_secs": init_delay_secs,
         "compute_delay_secs": compute_delay_secs,
         "local_test": local_test,
-        "sync_handle": sync_handle,
     }
     results["perf_metrics"] = [
         {

--- a/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/single_deployment_1k_noop_replica.py
@@ -71,7 +71,7 @@ def deploy_replicas(num_replicas, max_batch_size) -> List[str]:
         async def __call__(self, request):
             return await self.handle_batch(request)
 
-    Echo._deploy()
+    serve.run(Echo.bind(), route_prefix=f"/{name}")
     return [name]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Migrate Serve release tests to use v2 api rather than v1 api.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
