### PR TITLE
[serve] Migrate workflow tests using v1 api

### DIFF
--- a/python/ray/workflow/http_event_provider.py
+++ b/python/ray/workflow/http_event_provider.py
@@ -240,7 +240,7 @@ class HTTPListener(EventListener):
         super().__init__()
         try:
             self.handle = ray.serve.get_app_handle(common.HTTP_EVENT_PROVIDER_NAME)
-        except KeyError:
+        except ray.serve.exceptions.RayServeException:
             mgr = workflow_access.get_management_actor()
             ray.get(mgr.create_http_event_provider.remote())
             self.handle = ray.serve.get_app_handle(common.HTTP_EVENT_PROVIDER_NAME)

--- a/python/ray/workflow/http_event_provider.py
+++ b/python/ray/workflow/http_event_provider.py
@@ -28,9 +28,7 @@ class WorkflowEventHandleError(Exception):
 app = FastAPI()
 
 
-@serve.deployment(
-    name=common.HTTP_EVENT_PROVIDER_NAME, route_prefix="/event", num_replicas=1
-)
+@serve.deployment(num_replicas=1)
 @serve.ingress(app)
 class HTTPEventProvider:
     """HTTPEventProvider is defined to be a Ray Serve deployment with route_prefix='/event',
@@ -241,15 +239,11 @@ class HTTPListener(EventListener):
     def __init__(self):
         super().__init__()
         try:
-            self.handle = ray.serve._private.api.get_deployment(
-                common.HTTP_EVENT_PROVIDER_NAME
-            )._get_handle(sync=True)
+            self.handle = ray.serve.get_app_handle(common.HTTP_EVENT_PROVIDER_NAME)
         except KeyError:
             mgr = workflow_access.get_management_actor()
             ray.get(mgr.create_http_event_provider.remote())
-            self.handle = ray.serve._private.api.get_deployment(
-                common.HTTP_EVENT_PROVIDER_NAME
-            )._get_handle(sync=True)
+            self.handle = ray.serve.get_app_handle(common.HTTP_EVENT_PROVIDER_NAME)
 
     async def poll_for_event(self, event_key: str = None) -> Event:
         """workflow.wait_for_event calls this method to subscribe to the

--- a/python/ray/workflow/tests/test_event_resume_after_crash.py
+++ b/python/ray/workflow/tests/test_event_resume_after_crash.py
@@ -11,6 +11,7 @@ from ray.tests.conftest import *  # noqa
 from ray.workflow.tests import utils
 from ray.workflow.common import WorkflowStatus
 from ray.workflow import common, workflow_context
+from ray._private.test_utils import wait_for_condition
 
 import requests
 
@@ -71,10 +72,12 @@ def test_cluster_crash_before_checkpoint(workflow_start_regular_shared_serve):
     )
 
     # wait until HTTPEventProvider is ready
-    while (
-        serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status != "RUNNING"
-    ):
-        sleep(0.1)
+    def check_app_running():
+        status = serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME]
+        assert status.status == "RUNNING"
+        return True
+
+    wait_for_condition(check_app_running)
 
     test_msg = "first_try"
 
@@ -109,11 +112,7 @@ def test_cluster_crash_before_checkpoint(workflow_start_regular_shared_serve):
             workflow_id="workflow_test_cluster_crash_before_checkpoint"
         )
 
-        while (
-            serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status
-            != "RUNNING"
-        ):
-            sleep(0.1)
+        wait_for_condition(check_app_running)
 
         assert status_after_resume == WorkflowStatus.RUNNING
 

--- a/python/ray/workflow/tests/test_http_events.py
+++ b/python/ray/workflow/tests/test_http_events.py
@@ -5,7 +5,8 @@ import ray
 from ray import workflow
 from ray.workflow.http_event_provider import HTTPListener
 from ray.tests.conftest import *  # noqa
-from ray.serve._private import api as _private_api
+from ray import serve
+from ray.workflow import common
 
 import requests
 
@@ -37,7 +38,9 @@ def test_receive_event_by_http(workflow_start_regular_shared_serve):
     workflow.run_async(event_promise, workflow_id="workflow_test_receive_event_by_http")
 
     # wait until HTTPEventProvider is ready
-    while len(_private_api.list_deployments().keys()) < 1:
+    while (
+        serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status != "RUNNING"
+    ):
         sleep(0.1)
 
     # repeat send_event() until the returned status code is not 404
@@ -89,7 +92,9 @@ def test_dynamic_event_by_http(workflow_start_regular_shared_serve):
     )
 
     # wait until HTTPEventProvider is ready
-    while len(_private_api.list_deployments().keys()) < 1:
+    while (
+        serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status != "RUNNING"
+    ):
         sleep(0.1)
 
     # repeat send_event() until the returned status code is not 404

--- a/python/ray/workflow/tests/test_http_events.py
+++ b/python/ray/workflow/tests/test_http_events.py
@@ -7,6 +7,7 @@ from ray.workflow.http_event_provider import HTTPListener
 from ray.tests.conftest import *  # noqa
 from ray import serve
 from ray.workflow import common
+from ray._private.test_utils import wait_for_condition
 
 import requests
 
@@ -38,10 +39,12 @@ def test_receive_event_by_http(workflow_start_regular_shared_serve):
     workflow.run_async(event_promise, workflow_id="workflow_test_receive_event_by_http")
 
     # wait until HTTPEventProvider is ready
-    while (
-        serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status != "RUNNING"
-    ):
-        sleep(0.1)
+    def check_app_running():
+        status = serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME]
+        assert status.status == "RUNNING"
+        return True
+
+    wait_for_condition(check_app_running)
 
     # repeat send_event() until the returned status code is not 404
     while True:
@@ -92,11 +95,12 @@ def test_dynamic_event_by_http(workflow_start_regular_shared_serve):
     )
 
     # wait until HTTPEventProvider is ready
-    while (
-        serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status != "RUNNING"
-    ):
-        sleep(0.1)
+    def check_app_running():
+        status = serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME]
+        assert status.status == "RUNNING"
+        return True
 
+    wait_for_condition(check_app_running)
     # repeat send_event() until the returned status code is not 404
     while True:
         res = send_event()

--- a/python/ray/workflow/tests/test_http_events_2.py
+++ b/python/ray/workflow/tests/test_http_events_2.py
@@ -5,7 +5,8 @@ import ray
 from ray import workflow
 from ray.workflow.http_event_provider import HTTPListener
 from ray.tests.conftest import *  # noqa
-from ray.serve._private import api as _private_api
+from ray import serve
+from ray.workflow import common
 
 import requests
 
@@ -54,7 +55,9 @@ def test_multiple_events_by_http(workflow_start_regular_shared_serve):
     )
 
     # wait until HTTPEventProvider is ready
-    while len(_private_api.list_deployments().keys()) < 1:
+    while (
+        serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status != "RUNNING"
+    ):
         sleep(0.1)
 
     # repeat send_event1() until the returned status code is not 404

--- a/python/ray/workflow/tests/test_http_events_2.py
+++ b/python/ray/workflow/tests/test_http_events_2.py
@@ -7,6 +7,7 @@ from ray.workflow.http_event_provider import HTTPListener
 from ray.tests.conftest import *  # noqa
 from ray import serve
 from ray.workflow import common
+from ray._private.test_utils import wait_for_condition
 
 import requests
 
@@ -55,10 +56,12 @@ def test_multiple_events_by_http(workflow_start_regular_shared_serve):
     )
 
     # wait until HTTPEventProvider is ready
-    while (
-        serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status != "RUNNING"
-    ):
-        sleep(0.1)
+    def check_app_running():
+        status = serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME]
+        assert status.status == "RUNNING"
+        return True
+
+    wait_for_condition(check_app_running)
 
     # repeat send_event1() until the returned status code is not 404
     while True:

--- a/python/ray/workflow/tests/test_http_events_3.py
+++ b/python/ray/workflow/tests/test_http_events_3.py
@@ -5,7 +5,8 @@ from ray import workflow
 from ray.workflow.http_event_provider import HTTPListener
 from ray.tests.conftest import *  # noqa
 from ray.workflow.tests import utils
-from ray.serve._private import api as _private_api
+from ray import serve
+from ray.workflow import common
 
 import requests
 
@@ -52,7 +53,9 @@ def test_checkpoint_success_by_http(workflow_start_regular_shared_serve):
     )
 
     # wait until HTTPEventProvider is ready
-    while len(_private_api.list_deployments().keys()) < 1:
+    while (
+        serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status != "RUNNING"
+    ):
         sleep(0.1)
 
     test_msg = "new_event_message"
@@ -109,7 +112,9 @@ def test_checkpoint_failed_by_http(workflow_start_regular_shared_serve):
     )
 
     # wait until HTTPEventProvider is ready
-    while len(_private_api.list_deployments().keys()) < 1:
+    while (
+        serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status != "RUNNING"
+    ):
         sleep(0.1)
 
     test_msg = "new_event_message"

--- a/python/ray/workflow/tests/test_http_events_3.py
+++ b/python/ray/workflow/tests/test_http_events_3.py
@@ -7,6 +7,7 @@ from ray.tests.conftest import *  # noqa
 from ray.workflow.tests import utils
 from ray import serve
 from ray.workflow import common
+from ray._private.test_utils import wait_for_condition
 
 import requests
 
@@ -53,10 +54,12 @@ def test_checkpoint_success_by_http(workflow_start_regular_shared_serve):
     )
 
     # wait until HTTPEventProvider is ready
-    while (
-        serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status != "RUNNING"
-    ):
-        sleep(0.1)
+    def check_app_running():
+        status = serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME]
+        assert status.status == "RUNNING"
+        return True
+
+    wait_for_condition(check_app_running)
 
     test_msg = "new_event_message"
 
@@ -112,10 +115,12 @@ def test_checkpoint_failed_by_http(workflow_start_regular_shared_serve):
     )
 
     # wait until HTTPEventProvider is ready
-    while (
-        serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME].status != "RUNNING"
-    ):
-        sleep(0.1)
+    def check_app_running():
+        status = serve.status().applications[common.HTTP_EVENT_PROVIDER_NAME]
+        assert status.status == "RUNNING"
+        return True
+
+    wait_for_condition(check_app_running)
 
     test_msg = "new_event_message"
 

--- a/python/ray/workflow/workflow_access.py
+++ b/python/ray/workflow/workflow_access.py
@@ -319,12 +319,17 @@ class WorkflowManagementActor:
         name = common.HTTP_EVENT_PROVIDER_NAME, if one doesn't exist
         """
         ray.serve.start(detached=True)
-        try:
-            ray.serve._private.api.get_deployment(common.HTTP_EVENT_PROVIDER_NAME)
-        except KeyError:
+        provider_exists = (
+            common.HTTP_EVENT_PROVIDER_NAME in ray.serve.status().applications
+        )
+        if not provider_exists:
             from ray.workflow.http_event_provider import HTTPEventProvider
 
-            HTTPEventProvider._deploy()
+            ray.serve.run(
+                HTTPEventProvider.bind(),
+                name=common.HTTP_EVENT_PROVIDER_NAME,
+                route_prefix="/event",
+            )
 
     def ready(self) -> None:
         """A no-op to make sure the actor is ready."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Migrate workflow tests to use Serve v2 instead of v1 api. (We are removing v1 api)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
