### PR TITLE
[ci] move minimal tests to civ2

### DIFF
--- a/.buildkite/_forge.rayci.yml
+++ b/.buildkite/_forge.rayci.yml
@@ -94,6 +94,18 @@ steps:
   - name: oss-ci-base_gpu
     wanda: ci/docker/base.gpu.wanda.yaml
 
+  - name: minbuild
+    label: "wanda: minbuild.py{{matrix}}"
+    wanda: ci/docker/min.build.wanda.yaml
+    depends_on: oss-ci-base_build
+    matrix:
+      - "3.8"
+      - "3.9"
+      - "3.10"
+      - "3.11"
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+
   - name: docbuild
     wanda: ci/docker/doc.build.wanda.yaml
     depends_on: oss-ci-base_build

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -47,6 +47,42 @@ steps:
     depends_on: corebuild
     job_env: forge
 
+  - label: ":ray: core: minimal tests {{matrix}}"
+    tags: python
+    instance_type: medium
+    commands:
+      # validate minimal installation
+      - python ./ci/env/check_minimal_install.py
+      # core tests
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core 
+        --parallelism-per-worker 3
+        --build-name minbuild-py{{matrix}}
+        --test-env=RAY_MINIMAL=1
+        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --only-tags minimal
+      # core redis tests
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core 
+        --parallelism-per-worker 3
+        --build-name minbuild-py{{matrix}}
+        --test-env=RAY_MINIMAL=1
+        --test-env=TEST_EXTERNAL_REDIS=1
+        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --only-tags minimal
+        --skip-ray-installation
+      # serve tests
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... serve 
+        --parallelism-per-worker 3
+        --build-name minbuild-py{{matrix}}
+        --test-env=RAY_MINIMAL=1
+        --only-tags minimal
+        --skip-ray-installation
+    depends_on: minbuild
+    job_env: forge
+    matrix:
+      - "3.8"
+      - "3.9"
+      - "3.10"
+      - "3.11"
 
   - label: ":ray: core: flaky tests"
     tags: python

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -42,19 +42,6 @@
       --test_tag_filters=-post_wheel_build,-gpu,xcommit
       python/ray/serve/tests/...
 
-- label: ":python: Minimal install Python {{matrix}}"
-  conditions: ["RAY_CI_PYTHON_AFFECTED"]
-  instance_size: medium
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - ./ci/ci.sh test_minimal {{matrix}}
-    - ./ci/ci.sh test_latest_core_dependencies {{matrix}}
-  matrix:
-    - "3.8"
-    - "3.9"
-    - "3.10"
-    - "3.11"
-
 - label: ":python: Default install"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   instance_size: small

--- a/ci/docker/min.build.Dockerfile
+++ b/ci/docker/min.build.Dockerfile
@@ -1,0 +1,24 @@
+ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build
+FROM $DOCKER_IMAGE_BASE_BUILD
+
+ARG PYTHON_VERSION
+
+# Unset dind settings; we are using the host's docker daemon.
+ENV DOCKER_TLS_CERTDIR=
+ENV DOCKER_HOST=
+ENV DOCKER_TLS_VERIFY=
+ENV DOCKER_CERT_PATH=
+
+SHELL ["/bin/bash", "-ice"]
+
+COPY . .
+
+# minimal dependencies
+RUN MINIMAL_INSTALL=1 PYTHON=${PYTHON_VERSION} ci/env/install-dependencies.sh
+RUN rm -rf python/ray/thirdparty_files
+
+# install test requirements
+RUN python -m pip install -U pytest==7.0.1 numpy
+
+# core pre-release denpendencies
+RUN ./ci/env/install-core-prerelease-dependencies.sh

--- a/ci/docker/min.build.wanda.yaml
+++ b/ci/docker/min.build.wanda.yaml
@@ -1,0 +1,10 @@
+name: "minbuild-py$PYTHON_VERSION"
+froms: ["cr.ray.io/rayproject/oss-ci-base_build"]
+dockerfile: ci/docker/min.build.Dockerfile
+srcs:
+  - ci/env/install-dependencies.sh
+  - ci/env/install-core-prerelease-dependencies.sh
+build_args:
+  - PYTHON_VERSION
+tags:
+  - cr.ray.io/rayproject/minbuild-py$PYTHON_VERSION

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -235,6 +235,9 @@ if __name__ == "__main__":
             elif (
                 changed_file.startswith("ci/ray_ci")
                 or changed_file == ".buildkite/core.rayci.yml"
+                or changed_file == ".buildkite/_forge.rayci.yml"
+                or changed_file == "ci/docker/min.build.Dockerfile"
+                or changed_file == "ci/docker/min.build.wanda.yaml"
             ):
                 RAY_CI_PYTHON_AFFECTED = 1
             elif changed_file.startswith("java/"):

--- a/dashboard/BUILD
+++ b/dashboard/BUILD
@@ -79,7 +79,7 @@ py_test(
     size = "medium",
     srcs = ["tests/test_dashboard.py"],
     deps = [":conftest"],
-    tags = ["exclusive", "team:serve"],
+    tags = ["exclusive", "team:serve", "minimal"],
 )
 
 py_test(

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -39,10 +39,6 @@ py_test_module_list(
     "test_advanced_9.py",
     "test_array.py",
     "test_autoscaling_policy.py",
-    "test_basic.py",
-    "test_basic_2.py",
-    "test_basic_4.py",
-    "test_basic_5.py",
     "test_actor_cancel.py",
     "test_dashboard_profiler.py",
     "test_gcs_fault_tolerance.py",
@@ -189,6 +185,41 @@ py_test_module_list(
 
 py_test_module_list(
   files = [
+    "test_serve_ray_minimal.py",
+  ],
+  size = "small",
+  tags = ["exclusive", "minimal", "team:serve"],
+  deps = ["//:ray_lib", ":conftest"],
+)
+
+py_test_module_list(
+  files = [
+    "test_minimal_install.py",
+    "test_runtime_env_ray_minimal.py",
+    "test_basic.py",
+    "test_basic_2.py",
+    "test_basic_4.py",
+    "test_basic_5.py",
+    "test_utils.py",
+  ],
+  size = "medium",
+  tags = ["exclusive", "minimal", "team:core"],
+  deps = ["//:ray_lib", ":conftest"],
+)
+
+py_test_module_list(
+  files = [
+    "test_basic_3.py",
+    "test_output.py",
+    "test_usage_stats.py",
+  ],
+  size = "large",
+  tags = ["exclusive", "minimal", "team:core"],
+  deps = ["//:ray_lib", ":conftest"],
+)
+
+py_test_module_list(
+  files = [
     "test_actor_out_of_order.py",
     "test_autoscaler_fake_multinode.py",  # Temporarily owned by core.
     "test_annotations.py",
@@ -208,12 +239,10 @@ py_test_module_list(
     "test_metrics_agent_2.py",
     "test_microbenchmarks.py",
     "test_mini.py",
-    "test_minimal_install.py",
     "test_numba.py",
     "test_raylet_output.py",
     "test_top_level_api.py",
     "test_unhandled_error.py",
-    "test_utils.py",
     "test_widgets.py",
   ],
   size = "small",
@@ -327,7 +356,6 @@ py_test_module_list(
     "test_storage.py",
     "test_reference_counting_2.py",
     "test_exit_observability.py",
-    "test_usage_stats.py",
     "test_placement_group.py",
     "test_placement_group_3.py",
     "test_placement_group_5.py",
@@ -349,8 +377,6 @@ py_test(
 
 py_test_module_list(
   files = [
-    "test_basic_3.py",
-    "test_output.py",
     "test_tqdm.py",
     "test_out_of_disk_space.py",
     "test_failure_4.py",
@@ -506,22 +532,6 @@ py_test(
         "test_runtime_env_validation_2_schema.json",
     ],
     tags = ["exclusive", "small_size_python_tests", "team:core"],
-    deps = ["//:ray_lib", ":conftest"],
-)
-
-py_test(
-    name = "test_runtime_env_ray_minimal",
-    size = "medium",
-    srcs = ["test_runtime_env_ray_minimal.py"],
-    tags = ["exclusive", "medium_size_python_tests_k_to_z", "team:core"],
-    deps = ["//:ray_lib", ":conftest"],
-)
-
-py_test(
-    name = "test_serve_ray_minimal",
-    size = "small",
-    srcs = ["test_serve_ray_minimal.py"],
-    tags = ["exclusive", "small_size_python_tests", "team:serve"],
     deps = ["//:ray_lib", ":conftest"],
 )
 


### PR DESCRIPTION
- Create minimal wanda builds
- Use bazel tags to tag minimal tests
- 50% reduction in machine time for those jobs in this migration

Test:
- CI