### PR TITLE
[serve] Lazily construct `asyncio.Event` to avoid attaching to the wrong loop

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -344,7 +344,14 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
         # Updated via `update_replicas`.
         self._replica_id_set: Set[str] = set()
         self._replicas: Dict[str, ReplicaWrapper] = {}
-        self._replicas_updated_event = asyncio.Event()
+
+        # NOTE(edoakes): Python 3.10 removed the `loop` parameter to `asyncio.Event`.
+        # Now, the `asyncio.Event` will call `get_running_loop` in its constructor to
+        # determine the loop to attach to. This class can be constructed for the handle
+        # from a different loop than it uses for scheduling, so we need to construct it
+        # lazily to avoid an error due to the event being attached to the wrong loop.
+        self._lazily_constructed_replicas_updated_event: Optional[asyncio.Event] = None
+
         # Colocated replicas (e.g. wrt node, AZ)
         self._colocated_replica_ids: DefaultDict[LocalityScope, Set[str]] = defaultdict(
             set
@@ -408,6 +415,17 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
         self.num_scheduling_tasks_in_backoff_gauge.set(
             self.num_scheduling_tasks_in_backoff
         )
+
+    @property
+    def _replicas_updated_event(self) -> asyncio.Event:
+        """Lazily construct `asyncio.Event`.
+
+        See comment for self._lazily_constructed_replicas_updated_event.
+        """
+        if self._lazily_constructed_replicas_updated_event is None:
+            self._lazily_constructed_replicas_updated_event = asyncio.Event()
+
+        return self._lazily_constructed_replicas_updated_event
 
     @property
     def num_pending_requests(self) -> int:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cherry-pick https://github.com/ray-project/ray/pull/40629

## Related issue number

Closes https://github.com/ray-project/ray/issues/40631

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
