### PR TITLE
[cd] multi-collection file support

### DIFF
--- a/release/BUILD
+++ b/release/BUILD
@@ -592,6 +592,7 @@ py_test(
     ) + [
         "//python/ray/autoscaler/aws:test_configs",
         "//python/ray/autoscaler/gcp:test_configs",
+        "ray_release/tests/test_collection_data.yaml",
     ],
     exec_compatible_with = ["//:hermetic_python"],
     tags = [

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -40,11 +40,13 @@ RELEASE_TEST_SCHEMA_FILE = bazel_runfile("release/ray_release/schema.json")
 
 
 def read_and_validate_release_test_collection(
-    config_file: str, schema_file: Optional[str] = None
+    config_files: List[str], schema_file: Optional[str] = None
 ) -> List[Test]:
     """Read and validate test collection from config file"""
-    with open(config_file, "rt") as fp:
-        tests = parse_test_definition(yaml.safe_load(fp))
+    tests = []
+    for config_file in config_files:
+        with open(config_file, "rt") as fp:
+            tests += parse_test_definition(yaml.safe_load(fp))
 
     validate_release_test_collection(tests, schema_file=schema_file)
     return tests

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -2,7 +2,7 @@ import json
 import os
 import shutil
 import sys
-from typing import Optional
+from typing import Tuple
 from pathlib import Path
 
 import click
@@ -35,9 +35,9 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
 @click.command()
 @click.option(
     "--test-collection-file",
-    default=None,
+    multiple=True,
     type=str,
-    help="File containing test configurations",
+    help="Files containing test configurations",
 )
 @click.option(
     "--run-jailed-tests",
@@ -62,7 +62,7 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
     help="Global config to use for test execution.",
 )
 def main(
-    test_collection_file: Optional[str] = None,
+    test_collection_file: Tuple[str],
     run_jailed_tests: bool = False,
     run_unstable_tests: bool = False,
     global_config: str = "oss_config.yaml",
@@ -76,9 +76,12 @@ def main(
     tmpdir = None
 
     env = {}
-    test_collection_file = test_collection_file or os.path.join(
-        os.path.dirname(__file__), "..", "..", "release_tests.yaml"
-    )
+    if test_collection_file:
+        test_collection_file = list(test_collection_file)
+    else:
+        test_collection_file = [
+            os.path.join(os.path.dirname(__file__), "..", "..", "release_tests.yaml")
+        ]
 
     frequency = settings["frequency"]
     prefer_smoke_tests = settings["prefer_smoke_tests"]

--- a/release/ray_release/tests/test_collection_data.yaml
+++ b/release/ray_release/tests/test_collection_data.yaml
@@ -1,0 +1,11 @@
+- name: test_name
+  group: test_group
+  working_dir: cluster_tests
+  frequency: nightly
+  team: team
+  cluster:
+    byod: {}
+    cluster_compute: cpt_autoscaling_1-3_aws.yaml
+  run:
+    timeout: 3600
+    script: test_script.py

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -13,7 +13,10 @@ from ray_release.config import (
 )
 from ray_release.exception import ReleaseTestConfigError
 
-_TEST_COLLECTION_FILE = bazel_runfile("release/release_tests.yaml")
+_TEST_COLLECTION_FILES = [
+    bazel_runfile("release/release_tests.yaml"),
+    bazel_runfile("release/ray_release/tests/test_collection_data.yaml"),
+]
 
 VALID_TEST = Test(
     **{
@@ -217,7 +220,8 @@ def test_compute_config_invalid_ebs():
 
 
 def test_load_and_validate_test_collection_file():
-    read_and_validate_release_test_collection(_TEST_COLLECTION_FILE)
+    tests = read_and_validate_release_test_collection(_TEST_COLLECTION_FILES)
+    assert [test for test in tests if test.get_name() == "test_name"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Support creating release test pipeline with multiple collection files. This will allow us to split release_tests.yaml into multiple smaller files.

Test:
- CI
- Run `python release/ray_release/scripts/build_pipeline.py`

```
[INFO 2023-10-26 22:26:05,764] build_pipeline.py: 93  Found the following buildkite pipeline settings:

  frequency =               Frequency.ANY
  prefer_smoke_tests =      False
  test_attr_regex_filters = None
  ray_wheels =              None
  ray_test_repo =           None
  ray_test_branch =         None
  priority =                Priority.DEFAULT
  no_concurrency_limit =    False

[INFO 2023-10-26 22:26:14,592] build_pipeline.py: 108  [{'name': 'cluster_tune_scale_up_down.aws', 'group': 'Cluster tests', 'working_dir': 'cluster_tests', 'frequency': 'nightly', 'team': 'ml', 'cluster': {'byod': {}, 'cluster_compute': 'cpt_autoscaling_1-3_aws.yaml'}, 'run': {'timeout': 3600, 'script': 'python workloads/tune_scale_up_down.py', 'wait_for_nodes': {'num_nodes': 0}}, 'alert': 'default'}, {'name': 'cluster_tune_scale_up_down.gce', 'group': 'Cluster tests', 'working_dir': 'cluster_tests', 'frequency': 'manual', 'team': 'ml', 'cluster': {'byod': {}, 'cluster_compute': 'cpt_autoscaling_1-3_gce.yaml'}, 'run': {'timeout': 3600, 'script': 'python workloads/tune_scale_up_down.py', 'wait_for_nodes': {'num_nodes': 0}}, 'alert': 'default', 'env': 'gce'}, {'name': 'torch_batch_inference_1_gpu_10gb_raw.aws', 'group': 'AIR tests', 'working_dir': 'nightly_tests/dataset', 'frequency': 'nightly', 'team': 'data', 'cluster': {'byod': {'type': 'gpu'}, 'cluster_compute': 'compute_gpu_1_cpu_16_aws.yaml'}, 'run': {'timeout': 500, 'script': 'python gpu_batch_inference.py --data-directory=10G-image-data-synthetic-raw --data-format raw'}, 'alert': 'default'}, {'name': 'torch_batch_inference_1_gpu_10gb_raw.gce', 'group': 'AIR tests', 'working_dir': 'nightly_tests/dataset', 'frequency': 'manual', 'team'
```