### PR TITLE
[ci] make sure tests run serially within each docker

### DIFF
--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -25,8 +25,8 @@ def test_run_tests_in_docker() -> None:
     def _mock_popen(input: List[str]) -> None:
         input_str = " ".join(input)
         assert (
-            "bazel test --config=ci $(./ci/run/bazel_export_options) --config=ci-debug "
-            "--test_env v=k --test_arg flag t1 t2" in input_str
+            "bazel test --jobs=1 --config=ci $(./ci/run/bazel_export_options) "
+            "--config=ci-debug --test_env v=k --test_arg flag t1 t2" in input_str
         )
 
     with mock.patch("subprocess.Popen", side_effect=_mock_popen), mock.patch(

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -69,7 +69,9 @@ class TesterContainer(Container):
                     "trap cleanup EXIT",
                 ]
             )
-        test_cmd = "bazel test --config=ci $(./ci/run/bazel_export_options) "
+        # note that we run tests serially within each docker, since we already use
+        # multiple dockers to shard tests
+        test_cmd = "bazel test --jobs=1 --config=ci $(./ci/run/bazel_export_options) "
         if self.build_type == "debug":
             test_cmd += "--config=ci-debug "
         if self.build_type == "asan":


### PR DESCRIPTION
I just notice that a lot of rllib tests don't have the exclusive tags (https://github.com/ray-project/ray/blob/master/rllib/BUILD#L1324), and they run tests serially by passing`--jobs 1` flag to bazel. This causes the tests to be more flaky in civ2 as they start to run in parallel in each docker shard.

Since we move it to civ2 and use docker for parallelization, we need to make sure we run tests serially inside each docker.

Test:
- CI