### PR TITLE
[serve] Remove unused args

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -905,10 +905,6 @@ def build_serve_application(
         deployments = pipeline_build(app._get_internal_dag_node(), name)
         ingress = get_and_validate_ingress_deployment(deployments)
 
-        # Set code version and runtime env for each deployment
-        for deployment in deployments:
-            deployment.set_options(version=code_version, _internal=True)
-
         deploy_args_list = []
         for deployment in deployments:
             is_ingress = deployment.name == ingress.name
@@ -918,7 +914,7 @@ def build_serve_application(
                     replica_config=deployment._replica_config,
                     ingress=is_ingress,
                     deployment_config=deployment._deployment_config,
-                    version=deployment.version,
+                    version=code_version,
                     route_prefix=deployment.route_prefix,
                     docs_path=deployment._docs_path,
                 )

--- a/python/ray/serve/_private/deployment_function_node.py
+++ b/python/ray/serve/_private/deployment_function_node.py
@@ -50,9 +50,9 @@ class DeploymentFunctionNode(DAGNode):
             self._deployment = deployment_shell.options(
                 func_or_class=func_body,
                 name=self._deployment_name,
-                init_args=(),
-                init_kwargs={},
                 route_prefix=route_prefix,
+                _init_args=(),
+                _init_kwargs={},
                 _internal=True,
             )
         else:

--- a/python/ray/serve/_private/deployment_graph_build.py
+++ b/python/ray/serve/_private/deployment_graph_build.py
@@ -229,9 +229,9 @@ def transform_ray_dag_to_serve_dag(
         deployment = deployment_shell.options(
             func_or_class=dag_node._body,
             name=deployment_name,
-            init_args=replaced_deployment_init_args,
-            init_kwargs=replaced_deployment_init_kwargs,
             route_prefix=route_prefix,
+            _init_args=replaced_deployment_init_args,
+            _init_kwargs=replaced_deployment_init_kwargs,
             _internal=True,
         )
 
@@ -407,8 +407,8 @@ def generate_executor_dag_driver_deployment(
     )
 
     return original_driver_deployment.options(
-        init_args=replaced_deployment_init_args,
-        init_kwargs=replaced_deployment_init_kwargs,
+        _init_args=replaced_deployment_init_args,
+        _init_kwargs=replaced_deployment_init_kwargs,
         _internal=True,
     )
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 import warnings
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from fastapi import APIRouter, FastAPI
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -254,8 +254,6 @@ def deployment(
     name: Default[str] = DEFAULT.VALUE,
     version: Default[str] = DEFAULT.VALUE,
     num_replicas: Default[Optional[int]] = DEFAULT.VALUE,
-    init_args: Default[Tuple[Any]] = DEFAULT.VALUE,
-    init_kwargs: Default[Dict[Any, Any]] = DEFAULT.VALUE,
     route_prefix: Default[Union[str, None]] = DEFAULT.VALUE,
     ray_actor_options: Default[Dict] = DEFAULT.VALUE,
     placement_group_bundles: Optional[List[Dict[str, float]]] = DEFAULT.VALUE,
@@ -290,8 +288,6 @@ def deployment(
             this deployment. Defaults to 1.
         autoscaling_config: Parameters to configure autoscaling behavior. If this
             is set, `num_replicas` cannot be set.
-        init_args: [DEPRECATED] These should be passed to `.bind()` instead.
-        init_kwargs: [DEPRECATED] These should be passed to `.bind()` instead.
         route_prefix: [DEPRECATED] Route prefix should be set per-application
             through `serve.run()`.
         ray_actor_options: Options to pass to the Ray Actor decorator, such as
@@ -383,8 +379,8 @@ def deployment(
     def decorator(_func_or_class):
         replica_config = ReplicaConfig.create(
             _func_or_class,
-            init_args=(init_args if init_args is not DEFAULT.VALUE else None),
-            init_kwargs=(init_kwargs if init_kwargs is not DEFAULT.VALUE else None),
+            init_args=None,
+            init_kwargs=None,
             ray_actor_options=(
                 ray_actor_options if ray_actor_options is not DEFAULT.VALUE else None
             ),

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -338,8 +338,6 @@ class Deployment:
         name: Default[str] = DEFAULT.VALUE,
         version: Default[str] = DEFAULT.VALUE,
         num_replicas: Default[Optional[int]] = DEFAULT.VALUE,
-        init_args: Default[Tuple[Any]] = DEFAULT.VALUE,
-        init_kwargs: Default[Dict[Any, Any]] = DEFAULT.VALUE,
         route_prefix: Default[Union[str, None]] = DEFAULT.VALUE,
         ray_actor_options: Default[Optional[Dict]] = DEFAULT.VALUE,
         placement_group_bundles: Optional[List[Dict[str, float]]] = DEFAULT.VALUE,
@@ -354,6 +352,8 @@ class Deployment:
         graceful_shutdown_timeout_s: Default[float] = DEFAULT.VALUE,
         health_check_period_s: Default[float] = DEFAULT.VALUE,
         health_check_timeout_s: Default[float] = DEFAULT.VALUE,
+        _init_args: Default[Tuple[Any]] = DEFAULT.VALUE,
+        _init_kwargs: Default[Dict[Any, Any]] = DEFAULT.VALUE,
         _internal: bool = False,
     ) -> "Deployment":
         """Return a copy of this deployment with updated options.
@@ -423,11 +423,11 @@ class Deployment:
         if version is DEFAULT.VALUE:
             version = self._version
 
-        if init_args is DEFAULT.VALUE:
-            init_args = self._replica_config.init_args
+        if _init_args is DEFAULT.VALUE:
+            _init_args = self._replica_config.init_args
 
-        if init_kwargs is DEFAULT.VALUE:
-            init_kwargs = self._replica_config.init_kwargs
+        if _init_kwargs is DEFAULT.VALUE:
+            _init_kwargs = self._replica_config.init_kwargs
 
         if route_prefix is DEFAULT.VALUE:
             # Default is to keep the previous value
@@ -466,8 +466,8 @@ class Deployment:
 
         new_replica_config = ReplicaConfig.create(
             func_or_class,
-            init_args=init_args,
-            init_kwargs=init_kwargs,
+            init_args=_init_args,
+            init_kwargs=_init_kwargs,
             ray_actor_options=ray_actor_options,
             placement_group_bundles=placement_group_bundles,
             placement_group_strategy=placement_group_strategy,
@@ -495,8 +495,6 @@ class Deployment:
         name: Default[str] = DEFAULT.VALUE,
         version: Default[str] = DEFAULT.VALUE,
         num_replicas: Default[Optional[int]] = DEFAULT.VALUE,
-        init_args: Default[Tuple[Any]] = DEFAULT.VALUE,
-        init_kwargs: Default[Dict[Any, Any]] = DEFAULT.VALUE,
         route_prefix: Default[Union[str, None]] = DEFAULT.VALUE,
         ray_actor_options: Default[Optional[Dict]] = DEFAULT.VALUE,
         user_config: Default[Optional[Any]] = DEFAULT.VALUE,
@@ -528,8 +526,6 @@ class Deployment:
             func_or_class=func_or_class,
             name=name,
             version=version,
-            init_args=init_args,
-            init_kwargs=init_kwargs,
             route_prefix=route_prefix,
             num_replicas=num_replicas,
             ray_actor_options=ray_actor_options,

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -598,15 +598,6 @@ def test_input_validation():
 
     with pytest.raises(TypeError):
 
-        @serve.deployment(init_args={1, 2, 3})
-        class BadInitArgs:
-            pass
-
-    with pytest.raises(TypeError):
-        Base.options(_init_args="hi")
-
-    with pytest.raises(TypeError):
-
         @serve.deployment(ray_actor_options=[1, 2, 3])
         class BadActorOpts:
             pass

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -648,7 +648,6 @@ def test_deployment_properties():
 
     D = serve.deployment(
         name="name",
-        init_args=("hello", 123),
         version="version",
         num_replicas=2,
         user_config="hi",
@@ -658,7 +657,6 @@ def test_deployment_properties():
     )(DClass)
 
     assert D.name == "name"
-    assert D.init_args == ("hello", 123)
     assert D.version == "version"
     assert D.num_replicas == 2
     assert D.user_config == "hi"

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -603,7 +603,7 @@ def test_input_validation():
             pass
 
     with pytest.raises(TypeError):
-        Base.options(init_args="hi")
+        Base.options(_init_args="hi")
 
     with pytest.raises(TypeError):
 

--- a/python/ray/serve/tests/unit/test_deployment_class.py
+++ b/python/ray/serve/tests/unit/test_deployment_class.py
@@ -81,8 +81,6 @@ class TestDeploymentOptions:
         "name": "test",
         "version": "abcd",
         "num_replicas": 1,
-        "init_args": (),
-        "init_kwargs": {},
         "route_prefix": "/",
         "ray_actor_options": {},
         "user_config": {},


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Removing `init_args` and `init_kwargs` as public parameters for a deployment. They don't work with v2 api.
They are still kept as private args in `.options()` since we rely on that when building the graph.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
