### PR TITLE
[core] Deflake test_object_manager::test_object_transfer_during_oom

### DIFF
--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -2,7 +2,6 @@ flaky_tests:
   - //python/ray/tests:test_actor_advanced
   - //python/ray/tests:test_actor_cancel
   - //python/ray/tests:test_gcs_fault_tolerance
-  - //python/ray/tests:test_object_manager
   - //python/ray/tests:test_placement_group
   - //python/ray/tests:test_placement_group_3
   - //python/ray/tests:test_placement_group_5

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -8,7 +8,6 @@ import pytest
 
 import ray
 from ray.cluster_utils import Cluster, cluster_not_supported
-from ray.exceptions import GetTimeoutError
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 if (
@@ -56,7 +55,7 @@ def test_object_transfer_during_oom(ray_start_cluster_head):
     def put():
         return np.random.rand(5 * 1024 * 1024)  # 40 MB data
 
-    local_ref = ray.put(np.random.rand(5 * 1024 * 1024))
+    _ = ray.put(np.random.rand(5 * 1024 * 1024))
     remote_ref = put.remote()
 
     # Getting the remote ref is possible even though we don't have enough

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -59,9 +59,8 @@ def test_object_transfer_during_oom(ray_start_cluster_head):
     local_ref = ray.put(np.random.rand(5 * 1024 * 1024))
     remote_ref = put.remote()
 
-    with pytest.raises(GetTimeoutError):
-        ray.get(remote_ref, timeout=1)
-    del local_ref
+    # Getting the remote ref is possible even though we don't have enough
+    # memory locally to hold both objects once.
     ray.get(remote_ref)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This flaky test checks that it isn't possible to store more objects than the available object store memory, but it looks like it may have been written before object spilling was enabled. Now with spilling and fallback to object allocation on disk, the test should be modified.

## Related issue number

Closes #40446.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
