### PR TITLE
[ci] migrate rest of ml tests to civ2

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -41,6 +41,23 @@ steps:
     depends_on: mlbuild
     job_env: forge
 
+  - label: ":train: ml: train authentication tests"
+    tags:
+      - train
+      - branch
+    # run only on postmerge
+    if: build.env("BUILDKITE_PIPELINE_ID") == "0189e759-8c96-4302-b6b5-b4274406bf89"
+    instance_type: medium
+    commands:
+      - pip install -U boto3==1.28.70 awscli==1.29.70 
+      - $(python ci/env/setup_credentials.py)
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml 
+        --parallelism-per-worker 3
+        --only-tags needs_credentials
+        --test-env=WANDB_API_KEY --test-env=COMET_API_KEY
+    depends_on: mlbuild
+    job_env: forge
+
   - label: ":train: ml: tune tests"
     tags: tune
     instance_type: large

--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -1,18 +1,5 @@
 #ci:group=ML tests
 
-- label: ":train: :key: Train examples with authentication"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TRAIN_AFFECTED", "RAY_CI_BRANCH_BUILD"]
-  instance_size: medium
-  commands:
-    - if [[ "$BUILDKITE_PIPELINE_ID" != "0183465b-c6fb-479b-8577-4cfd743b545d" ]]; then exit 0; fi
-    - trap ./ci/build/upload_build_info.sh EXIT
-    - TRAIN_TESTING=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - $(python ci/env/setup_credentials.py)
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=needs_credentials 
-      --test_env=WANDB_API_KEY --test_env=COMET_API_KEY
-      python/ray/train/...
-
 - label: ":brain: RLlib: Memory leak tests TF2-eager-tracing"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
   instance_size: medium
@@ -57,15 +44,6 @@
 #    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
 #    - INSTALL_LUDWIG=1 INSTALL_HOROVOD=1 ./ci/env/install-dependencies.sh
 #    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/tests/ludwig/...
-
-- label: ":tropical_fish: ML Libraries w/ Ray Client."
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED"]
-  instance_size: medium
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - TUNE_TESTING=1 DATA_PROCESSING_TESTING=1 INSTALL_HOROVOD=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=client --test_env=RAY_CLIENT_MODE=1 python/ray/util/dask/...
 
 - label: ":potable_water: Dataset library integrations tests and examples"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED"]

--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -24,6 +24,18 @@ steps:
     depends_on: serverlessbuild
     job_env: forge
 
+  - label: ":serverless: serverless: ml tests"
+    tags: python
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/util/dask/... serverless
+        --build-name mlbuild
+        --parallelism-per-worker 2
+        --only-tags client
+        --test-env=RAY_CLIENT_MODE=1
+    depends_on: mlbuild
+    job_env: forge
+
   - label: ":serverless: serverless: flaky tests"
     tags: python
     instance_type: medium

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -29,9 +29,16 @@ class Container:
     A wrapper for running commands in ray ci docker container
     """
 
-    def __init__(self, docker_tag: str, volumes: Optional[List[str]] = None) -> None:
+    def __init__(
+        self,
+        docker_tag: str,
+        volumes: Optional[List[str]] = None,
+        envs: Optional[List[str]] = None,
+    ) -> None:
         self.docker_tag = docker_tag
         self.volumes = volumes or []
+        self.envs = envs or []
+        self.envs += _DOCKER_ENV
 
     def run_script_with_output(self, script: List[str]) -> bytes:
         """
@@ -87,7 +94,7 @@ class Container:
         ]
         for volume in self.volumes:
             command += ["--volume", volume]
-        for env in _DOCKER_ENV:
+        for env in self.envs:
             command += ["--env", env]
         for cap in _DOCKER_CAP_ADD:
             command += ["--cap-add", cap]

--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -40,6 +40,7 @@ def test_enough_gpus() -> None:
 def test_run_tests_in_docker() -> None:
     def _mock_popen(input: List[str]) -> None:
         input_str = " ".join(input)
+        assert "--env ENV_01 --env ENV_02 --env BUILDKITE_BUILD_URL" in input_str
         assert '--gpus "device=0,1"' in input_str
         assert (
             "bazel test --jobs=1 --config=ci $(./ci/run/bazel_export_options) "
@@ -50,7 +51,9 @@ def test_run_tests_in_docker() -> None:
         "ci.ray_ci.tester_container.TesterContainer.install_ray",
         return_value=None,
     ):
-        container = TesterContainer("team", build_type="debug")
+        container = TesterContainer(
+            "team", build_type="debug", envs=["ENV_01", "ENV_02"]
+        )
         container._run_tests_in_docker(["t1", "t2"], [0, 1], ["v=k"], "flag")
 
 

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import List, Optional
+from typing import List, Tuple, Optional
 
 import yaml
 import click
@@ -114,7 +114,7 @@ def main(
     run_flaky_tests: bool,
     skip_ray_installation: bool,
     gpus: int,
-    test_env: List[str],
+    test_env: Tuple[str],
     test_arg: Optional[str],
     build_name: Optional[str],
     build_type: Optional[str],
@@ -130,9 +130,10 @@ def main(
         worker_id,
         parallelism_per_worker,
         gpus,
-        build_name,
-        build_type,
-        skip_ray_installation,
+        test_env=list(test_env),
+        build_name=build_name,
+        build_type=build_type,
+        skip_ray_installation=skip_ray_installation,
     )
     test_targets = _get_test_targets(
         container,
@@ -142,7 +143,7 @@ def main(
         only_tags=only_tags,
         get_flaky_tests=run_flaky_tests,
     )
-    success = container.run_tests(test_targets, test_env, test_arg)
+    success = container.run_tests(test_targets, test_arg)
     sys.exit(0 if success else 1)
 
 
@@ -152,6 +153,7 @@ def _get_container(
     worker_id: int,
     parallelism_per_worker: int,
     gpus: int,
+    test_env: Optional[List[str]] = None,
     build_name: Optional[str] = None,
     build_type: Optional[str] = None,
     skip_ray_installation: bool = False,
@@ -162,6 +164,7 @@ def _get_container(
 
     return TesterContainer(
         build_name or f"{team}build",
+        envs=test_env,
         shard_count=shard_count,
         shard_ids=list(range(shard_start, shard_end)),
         gpus=gpus,

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -17,6 +17,7 @@ class TesterContainer(Container):
         docker_tag: str,
         shard_count: int = 1,
         gpus: int = 0,
+        envs: Optional[List[str]] = None,
         shard_ids: Optional[List[int]] = None,
         skip_ray_installation: bool = False,
         build_type: Optional[str] = None,
@@ -28,9 +29,10 @@ class TesterContainer(Container):
         used to run tests in a distributed fashion.
         :param shard_ids: The list of shard ids to run. If none, run no shards.
         """
-        super().__init__(docker_tag)
+        super().__init__(docker_tag, envs=envs)
         self.shard_count = shard_count
         self.shard_ids = shard_ids or []
+        self.envs = envs or []
         self.build_type = build_type
         self.gpus = gpus
         assert (
@@ -43,7 +45,6 @@ class TesterContainer(Container):
     def run_tests(
         self,
         test_targets: List[str],
-        test_envs: List[str],
         test_arg: Optional[str] = None,
     ) -> bool:
         """
@@ -66,7 +67,7 @@ class TesterContainer(Container):
         # divide gpus evenly among chunks
         gpu_ids = chunk_into_n(list(range(self.gpus)), len(chunks))
         runs = [
-            self._run_tests_in_docker(chunks[i], gpu_ids[i], test_envs, test_arg)
+            self._run_tests_in_docker(chunks[i], gpu_ids[i], self.envs, test_arg)
             for i in range(len(chunks))
         ]
         exits = [run.wait() for run in runs]


### PR DESCRIPTION
Move credential + client ml tests to civ2. Notice that the credential tests only run on postmerge (which is the same behavior as civ1)

Test:
- CI
- Post-merge run: https://buildkite.com/ray-project/postmerge/builds/1384#018b6522-00f1-4d71-afea-8556039769c8 (I cancel the run since the other parts are irrelevant)