### PR TITLE
[ci] migrate doc gpu examples

### DIFF
--- a/.buildkite/_forge.rayci.yml
+++ b/.buildkite/_forge.rayci.yml
@@ -157,3 +157,7 @@ steps:
       IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_gpu
       IMAGE_TO: mlgpubuild
       RAYCI_IS_GPU_BUILD: "true"
+
+  - name: docgpubuild
+    wanda: ci/docker/docgpu.build.wanda.yaml
+    depends_on: oss-ci-base_gpu

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -48,6 +48,19 @@ steps:
     depends_on: datanbuild
     job_env: forge
 
+  - label: ":database: data: doc gpu"
+    tags: 
+      - data
+      - ci_doc
+      - gpu
+    instance_type: gpu-large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //doc/... data 
+        --build-name docgpubuild
+        --only-tags gpu
+    depends_on: docgpubuild
+    job_env: forge
+
   - label: ":database: data: flaky tests"
     tags: 
       - python

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -114,7 +114,6 @@ steps:
         --parallelism-per-worker 2
         --build-name mlgpubuild
         --only-tags gpu,gpu_only
-        --except-tags doctest
     depends_on: mlgpubuild
     job_env: forge
 

--- a/.buildkite/pipeline.gpu_large.yml
+++ b/.buildkite/pipeline.gpu_large.yml
@@ -1,37 +1,5 @@
 #ci:group=Large GPU tests
 
-- label: ":tv: :book: Doc GPU tests and examples"
-  conditions:
-    ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_TUNE_AFFECTED", "RAY_CI_DOC_AFFECTED"]
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - DOC_TESTING=1 TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh
-    - pip install -Ur ./python/requirements/ml/dl-gpu-requirements.txt
-    - ./ci/env/env_info.sh
-    # Test examples with newer version of `transformers`
-    # TODO(amogkam): Remove when https://github.com/ray-project/ray/issues/36011
-    # is resolved.
-    - pip install -U transformers
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=gpu,-timeseries_libs,-post_wheel_build,-doctest,-team:ml 
-      doc/...
-
-- label: ":book: Doctest (GPU)"
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - DOC_TESTING=1 TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh
-    - pip install -Ur ./python/requirements/ml/dl-gpu-requirements.txt
-    - ./ci/env/install-horovod.sh
-    # Test examples with newer version of `transformers`
-    # TODO(amogkam): Remove when https://github.com/ray-project/ray/issues/36011 
-    # is resolved.
-    # TODO(scottjlee): Move datasets to train/data-test-requirements.txt 
-    # (see https://github.com/ray-project/ray/pull/38432/)
-    - pip install transformers==4.30.2 datasets==2.14.0
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./scripts/bazel_export_options)
-      --test_tag_filters=doctest,-cpu
-      python/ray/... doc/...
-
 - label: ":zap: :python: Lightning 2.0 Train GPU tests"
   conditions:
     ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED"]

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -60,6 +60,18 @@ steps:
         --only-tags minimal
     depends_on: minbuild-serve
     job_env: forge
+
+  - label: ":ray-serve: serve: doc gpu tests"
+    tags: 
+      - serve
+      - ci_doc
+    instance_type: gpu
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //doc/... serve 
+        --build-name docgpubuild
+        --only-tags gpu
+    depends_on: docgpubuild
+    job_env: forge
   
   - label: ":ray-serve: serve: flaky tests"
     tags: 

--- a/ci/docker/docgpu.build.Dockerfile
+++ b/ci/docker/docgpu.build.Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1.3-labs
+
+ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_gpu
+FROM $DOCKER_IMAGE_BASE_BUILD
+
+# Unset dind settings; we are using the host's docker daemon.
+ENV DOCKER_TLS_CERTDIR=
+ENV DOCKER_HOST=
+ENV DOCKER_TLS_VERIFY=
+ENV DOCKER_CERT_PATH=
+
+SHELL ["/bin/bash", "-ice"]
+
+COPY . .
+
+RUN <<EOF
+#!/bin/bash
+
+set -euo pipefail
+
+DOC_TESTING=1 TRAIN_TESTING=1 TUNE_TESTING=1 ci/env/install-dependencies.sh
+pip install -Ur ./python/requirements/ml/dl-gpu-requirements.txt
+
+# TODO(amogkam): Remove when https://github.com/ray-project/ray/issues/36011 
+# is resolved.
+pip install -U transformers==4.34.1
+
+EOF

--- a/ci/docker/docgpu.build.wanda.yaml
+++ b/ci/docker/docgpu.build.wanda.yaml
@@ -1,0 +1,19 @@
+name: "docgpubuild"
+froms: ["cr.ray.io/rayproject/oss-ci-base_gpu"]
+dockerfile: ci/docker/docgpu.build.Dockerfile
+srcs:
+  - ci/env/install-dependencies.sh
+  - python/requirements.txt
+  - python/requirements_compiled.txt
+  - python/requirements/test-requirements.txt
+  - python/requirements/ml/core-requirements.txt
+  - python/requirements/ml/dl-cpu-requirements.txt
+  - python/requirements/ml/dl-gpu-requirements.txt
+  - python/requirements/ml/train-requirements.txt
+  - python/requirements/ml/train-test-requirements.txt
+  - python/requirements/ml/tune-requirements.txt
+  - python/requirements/ml/tune-test-requirements.txt
+  - python/requirements/ml/data-requirements.txt
+  - python/requirements/ml/data-test-requirements.txt
+tags:
+  - cr.ray.io/rayproject/docgpubuild

--- a/ci/docker/ml.build.Dockerfile
+++ b/ci/docker/ml.build.Dockerfile
@@ -15,8 +15,8 @@ COPY . .
 
 # TODO (can): Move mosaicml to train-test-requirements.txt
 RUN pip install "mosaicml==0.12.1"
-RUN TRAIN_TESTING=1 TUNE_TESTING=1 DATA_PROCESSING_TESTING=1 INSTALL_HOROVOD=1 \
-  ./ci/env/install-dependencies.sh
+RUN DOC_TESTING=1 TRAIN_TESTING=1 TUNE_TESTING=1 \
+  DATA_PROCESSING_TESTING=1 INSTALL_HOROVOD=1 ./ci/env/install-dependencies.sh
 
 RUN if [[ "$RAYCI_IS_GPU_BUILD" == "true" ]]; then \
   pip install -Ur ./python/requirements/ml/dl-gpu-requirements.txt; \

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -154,7 +154,12 @@ if __name__ == "__main__":
                 RAY_CI_DATA_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
-            elif changed_file.startswith("python/ray/data"):
+            elif (
+                changed_file.startswith("python/ray/data")
+                or changed_file == ".buildkite/data.rayci.yml"
+                or changed_file == "ci/docker/data.build.Dockerfile"
+                or changed_file == "ci/docker/data.build.wanda.yaml"
+            ):
                 RAY_CI_DATA_AFFECTED = 1
                 RAY_CI_ML_AFFECTED = 1
                 RAY_CI_TRAIN_AFFECTED = 1
@@ -180,6 +185,9 @@ if __name__ == "__main__":
             elif (
                 changed_file == ".buildkite/ml.rayci.yml"
                 or changed_file == ".buildkite/pipeline.ml.yml"
+                or changed_file == "ci/docker/ml.build.Dockerfile"
+                or changed_file == ".buildkite/pipeline.gpu.yml"
+                or changed_file == ".buildkite/pipeline.gpu_large.yml"
             ):
                 RAY_CI_ML_AFFECTED = 1
                 RAY_CI_TRAIN_AFFECTED = 1
@@ -188,8 +196,6 @@ if __name__ == "__main__":
                 re.match("^(python/ray/)?rllib/", changed_file)
                 or changed_file == "ray_ci/rllib.tests.yml"
                 or changed_file == ".buildkite/rllib.rayci.yml"
-                or changed_file == ".buildkite/pipeline.gpu.yml"
-                or changed_file == ".buildkite/pipeline.gpu_large.yml"
             ):
                 RAY_CI_RLLIB_AFFECTED = 1
                 RAY_CI_RLLIB_DIRECTLY_AFFECTED = 1


### PR DESCRIPTION
Migrate the two large gpu doc jobs
- Create a gpu doc build
- Use it to run serve + data tests
- Merge the ml example doc tests with the ml gpu jobs, there is only one of such test

Test:
- CI