### PR TITLE
Fix ray docker build

### DIFF
--- a/ci/build/build-ray-docker.sh
+++ b/ci/build/build-ray-docker.sh
@@ -9,9 +9,7 @@ PIP_FREEZE_FILE="$5"
 
 CPU_TMP="$(mktemp -d)"
 
-mkdir -p "${CPU_TMP}/.whl"
-
-cp .whl/"$WHEEL_NAME" "${CPU_TMP}/.whl/${WHEEL_NAME}"
+cp -r .whl "${CPU_TMP}/.whl"
 cp docker/ray/Dockerfile "${CPU_TMP}/Dockerfile"
 cp python/requirements_compiled.txt "${CPU_TMP}/."
 


### PR DESCRIPTION
Fix ray docker build step. The .whl folder contains both the ray and ray-cpp wheel, and we need to copy both over.

Test:
- CI