### PR TITLE
[serve] Remove custom FastAPI encoders

### DIFF
--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -68,60 +68,6 @@ Default = Union[DEFAULT, T]
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
-class _ServeCustomEncoders:
-    """Group of custom encoders for common types that's not handled by FastAPI."""
-
-    @staticmethod
-    def encode_np_array(obj):
-        assert isinstance(obj, np.ndarray)
-        if obj.dtype.kind == "f":  # floats
-            obj = obj.astype(float)
-        if obj.dtype.kind in {"i", "u"}:  # signed and unsigned integers.
-            obj = obj.astype(int)
-        return obj.tolist()
-
-    @staticmethod
-    def encode_np_scaler(obj):
-        assert isinstance(obj, np.generic)
-        return obj.item()
-
-    @staticmethod
-    def encode_exception(obj):
-        assert isinstance(obj, Exception)
-        return str(obj)
-
-    @staticmethod
-    def encode_pandas_dataframe(obj):
-        assert isinstance(obj, pd.DataFrame)
-        return obj.to_dict(orient="records")
-
-
-serve_encoders = {
-    np.ndarray: _ServeCustomEncoders.encode_np_array,
-    np.generic: _ServeCustomEncoders.encode_np_scaler,
-    Exception: _ServeCustomEncoders.encode_exception,
-}
-
-if pd is not None:
-    serve_encoders[pd.DataFrame] = _ServeCustomEncoders.encode_pandas_dataframe
-
-
-def install_serve_encoders_to_fastapi():
-    """Inject Serve's encoders so FastAPI's jsonable_encoder can pick it up."""
-    if IS_PYDANTIC_2:
-        # TODO(edoakes): add support for Pydantic 2.0 or drop custom encoders.
-        return
-
-    # https://stackoverflow.com/questions/62311401/override-default-encoders-for-jsonable-encoder-in-fastapi # noqa
-    pydantic.json.ENCODERS_BY_TYPE.update(serve_encoders)
-    # FastAPI cache these encoders at import time, so we also needs to refresh it.
-    fastapi.encoders.encoders_by_class_tuples = (
-        fastapi.encoders.generate_encoders_by_class_tuples(
-            pydantic.json.ENCODERS_BY_TYPE
-        )
-    )
-
-
 @ray.remote(num_cpus=0)
 def block_until_http_ready(
     http_endpoint,

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -15,15 +15,10 @@ from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
-import fastapi.encoders
-import numpy as np
-import pydantic
-import pydantic.json
 import requests
 
 import ray
 import ray.util.serialization_addons
-from ray._private.pydantic_compat import IS_PYDANTIC_2
 from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
 from ray._private.utils import import_attr
 from ray._private.worker import LOCAL_MODE, SCRIPT_MODE

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -16,7 +16,6 @@ from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
 import numpy as np
-import pydantic
 import requests
 
 import ray

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -31,7 +31,6 @@ from ray.serve._private.utils import (
     ensure_serialization_context,
     extract_self_if_method_call,
     get_random_letters,
-    install_serve_encoders_to_fastapi,
 )
 from ray.serve.config import (
     AutoscalingConfig,
@@ -231,7 +230,6 @@ def ingress(app: Union["FastAPI", "APIRouter", Callable]) -> Callable:
                 cls.__init__(self, *args, **kwargs)
 
                 ServeUsageTag.FASTAPI_USED.record("1")
-                install_serve_encoders_to_fastapi()
                 ASGIAppReplicaWrapper.__init__(self, frozen_app)
 
             async def __del__(self):

--- a/python/ray/serve/drivers.py
+++ b/python/ray/serve/drivers.py
@@ -8,7 +8,6 @@ from ray import cloudpickle, serve
 from ray.serve._private.constants import DAG_DEPRECATION_MESSAGE, SERVE_LOGGER_NAME
 from ray.serve._private.http_util import ASGIAppReplicaWrapper
 from ray.serve._private.usage import ServeUsageTag
-from ray.serve._private.utils import install_serve_encoders_to_fastapi
 from ray.serve.deployment_graph import RayServeDAGHandle
 from ray.serve.drivers_utils import load_http_adapter
 from ray.serve.exceptions import RayServeException
@@ -42,7 +41,6 @@ class DAGDriver(ASGIAppReplicaWrapper):
         if http_adapter is not None:
             ServeUsageTag.HTTP_ADAPTER_USED.record("1")
 
-        install_serve_encoders_to_fastapi()
         http_adapter = load_http_adapter(http_adapter)
         app = FastAPI()
 

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -3,7 +3,6 @@ import tempfile
 import time
 from typing import Any, List, Optional
 
-import numpy as np
 import pytest
 import requests
 import starlette.responses
@@ -25,7 +24,7 @@ from starlette.routing import Route
 
 import ray
 from ray import serve
-from ray._private.pydantic_compat import IS_PYDANTIC_2, BaseModel, Field
+from ray._private.pydantic_compat import BaseModel, Field
 from ray._private.test_utils import SignalActor, wait_for_condition
 from ray.exceptions import GetTimeoutError
 from ray.serve._private.client import ServeControllerClient
@@ -672,28 +671,6 @@ def test_fastapi_same_app_multiple_deployments(serve_instance):
     ]
     for path in should_404:
         assert requests.get("http://localhost:8000" + path).status_code == 404, path
-
-
-@pytest.mark.skipif(
-    IS_PYDANTIC_2,
-    reason="We don't currently install custom encoders for pydantic >= 2.",
-)
-def test_fastapi_custom_serializers(serve_instance):
-    app = FastAPI()
-
-    @serve.deployment
-    @serve.ingress(app)
-    class D:
-        @app.get("/np_array")
-        def incr(self):
-            return np.zeros(2)
-
-    serve.run(D.bind())
-
-    resp = requests.get("http://localhost:8000/np_array")
-    print(resp.text)
-    resp.raise_for_status()
-    assert resp.json() == [0, 0]
 
 
 @pytest.mark.parametrize("two_fastapi", [True, False])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is undocumented behavior and it's reaching into private APIs in `pydantic` that no longer exist in 2.0+.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
