### PR TITLE
[Cherry-pick][KubeRay][Autoscaler] Make KubeRay CRD version configurable

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -31,8 +31,10 @@ KUBERAY_LABEL_KEY_KIND = "ray.io/node-type"
 KUBERAY_LABEL_KEY_TYPE = "ray.io/group"
 # Kind label value indicating the pod is the head.
 KUBERAY_KIND_HEAD = "head"
-# Group name (node type) to use for the  head.
+# Group name (node type) to use for the head.
 KUBERAY_TYPE_HEAD = "head-group"
+# KubeRay CRD version
+KUBERAY_CRD_VER = os.getenv("KUBERAY_CRD_VER", "v1alpha1")
 
 RAY_HEAD_POD_NAME = os.getenv("RAY_HEAD_POD_NAME")
 
@@ -162,7 +164,7 @@ def url_from_resource(namespace: str, path: str) -> str:
     if path.startswith("pods"):
         api_group = "/api/v1"
     elif path.startswith("rayclusters"):
-        api_group = "/apis/ray.io/v1alpha1"
+        api_group = "/apis/ray.io/" + KUBERAY_CRD_VER
     else:
         raise NotImplementedError("Tried to access unknown entity at {}".format(path))
     return (
@@ -398,7 +400,7 @@ class KuberayNodeProvider(BatchingNodeProvider):  # type: ignore
         if path.startswith("pods"):
             api_group = "/api/v1"
         elif path.startswith("rayclusters"):
-            api_group = "/apis/ray.io/v1alpha1"
+            api_group = "/apis/ray.io/" + KUBERAY_CRD_VER
         else:
             raise NotImplementedError(
                 "Tried to access unknown entity at {}".format(path)


### PR DESCRIPTION
---------

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cherry-pick #40357. Without this PR, KubeRay v1.1.0 will not be able to support this Ray version. See the PR description of #40357 for more details.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
