### PR TITLE
[ci] increase docker memory size

### DIFF
--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -96,7 +96,7 @@ class Container:
         command += [
             "--workdir",
             "/rayci",
-            "--shm-size=2.5gb",
+            "--shm-size=4.77gb",
             self._get_docker_image(),
             "/bin/bash",
             "-iecuo",


### PR DESCRIPTION
As requested by @rickyyx; the theory is that this memory size causes some tests to be flaky 

Test:
- CI