### PR TITLE
Revert "[docker image] use buildkit to build ray image"

### DIFF
--- a/ci/build/build-ray-docker.sh
+++ b/ci/build/build-ray-docker.sh
@@ -15,8 +15,6 @@ cp .whl/"$WHEEL_NAME" "${CPU_TMP}/.whl/${WHEEL_NAME}"
 cp docker/ray/Dockerfile "${CPU_TMP}/Dockerfile"
 cp python/requirements_compiled.txt "${CPU_TMP}/."
 
-export DOCKER_BUILDKIT=1
-
 # Build the image.
 cd "${CPU_TMP}"
 tar --mtime="UTC 2020-01-01" -c -f - . \

--- a/docker/ray/Dockerfile
+++ b/docker/ray/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.3-labs
-
 ARG BASE_IMAGE
 ARG FULL_BASE_IMAGE=rayproject/ray-deps:nightly"$BASE_IMAGE"
 FROM $FULL_BASE_IMAGE
@@ -12,19 +10,8 @@ COPY requirements_compiled.txt ./
 COPY $WHEEL_PATH .
 COPY $FIND_LINKS_PATH $FIND_LINKS_PATH
 
-RUN <<EOF
-#!/bin/bash
-
-set -euo pipefail
-
-WHEEL_NAME="$(basename $WHEEL_PATH)"
-
-$HOME/anaconda3/bin/pip --no-cache-dir \
-    install -c $CONSTRAINTS_FILE "${WHEEL_NAME}" \
-    --find-links $FIND_LINKS_PATH
-
-sudo rm "${WHEEL_NAME}"
-
-EOF
+RUN $HOME/anaconda3/bin/pip --no-cache-dir install -c $CONSTRAINTS_FILE \
+    `basename $WHEEL_PATH`[all] \
+    --find-links $FIND_LINKS_PATH && sudo rm `basename $WHEEL_PATH`
 
 RUN $HOME/anaconda3/bin/pip freeze > /home/ray/pip-freeze.txt


### PR DESCRIPTION
Reverts ray-project/ray#40365

There are still many places using old way of building that uses python docker api and cannot enable buildkit.