### PR TITLE
[data] log op metrics on completion

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -2,7 +2,7 @@ import os
 import threading
 import time
 import uuid
-from typing import Iterator, List, Optional
+from typing import Dict, Iterator, List, Optional
 
 import ray
 from ray.data._internal.dataset_logger import DatasetLogger
@@ -83,6 +83,9 @@ class StreamingExecutor(Executor, threading.Thread):
         self._backpressure_policies: Optional[List[BackpressurePolicy]] = None
 
         self._dataset_tag = dataset_tag
+        # Stores if an operator is completed,
+        # used for marking when an op has just completed.
+        self._op_completed: Optional[Dict[PhysicalOperator, bool]] = None
 
         Executor.__init__(self, options)
         thread_name = f"StreamingExecutor-{self._execution_id}"
@@ -113,6 +116,8 @@ class StreamingExecutor(Executor, threading.Thread):
         # Setup the streaming DAG topology and start the runner thread.
         self._topology, _ = build_streaming_topology(dag, self._options)
         self._backpressure_policies = get_backpressure_policies(self._topology)
+
+        self._op_completed = {op: False for op in self._topology}
 
         if not isinstance(dag, InputDataBuffer):
             # Note: DAG must be initialized in order to query num_outputs_total.
@@ -292,6 +297,15 @@ class StreamingExecutor(Executor, threading.Thread):
         update_stats_actor_metrics(
             [op.metrics for op in self._topology], {"dataset": self._dataset_tag}
         )
+
+        # Log metrics of newly completed operators.
+        for op in topology:
+            if op.completed() and not self._op_completed[op]:
+                log_str = f"Operator {op} completed. Operator Metrics:\n" + str(
+                    op._metrics.as_dict()
+                )
+                logger.get_logger(log_to_stdout=False).info(log_str)
+                self._op_completed[op] = True
 
         # Keep going until all operators run to completion.
         return not all(op.completed() for op in topology)

--- a/python/ray/data/tests/test.py
+++ b/python/ray/data/tests/test.py
@@ -1,7 +1,0 @@
-import ray
-
-ds = ray.data.range(100, parallelism=100).map_batches(lambda x: x).materialize()
-
-ds.write_parquet("/tmp/test")
-print("stats after", ds.stats())
-print("stats internal", ds._write_ds.stats())

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1234,6 +1234,33 @@ def test_dataset_name():
     )
 
 
+def test_op_metrics_logging():
+    logger = DatasetLogger(
+        "ray.data._internal.execution.streaming_executor"
+    ).get_logger()
+    with patch.object(logger, "info") as mock_logger:
+        ray.data.range(100).map_batches(lambda x: x).materialize()
+        logs = [canonicalize(call.args[0]) for call in mock_logger.call_args_list]
+        input_str = (
+            "Operator InputDataBuffer[Input] completed. Operator Metrics:\n"
+            + gen_expected_metrics(is_map=False)
+        )
+        map_str = (
+            "Operator InputDataBuffer[Input] -> "
+            "TaskPoolMapOperator[ReadRange->MapBatches(<lambda>)] completed. "
+            "Operator Metrics:\n"
+        ) + gen_expected_metrics(
+            is_map=True,
+            extra_metrics=[
+                "'ray_remote_args': " "{'num_cpus': N, 'scheduling_strategy': 'SPREAD'}"
+            ],
+        )
+
+        # Check that these strings are logged exactly once.
+        assert sum([log == input_str for log in logs]) == 1
+        assert sum([log == map_str for log in logs]) == 1
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1249,12 +1249,7 @@ def test_op_metrics_logging():
             "Operator InputDataBuffer[Input] -> "
             "TaskPoolMapOperator[ReadRange->MapBatches(<lambda>)] completed. "
             "Operator Metrics:\n"
-        ) + gen_expected_metrics(
-            is_map=True,
-            extra_metrics=[
-                "'ray_remote_args': " "{'num_cpus': N, 'scheduling_strategy': 'SPREAD'}"
-            ],
-        )
+        ) + STANDARD_EXTRA_METRICS
 
         # Check that these strings are logged exactly once.
         assert sum([log == input_str for log in logs]) == 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Logs operator metrics to `ray-data.log` upon operator completion. 
Example:
```
>>> ray.data.range(100).map_batches(lambda x: x).materialize()
2023-10-23 09:20:13,141 INFO streaming_executor.py:305 -- Operator InputDataBuffer[Input] completed. Operator Metrics:
{'num_inputs_received': 20, 'bytes_inputs_received': 45900, 'num_outputs_taken': 20, 'bytes_outputs_taken': 45900, 'cpu_usage': 0, 'gpu_usage': 0}
2023-10-23 09:20:13,592 INFO streaming_executor.py:305 -- Operator InputDataBuffer[Input] -> TaskPoolMapOperator[ReadRange->MapBatches(<lambda>)] completed. Operator Metrics:
{'num_inputs_received': 20, 'bytes_inputs_received': 45900, 'num_inputs_processed': 20, 'bytes_inputs_processed': 45900, 'num_outputs_generated': 20, 'bytes_outputs_generated': 800, 'num_outputs_taken': 20, 'bytes_outputs_taken': 800, 'num_outputs_of_finished_tasks': 20, 'bytes_outputs_of_finished_tasks': 800, 'num_tasks_submitted': 20, 'num_tasks_running': 0, 'num_tasks_have_outputs': 20, 'num_tasks_finished': 20, 'obj_store_mem_alloc': 800, 'obj_store_mem_freed': 45900, 'obj_store_mem_cur': 0, 'obj_store_mem_peak': 22990, 'obj_store_mem_spilled': 0, 'cpu_usage': 0, 'gpu_usage': 0, 'ray_remote_args': {'num_cpus': 1, 'scheduling_strategy': 'SPREAD'}}
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
