### PR TITLE
[data] add block/user time to ray data dashboard

### DIFF
--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -204,6 +204,38 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
         title: "Bytes Outputted",
         pathParams: "orgId=1&theme=light&panelId=7",
       },
+      {
+        title: "Iteration Wait Time",
+        pathParams: "orgId=1&theme=light&panelId=8",
+      },
+      {
+        title: "Iteration Get Time",
+        pathParams: "orgId=1&theme=light&panelId=9",
+      },
+      {
+        title: "Iteration Next Batch Time",
+        pathParams: "orgId=1&theme=light&panelId=10",
+      },
+      {
+        title: "Iteration Format Batch Time",
+        pathParams: "orgId=1&theme=light&panelId=11",
+      },
+      {
+        title: "Iteration Collate Batch Time",
+        pathParams: "orgId=1&theme=light&panelId=12",
+      },
+      {
+        title: "Iteration Finalize Batch Time",
+        pathParams: "orgId=1&theme=light&panelId=13",
+      },
+      {
+        title: "Iteration Blocked Time",
+        pathParams: "orgId=1&theme=light&panelId=14",
+      },
+      {
+        title: "Iteration User Time",
+        pathParams: "orgId=1&theme=light&panelId=15",
+      },
     ],
   },
 ];

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -208,6 +208,10 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
         title: "Iteration Blocked Time",
         pathParams: "orgId=1&theme=light&panelId=8",
       },
+      {
+        title: "Iteration User Time",
+        pathParams: "orgId=1&theme=light&panelId=9",
+      },
     ],
   },
 ];

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -205,36 +205,8 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
         pathParams: "orgId=1&theme=light&panelId=7",
       },
       {
-        title: "Iteration Wait Time",
-        pathParams: "orgId=1&theme=light&panelId=8",
-      },
-      {
-        title: "Iteration Get Time",
-        pathParams: "orgId=1&theme=light&panelId=9",
-      },
-      {
-        title: "Iteration Next Batch Time",
-        pathParams: "orgId=1&theme=light&panelId=10",
-      },
-      {
-        title: "Iteration Format Batch Time",
-        pathParams: "orgId=1&theme=light&panelId=11",
-      },
-      {
-        title: "Iteration Collate Batch Time",
-        pathParams: "orgId=1&theme=light&panelId=12",
-      },
-      {
-        title: "Iteration Finalize Batch Time",
-        pathParams: "orgId=1&theme=light&panelId=13",
-      },
-      {
         title: "Iteration Blocked Time",
-        pathParams: "orgId=1&theme=light&panelId=14",
-      },
-      {
-        title: "Iteration User Time",
-        pathParams: "orgId=1&theme=light&panelId=15",
+        pathParams: "orgId=1&theme=light&panelId=8",
       },
     ],
   },

--- a/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -103,6 +103,18 @@ DATA_GRAFANA_PANELS = [
             )
         ],
     ),
+    Panel(
+        id=9,
+        title="Iteration User Time",
+        description="Seconds spent in user code",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_data_iter_user_seconds{{{global_filters}}}) by (dataset)",
+                legend="Seconds: {{dataset}}",
+            )
+        ],
+    ),
 ]
 
 ids = []

--- a/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -91,6 +91,102 @@ DATA_GRAFANA_PANELS = [
             )
         ],
     ),
+    Panel(
+        id=8,
+        title="Iteration Wait Time",
+        description="Seconds spent in ray.wait()",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_data_iter_wait_seconds{{{global_filters}}}) by (dataset)",
+                legend="Seconds: {{dataset}}",
+            )
+        ],
+    ),
+    Panel(
+        id=9,
+        title="Iteration Get Time",
+        description="Seconds spent in ray.get()",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_data_iter_get_seconds{{{global_filters}}}) by (dataset)",
+                legend="Seconds: {{dataset}}",
+            )
+        ],
+    ),
+    Panel(
+        id=10,
+        title="Iteration Next Batch Time",
+        description="Seconds spent in next_batch()",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_data_iter_next_seconds{{{global_filters}}}) by (dataset)",
+                legend="Seconds: {{dataset}}",
+            )
+        ],
+    ),
+    Panel(
+        id=11,
+        title="Iteration Format Batch Time",
+        description="Seconds spent in format_batch()",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_data_iter_format_batch_seconds{{{global_filters}}}) by (dataset)",
+                legend="Seconds: {{dataset}}",
+            )
+        ],
+    ),
+    Panel(
+        id=12,
+        title="Iteration Collate Batch Time",
+        description="Seconds spent in collate_fn()",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_data_iter_collate_batch_seconds{{{global_filters}}}) by (dataset)",
+                legend="Seconds: {{dataset}}",
+            )
+        ],
+    ),
+    Panel(
+        id=13,
+        title="Iteration Finalize Batch Time",
+        description="Seconds spent in finalize_fn()",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_data_iter_finalize_batch_seconds{{{global_filters}}}) by (dataset)",
+                legend="Seconds: {{dataset}}",
+            )
+        ],
+    ),
+    Panel(
+        id=14,
+        title="Iteration Blocked Time",
+        description="Seconds user thread is blocked by iter_batches()",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_data_iter_total_blocked_seconds{{{global_filters}}}) by (dataset)",
+                legend="Seconds: {{dataset}}",
+            )
+        ],
+    ),
+    Panel(
+        id=15,
+        title="Iteration User Time",
+        description="Seconds spent in user code",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_data_iter_user_seconds{{{global_filters}}}) by (dataset)",
+                legend="Seconds: {{dataset}}",
+            )
+        ],
+    ),
 ]
 
 ids = []

--- a/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -93,96 +93,12 @@ DATA_GRAFANA_PANELS = [
     ),
     Panel(
         id=8,
-        title="Iteration Wait Time",
-        description="Seconds spent in ray.wait()",
-        unit="seconds",
-        targets=[
-            Target(
-                expr="sum(ray_data_iter_wait_seconds{{{global_filters}}}) by (dataset)",
-                legend="Seconds: {{dataset}}",
-            )
-        ],
-    ),
-    Panel(
-        id=9,
-        title="Iteration Get Time",
-        description="Seconds spent in ray.get()",
-        unit="seconds",
-        targets=[
-            Target(
-                expr="sum(ray_data_iter_get_seconds{{{global_filters}}}) by (dataset)",
-                legend="Seconds: {{dataset}}",
-            )
-        ],
-    ),
-    Panel(
-        id=10,
-        title="Iteration Next Batch Time",
-        description="Seconds spent in next_batch()",
-        unit="seconds",
-        targets=[
-            Target(
-                expr="sum(ray_data_iter_next_seconds{{{global_filters}}}) by (dataset)",
-                legend="Seconds: {{dataset}}",
-            )
-        ],
-    ),
-    Panel(
-        id=11,
-        title="Iteration Format Batch Time",
-        description="Seconds spent in format_batch()",
-        unit="seconds",
-        targets=[
-            Target(
-                expr="sum(ray_data_iter_format_batch_seconds{{{global_filters}}}) by (dataset)",
-                legend="Seconds: {{dataset}}",
-            )
-        ],
-    ),
-    Panel(
-        id=12,
-        title="Iteration Collate Batch Time",
-        description="Seconds spent in collate_fn()",
-        unit="seconds",
-        targets=[
-            Target(
-                expr="sum(ray_data_iter_collate_batch_seconds{{{global_filters}}}) by (dataset)",
-                legend="Seconds: {{dataset}}",
-            )
-        ],
-    ),
-    Panel(
-        id=13,
-        title="Iteration Finalize Batch Time",
-        description="Seconds spent in finalize_fn()",
-        unit="seconds",
-        targets=[
-            Target(
-                expr="sum(ray_data_iter_finalize_batch_seconds{{{global_filters}}}) by (dataset)",
-                legend="Seconds: {{dataset}}",
-            )
-        ],
-    ),
-    Panel(
-        id=14,
         title="Iteration Blocked Time",
         description="Seconds user thread is blocked by iter_batches()",
         unit="seconds",
         targets=[
             Target(
                 expr="sum(ray_data_iter_total_blocked_seconds{{{global_filters}}}) by (dataset)",
-                legend="Seconds: {{dataset}}",
-            )
-        ],
-    ),
-    Panel(
-        id=15,
-        title="Iteration User Time",
-        description="Seconds spent in user code",
-        unit="seconds",
-        targets=[
-            Target(
-                expr="sum(ray_data_iter_user_seconds{{{global_filters}}}) by (dataset)",
                 legend="Seconds: {{dataset}}",
             )
         ],

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -15,7 +15,11 @@ from ray.data._internal.block_batching.util import (
     resolve_block_refs,
 )
 from ray.data._internal.memory_tracing import trace_deallocation
-from ray.data._internal.stats import DatasetStats
+from ray.data._internal.stats import (
+    DatasetStats,
+    clear_stats_actor_iter_metrics,
+    update_stats_actor_iter_metrics,
+)
 from ray.data._internal.util import make_async_gen
 from ray.data.block import Block, BlockMetadata, DataBatch
 from ray.data.context import DataContext
@@ -36,6 +40,7 @@ def iter_batches(
     shuffle_seed: Optional[int] = None,
     ensure_copy: bool = False,
     prefetch_batches: int = 1,
+    dataset_tag: str = "unknown_dataset",
 ) -> Iterator[DataBatch]:
     """Create formatted batches of data from an iterator of block object references and
     corresponding metadata.
@@ -169,6 +174,7 @@ def iter_batches(
     # Run everything in a separate thread to not block the main thread when waiting
     # for streaming results.
     async_batch_iter = make_async_gen(block_refs, fn=_async_iter_batches, num_workers=1)
+    metrics_tag = {"dataset": dataset_tag}
 
     while True:
         with stats.iter_total_blocked_s.timer() if stats else nullcontext():
@@ -178,6 +184,8 @@ def iter_batches(
                 break
         with stats.iter_user_s.timer() if stats else nullcontext():
             yield next_batch
+        update_stats_actor_iter_metrics(stats, metrics_tag)
+    clear_stats_actor_iter_metrics(metrics_tag)
 
 
 def _format_in_threadpool(

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -28,6 +28,7 @@ from ray.types import ObjectRef
 
 def iter_batches(
     block_refs: Iterator[Tuple[ObjectRef[Block], BlockMetadata]],
+    dataset_tag: str,
     *,
     stats: Optional[DatasetStats] = None,
     clear_block_after_read: bool = False,
@@ -40,7 +41,6 @@ def iter_batches(
     shuffle_seed: Optional[int] = None,
     ensure_copy: bool = False,
     prefetch_batches: int = 1,
-    dataset_tag: str = "unknown_dataset",
 ) -> Iterator[DataBatch]:
     """Create formatted batches of data from an iterator of block object references and
     corresponding metadata.
@@ -135,7 +135,6 @@ def iter_batches(
             num_batches_to_prefetch=prefetch_batches,
             batch_size=batch_size,
             eager_free=eager_free,
-            stats=stats,
         )
 
         # Step 2: Resolve the blocks.
@@ -243,7 +242,6 @@ def prefetch_batches_locally(
     num_batches_to_prefetch: int,
     batch_size: Optional[int],
     eager_free: bool = False,
-    stats: Optional[DatasetStats] = None,
 ) -> Iterator[ObjectRef[Block]]:
     """Given an iterator of batched block references, returns an iterator over the same
     block references while prefetching `num_batches_to_prefetch` batches in advance.
@@ -284,8 +282,7 @@ def prefetch_batches_locally(
         sliding_window.append(next_block_ref_and_metadata)
         current_window_size += next_block_ref_and_metadata[1].num_rows
 
-    with stats.iter_wait_s.timer() if stats else nullcontext():
-        prefetcher.prefetch_blocks([block_ref for block_ref, _ in list(sliding_window)])
+    prefetcher.prefetch_blocks([block_ref for block_ref, _ in list(sliding_window)])
 
     while sliding_window:
         block_ref, metadata = sliding_window.popleft()
@@ -293,10 +290,9 @@ def prefetch_batches_locally(
         if batch_size is None or current_window_size < num_rows_to_prefetch:
             try:
                 sliding_window.append(next(block_ref_iter))
-                with stats.iter_wait_s.timer() if stats else nullcontext():
-                    prefetcher.prefetch_blocks(
-                        [block_ref for block_ref, _ in list(sliding_window)]
-                    )
+                prefetcher.prefetch_blocks(
+                    [block_ref for block_ref, _ in list(sliding_window)]
+                )
             except StopIteration:
                 pass
         yield block_ref

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -62,7 +62,7 @@ class StreamingExecutor(Executor, threading.Thread):
     a way that maximizes throughput under resource constraints.
     """
 
-    def __init__(self, options: ExecutionOptions, dataset_uuid: str = "unknown_uuid"):
+    def __init__(self, options: ExecutionOptions, dataset_tag: str = "unknown_dataset"):
         self._start_time: Optional[float] = None
         self._initial_stats: Optional[DatasetStats] = None
         self._final_stats: Optional[DatasetStats] = None
@@ -82,7 +82,7 @@ class StreamingExecutor(Executor, threading.Thread):
         self._output_node: Optional[OpState] = None
         self._backpressure_policies: List[BackpressurePolicy] = []
 
-        self._dataset_uuid = dataset_uuid
+        self._dataset_tag = dataset_tag
 
         Executor.__init__(self, options)
         thread_name = f"StreamingExecutor-{self._execution_id}"
@@ -208,7 +208,7 @@ class StreamingExecutor(Executor, threading.Thread):
             self._output_node.outqueue.append(None)
             # Clears metrics for this dataset so that they do
             # not persist in the grafana dashboard after execution
-            clear_stats_actor_metrics({"dataset": self._dataset_uuid})
+            clear_stats_actor_metrics({"dataset": self._dataset_tag})
 
     def get_stats(self):
         """Return the stats object for the streaming execution.
@@ -290,7 +290,7 @@ class StreamingExecutor(Executor, threading.Thread):
             op_state.refresh_progress_bar()
 
         update_stats_actor_metrics(
-            [op.metrics for op in self._topology], {"dataset": self._dataset_uuid}
+            [op.metrics for op in self._topology], {"dataset": self._dataset_tag}
         )
 
         # Keep going until all operators run to completion.

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -62,7 +62,7 @@ class StreamingExecutor(Executor, threading.Thread):
     a way that maximizes throughput under resource constraints.
     """
 
-    def __init__(self, options: ExecutionOptions, dataset_tag: str = "unknown_dataset"):
+    def __init__(self, options: ExecutionOptions, dataset_uuid: str = "unknown_uuid"):
         self._start_time: Optional[float] = None
         self._initial_stats: Optional[DatasetStats] = None
         self._final_stats: Optional[DatasetStats] = None
@@ -82,7 +82,7 @@ class StreamingExecutor(Executor, threading.Thread):
         self._output_node: Optional[OpState] = None
         self._backpressure_policies: List[BackpressurePolicy] = []
 
-        self._dataset_tag = dataset_tag
+        self._dataset_uuid = dataset_uuid
 
         Executor.__init__(self, options)
         thread_name = f"StreamingExecutor-{self._execution_id}"
@@ -208,7 +208,7 @@ class StreamingExecutor(Executor, threading.Thread):
             self._output_node.outqueue.append(None)
             # Clears metrics for this dataset so that they do
             # not persist in the grafana dashboard after execution
-            clear_stats_actor_metrics({"dataset": self._dataset_tag})
+            clear_stats_actor_metrics({"dataset": self._dataset_uuid})
 
     def get_stats(self):
         """Return the stats object for the streaming execution.
@@ -290,7 +290,7 @@ class StreamingExecutor(Executor, threading.Thread):
             op_state.refresh_progress_bar()
 
         update_stats_actor_metrics(
-            [op.metrics for op in self._topology], {"dataset": self._dataset_tag}
+            [op.metrics for op in self._topology], {"dataset": self._dataset_uuid}
         )
 
         # Keep going until all operators run to completion.

--- a/python/ray/data/_internal/iterator/iterator_impl.py
+++ b/python/ray/data/_internal/iterator/iterator_impl.py
@@ -56,3 +56,6 @@ class DataIteratorImpl(DataIterator):
             )
 
         raise AttributeError()
+
+    def _get_dataset_tag(self):
+        return (self._base_dataset._plan._dataset_name or "") + self._base_dataset._uuid

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -184,46 +184,9 @@ class _StatsActor:
             description="Bytes outputted by dataset operators",
             tag_keys=tags_keys,
         )
-
-        # Iteration timer metrics
-        self.iter_wait_s = Gauge(
-            "data_iter_wait_seconds",
-            description="Seconds spent in ray.wait()",
-            tag_keys=tags_keys,
-        )
-        self.iter_get_s = Gauge(
-            "data_iter_get_seconds",
-            description="Seconds spent in ray.get()",
-            tag_keys=tags_keys,
-        )
-        self.iter_next_batch_s = Gauge(
-            "data_iter_next_seconds",
-            description="Seconds spent in next_batch()",
-            tag_keys=tags_keys,
-        )
-        self.iter_format_batch_s = Gauge(
-            "data_iter_format_batch_seconds",
-            description="Seconds spent in format_batch()",
-            tag_keys=tags_keys,
-        )
-        self.iter_collate_batch_s = Gauge(
-            "data_iter_collate_batch_seconds",
-            description="Seconds spent in collate_fn()",
-            tag_keys=tags_keys,
-        )
-        self.iter_finalize_batch_s = Gauge(
-            "data_iter_finalize_batch_seconds",
-            description="Seconds spent in finalize_fn()",
-            tag_keys=tags_keys,
-        )
         self.iter_total_blocked_s = Gauge(
             "data_iter_total_blocked_seconds",
             description="Seconds user thread is blocked by iter_batches()",
-            tag_keys=tags_keys,
-        )
-        self.iter_user_s = Gauge(
-            "data_iter_user_seconds",
-            description="Seconds spent in user code",
             tag_keys=tags_keys,
         )
 
@@ -272,14 +235,7 @@ class _StatsActor:
         self.gpu_usage.set(stats["gpu_usage"], tags)
 
     def update_iter_metrics(self, stats: "DatasetStats", tags):
-        self.iter_wait_s.set(stats.iter_wait_s.get(), tags)
-        self.iter_get_s.set(stats.iter_get_s.get(), tags)
-        self.iter_next_batch_s.set(stats.iter_next_batch_s.get(), tags)
-        self.iter_format_batch_s.set(stats.iter_format_batch_s.get(), tags)
-        self.iter_collate_batch_s.set(stats.iter_collate_batch_s.get(), tags)
-        self.iter_finalize_batch_s.set(stats.iter_finalize_batch_s.get(), tags)
         self.iter_total_blocked_s.set(stats.iter_total_blocked_s.get(), tags)
-        self.iter_user_s.set(stats.iter_user_s.get(), tags)
 
     def clear_metrics(self, tags: Dict[str, str]):
         self.bytes_spilled.set(0, tags)
@@ -291,14 +247,7 @@ class _StatsActor:
         self.gpu_usage.set(0, tags)
 
     def clear_iter_metrics(self, tags: Dict[str, str]):
-        self.iter_wait_s.set(0, tags)
-        self.iter_get_s.set(0, tags)
-        self.iter_next_batch_s.set(0, tags)
-        self.iter_format_batch_s.set(0, tags)
-        self.iter_collate_batch_s.set(0, tags)
-        self.iter_finalize_batch_s.set(0, tags)
         self.iter_total_blocked_s.set(0, tags)
-        self.iter_user_s.set(0, tags)
 
 
 def _get_or_create_stats_actor():

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -185,6 +185,7 @@ class _StatsActor:
             tag_keys=tags_keys,
         )
 
+        # Iteration timer metrics
         self.iter_wait_s = Gauge(
             "data_iter_wait_seconds",
             description="Seconds spent in ray.wait()",
@@ -217,7 +218,7 @@ class _StatsActor:
         )
         self.iter_total_blocked_s = Gauge(
             "data_iter_total_blocked_seconds",
-            description="Seconds user thread is blocked by iter_batches",
+            description="Seconds user thread is blocked by iter_batches()",
             tag_keys=tags_keys,
         )
         self.iter_user_s = Gauge(

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -189,6 +189,11 @@ class _StatsActor:
             description="Seconds user thread is blocked by iter_batches()",
             tag_keys=tags_keys,
         )
+        self.iter_user_s = Gauge(
+            "data_iter_user_seconds",
+            description="Seconds spent in user code",
+            tag_keys=tags_keys,
+        )
 
     def record_start(self, stats_uuid):
         self.start_time[stats_uuid] = time.perf_counter()
@@ -236,6 +241,7 @@ class _StatsActor:
 
     def update_iter_metrics(self, stats: "DatasetStats", tags):
         self.iter_total_blocked_s.set(stats.iter_total_blocked_s.get(), tags)
+        self.iter_user_s.set(stats.iter_user_s.get(), tags)
 
     def clear_metrics(self, tags: Dict[str, str]):
         self.bytes_spilled.set(0, tags)
@@ -248,6 +254,7 @@ class _StatsActor:
 
     def clear_iter_metrics(self, tags: Dict[str, str]):
         self.iter_total_blocked_s.set(0, tags)
+        self.iter_user_s.set(0, tags)
 
 
 def _get_or_create_stats_actor():

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -176,7 +176,7 @@ class DataIterator(abc.ABC):
                     shuffle_buffer_min_size=local_shuffle_buffer_size,
                     shuffle_seed=local_shuffle_seed,
                     prefetch_batches=prefetch_batches,
-                    metrics_tags=self._get_dataset_tag(),
+                    dataset_tag=self._get_dataset_tag(),
                 )
             )
 

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -176,6 +176,7 @@ class DataIterator(abc.ABC):
                     shuffle_buffer_min_size=local_shuffle_buffer_size,
                     shuffle_seed=local_shuffle_seed,
                     prefetch_batches=prefetch_batches,
+                    metrics_tags=self._get_dataset_tag(),
                 )
             )
 
@@ -186,6 +187,9 @@ class DataIterator(abc.ABC):
                 stats.iter_total_s.add(time.perf_counter() - time_start)
 
         return _IterableFromIterator(_create_iterator)
+
+    def _get_dataset_tag(self) -> str:
+        return "unknown_dataset"
 
     def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterable[Dict[str, Any]]:
         """Return a local row iterable over the dataset.

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -166,6 +166,7 @@ class DataIterator(abc.ABC):
             iterator = iter(
                 iter_batches(
                     block_iterator,
+                    dataset_tag=self._get_dataset_tag(),
                     stats=stats,
                     clear_block_after_read=blocks_owned_by_consumer,
                     batch_size=batch_size,
@@ -176,7 +177,6 @@ class DataIterator(abc.ABC):
                     shuffle_buffer_min_size=local_shuffle_buffer_size,
                     shuffle_seed=local_shuffle_seed,
                     prefetch_batches=prefetch_batches,
-                    dataset_tag=self._get_dataset_tag(),
                 )
             )
 

--- a/python/ray/data/tests/block_batching/test_iter_batches.py
+++ b/python/ray/data/tests/block_batching/test_iter_batches.py
@@ -120,6 +120,7 @@ def test_finalize_fn_uses_single_thread(ray_start_regular_shared):
     # even if prefetch_batches is set.
     output_batches = iter_batches(
         block_refs_iter,
+        dataset_tag="dataset",
         collate_fn=lambda batch: batch,
         finalize_fn=finalize_enforce_single_thread,
         prefetch_batches=4,
@@ -156,6 +157,7 @@ def test_iter_batches_e2e(
 
     output_batches = iter_batches(
         block_refs_iter,
+        dataset_tag="dataset",
         batch_size=batch_size,
         prefetch_batches=prefetch_batches,
         batch_format="pandas",
@@ -200,7 +202,11 @@ def test_iter_batches_e2e_async(ray_start_regular_shared):
     )
     start_time = time.time()
     output_batches = iter_batches(
-        block_refs_iter, batch_size=None, collate_fn=collate_fn, prefetch_batches=4
+        block_refs_iter,
+        dataset_tag="dataset",
+        batch_size=None,
+        collate_fn=collate_fn,
+        prefetch_batches=4,
     )
     batches = []
     for batch in output_batches:

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -145,6 +145,14 @@ def patch_update_stats_actor():
         yield update_fn
 
 
+@contextmanager
+def patch_update_stats_actor_iter():
+    with patch(
+        "ray.data._internal.block_batching.iter_batches.update_stats_actor_iter_metrics"
+    ) as update_fn:
+        yield update_fn
+
+
 def test_streaming_split_stats(ray_start_regular_shared):
     ds = ray.data.range(1000, parallelism=10)
     it = ds.map_batches(dummy_map_batches).streaming_split(1)[0]
@@ -1160,7 +1168,7 @@ Dataset memory:
 
 
 def test_stats_actor_metrics():
-    ray.init(object_store_memory=100e6, num_gpus=1)
+    ray.init(object_store_memory=100e6)
     with patch_update_stats_actor() as update_fn:
         ds = ray.data.range(1000 * 80 * 80 * 4).map_batches(lambda x: x).materialize()
 
@@ -1180,6 +1188,18 @@ def test_stats_actor_metrics():
     # There should be nothing in object store at the end of execution.
     assert final_metric.obj_store_mem_cur == 0
 
+    assert ds._uuid == update_fn.call_args_list[-1].args[1]["dataset"]
+
+
+def test_stats_actor_iter_metrics():
+    ds = ray.data.range(1e6).map_batches(lambda x: x)
+    with patch_update_stats_actor_iter() as update_fn:
+        ds.take_all()
+
+    ds_stats = ds._plan.stats()
+    final_stats = update_fn.call_args_list[-1].args[0]
+
+    assert final_stats == ds_stats
     assert ds._uuid == update_fn.call_args_list[-1].args[1]["dataset"]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds block time and user time from`IterStatsSummary` to `_StatsActor`.  Collected at each loop of `iter_batches`.

<img width="1728" alt="Screenshot 2023-10-23 at 2 39 22 PM" src="https://github.com/ray-project/ray/assets/39287272/c2626733-9ef4-410f-83d9-5d26897efb1c">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
