### PR TITLE
[Serve] Support arg builders with non-Pydantic type hints

### DIFF
--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -330,7 +330,7 @@ def call_app_builder_with_args_if_necessary(
     # that model. This will perform standard pydantic validation (e.g., raise an
     # exception if required fields are missing).
     param = signature.parameters[list(signature.parameters.keys())[0]]
-    if issubclass(param.annotation, BaseModel):
+    if inspect.isclass(param.annotation) and issubclass(param.annotation, BaseModel):
         args = param.annotation.parse_obj(args)
 
     app = builder(args)

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import sys
-from typing import Optional
+from typing import Dict, Optional
 
 import pytest
 import requests
@@ -719,7 +719,30 @@ class TestAppBuilder:
     def test_args_typed(self):
         args_dict = {"message": "hiya", "num_replicas": "3"}
 
+        def build(args: Dict[str, str]):
+            """Builder with vanilla type hint."""
+
+            return self.A.options(num_replicas=args["num_replicas"]).bind(
+                args["message"]
+            )
+
+        app = call_app_builder_with_args_if_necessary(build, args_dict)
+        assert isinstance(app, Application)
+
+        class ForwardRef:
+            def build(args: "ForwardRef"):
+                """Builder with forward reference as type hint."""
+
+                return self.A.options(num_replicas=args["num_replicas"]).bind(
+                    args["message"]
+                )
+
+        app = call_app_builder_with_args_if_necessary(ForwardRef.build, args_dict)
+        assert isinstance(app, Application)
+
         def build(args: self.TypedArgs):
+            """Builder with Pydantic model type hint."""
+
             assert isinstance(args, self.TypedArgs)
             assert args.message == "hiya"
             assert args.num_replicas == 3

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -719,6 +719,16 @@ class TestAppBuilder:
     def test_args_typed(self):
         args_dict = {"message": "hiya", "num_replicas": "3"}
 
+        def build(args):
+            """Builder with no type hint."""
+
+            return self.A.options(num_replicas=args["num_replicas"]).bind(
+                args["message"]
+            )
+
+        app = call_app_builder_with_args_if_necessary(build, args_dict)
+        assert isinstance(app, Application)
+
         def build(args: Dict[str, str]):
             """Builder with vanilla type hint."""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, app builder functions in Serve fail if they have a non-Pydantic type hint. For example, running the following config fails:

```yaml
# broken_app.yaml

proxy_location: EveryNode
applications:
  - args:
      num_forwards: 0
    name: no_ops
    deployments:
      - name: NoOp
        num_replicas: 1
    import_path: 'microbenchmarks.no_ops:app_builder'
    runtime_env:
      working_dir: >-
        https://github.com/ray-project/serve_workloads/archive/0337024a7120ac9bb90f3bcbd957b2d4c56a33a8.zip
    route_prefix: /
http_options:
  request_timeout_s: -1
  keep_alive_timeout_s: 400
```

Error:

```
$ serve status
2023-10-18 15:38:39,128 WARN scripts.py:133 -- The `RAY_AGENT_ADDRESS` env var has been deprecated in favor of the `RAY_DASHBOARD_ADDRESS` env var. The `RAY_AGENT_ADDRESS` is ignored.
proxies:
  628106078faaafc0d1fe79285d674ea0699c3fb1c2f72d45cafd600e: HEALTHY
applications:
  no_ops:
    status: DEPLOY_FAILED
    message: |
      Deploying app 'no_ops' failed with exception:
      Traceback (most recent call last):
        File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/serve/_private/application_state.py", line 904, in build_serve_application
          app = call_app_builder_with_args_if_necessary(import_attr(import_path), args)
        File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/serve/_private/api.py", line 333, in call_app_builder_with_args_if_necessary
          if issubclass(param.annotation, BaseModel):
        File "/home/ray/anaconda3/lib/python3.9/abc.py", line 123, in __subclasscheck__
          return _abc_subclasscheck(cls, subclass)
      TypeError: issubclass() arg 1 must be a class
    last_deployed_time_s: 1697659632.2143407
    deployments: {}
```

The application's app builder function has the following signature:

```python
def app_builder(args: Dict[str, str]) -> Application:
    ...
```

This change allows app builders with non-Pydantic type hints to run successfully.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds checks to the `test_args_typed` unit test.
