### PR TITLE
[data] ignore zeros in dataset metrics for test_streaming_stats_full

### DIFF
--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -98,7 +98,9 @@ Dataset memory:
 """
 
 
-def canonicalize(stats: str, filter_global_stats: bool = True, ignore_zeros: bool = False) -> str:
+def canonicalize(
+    stats: str, filter_global_stats: bool = True, ignore_zeros: bool = False
+) -> str:
     # Dataset UUID expression.
     s0 = re.sub("([a-f\d]{32})", "U", stats)
     # Time expressions.

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -992,20 +992,22 @@ def test_streaming_stats_full(ray_start_regular_shared, restore_data_context):
 * Output num rows: N min, N max, N mean, N total
 * Output size bytes: N min, N max, N mean, N total
 * Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {STANDARD_EXTRA_METRICS.replace(": Z", ": N")}
+* Extra metrics: {STANDARD_EXTRA_METRICS}
 
 Dataset iterator time breakdown:
 * Total time user code is blocked: T
 * Total time in user code: T
 * Total time overall: T
-* Num blocks local: N
-* Num blocks remote: N
+* Num blocks local: Z
+* Num blocks remote: Z
 * Num blocks unknown location: N
 * Batch iteration time breakdown (summed across prefetch threads):
     * In ray.get(): T min, T max, T avg, T total
     * In batch creation: T min, T max, T avg, T total
     * In batch formatting: T min, T max, T avg, T total
-"""
+""".replace(
+            ": Z", ": N"
+        )
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This test is being flaky because we are asserting on the stats while the dataset is executing (`execute_to_iterator`). Metrics like `num_tasks_running` can be both zero and non-zero.

This PR adds an option to canonicalize zeros and non-zeros into the same value for testing.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
