### PR TITLE
[ci] migrate debug + asan core builds to civ2

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -23,6 +23,31 @@ steps:
     depends_on: corebuild
     job_env: forge
 
+  - label: ":ray: core: debug test"
+    tags: python
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core 
+        --build-type debug
+        --parallelism-per-worker 3
+        --only-tags debug_tests
+        --except-tags kubernetes
+    depends_on: corebuild
+    job_env: forge
+
+  - label: ":ray: core: asan tests"
+    tags: python
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core 
+        --build-type asan
+        --parallelism-per-worker 2
+        --only-tags asan_tests
+        --except-tags kubernetes 
+    depends_on: corebuild
+    job_env: forge
+
+
   - label: ":ray: core: flaky tests"
     tags: python
     instance_type: large

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -93,36 +93,6 @@
       --test_env=DOCKER_TLS_CERTDIR=/certs
       -- python/ray/tests/...
 
-- label: ":python: Debug Test"
-  conditions: ["RAY_CI_PYTHON_AFFECTED"]
-  instance_size: medium
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - pip uninstall -y ray
-    - RAY_DEBUG_BUILD=debug ./ci/ci.sh build
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci-debug $(./ci/run/bazel_export_options)
-      --test_tag_filters=-kubernetes,debug_tests
-      python/ray/tests/...
-
-- label: ":python: (ASAN tests)"
-  conditions: ["RAY_CI_PYTHON_AFFECTED"]
-  instance_size: medium
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - bazel build $(./ci/run/bazel_export_options) --no//:jemalloc_flag //:ray_pkg
-    - bazel test --config=ci --config=asan $(./ci/run/bazel_export_options)
-      --config=asan-buildkite
-      --test_tag_filters=-kubernetes,asan_tests
-      --test_env=CONDA_EXE
-      --test_env=CONDA_PYTHON_EXE
-      --test_env=CONDA_SHLVL
-      --test_env=CONDA_PREFIX
-      --test_env=CONDA_DEFAULT_ENV
-      python/ray/tests/...
-
 - label: ":book: Doctest (CPU)"
   instance_size: large
   commands:

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -232,6 +232,11 @@ if __name__ == "__main__":
                     if changed_file.endswith(compiled_extension):
                         RAY_CI_COMPILED_PYTHON_AFFECTED = 1
                         break
+            elif (
+                changed_file.startswith("ci/ray_ci")
+                or changed_file == ".buildkite/core.rayci.yml"
+            ):
+                RAY_CI_PYTHON_AFFECTED = 1
             elif changed_file.startswith("java/"):
                 RAY_CI_JAVA_AFFECTED = 1
             elif changed_file.startswith("cpp/"):

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -49,7 +49,7 @@ class Container:
             stderr=sys.stderr,
         )
 
-    def install_ray(self) -> None:
+    def install_ray(self, build_type: Optional[str] = None) -> None:
         env = os.environ.copy()
         env["DOCKER_BUILDKIT"] = "1"
         subprocess.check_call(
@@ -59,6 +59,8 @@ class Container:
                 "--pull",
                 "--build-arg",
                 f"BASE_IMAGE={self._get_docker_image()}",
+                "--build-arg",
+                f"BUILD_TYPE={build_type or ''}",
                 "-t",
                 self._get_docker_image(),
                 "-f",

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -92,6 +92,11 @@ bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
     type=str,
     help="Name of the build used to run tests",
 )
+@click.option(
+    "--build-type",
+    type=click.Choice(["optimized", "debug", "asan"]),
+    default="optimized",
+)
 def main(
     targets: List[str],
     team: str,
@@ -105,6 +110,7 @@ def main(
     test_env: List[str],
     test_arg: Optional[str],
     build_name: Optional[str],
+    build_type: Optional[str],
 ) -> None:
     if not bazel_workspace_dir:
         raise Exception("Please use `bazelisk run //ci/ray_ci`")
@@ -117,6 +123,7 @@ def main(
         worker_id,
         parallelism_per_worker,
         build_name,
+        build_type,
         skip_ray_installation,
     )
     test_targets = _get_test_targets(
@@ -137,6 +144,7 @@ def _get_container(
     worker_id: int,
     parallelism_per_worker: int,
     build_name: Optional[str] = None,
+    build_type: Optional[str] = None,
     skip_ray_installation: bool = False,
 ) -> TesterContainer:
     shard_count = workers * parallelism_per_worker
@@ -148,6 +156,7 @@ def _get_container(
         shard_count=shard_count,
         shard_ids=list(range(shard_start, shard_end)),
         skip_ray_installation=skip_ray_installation,
+        build_type=build_type,
     )
 
 

--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -3,6 +3,8 @@
 ARG BASE_IMAGE
 FROM "$BASE_IMAGE"
 
+ARG BUILD_TYPE
+
 ENV CC=clang
 ENV CXX=clang++-12
 
@@ -19,6 +21,13 @@ RUN <<EOF
   npm run build
 )
 
-pip install -v -e python/
+if [[ "$BUILD_TYPE" == "debug" ]]; then
+  RAY_DEBUG_BUILD=debug pip install -v -e python/
+elif [[ "$BUILD_TYPE" == "asan" ]]; then
+  pip install -v -e python/
+  bazel build $(./ci/run/bazel_export_options) --no//:jemalloc_flag //:ray_pkg
+else
+  pip install -v -e python/
+fi
 
 EOF


### PR DESCRIPTION
- Add an --build-type flag to ray_ci, which can accept either a 'debug' or 'asan' value. This controls how we install ray + some of the bazel flags
- Add unit-tests
- Update determine_test_to_run.py for .buildkite yaml files

Test:
- CI