### PR TITLE
[2.8][Train] Fix GPT-J Deepspeed Fine-tuning Release Test

### DIFF
--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -120,13 +120,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "tags": [
      "hide-cell"
@@ -305,8 +298,6 @@
    ],
    "source": [
     "from transformers import AutoTokenizer\n",
-    "\n",
-    "ray.data.DataContext.get_current().target_max_block_size = 512 * 1024 * 1024\n",
     "\n",
     "def split_text(batch: pd.DataFrame) -> pd.DataFrame:\n",
     "    text = list(batch[\"text\"])\n",

--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -333,13 +333,10 @@
     "    return dict(ret)\n",
     "\n",
     "processed_datasets = {\n",
-    "    key: ds.map_batches(split_text, batch_format=\"pandas\").map_batches(tokenize, batch_format=\"pandas\")\n",
+    "    key: ds.map_batches(split_text, batch_format=\"pandas\").map_batches(tokenize, batch_format=\"pandas\").random_shuffle()\n",
     "    for key, ds in ray_datasets.items()\n",
     "}\n",
-    "processed_datasets\n",
-    "\n",
-    "for k, v in processed_datasets.items():\n",
-    "    processed_datasets[k] = v.random_shuffle()"
+    "processed_datasets"
    ]
   },
   {

--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -336,7 +336,10 @@
     "    key: ds.map_batches(split_text, batch_format=\"pandas\").map_batches(tokenize, batch_format=\"pandas\")\n",
     "    for key, ds in ray_datasets.items()\n",
     "}\n",
-    "processed_datasets"
+    "processed_datasets\n",
+    "\n",
+    "for k, v in processed_datasets.items():\n",
+    "    processed_datasets[k] = v.random_shuffle()"
    ]
   },
   {

--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -120,6 +120,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ray.data.DataContext.get_current().target_max_block_size = 512 * 1024 * 1024"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": [
      "hide-cell"

--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -333,7 +333,7 @@
     "    return dict(ret)\n",
     "\n",
     "processed_datasets = {\n",
-    "    key: ds.map_batches(split_text, batch_format=\"pandas\").map_batches(tokenize, batch_format=\"pandas\").random_shuffle()\n",
+    "    key: ds.map_batches(split_text, batch_format=\"pandas\").map_batches(tokenize, batch_format=\"pandas\").random_shuffle(seed=42)\n",
     "    for key, ds in ray_datasets.items()\n",
     "}\n",
     "processed_datasets"

--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -122,9 +122,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "ray.data.DataContext.get_current().target_max_block_size = 512 * 1024 * 1024"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -307,6 +305,8 @@
    ],
    "source": [
     "from transformers import AutoTokenizer\n",
+    "\n",
+    "ray.data.DataContext.get_current().target_max_block_size = 512 * 1024 * 1024\n",
     "\n",
     "def split_text(batch: pd.DataFrame) -> pd.DataFrame:\n",
     "    text = list(batch[\"text\"])\n",

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -897,15 +897,6 @@
     timeout: 4500
     script: python test_myst_doc.py --path gptj_deepspeed_fine_tuning.ipynb
 
-  variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_compute: gptj_deepspeed_compute_gce.yaml
-
-
 - name: air_example_dolly_v2_lightning_fsdp_finetuning
   group: AIR examples
   working_dir: air_examples/dolly_v2_lightning_fsdp_finetuning


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The GPTJ finetuning test failed since PR [#39710](https://github.com/ray-project/ray/pull/39710). It's because that PR changed the ordering of dataset shard, and the training process is unstable and the loss explode with the new data partitions. This PR added a random shuffling on the dataset that fixed this issue.


## Related issue number

<!-- For example: "Closes #1234" -->

Close #40547 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
