### PR TITLE
Added `--route-prefix` option to serve run command line interface

### DIFF
--- a/ci/build/build-manylinux-wheel.sh
+++ b/ci/build/build-manylinux-wheel.sh
@@ -25,9 +25,12 @@ fi
 PATH="/opt/python/${PYTHON}/bin:$PATH" RAY_INSTALL_JAVA=0 \
 "/opt/python/${PYTHON}/bin/python" setup.py -q bdist_wheel
 
-# build ray-cpp wheel
-PATH="/opt/python/${PYTHON}/bin:$PATH" RAY_INSTALL_JAVA=0 \
-RAY_INSTALL_CPP=1 "/opt/python/${PYTHON}/bin/python" setup.py -q bdist_wheel
+
+if [[ "${RAY_DISABLE_EXTRA_CPP:-}" != 1 ]]; then
+  # build ray-cpp wheel
+  PATH="/opt/python/${PYTHON}/bin:$PATH" RAY_INSTALL_JAVA=0 \
+  RAY_INSTALL_CPP=1 "/opt/python/${PYTHON}/bin/python" setup.py -q bdist_wheel
+fi
 
 # Rename the wheels so that they can be uploaded to PyPI. TODO(rkn): This is a
 # hack, we should use auditwheel instead.

--- a/ci/ray_ci/builder_container.py
+++ b/ci/ray_ci/builder_container.py
@@ -39,6 +39,12 @@ class BuilderContainer(Container):
         cmds = []
         if self.build_type == "debug":
             cmds += ["export RAY_DEBUG_BUILD=debug"]
+
+        if os.environ.get("RAYCI_DISABLE_CPP_WHEEL") == "true":
+            cmds += ["export RAY_DISABLE_EXTRA_CPP=1"]
+        if os.environ.get("RAYCI_DISABLE_JAVA", "") == "true":
+            cmds += ["export RAY_INSTALL_JAVA=0"]
+
         cmds += [
             "./ci/build/build-manylinux-ray.sh",
             f"./ci/build/build-manylinux-wheel.sh {self.bin_path} {self.numpy_version}",

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -397,6 +397,12 @@ def deploy(config_file_name: str, address: str):
         "app."
     ),
 )
+@click.option(
+    "--route-prefix",
+    default="/",
+    type=str,
+    help=("Route prefix for HTTP requestes. defaults to '/'."),
+)
 def run(
     config_or_import_path: str,
     arguments: Tuple[str],
@@ -410,6 +416,7 @@ def run(
     blocking: bool,
     gradio: bool,
     reload: bool,
+    route_prefix: str,
 ):
     if host is not None or port is not None:
         cli_logger.warning(
@@ -578,7 +585,7 @@ def run(
                     app = _private_api.call_app_builder_with_args_if_necessary(
                         import_attr(import_path, reload_module=True), args_dict
                     )
-                    serve.run(app, host=host, port=port)
+                    serve.run(app, host=host, port=port, route_prefix=route_prefix)
 
         if blocking:
             while True:

--- a/python/ray/serve/tests/test_cli_2.py
+++ b/python/ray/serve/tests/test_cli_2.py
@@ -895,6 +895,26 @@ msg_app = MessageDeployment.bind("Hello {message}!")
     assert ping_endpoint("") == CONNECTION_ERROR_MSG
 
 
+def test_run_route_prefix(ray_start_stop):
+    """Test `serve run --route-prefix="/api"`."""
+
+    p = subprocess.Popen(
+        [
+            "serve",
+            "run",
+            "--address=auto",
+            "--route-prefix=/api",
+            "ray.serve.tests.test_cli_2.molly_macaw",
+        ]
+    )
+    wait_for_condition(
+        lambda: ping_endpoint("api/Macaw") == "Molly is green!", timeout=10
+    )
+    p.send_signal(signal.SIGINT)
+    p.wait()
+    assert ping_endpoint("Macaw") == CONNECTION_ERROR_MSG
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
 def test_serving_request_through_grpc_proxy(ray_start_stop):
     """Test serving request through gRPC proxy

--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -7,7 +7,11 @@ import ray
 import ray._private.gcs_utils as gcs_utils
 import ray.cluster_utils
 import ray.experimental.internal_kv as internal_kv
-from ray._private.ray_constants import DEBUG_AUTOSCALING_ERROR, DEBUG_AUTOSCALING_STATUS
+from ray._private.ray_constants import (
+    DEBUG_AUTOSCALING_ERROR,
+    DEBUG_AUTOSCALING_STATUS,
+)
+from ray.autoscaler._private.constants import AUTOSCALER_UPDATE_INTERVAL_S
 from ray._private.test_utils import (
     convert_actor_state,
     generate_system_config_map,
@@ -623,17 +627,21 @@ def test_placement_group_status(ray_start_cluster, enable_v2):
     pg = ray.util.placement_group([{"CPU": 1}])
     ray.get(pg.ready())
 
-    # Wait until the usage is updated, which is
+    # Wait until the usage is updated to the expected, which is
     # when the demand is also updated.
     def is_usage_updated():
         demand_output = get_ray_status_output(cluster.address)
-        return demand_output["usage"] != ""
+        cpu_usage = demand_output["usage"]
+        if cpu_usage == "":
+            return False
+        cpu_usage = cpu_usage.split("\n")[0]
+        expected = "0.0/4.0 CPU (0.0 used of 1.0 reserved in placement groups)"
+        if cpu_usage != expected:
+            assert cpu_usage == "0.0/4.0 CPU"
+            return False
+        return True
 
-    wait_for_condition(is_usage_updated)
-    demand_output = get_ray_status_output(cluster.address)
-    cpu_usage = demand_output["usage"].split("\n")[0]
-    expected = "0.0/4.0 CPU (0.0 used of 1.0 reserved in placement groups)"
-    assert cpu_usage == expected
+    wait_for_condition(is_usage_updated, AUTOSCALER_UPDATE_INTERVAL_S)
 
     # 2 CPU + 1 PG CPU == 3.0/4.0 CPU (1 used by pg)
     actors = [A.remote() for _ in range(2)]
@@ -647,7 +655,7 @@ def test_placement_group_status(ray_start_cluster, enable_v2):
     ray.get([actor.ready.remote() for actor in actors])
     ray.get([actor.ready.remote() for actor in actors_in_pg])
     # Wait long enough until the usage is propagated to GCS.
-    time.sleep(5)
+    time.sleep(AUTOSCALER_UPDATE_INTERVAL_S)
     demand_output = get_ray_status_output(cluster.address)
     cpu_usage = demand_output["usage"].split("\n")[0]
     expected = "3.0/4.0 CPU (1.0 used of 1.0 reserved in placement groups)"

--- a/python/ray/train/examples/accelerate/accelerate_torch_trainer.py
+++ b/python/ray/train/examples/accelerate/accelerate_torch_trainer.py
@@ -1,6 +1,6 @@
 # __accelerate_torch_basic_example_start__
 """
-Minimal Ray Train + Accelerate example adapted from
+Minimal Ray Train and Accelerate example adapted from
 https://github.com/huggingface/accelerate/blob/main/examples/nlp_example.py
 
 Fine-tune a BERT model with Hugging Face Accelerate and Ray Train and Ray Data
@@ -27,7 +27,7 @@ from ray.train.torch import TorchTrainer
 
 
 def train_func(config):
-    """Your training function that will be launched on each worker."""
+    """Your training function that launches on each worker."""
 
     # Unpack training configs
     lr = config["lr"]
@@ -118,7 +118,7 @@ def train_func(config):
         eval_metric = metric.compute()
         accelerator.print(f"epoch {epoch}:", eval_metric)
 
-        # Report Checkpoint and metrics to Ray Train
+        # Report checkpoint and metrics to Ray Train
         # ==========================================
         with TemporaryDirectory() as tmpdir:
             if accelerator.is_main_process:

--- a/python/ray/train/examples/pytorch/torch_fashion_mnist_example.py
+++ b/python/ray/train/examples/pytorch/torch_fashion_mnist_example.py
@@ -19,7 +19,7 @@ def get_dataloaders(batch_size):
     transform = transforms.Compose([ToTensor(), Normalize((0.5,), (0.5,))])
 
     with FileLock(os.path.expanduser("~/data.lock")):
-        # Download training data from open datasets.
+        # Download training data from open datasets
         training_data = datasets.FashionMNIST(
             root="~/data",
             train=True,
@@ -27,7 +27,7 @@ def get_dataloaders(batch_size):
             transform=transform,
         )
 
-        # Download test data from open datasets.
+        # Download test data from open datasets
         test_data = datasets.FashionMNIST(
             root="~/data",
             train=False,
@@ -35,7 +35,7 @@ def get_dataloaders(batch_size):
             transform=transform,
         )
 
-    # Create data loaders.
+    # Create data loaders
     train_dataloader = DataLoader(training_data, batch_size=batch_size)
     test_dataloader = DataLoader(test_data, batch_size=batch_size)
 
@@ -69,7 +69,7 @@ def train_func_per_worker(config: Dict):
     epochs = config["epochs"]
     batch_size = config["batch_size_per_worker"]
 
-    # Get dataloaders inside worker training function
+    # Get dataloaders inside the worker training function
     train_dataloader, test_dataloader = get_dataloaders(batch_size=batch_size)
 
     # [1] Prepare Dataloader for distributed training
@@ -81,7 +81,7 @@ def train_func_per_worker(config: Dict):
     model = NeuralNetwork()
 
     # [2] Prepare and wrap your model with DistributedDataParallel
-    # Move the model the correct GPU/CPU device
+    # Move the model to the correct GPU/CPU device
     # ============================================================
     model = ray.train.torch.prepare_model(model)
 
@@ -137,7 +137,7 @@ def train_fashion_mnist(num_workers=2, use_gpu=False):
         scaling_config=scaling_config,
     )
 
-    # [4] Start Distributed Training
+    # [4] Start distributed training
     # Run `train_func_per_worker` on all workers
     # =============================================
     result = trainer.fit()

--- a/python/ray/train/examples/transformers/transformers_torch_trainer_basic.py
+++ b/python/ray/train/examples/transformers/transformers_torch_trainer_basic.py
@@ -15,8 +15,8 @@ from ray.train.huggingface.transformers import RayTrainReportCallback, prepare_t
 from ray.train.torch import TorchTrainer
 
 
-# [1] Define a training function that includes all your training logics
-# =====================================================================
+# [1] Define a training function that includes all your training logic
+# ====================================================================
 def train_func(config):
     # Datasets
     dataset = load_dataset("yelp_review_full")
@@ -35,7 +35,7 @@ def train_func(config):
         "bert-base-cased", num_labels=5
     )
 
-    # Evaluation Metrics
+    # Evaluation metrics
     metric = evaluate.load("accuracy")
 
     def compute_metrics(eval_pred):
@@ -43,7 +43,7 @@ def train_func(config):
         predictions = np.argmax(logits, axis=-1)
         return metric.compute(predictions=predictions, references=labels)
 
-    # HuggingFace Trainer
+    # Hugging Face Trainer
     training_args = TrainingArguments(
         output_dir="test_trainer", evaluation_strategy="epoch", report_to="none"
     )
@@ -60,7 +60,7 @@ def train_func(config):
     # ===============================================
     trainer.add_callback(RayTrainReportCallback())
 
-    # [3] Prepare your trainer for Ray Data Integration
+    # [3] Prepare your trainer for Ray Data integration
     # =================================================
     trainer = prepare_trainer(trainer)
 

--- a/python/ray/train/torch/torch_trainer.py
+++ b/python/ray/train/torch/torch_trainer.py
@@ -23,7 +23,11 @@ class TorchTrainer(DataParallelTrainer):
     4. Runs the input ``train_loop_per_worker(train_loop_config)``
        on all workers.
 
-    For more details, see the :ref:`PyTorch User Guide <train-pytorch>`.
+    For more details, see:
+
+    * :ref:`PyTorch Guide <train-pytorch>`
+    * :ref:`PyTorch Lightning Guide <train-pytorch-lightning>`
+    * :ref:`Hugging Face Transformers Guide <train-pytorch-transformers>`
 
     Example:
 


### PR DESCRIPTION
## Why are these changes needed?

I use the `serve run` command to start my Ray Serve application/deployment, e.g.,

```sh
serve run deploy:theia_app --working-dir=./
```

I also use the `route_prefix` argument for my deployment:

```python
@serve.deployment(route_prefix="/api")
@serve.ingress(app)
class Api:
   ...
```

As of Ray v2.7.1, I receive the following warning message:

```sh
(ServeReplica:default:Api pid=139) DeprecationWarning: `route_prefix` in `@serve.deployment` has been deprecated. To specify a route prefix for an application, pass it into `serve.run` instead.
```

I do not use `serve.run` nor a YAML configuration file, which appears to have the `route_prefix` field. I do not use the YAML configuration because then I need to implement a packaging scheme for the code to be shared with nodes in the cluster, but `ray serve` without the configuration file will handle packaging automatically.

The `serve run` appears to be missing a `--route-prefix` option to be consistent with the deprecation message and the YAML configuration.

## Related issue number

There is not a specific issue associated with this PR, but here are some related issued for the `route_prefix` changes:

- #38627
- #38749
- #39133

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
