### PR TITLE
[serve] Lazily construct `asyncio.Event` to avoid attaching to the wrong loop

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -350,7 +350,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
         # determine the loop to attach to. This class can be constructed for the handle
         # from a different loop than it uses for scheduling, so we need to construct it
         # lazily to avoid an error due to the event being attached to the wrong loop.
-        self._lazily_initialied_replicas_updated_event: Optional[asyncio.Event] = None
+        self._lazily_constructed_replicas_updated_event: Optional[asyncio.Event] = None
 
         # Colocated replicas (e.g. wrt node, AZ)
         self._colocated_replica_ids: DefaultDict[LocalityScope, Set[str]] = defaultdict(
@@ -420,12 +420,12 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
     def _replicas_updated_event(self) -> asyncio.Event:
         """Lazily construct `asyncio.Event`.
 
-        See comment for self._lazily_initialied_replicas_updated_event.
+        See comment for self._lazily_constructed_replicas_updated_event.
         """
-        if self._lazily_initialied_replicas_updated_event is None:
-            self._lazily_initialied_replicas_updated_event = asyncio.Event()
+        if self._lazily_constructed_replicas_updated_event is None:
+            self._lazily_constructed_replicas_updated_event = asyncio.Event()
 
-        return self._lazily_initialied_replicas_updated_event
+        return self._lazily_constructed_replicas_updated_event
 
     @property
     def num_pending_requests(self) -> int:

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -418,6 +418,10 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
 
     @property
     def _replicas_updated_event(self) -> asyncio.Event:
+        """Lazily construct `asyncio.Event`.
+
+        See comment for self._lazily_initialied_replicas_updated_event.
+        """
         if self._lazily_initialied_replicas_updated_event is None:
             self._lazily_initialied_replicas_updated_event = asyncio.Event()
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -344,7 +344,14 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
         # Updated via `update_replicas`.
         self._replica_id_set: Set[str] = set()
         self._replicas: Dict[str, ReplicaWrapper] = {}
-        self._replicas_updated_event = asyncio.Event()
+
+        # NOTE(edoakes): Python 3.10 removed the `loop` parameter to `asyncio.Event`.
+        # Now, the `asyncio.Event` will call `get_running_loop` in its constructor to
+        # determine the loop to attach to. This class can be constructed for the handle
+        # from a different loop than it uses for scheduling, so we need to construct it
+        # lazily to avoid an error due to the event being attached to the wrong loop.
+        self._lazily_initialied_replicas_updated_event: Optional[asyncio.Event] = None
+
         # Colocated replicas (e.g. wrt node, AZ)
         self._colocated_replica_ids: DefaultDict[LocalityScope, Set[str]] = defaultdict(
             set
@@ -408,6 +415,13 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
         self.num_scheduling_tasks_in_backoff_gauge.set(
             self.num_scheduling_tasks_in_backoff
         )
+
+    @property
+    def _replicas_updated_event(self) -> asyncio.Event:
+        if self._lazily_initialied_replicas_updated_event is None:
+            self._lazily_initialied_replicas_updated_event = asyncio.Event()
+
+        return self._lazily_initialied_replicas_updated_event
 
     @property
     def num_pending_requests(self) -> int:

--- a/python/ray/serve/tests/unit/test_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_replica_scheduler.py
@@ -1179,8 +1179,10 @@ async def test_get_queue_state_cancelled_on_timeout(pow_2_scheduler, fake_query)
 
 @pytest.mark.asyncio
 async def test_replicas_updated_event_on_correct_loop(pow_2_scheduler):
-    """
-    See https://github.com/ray-project/ray/issues/40631.
+    """See https://github.com/ray-project/ray/issues/40631.
+
+    The `await` statements below would fail with
+    "RuntimeError: ... got Future <Future pending> attached to a different loop."
     """
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(pow_2_scheduler._replicas_updated_event.wait(), timeout=0.001)

--- a/python/ray/serve/tests/unit/test_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_replica_scheduler.py
@@ -101,14 +101,21 @@ def pow_2_scheduler(request) -> PowerOfTwoChoicesReplicaScheduler:
     if not hasattr(request, "param"):
         request.param = {}
 
-    s = PowerOfTwoChoicesReplicaScheduler(
-        get_or_create_event_loop(),
-        DeploymentID("TEST_DEPLOYMENT", "TEST_APP"),
-        prefer_local_node_routing=request.param.get("prefer_local_node", False),
-        prefer_local_az_routing=request.param.get("prefer_local_az", False),
-        self_node_id=SCHEDULER_NODE_ID,
-        self_actor_id="fake-actor-id",
-        self_availability_zone=request.param.get("az", None),
+    # In order to prevent issues like https://github.com/ray-project/ray/issues/40631,
+    # construct the scheduler on a different loop to mimic the deployment handle path.
+    async def construct_scheduler(loop: asyncio.AbstractEventLoop):
+        return PowerOfTwoChoicesReplicaScheduler(
+            loop,
+            DeploymentID("TEST_DEPLOYMENT", "TEST_APP"),
+            prefer_local_node_routing=request.param.get("prefer_local_node", False),
+            prefer_local_az_routing=request.param.get("prefer_local_az", False),
+            self_node_id=SCHEDULER_NODE_ID,
+            self_actor_id="fake-actor-id",
+            self_availability_zone=request.param.get("az", None),
+        )
+
+    s = asyncio.new_event_loop().run_until_complete(
+        construct_scheduler(get_or_create_event_loop())
     )
 
     # Update the RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S
@@ -1168,6 +1175,18 @@ async def test_get_queue_state_cancelled_on_timeout(pow_2_scheduler, fake_query)
 
     r1.set_queue_state_response(0, accepted=True)
     assert (await task) == r1
+
+
+@pytest.mark.asyncio
+async def test_replicas_updated_event_on_correct_loop(pow_2_scheduler):
+    """
+    See https://github.com/ray-project/ray/issues/40631.
+    """
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(pow_2_scheduler._replicas_updated_event.wait(), timeout=0.001)
+
+    pow_2_scheduler._replicas_updated_event.set()
+    await pow_2_scheduler._replicas_updated_event.wait()
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_replica_scheduler.py
@@ -1185,7 +1185,9 @@ async def test_replicas_updated_event_on_correct_loop(pow_2_scheduler):
     "RuntimeError: ... got Future <Future pending> attached to a different loop."
     """
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(pow_2_scheduler._replicas_updated_event.wait(), timeout=0.001)
+        await asyncio.wait_for(
+            pow_2_scheduler._replicas_updated_event.wait(), timeout=0.001
+        )
 
     pow_2_scheduler._replicas_updated_event.set()
     await pow_2_scheduler._replicas_updated_event.wait()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Python 3.10 removed the `loop` parameter to `asyncio.Event`. Now, the `asyncio.Event` will call `get_running_loop` in its constructor to determine the loop to attach to. This class can be constructed for the handle from a different loop than it uses for scheduling, so we need to construct it lazily to avoid an error due to the event being attached to the wrong loop.

## Related issue number

Closes https://github.com/ray-project/ray/issues/40631

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
