### PR TITLE
[Data] Deflake Data CI test suites: `test_stats`, `test_streaming_executor`, `test_object_gc`

### DIFF
--- a/ci/ray_ci/data.tests.yml
+++ b/ci/ray_ci/data.tests.yml
@@ -1,5 +1,3 @@
 flaky_tests:
-  - //python/ray/data:test_streaming_executor
   - //python/ray/data:test_streaming_integration
   - //python/ray/data:test_split
-  - //python/ray/data:test_stats

--- a/ci/ray_ci/data.tests.yml
+++ b/ci/ray_ci/data.tests.yml
@@ -2,5 +2,4 @@ flaky_tests:
   - //python/ray/data:test_streaming_executor
   - //python/ray/data:test_streaming_integration
   - //python/ray/data:test_split
-  - //python/ray/data:test_object_gc
   - //python/ray/data:test_stats

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -974,6 +974,10 @@ def test_get_total_stats(ray_start_regular_shared, stage_two_block):
     assert dataset_stats_summary.get_max_heap_memory() == peak_memory_stats.get("max")
 
 
+@pytest.mark.skip(
+    reason="Temporarily disable to deflake rest of test suite. "
+    "See: https://github.com/ray-project/ray/pull/40173"
+)
 def test_streaming_stats_full(ray_start_regular_shared, restore_data_context):
     DataContext.get_current().new_execution_backend = True
     DataContext.get_current().use_streaming_executor = True

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -348,6 +348,10 @@ def test_execution_allowed():
     )
 
 
+@pytest.mark.skip(
+    reason="Temporarily disable to deflake rest of test suite. Started being flaky "
+    "after moving to civ2? Needs further investigation to confirm."
+)
 def test_resource_constrained_triggers_autoscaling(monkeypatch):
     RESOURCE_REQUEST_TIMEOUT = 5
     monkeypatch.setattr(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
- `test_stats`, `test_streaming_executor` tests in the Data CI are flakey, each due to a single problematic unit test. To un-flake the rest of each test suite, we temporarily disable the problematic unit tests while we investigate the issues, so that we can get as many Data tests back on the regular test pipeline for everyone.
- [x] Remove `test_stats` and `test_streaming_executor` from flakey tests once the PR CI passes.
  - After disabling the problematic tests, I saw [three passing runs](https://buildkite.com/ray-project/premerge/builds/8998#_) without flakiness. So, I think we can try marking these test suites as not flakey now.
![Screenshot at Oct 18 12-39-44](https://github.com/ray-project/ray/assets/5122851/e99f99e2-24fc-40ef-a3ad-eaad2a586dc4)


- `test_object_gc` has been green on https://flakey-tests.ray.io for a while after fully deprecating `BulkExecutor` path, should be good to remove from flakey tests:
![Screenshot at Oct 18 11-29-06](https://github.com/ray-project/ray/assets/5122851/0af1dce7-f2e3-404e-af45-5d6cb6309e3b)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
