### PR TITLE
get_pyvmomi_obj_by_name and get_pyvmomi_obj_by_moid are replaced by g…

### DIFF
--- a/python/ray/autoscaler/_private/vsphere/gpu_utils.py
+++ b/python/ray/autoscaler/_private/vsphere/gpu_utils.py
@@ -81,7 +81,7 @@ def get_vm_2_gpu_ids_map(pool_name, desired_gpu_number):
     """
     result = {}
     pyvmomi_sdk_provider = get_sdk_provider(ClientType.PYVMOMI_SDK)
-    pool = pyvmomi_sdk_provider.get_pyvmomi_obj_by_name([vim.ResourcePool], pool_name)
+    pool = pyvmomi_sdk_provider.get_pyvmomi_obj([vim.ResourcePool], pool_name)
     if not pool.vm:
         logger.error(f"No frozen-vm in pool {pool.name}")
         return result
@@ -226,7 +226,7 @@ def add_gpus_to_vm(vm_name: str, gpu_ids: list):
     3. Power on the VM.
     """
     pyvmomi_sdk_provider = get_sdk_provider(ClientType.PYVMOMI_SDK)
-    vm_obj = pyvmomi_sdk_provider.get_pyvmomi_obj_by_name([vim.VirtualMachine], vm_name)
+    vm_obj = pyvmomi_sdk_provider.get_pyvmomi_obj([vim.VirtualMachine], vm_name)
     # The VM is supposed to be at powered on status after instant clone.
     # We need to power it off.
     if vm_obj.runtime.powerState == vim.VirtualMachinePowerState.poweredOn:

--- a/python/ray/autoscaler/_private/vsphere/node_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/node_provider.py
@@ -417,7 +417,7 @@ class VsphereNodeProvider(NodeProvider):
         requested_gpu_num = resources.get("GPU", 0)
         if requested_gpu_num > 0:
             for vm_name in gpu_ids_map:
-                parent_vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj_by_name(
+                parent_vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
                     [vim.VirtualMachine], vm_name
                 )
                 to_be_plugged_gpu = gpu_ids_map[vm_name]

--- a/python/ray/autoscaler/_private/vsphere/pyvmomi_sdk_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/pyvmomi_sdk_provider.py
@@ -47,32 +47,6 @@ class PyvmomiSdkProvider:
             raise ValueError("Could not connect to the specified host")
         atexit.register(Disconnect, self.pyvmomi_sdk_client)
 
-    def get_pyvmomi_obj_by_moid(self, vimtype, moid):
-        """
-        This function finds the vSphere object by the object moid and the object type.
-        The object type can be "VM", "Host", "Datastore", etc.
-        The object moid is a unique id for this object type under the vCenter server.
-        To check all such object information, you can go to the managed object board
-        page of your vCenter Server, such as: https://<your_vc_ip/mob
-        """
-        obj = None
-        if self.pyvmomi_sdk_client is None:
-            raise RuntimeError("Must init pyvmomi_sdk_client first.")
-
-        if not moid:
-            raise ValueError("Invalid argument for moid")
-
-        container = self.pyvmomi_sdk_client.content.viewManager.CreateContainerView(
-            self.pyvmomi_sdk_client.content.rootFolder, vimtype, True
-        )
-
-        for c in container.view:
-            if moid in str(c):
-                obj = c
-                break
-
-        return obj
-
     def get_pyvmomi_obj(self, vimtype, name=None, obj_id=None):
         """
         This function will return the vSphere object.


### PR DESCRIPTION
# Why are these changes needed?
Functions get_pyvmomi_obj_by_name and get_pyvmomi_obj_by_moid are replaced by get_pyvmomi_obj, which is comment from upstream team. There are some places miss it.

# Test 
We have internal automation pipelines passed. Also team tested the GPU functionalities manually.
![image](https://github.com/ray-project/ray/assets/85480625/3117e804-80ea-4ea6-bc85-46a79d9b89c2)
![image](https://github.com/ray-project/ray/assets/85480625/0a25cc22-df10-4ab3-9d04-aafe5fb1b51c)


## Checks

- [*] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [*] I've run `scripts/format.sh` to lint the changes in this PR.
- [*] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [* I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [*] Unit tests
   - [*] Release tests
   - [ ] This PR is not tested :(
