### PR TITLE
[data] add dataset name

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -62,7 +62,7 @@ class StreamingExecutor(Executor, threading.Thread):
     a way that maximizes throughput under resource constraints.
     """
 
-    def __init__(self, options: ExecutionOptions, dataset_uuid: str = "unknown_uuid"):
+    def __init__(self, options: ExecutionOptions, dataset_tag: str = "unknown_dataset"):
         self._start_time: Optional[float] = None
         self._initial_stats: Optional[DatasetStats] = None
         self._final_stats: Optional[DatasetStats] = None
@@ -82,7 +82,7 @@ class StreamingExecutor(Executor, threading.Thread):
         self._output_node: Optional[OpState] = None
         self._backpressure_policies: Optional[List[BackpressurePolicy]] = None
 
-        self._dataset_uuid = dataset_uuid
+        self._dataset_tag = dataset_tag
 
         Executor.__init__(self, options)
         thread_name = f"StreamingExecutor-{self._execution_id}"
@@ -208,7 +208,7 @@ class StreamingExecutor(Executor, threading.Thread):
             self._output_node.outqueue.append(None)
             # Clears metrics for this dataset so that they do
             # not persist in the grafana dashboard after execution
-            clear_stats_actor_metrics({"dataset": self._dataset_uuid})
+            clear_stats_actor_metrics({"dataset": self._dataset_tag})
 
     def get_stats(self):
         """Return the stats object for the streaming execution.
@@ -290,7 +290,7 @@ class StreamingExecutor(Executor, threading.Thread):
             op_state.refresh_progress_bar()
 
         update_stats_actor_metrics(
-            [op.metrics for op in self._topology], {"dataset": self._dataset_uuid}
+            [op.metrics for op in self._topology], {"dataset": self._dataset_tag}
         )
 
         # Keep going until all operators run to completion.

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -576,7 +576,7 @@ class ExecutionPlan:
                     StreamingExecutor,
                 )
 
-                metrics_tag = (self._dataset_name or None) + self._dataset_uuid
+                metrics_tag = (self._dataset_name or "") + self._dataset_uuid
                 executor = StreamingExecutor(
                     copy.deepcopy(context.execution_options),
                     metrics_tag,

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -224,8 +224,17 @@ class ExecutionPlan:
             num_blocks = "?"
         else:
             num_blocks = dataset_blocks.estimated_num_blocks()
-        dataset_str = "{}(num_blocks={}, num_rows={}, schema={})".format(
-            classname, num_blocks, count, schema_str
+        name_str = (
+            "name={}, ".format(self._dataset_name)
+            if self._dataset_name is not None
+            else ""
+        )
+        dataset_str = "{}({}num_blocks={}, num_rows={}, schema={})".format(
+            classname,
+            name_str,
+            num_blocks,
+            count,
+            schema_str,
         )
 
         # If the resulting string representation fits in one line, use it directly.
@@ -265,8 +274,14 @@ class ExecutionPlan:
                 schema_str = (
                     "{\n" + schema_str + f"\n{trailing_space}{INDENT_STR}" + "}"
                 )
+            name_str = (
+                f"\n{trailing_space}{INDENT_STR}name={self._dataset_name},"
+                if self._dataset_name is not None
+                else ""
+            )
             dataset_str = (
                 f"{classname}("
+                f"{name_str}"
                 f"\n{trailing_space}{INDENT_STR}num_blocks={num_blocks},"
                 f"\n{trailing_space}{INDENT_STR}num_rows={count},"
                 f"\n{trailing_space}{INDENT_STR}schema={schema_str}"

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -137,6 +137,7 @@ class ExecutionPlan:
         self._dataset_uuid = None
 
         self._run_by_consumer = run_by_consumer
+        self._dataset_name = None
 
         # Snapshot the current context, so that the config of Datasets is always
         # determined by the config at the time it was created.
@@ -318,6 +319,7 @@ class ExecutionPlan:
             plan_copy._snapshot_stats = self._snapshot_stats
         plan_copy._stages_before_snapshot = self._stages_before_snapshot.copy()
         plan_copy._stages_after_snapshot = self._stages_after_snapshot.copy()
+        plan_copy._dataset_name = self._dataset_name
         return plan_copy
 
     def deep_copy(self) -> "ExecutionPlan":
@@ -342,6 +344,7 @@ class ExecutionPlan:
             plan_copy._snapshot_stats = copy.copy(self._snapshot_stats)
         plan_copy._stages_before_snapshot = self._stages_before_snapshot.copy()
         plan_copy._stages_after_snapshot = self._stages_after_snapshot.copy()
+        plan_copy._dataset_name = self._dataset_name
         return plan_copy
 
     def initial_num_blocks(self) -> int:
@@ -573,8 +576,10 @@ class ExecutionPlan:
                     StreamingExecutor,
                 )
 
+                metrics_tag = (self._dataset_name or None) + self._dataset_uuid
                 executor = StreamingExecutor(
-                    copy.deepcopy(context.execution_options), self._dataset_uuid
+                    copy.deepcopy(context.execution_options),
+                    metrics_tag,
                 )
                 blocks = execute_to_legacy_block_list(
                     executor,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -389,7 +389,7 @@ class Dataset:
             logical_plan = LogicalPlan(map_op)
         return Dataset(plan, logical_plan)
 
-    def set_name(self, name: Optional[str]):
+    def _set_name(self, name: Optional[str]):
         """Set the name of the dataset.
 
         Used as a prefix for metrics tags.
@@ -397,7 +397,7 @@ class Dataset:
         self._plan._dataset_name = name
 
     @property
-    def name(self) -> Optional[str]:
+    def _name(self) -> Optional[str]:
         """Returns the dataset name"""
         return self._plan._dataset_name
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -396,6 +396,11 @@ class Dataset:
         """
         self._plan._dataset_name = name
 
+    @property
+    def name(self) -> Optional[str]:
+        """Returns the dataset name"""
+        return self._plan._dataset_name
+
     def map_batches(
         self,
         fn: UserDefinedFunction[DataBatch, DataBatch],

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -389,6 +389,13 @@ class Dataset:
             logical_plan = LogicalPlan(map_op)
         return Dataset(plan, logical_plan)
 
+    def set_name(self, name: Optional[str]):
+        """Set the name of the dataset.
+
+        Used as a prefix for metrics tags.
+        """
+        self._plan._dataset_name = name
+
     def map_batches(
         self,
         fn: UserDefinedFunction[DataBatch, DataBatch],

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1175,39 +1175,43 @@ def test_stats_actor_metrics():
 def test_dataset_name():
     ds = ray.data.range(100).map_batches(lambda x: x)
     ds.set_name("test_ds")
+    assert ds.name == "test_ds"
     with patch(
         "ray.data._internal.execution.streaming_executor.update_stats_actor_metrics"
     ) as update_fn:
-        ds.materialize()
+        mds = ds.materialize()
 
-    assert update_fn.call_args_list[-1].args[1]["dataset"].startswith("test_ds")
+    assert update_fn.call_args_list[-1].args[1]["dataset"] == "test_ds" + mds._uuid
 
     # Names persist after an execution
     ds = ds.random_shuffle()
+    assert ds.name == "test_ds"
     with patch(
         "ray.data._internal.execution.streaming_executor.update_stats_actor_metrics"
     ) as update_fn:
-        ds.materialize()
+        mds = ds.materialize()
 
-    assert update_fn.call_args_list[-1].args[1]["dataset"].startswith("test_ds")
+    assert update_fn.call_args_list[-1].args[1]["dataset"] == "test_ds" + mds._uuid
 
     ds.set_name("test_ds_two")
     ds = ds.map_batches(lambda x: x)
+    assert ds.name == "test_ds_two"
     with patch(
         "ray.data._internal.execution.streaming_executor.update_stats_actor_metrics"
     ) as update_fn:
-        ds.materialize()
+        mds = ds.materialize()
 
-    assert update_fn.call_args_list[-1].args[1]["dataset"].startswith("test_ds_two")
+    assert update_fn.call_args_list[-1].args[1]["dataset"] == "test_ds_two" + mds._uuid
 
     ds.set_name(None)
     ds = ds.map_batches(lambda x: x)
+    assert ds.name is None
     with patch(
         "ray.data._internal.execution.streaming_executor.update_stats_actor_metrics"
     ) as update_fn:
-        ds.materialize()
+        mds = ds.materialize()
 
-    assert not update_fn.call_args_list[-1].args[1]["dataset"].startswith("test_ds_two")
+    assert update_fn.call_args_list[-1].args[1]["dataset"] == mds._uuid
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1174,8 +1174,8 @@ def test_stats_actor_metrics():
 
 def test_dataset_name():
     ds = ray.data.range(100).map_batches(lambda x: x)
-    ds.set_name("test_ds")
-    assert ds.name == "test_ds"
+    ds._set_name("test_ds")
+    assert ds._name == "test_ds"
     with patch(
         "ray.data._internal.execution.streaming_executor.update_stats_actor_metrics"
     ) as update_fn:
@@ -1185,7 +1185,7 @@ def test_dataset_name():
 
     # Names persist after an execution
     ds = ds.random_shuffle()
-    assert ds.name == "test_ds"
+    assert ds._name == "test_ds"
     with patch(
         "ray.data._internal.execution.streaming_executor.update_stats_actor_metrics"
     ) as update_fn:
@@ -1193,9 +1193,9 @@ def test_dataset_name():
 
     assert update_fn.call_args_list[-1].args[1]["dataset"] == "test_ds" + mds._uuid
 
-    ds.set_name("test_ds_two")
+    ds._set_name("test_ds_two")
     ds = ds.map_batches(lambda x: x)
-    assert ds.name == "test_ds_two"
+    assert ds._name == "test_ds_two"
     with patch(
         "ray.data._internal.execution.streaming_executor.update_stats_actor_metrics"
     ) as update_fn:
@@ -1203,9 +1203,9 @@ def test_dataset_name():
 
     assert update_fn.call_args_list[-1].args[1]["dataset"] == "test_ds_two" + mds._uuid
 
-    ds.set_name(None)
+    ds._set_name(None)
     ds = ds.map_batches(lambda x: x)
-    assert ds.name is None
+    assert ds._name is None
     with patch(
         "ray.data._internal.execution.streaming_executor.update_stats_actor_metrics"
     ) as update_fn:

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1176,6 +1176,11 @@ def test_dataset_name():
     ds = ray.data.range(100).map_batches(lambda x: x)
     ds._set_name("test_ds")
     assert ds._name == "test_ds"
+    assert (
+        str(ds)
+        == """MapBatches(<lambda>)
++- Dataset(name=test_ds, num_blocks=20, num_rows=100, schema={id: int64})"""
+    )
     with patch(
         "ray.data._internal.execution.streaming_executor.update_stats_actor_metrics"
     ) as update_fn:
@@ -1212,6 +1217,18 @@ def test_dataset_name():
         mds = ds.materialize()
 
     assert update_fn.call_args_list[-1].args[1]["dataset"] == mds._uuid
+
+    ds = ray.data.range(100)
+    ds._set_name("very_loooooooong_name")
+    assert (
+        str(ds)
+        == """Dataset(
+   name=very_loooooooong_name,
+   num_blocks=20,
+   num_rows=100,
+   schema={id: int64}
+)"""
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1173,7 +1173,7 @@ def test_stats_actor_metrics():
 
 
 def test_dataset_name():
-    ds = ray.data.range(100).map_batches(lambda x: x)
+    ds = ray.data.range(100, parallelism=20).map_batches(lambda x: x)
     ds._set_name("test_ds")
     assert ds._name == "test_ds"
     assert (
@@ -1218,7 +1218,7 @@ def test_dataset_name():
 
     assert update_fn.call_args_list[-1].args[1]["dataset"] == mds._uuid
 
-    ds = ray.data.range(100)
+    ds = ray.data.range(100, parallelism=20)
     ds._set_name("very_loooooooong_name")
     assert (
         str(ds)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a name field to `Dataset`. The metrics tag for a dataset is now: name + uuid.

Right now the name isn't actually stored in `Dataset` since we have no use for it here currently. This might change if we decide to use this name for other purposes.

`_dataset_name` is stored in `ExecutionPlan`. It is copied over in `copy` and `deepcopy`, so the name field of a plan stays when an operator is added to the dataset. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
