### PR TITLE
Fix test_modin.py

### DIFF
--- a/python/ray/tests/modin/test_modin.py
+++ b/python/ray/tests/modin/test_modin.py
@@ -21,8 +21,7 @@ import pytest
 import pandas
 import numpy as np
 from numpy.testing import assert_array_equal
-import ray
-from ray.tests.conftest import start_cluster  # noqa F401
+from ray.tests.conftest import ray_start_regular_shared  # noqa F401
 
 modin_installed = True
 
@@ -45,11 +44,8 @@ if not skip:
     import modin.pandas as pd
 
 
-# Module scoped fixture. Will first run all tests without ray
-# client, then rerun all tests with a single ray client session.
 @pytest.fixture(autouse=True)
-def run_ray_client(start_cluster):  # noqa F811
-    ray.init(start_cluster[1])
+def run_ray_client(ray_start_regular_shared):  # noqa F811
     yield
 
 

--- a/python/ray/tests/modin/test_modin.py
+++ b/python/ray/tests/modin/test_modin.py
@@ -45,7 +45,7 @@ if not skip:
 
 
 @pytest.fixture(autouse=True)
-def run_ray_client(ray_start_regular_shared):  # noqa F811
+def connect_to_ray_cluster(ray_start_regular_shared):  # noqa F811
     yield
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Modin uses global variables to store ObjectRefs (e.g., [here](https://github.com/modin-project/modin/blob/e12b21703494dcbb8f7aa951b40ebe1d033307ba/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py#L64)).

In test_modin.py, now we recreate a new cluster for each test case. This makes the cache invalid. This PR fixes this issue by reusing a shared cluster. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/40681

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
