### PR TITLE
[ci] support gpu core assignment per test shard

### DIFF
--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -150,24 +150,10 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
         --parallelism-per-worker 2
+        --gpus 4
         --build-name rllibgpubuild
         --only-tags multi_gpu
     depends_on: rllibgpubuild
-    job_env: forge
-
-  - label: ":brain: rllib: flaky multi-gpu tests"
-    tags: 
-      - rllib
-      - gpu
-    instance_type: gpu-large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --run-flaky-tests
-        --parallelism-per-worker 2
-        --build-name rllibgpubuild
-        --only-tags multi_gpu
-    depends_on: rllibgpubuild
-    soft_fail: true
     job_env: forge
 
   - label: ":brain: rllib: flaky tests"

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -243,8 +243,7 @@ if __name__ == "__main__":
                         RAY_CI_COMPILED_PYTHON_AFFECTED = 1
                         break
             elif (
-                changed_file.startswith("ci/ray_ci")
-                or changed_file == ".buildkite/core.rayci.yml"
+                changed_file == ".buildkite/core.rayci.yml"
                 or changed_file == ".buildkite/_forge.rayci.yml"
                 or changed_file == "ci/docker/min.build.Dockerfile"
                 or changed_file == "ci/docker/min.build.wanda.yaml"
@@ -284,7 +283,9 @@ if __name__ == "__main__":
             elif changed_file.startswith("ci/lint"):
                 # Linter will always be run
                 RAY_CI_TOOLS_AFFECTED = 1
-            elif changed_file.startswith("ci/pipeline"):
+            elif changed_file.startswith("ci/pipeline") or changed_file.startswith(
+                "ci/ray_ci"
+            ):
                 # These scripts are always run as part of the build process
                 RAY_CI_TOOLS_AFFECTED = 1
             elif changed_file.endswith("build-docker-images.py"):

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -72,7 +72,11 @@ class Container:
             stderr=sys.stderr,
         )
 
-    def _get_run_command(self, script: List[str]) -> List[str]:
+    def _get_run_command(
+        self,
+        script: List[str],
+        gpu_ids: Optional[List[int]] = None,
+    ) -> List[str]:
         command = [
             "docker",
             "run",
@@ -87,6 +91,8 @@ class Container:
             command += ["--env", env]
         for cap in _DOCKER_CAP_ADD:
             command += ["--cap-add", cap]
+        if gpu_ids:
+            command += ["--gpus", f'"device={",".join(map(str, gpu_ids))}"']
         command += [
             "--workdir",
             "/rayci",

--- a/ci/ray_ci/rllib.tests.yml
+++ b/ci/ray_ci/rllib.tests.yml
@@ -31,5 +31,3 @@ flaky_tests:
   - //rllib:test_memory_leak_ddpg
   # tests/ dir
   - //rllib:tests/test_io
-  # multi-gpu
-  - //rllib:TestLearnerGroupAsyncUpdate

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -34,7 +34,7 @@ def test_get_container() -> None:
         "ci.ray_ci.tester_container.TesterContainer.install_ray",
         return_value=None,
     ):
-        container = _get_container("core", 3, 1, 2)
+        container = _get_container("core", 3, 1, 2, 0)
         assert container.docker_tag == "corebuild"
         assert container.shard_count == 6
         assert container.shard_ids == [2, 3]

--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -21,9 +21,26 @@ class MockPopen:
         return 1 if "bad_test" in self.test_targets or not self.test_targets else 0
 
 
+def test_enough_gpus() -> None:
+    # not enough gpus
+    try:
+        TesterContainer("team", shard_count=2, gpus=1, skip_ray_installation=True)
+    except AssertionError:
+        pass
+    else:
+        assert False, "Should raise an AssertionError"
+
+    # not enough gpus
+    try:
+        TesterContainer("team", shard_count=1, gpus=1, skip_ray_installation=True)
+    except AssertionError:
+        assert False, "Should not raise an AssertionError"
+
+
 def test_run_tests_in_docker() -> None:
     def _mock_popen(input: List[str]) -> None:
         input_str = " ".join(input)
+        assert '--gpus "device=0,1"' in input_str
         assert (
             "bazel test --config=ci $(./ci/run/bazel_export_options) --config=ci-debug "
             "--test_env v=k --test_arg flag t1 t2" in input_str
@@ -34,7 +51,7 @@ def test_run_tests_in_docker() -> None:
         return_value=None,
     ):
         container = TesterContainer("team", build_type="debug")
-        container._run_tests_in_docker(["t1", "t2"], ["v=k"], "flag")
+        container._run_tests_in_docker(["t1", "t2"], [0, 1], ["v=k"], "flag")
 
 
 def test_run_script_in_docker() -> None:
@@ -97,6 +114,7 @@ def test_ray_installation() -> None:
 def test_run_tests() -> None:
     def _mock_run_tests_in_docker(
         test_targets: List[str],
+        gpu_ids: List[int],
         test_envs: List[str],
         test_arg: Optional[str] = None,
     ) -> MockPopen:

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -77,6 +77,12 @@ bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
     help=("Skip ray installation."),
 )
 @click.option(
+    "--gpus",
+    default=0,
+    type=int,
+    help=("Number of GPUs to use for the test."),
+)
+@click.option(
     "--test-env",
     multiple=True,
     type=str,
@@ -107,6 +113,7 @@ def main(
     only_tags: str,
     run_flaky_tests: bool,
     skip_ray_installation: bool,
+    gpus: int,
     test_env: List[str],
     test_arg: Optional[str],
     build_name: Optional[str],
@@ -122,6 +129,7 @@ def main(
         workers,
         worker_id,
         parallelism_per_worker,
+        gpus,
         build_name,
         build_type,
         skip_ray_installation,
@@ -143,6 +151,7 @@ def _get_container(
     workers: int,
     worker_id: int,
     parallelism_per_worker: int,
+    gpus: int,
     build_name: Optional[str] = None,
     build_type: Optional[str] = None,
     skip_ray_installation: bool = False,
@@ -155,6 +164,7 @@ def _get_container(
         build_name or f"{team}build",
         shard_count=shard_count,
         shard_ids=list(range(shard_start, shard_end)),
+        gpus=gpus,
         skip_ray_installation=skip_ray_installation,
         build_type=build_type,
     )

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from typing import List, Optional
 
-from ci.ray_ci.utils import shard_tests
+from ci.ray_ci.utils import shard_tests, chunk_into_n
 from ci.ray_ci.container import Container
 from ci.ray_ci.utils import logger
 
@@ -16,12 +16,14 @@ class TesterContainer(Container):
         self,
         docker_tag: str,
         shard_count: int = 1,
+        gpus: int = 0,
         shard_ids: Optional[List[int]] = None,
         skip_ray_installation: bool = False,
         build_type: Optional[str] = None,
     ) -> None:
         """
         :param docker_tag: Name of the wanda build to be used as test container.
+        :param gpu: Number of gpus to use in the container. If 0, used all gpus.
         :param shard_count: The number of shards to split the tests into. This can be
         used to run tests in a distributed fashion.
         :param shard_ids: The list of shard ids to run. If none, run no shards.
@@ -30,6 +32,10 @@ class TesterContainer(Container):
         self.shard_count = shard_count
         self.shard_ids = shard_ids or []
         self.build_type = build_type
+        self.gpus = gpus
+        assert (
+            self.gpus == 0 or self.gpus >= self.shard_count
+        ), f"Not enough gpus ({self.gpus} provided) for {self.shard_count} shards"
 
         if not skip_ray_installation:
             self.install_ray(build_type)
@@ -43,13 +49,25 @@ class TesterContainer(Container):
         """
         Run tests parallelly in docker.  Return whether all tests pass.
         """
-        chunks = [
-            shard_tests(test_targets, self.shard_count, i) for i in self.shard_ids
-        ]
+        # shard tests and remove empty chunks
+        chunks = list(
+            filter(
+                len,
+                [
+                    shard_tests(test_targets, self.shard_count, i)
+                    for i in self.shard_ids
+                ],
+            )
+        )
+        if not chunks:
+            # no tests to run
+            return True
+
+        # divide gpus evenly among chunks
+        gpu_ids = chunk_into_n(list(range(self.gpus)), len(chunks))
         runs = [
-            self._run_tests_in_docker(chunk, test_envs, test_arg)
-            for chunk in chunks
-            if chunk
+            self._run_tests_in_docker(chunks[i], gpu_ids[i], test_envs, test_arg)
+            for i in range(len(chunks))
         ]
         exits = [run.wait() for run in runs]
         return all(exit == 0 for exit in exits)
@@ -57,6 +75,7 @@ class TesterContainer(Container):
     def _run_tests_in_docker(
         self,
         test_targets: List[str],
+        gpu_ids: List[int],
         test_envs: List[str],
         test_arg: Optional[str] = None,
     ) -> subprocess.Popen:
@@ -80,4 +99,4 @@ class TesterContainer(Container):
             test_cmd += f"--test_arg {test_arg} "
         test_cmd += f"{' '.join(test_targets)}"
         commands.append(test_cmd)
-        return subprocess.Popen(self._get_run_command(commands))
+        return subprocess.Popen(self._get_run_command(commands, gpu_ids))


### PR DESCRIPTION
In order to run tests in parallel in gpu core, this PR we assign specific set of gpu cores to each job shard. This avoids multiple tests sharing a same GPU core at the same time, which GPU seems to be quite sensitive about.

Also remove the flaky gpu tests, the test seems to be much more reliable running in this way.

Test:
- CI