### PR TITLE
[release] Release logs for 2.7.1

### DIFF
--- a/release/release_logs/2.7.1/benchmarks/many_actors.json
+++ b/release/release_logs/2.7.1/benchmarks/many_actors.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 474.591232,
+    "_dashboard_test_success": true,
+    "_peak_memory": 14.33,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n216\t1.45GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2111\t0.83GiB\tpython distributed/test_many_actors.py\n322\t0.29GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n59\t0.08GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n409\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n1939\t0.06GiB\tray::JobSupervisor\n52\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n2221\t0.06GiB\tray::MemoryMonitorActor.run\n407\t0.05GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n2299\t0.05GiB\tray::DashboardTester.run",
+    "actors_per_second": 738.330085638146,
+    "num_actors": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "actors_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 738.330085638146
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 35.742
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3539.897
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 6204.525
+        }
+    ],
+    "success": "1",
+    "time": 13.544077634811401
+}

--- a/release/release_logs/2.7.1/benchmarks/many_nodes.json
+++ b/release/release_logs/2.7.1/benchmarks/many_nodes.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 169.508864,
+    "_dashboard_test_success": true,
+    "_peak_memory": 3.48,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n216\t0.42GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n322\t0.15GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n3068\t0.15GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n59\t0.08GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n409\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n2896\t0.06GiB\tray::JobSupervisor\n3291\t0.06GiB\tray::StateAPIGeneratorActor.start\n52\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3255\t0.06GiB\tray::DashboardTester.run\n407\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen",
+    "num_tasks": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 275.25470863736416
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.687
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 46.348
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 145.645
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 275.25470863736416,
+    "time": 303.6329987049103,
+    "used_cpus": 250.0
+}

--- a/release/release_logs/2.7.1/benchmarks/many_tasks.json
+++ b/release/release_logs/2.7.1/benchmarks/many_tasks.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 708.866048,
+    "_dashboard_test_success": true,
+    "_peak_memory": 15.93,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n216\t1.7GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n322\t1.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n942\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1108\t0.08GiB\tray::DashboardTester.run\n59\t0.08GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/anyscale session web_terminal_server --deploy\n409\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n753\t0.07GiB\tray::JobSupervisor\n1165\t0.06GiB\tray::StateAPIGeneratorActor.start\n52\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1053\t0.06GiB\tray::MemoryMonitorActor.run",
+    "num_tasks": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 429.0546317074886
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2500.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 6.852
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 8149.28
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 14019.625
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 429.0546317074886,
+    "time": 323.30705523490906,
+    "used_cpus": 2500.0
+}

--- a/release/release_logs/2.7.1/microbenchmark.json
+++ b/release/release_logs/2.7.1/microbenchmark.json
@@ -1,0 +1,283 @@
+{
+    "1_1_actor_calls_async": [
+        7456.112509761211,
+        136.52188020296327
+    ],
+    "1_1_actor_calls_concurrent": [
+        4554.146655326606,
+        134.12052909284716
+    ],
+    "1_1_actor_calls_sync": [
+        2273.2464988756947,
+        57.4526135954541
+    ],
+    "1_1_async_actor_calls_async": [
+        2779.1973441702703,
+        104.6581718393757
+    ],
+    "1_1_async_actor_calls_sync": [
+        1371.8411355321223,
+        27.6103056260327
+    ],
+    "1_1_async_actor_calls_with_args_async": [
+        1978.9663710615514,
+        109.43588984234685
+    ],
+    "1_n_actor_calls_async": [
+        9672.982187721544,
+        90.73517883993567
+    ],
+    "1_n_async_actor_calls_async": [
+        8657.20480299259,
+        218.95955379270762
+    ],
+    "client__1_1_actor_calls_async": [
+        982.5793246271417,
+        20.034934949821864
+    ],
+    "client__1_1_actor_calls_concurrent": [
+        961.1926184467325,
+        12.817133953922866
+    ],
+    "client__1_1_actor_calls_sync": [
+        510.96946901735663,
+        36.85401048533518
+    ],
+    "client__get_calls": [
+        1093.4297114966203,
+        29.826420244458532
+    ],
+    "client__put_calls": [
+        821.9975673342932,
+        34.21332354553183
+    ],
+    "client__put_gigabytes": [
+        0.12778429919203013,
+        0.0012623190627529227
+    ],
+    "client__tasks_and_get_batch": [
+        0.9574694946141461,
+        0.014799801096296333
+    ],
+    "client__tasks_and_put_batch": [
+        11449.695712792654,
+        206.5805598367258
+    ],
+    "multi_client_put_calls_Plasma_Store": [
+        12344.39546658664,
+        280.63475298328734
+    ],
+    "multi_client_put_gigabytes": [
+        33.620993378733125,
+        1.5648521655470504
+    ],
+    "multi_client_tasks_async": [
+        27850.61204431569,
+        1595.6673641989205
+    ],
+    "n_n_actor_calls_async": [
+        29270.036133623737,
+        1050.4778967813554
+    ],
+    "n_n_actor_calls_with_arg_async": [
+        2856.1365651709334,
+        24.754091149071982
+    ],
+    "n_n_async_actor_calls_async": [
+        24458.207679236828,
+        491.27085225771714
+    ],
+    "perf_metrics": [
+        {
+            "perf_metric_name": "single_client_get_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 7536.924380935448
+        },
+        {
+            "perf_metric_name": "single_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5845.356422909845
+        },
+        {
+            "perf_metric_name": "multi_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 12344.39546658664
+        },
+        {
+            "perf_metric_name": "single_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 18.413557260686837
+        },
+        {
+            "perf_metric_name": "single_client_tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 9.129595770052905
+        },
+        {
+            "perf_metric_name": "multi_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 33.620993378733125
+        },
+        {
+            "perf_metric_name": "single_client_get_object_containing_10k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 13.009554585474522
+        },
+        {
+            "perf_metric_name": "single_client_wait_1k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5.52141006441801
+        },
+        {
+            "perf_metric_name": "single_client_tasks_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1177.0860205196755
+        },
+        {
+            "perf_metric_name": "single_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 9563.116886637355
+        },
+        {
+            "perf_metric_name": "multi_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 27850.61204431569
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2273.2464988756947
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 7456.112509761211
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 4554.146655326606
+        },
+        {
+            "perf_metric_name": "1_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 9672.982187721544
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 29270.036133623737
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_with_arg_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2856.1365651709334
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1371.8411355321223
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2779.1973441702703
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_with_args_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1978.9663710615514
+        },
+        {
+            "perf_metric_name": "1_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8657.20480299259
+        },
+        {
+            "perf_metric_name": "n_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 24458.207679236828
+        },
+        {
+            "perf_metric_name": "placement_group_create/removal",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 997.6322375478999
+        },
+        {
+            "perf_metric_name": "client__get_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1093.4297114966203
+        },
+        {
+            "perf_metric_name": "client__put_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 821.9975673342932
+        },
+        {
+            "perf_metric_name": "client__put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.12778429919203013
+        },
+        {
+            "perf_metric_name": "client__tasks_and_put_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 11449.695712792654
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 510.96946901735663
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 982.5793246271417
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 961.1926184467325
+        },
+        {
+            "perf_metric_name": "client__tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.9574694946141461
+        }
+    ],
+    "placement_group_create/removal": [
+        997.6322375478999,
+        16.292281367997795
+    ],
+    "single_client_get_calls_Plasma_Store": [
+        7536.924380935448,
+        276.43446140729617
+    ],
+    "single_client_get_object_containing_10k_refs": [
+        13.009554585474522,
+        0.09976541297055666
+    ],
+    "single_client_put_calls_Plasma_Store": [
+        5845.356422909845,
+        65.9552050399532
+    ],
+    "single_client_put_gigabytes": [
+        18.413557260686837,
+        5.1489733273061535
+    ],
+    "single_client_tasks_and_get_batch": [
+        9.129595770052905,
+        0.9598685988803987
+    ],
+    "single_client_tasks_async": [
+        9563.116886637355,
+        335.0507094167212
+    ],
+    "single_client_tasks_sync": [
+        1177.0860205196755,
+        15.752017951134594
+    ],
+    "single_client_wait_1k_refs": [
+        5.52141006441801,
+        0.0745115356439463
+    ]
+}

--- a/release/release_logs/2.7.1/scalability/object_store.json
+++ b/release/release_logs/2.7.1/scalability/object_store.json
@@ -1,0 +1,13 @@
+{
+    "broadcast_time": 85.80861040199989,
+    "num_nodes": 50,
+    "object_size": 1073741824,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 85.80861040199989
+        }
+    ],
+    "success": "1"
+}

--- a/release/release_logs/2.7.1/scalability/single_node.json
+++ b/release/release_logs/2.7.1/scalability/single_node.json
@@ -1,0 +1,40 @@
+{
+    "args_time": 17.291354780999995,
+    "get_time": 25.08259386100002,
+    "large_object_size": 107374182400,
+    "large_object_time": 30.62209055699998,
+    "num_args": 10000,
+    "num_get_args": 10000,
+    "num_queued": 1000000,
+    "num_returns": 3000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "10000_args_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 17.291354780999995
+        },
+        {
+            "perf_metric_name": "3000_returns_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 7.291479848000009
+        },
+        {
+            "perf_metric_name": "10000_get_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 25.08259386100002
+        },
+        {
+            "perf_metric_name": "1000000_queued_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 177.93132558000002
+        },
+        {
+            "perf_metric_name": "107374182400_large_object_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 30.62209055699998
+        }
+    ],
+    "queued_time": 177.93132558000002,
+    "returns_time": 7.291479848000009,
+    "success": "1"
+}

--- a/release/release_logs/2.7.1/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.7.1/stress_tests/stress_test_dead_actors.json
@@ -1,0 +1,14 @@
+{
+    "avg_iteration_time": 1.5400808811187745,
+    "max_iteration_time": 4.024231910705566,
+    "min_iteration_time": 0.780940055847168,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1.5400808811187745
+        }
+    ],
+    "success": 1,
+    "total_time": 154.0085301399231
+}

--- a/release/release_logs/2.7.1/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.7.1/stress_tests/stress_test_many_tasks.json
@@ -1,0 +1,47 @@
+{
+    "perf_metrics": [
+        {
+            "perf_metric_name": "stage_0_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 10.076338529586792
+        },
+        {
+            "perf_metric_name": "stage_1_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 23.342886781692506
+        },
+        {
+            "perf_metric_name": "stage_2_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 60.438395738601685
+        },
+        {
+            "perf_metric_name": "stage_3_creation_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2.1919972896575928
+        },
+        {
+            "perf_metric_name": "stage_3_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2875.2445271015167
+        },
+        {
+            "perf_metric_name": "stage_4_spread",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.7296295246039273
+        }
+    ],
+    "stage_0_time": 10.076338529586792,
+    "stage_1_avg_iteration_time": 23.342886781692506,
+    "stage_1_max_iteration_time": 24.54859232902527,
+    "stage_1_min_iteration_time": 21.486624479293823,
+    "stage_1_time": 233.42897415161133,
+    "stage_2_avg_iteration_time": 60.438395738601685,
+    "stage_2_max_iteration_time": 61.567734479904175,
+    "stage_2_min_iteration_time": 58.07151389122009,
+    "stage_2_time": 302.19288325309753,
+    "stage_3_creation_time": 2.1919972896575928,
+    "stage_3_time": 2875.2445271015167,
+    "stage_4_spread": 0.7296295246039273,
+    "success": 1
+}

--- a/release/release_logs/2.7.1/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.7.1/stress_tests/stress_test_placement_group.json
@@ -1,0 +1,17 @@
+{
+    "avg_pg_create_time_ms": 0.917001803304134,
+    "avg_pg_remove_time_ms": 0.8126442147154302,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_pg_create_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.917001803304134
+        },
+        {
+            "perf_metric_name": "avg_pg_remove_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.8126442147154302
+        }
+    ],
+    "success": 1
+}


### PR DESCRIPTION
Compare 2.7.0 to 2.7.1
```
REGRESSION 28.82%: 3000_returns_time (LATENCY) regresses from 5.6602293089999876 to 7.291479848000009 (28.82%) in 2.7.1/scalability/single_node.json
REGRESSION 23.82%: dashboard_p50_latency_ms (LATENCY) regresses from 5.534 to 6.852 (23.82%) in 2.7.1/benchmarks/many_tasks.json
REGRESSION 22.35%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 70.13534577099995 to 85.80861040199989 (22.35%) in 2.7.1/scalability/object_store.json
REGRESSION 21.09%: dashboard_p95_latency_ms (LATENCY) regresses from 6729.761 to 8149.28 (21.09%) in 2.7.1/benchmarks/many_tasks.json
REGRESSION 12.91%: multi_client_put_gigabytes (THROUGHPUT) regresses from 38.605668097256924 to 33.620993378733125 (12.91%) in 2.7.1/microbenchmark.json
REGRESSION 11.83%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 14.755162462843568 to 13.009554585474522 (11.83%) in 2.7.1/microbenchmark.json
REGRESSION 11.02%: client__get_calls (THROUGHPUT) regresses from 1228.917179853001 to 1093.4297114966203 (11.02%) in 2.7.1/microbenchmark.json
REGRESSION 11.02%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1080.2139341634759 to 961.1926184467325 (11.02%) in 2.7.1/microbenchmark.json
REGRESSION 10.95%: single_client_tasks_async (THROUGHPUT) regresses from 10739.407361558973 to 9563.116886637355 (10.95%) in 2.7.1/microbenchmark.json
REGRESSION 10.89%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 573.4457553242221 to 510.96946901735663 (10.89%) in 2.7.1/microbenchmark.json
REGRESSION 10.27%: single_client_tasks_sync (THROUGHPUT) regresses from 1311.812164358857 to 1177.0860205196755 (10.27%) in 2.7.1/microbenchmark.json
REGRESSION 9.35%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1083.9300708022135 to 982.5793246271417 (9.35%) in 2.7.1/microbenchmark.json
REGRESSION 7.09%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 3074.0790016310475 to 2856.1365651709334 (7.09%) in 2.7.1/microbenchmark.json
REGRESSION 6.48%: 10000_get_time (LATENCY) regresses from 23.55671212599998 to 25.08259386100002 (6.48%) in 2.7.1/scalability/single_node.json
REGRESSION 6.41%: dashboard_p50_latency_ms (LATENCY) regresses from 3.465 to 3.687 (6.41%) in 2.7.1/benchmarks/many_nodes.json
REGRESSION 5.37%: stage_0_time (LATENCY) regresses from 9.562453985214233 to 10.076338529586792 (5.37%) in 2.7.1/stress_tests/stress_test_many_tasks.json
REGRESSION 5.32%: avg_iteration_time (LATENCY) regresses from 1.4622855401039123 to 1.5400808811187745 (5.32%) in 2.7.1/stress_tests/stress_test_dead_actors.json
REGRESSION 5.12%: n_n_actor_calls_async (THROUGHPUT) regresses from 30847.92669705198 to 29270.036133623737 (5.12%) in 2.7.1/microbenchmark.json
REGRESSION 5.12%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 9124.377528222414 to 8657.20480299259 (5.12%) in 2.7.1/microbenchmark.json
REGRESSION 4.79%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 25688.484755543966 to 24458.207679236828 (4.79%) in 2.7.1/microbenchmark.json
REGRESSION 4.55%: 1_n_actor_calls_async (THROUGHPUT) regresses from 10133.72696574923 to 9672.982187721544 (4.55%) in 2.7.1/microbenchmark.json
REGRESSION 4.45%: client__tasks_and_get_batch (THROUGHPUT) regresses from 1.002041264301031 to 0.9574694946141461 (4.45%) in 2.7.1/microbenchmark.json
REGRESSION 4.16%: client__put_calls (THROUGHPUT) regresses from 857.6367908455961 to 821.9975673342932 (4.16%) in 2.7.1/microbenchmark.json
REGRESSION 4.04%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 4745.83263563276 to 4554.146655326606 (4.04%) in 2.7.1/microbenchmark.json
REGRESSION 3.92%: stage_2_avg_iteration_time (LATENCY) regresses from 58.160910558700564 to 60.438395738601685 (3.92%) in 2.7.1/stress_tests/stress_test_many_tasks.json
REGRESSION 3.80%: client__put_gigabytes (THROUGHPUT) regresses from 0.13283428838343245 to 0.12778429919203013 (3.80%) in 2.7.1/microbenchmark.json
REGRESSION 3.20%: tasks_per_second (THROUGHPUT) regresses from 443.2356047821634 to 429.0546317074886 (3.20%) in 2.7.1/benchmarks/many_tasks.json
REGRESSION 3.06%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12734.699835552969 to 12344.39546658664 (3.06%) in 2.7.1/microbenchmark.json
REGRESSION 2.61%: stage_3_time (LATENCY) regresses from 2802.1650245189667 to 2875.2445271015167 (2.61%) in 2.7.1/stress_tests/stress_test_many_tasks.json
REGRESSION 2.56%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 9.369535279594958 to 9.129595770052905 (2.56%) in 2.7.1/microbenchmark.json
REGRESSION 2.37%: 10000_args_time (LATENCY) regresses from 16.89121779300001 to 17.291354780999995 (2.37%) in 2.7.1/scalability/single_node.json
REGRESSION 2.09%: 1_1_actor_calls_async (THROUGHPUT) regresses from 7615.355914488919 to 7456.112509761211 (2.09%) in 2.7.1/microbenchmark.json
REGRESSION 2.02%: multi_client_tasks_async (THROUGHPUT) regresses from 28423.644858766176 to 27850.61204431569 (2.02%) in 2.7.1/microbenchmark.json
REGRESSION 1.50%: dashboard_p99_latency_ms (LATENCY) regresses from 143.498 to 145.645 (1.50%) in 2.7.1/benchmarks/many_nodes.json
REGRESSION 1.46%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1392.1278469787085 to 1371.8411355321223 (1.46%) in 2.7.1/microbenchmark.json
REGRESSION 1.36%: actors_per_second (THROUGHPUT) regresses from 748.5322140167257 to 738.330085638146 (1.36%) in 2.7.1/benchmarks/many_actors.json
REGRESSION 1.10%: stage_4_spread (LATENCY) regresses from 0.7217020493267903 to 0.7296295246039273 (1.10%) in 2.7.1/stress_tests/stress_test_many_tasks.json
REGRESSION 0.56%: dashboard_p99_latency_ms (LATENCY) regresses from 13941.91 to 14019.625 (0.56%) in 2.7.1/benchmarks/many_tasks.json
REGRESSION 0.16%: stage_1_avg_iteration_time (LATENCY) regresses from 23.305240750312805 to 23.342886781692506 (0.16%) in 2.7.1/stress_tests/stress_test_many_tasks.json
```

Just backfilling for minor version, the release is already done :) 