### PR TITLE
[Metrics] Refactored metrics exporting to properly handle high-cardinality cases

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -374,8 +374,8 @@ GRPC_CPP_MAX_MESSAGE_SIZE = 250 * 1024 * 1024
 
 # The gRPC send & receive max length for "dashboard agent" server.
 # NOTE: This is equal to the C++ limit of RayConfig::max_grpc_message_size
-#       and HAVE TO STAY IN SYNC with it (ie, meaning that both of these values have to be set
-#       at the same time)
+#       and HAVE TO STAY IN SYNC with it (ie, meaning that both of these values
+#       have to be set at the same time)
 AGENT_GRPC_MAX_MESSAGE_LENGTH = env_integer(
     "AGENT_GRPC_MAX_MESSAGE_LENGTH", 20 * 1024 * 1024  # 20MB
 )

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -371,7 +371,11 @@ CALL_STACK_LINE_DELIMITER = " | "
 # The default gRPC max message size is 4 MiB, we use a larger number of 250 MiB
 # NOTE: This is equal to the C++ limit of (RAY_CONFIG::max_grpc_message_size)
 GRPC_CPP_MAX_MESSAGE_SIZE = 250 * 1024 * 1024
+
 # The gRPC send & receive max length for "dashboard agent" server.
+# NOTE: This is equal to the C++ limit of RayConfig::max_grpc_message_size
+#       and HAVE TO STAY IN SYNC with it (ie, meaning that both of these values have to be set
+#       at the same time)
 AGENT_GRPC_MAX_MESSAGE_LENGTH = env_integer(
     "AGENT_GRPC_MAX_MESSAGE_LENGTH", 20 * 1024 * 1024  # 20MB
 )

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -483,8 +483,9 @@ RAY_CONFIG(int64_t, ray_syncer_polling_buffer, 5)
 RAY_CONFIG(uint64_t, gcs_service_address_check_interval_milliseconds, 1000)
 
 /// The batch size for metrics export.
-/// Normally each metrics is about < 1KB. 1000 means it is around 1MB.
-RAY_CONFIG(int64_t, metrics_report_batch_size, 1000)
+/// Normally each time-series << 1Kb. Batch size of 10_000 means expected payload
+/// will be under 10Mb.
+RAY_CONFIG(int64_t, metrics_report_batch_size, 10000)
 
 /// If task events (status change and profiling events) from driver should be ignored.
 /// Currently for testing only.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -220,6 +220,10 @@ RAY_CONFIG(int64_t, max_direct_call_object_size, 100 * 1024)
 // Keep in sync with GCS_STORAGE_MAX_SIZE in packaging.py.
 RAY_CONFIG(int64_t, max_grpc_message_size, 512 * 1024 * 1024)
 
+// The max gRPC message size (the gRPC internal default is 4MB) in communication with the Agent.
+// NOTE: This has to be kept in sync with AGENT_GRPC_MAX_MESSAGE_LENGTH in ray_constants.py)
+RAY_CONFIG(int64_t, agent_max_grpc_message_size, 20 * 1024 * 1024)
+
 // Retry timeout for trying to create a gRPC server. Only applies if the number
 // of retries is non zero.
 RAY_CONFIG(int64_t, grpc_server_retry_timeout_milliseconds, 1000)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -220,8 +220,11 @@ RAY_CONFIG(int64_t, max_direct_call_object_size, 100 * 1024)
 // Keep in sync with GCS_STORAGE_MAX_SIZE in packaging.py.
 RAY_CONFIG(int64_t, max_grpc_message_size, 512 * 1024 * 1024)
 
-// The max gRPC message size (the gRPC internal default is 4MB) in communication with the Agent.
-// NOTE: This has to be kept in sync with AGENT_GRPC_MAX_MESSAGE_LENGTH in ray_constants.py)
+// The max gRPC message size (the gRPC internal default is 4MB) in communication with the
+// Agent.
+//
+// NOTE: This has to be kept in sync with AGENT_GRPC_MAX_MESSAGE_LENGTH in
+// ray_constants.py
 RAY_CONFIG(int64_t, agent_max_grpc_message_size, 20 * 1024 * 1024)
 
 // Retry timeout for trying to create a gRPC server. Only applies if the number

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -39,8 +39,8 @@ namespace rpc {
       method_timeout_ms))
 
 // Define a void RPC client method declaration
-#define VOID_RPC_CLIENT_VIRTUAL_METHOD_DECL(SERVICE, METHOD)        \
-  virtual void METHOD(const METHOD##Request &request,               \
+#define VOID_RPC_CLIENT_VIRTUAL_METHOD_DECL(SERVICE, METHOD) \
+  virtual void METHOD(const METHOD##Request &request,        \
                       const ClientCallback<METHOD##Reply> &callback) = 0;
 
 // Define a void RPC client method.

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -38,6 +38,11 @@ namespace rpc {
       #SERVICE ".grpc_client." #METHOD,                                \
       method_timeout_ms))
 
+// Define a void RPC client method declaration
+#define VOID_RPC_CLIENT_VIRTUAL_METHOD_DECL(SERVICE, METHOD)        \
+  virtual void METHOD(const METHOD##Request &request,               \
+                      const ClientCallback<METHOD##Reply> &callback) = 0;
+
 // Define a void RPC client method.
 #define VOID_RPC_CLIENT_METHOD(SERVICE, METHOD, rpc_client, method_timeout_ms, SPECS)   \
   void METHOD(const METHOD##Request &request,                                           \

--- a/src/ray/rpc/metrics_agent_client.h
+++ b/src/ray/rpc/metrics_agent_client.h
@@ -55,12 +55,11 @@ class MetricsAgentClientImpl : public MetricsAgentClient {
   MetricsAgentClientImpl(const std::string &address,
                          const int port,
                          instrumented_io_context &io_service)
-    : client_call_manager_(io_service)
-  {
+      : client_call_manager_(io_service) {
     RAY_LOG(DEBUG) << "Initiate the metrics client of address:" << address
                    << " port:" << port;
-    grpc_client_ =
-        std::make_unique<GrpcClient<ReporterService>>(address, port, client_call_manager_);
+    grpc_client_ = std::make_unique<GrpcClient<ReporterService>>(
+        address, port, client_call_manager_);
   };
 
   VOID_RPC_CLIENT_METHOD(ReporterService,

--- a/src/ray/rpc/metrics_agent_client.h
+++ b/src/ray/rpc/metrics_agent_client.h
@@ -37,11 +37,13 @@ class MetricsAgentClient {
   /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
   MetricsAgentClient(const std::string &address,
                      const int port,
-                     ClientCallManager &client_call_manager) {
+                     instrumented_io_context &io_service)
+    : client_call_manager_(io_service)
+  {
     RAY_LOG(DEBUG) << "Initiate the metrics client of address:" << address
                    << " port:" << port;
     grpc_client_ =
-        std::make_unique<GrpcClient<ReporterService>>(address, port, client_call_manager);
+        std::make_unique<GrpcClient<ReporterService>>(address, port, client_call_manager_);
   };
 
   /// Report metrics to metrics agent.
@@ -63,6 +65,8 @@ class MetricsAgentClient {
                          /*method_timeout_ms*/ -1, )
 
  private:
+  /// Call Manager for gRPC client.
+  rpc::ClientCallManager client_call_manager_;
   /// The RPC client.
   std::unique_ptr<GrpcClient<ReporterService>> grpc_client_;
 };

--- a/src/ray/rpc/metrics_agent_client.h
+++ b/src/ray/rpc/metrics_agent_client.h
@@ -30,14 +30,31 @@ namespace rpc {
 /// Client used for communicating with a remote node manager server.
 class MetricsAgentClient {
  public:
+  virtual ~MetricsAgentClient() = default;
+
+  /// Report metrics to metrics agent.
+  ///
+  /// \param[in] request The request message.
+  /// \param[in] callback The callback function that handles reply.
+  VOID_RPC_CLIENT_VIRTUAL_METHOD_DECL(ReporterService, ReportMetrics)
+
+  /// Report open census protobuf metrics to metrics agent.
+  ///
+  /// \param[in] request The request message.
+  /// \param[in] callback The callback function that handles reply.
+  VOID_RPC_CLIENT_VIRTUAL_METHOD_DECL(ReporterService, ReportOCMetrics)
+};
+
+class MetricsAgentClientImpl : public MetricsAgentClient {
+ public:
   /// Constructor.
   ///
   /// \param[in] address Address of the metrics agent server.
   /// \param[in] port Port of the metrics agent server.
   /// \param[in] client_call_manager The `ClientCallManager` used for managing requests.
-  MetricsAgentClient(const std::string &address,
-                     const int port,
-                     instrumented_io_context &io_service)
+  MetricsAgentClientImpl(const std::string &address,
+                         const int port,
+                         instrumented_io_context &io_service)
     : client_call_manager_(io_service)
   {
     RAY_LOG(DEBUG) << "Initiate the metrics client of address:" << address
@@ -46,23 +63,17 @@ class MetricsAgentClient {
         std::make_unique<GrpcClient<ReporterService>>(address, port, client_call_manager_);
   };
 
-  /// Report metrics to metrics agent.
-  ///
-  /// \param[in] request The request message.
-  /// \param[in] callback The callback function that handles reply.
   VOID_RPC_CLIENT_METHOD(ReporterService,
                          ReportMetrics,
                          grpc_client_,
-                         /*method_timeout_ms*/ -1, )
+                         /*method_timeout_ms*/ -1,
+                         override)
 
-  /// Report open census protobuf metrics to metrics agent.
-  ///
-  /// \param[in] request The request message.
-  /// \param[in] callback The callback function that handles reply.
   VOID_RPC_CLIENT_METHOD(ReporterService,
                          ReportOCMetrics,
                          grpc_client_,
-                         /*method_timeout_ms*/ -1, )
+                         /*method_timeout_ms*/ -1,
+                         override)
 
  private:
   /// Call Manager for gRPC client.

--- a/src/ray/stats/metric_exporter.cc
+++ b/src/ray/stats/metric_exporter.cc
@@ -190,7 +190,7 @@ void OpenCensusProtoExporter::ExportViewData(
 }
 
 void OpenCensusProtoExporter::SendData(rpc::ReportOCMetricsRequest &request) {
-  RAY_LOG(DEBUG) << "Exproting metrics. request_proto numbers: " << request.metrics_size() << ", request_proto size bytes: " << request.ByteSizeLong();
+  RAY_LOG(DEBUG) << "Exporting metrics. request_proto numbers: " << request.metrics_size() << ", request_proto size bytes: " << request.ByteSizeLong();
   absl::MutexLock l(&mu_);
   client_->ReportOCMetrics(
       request, [](const Status &status, const rpc::ReportOCMetricsReply &reply) {
@@ -286,7 +286,7 @@ size_t OpenCensusProtoExporter::AddMetricsData(const std::pair<opencensus::stats
     RAY_LOG(FATAL) << "Unknown view data type.";
     break;
   }
-
+  // NOTE: We add global tags at the end to make sure these are not overridden by the emitter
   addGlobalTagsToGrpcMetric(*request_point_proto);
 
   return num_series;

--- a/src/ray/stats/metric_exporter.cc
+++ b/src/ray/stats/metric_exporter.cc
@@ -133,13 +133,13 @@ OpenCensusProtoExporter::OpenCensusProtoExporter(const int port,
                                                  size_t report_batch_size,
                                                  size_t max_grpc_payload_size)
   : OpenCensusProtoExporter(
-      std::make_unique<rpc::MetricsAgentClient>(address, port, io_service),
+      std::make_shared<rpc::MetricsAgentClientImpl>(address, port, io_service),
       worker_id,
       report_batch_size,
       max_grpc_payload_size
   ) {}
 
-OpenCensusProtoExporter::OpenCensusProtoExporter(std::unique_ptr<rpc::MetricsAgentClient> &&agent_client,
+OpenCensusProtoExporter::OpenCensusProtoExporter(std::shared_ptr<rpc::MetricsAgentClient> agent_client,
                                                   const WorkerID &worker_id,
                                                   size_t report_batch_size,
                                                   size_t max_grpc_payload_size)

--- a/src/ray/stats/metric_exporter.cc
+++ b/src/ray/stats/metric_exporter.cc
@@ -173,7 +173,7 @@ void OpenCensusProtoExporter::ExportViewData(
   for (const auto &datum : data) {
     num_series += AddMetricsData(datum, request_proto);
     // NOTE: Because each payload size check is linear in the number of fields w/in the payload
-    //       we intentionally sample it to happen only every 25 iterations to avoid affecting performance
+    //       we intentionally sample it to happen only every 1000 series produced to avoid affecting performance
     bool should_check_payload_size = (num_series + 1) % 1000 == 0;
     /// If it exceeds the batch size, send data.
     if (num_series >= report_batch_size_ || (should_check_payload_size && request_proto.ByteSizeLong() >= binary_size_payload_threshold)) {

--- a/src/ray/stats/metric_exporter.cc
+++ b/src/ray/stats/metric_exporter.cc
@@ -235,7 +235,7 @@ opencensus::proto::metrics::v1::Metric *addMetricProtoPayload(
     metric_descriptor_proto->add_label_keys()->set_key(tag_key.name());
   };
 
-  return *metric_proto;
+  return metric_proto;
 }
 
 bool OpenCensusProtoExporter::handleBatchOverflows(
@@ -302,7 +302,7 @@ void OpenCensusProtoExporter::ProcessMetricsData(
     cur_batch_size++;
 
     // Add new time-series to a proto payload
-    auto metric_timeseries_proto = metric_proto.add_timeseries();
+    auto metric_timeseries_proto = metric_proto_ptr->add_timeseries();
 
     metric_timeseries_proto->mutable_start_timestamp()->set_seconds(start_time);
 
@@ -359,7 +359,7 @@ void OpenCensusProtoExporter::ProcessMetricsData(
   }
   // NOTE: We add global tags at the end to make sure these are not overridden by
   //       the emitter
-  addGlobalTagsToGrpcMetric(metric_proto);
+  addGlobalTagsToGrpcMetric(*metric_proto_ptr);
 }
 
 }  // namespace stats

--- a/src/ray/stats/metric_exporter.cc
+++ b/src/ray/stats/metric_exporter.cc
@@ -168,13 +168,13 @@ void OpenCensusProtoExporter::ExportViewData(
   size_t num_series = 0;
   // To make sure we're not overflowing Agent's set gRPC max message size, we will be tracking
   // target payload binary size and make sure it stays w/in 95% of the threshold
-  size_t binary_size_payload_threshold = (size_t) (max_grpc_payload_size * .95f);
+  size_t binary_size_payload_threshold = (size_t) (max_grpc_payload_size_ * .95f);
 
   for (const auto &datum : data) {
     num_series += AddMetricsData(datum, request_proto);
     // NOTE: Because each payload size check is linear in the number of fields w/in the payload
     //       we intentionally sample it to happen only every 25 iterations to avoid affecting performance
-    bool should_check_payload_size = (num_series + 1) % 1000 == 0
+    bool should_check_payload_size = (num_series + 1) % 1000 == 0;
     /// If it exceeds the batch size, send data.
     if (num_series >= report_batch_size_ || (should_check_payload_size && request_proto.ByteSizeLong() >= binary_size_payload_threshold)) {
       SendData(request_proto);

--- a/src/ray/stats/metric_exporter.cc
+++ b/src/ray/stats/metric_exporter.cc
@@ -130,8 +130,12 @@ OpenCensusProtoExporter::OpenCensusProtoExporter(const int port,
                                                  instrumented_io_context &io_service,
                                                  const std::string address,
                                                  const WorkerID &worker_id,
-                                                 size_t report_batch_size)
-    : client_call_manager_(io_service), worker_id_(worker_id), report_batch_size_(report_batch_size) {
+                                                 size_t report_batch_size,
+                                                 size_t max_grpc_payload_size)
+    : client_call_manager_(io_service)
+    , worker_id_(worker_id)
+    , report_batch_size_(report_batch_size)
+    , max_grpc_payload_size_(max_grpc_payload_size) {
   absl::MutexLock l(&mu_);
   client_.reset(new rpc::MetricsAgentClient(address, port, client_call_manager_));
 };
@@ -164,14 +168,13 @@ void OpenCensusProtoExporter::ExportViewData(
   size_t num_series = 0;
   // To make sure we're not overflowing Agent's set gRPC max message size, we will be tracking
   // target payload binary size and make sure it stays w/in 95% of the threshold
-  // TODO define AGENT_GRPC_MAX_MESSAGE_LENGTH to keep it consistent b/w cpp/python
-  size_t binary_size_payload_threshold = (size_t) (AGENT_GRPC_MAX_MESSAGE_LENGTH * .95f);
+  size_t binary_size_payload_threshold = (size_t) (max_grpc_payload_size * .95f);
 
   for (const auto &datum : data) {
     num_series += AddMetricsData(datum, request_proto);
     // NOTE: Because each payload size check is linear in the number of fields w/in the payload
     //       we intentionally sample it to happen only every 25 iterations to avoid affecting performance
-    bool should_check_payload_size = data_batched % 25 == 0
+    bool should_check_payload_size = (num_series + 1) % 1000 == 0
     /// If it exceeds the batch size, send data.
     if (num_series >= report_batch_size_ || (should_check_payload_size && request_proto.ByteSizeLong() >= binary_size_payload_threshold)) {
       SendData(request_proto);

--- a/src/ray/stats/metric_exporter.cc
+++ b/src/ray/stats/metric_exporter.cc
@@ -148,7 +148,7 @@ OpenCensusProtoExporter::OpenCensusProtoExporter(
       // To make sure we're not overflowing Agent's set gRPC max message size, we will be
       // tracking target payload binary size and make sure it stays w/in 95% of the
       // threshold
-      proto_payload_size_threshold_((size_t)(max_grpc_payload_size * .95f)) {
+      proto_payload_size_threshold_bytes_((size_t)(max_grpc_payload_size * .95f)) {
   absl::MutexLock l(&mu_);
   client_ = std::move(agent_client);
 };
@@ -249,7 +249,7 @@ bool OpenCensusProtoExporter::handleBatchOverflows(
     return true;
   } else if (should_check_payload_size) {
     size_t cur_payload_size = request_proto.ByteSizeLong();
-    if (cur_payload_size >= proto_payload_size_threshold_) {
+    if (cur_payload_size >= proto_payload_size_threshold_bytes_) {
       SendData(request_proto);
       return true;
     }

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -105,6 +105,11 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
                           size_t report_batch_size,
                           size_t max_grpc_payload_size);
 
+  OpenCensusProtoExporter(std::unique_ptr<rpc::MetricsAgentClient> &&agent_client,
+                          const WorkerID &worker_id,
+                          size_t report_batch_size,
+                          size_t max_grpc_payload_size);
+
   ~OpenCensusProtoExporter() = default;
 
   static void Register(const int port,
@@ -137,8 +142,6 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
   void addGlobalTagsToGrpcMetric(opencensus::proto::metrics::v1::Metric &metric);
 
  private:
-  /// Call Manager for gRPC client.
-  rpc::ClientCallManager client_call_manager_;
   /// Lock to protect the client
   mutable absl::Mutex mu_;
   /// Client to call a metrics agent gRPC server.

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -119,7 +119,12 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
                        size_t report_batch_size,
                        size_t max_grpc_payload_size) {
     opencensus::stats::StatsExporter::RegisterPushHandler(
-        absl::make_unique<OpenCensusProtoExporter>(port, io_service, address, worker_id, report_batch_size, max_grpc_payload_size));
+        absl::make_unique<OpenCensusProtoExporter>(port,
+                                                   io_service,
+                                                   address,
+                                                   worker_id,
+                                                   report_batch_size,
+                                                   max_grpc_payload_size));
   }
 
   void ExportViewData(
@@ -129,17 +134,22 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
 
   /// Processes data from the provided ViewData container by
   ///   - Adding it into corresponding proto request payload
-  ///   - Submitting request payload to agent client (when it's reached target batch size or
-  ///     payload size limits)
+  ///   - Submitting request payload to agent client (when it's reached target batch
+  ///     size or payload size limits)
   ///
-  /// Upon returning of this method all of the time-series from the provided ViewData container will
-  /// either be a) contained inside provide proto request payload or b) already submitted to the client
+  /// Upon returning of this method all of the time-series from the provided ViewData
+  /// container will either be a) contained inside provide proto request payload or b)
+  /// already submitted to the client
   ///
   /// \param view_descriptor, descriptor of the metric
-  /// \param view_data, data container aggregating time-series for this metric (across different set of tags)
-  /// \param request_proto, target proto payload to embed metric values into
-  /// \param cur_batch_size current size of the batch (in terms of number of time-series already added)
-  /// \param next_payload_size_check_at next batch size when payload (binary) size have to be checked
+  /// \param view_data, data container aggregating time-series for this metric (across
+  /// different set of tags)
+  /// \param request_proto, target proto payload to embed metric
+  /// values into
+  /// \param cur_batch_size current size of the batch (in terms of number of time-series
+  /// already added)
+  /// \param next_payload_size_check_at next batch size when payload (binary) size have
+  /// to be checked
   void ProcessMetricsData(const opencensus::stats::ViewDescriptor &view_descriptor,
                           const opencensus::stats::ViewData &view_data,
                           rpc::ReportOCMetricsRequest &request_proto,
@@ -164,9 +174,10 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
   WorkerID worker_id_;
   /// The maximum batch size to be included in a single gRPC metrics report request.
   size_t report_batch_size_;
-  /// Proto request payload size threshold upon reaching which request have to be flushed immediately,
-  /// so that we can make sure that batches stay w/in the threshold of the gRPC max message size
-  /// set by an agent (usually calculated as 95% of agent's gRPC max-message size)
+  /// Proto request payload size threshold upon reaching which request have to be flushed
+  /// immediately, so that we can make sure that batches stay w/in the threshold of the
+  /// gRPC max message size set by an agent (usually calculated as 95% of agent's gRPC
+  /// max-message size)
   size_t proto_payload_size_threshold_;
 };
 

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -102,7 +102,8 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
                           instrumented_io_context &io_service,
                           const std::string address,
                           const WorkerID &worker_id,
-                          size_t report_batch_size);
+                          size_t report_batch_size,
+                          size_t max_grpc_payload_size);
 
   ~OpenCensusProtoExporter() = default;
 
@@ -136,6 +137,9 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
   WorkerID worker_id_;
   /// The maximum batch size to be included in a single gRPC metrics report request.
   size_t report_batch_size_;
+  /// Max gRPC payload size being sent to an agent, allowing us to make sure
+  /// that batches stays w/in the threshold of the gRPC max message size set by an agent
+  size_t max_grpc_payload_size_;
 };
 
 }  // namespace stats

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -139,17 +139,19 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
   /// \param view_data, data container aggregating time-series for this metric (across different set of tags)
   /// \param request_proto, target proto payload to embed metric values into
   /// \param cur_batch_size current size of the batch (in terms of number of time-series already added)
+  /// \param next_payload_size_check_at next batch size when payload (binary) size have to be checked
   void ProcessMetricsData(const opencensus::stats::ViewDescriptor &view_descriptor,
                           const opencensus::stats::ViewData &view_data,
                           rpc::ReportOCMetricsRequest &request_proto,
-                          size_t &cur_batch_size);
-
+                          size_t &cur_batch_size,
+                          size_t &next_payload_size_check_at);
 
  protected:
   rpc::ReportOCMetricsRequest createRequestProtoPayload();
-
+  size_t nextPayloadSizeCheckAt(size_t cur_batch_size);
   bool handleBatchOverflows(const rpc::ReportOCMetricsRequest &request_proto,
-                            size_t cur_batch_size);
+                            size_t cur_batch_size,
+                            size_t &next_batch_size_check_at);
 
   void addGlobalTagsToGrpcMetric(opencensus::proto::metrics::v1::Metric &metric);
 

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -111,9 +111,10 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
                        instrumented_io_context &io_service,
                        const std::string address,
                        const WorkerID &worker_id,
-                       size_t report_batch_size) {
+                       size_t report_batch_size,
+                       size_t max_grpc_payload_size) {
     opencensus::stats::StatsExporter::RegisterPushHandler(
-        absl::make_unique<OpenCensusProtoExporter>(port, io_service, address, worker_id, report_batch_size));
+        absl::make_unique<OpenCensusProtoExporter>(port, io_service, address, worker_id, report_batch_size, max_grpc_payload_size));
   }
 
   void ExportViewData(

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -53,6 +53,8 @@ class MetricPointExporter final : public opencensus::stats::StatsExporter::Handl
   void ExportViewData(
       const std::vector<std::pair<opencensus::stats::ViewDescriptor,
                                   opencensus::stats::ViewData>> &data) override;
+
+ protected:
   void addGlobalTagsToGrpcMetric(MetricPoint &metric);
 
  private:
@@ -116,7 +118,6 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
   void ExportViewData(
       const std::vector<std::pair<opencensus::stats::ViewDescriptor,
                                   opencensus::stats::ViewData>> &data) override;
-  void addGlobalTagsToGrpcMetric(opencensus::proto::metrics::v1::Metric &metric);
   void SendData(rpc::ReportOCMetricsRequest &request);
   void UpdateMetricsData(const std::pair<opencensus::stats::ViewDescriptor,
                                 opencensus::stats::ViewData> &datum, rpc::ReportOCMetricsRequest &request_proto);

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -178,7 +178,7 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
   /// immediately, so that we can make sure that batches stay w/in the threshold of the
   /// gRPC max message size set by an agent (usually calculated as 95% of agent's gRPC
   /// max-message size)
-  size_t proto_payload_size_threshold_;
+  size_t proto_payload_size_threshold_bytes_;
 };
 
 }  // namespace stats

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -105,7 +105,7 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
                           size_t report_batch_size,
                           size_t max_grpc_payload_size);
 
-  OpenCensusProtoExporter(std::unique_ptr<rpc::MetricsAgentClient> &&agent_client,
+  OpenCensusProtoExporter(std::shared_ptr<rpc::MetricsAgentClient> agent_client,
                           const WorkerID &worker_id,
                           size_t report_batch_size,
                           size_t max_grpc_payload_size);
@@ -145,7 +145,7 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
   /// Lock to protect the client
   mutable absl::Mutex mu_;
   /// Client to call a metrics agent gRPC server.
-  std::unique_ptr<rpc::MetricsAgentClient> client_ ABSL_GUARDED_BY(&mu_);
+  std::shared_ptr<rpc::MetricsAgentClient> client_ ABSL_GUARDED_BY(&mu_);
   /// The worker ID of the current component.
   WorkerID worker_id_;
   /// The maximum batch size to be included in a single gRPC metrics report request.

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -121,8 +121,17 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
       const std::vector<std::pair<opencensus::stats::ViewDescriptor,
                                   opencensus::stats::ViewData>> &data) override;
   void SendData(rpc::ReportOCMetricsRequest &request);
-  size_t AddMetricsData(const std::pair<opencensus::stats::ViewDescriptor,
-                        opencensus::stats::ViewData> &datum, rpc::ReportOCMetricsRequest &request_proto);
+
+  /// Adds data from the provided ViewDescriptor into target proto payload to be sent to an
+  /// agent aggregating metrics on this node
+  ///
+  /// \param view_descriptor, descriptor of the metric
+  /// \param view_data, data container aggregating time-series for this metric (across different set of tags)
+  /// \param request_proto, target proto payload to embed metric values into
+  /// \return number of time-series added to proto payload
+  size_t AddMetricsData(const opencensus::stats::ViewDescriptor &view_descriptor,
+                        const opencensus::stats::ViewData &view_data,
+                        rpc::ReportOCMetricsRequest &request_proto);
 
  protected:
   void addGlobalTagsToGrpcMetric(opencensus::proto::metrics::v1::Metric &metric);

--- a/src/ray/stats/metric_exporter.h
+++ b/src/ray/stats/metric_exporter.h
@@ -119,8 +119,11 @@ class OpenCensusProtoExporter final : public opencensus::stats::StatsExporter::H
       const std::vector<std::pair<opencensus::stats::ViewDescriptor,
                                   opencensus::stats::ViewData>> &data) override;
   void SendData(rpc::ReportOCMetricsRequest &request);
-  void UpdateMetricsData(const std::pair<opencensus::stats::ViewDescriptor,
-                                opencensus::stats::ViewData> &datum, rpc::ReportOCMetricsRequest &request_proto);
+  size_t AddMetricsData(const std::pair<opencensus::stats::ViewDescriptor,
+                        opencensus::stats::ViewData> &datum, rpc::ReportOCMetricsRequest &request_proto);
+
+ protected:
+  void addGlobalTagsToGrpcMetric(opencensus::proto::metrics::v1::Metric &metric);
 
  private:
   /// Call Manager for gRPC client.

--- a/src/ray/stats/metric_exporter_grpc_test.cc
+++ b/src/ray/stats/metric_exporter_grpc_test.cc
@@ -384,7 +384,7 @@ TEST(OpenCensusProtoExporterTest, export_view_data_split_by_payload_size) {
     for (int i = 0; i < 6; ++i) {
       // Each of the batches have to have 1 metric with 2 time-series each
       auto metrics = requests[i].metrics();
-      ASSERT_THAT(metrics.size(), 1);
+      //ASSERT_THAT(metrics.size(), 1);
       ASSERT_THAT(metrics[0].timeseries().size(), 2);
     }
 

--- a/src/ray/stats/metric_exporter_grpc_test.cc
+++ b/src/ray/stats/metric_exporter_grpc_test.cc
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "absl/memory/memory.h"
+#include "absl/strings/str_join.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "opencensus/stats/internal/delta_producer.h"
@@ -87,38 +88,35 @@ class MockExporterClientKeepsAll : public MetricExporterClient {
   std::vector<ExpectedPoint> points_;
 };
 
-const size_t kMockReportBatchSize = 10;
-const int MetricsAgentPort = 10054;
 const auto method_tag_key = TagKey::Register("grpc_client_method");
 const auto status_tag_key = TagKey::Register("grpc_client_status");
 
-MeasureInt64 RpcClientReceivedMessagesPerRpc() {
-  static const auto measure = MeasureInt64::Register(
-      "grpc.io/client/sent_messages_per_rpc", "Number of messages received per RPC", "1");
-  return measure;
-}
-
-const static opencensus::stats::ViewDescriptor descriptor =
-    ViewDescriptor()
-        .set_name("grpc.io/client/received_messages_per_rpc/cumulative")
-        .set_measure(RpcClientReceivedMessagesPerRpc().GetDescriptor().name())
-        .set_aggregation(Aggregation::Distribution(
-            opencensus::stats::BucketBoundaries::Exponential(17, 1.0, 2.0)))
-        .add_column(method_tag_key);
 
 TEST(MetricPointExporterTest, adds_global_tags_to_grpc) {
-  RpcClientReceivedMessagesPerRpc();
-  descriptor.RegisterForExport();
+  const int MetricsAgentPort = 10054;
+
+  auto measure = MeasureInt64::Register(
+      "grpc.io/client/sent_messages_per_rpc", "Number of messages received per RPC", "1");
+
+  const opencensus::stats::ViewDescriptor view_descriptor =
+      ViewDescriptor()
+          .set_name("grpc.io/client/received_messages_per_rpc/cumulative")
+          .set_measure(measure.GetDescriptor().name())
+          .set_aggregation(Aggregation::Distribution(
+              opencensus::stats::BucketBoundaries::Exponential(17, 1.0, 2.0)))
+          .add_column(method_tag_key);
+
+  view_descriptor.RegisterForExport();
 
   auto exporter = std::make_shared<MockExporterClientKeepsAll>();
 
   const stats::TagsType global_tags = {{stats::LanguageKey, "CPP"},
                                        {stats::WorkerPidKey, "1000"}};
   ray::stats::Init(
-      global_tags, MetricsAgentPort, WorkerID::Nil(), exporter, kMockReportBatchSize);
+      global_tags, MetricsAgentPort, WorkerID::Nil(), exporter, 10);
 
   opencensus::stats::Record(
-      {{RpcClientReceivedMessagesPerRpc(), 1}},
+      {{measure, 1}},
       {{method_tag_key, "MyService.myMethod"}, {status_tag_key, "OK"}});
 
   opencensus::stats::DeltaProducer::Get()->Flush();
@@ -149,6 +147,288 @@ TEST(MetricPointExporterTest, adds_global_tags_to_grpc) {
                         /*.tags=*/expected_tags}));
   ray::stats::Shutdown();
 }
+
+
+class MockMetricsAgentClient : public rpc::MetricsAgentClient {
+ public:
+  MockMetricsAgentClient() {}
+
+  void ReportMetrics(const rpc::ReportMetricsRequest& request,
+                     const rpc::ClientCallback<rpc::ReportMetricsReply> &callback) override {
+    reportMetricsRequests_.push_back(request);
+    callback(Status::OK(), {});
+  }
+
+  void ReportOCMetrics(const rpc::ReportOCMetricsRequest& request,
+                       const rpc::ClientCallback<rpc::ReportOCMetricsReply> &callback) override {
+    reportOCMetricsRequests_.push_back(request);
+    callback(Status::OK(), {});
+  }
+
+  const std::vector<rpc::ReportMetricsRequest> &CollectedReportMetricsRequests() const {
+    return reportMetricsRequests_;
+  }
+
+  const std::vector<rpc::ReportOCMetricsRequest> &CollectedReportOCMetricsRequests() const {
+    return reportOCMetricsRequests_;
+  }
+
+ private:
+  std::vector<rpc::ReportMetricsRequest> reportMetricsRequests_;
+  std::vector<rpc::ReportOCMetricsRequest> reportOCMetricsRequests_;
+};
+
+
+// Register view
+auto measure = MeasureInt64::Register(
+      "rpc_counter", "Simply counting RPCs, one at a time", "1");
+
+TEST(OpenCensusProtoExporterTest, export_view_data_split_by_batch_size) {
+  const opencensus::stats::ViewDescriptor view_descriptor =
+      ViewDescriptor()
+          .set_name("rpc_counter")
+          .set_measure(measure.GetDescriptor().name())
+          .set_aggregation(opencensus::stats::Aggregation::Count())
+          .add_column(method_tag_key)
+          .add_column(status_tag_key);
+
+  view_descriptor.RegisterForExport();
+
+  opencensus::stats::View view(view_descriptor);
+
+  // Record metrics (2 distinct time-series)
+  opencensus::stats::Record(
+      {{measure, 1}},
+      {{method_tag_key, "Service.FirstMethod"}, {status_tag_key, "OK"}}
+  );
+  opencensus::stats::Record(
+      {{measure, 1}},
+      {{method_tag_key, "Service.FirstMethod"}, {status_tag_key, "INTERNAL_FAILURE"}}
+  );
+  opencensus::stats::Record(
+      {{measure, 1}},
+      {{method_tag_key, "Service.SecondMethod"}, {status_tag_key, "OK"}}
+  );
+  opencensus::stats::Record(
+      {{measure, 1}},
+      {{method_tag_key, "Service.SecondMethod"}, {status_tag_key, "UNAVAILABLE"}}
+  );
+
+  opencensus::stats::DeltaProducer::Get()->Flush();
+  opencensus::stats::StatsExporterImpl::Get()->Export();
+
+  const auto view_data = view.GetData();
+
+  {
+    //
+    // Test #1: Fitting all time-series inside of single batch
+    //   - Batch-size is 4
+    //   - Exporting 4 time-series
+    //   - Only 1 RPC payload should be sent
+    //
+    RAY_LOG(INFO) << "Test #1";
+
+    size_t kBatchSize = 4;
+    // Initialize the exporter
+    auto mockClient = std::make_shared<MockMetricsAgentClient>();
+    OpenCensusProtoExporter ocProtoExporter(mockClient, WorkerID::Nil(), kBatchSize, 10000);
+
+    rpc::ReportOCMetricsRequest proto;
+
+    ocProtoExporter.ExportViewData({
+      {view_descriptor, view_data},
+    });
+
+    ASSERT_THAT(mockClient->CollectedReportOCMetricsRequests().size(), 1);
+    ASSERT_THAT(mockClient->CollectedReportMetricsRequests().size(), 0);
+  }
+
+  {
+    //
+    // Test #2: Splitting time-series across 2 batches
+    //   - Batch-size is 2
+    //   - Exporting 4 time-series
+    //   - 2 RPC payloads should be sent
+    //
+    RAY_LOG(INFO) << "Test #2";
+
+    size_t kBatchSize = 2;
+    // Initialize the exporter
+    auto mockClient = std::make_shared<MockMetricsAgentClient>();
+    OpenCensusProtoExporter ocProtoExporter(mockClient, WorkerID::Nil(), kBatchSize, 10000);
+
+    rpc::ReportOCMetricsRequest proto;
+
+    ocProtoExporter.ExportViewData({
+      {view_descriptor, view_data}
+    });
+
+    ASSERT_THAT(mockClient->CollectedReportOCMetricsRequests().size(), 2);
+    ASSERT_THAT(mockClient->CollectedReportMetricsRequests().size(), 0);
+  }
+
+}
+
+TEST(OpenCensusProtoExporterTest, export_view_data_split_by_payload_size) {
+ const opencensus::stats::ViewDescriptor view_descriptor =
+      ViewDescriptor()
+          .set_name("rpc_counter")
+          .set_measure(measure.GetDescriptor().name())
+          .set_aggregation(opencensus::stats::Aggregation::Count())
+          .add_column(method_tag_key)
+          .add_column(status_tag_key);
+
+  view_descriptor.RegisterForExport();
+
+  opencensus::stats::View view(view_descriptor);
+
+  // Record metrics (2 distinct time-series)
+  opencensus::stats::Record(
+      {{measure, 1}},
+      {{method_tag_key, "Service.FirstMethod"}, {status_tag_key, "OK"}}
+  );
+  opencensus::stats::Record(
+      {{measure, 1}},
+      {{method_tag_key, "Service.FirstMethod"}, {status_tag_key, "INTERNAL_FAILURE"}}
+  );
+  opencensus::stats::Record(
+      {{measure, 1}},
+      {{method_tag_key, "Service.SecondMethod"}, {status_tag_key, "OK"}}
+  );
+  opencensus::stats::Record(
+      {{measure, 1}},
+      {{method_tag_key, "Service.SecondMethod"}, {status_tag_key, "UNAVAILABLE"}}
+  );
+
+  opencensus::stats::DeltaProducer::Get()->Flush();
+  opencensus::stats::StatsExporterImpl::Get()->Export();
+
+  const auto view_data = view.GetData();
+
+  /*
+  for (auto &[vd, value] : view_data.int_data()) {
+    RAY_LOG(INFO) << "Metric: " << absl::StrJoin(vd, ",") << ", value: " << value;
+  }
+  */
+
+  {
+    //
+    // Test #1: Splitting time-series across 2 batches (overflows payload size)
+    //   - Batch-size is 4, max-payload size is 250 (1 metric def + 2 time-series)
+    //   - Exporting 4 time-series
+    //   - 2 RPC payloads should be sent (1 payload will be taking ~180 bytes, it'll be split in 2)
+    //
+    RAY_LOG(INFO) << "Test #1";
+
+    size_t kBatchSize = 4;
+    size_t maxPayloadSize = 250;
+    // Initialize the exporter
+    auto mockClient = std::make_shared<MockMetricsAgentClient>();
+    OpenCensusProtoExporter ocProtoExporter(mockClient, WorkerID::Nil(), kBatchSize, maxPayloadSize);
+
+    rpc::ReportOCMetricsRequest proto;
+
+    ocProtoExporter.ExportViewData({
+      {view_descriptor, view_data},
+    });
+
+    ASSERT_THAT(mockClient->CollectedReportMetricsRequests().size(), 0);
+
+    auto requests = mockClient->CollectedReportOCMetricsRequests();
+
+    RAY_LOG(INFO) << "Request payload: " << requests[0].DebugString();
+
+    ASSERT_THAT(requests.size(), 2);
+    for (int i = 0; i < 2; ++i) {
+      // Both batches have to have 1 metric with 2 time-series each
+      auto metrics = requests[i].metrics();
+      ASSERT_THAT(metrics.size(), 1);
+      ASSERT_THAT(metrics[0].timeseries().size(), 2);
+    }
+
+  }
+
+  {
+    //
+    // Test #2: Splitting time-series across 6 batches (overflows payload size)
+    //   - Batch-size is 6, max-payload size is 250 (1 metric def + 2 time-series)
+    //   - Exporting 12 time-series
+    //   - 6 RPC payloads should be sent (since 1 payload will be taking ~250 bytes, it'll be split in 6)
+    //
+    RAY_LOG(INFO) << "Test #2";
+
+    size_t kBatchSize = 6;
+    size_t maxPayloadSize = 250;  // 50% of the expected target payload size
+    // Initialize the exporter
+    auto mockClient = std::make_shared<MockMetricsAgentClient>();
+    OpenCensusProtoExporter ocProtoExporter(mockClient, WorkerID::Nil(), kBatchSize, maxPayloadSize);
+
+    rpc::ReportOCMetricsRequest proto;
+
+    ocProtoExporter.ExportViewData({
+      // NOTE: To avoid excessive boilerplate we just feed in same metrics to simulate larger batches
+      {view_descriptor, view_data},
+      {view_descriptor, view_data},
+      {view_descriptor, view_data}
+    });
+
+    ASSERT_THAT(mockClient->CollectedReportMetricsRequests().size(), 0);
+
+    auto requests = mockClient->CollectedReportOCMetricsRequests();
+
+    RAY_LOG(INFO) << "Request payload: " << requests[0].DebugString();
+    RAY_LOG(INFO) << "Request payload: " << requests[1].DebugString();
+    RAY_LOG(INFO) << "Request payload: " << requests[2].DebugString();
+
+    ASSERT_THAT(requests.size(), 6);
+    for (int i = 0; i < 6; ++i) {
+      // Each of the batches have to have 1 metric with 2 time-series each
+      auto metrics = requests[i].metrics();
+      ASSERT_THAT(metrics.size(), 1);
+      ASSERT_THAT(metrics[0].timeseries().size(), 2);
+    }
+
+  }
+
+  {
+    //
+    // Test #3: Splitting time-series across 1 batches (no overflowing)
+    //   - Batch-size is 12 (all), max-payload size is 1000
+    //   - Exporting 12 time-series
+    //   - 1 RPC payloads should be sent (since 1 payload will be taking ~180 bytes, it'll be split in 6)
+    //
+    RAY_LOG(INFO) << "Test #3";
+
+    size_t kBatchSize = 12;
+    size_t maxPayloadSize = 1000;  // 50% of the expected target payload size
+    // Initialize the exporter
+    auto mockClient = std::make_shared<MockMetricsAgentClient>();
+    OpenCensusProtoExporter ocProtoExporter(mockClient, WorkerID::Nil(), kBatchSize, maxPayloadSize);
+
+    rpc::ReportOCMetricsRequest proto;
+
+    ocProtoExporter.ExportViewData({
+      // NOTE: To avoid excessive boilerplate we just feed in same metrics to simulate larger batches
+      {view_descriptor, view_data},
+      {view_descriptor, view_data},
+      {view_descriptor, view_data}
+    });
+
+    RAY_LOG(INFO) << mockClient->CollectedReportOCMetricsRequests()[0].ByteSizeLong();
+
+    auto requests = mockClient->CollectedReportOCMetricsRequests();
+
+    RAY_LOG(INFO) << "Payload: " << requests[0].DebugString();
+
+    ASSERT_THAT(requests.size(), 1);
+    ASSERT_THAT(requests[0].metrics().size(), 3);
+    // Batch have to have 3 metric with 4 time-series each
+    for (int i = 0; i < 3; ++i) {
+      ASSERT_THAT(requests[0].metrics()[i].timeseries().size(), 4);
+    }
+  }
+}
+
 }  // namespace ray
 
 int main(int argc, char **argv) {

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -105,7 +105,12 @@ static inline void Init(const TagsType &global_tags,
 
   MetricPointExporter::Register(exporter, metrics_report_batch_size);
   OpenCensusProtoExporter::Register(
-      metrics_agent_port, (*metrics_io_service), "127.0.0.1", worker_id, RayConfig::instance().metrics_report_batch_size());
+      metrics_agent_port,
+      (*metrics_io_service),
+      "127.0.0.1",
+      worker_id,
+      RayConfig::instance().metrics_report_batch_size(),
+      RayConfig::instance().agent_max_grpc_message_size());
   StatsConfig::instance().SetGlobalTags(global_tags);
   for (auto &f : StatsConfig::instance().PopInitializers()) {
     f();

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -61,7 +61,9 @@ static inline void Init(const TagsType &global_tags,
                         const WorkerID &worker_id,
                         std::shared_ptr<MetricExporterClient> exporter_to_use = nullptr,
                         int64_t metrics_report_batch_size =
-                            RayConfig::instance().metrics_report_batch_size()) {
+                            RayConfig::instance().metrics_report_batch_size(),
+                        int64_t max_grpc_payload_size =
+                            RayConfig::instance().agent_max_grpc_message_size()) {
   absl::MutexLock lock(&stats_mutex);
   if (StatsConfig::instance().IsInitialized()) {
     RAY_CHECK(metrics_io_service_pool != nullptr);
@@ -109,8 +111,10 @@ static inline void Init(const TagsType &global_tags,
       (*metrics_io_service),
       "127.0.0.1",
       worker_id,
-      RayConfig::instance().metrics_report_batch_size(),
-      RayConfig::instance().agent_max_grpc_message_size());
+      metrics_report_batch_size,
+      max_grpc_payload_size
+  );
+
   StatsConfig::instance().SetGlobalTags(global_tags);
   for (auto &f : StatsConfig::instance().PopInitializers()) {
     f();

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -56,14 +56,13 @@ static absl::Mutex stats_mutex;
 /// \param metrics_agent_port[in] The port to export metrics at each node.
 /// \param worker_id[in] The worker ID of the current component.
 /// \param exporter_to_use[in] The exporter client you will use for this process' metrics.
-static inline void Init(const TagsType &global_tags,
-                        const int metrics_agent_port,
-                        const WorkerID &worker_id,
-                        std::shared_ptr<MetricExporterClient> exporter_to_use = nullptr,
-                        int64_t metrics_report_batch_size =
-                            RayConfig::instance().metrics_report_batch_size(),
-                        int64_t max_grpc_payload_size =
-                            RayConfig::instance().agent_max_grpc_message_size()) {
+static inline void Init(
+    const TagsType &global_tags,
+    const int metrics_agent_port,
+    const WorkerID &worker_id,
+    std::shared_ptr<MetricExporterClient> exporter_to_use = nullptr,
+    int64_t metrics_report_batch_size = RayConfig::instance().metrics_report_batch_size(),
+    int64_t max_grpc_payload_size = RayConfig::instance().agent_max_grpc_message_size()) {
   absl::MutexLock lock(&stats_mutex);
   if (StatsConfig::instance().IsInitialized()) {
     RAY_CHECK(metrics_io_service_pool != nullptr);
@@ -106,14 +105,12 @@ static inline void Init(const TagsType &global_tags,
       StatsConfig::instance().GetHarvestInterval());
 
   MetricPointExporter::Register(exporter, metrics_report_batch_size);
-  OpenCensusProtoExporter::Register(
-      metrics_agent_port,
-      (*metrics_io_service),
-      "127.0.0.1",
-      worker_id,
-      metrics_report_batch_size,
-      max_grpc_payload_size
-  );
+  OpenCensusProtoExporter::Register(metrics_agent_port,
+                                    (*metrics_io_service),
+                                    "127.0.0.1",
+                                    worker_id,
+                                    metrics_report_batch_size,
+                                    max_grpc_payload_size);
 
   StatsConfig::instance().SetGlobalTags(global_tags);
   for (auto &f : StatsConfig::instance().PopInitializers()) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Problem
----

We have a use-case where some of our metrics have very high-cardinality (> 60k time-series per metrics), and current implementation unfortunately fails to export metrics reliably in that case due to:

 - Current implementation counts `Metric` proto objects rather than `TimeSeries` towards the batch size limit
 - Eventually once it comes to ~50k time-series we cross default threshold of 20Mb max payload size for gRPC, failing to export metrics and eventually losing them

Solution
----

I'm addressing this by refactoring exporting sequence:

 - Now instead of counting metrics, it'll be appropriately accounting for time-series added into the batch
 - Requests to an agent are now flushed while filling in the time-series, allowing to break up metrics w/ the large number of time-series across multiple requests to an agent

Additionally, to protect from metric loss i'm adding iterative proto payload size checking which is:
 - Checking payload size log(N) times (at 1/2, 3/4, 7/8, ... of the batch size)
 - Validating that the batch stays w/in the max gRPC message size limits set (currently 20Mb)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
