### PR TITLE
should not fetch runtime-info of vm from cached_nodes

### DIFF
--- a/python/ray/autoscaler/_private/vsphere/node_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/node_provider.py
@@ -176,12 +176,16 @@ class VsphereNodeProvider(NodeProvider):
             return nodes
 
     def is_running(self, node_id):
-        node = self._get_cached_node(node_id)
-        return node.power_state in {HardPower.State.POWERED_ON}
+        vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
+            [vim.VirtualMachine], obj_id=node_id
+        )
+        return vm.runtime.powerState != vim.VirtualMachinePowerState.poweredOn
 
     def is_terminated(self, node_id):
-        node = self._get_cached_node(node_id)
-        return node.power_state not in {HardPower.State.POWERED_ON}
+        vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
+            [vim.VirtualMachine], obj_id=node_id
+        )
+        return vm.runtime.powerState != vim.VirtualMachinePowerState.poweredOn
 
     def node_tags(self, node_id):
         with self.tag_cache_lock:


### PR DESCRIPTION
# Why are these changes needed?
Power-on-off status is runtime info of VM, should not fetch it from cached-nodes, which is probably dirty data.
It should query by pyvmomi_sdk every time. 


# Test
We have internal automation pipelines passed. Also team tested the GPU functionalities manually.
![image](https://github.com/ray-project/ray/assets/85480625/40154468-91e0-41f8-bb56-d0aa305c549e)
![image](https://github.com/ray-project/ray/assets/85480625/52bab37c-0349-42d9-9070-a06688af0a7c)




## Checks

- [* ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [* ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ *] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [* ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [* ] Unit tests
   - [ *] Release tests
   - [ ] This PR is not tested :(
