### PR TITLE
[Train] Fix GPT-J Fine-tuning Test by setting Ray Data max_block_size

### DIFF
--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -120,6 +120,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ray.data.DataContext.get_current().target_max_block_size = 512 * 1024 * 1024"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": [
      "hide-cell"

--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -122,9 +122,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "ray.data.DataContext.get_current().target_max_block_size = 512 * 1024 * 1024"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -307,6 +305,8 @@
    ],
    "source": [
     "from transformers import AutoTokenizer\n",
+    "\n",
+    "ray.data.DataContext.get_current().target_max_block_size = 512 * 1024 * 1024\n",
     "\n",
     "def split_text(batch: pd.DataFrame) -> pd.DataFrame:\n",
     "    text = list(batch[\"text\"])\n",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
