### PR TITLE
[docs] fix from Kapa for clipped Ray logo in Ask AI button

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -904,3 +904,13 @@ footer.col.footer > p {
     display: flex;
     align-items: stretch;
 }
+
+/* Kapa Ask AI button */
+#kapa-widget-container figure {
+    padding: 0 !important;
+  }
+  
+  .mantine-Modal-root figure {
+    padding: 0 !important;
+  }
+  

--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -913,4 +913,3 @@ footer.col.footer > p {
   .mantine-Modal-root figure {
     padding: 0 !important;
   }
-  


### PR DESCRIPTION

The Ray logo in the Kapa Ask AI button is borked. This restores the logo to it's original beauty.

cc: @zhe-thoughts @vitsai @can-anyscale @pcmoritz 

Closes https://github.com/ray-project/ray/issues/39911

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
