### PR TITLE
[Train] Support rank_zero_only uploading for Lightning RayTrainReportCallback

### DIFF
--- a/python/ray/train/lightning/_lightning_utils.py
+++ b/python/ray/train/lightning/_lightning_utils.py
@@ -226,8 +226,14 @@ class RayTrainReportCallback(pl.callbacks.Callback):
     This callback is a subclass of `lightning.pytorch.callbacks.Callback
     <https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.Callback.html#lightning.pytorch.callbacks.Callback>`_.
 
-    It fetches the latest `trainer.callback_metrics` and reports together with
-    the checkpoint on each training epoch end.
+    At the end of each training epoch, this callback dumps a checkpoint with
+    `lightning.pytorch.Trainer.save_checkpoint`, and fetches the latest metrics
+    with `trainer.callback_metrics`. It then reports the metrics and checkpoint
+    via `ray.train.report`.
+
+    This callback supports distributed checkpointing. It efficiently uploads
+    checkpoint shards from individual workers in parallel, such as those from
+    Deepspeed ZeRO and FSDP.
 
     Checkpoints will be saved in the following structure::
 
@@ -235,14 +241,21 @@ class RayTrainReportCallback(pl.callbacks.Callback):
         └─ checkpoint.ckpt      PyTorch Lightning Checkpoint
 
     For customized reporting and checkpointing logic, implement your own
-    `lightning.pytorch.callbacks.Callback` following this user
+    lightning callback following this user
     guide: :ref:`Saving and Loading Checkpoints <train-dl-saving-checkpoints>`.
+
+    Args:
+        rank_zero_only: Whether to upload checkpoints from world rank
+        zero worker only. Default is False.
+
     """
 
-    def __init__(self) -> None:
+    def __init__(self, rank_zero_only=False) -> None:
         super().__init__()
+        self.rank_zero_only = rank_zero_only
         self.trial_name = train.get_context().get_trial_name()
         self.local_rank = train.get_context().get_local_rank()
+        self.world_rank = train.get_context().get_world_rank()
         self.tmpdir_prefix = os.path.join(tempfile.gettempdir(), self.trial_name)
         if os.path.isdir(self.tmpdir_prefix) and self.local_rank == 0:
             shutil.rmtree(self.tmpdir_prefix)
@@ -264,10 +277,15 @@ class RayTrainReportCallback(pl.callbacks.Callback):
 
         # Save checkpoint to local
         ckpt_path = os.path.join(tmpdir, "checkpoint.ckpt")
+
+        # Lightning determines saving on rank zero or all ranks
         trainer.save_checkpoint(ckpt_path, weights_only=False)
 
         # Report to train session
-        checkpoint = Checkpoint.from_directory(tmpdir)
+        if self.rank_zero_only and self.world_rank != 0:
+            checkpoint = None
+        else:
+            checkpoint = Checkpoint.from_directory(tmpdir)
         train.report(metrics=metrics, checkpoint=checkpoint)
 
         if self.local_rank == 0:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Previously, `RayTrainReportCallback` uploaded from all workers by default. A train checkpoint will be created from an empty directory on rank>0 workers, even if Lightning only saved checkpoints on the rank 0.

Firstly, some users may prefer to only upload from rank 0. Moreover, when there are a large number of workers, uploading N-1 empty folders to remote storage introduces unnecessary overhead. This PR provides a `rank_zero_only` flag, allowing users to decide whether to disable uploads from all ranks.



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
