### PR TITLE
[docs] [core] link to file in repo with list of accelerator types

### DIFF
--- a/doc/source/ray-core/accelerator-types.rst
+++ b/doc/source/ray-core/accelerator-types.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _accelerator_types:
 
 Accelerator Types

--- a/doc/source/ray-core/accelerator-types.rst
+++ b/doc/source/ray-core/accelerator-types.rst
@@ -1,0 +1,9 @@
+.. _accelerator_types:
+
+Accelerator Types
+=================
+
+Ray supports the following accelerator types:
+
+.. literalinclude:: ../../../python/ray/util/accelerators/accelerators.py
+    :language: python

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -3342,7 +3342,7 @@ def remote(
         _metadata: Extended options for Ray libraries. For example,
             _metadata={"workflows.io/options": <workflow options>} for Ray workflows.
 
-    """  # noqa: E501
+    """
     # "callable" returns true for both function and class.
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
         # This is the case where the decorator is just @ray.remote.

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -3342,7 +3342,7 @@ def remote(
         _metadata: Extended options for Ray libraries. For example,
             _metadata={"workflows.io/options": <workflow options>} for Ray workflows.
 
-    """ #noqa: E501
+    """  # noqa: E501
     # "callable" returns true for both function and class.
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
         # This is the case where the decorator is just @ray.remote.

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -3342,7 +3342,7 @@ def remote(
         _metadata: Extended options for Ray libraries. For example,
             _metadata={"workflows.io/options": <workflow options>} for Ray workflows.
 
-    """
+    """ #noqa: E501
     # "callable" returns true for both function and class.
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
         # This is the case where the decorator is just @ray.remote.

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -3281,7 +3281,7 @@ def remote(
             By default it is empty.
         accelerator_type: If specified, requires that the task or actor run
             on a node with the specified type of accelerator.
-            See `ray.util.accelerators` for accelerator types.
+            See `ray.util.accelerators <https://github.com/ray-project/ray/blob/master/python/ray/util/accelerators/accelerators.py>`_ for accelerator types.
         memory: The heap memory request in bytes for this task/actor,
             rounded down to the nearest integer.
         max_calls: Only for *remote functions*. This specifies the

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -3281,7 +3281,7 @@ def remote(
             By default it is empty.
         accelerator_type: If specified, requires that the task or actor run
             on a node with the specified type of accelerator.
-            See `ray.util.accelerators <https://github.com/ray-project/ray/blob/master/python/ray/util/accelerators/accelerators.py>`_ for accelerator types.
+            See :ref:`accelerator types <accelerator_types>`.
         memory: The heap memory request in bytes for this task/actor,
             rounded down to the nearest integer.
         max_calls: Only for *remote functions*. This specifies the

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -352,8 +352,8 @@ class _ActorClassMetadata:
         memory: The heap memory quota for this actor.
         resources: The default resources required by the actor creation task.
         accelerator_type: The specified type of accelerator required for the
-            node on which this actor runs. See 
-            :ref:`accelerator types <accelerator_types>`.
+            node on which this actor runs.
+            See :ref:`accelerator types <accelerator_types>`.
         runtime_env: The runtime environment for this actor.
         scheduling_strategy: Strategy about how to schedule this actor.
         last_export_session_and_job: A pair of the last exported session

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -661,7 +661,7 @@ class ActorClass:
             # Class Bar will require 1 cpu instead of 2.
             # It will also require no custom resources.
             Bar = Foo.options(num_cpus=1, resources=None)
-        """ #noqa: E501
+        """  # noqa: E501
 
         actor_cls = self
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -352,7 +352,8 @@ class _ActorClassMetadata:
         memory: The heap memory quota for this actor.
         resources: The default resources required by the actor creation task.
         accelerator_type: The specified type of accelerator required for the
-            node on which this actor runs.
+            node on which this actor runs. See 
+            :ref:`accelerator types <accelerator_types>`.
         runtime_env: The runtime environment for this actor.
         scheduling_strategy: Strategy about how to schedule this actor.
         last_export_session_and_job: A pair of the last exported session
@@ -591,7 +592,7 @@ class ActorClass:
                 This is a dictionary mapping strings (resource names) to floats.
             accelerator_type: If specified, requires that the task or actor run
                 on a node with the specified type of accelerator.
-                See `ray.util.accelerators <https://github.com/ray-project/ray/blob/master/python/ray/util/accelerators/accelerators.py>`_ for accelerator types.
+                See :ref:`accelerator types <accelerator_types>`.
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
             object_store_memory: The object store memory request for actors only.
@@ -661,7 +662,7 @@ class ActorClass:
             # Class Bar will require 1 cpu instead of 2.
             # It will also require no custom resources.
             Bar = Foo.options(num_cpus=1, resources=None)
-        """  # noqa: E501
+        """
 
         actor_cls = self
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -591,7 +591,7 @@ class ActorClass:
                 This is a dictionary mapping strings (resource names) to floats.
             accelerator_type: If specified, requires that the task or actor run
                 on a node with the specified type of accelerator.
-                See `ray.util.accelerators` for accelerator types.
+                See `ray.util.accelerators <https://github.com/ray-project/ray/blob/master/python/ray/util/accelerators/accelerators.py>`_ for accelerator types.
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
             object_store_memory: The object store memory request for actors only.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -661,7 +661,7 @@ class ActorClass:
             # Class Bar will require 1 cpu instead of 2.
             # It will also require no custom resources.
             Bar = Foo.options(num_cpus=1, resources=None)
-        """
+        """ #noqa: E501
 
         actor_cls = self
 

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -173,8 +173,8 @@ class RemoteFunction:
                 to reserve for this task or for the lifetime of the actor.
                 This is a dictionary mapping strings (resource names) to floats.
             accelerator_type: If specified, requires that the task or actor run
-                on a node with the specified type of accelerator. See 
-                :ref:`accelerator types <accelerator_types>`.
+                on a node with the specified type of accelerator.
+                See :ref:`accelerator types <accelerator_types>`.
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
             object_store_memory: The object store memory request for actors only.

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -173,8 +173,8 @@ class RemoteFunction:
                 to reserve for this task or for the lifetime of the actor.
                 This is a dictionary mapping strings (resource names) to floats.
             accelerator_type: If specified, requires that the task or actor run
-                on a node with the specified type of accelerator.
-                See `ray.util.accelerators <https://github.com/ray-project/ray/blob/master/python/ray/util/accelerators/accelerators.py>`_ for accelerator types.
+                on a node with the specified type of accelerator. See 
+                :ref:`accelerator types <accelerator_types>`.
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
             object_store_memory: The object store memory request for actors only.

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -174,7 +174,7 @@ class RemoteFunction:
                 This is a dictionary mapping strings (resource names) to floats.
             accelerator_type: If specified, requires that the task or actor run
                 on a node with the specified type of accelerator.
-                See `ray.util.accelerators` for accelerator types.
+                See `ray.util.accelerators <https://github.com/ray-project/ray/blob/master/python/ray/util/accelerators/accelerators.py>`_ for accelerator types.
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
             object_store_memory: The object store memory request for actors only.

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -222,7 +222,7 @@ class RemoteFunction:
                return 1, 2
             # Task g will require 2 gpus instead of 1.
             g = f.options(num_gpus=2)
-        """
+        """ #noqa: E501
 
         func_cls = self
 

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -222,7 +222,7 @@ class RemoteFunction:
                return 1, 2
             # Task g will require 2 gpus instead of 1.
             g = f.options(num_gpus=2)
-        """  # noqa: E501
+        """
 
         func_cls = self
 

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -222,7 +222,7 @@ class RemoteFunction:
                return 1, 2
             # Task g will require 2 gpus instead of 1.
             g = f.options(num_gpus=2)
-        """ #noqa: E501
+        """  # noqa: E501
 
         func_cls = self
 

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -185,6 +185,7 @@ class RayActorOptionsSchema(BaseModel):
         default=None,
         description=(
             "Forces replicas to run on nodes with the specified accelerator type."
+            " See :ref:`accelerator types <accelerator_types>`."
         ),
     )
 

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -185,7 +185,7 @@ class RayActorOptionsSchema(BaseModel):
         default=None,
         description=(
             "Forces replicas to run on nodes with the specified accelerator type."
-            " See :ref:`accelerator types <accelerator_types>`."
+            "See :ref:`accelerator types <accelerator_types>`."
         ),
     )
 


### PR DESCRIPTION
In the docs for [ray remote](https://docs.ray.io/en/latest/ray-core/api/doc/ray.remote.html), I see:
accelerator_type – If specified, requires that the task or actor run on a node with the specified type of accelerator. See ray.util.accelerators for accelerator types.
It will be nice to have a link for ray.util.accelerators (https://github.com/ray-project/ray/blob/master/python/ray/util/accelerators/accelerators.py)

Request from @sriram-anyscale.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
