### PR TITLE
[Ray Train] Implement strict even-split of training workers for pretraining

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -136,6 +136,7 @@ class ScalingConfig:
     use_gpu: Union[bool, SampleRange] = False
     resources_per_worker: Optional[Union[Dict, SampleRange]] = None
     placement_strategy: Union[str, SampleRange] = "PACK"
+    force_pack_num_workers: Optional[int] = None
 
     def __post_init__(self):
         if self.resources_per_worker:
@@ -251,7 +252,9 @@ class ScalingConfig:
             for _ in range(self.num_workers if self.num_workers else 0)
         ]
         bundles = trainer_bundle + worker_bundles
-        return PlacementGroupFactory(bundles, strategy=self.placement_strategy)
+        return PlacementGroupFactory(
+            bundles, strategy=self.placement_strategy, merge_bundles_by=self.force_pack_num_workers
+            )
 
     @classmethod
     def from_placement_group_factory(

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -175,6 +175,7 @@ class BaseTrainer(abc.ABC):
 
     _scaling_config_allowed_keys: List[str] = [
         "trainer_resources",
+        "force_pack_num_workers"
     ]
     _handles_checkpoint_freq: bool = False
     _handles_checkpoint_at_end: bool = False

--- a/python/ray/tune/trainable/session.py
+++ b/python/ray/tune/trainable/session.py
@@ -87,10 +87,11 @@ def _tune_task_and_actor_launch_hook(
         available_bundles = cur_pg.bundle_specs[0:]
     else:
         available_bundles = cur_pg.bundle_specs[1:]
-
+    print(cur_pg.bundle_specs)
     # Check if the request can be fulfilled by the current placement group.
     if _valid_resource_shape(resources, available_bundles):
         return
+    print(resources, available_bundles)
 
     if fn.class_name:
         submitted = "actor"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In LLM pretraining, it is common practice to do tensor-parallel, pipeline parallel, and model parallel on a single machine with multiple cards. In such case, each machine should have the same number of actors. Normally, using "PACK" strategy can achieve this. But if some machines in the cluster have fewer cards due to failure, "PACK" strategy does not guarantee these machines are not considered to schedule actors.

This PR adds an option to ScalingConfig. Set this to the number of actors must resides on one machine. The actors are guaranteed to distribute like num_nodes * num_workers_per_node strictly by merging the bundles of placement group. 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
