### PR TITLE
[data] Add spilled memory in report current usage

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -33,6 +33,7 @@ from ray.data._internal.execution.streaming_executor_state import (
     select_operator_to_run,
     update_operator_states,
 )
+from ray.data._internal.execution.util import memory_string
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.stats import (
     DatasetStats,
@@ -330,6 +331,12 @@ class StreamingExecutor(Executor, threading.Thread):
             f"{cur_usage.overall.object_store_memory_str()}/"
             f"{limits.object_store_memory_str()} object_store_memory"
         )
+        if not cur_usage.overall.satisfies_limit(limits):
+            spilled_obj_memory = cur_usage.overall.object_store_memory - limits.object_store_memory
+            resources_status += (
+                f" ({memory_string(spilled_obj_memory)} spilled to external storage)"
+            )
+
         if self._global_info:
             self._global_info.set_description(resources_status)
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -331,7 +331,11 @@ class StreamingExecutor(Executor, threading.Thread):
             f"{cur_usage.overall.object_store_memory_str()}/"
             f"{limits.object_store_memory_str()} object_store_memory"
         )
-        if not cur_usage.overall.satisfies_limit(limits):
+        if (
+            cur_usage.overall.object_store_memory is not None
+            and limits.object_store_memory is not None
+            and cur_usage.overall.object_store_memory > limits.object_store_memory
+        ):
             spilled_obj_memory = (
                 cur_usage.overall.object_store_memory - limits.object_store_memory
             )

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -332,7 +332,9 @@ class StreamingExecutor(Executor, threading.Thread):
             f"{limits.object_store_memory_str()} object_store_memory"
         )
         if not cur_usage.overall.satisfies_limit(limits):
-            spilled_obj_memory = cur_usage.overall.object_store_memory - limits.object_store_memory
+            spilled_obj_memory = (
+                cur_usage.overall.object_store_memory - limits.object_store_memory
+            )
             resources_status += (
                 f" ({memory_string(spilled_obj_memory)} spilled to external storage)"
             )

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -3,7 +3,7 @@ import time
 from collections import Counter
 from contextlib import contextmanager
 from typing import List, Optional
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch
 
 import numpy as np
 import pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To improve the object store usage info in StreamingExecutor, add the spilled memory info if current usage exceeds the limit.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#39804
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests (only test_streaming_integration.py & test_streaming_executor.py)
   - [ ] Release tests
   - [ ] This PR is not tested :(
