### PR TITLE
[ci] move train/serve/default minimal tests to civ2

### DIFF
--- a/.buildkite/_forge.rayci.yml
+++ b/.buildkite/_forge.rayci.yml
@@ -94,18 +94,6 @@ steps:
   - name: oss-ci-base_gpu
     wanda: ci/docker/base.gpu.wanda.yaml
 
-  - name: minbuild
-    label: "wanda: minbuild.py{{matrix}}"
-    wanda: ci/docker/min.build.wanda.yaml
-    depends_on: oss-ci-base_build
-    matrix:
-      - "3.8"
-      - "3.9"
-      - "3.10"
-      - "3.11"
-    env:
-      PYTHON_VERSION: "{{matrix}}"
-
   - name: docbuild
     wanda: ci/docker/doc.build.wanda.yaml
     depends_on: oss-ci-base_build

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -56,14 +56,14 @@ steps:
       # core tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core 
         --parallelism-per-worker 3
-        --build-name minbuild-py{{matrix}}
+        --build-name minbuild-core-py{{matrix}}
         --test-env=RAY_MINIMAL=1
         --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
         --only-tags minimal
       # core redis tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core 
         --parallelism-per-worker 3
-        --build-name minbuild-py{{matrix}}
+        --build-name minbuild-core-py{{matrix}}
         --test-env=RAY_MINIMAL=1
         --test-env=TEST_EXTERNAL_REDIS=1
         --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
@@ -72,11 +72,11 @@ steps:
       # serve tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... serve 
         --parallelism-per-worker 3
-        --build-name minbuild-py{{matrix}}
+        --build-name minbuild-core-py{{matrix}}
         --test-env=RAY_MINIMAL=1
         --only-tags minimal
         --skip-ray-installation
-    depends_on: minbuild
+    depends_on: minbuild-core
     job_env: forge
     matrix:
       - "3.8"
@@ -92,3 +92,16 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //... core --run-flaky-tests --parallelism-per-worker 3
     depends_on: corebuild
     job_env: forge
+
+  - name: minbuild-core
+    label: "wanda: minbuild-core-py{{matrix}}"
+    wanda: ci/docker/min.build.wanda.yaml
+    depends_on: oss-ci-base_build
+    matrix:
+      - "3.8"
+      - "3.9"
+      - "3.10"
+      - "3.11"
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+      EXTRA_DEPENDENCY: core

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -1,15 +1,15 @@
 group: ml tests
 steps:
-  # - label: ":train: ml: train tests"
-  #   tags: train
-  #   instance_type: large
-  #   parallelism: 2
-  #   commands:
-  #     - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml 
-  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-  #       --except-tags gpu_only,gpu,minimal,tune,doctest,needs_credentials 
-  #   depends_on: mlbuild
-  #   job_env: forge
+  - label: ":train: ml: train tests"
+    tags: train
+    instance_type: large
+    parallelism: 2
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --except-tags gpu_only,gpu,minimal,tune,doctest,needs_credentials 
+    depends_on: mlbuild
+    job_env: forge
 
   - label: ":train: ml: air tests"
     tags: ml
@@ -48,6 +48,18 @@ steps:
     depends_on: mlbuild
     job_env: forge
 
+  - label: ":train: ml: train minimal"
+    tags: train
+    instance_type: small
+    commands:
+      - python ./ci/env/check_minimal_install.py
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml
+        --parallelism-per-worker 3
+        --build-name minbuild-ml-py3.8
+        --only-tags minimal
+    depends_on: minbuild-ml
+    job_env: forge
+
   - label: ":train: ml: train gpu tests"
     tags: 
       - train
@@ -61,3 +73,11 @@ steps:
         --except-tags doctest
     depends_on: mlgpubuild
     job_env: forge
+
+  - name: minbuild-ml
+    label: "wanda: minbuild-ml-py38"
+    wanda: ci/docker/min.build.wanda.yaml
+    depends_on: oss-ci-base_build
+    env:
+      PYTHON_VERSION: "3.8"
+      EXTRA_DEPENDENCY: ml

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -1,15 +1,15 @@
 group: ml tests
 steps:
-  - label: ":train: ml: train tests"
-    tags: train
-    instance_type: large
-    parallelism: 2
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml 
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --except-tags gpu_only,gpu,minimal,tune,doctest,needs_credentials 
-    depends_on: mlbuild
-    job_env: forge
+  # - label: ":train: ml: train tests"
+  #   tags: train
+  #   instance_type: large
+  #   parallelism: 2
+  #   commands:
+  #     - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml 
+  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+  #       --except-tags gpu_only,gpu,minimal,tune,doctest,needs_credentials 
+  #   depends_on: mlbuild
+  #   job_env: forge
 
   - label: ":train: ml: air tests"
     tags: ml

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -42,28 +42,6 @@
       --test_tag_filters=-post_wheel_build,-gpu,xcommit
       python/ray/serve/tests/...
 
-- label: ":python: Default install"
-  conditions: ["RAY_CI_PYTHON_AFFECTED"]
-  instance_size: small
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - ./ci/env/install-default.sh
-    - ./ci/env/env_info.sh
-    - bazel test --test_output=streamed --config=ci --test_env=RAY_DEFAULT=1 $(./ci/run/bazel_export_options)
-      python/ray/dashboard/test_dashboard
-
-- label: ":python: Ray Serve default install"
-  conditions: ["RAY_CI_PYTHON_AFFECTED"]
-  instance_size: small
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - ./ci/env/install-serve.sh
-    - ./ci/env/env_info.sh
-    - bazel test --test_output=streamed --config=ci --test_env=RAY_DEFAULT=1 $(./ci/run/bazel_export_options)
-      python/ray/serve/tests/test_deployment_graph
-    - bazel test --test_output=streamed --config=ci --test_env=RAY_DEFAULT=1 $(./ci/run/bazel_export_options)
-      python/ray/serve/tests/test_api
-
 - label: ":python: civ1 tests"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   instance_size: medium
@@ -183,16 +161,3 @@
     - ./ci/env/env_info.sh
     - cat /tmp/hdfs_env
     - bazel test --config=ci $(./ci/run/bazel_export_options) --test_tag_filters=hdfs python/ray/air/...
-
-
-# Test to see if Train can be used without torch, tf, etc. installed
-- label: ":steam_locomotive: Train minimal install"
-  conditions: ["RAY_CI_TRAIN_AFFECTED"]
-  instance_size: small
-  commands:
-      - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-      - TRAIN_MINIMAL_INSTALL=1 ./ci/env/install-minimal.sh
-      - ./ci/env/env_info.sh
-      - python ./ci/env/check_minimal_install.py
-      - bazel test --config=ci $(./ci/run/bazel_export_options)  --build_tests_only --test_tag_filters=minimal
-        python/ray/train/...

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -1,168 +1,168 @@
 group: rllib tests
-steps: []
-  # - label: ":brain: rllib: algorithm, model and others"
-  #   tags: rllib_directly
-  #   parallelism: 4
-  #   instance_type: large
-  #   commands:
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
-  #       --except-tags learning_tests,memory_leak_tests,examples,tests_dir,documentation,multi_gpu,no_cpu,torch_2.x_only_benchmark,manual
-  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-  #   depends_on: rllibbuild
-  #   job_env: forge
+steps:
+  - label: ":brain: rllib: algorithm, model and others"
+    tags: rllib_directly
+    parallelism: 4
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
+        --except-tags learning_tests,memory_leak_tests,examples,tests_dir,documentation,multi_gpu,no_cpu,torch_2.x_only_benchmark,manual
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+    depends_on: rllibbuild
+    job_env: forge
 
-  # - label: ":brain: rllib: learning tests tf2-static-graph"
-  #   tags: rllib
-  #   parallelism: 3
-  #   instance_type: large
-  #   commands:
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-  #       --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
-  #       --except-tags torch_only,tf2_only,no_tf_static_graph,multi_gpu
-  #       --test-arg --framework=tf
-  #   depends_on: rllibbuild
-  #   job_env: forge
+  - label: ":brain: rllib: learning tests tf2-static-graph"
+    tags: rllib
+    parallelism: 3
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
+        --except-tags torch_only,tf2_only,no_tf_static_graph,multi_gpu
+        --test-arg --framework=tf
+    depends_on: rllibbuild
+    job_env: forge
 
-  # - label: ":brain: rllib: learning tests pytorch"
-  #   tags: rllib
-  #   parallelism: 3
-  #   instance_type: large
-  #   commands:
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-  #       --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
-  #       --except-tags tf_only,tf2_only,multi_gpu
-  #       --test-arg --framework=torch
-  #   depends_on: rllibbuild
-  #   job_env: forge
+  - label: ":brain: rllib: learning tests pytorch"
+    tags: rllib
+    parallelism: 3
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
+        --except-tags tf_only,tf2_only,multi_gpu
+        --test-arg --framework=torch
+    depends_on: rllibbuild
+    job_env: forge
 
-  # - label: ":brain: rllib: examples"
-  #   tags: rllib
-  #   parallelism: 3
-  #   instance_type: large
-  #   commands:
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-  #       --only-tags examples
-  #       --except-tags multi_gpu,gpu 
-  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-  #   depends_on: rllibbuild
-  #   job_env: forge
+  - label: ":brain: rllib: examples"
+    tags: rllib
+    parallelism: 3
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --only-tags examples
+        --except-tags multi_gpu,gpu 
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+    depends_on: rllibbuild
+    job_env: forge
 
-  # - label: ":brain: rllib: learning tests tf2-eager-tracing"
-  #   tags: rllib
-  #   parallelism: 2
-  #   instance_type: large
-  #   commands:
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-  #       --only-tags learning_tests_discrete,learning_tests_continuous,crashing_cartpole,stateless_cartpole
-  #       --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
-  #       --test-arg --framework=tf2
-  #   depends_on: rllibbuild
-  #   job_env: forge
+  - label: ":brain: rllib: learning tests tf2-eager-tracing"
+    tags: rllib
+    parallelism: 2
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --only-tags learning_tests_discrete,learning_tests_continuous,crashing_cartpole,stateless_cartpole
+        --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
+        --test-arg --framework=tf2
+    depends_on: rllibbuild
+    job_env: forge
 
-  # - label: ":brain: rllib: tests dir"
-  #   tags: rllib_directly
-  #   parallelism: 2
-  #   instance_type: large
-  #   commands:
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
-  #       --only-tags tests_dir
-  #       --except-tags multi_gpu,manual
-  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-  #   depends_on: rllibbuild
-  #   job_env: forge
+  - label: ":brain: rllib: tests dir"
+    tags: rllib_directly
+    parallelism: 2
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
+        --only-tags tests_dir
+        --except-tags multi_gpu,manual
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+    depends_on: rllibbuild
+    job_env: forge
 
-  # - label: ":brain: rllib: rlmodule tests"
-  #   tags: rllib_directly
-  #   instance_type: large
-  #   commands:
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-  #       --parallelism-per-worker 3
-  #       --only-tags rlm
-  #       --test-env RLLIB_ENABLE_RL_MODULE=1
-  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-  #   depends_on: rllibbuild
-  #   job_env: forge
+  - label: ":brain: rllib: rlmodule tests"
+    tags: rllib_directly
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --parallelism-per-worker 3
+        --only-tags rlm
+        --test-env RLLIB_ENABLE_RL_MODULE=1
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+    depends_on: rllibbuild
+    job_env: forge
 
-  # - label: ":brain: rllib: data tests"
-  #   if: build.branch != "master"
-  #   tags: data
-  #   instance_type: large
-  #   commands:
-  #     # learning tests pytorch
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-  #       --parallelism-per-worker 3
-  #       --only-tags learning_tests_with_ray_data
-  #       --except-tags multi_gpu,gpu,tf_only,tf2_only
-  #       --test-arg --framework=torch
+  - label: ":brain: rllib: data tests"
+    if: build.branch != "master"
+    tags: data
+    instance_type: large
+    commands:
+      # learning tests pytorch
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --parallelism-per-worker 3
+        --only-tags learning_tests_with_ray_data
+        --except-tags multi_gpu,gpu,tf_only,tf2_only
+        --test-arg --framework=torch
 
-  #     # learning tests tF2
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-  #       --parallelism-per-worker 3
-  #       --only-tags learning_tests_with_ray_data
-  #       --except-tags multi_gpu,gpu,torch_only
-  #       --test-arg --framework=tf2
-  #       --skip-ray-installation # reuse the same docker image as the previous run
+      # learning tests tF2
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --parallelism-per-worker 3
+        --only-tags learning_tests_with_ray_data
+        --except-tags multi_gpu,gpu,torch_only
+        --test-arg --framework=tf2
+        --skip-ray-installation # reuse the same docker image as the previous run
 
-  #     # rllib unittests
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-  #       --parallelism-per-worker 3
-  #       --only-tags ray_data
-  #       --except-tags learning_tests_with_ray_data,multi_gpu,gpu
-  #       --skip-ray-installation # reuse the same docker image as the previous run
-  #   depends_on: rllibbuild
-  #   job_env: forge
+      # rllib unittests
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --parallelism-per-worker 3
+        --only-tags ray_data
+        --except-tags learning_tests_with_ray_data,multi_gpu,gpu
+        --skip-ray-installation # reuse the same docker image as the previous run
+    depends_on: rllibbuild
+    job_env: forge
 
-  # - label: ":brain: rllib: benchmarks"
-  #   tags: rllib
-  #   instance_type: medium
-  #   commands:
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --only-tags torch_2.x_only_benchmark
-  #   depends_on: rllibbuild
-  #   job_env: forge
+  - label: ":brain: rllib: benchmarks"
+    tags: rllib
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --only-tags torch_2.x_only_benchmark
+    depends_on: rllibbuild
+    job_env: forge
 
-  # - label: ":brain: rllib: flaky tests"
-  #   tags: rllib
-  #   instance_type: large
-  #   commands:
-  #     # torch
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
-  #       --only-tags fake_gpus,learning_tests_discrete,learning_tests_with_ray_data,crashing_cartpole,stateless_cartpole,learning_tests_continuous
-  #       --except-tags tf_only,tf2_only,multi_gpu
-  #       --test-arg --framework=torch
+  - label: ":brain: rllib: flaky tests"
+    tags: rllib
+    instance_type: large
+    commands:
+      # torch
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+        --only-tags fake_gpus,learning_tests_discrete,learning_tests_with_ray_data,crashing_cartpole,stateless_cartpole,learning_tests_continuous
+        --except-tags tf_only,tf2_only,multi_gpu
+        --test-arg --framework=torch
 
-  #     # tf2-static-graph
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
-  #       --only-tags tf_only
-  #       --except-tags torch_only,tf2_only,no_tf_static_graph,multi_gpu
-  #       --test-arg --framework=tf
-  #       --skip-ray-installation # reuse the same docker image as the previous run
+      # tf2-static-graph
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+        --only-tags tf_only
+        --except-tags torch_only,tf2_only,no_tf_static_graph,multi_gpu
+        --test-arg --framework=tf
+        --skip-ray-installation # reuse the same docker image as the previous run
 
-  #     # tf2-eager-tracing
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
-  #       --only-tags tf2_only
-  #       --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
-  #       --test-arg --framework=tf2
-  #       --skip-ray-installation # reuse the same docker image as the previous run
+      # tf2-eager-tracing
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+        --only-tags tf2_only
+        --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
+        --test-arg --framework=tf2
+        --skip-ray-installation # reuse the same docker image as the previous run
 
-  #     # examples
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib  --run-flaky-tests --parallelism-per-worker 3
-  #       --only-tags examples
-  #       --except-tags multi_gpu,gpu 
-  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-  #       --skip-ray-installation # reuse the same docker image as the previous run
+      # examples
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib  --run-flaky-tests --parallelism-per-worker 3
+        --only-tags examples
+        --except-tags multi_gpu,gpu 
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+        --skip-ray-installation # reuse the same docker image as the previous run
 
-  #     # rlmodule tests
-  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
-  #       --only-tags rlm
-  #       --test-env RLLIB_ENABLE_RL_MODULE=1
-  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-  #       --skip-ray-installation # reuse the same docker image as the previous run
-  #   depends_on: rllibbuild
-  #   soft_fail: true
-  #   job_env: forge
+      # rlmodule tests
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+        --only-tags rlm
+        --test-env RLLIB_ENABLE_RL_MODULE=1
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+        --skip-ray-installation # reuse the same docker image as the previous run
+    depends_on: rllibbuild
+    soft_fail: true
+    job_env: forge

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -1,168 +1,168 @@
 group: rllib tests
-steps:
-  - label: ":brain: rllib: algorithm, model and others"
-    tags: rllib_directly
-    parallelism: 4
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
-        --except-tags learning_tests,memory_leak_tests,examples,tests_dir,documentation,multi_gpu,no_cpu,torch_2.x_only_benchmark,manual
-        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-    depends_on: rllibbuild
-    job_env: forge
+steps: []
+  # - label: ":brain: rllib: algorithm, model and others"
+  #   tags: rllib_directly
+  #   parallelism: 4
+  #   instance_type: large
+  #   commands:
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
+  #       --except-tags learning_tests,memory_leak_tests,examples,tests_dir,documentation,multi_gpu,no_cpu,torch_2.x_only_benchmark,manual
+  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+  #   depends_on: rllibbuild
+  #   job_env: forge
 
-  - label: ":brain: rllib: learning tests tf2-static-graph"
-    tags: rllib
-    parallelism: 3
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
-        --except-tags torch_only,tf2_only,no_tf_static_graph,multi_gpu
-        --test-arg --framework=tf
-    depends_on: rllibbuild
-    job_env: forge
+  # - label: ":brain: rllib: learning tests tf2-static-graph"
+  #   tags: rllib
+  #   parallelism: 3
+  #   instance_type: large
+  #   commands:
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+  #       --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
+  #       --except-tags torch_only,tf2_only,no_tf_static_graph,multi_gpu
+  #       --test-arg --framework=tf
+  #   depends_on: rllibbuild
+  #   job_env: forge
 
-  - label: ":brain: rllib: learning tests pytorch"
-    tags: rllib
-    parallelism: 3
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
-        --except-tags tf_only,tf2_only,multi_gpu
-        --test-arg --framework=torch
-    depends_on: rllibbuild
-    job_env: forge
+  # - label: ":brain: rllib: learning tests pytorch"
+  #   tags: rllib
+  #   parallelism: 3
+  #   instance_type: large
+  #   commands:
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+  #       --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
+  #       --except-tags tf_only,tf2_only,multi_gpu
+  #       --test-arg --framework=torch
+  #   depends_on: rllibbuild
+  #   job_env: forge
 
-  - label: ":brain: rllib: examples"
-    tags: rllib
-    parallelism: 3
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --only-tags examples
-        --except-tags multi_gpu,gpu 
-        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-    depends_on: rllibbuild
-    job_env: forge
+  # - label: ":brain: rllib: examples"
+  #   tags: rllib
+  #   parallelism: 3
+  #   instance_type: large
+  #   commands:
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+  #       --only-tags examples
+  #       --except-tags multi_gpu,gpu 
+  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+  #   depends_on: rllibbuild
+  #   job_env: forge
 
-  - label: ":brain: rllib: learning tests tf2-eager-tracing"
-    tags: rllib
-    parallelism: 2
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --only-tags learning_tests_discrete,learning_tests_continuous,crashing_cartpole,stateless_cartpole
-        --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
-        --test-arg --framework=tf2
-    depends_on: rllibbuild
-    job_env: forge
+  # - label: ":brain: rllib: learning tests tf2-eager-tracing"
+  #   tags: rllib
+  #   parallelism: 2
+  #   instance_type: large
+  #   commands:
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+  #       --only-tags learning_tests_discrete,learning_tests_continuous,crashing_cartpole,stateless_cartpole
+  #       --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
+  #       --test-arg --framework=tf2
+  #   depends_on: rllibbuild
+  #   job_env: forge
 
-  - label: ":brain: rllib: tests dir"
-    tags: rllib_directly
-    parallelism: 2
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
-        --only-tags tests_dir
-        --except-tags multi_gpu,manual
-        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-    depends_on: rllibbuild
-    job_env: forge
+  # - label: ":brain: rllib: tests dir"
+  #   tags: rllib_directly
+  #   parallelism: 2
+  #   instance_type: large
+  #   commands:
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+  #       --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
+  #       --only-tags tests_dir
+  #       --except-tags multi_gpu,manual
+  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+  #   depends_on: rllibbuild
+  #   job_env: forge
 
-  - label: ":brain: rllib: rlmodule tests"
-    tags: rllib_directly
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --parallelism-per-worker 3
-        --only-tags rlm
-        --test-env RLLIB_ENABLE_RL_MODULE=1
-        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-    depends_on: rllibbuild
-    job_env: forge
+  # - label: ":brain: rllib: rlmodule tests"
+  #   tags: rllib_directly
+  #   instance_type: large
+  #   commands:
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+  #       --parallelism-per-worker 3
+  #       --only-tags rlm
+  #       --test-env RLLIB_ENABLE_RL_MODULE=1
+  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+  #   depends_on: rllibbuild
+  #   job_env: forge
 
-  - label: ":brain: rllib: data tests"
-    if: build.branch != "master"
-    tags: data
-    instance_type: large
-    commands:
-      # learning tests pytorch
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --parallelism-per-worker 3
-        --only-tags learning_tests_with_ray_data
-        --except-tags multi_gpu,gpu,tf_only,tf2_only
-        --test-arg --framework=torch
+  # - label: ":brain: rllib: data tests"
+  #   if: build.branch != "master"
+  #   tags: data
+  #   instance_type: large
+  #   commands:
+  #     # learning tests pytorch
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+  #       --parallelism-per-worker 3
+  #       --only-tags learning_tests_with_ray_data
+  #       --except-tags multi_gpu,gpu,tf_only,tf2_only
+  #       --test-arg --framework=torch
 
-      # learning tests tF2
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --parallelism-per-worker 3
-        --only-tags learning_tests_with_ray_data
-        --except-tags multi_gpu,gpu,torch_only
-        --test-arg --framework=tf2
-        --skip-ray-installation # reuse the same docker image as the previous run
+  #     # learning tests tF2
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+  #       --parallelism-per-worker 3
+  #       --only-tags learning_tests_with_ray_data
+  #       --except-tags multi_gpu,gpu,torch_only
+  #       --test-arg --framework=tf2
+  #       --skip-ray-installation # reuse the same docker image as the previous run
 
-      # rllib unittests
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --parallelism-per-worker 3
-        --only-tags ray_data
-        --except-tags learning_tests_with_ray_data,multi_gpu,gpu
-        --skip-ray-installation # reuse the same docker image as the previous run
-    depends_on: rllibbuild
-    job_env: forge
+  #     # rllib unittests
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+  #       --parallelism-per-worker 3
+  #       --only-tags ray_data
+  #       --except-tags learning_tests_with_ray_data,multi_gpu,gpu
+  #       --skip-ray-installation # reuse the same docker image as the previous run
+  #   depends_on: rllibbuild
+  #   job_env: forge
 
-  - label: ":brain: rllib: benchmarks"
-    tags: rllib
-    instance_type: medium
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --only-tags torch_2.x_only_benchmark
-    depends_on: rllibbuild
-    job_env: forge
+  # - label: ":brain: rllib: benchmarks"
+  #   tags: rllib
+  #   instance_type: medium
+  #   commands:
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --only-tags torch_2.x_only_benchmark
+  #   depends_on: rllibbuild
+  #   job_env: forge
 
-  - label: ":brain: rllib: flaky tests"
-    tags: rllib
-    instance_type: large
-    commands:
-      # torch
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
-        --only-tags fake_gpus,learning_tests_discrete,learning_tests_with_ray_data,crashing_cartpole,stateless_cartpole,learning_tests_continuous
-        --except-tags tf_only,tf2_only,multi_gpu
-        --test-arg --framework=torch
+  # - label: ":brain: rllib: flaky tests"
+  #   tags: rllib
+  #   instance_type: large
+  #   commands:
+  #     # torch
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+  #       --only-tags fake_gpus,learning_tests_discrete,learning_tests_with_ray_data,crashing_cartpole,stateless_cartpole,learning_tests_continuous
+  #       --except-tags tf_only,tf2_only,multi_gpu
+  #       --test-arg --framework=torch
 
-      # tf2-static-graph
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
-        --only-tags tf_only
-        --except-tags torch_only,tf2_only,no_tf_static_graph,multi_gpu
-        --test-arg --framework=tf
-        --skip-ray-installation # reuse the same docker image as the previous run
+  #     # tf2-static-graph
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+  #       --only-tags tf_only
+  #       --except-tags torch_only,tf2_only,no_tf_static_graph,multi_gpu
+  #       --test-arg --framework=tf
+  #       --skip-ray-installation # reuse the same docker image as the previous run
 
-      # tf2-eager-tracing
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
-        --only-tags tf2_only
-        --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
-        --test-arg --framework=tf2
-        --skip-ray-installation # reuse the same docker image as the previous run
+  #     # tf2-eager-tracing
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+  #       --only-tags tf2_only
+  #       --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
+  #       --test-arg --framework=tf2
+  #       --skip-ray-installation # reuse the same docker image as the previous run
 
-      # examples
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib  --run-flaky-tests --parallelism-per-worker 3
-        --only-tags examples
-        --except-tags multi_gpu,gpu 
-        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-        --skip-ray-installation # reuse the same docker image as the previous run
+  #     # examples
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib  --run-flaky-tests --parallelism-per-worker 3
+  #       --only-tags examples
+  #       --except-tags multi_gpu,gpu 
+  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+  #       --skip-ray-installation # reuse the same docker image as the previous run
 
-      # rlmodule tests
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
-        --only-tags rlm
-        --test-env RLLIB_ENABLE_RL_MODULE=1
-        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-        --skip-ray-installation # reuse the same docker image as the previous run
-    depends_on: rllibbuild
-    soft_fail: true
-    job_env: forge
+  #     # rlmodule tests
+  #     - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+  #       --only-tags rlm
+  #       --test-env RLLIB_ENABLE_RL_MODULE=1
+  #       --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+  #       --skip-ray-installation # reuse the same docker image as the previous run
+  #   depends_on: rllibbuild
+  #   soft_fail: true
+  #   job_env: forge

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -37,6 +37,30 @@ steps:
     depends_on: servebuild
     job_env: forge
 
+  - label: ":ray-serve: serve: default minimal"
+    tags: python
+    instance_type: small
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/dashboard/... serve 
+        --parallelism-per-worker 2
+        --build-name minbuild-default-py3.8
+        --test-env=RAY_DEFAULT=1
+        --only-tags minimal
+    depends_on: minbuild-serve
+    job_env: forge
+
+  - label: ":ray-serve: serve: serve minimal"
+    tags: python
+    instance_type: small
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/tests/... serve 
+        --parallelism-per-worker 2
+        --build-name minbuild-serve-py3.8
+        --test-env=RAY_DEFAULT=1
+        --only-tags minimal
+    depends_on: minbuild-serve
+    job_env: forge
+  
   - label: ":ray-serve: serve: flaky tests"
     tags: 
       - serve
@@ -47,3 +71,14 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //... serve --run-flaky-tests --parallelism-per-worker 3
     depends_on: servebuild
     job_env: forge
+
+  - name: minbuild-serve
+    label: "wanda: minbuild-{{matrix}}-py38"
+    wanda: ci/docker/min.build.wanda.yaml
+    depends_on: oss-ci-base_build
+    matrix:
+      - serve
+      - default
+    env:
+      PYTHON_VERSION: "3.8"
+      EXTRA_DEPENDENCY: "{{matrix}}"

--- a/ci/docker/min.build.Dockerfile
+++ b/ci/docker/min.build.Dockerfile
@@ -1,7 +1,10 @@
+# syntax=docker/dockerfile:1.3-labs
+
 ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build
 FROM $DOCKER_IMAGE_BASE_BUILD
 
 ARG PYTHON_VERSION
+ARG EXTRA_DEPENDENCY
 
 # Unset dind settings; we are using the host's docker daemon.
 ENV DOCKER_TLS_CERTDIR=
@@ -13,12 +16,30 @@ SHELL ["/bin/bash", "-ice"]
 
 COPY . .
 
+RUN <<EOF
+#!/bin/bash
+
+set -euo pipefail
+
 # minimal dependencies
-RUN MINIMAL_INSTALL=1 PYTHON=${PYTHON_VERSION} ci/env/install-dependencies.sh
-RUN rm -rf python/ray/thirdparty_files
+MINIMAL_INSTALL=1 PYTHON=${PYTHON_VERSION} ci/env/install-dependencies.sh
+rm -rf python/ray/thirdparty_files
 
 # install test requirements
-RUN python -m pip install -U pytest==7.0.1 numpy
+python -m pip install -U pytest==7.0.1 numpy
 
-# core pre-release denpendencies
-RUN ./ci/env/install-core-prerelease-dependencies.sh
+# install extra dependencies
+if [[ "${EXTRA_DEPENDENCY}" == "core" ]]; then
+  ./ci/env/install-core-prerelease-dependencies.sh
+elif [[ "${EXTRA_DEPENDENCY}" == "ml" ]]; then 
+  python -m pip install -U "ray[tune]"
+elif [[ "${EXTRA_DEPENDENCY}" == "default" ]]; then
+  python -m pip install -U "ray[default]"
+elif [[ "${EXTRA_DEPENDENCY}" == "serve" ]]; then
+  python -m pip install -U "ray[serve]"
+fi
+
+EOF
+
+
+

--- a/ci/docker/min.build.wanda.yaml
+++ b/ci/docker/min.build.wanda.yaml
@@ -1,4 +1,4 @@
-name: "minbuild-py$PYTHON_VERSION"
+name: "minbuild-$EXTRA_DEPENDENCY-py$PYTHON_VERSION"
 froms: ["cr.ray.io/rayproject/oss-ci-base_build"]
 dockerfile: ci/docker/min.build.Dockerfile
 srcs:
@@ -6,5 +6,6 @@ srcs:
   - ci/env/install-core-prerelease-dependencies.sh
 build_args:
   - PYTHON_VERSION
+  - EXTRA_DEPENDENCY
 tags:
-  - cr.ray.io/rayproject/minbuild-py$PYTHON_VERSION
+  - cr.ray.io/rayproject/minbuild-$EXTRA_DEPENDENCY-py$PYTHON_VERSION

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -65,7 +65,6 @@ py_test_module_list(
     "test_cluster.py",
     "test_autoscaling_policy.py",
     "test_fastapi.py",
-    "test_deployment_graph.py",
     "test_deployment_graph_autoscaling.py",
     "test_cancellation.py",
     "test_streaming_response.py",
@@ -89,7 +88,6 @@ py_test_module_list(
 # Large tests.
 py_test_module_list(
   files = [
-    "test_api.py",
     "test_deploy.py",
     "test_deploy_2.py",
     "test_metrics.py",
@@ -102,6 +100,17 @@ py_test_module_list(
   ],
   size = "large",
   tags = ["exclusive", "team:serve"],
+  deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
+)
+
+# Minimal tests
+py_test_module_list(
+  files = [
+    "test_api.py",
+    "test_deployment_graph.py",
+  ],
+  size = "large",
+  tags = ["exclusive", "team:serve", "minimal"],
   deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
 )
 


### PR DESCRIPTION
- Make min.build configurable to build with extra dependencies (default, serve, tune, core)
- Mark all minimal tests with 'minimal' bazel tag

Test:
- CI