### PR TITLE
[vSphere Provider] Fix vc conn timout issue

### DIFF
--- a/python/ray/tests/vsphere/test_vsphere_node_provider.py
+++ b/python/ray/tests/vsphere/test_vsphere_node_provider.py
@@ -222,7 +222,7 @@ def test_create_instant_clone_node(mock_wait_task, mock_ic_spec, mock_relo_spec)
     VM.InstantCloneSpec = MagicMock(return_value="Clone Spec")
     vnp.vsphere_sdk_client.vcenter.VM.instant_clone.return_value = "test_id_1"
     vnp.vsphere_sdk_client.vcenter.vm.Power.stop.return_value = None
-    vnp.get_pyvmomi_obj_by_name = MagicMock(return_value=MagicMock())
+    vnp.get_pyvmomi_obj = MagicMock(return_value=MagicMock())
     vnp.set_node_tags = MagicMock(return_value=None)
     vnp.vsphere_sdk_client.vcenter.VM.list = MagicMock(
         return_value=[MagicMock(vm="test VM")]


### PR DESCRIPTION
## Why are these changes needed?

Fixed the issue using SessionOrientedStub. A session-oriented stub adapter that will relogin to the destination if a session-oriented exception is thrown.

Issue here is soap request session is timing out after 30 mins on the server side.

Increasing connectionPoolTimeout Value on the client side or setting it to -1 doesn't solve the issue. Tested it. Issue still persists.This is because connectionPooltimeout parameter only close idle connections from the client side, and if the client connection was idle longer than the timeout value, a new connection will be created automatically. Passing connectionPoolTimeout = -1 does not have any effect on the session timeout. -1 only means client will never close an idle connection. Also, it doesn't mean that the connection will be valid forever. A soap request session will be timeout after 30min on server side, regardless whether or not the client closes the connection.

Fixed the issue using SessionOrientedStub. A session-oriented stub adapter that will relogin to the destination if a session-oriented exception is thrown. The stub starts off in the "unauthenticated" state, so it will call the loginMethod on the first invocation of a method.  If a communication error is encountered, the stub will wait for retryDelay seconds and then try to call the method again.  If the server throws an exception that is in the SESSION_EXCEPTIONS tuple, it will be caught and the stub will transition back into the "unauthenticated" state so that another login will be performed.

Modified the code to use SmartStubAdapter using below as reference: https://github.com/vmware/pyvmomi/blob/912e365564c927dc9201eb6f46262924dc1dd275/pyVmomi/SoapAdapter.py#L1530

https://developer.vmware.com/samples/6889/esxi_certtool?h=connectionPoolTimeout#code

https://github.com/vmware/pyvmomi/issues/347

## Test

After doing Ray up, left the env there for more than 30 mins, 1 hour and 18 hours respectively. Then delete one worker node VM from the vSphere client. Verified that a new worker node is created by autoscaler calling the vSphere API, which proves that the session is still alive.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
