### PR TITLE
[serve] Add microbenchmarks for streaming HTTP and `DeploymentHandle` calls

### DIFF
--- a/python/ray/serve/_private/benchmarks/streaming_handle_throughput.py
+++ b/python/ray/serve/_private/benchmarks/streaming_handle_throughput.py
@@ -35,7 +35,8 @@ class Caller:
         logging.getLogger("ray.serve").setLevel(logging.WARNING)
 
         self._h: DeploymentHandle = downstream.options(
-            use_new_handle_api=True, stream=True,
+            use_new_handle_api=True,
+            stream=True,
         )
         self._tokens_per_request = tokens_per_request
         self._batch_size = batch_size
@@ -47,7 +48,9 @@ class Caller:
             pass
 
     async def _do_single_batch(self):
-        await asyncio.gather(*[self._consume_single_stream() for _ in range(self._batch_size)])
+        await asyncio.gather(
+            *[self._consume_single_stream() for _ in range(self._batch_size)]
+        )
 
     async def run_benchmark(self) -> Tuple[float, float]:
         return await run_throughput_benchmark(
@@ -110,7 +113,9 @@ def main(
     mean, stddev = h.run_benchmark.remote().result()
     print(
         "DeploymentHandle streaming throughput {}: {} +- {} tokens/s".format(
-            f"(num_replicas={num_replicas}, tokens_per_request={tokens_per_request}, batch_size={batch_size})",
+            f"(num_replicas={num_replicas}, "
+            "tokens_per_request={tokens_per_request}, "
+            "batch_size={batch_size})",
             mean,
             stddev,
         )

--- a/python/ray/serve/_private/benchmarks/streaming_handle_throughput.py
+++ b/python/ray/serve/_private/benchmarks/streaming_handle_throughput.py
@@ -114,8 +114,8 @@ def main(
     print(
         "DeploymentHandle streaming throughput {}: {} +- {} tokens/s".format(
             f"(num_replicas={num_replicas}, "
-            "tokens_per_request={tokens_per_request}, "
-            "batch_size={batch_size})",
+            f"tokens_per_request={tokens_per_request}, "
+            f"batch_size={batch_size})",
             mean,
             stddev,
         )

--- a/python/ray/serve/_private/benchmarks/streaming_http_throughput.py
+++ b/python/ray/serve/_private/benchmarks/streaming_http_throughput.py
@@ -130,9 +130,9 @@ def main(
     print(
         "HTTP streaming throughput {}: {} +- {} tokens/s".format(
             f"(num_replicas={num_replicas}, "
-            "tokens_per_request={tokens_per_request}, "
-            "batch_size={batch_size}, "
-            "use_intermediate_deployment={use_intermediate_deployment})",
+            f"tokens_per_request={tokens_per_request}, "
+            f"batch_size={batch_size}, "
+            f"use_intermediate_deployment={use_intermediate_deployment})",
             mean,
             stddev,
         )

--- a/python/ray/serve/_private/benchmarks/streaming_http_throughput.py
+++ b/python/ray/serve/_private/benchmarks/streaming_http_throughput.py
@@ -1,0 +1,139 @@
+import asyncio
+import logging
+from typing import Tuple
+
+import aiohttp
+import click
+from starlette.responses import StreamingResponse
+
+from ray import serve
+from ray.serve._private.benchmarks.common import run_throughput_benchmark
+from ray.serve.handle import DeploymentHandle, RayServeHandle
+
+
+@serve.deployment(ray_actor_options={"num_cpus": 0})
+class Downstream:
+    def __init__(self, tokens_per_request: int):
+        logging.getLogger("ray.serve").setLevel(logging.WARNING)
+
+        self._tokens_per_request = tokens_per_request
+
+    def stream(self):
+        for i in range(self._tokens_per_request):
+            yield "hi"
+
+    def __call__(self, *args):
+        return StreamingResponse(self.stream())
+
+
+@serve.deployment(ray_actor_options={"num_cpus": 0})
+class Intermediate:
+    def __init__(self, downstream: RayServeHandle):
+        logging.getLogger("ray.serve").setLevel(logging.WARNING)
+
+        self._h = downstream.options(
+            stream=True,
+            use_new_handle_api=True,
+        )
+
+    async def stream(self):
+        async for token in self._h.stream.remote():
+            yield token
+
+    def __call__(self, *args):
+        return StreamingResponse(self.stream())
+
+
+async def _consume_single_stream():
+    async with aiohttp.ClientSession(raise_for_status=True) as session:
+        async with session.get("http://localhost:8000") as r:
+            async for line in r.content:
+                pass
+
+async def run_benchmark(
+    tokens_per_request: int,
+    batch_size: int,
+    num_trials: int,
+    trial_runtime: float,
+) -> Tuple[float, float]:
+    async def _do_single_batch():
+        await asyncio.gather(*[_consume_single_stream() for _ in range(batch_size)])
+
+    return await run_throughput_benchmark(
+        fn=_do_single_batch,
+        multiplier=batch_size * tokens_per_request,
+        num_trials=num_trials,
+        trial_runtime=trial_runtime,
+    )
+
+
+@click.command(help="Benchmark streaming HTTP throughput.")
+@click.option(
+    "--tokens-per-request",
+    type=int,
+    default=1000,
+    help="Number of requests to send to downstream deployment in each trial.",
+)
+@click.option(
+    "--batch-size",
+    type=int,
+    default=10,
+    help="Number of requests to send to downstream deployment in each trial.",
+)
+@click.option(
+    "--num-replicas",
+    type=int,
+    default=1,
+    help="Number of replicas in the downstream deployment.",
+)
+@click.option(
+    "--num-trials",
+    type=int,
+    default=5,
+    help="Number of trials of the benchmark to run.",
+)
+@click.option(
+    "--trial-runtime",
+    type=int,
+    default=1,
+    help="Duration to run each trial of the benchmark for (seconds).",
+)
+@click.option(
+    "--intermediate-deployment",
+    is_flag=True,
+    default=False,
+    help="Whether to run an intermediate deployment proxying the requests.",
+)
+def main(
+    tokens_per_request: int,
+    batch_size: int,
+    num_replicas: int,
+    num_trials: int,
+    trial_runtime: float,
+    intermediate_deployment: bool,
+):
+    app = Downstream.options(num_replicas=num_replicas).bind(tokens_per_request)
+    if intermediate_deployment:
+        app = Intermediate.bind(app)
+
+    serve.run(app)
+
+    mean, stddev = asyncio.new_event_loop().run_until_complete(
+        run_benchmark(
+            tokens_per_request,
+            batch_size,
+            num_trials,
+            trial_runtime,
+        )
+    )
+    print(
+        "HTTP streaming throughput {}: {} +- {} tokens/s".format(
+            f"(num_replicas={num_replicas}, tokens_per_request={tokens_per_request}, batch_size={batch_size})",
+            mean,
+            stddev,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds two new microbenchmarks:

- `streaming_handle_throughput.py`
- `streaming_http_throughput.py` (supports with and without an intermediate deployment)

These are motivated by https://github.com/ray-project/ray/issues/39705 and reproduce the issue:

```python
(ray) eoakes@Edwards-MacBook-Pro-2 benchmarks % python streaming_handle_throughput.py
2023-10-19 14:33:59,862 INFO worker.py:1659 -- Started a local Ray instance. View the dashboard at http://127.0.0.1:8265
(ServeController pid=63629) INFO 2023-10-19 14:34:02,354 controller 63629 deployment_state.py:1379 - Deploying new version of deployment Downstream in application 'default'.
(ServeController pid=63629) INFO 2023-10-19 14:34:02,354 controller 63629 deployment_state.py:1379 - Deploying new version of deployment Caller in application 'default'.
(ProxyActor pid=63639) INFO 2023-10-19 14:34:02,311 proxy 127.0.0.1 proxy.py:1072 - Proxy actor 4c79d0aa7ed765b6e07653c601000000 starting on node db00f2b439f64a783a4b8981797192524f5470c757561caf0f00448f.
(ProxyActor pid=63639) INFO 2023-10-19 14:34:02,315 proxy 127.0.0.1 proxy.py:1257 - Starting HTTP server on node: db00f2b439f64a783a4b8981797192524f5470c757561caf0f00448f listening on port 8000
(ProxyActor pid=63639) INFO:     Started server process [63639]
(ServeController pid=63629) INFO 2023-10-19 14:34:02,457 controller 63629 deployment_state.py:1668 - Adding 1 replica to deployment Downstream in application 'default'.
(ServeController pid=63629) INFO 2023-10-19 14:34:02,459 controller 63629 deployment_state.py:1668 - Adding 1 replica to deployment Caller in application 'default'.
2023-10-19 14:34:04,362 INFO router.py:910 -- Using router <class 'ray.serve._private.router.PowerOfTwoChoicesReplicaScheduler'>.
2023-10-19 14:34:04,372 INFO router.py:470 -- Got updated replicas for deployment 'Caller' in application 'default': {'default#Caller#xhvwap'}.
DeploymentHandle streaming throughput (num_replicas=1, tokens_per_request=1000, batch_size=10): 12422.19 +- 136.95 tokens/s

(ray) eoakes@Edwards-MacBook-Pro-2 benchmarks % python streaming_http_throughput.py
2023-10-19 14:34:18,357 INFO worker.py:1659 -- Started a local Ray instance. View the dashboard at http://127.0.0.1:8265
(ProxyActor pid=63729) INFO 2023-10-19 14:34:20,728 proxy 127.0.0.1 proxy.py:1072 - Proxy actor a80a996bfb1cab2c163e0a6801000000 starting on node 5b749fe61b48632b9c47c453f050fee52c42f63f2043e9b7d7efc618.
(ProxyActor pid=63729) INFO 2023-10-19 14:34:20,731 proxy 127.0.0.1 proxy.py:1257 - Starting HTTP server on node: 5b749fe61b48632b9c47c453f050fee52c42f63f2043e9b7d7efc618 listening on port 8000
(ProxyActor pid=63729) INFO:     Started server process [63729]
(ServeController pid=63726) INFO 2023-10-19 14:34:20,776 controller 63726 deployment_state.py:1379 - Deploying new version of deployment Downstream in application 'default'.
(ServeController pid=63726) INFO 2023-10-19 14:34:20,878 controller 63726 deployment_state.py:1668 - Adding 1 replica to deployment Downstream in application 'default'.
HTTP streaming throughput (num_replicas=1, tokens_per_request=1000, batch_size=10, use_intermediate_deployment=False): 7960.39 +- 109.88 tokens/s

(ray) eoakes@Edwards-MacBook-Pro-2 benchmarks % python streaming_http_throughput.py --use-intermediate-deployment
2023-10-19 14:34:35,189 INFO worker.py:1659 -- Started a local Ray instance. View the dashboard at http://127.0.0.1:8265
(ServeController pid=63774) INFO 2023-10-19 14:34:37,617 controller 63774 deployment_state.py:1379 - Deploying new version of deployment Downstream in application 'default'.
(ServeController pid=63774) INFO 2023-10-19 14:34:37,617 controller 63774 deployment_state.py:1379 - Deploying new version of deployment Intermediate in application 'default'.
(ProxyActor pid=63777) INFO 2023-10-19 14:34:37,569 proxy 127.0.0.1 proxy.py:1072 - Proxy actor 9bc9137ee662ec059a3324bc01000000 starting on node 56089721b1dc5a074a022cc84aa7f240bda893b2aa3852182344876c.
(ProxyActor pid=63777) INFO 2023-10-19 14:34:37,573 proxy 127.0.0.1 proxy.py:1257 - Starting HTTP server on node: 56089721b1dc5a074a022cc84aa7f240bda893b2aa3852182344876c listening on port 8000
(ProxyActor pid=63777) INFO:     Started server process [63777]
(ServeController pid=63774) INFO 2023-10-19 14:34:37,720 controller 63774 deployment_state.py:1668 - Adding 1 replica to deployment Downstream in application 'default'.
(ServeController pid=63774) INFO 2023-10-19 14:34:37,722 controller 63774 deployment_state.py:1668 - Adding 1 replica to deployment Intermediate in application 'default'.
HTTP streaming throughput (num_replicas=1, tokens_per_request=1000, batch_size=10, use_intermediate_deployment=True): 5454.23 +- 126.74 tokens/s
```

Adding an intermediate "router" deployment causes a ~30% reduction in throughput for HTTP streaming.

## Related issue number

https://github.com/ray-project/ray/issues/39705

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
