### PR TITLE
[Data] Fix bug where `_StatsActor` errors with `PandasBlock`

### DIFF
--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -238,7 +238,7 @@ class PandasBlockAccessor(TableBlockAccessor):
         return self._table.shape[0]
 
     def size_bytes(self) -> int:
-        return self._table.memory_usage(index=True, deep=True).sum()
+        return int(self._table.memory_usage(index=True, deep=True).sum())
 
     def _zip(self, acc: BlockAccessor) -> "pandas.DataFrame":
         r = self.to_pandas().copy(deep=False)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

**tl;dr: `StatsActor` errors if your dataset contains pandas blocks.**

Results from write tasks are stored in pandas blocks.

https://github.com/ray-project/ray/blob/7c44833720b395fd575ef9ff5c8d828f9c7e7474/python/ray/data/_internal/planner/plan_write_op.py#L22-L30

The problem is that Ray expects stats to be an `int` or `float`:

https://github.com/ray-project/ray/blob/7c44833720b395fd575ef9ff5c8d828f9c7e7474/python/ray/data/_internal/stats.py#L225

But `PandasBlock.size_bytes()` returns a NumPy scalar.

https://github.com/ray-project/ray/blob/7c44833720b395fd575ef9ff5c8d828f9c7e7474/python/ray/data/_internal/pandas_block.py#L241

This PR fixes the issue by converting the NumPy scalar to an `int`.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/40480

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
