### PR TITLE
[ci] add rllib and ml flaky tests jobs

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -118,6 +118,18 @@ steps:
     depends_on: mlgpubuild
     job_env: forge
 
+  - label: ":train: ml: flaky tests"
+    tags: 
+      - train
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tune/... ml 
+        --run-flaky-tests
+        --except-tags soft_imports,gpu_only,rllib,multinode
+    depends_on: mlbuild
+    soft_fail: true
+    job_env: forge
+
   - name: minbuild-ml
     label: "wanda: minbuild-ml-py38"
     wanda: ci/docker/min.build.wanda.yaml

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -171,7 +171,7 @@ steps:
     soft_fail: true
     job_env: forge
 
-  - label: ":brain: rllib: flaky tests"
+  - label: ":brain: rllib: flaky tests (learning tests)"
     tags: rllib
     instance_type: large
     commands:
@@ -194,18 +194,37 @@ steps:
         --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
         --test-arg --framework=tf2
         --skip-ray-installation # reuse the same docker image as the previous run
+    depends_on: rllibbuild
+    soft_fail: true
+    job_env: forge
 
+  - label: ":brain: rllib: flaky tests (examples/rlmodule/models/tests_dir)"
+    tags: rllib
+    instance_type: large
+    commands:
       # examples
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib  --run-flaky-tests --parallelism-per-worker 3
         --only-tags examples
         --except-tags multi_gpu,gpu 
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-        --skip-ray-installation # reuse the same docker image as the previous run
 
       # rlmodule tests
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
         --only-tags rlm
         --test-env RLLIB_ENABLE_RL_MODULE=1
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+        --skip-ray-installation # reuse the same docker image as the previous run
+
+      # algorithm, models
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib  --run-flaky-tests --parallelism-per-worker 3
+        --except-tags learning_tests,memory_leak_tests,examples,tests_dir,documentation,multi_gpu,no_cpu,torch_2.x_only_benchmark,manual
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+        --skip-ray-installation # reuse the same docker image as the previous run
+
+      # tests/ dir
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests --parallelism-per-worker 3
+        --only-tags tests_dir
+        --except-tags multi_gpu,manual
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
         --skip-ray-installation # reuse the same docker image as the previous run
     depends_on: rllibbuild

--- a/ci/ray_ci/ml.tests.yml
+++ b/ci/ray_ci/ml.tests.yml
@@ -1,1 +1,4 @@
-flaky_tests: []
+flaky_tests:
+  # tune
+  - //python/ray/tune:cifar10_pytorch
+  - //python/ray/tune:test_commands

--- a/ci/ray_ci/rllib.tests.yml
+++ b/ci/ray_ci/rllib.tests.yml
@@ -7,6 +7,7 @@ flaky_tests:
   - //rllib:learning_tests_cartpole_ddppo
   - //rllib:learning_tests_two_step_game_qmix
   - //rllib:learning_tests_pendulum_cql
+  - //rllib:learning_tests_two_step_game_qmix_no_mixer
   # algorithm, model and other tests
   - //rllib:test_bc 
   - //rllib:test_a3c
@@ -23,6 +24,7 @@ flaky_tests:
   - //rllib:examples/action_masking_torch
   - //rllib:examples/action_masking_tf2
   - //rllib:examples/learner/train_w_bc_finetune_w_ppo
+  - //rllib:examples/custom_recurrent_rnn_tokenizer_repeat_initial_obs_env_torch
   # memory leak tf2-eager-tracing
   - //rllib:test_memory_leak_ppo
   - //rllib:test_memory_leak_sac


### PR DESCRIPTION
Jail some flaky rllib and ml tests
- Split the rllib flaky jobs into 2, they are now too large
- Create a flaky ml test jobs

Test:
- CI