### PR TITLE
[Core] Fix flaky reference_counting test

### DIFF
--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -33,19 +33,24 @@ def one_worker_100MiB(request):
 
 
 def _fill_object_store_and_get(obj, succeed=True, object_MiB=20, num_objects=5):
+    objs = []
     for _ in range(num_objects):
-        ray.put(np.zeros(object_MiB * 1024 * 1024, dtype=np.uint8))
+        objs.append(ray.put(np.zeros(object_MiB * 1024 * 1024, dtype=np.uint8)))
 
     if type(obj) is bytes:
         obj = ray.ObjectRef(obj)
 
     if succeed:
         wait_for_condition(
-            lambda: ray._private.worker.global_worker.core_worker.object_exists(obj)
+            lambda: ray._private.worker.global_worker.core_worker.object_exists(obj),
+            timeout=30,
         )
     else:
         wait_for_condition(
-            lambda: not ray._private.worker.global_worker.core_worker.object_exists(obj)
+            lambda: not ray._private.worker.global_worker.core_worker.object_exists(
+                obj
+            ),
+            timeout=30,
         )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks like in the environment with more & faster CPUs, objects could be GC'ed before it fills up the object store (because we don't pin the ref). This PR fixes it by pinning the objects to memory until _fill_object_store_and_get finishes.

I am validating if this fixes the issue now

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
