### PR TITLE
Add xgboost uber blog post back to example gallery

### DIFF
--- a/doc/source/ray-overview/examples.rst
+++ b/doc/source/ray-overview/examples.rst
@@ -1318,14 +1318,14 @@ Ray Examples
         :link-type: doc
 
         Fine-tune vicuna-13b-v1.3 with DeepSpeed, PyTorch Lightning and Ray Train
-    
+
     .. grid-item-card:: :bdg-secondary:`Code example`
         :class-item: gallery-item training llm pytorch nlp
         :link: deepspeed_example
         :link-type: ref
 
         Distributed Training with DeepSpeed ZeRO-3 and TorchTrainer
-    
+
     .. grid-item-card:: :bdg-secondary:`Code example`
         :class-item: gallery-item training llm pytorch huggingface nlp
         :link: deepspeed_example
@@ -1339,3 +1339,9 @@ Ray Examples
         :link-type: ref
 
         RayJob Batch Inference Example on Kubernetes with Ray
+
+    .. grid-item-card:: :bdg-primary:`Blog`
+        :class-item: gallery-item train
+        :link: https://www.uber.com/blog/elastic-xgboost-ray/
+
+        Elastic Distributed Training with XGBoost on Ray


### PR DESCRIPTION
## Why are these changes needed?

This PR adds the XGBoost Uber blog post back to the example gallery

## Related issue number

Closes #37618.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
