### PR TITLE
[ci] fix flaky test dashboard

### DIFF
--- a/ci/ray_ci/test_tester_container.py
+++ b/ci/ray_ci/test_tester_container.py
@@ -38,8 +38,19 @@ def test_enough_gpus() -> None:
 
 
 def test_run_tests_in_docker() -> None:
+    inputs = []
+
     def _mock_popen(input: List[str]) -> None:
-        input_str = " ".join(input)
+        inputs.append(" ".join(input))
+
+    with mock.patch("subprocess.Popen", side_effect=_mock_popen), mock.patch(
+        "ci.ray_ci.tester_container.TesterContainer.install_ray",
+        return_value=None,
+    ):
+        TesterContainer(
+            "team", build_type="debug", test_envs=["ENV_01", "ENV_02"]
+        )._run_tests_in_docker(["t1", "t2"], [0, 1], ["v=k"], "flag")
+        input_str = inputs[-1]
         assert "--env ENV_01 --env ENV_02 --env BUILDKITE_BUILD_URL" in input_str
         assert '--gpus "device=0,1"' in input_str
         assert (
@@ -47,14 +58,10 @@ def test_run_tests_in_docker() -> None:
             "--config=ci-debug --test_env v=k --test_arg flag t1 t2" in input_str
         )
 
-    with mock.patch("subprocess.Popen", side_effect=_mock_popen), mock.patch(
-        "ci.ray_ci.tester_container.TesterContainer.install_ray",
-        return_value=None,
-    ):
-        container = TesterContainer(
-            "team", build_type="debug", envs=["ENV_01", "ENV_02"]
-        )
-        container._run_tests_in_docker(["t1", "t2"], [0, 1], ["v=k"], "flag")
+        TesterContainer("team")._run_tests_in_docker(["t1", "t2"], [], ["v=k"])
+        input_str = inputs[-1]
+        assert "--env BUILDKITE_BUILD_URL" in input_str
+        assert "--gpus" not in input_str
 
 
 def test_run_script_in_docker() -> None:

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -164,7 +164,7 @@ def _get_container(
 
     return TesterContainer(
         build_name or f"{team}build",
-        envs=test_env,
+        test_envs=test_env,
         shard_count=shard_count,
         shard_ids=list(range(shard_start, shard_end)),
         gpus=gpus,

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -17,7 +17,7 @@ class TesterContainer(Container):
         docker_tag: str,
         shard_count: int = 1,
         gpus: int = 0,
-        envs: Optional[List[str]] = None,
+        test_envs: Optional[List[str]] = None,
         shard_ids: Optional[List[int]] = None,
         skip_ray_installation: bool = False,
         build_type: Optional[str] = None,
@@ -29,10 +29,10 @@ class TesterContainer(Container):
         used to run tests in a distributed fashion.
         :param shard_ids: The list of shard ids to run. If none, run no shards.
         """
-        super().__init__(docker_tag, envs=envs)
+        super().__init__(docker_tag, envs=test_envs)
         self.shard_count = shard_count
         self.shard_ids = shard_ids or []
-        self.envs = envs or []
+        self.test_envs = test_envs or []
         self.build_type = build_type
         self.gpus = gpus
         assert (
@@ -67,7 +67,7 @@ class TesterContainer(Container):
         # divide gpus evenly among chunks
         gpu_ids = chunk_into_n(list(range(self.gpus)), len(chunks))
         runs = [
-            self._run_tests_in_docker(chunks[i], gpu_ids[i], self.envs, test_arg)
+            self._run_tests_in_docker(chunks[i], gpu_ids[i], self.test_envs, test_arg)
             for i in range(len(chunks))
         ]
         exits = [run.wait() for run in runs]


### PR DESCRIPTION
The parent class (container) and child class (tester_container) both use `self.envs` as the name of its fields, so in the child class, it override the self.envs again and remove all the _DOCKER_ENV from the list. This causes docker now loses a bunch of default _DOCKER_ENV (and stop writing data to flaky dash board).

Rename the field of tester_container to test_envs.

Test:
- CI