### PR TITLE
[data] incr test_split size

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -428,7 +428,7 @@ py_test(
 
 py_test(
     name = "test_split",
-    size = "medium",
+    size = "large",
     srcs = ["tests/test_split.py"],
     tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I think `test_split.py` is timing out because it is only medium size. This pr increases the size to large
<img width="711" alt="Screenshot 2023-10-16 at 5 27 14 PM" src="https://github.com/ray-project/ray/assets/39287272/153da437-889e-444d-b893-6f1f9b2b3359">
375s times out for medium

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
