### PR TITLE
Add secret_env_vars to runtime-env parameter of job submission

### DIFF
--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -27,6 +27,7 @@ from ray._private.utils import get_or_create_event_loop
 from ray._private.runtime_env.plugin import RuntimeEnvPluginManager
 from ray._private.runtime_env.py_modules import PyModulesPlugin
 from ray._private.runtime_env.working_dir import WorkingDirPlugin
+from ray._private.runtime_env.secret_env_vars import SecretEnvVarsPlugin
 from ray._private.runtime_env.nsight import NsightPlugin
 from ray.core.generated import (
     runtime_env_agent_pb2,
@@ -199,6 +200,8 @@ class RuntimeEnvAgent:
         self._working_dir_plugin = WorkingDirPlugin(
             self._runtime_env_dir, self._gcs_aio_client
         )
+        self._secret_env_vars = SecretEnvVarsPlugin()
+
         # TODO(jonathan-anyscale): change the plugin to ProfilerPlugin
         # and unify with nsight and other profilers.
         self._nsight_plugin = NsightPlugin(self._runtime_env_dir)
@@ -214,6 +217,7 @@ class RuntimeEnvAgent:
             self._py_modules_plugin,
             self._java_jars_plugin,
             self._nsight_plugin,
+            self._secret_env_vars,
         ]
         self._plugin_manager = RuntimeEnvPluginManager()
         for plugin in self._base_plugins:

--- a/python/ray/_private/runtime_env/secret_env_vars.py
+++ b/python/ray/_private/runtime_env/secret_env_vars.py
@@ -31,7 +31,8 @@ class SecretEnvVarsPlugin(RuntimeEnvPlugin):
             raise ValueError(
                 f"secret_env_vars must be a dict, got {type(secret_env_vars)}."
             )
-        # Validate each key and value is str. Collect all violations and raise in the end.
+        # Validate each key and value is str.
+        # Collect all violations and raise in the end.
         violations = []
         for key, value in secret_env_vars.items():
             if not isinstance(key, str):
@@ -74,7 +75,8 @@ class SecretEnvVarsPlugin(RuntimeEnvPlugin):
 
         # Add secrets to context env vars.
         encoded_secret_env_vars = runtime_env_dict.get(_PLUGIN_NAME, {})
-        # The secrets are base64 encoded for safety. We decode them before adding to the context.
+        # The secrets are base64 encoded for safety.
+        # We decode them before adding to the context.
         secret_env_vars = decode_secret_env_vars(encoded_secret_env_vars)
         for key, value in secret_env_vars.items():
             context.env_vars[key] = value

--- a/python/ray/_private/runtime_env/secret_env_vars.py
+++ b/python/ray/_private/runtime_env/secret_env_vars.py
@@ -1,0 +1,79 @@
+import logging
+from typing import List, Optional
+
+from ray._private.runtime_env.context import RuntimeEnvContext
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray._private.runtime_env.runtime_env import decode_secret_env_vars
+
+default_logger = logging.getLogger(__name__)
+
+_PLUGIN_NAME = "secret_env_vars"
+
+
+class SecretEnvVarsPlugin(RuntimeEnvPlugin):
+
+    @staticmethod
+    def validate(runtime_env_dict: dict) -> None:
+        """Validate user entry for this plugin.
+
+        Args:
+            runtime_env_dict: the user-supplied runtime environment dict.
+
+        Raises:
+            ValueError: if the validation fails.
+        """
+        
+        if not _PLUGIN_NAME in runtime_env_dict.keys():
+            return
+        
+        secret_env_vars = runtime_env_dict[_PLUGIN_NAME]
+        # Validate the secret_env_vars is ad dict.
+        if not isinstance(secret_env_vars, dict):
+            raise ValueError(
+                f"secret_env_vars must be a dict, got {type(secret_env_vars)}."
+            )
+        # Validate each key and value is str. Collect all violations and raise in the end.
+        violations = []
+        for key, value in secret_env_vars.items():
+            if not isinstance(key, str):
+                violations.append(f"key {key} is of type {type(key)}.")
+            if not isinstance(value, str):
+                violations.append(f"value {value} is of type {type(value)}.")
+        if violations:
+            raise ValueError(
+                "All keys and values in secret_env_vars must be of type str. " + " ".join(violations))
+
+    def delete_uri(
+        self, uri: str, logger: Optional[logging.Logger] = default_logger
+    ) -> int:
+        """Delete URI and return the number of bytes deleted. No-op for this plugin."""
+        return 0
+
+    def get_uris(self, runtime_env: "RuntimeEnv") -> List[str]:  # noqa: F821
+        return []
+
+    async def create(
+        self,
+        uri: Optional[str],
+        runtime_env: dict,
+        context: RuntimeEnvContext,
+        logger: logging.Logger = default_logger,
+    ) -> int:
+        """Create URI and return the number of bytes used. No-op for this plugin."""
+        return 0
+
+    def modify_context(
+        self,
+        uris: List[str],
+        runtime_env_dict: dict,
+        context: RuntimeEnvContext,
+        logger: Optional[logging.Logger] = default_logger,
+    ):
+        """Modify context to change worker startup behavior."""
+
+        # Add secrets to context env vars.
+        encoded_secret_env_vars = runtime_env_dict.get(_PLUGIN_NAME, {})
+        # The secrets are base64 encoded for safety. We decode them before adding to the context.
+        secret_env_vars = decode_secret_env_vars(encoded_secret_env_vars)
+        for key, value in secret_env_vars.items():
+            context.env_vars[key] = value

--- a/python/ray/_private/runtime_env/secret_env_vars.py
+++ b/python/ray/_private/runtime_env/secret_env_vars.py
@@ -22,7 +22,7 @@ class SecretEnvVarsPlugin(RuntimeEnvPlugin):
             ValueError: if the validation fails.
         """
 
-        if not _PLUGIN_NAME in runtime_env_dict.keys():
+        if _PLUGIN_NAME not in runtime_env_dict.keys():
             return
 
         secret_env_vars = runtime_env_dict[_PLUGIN_NAME]
@@ -45,7 +45,7 @@ class SecretEnvVarsPlugin(RuntimeEnvPlugin):
             )
 
     def delete_uri(
-        self, uri: str, logger: Optional[logging.Logger] = default_logger
+        self, uri: str, logger: Optional[logging.Logger] = default_logger  # noqa: F821
     ) -> int:
         """Delete URI and return the number of bytes deleted. No-op for this plugin."""
         return 0
@@ -55,20 +55,20 @@ class SecretEnvVarsPlugin(RuntimeEnvPlugin):
 
     async def create(
         self,
-        uri: Optional[str],
-        runtime_env: dict,
-        context: RuntimeEnvContext,
-        logger: logging.Logger = default_logger,
+        uri: Optional[str],  # noqa: F821
+        runtime_env: dict,  # noqa: F821
+        context: RuntimeEnvContext,  # noqa: F821
+        logger: logging.Logger = default_logger,  # noqa: F821
     ) -> int:
         """Create URI and return the number of bytes used. No-op for this plugin."""
         return 0
 
     def modify_context(
         self,
-        uris: List[str],
+        uris: List[str],  # noqa: F821
         runtime_env_dict: dict,
         context: RuntimeEnvContext,
-        logger: Optional[logging.Logger] = default_logger,
+        logger: Optional[logging.Logger] = default_logger,  # noqa: F821
     ):
         """Modify context to change worker startup behavior."""
 

--- a/python/ray/_private/runtime_env/secret_env_vars.py
+++ b/python/ray/_private/runtime_env/secret_env_vars.py
@@ -11,7 +11,6 @@ _PLUGIN_NAME = "secret_env_vars"
 
 
 class SecretEnvVarsPlugin(RuntimeEnvPlugin):
-
     @staticmethod
     def validate(runtime_env_dict: dict) -> None:
         """Validate user entry for this plugin.
@@ -22,10 +21,10 @@ class SecretEnvVarsPlugin(RuntimeEnvPlugin):
         Raises:
             ValueError: if the validation fails.
         """
-        
+
         if not _PLUGIN_NAME in runtime_env_dict.keys():
             return
-        
+
         secret_env_vars = runtime_env_dict[_PLUGIN_NAME]
         # Validate the secret_env_vars is ad dict.
         if not isinstance(secret_env_vars, dict):
@@ -41,7 +40,9 @@ class SecretEnvVarsPlugin(RuntimeEnvPlugin):
                 violations.append(f"value {value} is of type {type(value)}.")
         if violations:
             raise ValueError(
-                "All keys and values in secret_env_vars must be of type str. " + " ".join(violations))
+                "All keys and values in secret_env_vars must be of type str. "
+                + " ".join(violations)
+            )
 
     def delete_uri(
         self, uri: str, logger: Optional[logging.Logger] = default_logger

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -1,7 +1,7 @@
+import base64
 import json
 import logging
 import os
-import base64
 from copy import deepcopy
 from dataclasses import asdict, is_dataclass
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
@@ -25,27 +25,29 @@ CHAR_ENCODING = "utf-8"
 def encode_secret_env_vars(secret_env_vars: dict) -> dict:
     """Encode secret env vars (values in the dict) to base64.
     This encoding can be used as a mild safety mechanism to avoid printing or logging secrets in plain text.
-    
+
     NOTE: base64 encoding is not a security mechanism and secrets should just not be printed to be secure.
     But the encoding avoids a common mistake of printing secrets in plain text.
-    
+
     Args:
         secret_env_vars: a dict of secret env vars (str -> str).
-    
+
     Returns:
         A dict of encoded secret env vars (str -> str). The keys are the same as the input dict.
         The values are base64 encoded.
     """
     encoded_dict = {}
     for key, value in secret_env_vars.items():
-        encoded_value = base64.b64encode(value.encode(CHAR_ENCODING)).decode(CHAR_ENCODING)
+        encoded_value = base64.b64encode(value.encode(CHAR_ENCODING)).decode(
+            CHAR_ENCODING
+        )
         encoded_dict[key] = encoded_value
     return encoded_dict
 
 
 def decode_secret_env_vars(encoded_env_vars: dict) -> dict:
     """Decode secret env vars (values in the dict) from base64.
-    
+
     Args:
         encoded_env_vars: a dict of encoded secret env vars (str -> str). The values are base64 encoded.
 
@@ -55,7 +57,9 @@ def decode_secret_env_vars(encoded_env_vars: dict) -> dict:
     """
     decoded_dict = {}
     for key, encoded_value in encoded_env_vars.items():
-        decoded_value = base64.b64decode(encoded_value.encode(CHAR_ENCODING)).decode(CHAR_ENCODING)
+        decoded_value = base64.b64decode(encoded_value.encode(CHAR_ENCODING)).decode(
+            CHAR_ENCODING
+        )
         decoded_dict[key] = decoded_value
     return decoded_dict
 
@@ -612,7 +616,9 @@ def _merge_runtime_env(
             return None
         if set(parent_env_vars.keys()).intersection(set(child_env_vars.keys())):  # noqa
             return None
-        if set(parent_secret_env_vars.keys()).intersection(set(child_secret_env_vars.keys())):  # noqa
+        if set(parent_secret_env_vars.keys()).intersection(
+            set(child_secret_env_vars.keys())
+        ):  # noqa
             return None
 
     parent.update(child)

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 CHAR_ENCODING = "utf-8"
 
 
+@PublicAPI(stability="alpha")
 def encode_secret_env_vars(secret_env_vars: dict) -> dict:
     """Encode secret env vars (values in the dict) to base64.
     This encoding can be used as a mild safety mechanism to avoid printing or logging secrets in plain text.
@@ -45,6 +46,7 @@ def encode_secret_env_vars(secret_env_vars: dict) -> dict:
     return encoded_dict
 
 
+@PublicAPI(stability="alpha")
 def decode_secret_env_vars(encoded_env_vars: dict) -> dict:
     """Decode secret env vars (values in the dict) from base64.
 

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -16,13 +16,13 @@ from ray._private.thirdparty.dacite import from_dict
 from ray.core.generated.runtime_env_common_pb2 import (
     RuntimeEnvConfig as ProtoRuntimeEnvConfig,
 )
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI, PublicAPI
 
 logger = logging.getLogger(__name__)
 CHAR_ENCODING = "utf-8"
 
 
-@PublicAPI(stability="alpha")
+@DeveloperAPI
 def encode_secret_env_vars(secret_env_vars: dict) -> dict:
     """Encode secret env vars (values in the dict) to base64.
     This encoding can be used as a mild safety mechanism to avoid printing or logging secrets in plain text.
@@ -46,7 +46,7 @@ def encode_secret_env_vars(secret_env_vars: dict) -> dict:
     return encoded_dict
 
 
-@PublicAPI(stability="alpha")
+@DeveloperAPI
 def decode_secret_env_vars(encoded_env_vars: dict) -> dict:
     """Decode secret env vars (values in the dict) from base64.
 
@@ -241,8 +241,11 @@ class RuntimeEnv(dict):
             "worker_path": "/root/python/ray/_private/workers/default_worker.py",
             "run_options": ["--cap-drop SYS_ADMIN","--log-level=debug"]})
 
-        # Example for set env_vars
+        # Example for setting env_vars
         RuntimeEnv(env_vars={"OMP_NUM_THREADS": "32", "TF_WARNINGS": "none"})
+
+        # Example for setting secret_env_vars
+        RuntimeEnv(secret_env_vars={"AUTH_TOKEN": "<my-auth-bearer-token>"})
 
         # Example for set pip
         RuntimeEnv(
@@ -291,6 +294,7 @@ class RuntimeEnv(dict):
             a dict or a RuntimeEnvConfig. Field: (1) setup_timeout_seconds, the
             timeout of runtime environment creation,  timeout is in seconds.
         secret_env_vars: Secrets to set as environment variables.
+            These secrets are stored in memory as encoded strings, to protect from unintentional logging.
     """
 
     known_fields: Set[str] = {

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -25,16 +25,19 @@ ENCODING_SHIFT = 1
 @DeveloperAPI
 def encode_secret_env_vars(secret_env_vars: dict) -> dict:
     """Encode secret env vars (values in the dict) to base64.
-    This encoding can be used as a mild safety mechanism to avoid printing or logging secrets in plain text.
+    This encoding can be used as a mild safety mechanism to avoid printing or
+    logging secrets in plain text.
 
-    NOTE: base64 encoding is not a security mechanism and secrets should just not be printed to be secure.
+    NOTE: base64 encoding is not a security mechanism and secrets should just
+    not be printed to be secure.
     But the encoding avoids a common mistake of printing secrets in plain text.
 
     Args:
         secret_env_vars: a dict of secret env vars (str -> str).
 
     Returns:
-        A dict of encoded secret env vars (str -> str). The keys are the same as the input dict.
+        A dict of encoded secret env vars (str -> str).
+        The keys are the same as the input dict.
         The values are base64 encoded.
     """
     return {key: _encode_with_shift(value) for key, value in secret_env_vars.items()}
@@ -45,10 +48,12 @@ def decode_secret_env_vars(encoded_env_vars: dict) -> dict:
     """Decode secret env vars (values in the dict) from base64.
 
     Args:
-        encoded_env_vars: a dict of encoded secret env vars (str -> str). The values are base64 encoded.
+        encoded_env_vars: a dict of encoded secret env vars (str -> str).
+        The values are base64 encoded.
 
     Returns:
-        A dict of decoded secret env vars (str -> str). The keys are the same as the input dict.
+        A dict of decoded secret env vars (str -> str).
+        The keys are the same as the input dict.
         The values are base64 decoded.
     """
     return {
@@ -285,7 +290,8 @@ class RuntimeEnv(dict):
             a dict or a RuntimeEnvConfig. Field: (1) setup_timeout_seconds, the
             timeout of runtime environment creation,  timeout is in seconds.
         secret_env_vars: Secrets to set as environment variables.
-            These secrets are stored in memory as encoded strings, to protect from unintentional logging.
+            These secrets are stored in memory as encoded bytes,
+            to protect from unintentional logging.
     """
 
     known_fields: Set[str] = {

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -38,7 +38,7 @@ from ray._private.utils import (
     get_wheel_filename,
 )
 from ray.exceptions import RuntimeEnvSetupError
-from ray.runtime_env import RuntimeEnv
+from ray.runtime_env import RuntimeEnv, encode_secret_env_vars, decode_secret_env_vars
 
 import ray._private.ray_constants as ray_constants
 
@@ -922,6 +922,20 @@ def test_secret_env_vars_available(start_cluster, runtime_env_class):
         return os.environ.get("foo")
 
     assert ray.get(f.remote()) == "bar"
+
+
+@pytest.mark.parametrize(
+    "secret",
+    ["foo", "bar", "!@#@$#@#$#@$@#$#", "12345", "bHWtcH:4JIewdnylJR>>"],
+)
+def test_encode_decode_secret_env_vars(secret):
+    secret_env_vars = {"my-secret": secret}
+    encoded = encode_secret_env_vars(secret_env_vars)
+    decoded = decode_secret_env_vars(encoded)
+    assert decoded == secret_env_vars
+    assert decoded["my-secret"] == secret
+    assert encoded != secret_env_vars
+    assert encoded["my-secret"] != secret
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -910,6 +910,20 @@ def test_runtime_env_interface():
     assert runtime_env.to_dict() == {}
 
 
+@pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])
+def test_secret_env_vars_available(start_cluster, runtime_env_class):
+    cluster, address = start_cluster
+    ray.init(address)
+
+    runtime_env = runtime_env_class(secret_env_vars={"foo": "bar"})
+
+    @ray.remote(runtime_env=runtime_env)
+    def f():
+        return os.environ.get("foo")
+
+    assert ray.get(f.remote()) == "bar"
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
These changes enable passing secrets to ray jobs without leaking them. 

The `runtime_env` is a variable that is packaged and made available to all workers running the job, and it has `env_vars` key that allows passing arbitrary environment variables to the workers, scoped to this job. But the env vars are visible on the dashboard and logged in plain text. So this is not suitable for passing secrets. To address this limitation, we introduce another key `secret_env_vars` in the `runtime_env`, which behaves similar to the `env_vars` but will not be exposed anywhere. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #39502
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
