### PR TITLE
[Doc] Fix sample code of leaking gpus in GPU Support chapter.

### DIFF
--- a/doc/source/ray-core/doc_code/gpus.py
+++ b/doc/source/ray-core/doc_code/gpus.py
@@ -86,7 +86,7 @@ fractional_gpu_actors = [FractionalGPUActor.remote() for _ in range(3)]
 # __leak_gpus_start__
 # By default, ray will not reuse workers for GPU tasks to prevent
 # GPU resource leakage.
-@ray.remote(num_gpus=1)
+@ray.remote(max_calls=0)
 def leak_gpus():
     import tensorflow as tf
 


### PR DESCRIPTION

As described in the document, we can re-enable worker reuse by setting (max_calls=0) in the ray.remote decorator, rather than (num_gpus=1).