### PR TITLE
[ci] using typing_extensions for release test infra

### DIFF
--- a/release/ray_release/configs/global_config.py
+++ b/release/ray_release/configs/global_config.py
@@ -1,7 +1,7 @@
 import os
 
 import yaml
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 
 class GlobalConfig(TypedDict):


### PR DESCRIPTION
#40336 remove typing extensions due to the deprecation of python 3.7 (sorry @pcmoritz  I should have caught this during review); but release test infra still runs on 3.7. The right solution here is to upgrade buildkite pool to use python 3.8, but I undo this change to unblock this for now to give us more time to do the upgrade.

Error: https://buildkite.com/ray-project/release-tests-branch/builds/2266#018b3c38-e80f-4a70-a43a-4eca9eb48012/142-563

Test:
- CI

