### PR TITLE
[data] assign dataset ids using statsactor

### DIFF
--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -591,7 +591,7 @@ class ExecutionPlan:
                     StreamingExecutor,
                 )
 
-                metrics_tag = (self._dataset_name or "") + self._dataset_uuid
+                metrics_tag = (self._dataset_name or "dataset") + self._dataset_uuid
                 executor = StreamingExecutor(
                     copy.deepcopy(context.execution_options),
                     metrics_tag,

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -314,6 +314,8 @@ def get_dataset_id_from_stats_actor() -> str:
     try:
         return ray.get(_stats_actor.get_dataset_id.remote())
     except ray.exceptions.RayError:
+        # Getting dataset id from _StatsActor may fail, in this case
+        # fall back to uuid4
         return uuid4().hex
 
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -3,6 +3,7 @@ import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set, Union
+from uuid import uuid4
 
 import numpy as np
 
@@ -308,9 +309,12 @@ def clear_stats_actor_metrics(tags: Dict[str, str]):
 
 
 def get_dataset_id_from_stats_actor() -> str:
-    # global _stats_actor
+    global _stats_actor
     _check_cluster_stats_actor()
-    return ray.get(_stats_actor.get_dataset_id.remote())
+    try:
+        return ray.get(_stats_actor.get_dataset_id.remote())
+    except ray.exceptions.RayError:
+        return uuid4().hex
 
 
 class DatasetStats:

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -224,7 +224,7 @@ class _StatsActor:
         return len(self.start_time), len(self.last_time), len(self.metadata)
 
     def get_dataset_id(self):
-        dataset_id = self.next_dataset_id
+        dataset_id = str(self.next_dataset_id)
         self.next_dataset_id += 1
         return dataset_id
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -310,10 +310,10 @@ def clear_stats_actor_metrics(tags: Dict[str, str]):
 
 def get_dataset_id_from_stats_actor() -> str:
     global _stats_actor
-    _check_cluster_stats_actor()
     try:
+        _check_cluster_stats_actor()
         return ray.get(_stats_actor.get_dataset_id.remote())
-    except ray.exceptions.RayError:
+    except Exception:
         # Getting dataset id from _StatsActor may fail, in this case
         # fall back to uuid4
         return uuid4().hex

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -2,7 +2,7 @@ import collections
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 import numpy as np
 
@@ -15,6 +15,9 @@ from ray.data.context import DataContext
 from ray.util.annotations import DeveloperAPI
 from ray.util.metrics import Gauge
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+if TYPE_CHECKING:
+    from ray.data import Dataset
 
 STATS_ACTOR_NAME = "datasets_stats_actor"
 STATS_ACTOR_NAMESPACE = "_dataset_stats_actor"
@@ -143,6 +146,10 @@ class _StatsActor:
         self.max_stats = max_stats
         self.fifo_queue = []
 
+        # Assign dataset uuids with a global counter.
+        self.dataset_id: Dict["Dataset", str] = {}
+        self.next_id = 0
+
         # Ray Data dashboard metrics
         # Everything is a gauge because we need to reset all of
         # a dataset's metrics to 0 after each finishes execution.
@@ -220,6 +227,12 @@ class _StatsActor:
     def _get_stats_dict_size(self):
         return len(self.start_time), len(self.last_time), len(self.metadata)
 
+    def register_dataset(self, dataset):
+        if dataset not in self.dataset_id:
+            self.dataset_id[dataset] = str(self.next_id)
+            self.next_id += 1
+        return self.dataset_id[dataset]
+
     def update_metrics(self, stats: Dict[str, Union[int, float]], tags: Dict[str, str]):
         self.bytes_spilled.set(stats["obj_store_mem_spilled"], tags)
         self.bytes_allocated.set(stats["obj_store_mem_alloc"], tags)
@@ -295,6 +308,12 @@ def clear_stats_actor_metrics(tags: Dict[str, str]):
     global _stats_actor
     _check_cluster_stats_actor()
     _stats_actor.clear_metrics.remote(tags)
+
+
+def register_dataset_to_stats_actor(dataset: "Dataset") -> str:
+    global _stats_actor
+    _check_cluster_stats_actor()
+    return ray.get(_stats_actor.register_dataset.remote(dataset))
 
 
 class DatasetStats:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -20,7 +20,6 @@ from typing import (
     TypeVar,
     Union,
 )
-from uuid import uuid4
 
 import numpy as np
 
@@ -83,7 +82,11 @@ from ray.data._internal.stage_impl import (
     SortStage,
     ZipStage,
 )
-from ray.data._internal.stats import DatasetStats, DatasetStatsSummary
+from ray.data._internal.stats import (
+    DatasetStats,
+    DatasetStatsSummary,
+    register_dataset_to_stats_actor,
+)
 from ray.data._internal.util import ConsumptionAPI, _is_local_scheme, validate_compute
 from ray.data.aggregate import AggregateFn, Max, Mean, Min, Std, Sum
 from ray.data.block import (
@@ -236,7 +239,6 @@ class Dataset:
         usage_lib.record_library_usage("dataset")  # Legacy telemetry name.
 
         self._plan = plan
-        self._set_uuid(uuid4().hex)
         self._logical_plan = logical_plan
         if logical_plan is not None:
             self._plan.link_logical_plan(logical_plan)
@@ -244,6 +246,8 @@ class Dataset:
         # Handle to currently running executor for this dataset.
         self._current_executor: Optional["Executor"] = None
         self._write_ds = None
+        self._uuid = None
+        self._set_uuid(register_dataset_to_stats_actor(self))
 
     @staticmethod
     def copy(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -85,7 +85,7 @@ from ray.data._internal.stage_impl import (
 from ray.data._internal.stats import (
     DatasetStats,
     DatasetStatsSummary,
-    register_dataset_to_stats_actor,
+    get_dataset_id_from_stats_actor,
 )
 from ray.data._internal.util import ConsumptionAPI, _is_local_scheme, validate_compute
 from ray.data.aggregate import AggregateFn, Max, Mean, Min, Std, Sum
@@ -247,7 +247,7 @@ class Dataset:
         self._current_executor: Optional["Executor"] = None
         self._write_ds = None
         self._uuid = None
-        self._set_uuid(register_dataset_to_stats_actor(self))
+        self._set_uuid(get_dataset_id_from_stats_actor())
 
     @staticmethod
     def copy(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -246,7 +246,7 @@ class Dataset:
         # Handle to currently running executor for this dataset.
         self._current_executor: Optional["Executor"] = None
         self._write_ds = None
-        self._uuid = None
+
         self._set_uuid(get_dataset_id_from_stats_actor())
 
     @staticmethod

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -1415,8 +1415,9 @@ def test_read_write_local_node_ray_client(ray_start_cluster_enabled):
     ray.init(address)
     with pytest.raises(ValueError):
         ray.data.read_parquet("local://" + path).materialize()
-    with pytest.raises(RuntimeError):
-        ray.data.from_pandas(df).write_parquet("local://" + data_path).materialize()
+    ds = ray.data.from_pandas(df)
+    with pytest.raises(ValueError):
+        ds.write_parquet("local://" + data_path).materialize()
 
 
 def test_read_warning_large_parallelism(ray_start_regular, propagate_logs, caplog):

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -1414,10 +1414,9 @@ def test_read_write_local_node_ray_client(ray_start_cluster_enabled):
     # Read/write from Ray Client will result in error.
     ray.init(address)
     with pytest.raises(ValueError):
-        ds = ray.data.read_parquet("local://" + path).materialize()
-    ds = ray.data.from_pandas(df)
-    with pytest.raises(ValueError):
-        ds.write_parquet("local://" + data_path).materialize()
+        ray.data.read_parquet("local://" + path).materialize()
+    with pytest.raises(RuntimeError):
+        ray.data.from_pandas(df).write_parquet("local://" + data_path).materialize()
 
 
 def test_read_warning_large_parallelism(ray_start_regular, propagate_logs, caplog):

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -1414,7 +1414,7 @@ def test_read_write_local_node_ray_client(ray_start_cluster_enabled):
     # Read/write from Ray Client will result in error.
     ray.init(address)
     with pytest.raises(ValueError):
-        ray.data.read_parquet("local://" + path).materialize()
+        ds = ray.data.read_parquet("local://" + path).materialize()
     ds = ray.data.from_pandas(df)
     with pytest.raises(ValueError):
         ds.write_parquet("local://" + data_path).materialize()

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1180,7 +1180,7 @@ def test_stats_actor_metrics():
     # There should be nothing in object store at the end of execution.
     assert final_metric.obj_store_mem_cur == 0
 
-    assert ds._uuid == update_fn.call_args_list[-1].args[1]["dataset"]
+    assert "dataset" + ds._uuid == update_fn.call_args_list[-1].args[1]["dataset"]
 
 
 def test_dataset_name():

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -483,7 +483,7 @@ def test_dataset__repr__(ray_start_regular_shared):
 
     expected_stats = (
         "DatasetStatsSummary(\n"
-        "   dataset_uuid=U,\n"
+        "   dataset_uuid=N,\n"
         "   base_name=None,\n"
         "   number=N,\n"
         "   extra_metrics={},\n"
@@ -539,7 +539,7 @@ def test_dataset__repr__(ray_start_regular_shared):
     assert len(ds2.take_all()) == n
     expected_stats2 = (
         "DatasetStatsSummary(\n"
-        "   dataset_uuid=U,\n"
+        "   dataset_uuid=N,\n"
         "   base_name=MapBatches(<lambda>),\n"
         "   number=N,\n"
         "   extra_metrics={\n"
@@ -596,7 +596,7 @@ def test_dataset__repr__(ray_start_regular_shared):
         "   dataset_bytes_spilled=M,\n"
         "   parents=[\n"
         "      DatasetStatsSummary(\n"
-        "         dataset_uuid=U,\n"
+        "         dataset_uuid=N,\n"
         "         base_name=None,\n"
         "         number=N,\n"
         "         extra_metrics={},\n"

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1219,7 +1219,7 @@ def test_dataset_name():
     with patch_update_stats_actor() as update_fn:
         mds = ds.materialize()
 
-    assert update_fn.call_args_list[-1].args[1]["dataset"] == mds._uuid
+    assert update_fn.call_args_list[-1].args[1]["dataset"] == "dataset" + mds._uuid
 
     ds = ray.data.range(100, parallelism=20)
     ds._set_name("very_loooooooong_name")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

UUID is too long and not user-friendly, and we use it for tagging data metrics. 
This PR removes `uuid4()` and assigns `Dataset._uuid` using a global counter stored in `_StatsActor` for a shorter dataset id.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
