### PR TITLE
[ci] migrate air + tune + release ml tests to civ02

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -11,6 +11,43 @@ steps:
     depends_on: mlbuild
     job_env: forge
 
+  - label: ":train: ml: air tests"
+    tags: ml
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/air/... ml 
+        --parallelism-per-worker 3
+        --except-tags gpu,hdfs
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... ml 
+        --parallelism-per-worker 3
+        --only-tags ray_air
+        --skip-ray-installation
+    depends_on: mlbuild
+    job_env: forge
+
+  - label: ":train: ml: tune tests"
+    tags: train
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml 
+        --parallelism-per-worker 3
+        --only-tags tune
+        --except-tags gpu_only,ray_air,gpu,doctest,needs_credentials
+    depends_on: mlbuild
+    job_env: forge
+
+  - label: ":train: ml: release tests"
+    tags:
+      - ml
+      - python
+      - release_tests
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //release/... ml 
+        --parallelism-per-worker 3
+    depends_on: mlbuild
+    job_env: forge
+
   - label: ":train: ml: train gpu tests"
     tags: 
       - train

--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -1,43 +1,5 @@
 #ci:group=ML tests
 
-- label: ":airplane: AIR tests (ray/air)"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_ML_AFFECTED"]
-  instance_size: large
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - DATA_PROCESSING_TESTING=1 INSTALL_HOROVOD=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-gpu,-hdfs
-      python/ray/air/...
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=ray_air 
-      python/ray/data/...
-
-- label: ":airplane: AIR/ML release smoke tests"
-  conditions:
-    [
-        "NO_WHEELS_REQUIRED",
-        "RAY_CI_RELEASE_TESTS_AFFECTED",
-        "RAY_CI_ML_AFFECTED",
-        "RAY_CI_PYTHON_AFFECTED",
-    ]
-  instance_size: large
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options)
-      --build_tests_only
-      --test_tag_filters=team:ml
-      release/...
-
-- label: ":steam_locomotive: :octopus: Train + Tune tests and examples"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]
-  instance_size: medium
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=tune,-gpu_only,-ray_air,-gpu,-doctest,-needs_credentials python/ray/train/...
-
 - label: ":train: :key: Train examples with authentication"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED", "RAY_CI_BRANCH_BUILD"]
   instance_size: medium

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -172,7 +172,11 @@ if __name__ == "__main__":
                 RAY_CI_TRAIN_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
-            elif changed_file.startswith("python/ray/train"):
+            elif (
+                changed_file.startswith("python/ray/train")
+                or changed_file == ".buildkite/ml.rayci.yml"
+                or changed_file == ".buildkite/pipeline.ml.yml"
+            ):
                 RAY_CI_ML_AFFECTED = 1
                 RAY_CI_TRAIN_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1


### PR DESCRIPTION
- Straightforward migrate ml air + tune + release ml tests to civ2
- Improve coverage too so this PR doesn't trigger any other tests except for ml