### PR TITLE
make submission id show as default over core job id. Fix download logs button not downloading full logs

### DIFF
--- a/dashboard/client/src/pages/log/hooks.ts
+++ b/dashboard/client/src/pages/log/hooks.ts
@@ -9,7 +9,7 @@ export const useStateApiLogs = (
   props: StateApiLogInput,
   path: string | undefined,
 ) => {
-  const downloadUrl = getStateApiDownloadLogUrl(props);
+  const downloadUrl = getStateApiDownloadLogUrl({ ...props, maxLines: -1 });
 
   const {
     data: log,

--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.component.test.tsx
@@ -54,31 +54,31 @@ describe("RecentJobsCard", () => {
   it("renders", async () => {
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
-    await screen.findByText("01000000");
+    await screen.findByText("raysubmit_12345 (01000000)");
     expect(screen.getByText("02000000")).toBeVisible();
     expect(screen.getByText("raysubmit_23456")).toBeVisible();
-    expect(screen.getByText("04000000")).toBeVisible();
-    expect(screen.getByText("05000000")).toBeVisible();
-    expect(screen.getByText("06000000")).toBeVisible();
-    expect(screen.queryByText("07000000")).toBeNull();
+    expect(screen.getByText("raysubmit_34567 (04000000)")).toBeVisible();
+    expect(screen.getByText("raysubmit_45678 (05000000)")).toBeVisible();
+    expect(screen.getByText("raysubmit_56789 (06000000)")).toBeVisible();
+    expect(screen.queryByText(/raysubmit_67890/)).toBeNull();
   });
 
   it("the link is active when job_id is not null", async () => {
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
-    await screen.findByText("01000000");
+    await screen.findByText(/raysubmit_12345/);
 
-    const link = screen.getByRole("link", { name: "05000000" });
+    const link = screen.getByRole("link", { name: /raysubmit_45678/ });
     expect(link).toHaveAttribute("href");
   });
 
   it("link is active for driverless job(only have submission_id)", async () => {
     render(<RecentJobsCard />, { wrapper: MemoryRouter });
 
-    await screen.findByText("01000000");
+    await screen.findByText(/raysubmit_12345/);
 
     expect(
-      screen.queryByRole("link", { name: "raysubmit_23456" }),
+      screen.queryByRole("link", { name: /raysubmit_23456/ }),
     ).toBeVisible();
   });
 });

--- a/dashboard/client/src/pages/overview/cards/RecentJobsCard.tsx
+++ b/dashboard/client/src/pages/overview/cards/RecentJobsCard.tsx
@@ -35,8 +35,14 @@ export const RecentJobsCard = ({ className }: RecentJobsCardProps) => {
   const sortedJobs = _.orderBy(jobList, ["startTime"], ["desc"]).slice(0, 6);
 
   const sortedJobToRender = sortedJobs.map((job) => {
+    let title: string | undefined;
+    if (job.submission_id && job.job_id) {
+      title = `${job.submission_id} (${job.job_id})`;
+    } else {
+      title = job.submission_id ?? job.job_id ?? undefined;
+    }
     return {
-      title: job.job_id ?? job.submission_id ?? undefined,
+      title,
       subtitle: job.entrypoint,
       link: getLink(job),
       className: className,

--- a/dashboard/client/src/service/log.ts
+++ b/dashboard/client/src/service/log.ts
@@ -66,6 +66,10 @@ export type StateApiLogInput = {
    * If filename is provided, suffix is not necessary
    */
   filename?: string | null;
+  /**
+   * -1 for all lines.
+   */
+  maxLines?: number;
 };
 
 export const getStateApiDownloadLogUrl = ({
@@ -74,6 +78,7 @@ export const getStateApiDownloadLogUrl = ({
   taskId,
   actorId,
   suffix,
+  maxLines = MAX_LINES_FOR_LOGS,
 }: StateApiLogInput) => {
   if (
     nodeId === null ||
@@ -94,7 +99,7 @@ export const getStateApiDownloadLogUrl = ({
       ? [`actor_id=${encodeURIComponent(actorId)}`]
       : []),
     ...(suffix !== undefined ? [`suffix=${encodeURIComponent(suffix)}`] : []),
-    `lines=${MAX_LINES_FOR_LOGS}`,
+    `lines=${maxLines}`,
   ];
 
   return `api/v0/logs/file?${variables.join("&")}`;


### PR DESCRIPTION
Cherry-pick of #40479

For people who use job submission, they are more likely to know about job submission ids than core job ids. So if a job submission id exists, we should show those first.

When downloading logs, we should enable downloading the full logs and not a truncated amount of logs.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
