### PR TITLE
[data] Fix sliced blocks performance issue

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -432,5 +432,8 @@ class ApplyAdditionalSplitToOutputBlocks(MapTransformFn):
             offset = 0
             split_sizes = _splitrange(block.num_rows(), self._additional_split_factor)
             for size in split_sizes:
-                yield block.slice(offset, offset + size)
+                # NOTE: copy=True is needed because this is an output block. If
+                # a block slice is put into the object store, the entire block
+                # will get serialized.
+                yield block.slice(offset, offset + size, copy=True)
                 offset += size


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#39710 introduced a performance regression in read ops that split their output blocks. Block slices were no longer copied, meaning that the entire block would get put in the object store whenever a slice was returned. The fix has been verified on the read_tfrecords_benchmark.

## Related issue number

Closes #40508.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
