### PR TITLE
[ci] jail //python/ray/tests:test_node_manager

### DIFF
--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -14,3 +14,4 @@ flaky_tests:
   - //python/ray/tests:test_unhandled_error
   - //python/ray/tests:test_state_api_log
   - //python/ray/tests:test_ray_init_2
+  - //python/ray/tests:test_node_manager 


### PR DESCRIPTION
jail //python/ray/tests:test_node_manager which is failing on master now; I don't think the blame PR caused it since it's a data change

<img width="1437" alt="Screenshot 2023-10-25 at 4 21 26 PM" src="https://github.com/ray-project/ray/assets/128072568/9c997687-e38d-48b3-990a-0654f46b6061">

Test:
- CI