### PR TITLE
[CI] [cluster launcher] Fix switched "latest" and "nightly" gcp tests

### DIFF
--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -165,9 +165,7 @@ class NodeUpdater:
 
             cli_logger.error("!!!")
             if hasattr(e, "cmd"):
-                stderr_output = getattr(
-                    e, "stderr", "No stderr available"
-                )  # Capture stderr if it exists, else default message
+                stderr_output = getattr(e, "stderr", "No stderr available")
                 cli_logger.error(
                     "Setup command `{}` failed with exit code {}. stderr: {}",
                     cf.bold(e.cmd),
@@ -175,13 +173,10 @@ class NodeUpdater:
                     stderr_output,
                 )
             else:
-                # Log the full attributes of the exception.
                 cli_logger.verbose_error("Exception details: {}", str(vars(e)))
-                # todo: handle this better somehow?
-                # Log the full stack trace for better debugging.
                 full_traceback = traceback.format_exc()
                 cli_logger.error("Full traceback: {}", full_traceback)
-
+                # todo: handle this better somehow?
                 cli_logger.error("Error message: {}", str(e))
             cli_logger.error("!!!")
             cli_logger.newline()

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import time
 from threading import Thread
+import traceback
 
 import click
 
@@ -164,16 +165,22 @@ class NodeUpdater:
 
             cli_logger.error("!!!")
             if hasattr(e, "cmd"):
+                stderr_output = getattr(e, "stderr", "No stderr available")  # Capture stderr if it exists, else default message
                 cli_logger.error(
-                    "Setup command `{}` failed with exit code {}. stderr:",
+                    "Setup command `{}` failed with exit code {}. stderr: {}",
                     cf.bold(e.cmd),
                     e.returncode,
+                    stderr_output
                 )
             else:
-                cli_logger.verbose_error("{}", str(vars(e)))
+                # Log the full attributes of the exception.
+                cli_logger.verbose_error("Exception details: {}", str(vars(e)))
                 # todo: handle this better somehow?
-                cli_logger.error("{}", str(e))
-            # todo: print stderr here
+                # Log the full stack trace for better debugging.
+                full_traceback = traceback.format_exc()
+                cli_logger.error("Full traceback: {}", full_traceback)
+
+                cli_logger.error("Error message: {}", str(e))
             cli_logger.error("!!!")
             cli_logger.newline()
 

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -2,8 +2,8 @@ import logging
 import os
 import subprocess
 import time
-from threading import Thread
 import traceback
+from threading import Thread
 
 import click
 
@@ -165,12 +165,14 @@ class NodeUpdater:
 
             cli_logger.error("!!!")
             if hasattr(e, "cmd"):
-                stderr_output = getattr(e, "stderr", "No stderr available")  # Capture stderr if it exists, else default message
+                stderr_output = getattr(
+                    e, "stderr", "No stderr available"
+                )  # Capture stderr if it exists, else default message
                 cli_logger.error(
                     "Setup command `{}` failed with exit code {}. stderr: {}",
                     cf.bold(e.cmd),
                     e.returncode,
-                    stderr_output
+                    stderr_output,
                 )
             else:
                 # Log the full attributes of the exception.

--- a/python/ray/autoscaler/launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/launch_and_verify_cluster.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import traceback
 from pathlib import Path
 
 import boto3
@@ -187,7 +188,15 @@ def cleanup_cluster(cluster_config):
             return
         except subprocess.CalledProcessError as e:
             print(f"ray down fails[{i+1}/{num_tries}]: ")
-            print(e.output)
+            print(e.output.decode("utf-8"))
+
+            # Print full traceback
+            traceback.print_exc()
+
+            # Print stdout and stderr from ray down
+            print(f"stdout:\n{e.stdout.decode('utf-8')}")
+            print(f"stderr:\n{e.stderr.decode('utf-8')}")
+
             last_error = e
 
     raise last_error
@@ -220,6 +229,9 @@ def run_ray_commands(cluster_config, retries, no_config_cache, num_expected_node
         subprocess.run(cmd, check=True, capture_output=True)
     except subprocess.CalledProcessError as e:
         print(e.output)
+        # print stdout and stderr
+        print(f"stdout:\n{e.stdout.decode('utf-8')}")
+        print(f"stderr:\n{e.stderr.decode('utf-8')}")
         raise e
 
     print("======================================")

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -6619,7 +6619,7 @@
 
   run:
     timeout: 3600
-    script: python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override nightly
+    script: python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override latest
 
 - name: gcp_cluster_launcher_nightly_image
   group: cluster-launcher-test
@@ -6637,7 +6637,7 @@
 
   run:
     timeout: 3600
-    script: python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override latest
+    script: python launch_and_verify_cluster.py gcp/example-full.yaml --num-expected-nodes 2 --retries 20  --docker-override nightly
 
 
 - name: gcp_cluster_launcher_release_image


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The GCP "latest" and "nightly" tests had their names switched. This PR unswitches them.

The PR also adds more debug logs for the issue https://github.com/ray-project/ray/issues/40241.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
