### PR TITLE
[docs] use requirements compiled in dev/test constraints

### DIFF
--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -369,7 +369,7 @@ Dependencies for running Ray unit tests under ``python/ray/tests`` can be instal
 
 .. code-block:: shell
 
- pip install -c python/requirements.txt -r python/requirements/test-requirements.txt
+ pip install -c python/requirements_compiled.txt -r python/requirements/test-requirements.txt
 
 Requirement files for running Ray Data / ML library tests are under ``python/requirements/``.
 

--- a/doc/source/ray-contribute/getting-involved.rst
+++ b/doc/source/ray-contribute/getting-involved.rst
@@ -108,7 +108,7 @@ If you are running tests for the first time, you can install the required depend
 
 .. code-block:: shell
 
-    pip install -c python/requirements.txt -r python/requirements/test-requirements.txt
+    pip install -c python/requirements_compiled.txt -r python/requirements/test-requirements.txt
 
 Testing for Python development
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
using `python/requirements.txt` as constraints do not work well today.