### PR TITLE
[data] link dataset ids in constructor, return correct metrics id for materialize

### DIFF
--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -323,27 +323,20 @@ class ExecutionPlan:
         plan_copy._stages_after_snapshot = self._stages_after_snapshot.copy()
         return plan_copy
 
-    def deep_copy(self, preserve_uuid: bool = False) -> "ExecutionPlan":
+    def deep_copy(self) -> "ExecutionPlan":
         """Create a deep copy of this execution plan.
 
         This copy can be executed AND cleared without mutating the original.
 
-        Args:
-            preserve_uuid: Whether to preserve the original UUID in the copy.
-
         Returns:
             A deep copy of this execution plan.
         """
-        dataset_uuid = None
-        if preserve_uuid:
-            dataset_uuid = self._dataset_uuid
         in_blocks = self._in_blocks
         if isinstance(in_blocks, BlockList):
             in_blocks = in_blocks.copy()
         plan_copy = ExecutionPlan(
             in_blocks,
             copy.copy(self._in_stats),
-            dataset_uuid=dataset_uuid,
             run_by_consumer=self._run_by_consumer,
         )
         if self._snapshot_blocks:

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -1,7 +1,6 @@
 import copy
 import functools
 import itertools
-import uuid
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -110,7 +109,6 @@ class ExecutionPlan:
         self,
         in_blocks: BlockList,
         stats: DatasetStats,
-        dataset_uuid=None,
         *,
         run_by_consumer: bool,
     ):
@@ -135,9 +133,7 @@ class ExecutionPlan:
         self._last_optimized_stages = None
         # Cached schema.
         self._schema = None
-        self._dataset_uuid = dataset_uuid or uuid.uuid4().hex
-        if not stats.dataset_uuid:
-            stats.dataset_uuid = self._dataset_uuid
+        self._dataset_uuid = None
 
         self._run_by_consumer = run_by_consumer
 

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -133,6 +133,7 @@ class ExecutionPlan:
         self._last_optimized_stages = None
         # Cached schema.
         self._schema = None
+        # Set when a Dataset is constructed with this plan
         self._dataset_uuid = None
 
         self._run_by_consumer = run_by_consumer

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4712,7 +4712,6 @@ class Dataset:
         ds = Dataset(plan_copy, logical_plan_copy)
         ds._plan.clear_block_refs()
         ds._set_uuid(self._get_uuid())
-        ds._plan._dataset_uuid = self._get_uuid()
 
         def _reduce_remote_fn(rf: ray.remote_function.RemoteFunction):
             # Custom reducer for Ray remote function handles that allows for
@@ -4969,6 +4968,7 @@ class Dataset:
 
     def _set_uuid(self, uuid: str) -> None:
         self._uuid = uuid
+        self._plan._dataset_uuid = uuid
 
     def _synchronize_progress_bar(self):
         """Flush progress bar output by shutting down the current executor.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -243,6 +243,7 @@ class Dataset:
 
         self._plan = plan
         self._uuid = uuid4().hex
+        self._plan._dataset_uuid = self._uuid
         self._logical_plan = logical_plan
         if logical_plan is not None:
             self._plan.link_logical_plan(logical_plan)
@@ -4557,6 +4558,9 @@ class Dataset:
         )
         output._plan.execute()  # No-op that marks the plan as fully executed.
         output._plan._in_stats.dataset_uuid = self._get_uuid()
+        # Metrics are tagged with `copy`s uuid, update the output uuid with
+        # this so the user can access the metrics label.
+        output._uuid = copy._get_uuid()
         return output
 
     @ConsumptionAPI(pattern="timing information.", insert_after=True)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4707,7 +4707,7 @@ class Dataset:
             )
         # Copy Dataset and clear the blocks from the execution plan so only the
         # Dataset's lineage is serialized.
-        plan_copy = self._plan.deep_copy(preserve_uuid=True)
+        plan_copy = self._plan.deep_copy()
         logical_plan_copy = copy.copy(self._plan._logical_plan)
         ds = Dataset(plan_copy, logical_plan_copy)
         ds._plan.clear_block_refs()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -242,8 +242,7 @@ class Dataset:
         usage_lib.record_library_usage("dataset")  # Legacy telemetry name.
 
         self._plan = plan
-        self._uuid = uuid4().hex
-        self._plan._dataset_uuid = self._uuid
+        self._set_uuid(uuid4().hex)
         self._logical_plan = logical_plan
         if logical_plan is not None:
             self._plan.link_logical_plan(logical_plan)
@@ -4557,10 +4556,9 @@ class Dataset:
             logical_plan,
         )
         output._plan.execute()  # No-op that marks the plan as fully executed.
-        output._plan._in_stats.dataset_uuid = self._get_uuid()
         # Metrics are tagged with `copy`s uuid, update the output uuid with
         # this so the user can access the metrics label.
-        output._uuid = copy._get_uuid()
+        output._set_uuid(copy._get_uuid())
         return output
 
     @ConsumptionAPI(pattern="timing information.", insert_after=True)
@@ -4969,6 +4967,7 @@ class Dataset:
     def _set_uuid(self, uuid: str) -> None:
         self._uuid = uuid
         self._plan._dataset_uuid = uuid
+        self._plan._in_stats.dataset_uuid = uuid
 
     def _synchronize_progress_bar(self):
         """Flush progress bar output by shutting down the current executor.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4712,6 +4712,7 @@ class Dataset:
         ds = Dataset(plan_copy, logical_plan_copy)
         ds._plan.clear_block_refs()
         ds._set_uuid(self._get_uuid())
+        ds._plan._dataset_uuid = self._get_uuid()
 
         def _reduce_remote_fn(rf: ray.remote_function.RemoteFunction):
             # Custom reducer for Ray remote function handles that allows for

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1169,6 +1169,8 @@ def test_stats_actor_metrics():
     # There should be nothing in object store at the end of execution.
     assert final_metric.obj_store_mem_cur == 0
 
+    assert ds._uuid == update_fn.call_args_list[-1].args[1]["dataset"]
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The dataset uuid that we record metrics with and the dataset uuid we return from `Dataset.materialize()` are different currently for two reasons:

`ExecutionPlan` is not getting it's dataset uuid as a parameter. The`dataset_uuid` parameter is only set in the deepcopy for `Dataset.serialize_lineage`. It's not useful anywhere else because we need to create the `ExecutionPlan` before the `Dataset`, and pass the plan into the dataset's constructor. Instead, we can link the dataset ids in the dataset's constructor. 

In `materialize`, we create a copy of the current dataset and execute it (this is the uuid that is used for metrics). We then create an output dataset (different uuid) and return that. This pr copies over the uuid of `copy` to `output`. Only `output` gets returned, and `copy` gets destroyed so this shouldn't create 2 datasets with same id. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
