### PR TITLE
[data] update _snapshot_stats with current executor stats

### DIFF
--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -128,7 +128,7 @@ class ExecutionPlan:
         # A computed snapshot of some prefix of stages.
         self._snapshot_blocks = None
         self._snapshot_stats = None
-        # Executor._generate_stats call for updating stats
+        # Executor.get_stats call for updating stats
         self._get_executor_stats = None
         # Chains of stages.
         self._stages_before_snapshot = []

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1006,6 +1006,11 @@ Dataset iterator time breakdown:
 """
     )
 
+    # Test extra metrics are updated
+    ds = ray.data.range(100, parallelism=100).map(lambda x: x)
+    ds.take_all()
+    assert ds._plan.stats().extra_metrics["num_tasks_finished"] == 100
+
 
 def test_write_ds_stats(ray_start_regular_shared, tmp_path):
     ds = ray.data.range(100, parallelism=100)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When executing to iterator, extra_metrics are not updated for `ExecutionPlan._snapshot_stats`. As a workaround, we can retrieve the current executor stats and update snapshot extra_metrics every time `ExecutionPlan.stats` is called. This should fix `test_streaming_stats_full`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
