### PR TITLE
[serve] Outdated API cleanup in docs

### DIFF
--- a/doc/source/ray-observability/user-guides/debug-apps/ray-debugging.rst
+++ b/doc/source/ray-observability/user-guides/debug-apps/ray-debugging.rst
@@ -249,7 +249,7 @@ Next, copy the following code into a file called ``serve_debugging.py``:
     model.fit(iris_dataset["data"], iris_dataset["target"])
 
     # Define Ray Serve model,
-    @serve.deployment(route_prefix="/iris")
+    @serve.deployment
     class BoostingModel:
         def __init__(self):
             self.model = model
@@ -264,8 +264,7 @@ Next, copy the following code into a file called ``serve_debugging.py``:
             return {"result": human_name}
 
     # Deploy model
-    serve.start()
-    BoostingModel.deploy()
+    serve.run(BoostingModel.bind(), route_prefix="/iris")
 
     time.sleep(3600.0)
 

--- a/doc/source/serve/doc_code/fastapi_example.py
+++ b/doc/source/serve/doc_code/fastapi_example.py
@@ -6,7 +6,7 @@ from ray import serve
 app = FastAPI()
 
 
-@serve.deployment(route_prefix="/")
+@serve.deployment
 @serve.ingress(app)
 class FastAPIDeployment:
     # FastAPI will automatically parse the HTTP request for us.
@@ -16,7 +16,7 @@ class FastAPIDeployment:
 
 
 # 2: Deploy the deployment.
-serve.run(FastAPIDeployment.bind())
+serve.run(FastAPIDeployment.bind(), route_prefix="/")
 
 # 3: Query the deployment and print the result.
 print(requests.get("http://localhost:8000/hello", params={"name": "Theodore"}).json())

--- a/doc/source/serve/doc_code/quickstart.py
+++ b/doc/source/serve/doc_code/quickstart.py
@@ -6,7 +6,7 @@ from ray import serve
 
 
 # 1: Define a Ray Serve application.
-@serve.deployment(route_prefix="/")
+@serve.deployment
 class MyModelDeployment:
     def __init__(self, msg: str):
         # Initialize model state: could be very large neural net weights.
@@ -19,7 +19,7 @@ class MyModelDeployment:
 app = MyModelDeployment.bind(msg="Hello world!")
 
 # 2: Deploy the application locally.
-serve.run(app)
+serve.run(app, route_prefix="/")
 
 # 3: Query the application and print the result.
 print(requests.get("http://localhost:8000/").json())

--- a/doc/source/serve/doc_code/sklearn_quickstart.py
+++ b/doc/source/serve/doc_code/sklearn_quickstart.py
@@ -18,7 +18,7 @@ model = GradientBoostingClassifier()
 model.fit(iris_dataset["data"], iris_dataset["target"])
 
 
-@serve.deployment(route_prefix="/iris")
+@serve.deployment
 class BoostingModel:
     def __init__(self, model):
         self.model = model
@@ -34,7 +34,7 @@ class BoostingModel:
 
 
 # Deploy model.
-serve.run(BoostingModel.bind(model))
+serve.run(BoostingModel.bind(model), route_prefix="/iris")
 
 # Query it!
 sample_request_input = {"vector": [1.2, 1.0, 1.1, 0.9]}

--- a/doc/source/serve/doc_code/transformers_example.py
+++ b/doc/source/serve/doc_code/transformers_example.py
@@ -8,7 +8,7 @@ from ray import serve
 
 
 # 1: Wrap the pretrained sentiment analysis model in a Serve deployment.
-@serve.deployment(route_prefix="/")
+@serve.deployment
 class SentimentAnalysisDeployment:
     def __init__(self):
         self._model = pipeline("sentiment-analysis")
@@ -18,7 +18,7 @@ class SentimentAnalysisDeployment:
 
 
 # 2: Deploy the deployment.
-serve.run(SentimentAnalysisDeployment.bind())
+serve.run(SentimentAnalysisDeployment.bind(), route_prefix="/")
 
 # 3: Query the deployment and print the result.
 print(

--- a/doc/source/templates/03_serving_stable_diffusion/app.py
+++ b/doc/source/templates/03_serving_stable_diffusion/app.py
@@ -9,7 +9,7 @@ from diffusers import EulerDiscreteScheduler, StableDiffusionPipeline
 app = FastAPI()
 
 
-@serve.deployment(num_replicas=1, route_prefix="/")
+@serve.deployment(num_replicas=1)
 @serve.ingress(app)
 class APIIngress:
     def __init__(self, diffusion_model_handle) -> None:

--- a/doc/source/templates/03_serving_stable_diffusion/start.ipynb
+++ b/doc/source/templates/03_serving_stable_diffusion/start.ipynb
@@ -175,7 +175,7 @@
     "app = FastAPI()\n",
     "\n",
     "\n",
-    "@serve.deployment(num_replicas=1, route_prefix=\"/\")\n",
+    "@serve.deployment(num_replicas=1)\n",
     "@serve.ingress(app)\n",
     "class APIIngress:\n",
     "    def __init__(self, diffusion_model_handle) -> None:\n",
@@ -219,7 +219,7 @@
     "\n",
     "# Shutdown any existing Serve replicas, if they're still around.\n",
     "serve.shutdown()\n",
-    "serve.run(entrypoint, port=port, name=\"serving_stable_diffusion_template\")\n",
+    "serve.run(entrypoint, port=port, name=\"serving_stable_diffusion_template\", route_prefix=\"/\")\n",
     "print(\"Done setting up replicas! Now accepting requests...\")\n"
    ]
   },

--- a/doc/source/tune/examples/tune-serve-integration-mnist.ipynb
+++ b/doc/source/tune/examples/tune-serve-integration-mnist.ipynb
@@ -576,7 +576,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@serve.deployment(name=\"mnist\", route_prefix=\"/mnist\")\n",
+    "@serve.deployment(name=\"mnist\")\n",
     "class MNISTDeployment:\n",
     "    def __init__(self, checkpoint_dir, config, metrics, use_gpu=False):\n",
     "        self.checkpoint_dir = checkpoint_dir\n",
@@ -629,7 +629,7 @@
     "    )\n",
     "\n",
     "    serve.start(detached=True)\n",
-    "    serve.run(MNISTDeployment.bind(checkpoint_path, config, metrics, use_gpu))\n",
+    "    serve.run(MNISTDeployment.bind(checkpoint_path, config, metrics, use_gpu), route_prefix=\"/mnist\")\n",
     "\n",
     "\n",
     "def _move_checkpoint_to_model_dir(model_dir, checkpoint, config, metrics):\n",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Clean up:
- (removed) v1 api doc code
- (Deprecated) using route prefix in serve deployment decorator

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
