### PR TITLE
[cherry-pick][data] implement streaming output backpressure

### DIFF
--- a/python/ray/data/_internal/execution/backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 import ray
 
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces.physical_operator import (
         PhysicalOperator,
     )
-    from ray.data._internal.execution.streaming_executor_state import Topology
+    from ray.data._internal.execution.streaming_executor_state import OpState, Topology
 
 logger = logging.getLogger(__name__)
 
@@ -36,14 +36,35 @@ class BackpressurePolicy(ABC):
     def __init__(self, topology: "Topology"):
         ...
 
-    @abstractmethod
-    def can_run(self, op: "PhysicalOperator") -> bool:
-        """Called when StreamingExecutor selects an operator to run in
-        `streaming_executor_state.select_operator_to_run()`.
+    def calculate_max_blocks_to_read_per_op(
+        self, topology: "Topology"
+    ) -> Dict["OpState", int]:
+        """Determine how many blocks of data we can read from each operator.
+        The `DataOpTask`s of the operators will stop reading blocks when the limit is
+        reached. Then the execution of these tasks will be paused when the streaming
+        generator backpressure threshold is reached.
+        Used in `streaming_executor_state.py::process_completed_tasks()`.
 
-        Returns: True if the operator can run, False otherwise.
+        Returns: A dict mapping from each operator's OpState to the desired number of
+            blocks to read. For operators that are not in the dict, all available blocks
+            will be read.
+
+        Note: Only one backpressure policy that implements this method can be enabled
+            at a time.
         """
-        ...
+        return {}
+
+    def can_add_input(self, op: "PhysicalOperator") -> bool:
+        """Determine if we can add a new input to the operator. If returns False, the
+        operator will be backpressured and will not be able to run new tasks.
+        Used in `streaming_executor_state.py::select_operator_to_run()`.
+
+        Returns: True if we can add a new input to the operator, False otherwise.
+
+        Note, if multiple backpressure policies are enabled, the operator will be
+        backpressured if any of the policies returns False.
+        """
+        return True
 
 
 class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
@@ -103,7 +124,7 @@ class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
         for op, _ in topology.items():
             self._concurrency_caps[op] = self._init_cap
 
-    def can_run(self, op: "PhysicalOperator") -> bool:
+    def can_add_input(self, op: "PhysicalOperator") -> bool:
         metrics = op.metrics
         while metrics.num_tasks_finished >= (
             self._concurrency_caps[op] * self._cap_multiply_threshold
@@ -113,3 +134,82 @@ class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
                 f"Concurrency cap for {op} increased to {self._concurrency_caps[op]}"
             )
         return metrics.num_tasks_running < self._concurrency_caps[op]
+
+
+class StreamingOutputBackpressurePolicy(BackpressurePolicy):
+    """A backpressure policy that throttles the streaming outputs of the `DataOpTask`s.
+
+    The are 2 levels of configs to control the behavior:
+    - At the Ray Core level, we use
+      `MAX_BLOCKS_IN_GENERATOR_BUFFER` to limit the number of blocks buffered in
+      the streaming generator of each OpDataTask. When it's reached, the task will
+      be blocked at `yield` until the caller reads another `ObjectRef.
+    - At the Ray Data level, we use
+      `MAX_BLOCKS_IN_GENERATOR_BUFFER` to limit the number of blocks buffered in the
+      output queue of each operator. When it's reached, we'll stop reading from the
+      streaming generators of the op's tasks, and thus trigger backpressure at the
+      Ray Core level.
+
+    Thus, total number of buffered blocks for each operator can be
+    `MAX_BLOCKS_IN_GENERATOR_BUFFER * num_running_tasks +
+    MAX_BLOCKS_IN_OP_OUTPUT_QUEUE`.
+    """
+
+    # The max number of blocks that can be buffered at the streaming generator
+    # of each `DataOpTask`.
+    MAX_BLOCKS_IN_GENERATOR_BUFFER = 10
+    MAX_BLOCKS_IN_GENERATOR_BUFFER_CONFIG_KEY = (
+        "backpressure_policies.streaming_output.max_blocks_in_generator_buffer"
+    )
+    # The max number of blocks that can be buffered at the operator output queue
+    # (`OpState.outqueue`).
+    MAX_BLOCKS_IN_OP_OUTPUT_QUEUE = 20
+    MAX_BLOCKS_IN_OP_OUTPUT_QUEUE_CONFIG_KEY = (
+        "backpressure_policies.streaming_output.max_blocks_in_op_output_queue"
+    )
+
+    def __init__(self, topology: "Topology"):
+        data_context = ray.data.DataContext.get_current()
+        self._max_num_blocks_in_streaming_gen_buffer = data_context.get_config(
+            self.MAX_BLOCKS_IN_GENERATOR_BUFFER_CONFIG_KEY,
+            self.MAX_BLOCKS_IN_GENERATOR_BUFFER,
+        )
+        assert self._max_num_blocks_in_streaming_gen_buffer > 0
+        # The `_generator_backpressure_num_objects` parameter should be
+        # `2 * self._max_num_blocks_in_streaming_gen_buffer` because we yield
+        # 2 objects for each block: the block and the block metadata.
+        data_context._task_pool_data_task_remote_args[
+            "_generator_backpressure_num_objects"
+        ] = (2 * self._max_num_blocks_in_streaming_gen_buffer)
+
+        self._max_num_blocks_in_op_output_queue = data_context.get_config(
+            self.MAX_BLOCKS_IN_OP_OUTPUT_QUEUE_CONFIG_KEY,
+            self.MAX_BLOCKS_IN_OP_OUTPUT_QUEUE,
+        )
+        assert self._max_num_blocks_in_op_output_queue > 0
+
+    def calculate_max_blocks_to_read_per_op(
+        self, topology: "Topology"
+    ) -> Dict["OpState", int]:
+        max_blocks_to_read_per_op: Dict["OpState", int] = {}
+        downstream_num_active_tasks = 0
+        for op, state in list(topology.items())[::-1]:
+            max_blocks_to_read_per_op[state] = (
+                self._max_num_blocks_in_op_output_queue - state.outqueue_num_blocks()
+            )
+            if downstream_num_active_tasks == 0:
+                # If all downstream operators are idle, it could be because no resources
+                # are available. In this case, we'll make sure to read at least one
+                # block to avoid deadlock.
+                # TODO(hchen): `downstream_num_active_tasks == 0` doesn't necessarily
+                # mean no enough resources. One false positive case is when the upstream
+                # op hasn't produced any blocks for the downstream op to consume.
+                # In this case, at least reading one block is fine.
+                # If there are other false positive cases, we may want to make this
+                # deadlock check more accurate by directly checking resources.
+                max_blocks_to_read_per_op[state] = max(
+                    max_blocks_to_read_per_op[state],
+                    1,
+                )
+            downstream_num_active_tasks += len(op.get_active_tasks())
+        return max_blocks_to_read_per_op

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -52,16 +52,18 @@ class TaskPoolMapOperator(MapOperator):
         # Submit the task as a normal Ray task.
         map_task = cached_remote_fn(_map_task, num_returns="streaming")
         input_blocks = [block for block, _ in bundle.blocks]
-
         ctx = TaskContext(
             task_idx=self._next_data_task_idx,
             target_max_block_size=self.actual_target_max_block_size,
         )
-        gen = map_task.options(
-            **self._get_runtime_ray_remote_args(input_bundle=bundle), name=self.name
-        ).remote(
+        data_context = DataContext.get_current()
+        ray_remote_args = self._get_runtime_ray_remote_args(input_bundle=bundle)
+        ray_remote_args["name"] = self.name
+        ray_remote_args.update(data_context._task_pool_data_task_remote_args)
+
+        gen = map_task.options(**ray_remote_args).remote(
             self._map_transformer_ref,
-            DataContext.get_current(),
+            data_context,
             ctx,
             *input_blocks,
         )

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -80,7 +80,7 @@ class StreamingExecutor(Executor, threading.Thread):
         # generator `yield`s.
         self._topology: Optional[Topology] = None
         self._output_node: Optional[OpState] = None
-        self._backpressure_policies: Optional[List[BackpressurePolicy]] = None
+        self._backpressure_policies: List[BackpressurePolicy] = []
 
         self._dataset_tag = dataset_tag
 
@@ -249,7 +249,7 @@ class StreamingExecutor(Executor, threading.Thread):
         # Note: calling process_completed_tasks() is expensive since it incurs
         # ray.wait() overhead, so make sure to allow multiple dispatch per call for
         # greater parallelism.
-        process_completed_tasks(topology)
+        process_completed_tasks(topology, self._backpressure_policies)
 
         # Dispatch as many operators as we can for completed tasks.
         limits = self._get_or_refresh_resource_limits()

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -20,7 +20,12 @@ from ray.data._internal.execution.interfaces import (
     PhysicalOperator,
     RefBundle,
 )
-from ray.data._internal.execution.interfaces.physical_operator import OpTask, Waitable
+from ray.data._internal.execution.interfaces.physical_operator import (
+    DataOpTask,
+    MetadataOpTask,
+    OpTask,
+    Waitable,
+)
 from ray.data._internal.execution.operators.base_physical_operator import (
     AllToAllOperator,
 )
@@ -260,6 +265,18 @@ class OpState:
                 break  # Concurrent pop from the outqueue by the consumer thread.
         return object_store_memory
 
+    def outqueue_num_blocks(self) -> int:
+        """Return the number of blocks in this operator's outqueue."""
+        num_blocks = 0
+        for i in range(len(self.outqueue)):
+            try:
+                bundle = self.outqueue[i]
+                if isinstance(bundle, RefBundle):
+                    num_blocks += len(bundle.blocks)
+            except IndexError:
+                break
+        return len(self.outqueue)
+
 
 def build_streaming_topology(
     dag: PhysicalOperator, options: ExecutionOptions
@@ -311,16 +328,28 @@ def build_streaming_topology(
     return (topology, i)
 
 
-def process_completed_tasks(topology: Topology) -> None:
+def process_completed_tasks(
+    topology: Topology,
+    backpressure_policies: List[BackpressurePolicy],
+) -> None:
     """Process any newly completed tasks. To update operator
     states, call `update_operator_states()` afterwards."""
 
-    # Update active tasks.
-    active_tasks: Dict[Waitable, OpTask] = {}
-
-    for op in topology.keys():
+    # All active tasks, keyed by their waitables.
+    active_tasks: Dict[Waitable, Tuple[OpState, OpTask]] = {}
+    for op, state in topology.items():
         for task in op.get_active_tasks():
-            active_tasks[task.get_waitable()] = task
+            active_tasks[task.get_waitable()] = (state, task)
+
+    max_blocks_to_read_per_op: Dict[OpState, int] = {}
+    for policy in backpressure_policies:
+        non_empty = len(max_blocks_to_read_per_op) > 0
+        max_blocks_to_read_per_op = policy.calculate_max_blocks_to_read_per_op(topology)
+        if non_empty and len(max_blocks_to_read_per_op) > 0:
+            raise ValueError(
+                "At most one backpressure policy that implements "
+                "calculate_max_blocks_to_read_per_op() can be used at a time."
+            )
 
     # Process completed Ray tasks and notify operators.
     if active_tasks:
@@ -331,7 +360,16 @@ def process_completed_tasks(topology: Topology) -> None:
             timeout=0.1,
         )
         for ref in ready:
-            active_tasks[ref].on_waitable_ready()
+            state, task = active_tasks.pop(ref)
+            if isinstance(task, DataOpTask):
+                num_blocks_read = task.on_data_ready(
+                    max_blocks_to_read_per_op.get(state, None)
+                )
+                if state in max_blocks_to_read_per_op:
+                    max_blocks_to_read_per_op[state] -= num_blocks_read
+            else:
+                assert isinstance(task, MetadataOpTask)
+                task.on_task_finished()
 
     # Pull any operator outputs into the streaming op state.
     for op, op_state in topology.items():
@@ -408,7 +446,7 @@ def select_operator_to_run(
             and op.should_add_input()
             and under_resource_limits
             and not op.completed()
-            and all(p.can_run(op) for p in backpressure_policies)
+            and all(p.can_add_input(op) for p in backpressure_policies)
         ):
             ops.append(op)
         # Update the op in all cases to enable internal autoscaling, etc.

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -219,6 +219,9 @@ class DataContext:
         self.enable_get_object_locations_for_metrics = (
             enable_get_object_locations_for_metrics
         )
+        # The additonal ray remote args that should be added to
+        # the task-pool-based data tasks.
+        self._task_pool_data_task_remote_args: Dict[str, Any] = {}
         # The extra key-value style configs.
         # These configs are managed by individual components or plugins via
         # `set_config`, `get_config` and `remove_config`.

--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -5,29 +5,14 @@ from collections import defaultdict
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
+import numpy as np
+
 import ray
 from ray.data._internal.execution.backpressure_policy import (
     ENABLED_BACKPRESSURE_POLICIES_CONFIG_KEY,
     ConcurrencyCapBackpressurePolicy,
+    StreamingOutputBackpressurePolicy,
 )
-
-
-@contextmanager
-def enable_backpressure_policies(policies):
-    data_context = ray.data.DataContext.get_current()
-    old_policies = data_context.get_config(
-        ENABLED_BACKPRESSURE_POLICIES_CONFIG_KEY,
-        [],
-    )
-    data_context.set_config(
-        ENABLED_BACKPRESSURE_POLICIES_CONFIG_KEY,
-        policies,
-    )
-    yield
-    data_context.set_config(
-        ENABLED_BACKPRESSURE_POLICIES_CONFIG_KEY,
-        old_policies,
-    )
 
 
 class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
@@ -37,10 +22,17 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
     def setUpClass(cls):
         cls._cluster_cpus = 10
         ray.init(num_cpus=cls._cluster_cpus)
+        data_context = ray.data.DataContext.get_current()
+        data_context.set_config(
+            ENABLED_BACKPRESSURE_POLICIES_CONFIG_KEY,
+            [ConcurrencyCapBackpressurePolicy],
+        )
 
     @classmethod
     def tearDownClass(cls):
         ray.shutdown()
+        data_context = ray.data.DataContext.get_current()
+        data_context.remove_config(ENABLED_BACKPRESSURE_POLICIES_CONFIG_KEY)
 
     @contextmanager
     def _patch_config(self, init_cap, cap_multiply_threshold, cap_multiplier):
@@ -84,15 +76,15 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
         self.assertEqual(policy._concurrency_caps[op], 4)
         # Gradually increase num_tasks_running to the cap.
         for i in range(1, init_cap + 1):
-            self.assertTrue(policy.can_run(op))
+            self.assertTrue(policy.can_add_input(op))
             op.metrics.num_tasks_running = i
-        # Now num_tasks_running reaches the cap, so can_run should return False.
-        self.assertFalse(policy.can_run(op))
+        # Now num_tasks_running reaches the cap, so can_add_input should return False.
+        self.assertFalse(policy.can_add_input(op))
 
         # If we increase num_task_finished to the threshold (4 * 0.5 = 2),
         # it should trigger the cap to increase.
         op.metrics.num_tasks_finished = init_cap * cap_multiply_threshold
-        self.assertEqual(policy.can_run(op), True)
+        self.assertEqual(policy.can_add_input(op), True)
         self.assertEqual(policy._concurrency_caps[op], init_cap * cap_multiplier)
 
         # Now the cap is 8 (4 * 2).
@@ -102,7 +94,7 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
             policy._concurrency_caps[op] * cap_multiplier * cap_multiply_threshold
         )
         op.metrics.num_tasks_running = 0
-        self.assertEqual(policy.can_run(op), True)
+        self.assertEqual(policy.can_add_input(op), True)
         self.assertEqual(policy._concurrency_caps[op], init_cap * cap_multiplier**3)
 
     def test_config(self):
@@ -150,28 +142,122 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
             yield data
             actor.record_end_time.remote(index)
 
-        with enable_backpressure_policies([ConcurrencyCapBackpressurePolicy]):
-            # Creat a dataset with 2 map ops. Each map op has N tasks, where N is
-            # the number of cluster CPUs.
-            N = self.__class__._cluster_cpus
-            ds = ray.data.range(N, parallelism=N)
-            # Use different `num_cpus` to make sure they don't fuse.
-            ds = ds.map_batches(
-                functools.partial(map_func, index=1), batch_size=None, num_cpus=1
-            )
-            ds = ds.map_batches(
-                functools.partial(map_func, index=2), batch_size=None, num_cpus=1.1
-            )
-            res = ds.take_all()
-            self.assertEqual(len(res), N)
+        # Creat a dataset with 2 map ops. Each map op has N tasks, where N is
+        # the number of cluster CPUs.
+        N = self.__class__._cluster_cpus
+        ds = ray.data.range(N, parallelism=N)
+        # Use different `num_cpus` to make sure they don't fuse.
+        ds = ds.map_batches(
+            functools.partial(map_func, index=1), batch_size=None, num_cpus=1
+        )
+        ds = ds.map_batches(
+            functools.partial(map_func, index=2), batch_size=None, num_cpus=1.1
+        )
+        res = ds.take_all()
+        self.assertEqual(len(res), N)
 
-            # We recorded the start and end time of each op,
-            # check that these 2 ops are executed interleavingly.
-            # This means that the executor didn't allocate all resources to the first
-            # op in the beginning.
-            start1, end1 = ray.get(actor.get_start_and_end_time.remote(1))
-            start2, end2 = ray.get(actor.get_start_and_end_time.remote(2))
-            assert start1 < start2 < end1 < end2, (start1, start2, end1, end2)
+        # We recorded the start and end time of each op,
+        # check that these 2 ops are executed interleavingly.
+        # This means that the executor didn't allocate all resources to the first
+        # op in the beginning.
+        start1, end1 = ray.get(actor.get_start_and_end_time.remote(1))
+        start2, end2 = ray.get(actor.get_start_and_end_time.remote(2))
+        assert start1 < start2 < end1 < end2, (start1, start2, end1, end2)
+
+
+class TestStreamOutputBackpressurePolicy(unittest.TestCase):
+    """Tests for StreamOutputBackpressurePolicy."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._cluster_cpus = 5
+        cls._cluster_object_memory = 500 * 1024 * 1024
+        ray.init(
+            num_cpus=cls._cluster_cpus, object_store_memory=cls._cluster_object_memory
+        )
+        data_context = ray.data.DataContext.get_current()
+        cls._num_blocks = 5
+        cls._block_size = 100 * 1024 * 1024
+        policy_cls = StreamingOutputBackpressurePolicy
+        cls._configs = {
+            ENABLED_BACKPRESSURE_POLICIES_CONFIG_KEY: [policy_cls],
+            policy_cls.MAX_BLOCKS_IN_OP_OUTPUT_QUEUE_CONFIG_KEY: 1,
+            policy_cls.MAX_BLOCKS_IN_GENERATOR_BUFFER_CONFIG_KEY: 1,
+        }
+        for k, v in cls._configs.items():
+            data_context.set_config(k, v)
+        data_context.execution_options.preserve_order = True
+
+    @classmethod
+    def tearDownClass(cls):
+        data_context = ray.data.DataContext.get_current()
+        for k in cls._configs.keys():
+            data_context.remove_config(k)
+        data_context.execution_options.preserve_order = False
+        ray.shutdown()
+
+    def _run_dataset(self, producer_num_cpus, consumer_num_cpus):
+        # Create a dataset with 2 operators:
+        # - The producer op has only 1 task, which produces 5 blocks, each of which
+        #   has 100MB data.
+        # - The consumer op has 5 slow tasks, each of which consumes 1 block.
+        # Return the timestamps at the producer and consumer tasks for each block.
+        num_blocks = self._num_blocks
+        block_size = self._block_size
+        ray.data.DataContext.get_current().target_max_block_size = block_size
+
+        def producer(batch):
+            for i in range(num_blocks):
+                print("Producing block", i)
+                yield {
+                    "id": [i],
+                    "data": [np.zeros(block_size, dtype=np.uint8)],
+                    "producer_timestamp": [time.time()],
+                }
+
+        def consumer(batch):
+            assert len(batch["id"]) == 1
+            time.sleep(0.1)
+            print("Consuming block", batch["id"][0])
+            del batch["data"]
+            batch["consumer_timestamp"] = [time.time()]
+            return batch
+
+        ds = ray.data.range(1, parallelism=1).materialize()
+        ds = ds.map_batches(producer, batch_size=None, num_cpus=producer_num_cpus)
+        ds = ds.map_batches(consumer, batch_size=None, num_cpus=consumer_num_cpus)
+
+        res = ds.take_all()
+        assert [row["id"] for row in res] == list(range(self._num_blocks))
+        return (
+            [row["producer_timestamp"] for row in res],
+            [row["consumer_timestamp"] for row in res],
+        )
+
+    def test_basic_backpressure(self):
+        producer_timestamps, consumer_timestamps = self._run_dataset(
+            producer_num_cpus=1, consumer_num_cpus=2
+        )
+        # We can buffer at most 2 blocks.
+        # Thus the producer should be backpressured after producing 2 blocks.
+        # Note, although block 2 is backpressured, but producer_timestamps[2] has
+        # been generated before the backpressure. Thus we assert
+        # producer_timestamps[2] < consumer_timestamps[0] < producer_timestamps[3].
+        assert (
+            producer_timestamps[2] < consumer_timestamps[0] < producer_timestamps[3]
+        ), (producer_timestamps, consumer_timestamps)
+
+    def test_no_deadlock(self):
+        # The producer needs all 5 CPUs, and the consumer has no CPU to run.
+        # In this case, we shouldn't backpressure the producer and let it run
+        # until it finishes.
+        producer_timestamps, consumer_timestamps = self._run_dataset(
+            producer_num_cpus=5, consumer_num_cpus=1
+        )
+        assert producer_timestamps[-1] < consumer_timestamps[0], (
+            producer_timestamps,
+            consumer_timestamps,
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -106,7 +106,7 @@ def test_process_completed_tasks():
 
     # Test processing output bundles.
     assert len(topo[o1].outqueue) == 0, topo
-    process_completed_tasks(topo)
+    process_completed_tasks(topo, [])
     update_operator_states(topo)
     assert len(topo[o1].outqueue) == 20, topo
 
@@ -117,7 +117,7 @@ def test_process_completed_tasks():
     o2.get_active_tasks = MagicMock(return_value=[sleep_task, done_task])
     o2.all_inputs_done = MagicMock()
     o1.all_dependents_complete = MagicMock()
-    process_completed_tasks(topo)
+    process_completed_tasks(topo, [])
     update_operator_states(topo)
     done_task_callback.assert_called_once()
     o2.all_inputs_done.assert_not_called()
@@ -131,7 +131,7 @@ def test_process_completed_tasks():
     o1.all_dependents_complete = MagicMock()
     o1.completed = MagicMock(return_value=True)
     topo[o1].outqueue.clear()
-    process_completed_tasks(topo)
+    process_completed_tasks(topo, [])
     update_operator_states(topo)
     done_task_callback.assert_called_once()
     o2.all_inputs_done.assert_called_once()
@@ -140,7 +140,7 @@ def test_process_completed_tasks():
     # Test dependents completed.
     o2.need_more_inputs = MagicMock(return_value=False)
     o1.all_dependents_complete = MagicMock()
-    process_completed_tasks(topo)
+    process_completed_tasks(topo, [])
     update_operator_states(topo)
     o1.all_dependents_complete.assert_called_once()
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -645,11 +645,11 @@ bool TaskManager::HandleReportGeneratorItemReturns(
   }
 
   // Otherwise, follow the regular backpressure logic.
-  auto total_unconsumed = total_generated - total_consumed;
+  // NOTE, here we check `item_index - last_consumed_index >= backpressure_threshold`,
+  // instead of the number of unconsumed items, because we may receive the
+  // `HandleReportGeneratorItemReturns` requests out of order.
   if (backpressure_threshold != -1 &&
-      total_unconsumed >= backpressure_threshold
-      // We can only backpressure the last generated item.
-      && item_index >= total_generated - 1) {
+      (item_index - stream_it->second.LastConsumedIndex()) >= backpressure_threshold) {
     RAY_LOG(DEBUG) << "Stream " << generator_id
                    << " is backpressured. total_generated: " << total_generated
                    << ". total_consumed: " << total_consumed

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -153,6 +153,9 @@ class ObjectRefStream {
   /// \return A list of object IDs that are not read yet.
   absl::flat_hash_set<ObjectID> GetItemsUnconsumed() const;
 
+  /// \return Index of the last consumed item, -1 if nothing is consumed yet.
+  int64_t LastConsumedIndex() const { return next_index_ - 1; }
+
   /// Total number of object that's written to the stream
   int64_t TotalNumObjectWritten() const { return total_num_object_written_; }
   int64_t TotalNumObjectConsumed() const { return total_num_object_consumed_; }


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cherry-pick #40387 to 2.8.0 release. 

This is the follow-up of #40591. Same as #40591, the new code is disabled by default. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
