### PR TITLE
[dashboard] ignore reinit error when getting dashboard url

### DIFF
--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -575,7 +575,7 @@ def ray_client_address_to_api_server_url(address: str):
     Returns:
         str: The API server URL of the cluster, e.g. "http://<head-node-ip>:8265".
     """
-    with ray.init(address=address) as client_context:
+    with ray.init(address=address, ignore_reinit_error=True) as client_context:
         dashboard_url = client_context.dashboard_url
 
     return f"http://{dashboard_url}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In've encountered this issue when creating a `JobSubmissionClient` from an already connected Ray application and using `ray://` address. 
Seems like `ignore_reinit_error=True` should fix this.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
