### PR TITLE
[core] remove ray data from leaky core test

### DIFF
--- a/python/ray/tests/test_node_manager.py
+++ b/python/ray/tests/test_node_manager.py
@@ -238,12 +238,16 @@ import ray
 import numpy as np
 import tensorflow
 
+@ray.remote
 def leak_repro(obj):
     tensorflow
     return []
 
-ds = ray.data.from_numpy(np.ones((100_000)))
-ds.map(leak_repro, max_retries=0)
+refs = []
+for i in range(100_000):
+    refs.append(leak_repro.remote(i))
+
+ray.get(refs)
   """
     try:
         run_string_as_driver(driver)

--- a/python/ray/tests/test_node_manager.py
+++ b/python/ray/tests/test_node_manager.py
@@ -238,7 +238,7 @@ import ray
 import numpy as np
 import tensorflow
 
-@ray.remote
+@ray.remote(max_retries=0)
 def leak_repro(obj):
     tensorflow
     return []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Modifies `test_reference_global_import_does_not_leak_worker_upon_driver_exit` to not use ray data. This test used to check that there are no leaks after running a script containing ray data code. But, Ray data has multiple global actor handlers that aren't gc'd because of `lifetime="detached"`. This happened to pass previously because the test was written when we used to eagerly execute datasets, but now that we do lazy execution, the old test doesn't actually execute anything.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
