### PR TITLE
[CI][core] mark the test stress_test_many_runtime_envs stable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4993,10 +4993,6 @@
   frequency: nightly
   team: core
 
-  # Marking unstable because it's not working right now beyond ~3000 runtime envs.
-  # Tracking issue: https://github.com/ray-project/ray/issues/38662
-  stable: false
-
   cluster:
     byod: {}
     cluster_compute: stress_tests/smoke_test_compute.yaml


### PR DESCRIPTION
The test was broken (https://github.com/ray-project/ray/issues/38662) and it should be fixed by https://github.com/ray-project/ray/pull/40579.