### PR TITLE
[vSphere Provider] is_terminated should consider the case that the VM is powered off for plugging the GPU

### DIFF
--- a/python/ray/autoscaler/_private/vsphere/node_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/node_provider.py
@@ -179,13 +179,26 @@ class VsphereNodeProvider(NodeProvider):
         vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
             [vim.VirtualMachine], obj_id=node_id
         )
-        return vm.runtime.powerState != vim.VirtualMachinePowerState.poweredOn
+        return vm.runtime.powerState == vim.VirtualMachinePowerState.poweredOn
 
     def is_terminated(self, node_id):
         vm = self.pyvmomi_sdk_provider.get_pyvmomi_obj(
             [vim.VirtualMachine], obj_id=node_id
         )
-        return vm.runtime.powerState != vim.VirtualMachinePowerState.poweredOn
+        if vm.runtime.powerState == vim.VirtualMachinePowerState.poweredOn:
+            return False
+        else:
+            vns = Constants.VSPHERE_NODE_STATUS
+            matched_tags, _ = self.get_matched_tags(
+                {vns: Constants.VsphereNodeStatus.CREATING.value},
+                DynamicID(type=Constants.TYPE_OF_RESOURCE, id=vm._moId),
+            )
+            if matched_tags:
+                # If the node is not powered on but has the creating tag, then it could
+                # be under reconfiguration, such as plugging the GPU. In this case we
+                # should consider the node is not terminated, it will be turned on later
+                return False
+        return True
 
     def node_tags(self, node_id):
         with self.tag_cache_lock:

--- a/python/ray/tests/vsphere/test_vsphere_node_provider.py
+++ b/python/ray/tests/vsphere/test_vsphere_node_provider.py
@@ -133,16 +133,6 @@ def test_non_terminated_nodes_with_multiple_filters_not_matching():
     assert len(nodes) == 0
 
 
-def test_is_running():
-    """Should return true if a cached node is in POWERED_ON state"""
-    vnp = mock_vsphere_node_provider()
-    node1 = MagicMock()
-    node1.power_state = HardPower.State.POWERED_ON
-    vnp.cached_nodes = {"node1": node1}
-    is_running = vnp.is_running("node1")
-    assert is_running is True
-
-
 def test_is_terminated():
     """Should return true if a cached node is not in POWERED_ON state"""
     vnp = mock_vsphere_node_provider()


### PR DESCRIPTION
…plug the GPU

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Before fix, occasionally creating worker node will fail because the worker is detected being powered off. Howwever, the power off is expected because we are plugging the GPU.

After fix, if the node has tag "vsphere-node-status:creating" and power off, we will regard it as a non-terminated node. This time, The worker node creation and join can success 100%.

## Related issue number

<!-- For example: "Closes #1234" -->


## Test

![image](https://github.com/ray-project/ray/assets/15973672/8c320c6d-eb56-4b39-be37-a400d19104d0)


See the tasks:

1. the first one for instant clone the node
1. the next two for reconfiguration for adding the CPU and Memory.
1. the next for power off the VM
1. the next for reconfiguration to add the GPU by PCI passthru.
1. the last for powering on the VM

There is no struggle, it succeed in one shot.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
