### PR TITLE
[ci] Deflake minimal test_basic_4 and test_output

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -71,6 +71,15 @@ steps:
         --test-env=RAY_MINIMAL=1
         --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
         --only-tags minimal
+        --except-tags basic_test
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core 
+        --parallelism-per-worker 3
+        --build-name minbuild-core-py{{matrix}}
+        --test-env=RAY_MINIMAL=1
+        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --only-tags minimal
+        --except-tags no_basic_test
+        --skip-ray-installation
       # core redis tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core 
         --parallelism-per-worker 3
@@ -79,7 +88,7 @@ steps:
         --test-env=TEST_EXTERNAL_REDIS=1
         --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
         --only-tags minimal
-        --except-tags no_redis
+        --except-tags no_basic_test
         --skip-ray-installation
       # serve tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... serve 

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -202,7 +202,7 @@ py_test_module_list(
     "test_basic_5.py",
   ],
   size = "medium",
-  tags = ["exclusive", "minimal", "team:core"],
+  tags = ["exclusive", "minimal", "basic_test", "team:core"],
   deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -211,7 +211,7 @@ py_test_module_list(
     "test_basic_3.py",
   ],
   size = "large",
-  tags = ["exclusive", "minimal", "team:core"],
+  tags = ["exclusive", "minimal", "basic_test", "team:core"],
   deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -222,7 +222,7 @@ py_test_module_list(
     "test_utils.py",
   ],
   size = "medium",
-  tags = ["exclusive", "minimal", "no_redis", "team:core"],
+  tags = ["exclusive", "minimal", "no_basic_test", "team:core"],
   deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -232,7 +232,7 @@ py_test_module_list(
     "test_usage_stats.py",
   ],
   size = "large",
-  tags = ["exclusive", "minimal", "no_redis", "team:core"],
+  tags = ["exclusive", "minimal", "no_basic_test", "team:core"],
   deps = ["//:ray_lib", ":conftest"],
 )
 


### PR DESCRIPTION
test_basic_4 and test_output on minimal test runs seem to cause flakiness to each other; separate test run the basic and non-basic tests

Test:
- CI