### PR TITLE
[serve] Fix flaky test_autoscaling_policy on windows

### DIFF
--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -758,7 +758,7 @@ def test_cold_start_time(serve_instance):
     start = time.time()
     result = ray.get(handle.remote())
     cold_start_time = time.time() - start
-    assert cold_start_time < 2
+    assert cold_start_time < 3
     print(
         "Time taken for deployment at 0 replicas to serve first request:",
         cold_start_time,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Originally we check that it takes at most 2 seconds for a deployment with 0 replicas to serve its first request.
This seems to be consistently enough time on Linux, but Windows is slower and often takes slightly more than 2 seconds to serve that first request. Increasing to 3 seconds to deflake.

<img width="291" alt="image" src="https://github.com/ray-project/ray/assets/15851518/956312f4-47ea-477b-ad77-1a89ef59a221">

Note that the purpose of the test is to make sure the cold start optimization works consistently, so increasing from 2 -> 3 seconds shouldn't make a difference. Without the cold start optimization, the time to serve the first request should be uniformly distributed between roughly 0-10 + cold-start-offset seconds.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
