### PR TITLE
[Serve] [Docs] Update Serve docs to use the dashboard head instead of the agent

### DIFF
--- a/dashboard/modules/serve/sdk.py
+++ b/dashboard/modules/serve/sdk.py
@@ -24,7 +24,7 @@ STATUS_PATH_V2 = "/api/serve/applications/"
 class ServeSubmissionClient(SubmissionClient):
     def __init__(
         self,
-        dashboard_agent_address: str,
+        dashboard_head_address: str,
         create_cluster_if_needed=False,
         cookies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
@@ -38,18 +38,18 @@ class ServeSubmissionClient(SubmissionClient):
 
         invalid_address_message = (
             "Got an unexpected address"
-            f'"{dashboard_agent_address}" while trying '
-            "to connect to the Ray dashboard agent. The Serve SDK/CLI requires the "
-            "Ray dashboard agent's HTTP(S) address (which should start with "
+            f'"{dashboard_head_address}" while trying '
+            "to connect to the Ray dashboard. The Serve SDK/CLI requires the "
+            "Ray dashboard's HTTP(S) address (which should start with "
             '"http://" or "https://". If this address '
-            "wasn't passed explicitly, it may be set in the RAY_AGENT_ADDRESS "
-            "environment variable."
+            "wasn't passed explicitly, it may be set in the "
+            "RAY_DASHBOARD_ADDRESS environment variable."
         )
 
-        if "://" not in dashboard_agent_address:
+        if "://" not in dashboard_head_address:
             raise ValueError(invalid_address_message)
 
-        module_string, _ = split_address(dashboard_agent_address)
+        module_string, _ = split_address(dashboard_head_address)
 
         # If user passes in ray://, raise error. Serve submission should
         # not use a Ray client address.
@@ -57,7 +57,7 @@ class ServeSubmissionClient(SubmissionClient):
             raise ValueError(invalid_address_message)
 
         super().__init__(
-            address=dashboard_agent_address,
+            address=dashboard_head_address,
             create_cluster_if_needed=create_cluster_if_needed,
             cookies=cookies,
             metadata=metadata,

--- a/dashboard/modules/serve/tests/test_serve_agent_fault_tolerance.py
+++ b/dashboard/modules/serve/tests/test_serve_agent_fault_tolerance.py
@@ -6,8 +6,8 @@ from ray import serve
 from ray.tests.conftest import *  # noqa: F401,F403
 from ray._private.test_utils import generate_system_config_map
 
-DEPLOYMENTS_URL = "http://localhost:52365/api/serve/deployments/"
-STATUS_URL = "http://localhost:52365/api/serve/deployments/status"
+DEPLOYMENTS_URL = "http://localhost:8265/api/serve/deployments/"
+STATUS_URL = "http://localhost:8265/api/serve/deployments/status"
 
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="Flaky on OSX.")

--- a/doc/source/serve/advanced-guides/deploy-vm.md
+++ b/doc/source/serve/advanced-guides/deploy-vm.md
@@ -42,53 +42,48 @@ It does **not** mean that your Serve application, including your deployments, ha
 
 ## Using a remote cluster
 
-By default, `serve deploy` deploys to a cluster running locally. However, you should also use `serve deploy` whenever you want to deploy your Serve application to a remote cluster. `serve deploy` takes in an optional `--address/-a` argument where you can specify your remote Ray cluster's dashboard agent address. This address should be of the form:
+By default, `serve deploy` deploys to a cluster running locally. However, you should also use `serve deploy` whenever you want to deploy your Serve application to a remote cluster. `serve deploy` takes in an optional `--address/-a` argument where you can specify your remote Ray cluster's dashboard address. This address should be of the form:
 
 ```
-[RAY_CLUSTER_URI]:[DASHBOARD_AGENT_PORT]
+[RAY_CLUSTER_URI]:[DASHBOARD_PORT]
 ```
 
-As an example, the address for the local cluster started by `ray start --head` is `http://127.0.0.1:52365`. We can explicitly deploy to this address using the command
+As an example, the address for the local cluster started by `ray start --head` is `http://127.0.0.1:8265`. We can explicitly deploy to this address using the command
 
 ```console
-$ serve deploy config_file.yaml -a http://127.0.0.1:52365
+$ serve deploy config_file.yaml -a http://127.0.0.1:8265
 ```
 
-The Ray Dashboard agent's default port is 52365. To set it to a different value, use the `--dashboard-agent-listen-port` argument when running `ray start`.
+The Ray Dashboard's default port is 8265. To set it to a different value, use the `--dashboard-port` argument when running `ray start`.
 
 :::{note}
 When running on a remote cluster, you need to ensure that the import path is accessible. See [Handle Dependencies](serve-handling-dependencies) for how to add a runtime environment.
 :::
 
-:::{note}
-If the port 52365 (or whichever port you specify with `--dashboard-agent-listen-port`) is unavailable when Ray starts, the dashboard agent’s HTTP server will fail. However, the dashboard agent and Ray will continue to run.
-You can check if an agent’s HTTP server is running by sending a curl request: `curl http://{node_ip}:{dashboard_agent_port}/api/serve/deployments/`. If the request succeeds, the server is running on that node. If the request fails, the server is not running on that node. To launch the server on that node, terminate the process occupying the dashboard agent’s port, and restart Ray on that node.
-:::
-
 :::{tip}
-By default, all the Serve CLI commands assume that you're working with a local cluster. All Serve CLI commands, except `serve start` and `serve run` use the Ray agent address associated with a local cluster started by `ray start --head`. However, if the `RAY_AGENT_ADDRESS` environment variable is set, these Serve CLI commands will default to that value instead.
+By default, all the Serve CLI commands assume that you're working with a local cluster. All Serve CLI commands, except `serve start` and `serve run` use the Ray Dashboard address associated with a local cluster started by `ray start --head`. However, if the `RAY_DASHBOARD_ADDRESS` environment variable is set, these Serve CLI commands will default to that value instead.
 
 Similarly, `serve start` and `serve run`, use the Ray head node address associated with a local cluster by default. If the `RAY_ADDRESS` environment variable is set, they will use that value instead.
 
-You can check `RAY_AGENT_ADDRESS`'s value by running:
+You can check `RAY_DASHBOARD_ADDRESS`'s value by running:
 
 ```console
-$ echo $RAY_AGENT_ADDRESS
+$ echo $RAY_DASHBOARD_ADDRESS
 ```
 
 You can set this variable by running the CLI command:
 
 ```console
-$ export RAY_AGENT_ADDRESS=[YOUR VALUE]
+$ export RAY_DASHBOARD_ADDRESS=[YOUR VALUE]
 ```
 
 You can unset this variable by running the CLI command:
 
 ```console
-$ unset RAY_AGENT_ADDRESS
+$ unset RAY_DASHBOARD_ADDRESS
 ```
 
-Check for this variable in your environment to make sure you're using your desired Ray agent address.
+Check for this variable in your environment to make sure you're using your desired Ray Dashboard address.
 :::
 
 To inspect the status of the Serve application in production, see [Inspect an application](serve-in-production-inspecting).

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -116,6 +116,8 @@ To opt into the new API, you can either use `handle.options(use_new_handle_api=T
 
 ## Serve REST API
 
+The Serve REST API is exposed at the same port as the Ray Dashboard. The Dashboard port is `8265` by default. This port can be changed using the `--dashboard-port` argument when running `ray start`. All example requests in this section use the default port.
+
 ### V1 REST API (Single-application)
 
 #### `PUT "/api/serve/deployments/"`
@@ -126,7 +128,7 @@ Declaratively deploys the Serve application. Starts Serve on the Ray cluster if 
 
 ```http
 PUT /api/serve/deployments/ HTTP/1.1
-Host: http://localhost:52365/
+Host: http://localhost:8265/
 Accept: application/json
 Content-Type: application/json
 
@@ -157,7 +159,7 @@ Gets the config for the application currently deployed on the Ray cluster. This 
 **Example Request**:
 ```http
 GET /api/serve/deployments/ HTTP/1.1
-Host: http://localhost:52365/
+Host: http://localhost:8265/
 Accept: application/json
 ```
 
@@ -188,7 +190,7 @@ Gets the Serve application's current status, including all the deployment status
 
 ```http
 GET /api/serve/deployments/status HTTP/1.1
-Host: http://localhost:52365/
+Host: http://localhost:8265/
 Accept: application/json
 ```
 
@@ -228,7 +230,7 @@ Shuts down Serve and the Serve application running on the Ray cluster. Has no ef
 
 ```http
 DELETE /api/serve/deployments/ HTTP/1.1
-Host: http://localhost:52365/
+Host: http://localhost:8265/
 Accept: application/json
 ```
 
@@ -249,7 +251,7 @@ Declaratively deploys a list of Serve applications. If Serve is already running 
 
 ```http
 PUT /api/serve/applications/ HTTP/1.1
-Host: http://localhost:52365/
+Host: http://localhost:8265/
 Accept: application/json
 Content-Type: application/json
 
@@ -287,7 +289,7 @@ Gets cluster-level info and comprehensive details on all Serve applications depl
 
 ```http
 GET /api/serve/applications/ HTTP/1.1
-Host: http://localhost:52365/
+Host: http://localhost:8265/
 Accept: application/json
 ```
 
@@ -439,7 +441,7 @@ Shuts down Serve and all applications running on the Ray cluster. Has no effect 
 
 ```http
 DELETE /api/serve/applications/ HTTP/1.1
-Host: http://localhost:52365/
+Host: http://localhost:8265/
 Accept: application/json
 ```
 

--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -135,7 +135,7 @@ def test_with_rest_api(ray_start_stop):
             }
         ],
     }
-    ServeSubmissionClient("http://localhost:52365").deploy_applications(config)
+    ServeSubmissionClient("http://localhost:8265").deploy_applications(config)
 
     def application_running():
         response = requests.get(
@@ -155,7 +155,7 @@ def test_with_rest_api(ray_start_stop):
     response = requests.get("http://localhost:8000")
     assert response.status_code == 200
     print("Requests succeeded! Deleting application.")
-    ServeSubmissionClient("http://localhost:52365").delete_applications()
+    ServeSubmissionClient("http://localhost:8265").delete_applications()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change replaces references to the dashboard agent with just the Ray dashboard in the Serve docs. It also updates some tests and code to use the dashboard head.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change only affects documentation without code examples.
