### PR TITLE
[data] emit block generation time as data metric

### DIFF
--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -205,12 +205,16 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
         pathParams: "orgId=1&theme=light&panelId=7",
       },
       {
-        title: "Iteration Blocked Time",
+        title: "Block Generation Time",
         pathParams: "orgId=1&theme=light&panelId=8",
       },
       {
-        title: "Iteration User Time",
+        title: "Iteration Blocked Time",
         pathParams: "orgId=1&theme=light&panelId=9",
+      },
+      {
+        title: "Iteration User Time",
+        pathParams: "orgId=1&theme=light&panelId=10",
       },
     ],
   },

--- a/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -93,6 +93,18 @@ DATA_GRAFANA_PANELS = [
     ),
     Panel(
         id=8,
+        title="Block Generation Time",
+        description="Time spent generating blocks.",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_data_block_generation_seconds{{{global_filters}}}) by (dataset)",
+                legend="Block Generation Time: {{dataset}}",
+            )
+        ],
+    ),
+    Panel(
+        id=9,
         title="Iteration Blocked Time",
         description="Seconds user thread is blocked by iter_batches()",
         unit="seconds",
@@ -104,7 +116,7 @@ DATA_GRAFANA_PANELS = [
         ],
     ),
     Panel(
-        id=9,
+        id=10,
         title="Iteration User Time",
         description="Seconds spent in user code",
         unit="seconds",

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -200,6 +200,7 @@ class _StatsActor:
             description="Seconds spent in user code",
             tag_keys=tags_keys,
         )
+
     def record_start(self, stats_uuid):
         self.start_time[stats_uuid] = time.perf_counter()
         self.fifo_queue.append(stats_uuid)

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -184,6 +184,12 @@ class _StatsActor:
             description="Bytes outputted by dataset operators",
             tag_keys=tags_keys,
         )
+        self.block_generation_time = Gauge(
+            "data_block_generation_seconds",
+            description="Time spent generating blocks.",
+            tag_keys=tags_keys,
+        )
+
         self.iter_total_blocked_s = Gauge(
             "data_iter_total_blocked_seconds",
             description="Seconds user thread is blocked by iter_batches()",
@@ -194,7 +200,6 @@ class _StatsActor:
             description="Seconds spent in user code",
             tag_keys=tags_keys,
         )
-
     def record_start(self, stats_uuid):
         self.start_time[stats_uuid] = time.perf_counter()
         self.fifo_queue.append(stats_uuid)
@@ -238,6 +243,7 @@ class _StatsActor:
         self.bytes_outputted.set(stats["bytes_outputs_generated"], tags)
         self.cpu_usage.set(stats["cpu_usage"], tags)
         self.gpu_usage.set(stats["gpu_usage"], tags)
+        self.block_generation_time.set(stats["block_generation_time"], tags)
 
     def update_iter_metrics(self, stats: "DatasetStats", tags):
         self.iter_total_blocked_s.set(stats.iter_total_blocked_s.get(), tags)
@@ -251,6 +257,7 @@ class _StatsActor:
         self.bytes_outputted.set(0, tags)
         self.cpu_usage.set(0, tags)
         self.gpu_usage.set(0, tags)
+        self.block_generation_time.set(0, tags)
 
     def clear_iter_metrics(self, tags: Dict[str, str]):
         self.iter_total_blocked_s.set(0, tags)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -44,6 +44,7 @@ def gen_expected_metrics(
             "'obj_store_mem_cur': Z",
             "'obj_store_mem_peak': N",
             f"""'obj_store_mem_spilled': {"N" if spilled else "Z"}""",
+            "'block_generation_time': N",
             "'cpu_usage': Z",
             "'gpu_usage': Z",
         ]
@@ -73,7 +74,7 @@ LARGE_ARGS_EXTRA_METRICS = gen_expected_metrics(
     is_map=True,
     spilled=False,
     extra_metrics=[
-        "'ray_remote_args': {'num_cpus': Z.N, 'scheduling_strategy': 'DEFAULT'}"
+        "'ray_remote_args': {'num_cpus': N, 'scheduling_strategy': 'DEFAULT'}"
     ],
 )
 
@@ -106,17 +107,19 @@ def canonicalize(stats: str, filter_global_stats: bool = True) -> str:
     s1 = re.sub("[0-9\.]+(ms|us|s)", "T", s0)
     # Memory expressions.
     s2 = re.sub("[0-9\.]+(B|MB|GB)", "M", s1)
+    # Handle floats in (0, 1)
+    s3 = re.sub(" (0\.0*[1-9][0-9]*)", " N", s2)
     # Handle zero values specially so we can check for missing values.
-    s3 = re.sub(" [0]+(\.[0]+)?", " Z", s2)
+    s4 = re.sub(" [0]+(\.[0])?", " Z", s3)
     # Other numerics.
-    s4 = re.sub("[0-9]+(\.[0-9]+)?", "N", s3)
+    s5 = re.sub("[0-9]+(\.[0-9]+)?", "N", s4)
     # Replace tabs with spaces.
-    s5 = re.sub("\t", "    ", s4)
+    s6 = re.sub("\t", "    ", s5)
     if filter_global_stats:
-        s6 = s5.replace(CLUSTER_MEMORY_STATS, "")
-        s7 = s6.replace(DATASET_MEMORY_STATS, "")
-        return s7
-    return s5
+        s7 = s6.replace(CLUSTER_MEMORY_STATS, "")
+        s8 = s7.replace(DATASET_MEMORY_STATS, "")
+        return s8
+    return s6
 
 
 def dummy_map_batches(x):
@@ -570,6 +573,7 @@ def test_dataset__repr__(ray_start_regular_shared):
         "      obj_store_mem_cur: Z,\n"
         "      obj_store_mem_peak: N,\n"
         "      obj_store_mem_spilled: Z,\n"
+        "      block_generation_time: N,\n"
         "      cpu_usage: Z,\n"
         "      gpu_usage: Z,\n"
         "      ray_remote_args: {'num_cpus': N, 'scheduling_strategy': 'SPREAD'},\n"
@@ -1189,6 +1193,18 @@ def test_stats_actor_metrics():
     assert final_metric.obj_store_mem_cur == 0
 
     assert ds._uuid == update_fn.call_args_list[-1].args[1]["dataset"]
+
+    def sleep_three(x):
+        import time
+
+        time.sleep(3)
+        return x
+
+    with patch_update_stats_actor() as update_fn:
+        ds = ray.data.range(3).map_batches(sleep_three, batch_size=1).materialize()
+
+    final_metric = update_fn.call_args_list[-1].args[0][-1]
+    assert final_metric.block_generation_time >= 9
 
 
 def test_stats_actor_iter_metrics():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Emits block generation time as a metric to ray data dashboard.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
