### PR TITLE
[RLlib] Fix RLlib stresstest (removed `minigrid` package)

### DIFF
--- a/release/ray_release/byod/byod_rllib_test.sh
+++ b/release/ray_release/byod/byod_rllib_test.sh
@@ -9,6 +9,7 @@ set -exo pipefail
 pip3 install https://ray-ci-deps-wheels.s3.us-west-2.amazonaws.com/AutoROM.accept_rom_license-0.5.4-py3-none-any.whl
 git clone https://github.com/ray-project/rl-experiments.git
 unzip rl-experiments/halfcheetah-sac/2022-12-17/halfcheetah_1500_mean_reward_sac.zip -d ~/.
+pip3 uninstall -y minigrid
 pip3 install torch==2.0.0+cu118 torchvision==0.15.1+cu118 --index-url https://download.pytorch.org/whl/cu118
 
 # not strictly necessary, but makes debugging easier

--- a/release/rllib_tests/app_config.yaml
+++ b/release/rllib_tests/app_config.yaml
@@ -27,6 +27,11 @@ post_build_cmds:
   - git clone https://github.com/ray-project/rl-experiments.git
   - unzip rl-experiments/halfcheetah-sac/2022-12-17/halfcheetah_1500_mean_reward_sac.zip -d ~/.
 
+  # Uninstall minigrid (it imports matplotlib, which sometimes causes a filelock error).
+  # We don't need minigrid for the release tests.
+  - pip3 uninstall -y minigrid
+
+  # Install torch.
   - pip3 install torch==2.0.0+cu118 torchvision==0.15.1+cu118 --index-url https://download.pytorch.org/whl/cu118
 
   # TODO(sven): remove once nightly image gets gymnasium and the other new dependencies.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix RLlib stresstest:
Solution: Removed `minigrid` package, which imports matplotlib, which sometimes causes strange filelock errors. The package is NOT needed by any of RLlib's release tests, so this will not break anything.

Error with the minigrid package installed (and tried to be imported by gymnasium automatically):
```
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/__init__.py", line 7, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     from ray.rllib.env.base_env import BaseEnv
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/env/__init__.py", line 1, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     from ray.rllib.env.base_env import BaseEnv
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/rllib/env/base_env.py", line 4, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     import gymnasium as gym
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/gymnasium/__init__.py", line 12, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     from gymnasium.envs.registration import (
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/gymnasium/envs/__init__.py", line 382, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     load_plugin_envs()
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/gymnasium/envs/registration.py", line 600, in load_plugin_envs
(TemporaryActor pid=369, ip=10.0.12.247)     fn = plugin.load()
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/importlib_metadata/__init__.py", line 209, in load
(TemporaryActor pid=369, ip=10.0.12.247)     module = import_module(match.group('module'))
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/importlib/__init__.py", line 127, in import_module
(TemporaryActor pid=369, ip=10.0.12.247)     return _bootstrap._gcd_import(name[level:], package, level)
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/minigrid/__init__.py", line 5, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     from minigrid import minigrid_env, wrappers
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/minigrid/minigrid_env.py", line 17, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     from minigrid.utils.window import Window
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/minigrid/utils/window.py", line 3, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     import matplotlib.pyplot as plt
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/matplotlib/pyplot.py", line 52, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     import matplotlib.colorbar
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/matplotlib/colorbar.py", line 19, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     from matplotlib import _api, cbook, collections, cm, colors, contour, ticker
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/matplotlib/contour.py", line 13, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     from matplotlib.backend_bases import MouseButton
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/matplotlib/backend_bases.py", line 45, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     from matplotlib import (
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/matplotlib/text.py", line 16, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     from .font_manager import FontProperties
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/matplotlib/font_manager.py", line 1551, in <module>
(TemporaryActor pid=369, ip=10.0.12.247)     fontManager = _load_fontmanager()
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/matplotlib/font_manager.py", line 1546, in _load_fontmanager
(TemporaryActor pid=369, ip=10.0.12.247)     json_dump(fm, fm_path)
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/matplotlib/font_manager.py", line 958, in json_dump
(TemporaryActor pid=369, ip=10.0.12.247)     with cbook._lock_path(filename), open(filename, 'w') as fh:
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/contextlib.py", line 113, in __enter__
(TemporaryActor pid=369, ip=10.0.12.247)     return next(self.gen)
(TemporaryActor pid=369, ip=10.0.12.247)   File "/home/ray/anaconda3/lib/python3.8/site-packages/matplotlib/cbook/__init__.py", line 1814, in _lock_path
(TemporaryActor pid=369, ip=10.0.12.247)     raise TimeoutError("""\
(TemporaryActor pid=369, ip=10.0.12.247) TimeoutError: Lock error: Matplotlib failed to acquire the following lock file:
(TemporaryActor pid=369, ip=10.0.12.247)     /home/ray/.cache/matplotlib/fontlist-v330.json.matplotlib-lock
(TemporaryActor pid=369, ip=10.0.12.247) This maybe due to another process holding this lock file.  If you are sure no
(TemporaryActor pid=369, ip=10.0.12.247) other Matplotlib process is running, remove this file and try again.
```

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
