### PR TITLE
[Train] Improve loggings for Train worker scheduling information

### DIFF
--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -426,7 +426,7 @@ class BackendExecutor:
         workers_info = "\n".join(
             [
                 f"- (ip={w.metadata.node_ip}, pid={w.metadata.pid}) "
-                f"rank={i}, local_rank={local_rank_map[i]}, node_rank={node_rank_map[i]}"
+                f"world_rank={i}, local_rank={local_rank_map[i]}, node_rank={node_rank_map[i]}"
                 for i, w in enumerate(self.worker_group.workers)
             ]
         )

--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -152,13 +152,6 @@ class BackendExecutor:
         trial_driver_ip = self._trial_info.driver_ip if self._trial_info else None
         self.worker_group.group_workers_by_ip(trial_driver_ip)
 
-        worker_locs = [
-            f"rank {i}: {w.metadata.pid} ({w.metadata.node_ip})"
-            for i, w in enumerate(self.worker_group.workers)
-        ]
-        worker_locs_repr = "\n".join(worker_locs)
-        logger.info(f"Starting distributed worker processes: \n{worker_locs_repr}")
-
         try:
             if initialization_hook:
                 self._initialization_hook = initialization_hook
@@ -429,6 +422,13 @@ class BackendExecutor:
             worker = self.worker_group.workers[world_rank]
             node_ip = worker.metadata.node_ip
             local_world_size_map[world_rank] = ip_dict[node_ip]
+
+        workers_info = "\n".join([
+            f"- (ip={w.metadata.node_ip}, pid={w.metadata.pid}) "
+            f"rank={i}, local_rank={local_rank_map[i]}, node_rank={node_rank_map[i]}"
+            for i, w in enumerate(self.worker_group.workers)
+        ])
+        logger.info(f"Started distributed worker processes: \n{workers_info}")
 
         return local_rank_map, local_world_size_map, node_rank_map
 

--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -423,11 +423,13 @@ class BackendExecutor:
             node_ip = worker.metadata.node_ip
             local_world_size_map[world_rank] = ip_dict[node_ip]
 
-        workers_info = "\n".join([
-            f"- (ip={w.metadata.node_ip}, pid={w.metadata.pid}) "
-            f"rank={i}, local_rank={local_rank_map[i]}, node_rank={node_rank_map[i]}"
-            for i, w in enumerate(self.worker_group.workers)
-        ])
+        workers_info = "\n".join(
+            [
+                f"- (ip={w.metadata.node_ip}, pid={w.metadata.pid}) "
+                f"rank={i}, local_rank={local_rank_map[i]}, node_rank={node_rank_map[i]}"
+                for i, w in enumerate(self.worker_group.workers)
+            ]
+        )
         logger.info(f"Started distributed worker processes: \n{workers_info}")
 
         return local_rank_map, local_world_size_map, node_rank_map

--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -153,10 +153,11 @@ class BackendExecutor:
         self.worker_group.group_workers_by_ip(trial_driver_ip)
 
         worker_locs = [
-            f"{w.metadata.pid} ({w.metadata.node_ip})"
-            for w in self.worker_group.workers
+            f"rank {i}: {w.metadata.pid} ({w.metadata.node_ip})"
+            for i, w in enumerate(self.worker_group.workers)
         ]
-        logger.info(f"Starting distributed worker processes: {worker_locs}")
+        worker_locs_repr = "\n".join(worker_locs)
+        logger.info(f"Starting distributed worker processes: \n{worker_locs_repr}")
 
         try:
             if initialization_hook:

--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -426,7 +426,8 @@ class BackendExecutor:
         workers_info = "\n".join(
             [
                 f"- (ip={w.metadata.node_ip}, pid={w.metadata.pid}) "
-                f"world_rank={i}, local_rank={local_rank_map[i]}, node_rank={node_rank_map[i]}"
+                f"world_rank={i}, local_rank={local_rank_map[i]}, "
+                f"node_rank={node_rank_map[i]}"
                 for i, w in enumerate(self.worker_group.workers)
             ]
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, the placement and ranking information of distributed process groups in the log is unclear. Users must manually print out the world ranking, local ranking, and node IP. This PR improves log messages with more placement information to improve observability and debuggability.

Previous:

```
(TorchTrainer pid=7236) Starting distributed worker processes: ['7410 (10.0.59.242)', '7411 (10.0.59.242)', '7412 (10.0.59.242)', '7413 (10.0.59.242)', '3381 (10.0.12.174)', '3382 (10.0.12.174)', '3383 (10.0.12.174)', '3384 (10.0.12.174)']
```

Now:

```
(TorchTrainer pid=7236) Started distributed worker processes: 
(TorchTrainer pid=7236) - (ip=10.0.59.242, pid=7410) rank=0, local_rank=0, node_rank=0
(TorchTrainer pid=7236) - (ip=10.0.59.242, pid=7411) rank=1, local_rank=1, node_rank=0
(TorchTrainer pid=7236) - (ip=10.0.59.242, pid=7412) rank=2, local_rank=2, node_rank=0
(TorchTrainer pid=7236) - (ip=10.0.59.242, pid=7413) rank=3, local_rank=3, node_rank=0
(TorchTrainer pid=7236) - (ip=10.0.12.174, pid=3381) rank=4, local_rank=0, node_rank=1
(TorchTrainer pid=7236) - (ip=10.0.12.174, pid=3382) rank=5, local_rank=1, node_rank=1
(TorchTrainer pid=7236) - (ip=10.0.12.174, pid=3383) rank=6, local_rank=2, node_rank=1
(TorchTrainer pid=7236) - (ip=10.0.12.174, pid=3384) rank=7, local_rank=3, node_rank=1
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
