### PR TITLE
[RLlib] Issue 40664: Fix `test_agent` (connector) test, which breaks with numpy>=1.24.4.

### DIFF
--- a/rllib/connectors/tests/test_agent.py
+++ b/rllib/connectors/tests/test_agent.py
@@ -111,7 +111,7 @@ class TestAgentConnector(unittest.TestCase):
                 "sensor2": 8.8,
             },
             SampleBatch.REWARDS: 5.8,
-            SampleBatch.ACTIONS: [[1, 1], [2]],
+            SampleBatch.ACTIONS: [[1, 1], [2, 2]],
             SampleBatch.INFOS: {"random": "info"},
         }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue 40664: Fix `test_agent` (connector) test, which breaks with numpy>=1.24.4.

Solution: The test case seems to use invalid data to begin with (action==[[1, 1], 2]), which would be output in a flattened fashion by any model anyways.
Also, since we are revisiting all Connector classes and utilities currently, this test might soon be obsoleted.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes: #40664 40664
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
