### PR TITLE
[ci] move core+data integrations tests to civ2

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -36,6 +36,16 @@ steps:
     depends_on: data12build
     job_env: forge
 
+  - label: ":ray: core: data tests"
+    tags: python
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- python/ray/util/dask/... core
+        --build-name data12build
+        --parallelism-per-worker 2
+    depends_on: data12build
+    job_env: forge
+
   - label: ":ray: core: debug test"
     tags: python
     instance_type: medium

--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -74,9 +74,7 @@
     - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
     - DATA_PROCESSING_TESTING=1 ./ci/env/install-dependencies.sh
     - ./ci/env/env_info.sh
-     - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/tests/modin/...
-    # Dask tests and examples.
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-client python/ray/util/dask/...
+    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/tests/modin/...
 
 - label: ":potable_water: Dataset datasource integration tests"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_PYTHON_AFFECTED", "RAY_CI_DATA_AFFECTED"]


### PR DESCRIPTION
As title, move core+data integration tests to civ2. Note that we don't need to filter the client_test tags in civ2 since we already filter it with core team as owner

Test:
- CI