### PR TITLE
[Core]Fix NullPointerException cause by raylet id is empty when get actor info in java worker

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/gcs/GcsClient.java
+++ b/java/runtime/src/main/java/io/ray/runtime/gcs/GcsClient.java
@@ -120,16 +120,19 @@ public class GcsClient {
         result -> {
           try {
             Gcs.ActorTableData info = Gcs.ActorTableData.parseFrom(result);
+            UniqueId nodeId = UniqueId.NIL;
+            if (!info.getAddress().getRayletId().isEmpty()) {
+              nodeId =
+                  UniqueId.fromByteBuffer(
+                      ByteBuffer.wrap(info.getAddress().getRayletId().toByteArray()));
+            }
             actorInfos.add(
                 new ActorInfo(
                     ActorId.fromBytes(info.getActorId().toByteArray()),
                     ActorState.fromValue(info.getState().getNumber()),
                     info.getNumRestarts(),
                     new Address(
-                        UniqueId.fromByteBuffer(
-                            ByteBuffer.wrap(info.getAddress().getRayletId().toByteArray())),
-                        info.getAddress().getIpAddress(),
-                        info.getAddress().getPort()),
+                        nodeId, info.getAddress().getIpAddress(), info.getAddress().getPort()),
                     info.getName()));
           } catch (InvalidProtocolBufferException e) {
             throw new RayException("Failed to parse actor info.", e);

--- a/java/runtime/src/main/java/io/ray/runtime/gcs/GlobalStateAccessor.java
+++ b/java/runtime/src/main/java/io/ray/runtime/gcs/GlobalStateAccessor.java
@@ -161,7 +161,7 @@ public class GlobalStateAccessor {
   private native List<byte[]> nativeGetAllNodeInfo(long nativePtr);
 
   private native List<byte[]> nativeGetAllActorInfo(
-      long nativePtr, byte[] jobId, String actor_state_name);
+      long nativePtr, byte[] jobId, String actorStateName);
 
   private native byte[] nativeGetActorInfo(long nativePtr, byte[] actorId);
 


### PR DESCRIPTION
## Why are these changes needed?

Fix NullPointerException cause by raylet id is empty when get actor info in java worker.
Calling get actor info API before the Actor is successfully scheduled will result in a NullPointerException.
![image](https://github.com/ray-project/ray/assets/11072802/a25f4728-ca8a-4841-b912-4ca757437dc2)




## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
