### PR TITLE
[ci] move dashboard tests to civ2

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -46,6 +46,21 @@ steps:
     depends_on: data12build
     job_env: forge
 
+  - label: ":ray: core: dashboard tests"
+    tags: 
+      - python
+      - dashboard
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- python/ray/dashboard/... core 
+        --parallelism-per-worker 3
+      # ui tests
+      - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
+        "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild /bin/bash -iecuo pipefail 
+        "./dashboard/tests/run_ui_tests.sh"
+    depends_on: corebuild
+    job_env: forge
+
   - label: ":ray: core: debug test"
     tags: python
     instance_type: medium

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -4,19 +4,6 @@
   commands:
     - ./java/test.sh
 
-- label: ":serverless: Dashboard Tests"
-  conditions:
-    [
-        "RAY_CI_DASHBOARD_AFFECTED",
-        "RAY_CI_PYTHON_AFFECTED",
-    ]
-  instance_size: medium
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - ./ci/env/env_info.sh
-    - ./dashboard/tests/run_ui_tests.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options) python/ray/dashboard/...
-
 # the bulk of serve tests are now run on civ2 infra, and defined in
 # pipeline.build_serve.yml
 - label: ":serverless: Serve HA Tests"

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -61,6 +61,17 @@ steps:
     depends_on: minbuild-serve
     job_env: forge
 
+  - label: ":ray-serve: serve: dashboard tests"
+    tags: 
+      - python
+      - dashboard
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- python/ray/dashboard/... serve 
+        --parallelism-per-worker 3
+    depends_on: servebuild
+    job_env: forge
+
   - label: ":ray-serve: serve: doc gpu tests"
     tags: 
       - serve

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -184,7 +184,6 @@ if __name__ == "__main__":
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
             elif (
                 changed_file == ".buildkite/ml.rayci.yml"
-                or changed_file == ".buildkite/pipeline.build.yml"
                 or changed_file == ".buildkite/pipeline.test.yml"
                 or changed_file == ".buildkite/pipeline.ml.yml"
                 or changed_file == "ci/docker/ml.build.Dockerfile"
@@ -257,6 +256,7 @@ if __name__ == "__main__":
                 or changed_file == "ci/docker/min.build.Dockerfile"
                 or changed_file == "ci/docker/min.build.wanda.yaml"
                 or changed_file == ".buildkite/serverless.rayci.yml"
+                or changed_file == ".buildkite/pipeline.build.yml"
             ):
                 RAY_CI_PYTHON_AFFECTED = 1
             elif changed_file.startswith("java/"):


### PR DESCRIPTION
As title, move dashboard tests to civ2
- Split them into core/serve tests
- Use docker directly to run the non-bazel tests