### PR TITLE
[wheel] skip cpp wheel building when env set

### DIFF
--- a/ci/build/build-manylinux-wheel.sh
+++ b/ci/build/build-manylinux-wheel.sh
@@ -25,9 +25,12 @@ fi
 PATH="/opt/python/${PYTHON}/bin:$PATH" RAY_INSTALL_JAVA=0 \
 "/opt/python/${PYTHON}/bin/python" setup.py -q bdist_wheel
 
-# build ray-cpp wheel
-PATH="/opt/python/${PYTHON}/bin:$PATH" RAY_INSTALL_JAVA=0 \
-RAY_INSTALL_CPP=1 "/opt/python/${PYTHON}/bin/python" setup.py -q bdist_wheel
+
+if [[ "${RAY_DISABLE_EXTRA_CPP:-}" != 1 ]]; then
+  # build ray-cpp wheel
+  PATH="/opt/python/${PYTHON}/bin:$PATH" RAY_INSTALL_JAVA=0 \
+  RAY_INSTALL_CPP=1 "/opt/python/${PYTHON}/bin/python" setup.py -q bdist_wheel
+fi
 
 # Rename the wheels so that they can be uploaded to PyPI. TODO(rkn): This is a
 # hack, we should use auditwheel instead.

--- a/ci/ray_ci/builder_container.py
+++ b/ci/ray_ci/builder_container.py
@@ -39,6 +39,12 @@ class BuilderContainer(Container):
         cmds = []
         if self.build_type == "debug":
             cmds += ["export RAY_DEBUG_BUILD=debug"]
+
+        if os.environ.get("RAYCI_DISABLE_CPP_WHEEL") == "true":
+            cmds += ["export RAY_DISABLE_EXTRA_CPP=1"]
+        if os.environ.get("RAYCI_DISABLE_JAVA", "") == "true":
+            cmds += ["export RAY_INSTALL_JAVA=0"]
+
         cmds += [
             "./ci/build/build-manylinux-ray.sh",
             f"./ci/build/build-manylinux-wheel.sh {self.bin_path} {self.numpy_version}",


### PR DESCRIPTION
when RAY_DISABLE_EXTRA_CPP is set to 1

also allow disabling cpp / java build with build job environment variables.