### PR TITLE
[Data] Improve error message when reading HTTP files

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -718,7 +718,7 @@ def _resolve_paths_and_filesystem(
                         from fsspec.implementations.http import HTTPFileSystem
                     except ModuleNotFoundError:
                         raise ImportError(
-                            "Please install fsspec to read files from HTTP."
+                            "To read files from HTTP, run `pip install fsspec[http]`."
                         ) from None
 
                     resolved_filesystem = PyFileSystem(FSSpecHandler(HTTPFileSystem()))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you try to read HTTP files with Ray Data, you get this error message if `fsspect[http]` isn't installed:

> Please install fsspec to read files from HTTP.

This PR updates the error message to clarify that you need the `http` extra:

> To read files from HTTP, run `pip install fsspec[http]`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
