### PR TITLE
[GCS FT] Mark job as finished for dead node (#40431)

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_job_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.h
@@ -79,6 +79,12 @@ class GcsJobManager : public rpc::JobInfoHandler {
 
   std::shared_ptr<rpc::JobConfig> GetJobConfig(const JobID &job_id) const;
 
+  /// Handle a node death. This will marks all jobs associated with the
+  /// specified node id as finished.
+  ///
+  /// \param node_id The specified node id.
+  void OnNodeDead(const NodeID &node_id);
+
  private:
   std::shared_ptr<GcsTableStorage> gcs_table_storage_;
   std::shared_ptr<GcsPublisher> gcs_publisher_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -740,6 +740,7 @@ void GcsServer::InstallEventListeners() {
         gcs_resource_manager_->OnNodeDead(node_id);
         gcs_placement_group_manager_->OnNodeDead(node_id);
         gcs_actor_manager_->OnNodeDead(node_id, node_ip_address);
+        gcs_job_manager_->OnNodeDead(node_id);
         raylet_client_pool_->Disconnect(node_id);
         gcs_healthcheck_manager_->RemoveNode(node_id);
         pubsub_handler_->RemoveSubscriberFrom(node_id.Binary());

--- a/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
@@ -553,6 +553,87 @@ TEST_F(GcsJobManagerTest, TestPreserveDriverInfo) {
   ASSERT_EQ(data.driver_pid(), 8264);
 }
 
+TEST_F(GcsJobManagerTest, TestNodeFailure) {
+  gcs::GcsJobManager gcs_job_manager(gcs_table_storage_,
+                                     gcs_publisher_,
+                                     runtime_env_manager_,
+                                     *function_manager_,
+                                     *fake_kv_,
+                                     client_factory_);
+
+  auto job_id1 = JobID::FromInt(1);
+  auto job_id2 = JobID::FromInt(2);
+  gcs::GcsInitData gcs_init_data(gcs_table_storage_);
+  gcs_job_manager.Initialize(/*init_data=*/gcs_init_data);
+
+  rpc::AddJobReply empty_reply;
+  std::promise<bool> promise1;
+  std::promise<bool> promise2;
+
+  auto add_job_request1 = Mocker::GenAddJobRequest(job_id1, "namespace_1");
+  gcs_job_manager.HandleAddJob(
+      *add_job_request1,
+      &empty_reply,
+      [&promise1](Status, std::function<void()>, std::function<void()>) {
+        promise1.set_value(true);
+      });
+  promise1.get_future().get();
+
+  auto add_job_request2 = Mocker::GenAddJobRequest(job_id2, "namespace_2");
+  gcs_job_manager.HandleAddJob(
+      *add_job_request2,
+      &empty_reply,
+      [&promise2](Status, std::function<void()>, std::function<void()>) {
+        promise2.set_value(true);
+      });
+  promise2.get_future().get();
+
+  rpc::GetAllJobInfoRequest all_job_info_request;
+  rpc::GetAllJobInfoReply all_job_info_reply;
+  std::promise<bool> all_job_info_promise;
+
+  // Check if all job are not dead
+  gcs_job_manager.HandleGetAllJobInfo(
+      all_job_info_request,
+      &all_job_info_reply,
+      [&all_job_info_promise](Status, std::function<void()>, std::function<void()>) {
+        all_job_info_promise.set_value(true);
+      });
+  all_job_info_promise.get_future().get();
+  for (auto job_info : all_job_info_reply.job_info_list()) {
+    ASSERT_TRUE(!job_info.is_dead());
+  }
+
+  // Remove node and then check that the job is dead.
+  auto address = all_job_info_reply.job_info_list().Get(0).driver_address();
+  auto node_id = NodeID::FromBinary(address.raylet_id());
+  gcs_job_manager.OnNodeDead(node_id);
+
+  // Test get all jobs and check if killed node jobs marked as finished
+  auto condition = [&gcs_job_manager, node_id]() -> bool {
+    rpc::GetAllJobInfoRequest all_job_info_request2;
+    rpc::GetAllJobInfoReply all_job_info_reply2;
+    std::promise<bool> all_job_info_promise2;
+    gcs_job_manager.HandleGetAllJobInfo(
+        all_job_info_request2,
+        &all_job_info_reply2,
+        [&all_job_info_promise2](Status, std::function<void()>, std::function<void()>) {
+          all_job_info_promise2.set_value(true);
+        });
+    all_job_info_promise2.get_future().get();
+
+    bool job_condition = true;
+    // job1 from the current node should dead, while job2 is still alive
+    for (auto job_info : all_job_info_reply2.job_info_list()) {
+      auto job_node_id = NodeID::FromBinary(job_info.driver_address().raylet_id());
+      job_condition = job_condition && (job_info.is_dead() == (job_node_id == node_id));
+    }
+    return job_condition;
+  };
+
+  EXPECT_TRUE(WaitForCondition(condition, 2000));
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
This blocks several customers, and lots of kuberay users complain about this issue.

The risk of the fix is pretty low, but we should still rerun the release tests.


The issue is ray list nodes is timeout before it managed to return list of all nodes. The issue is caused by the timeout when GcsJobManager tried to get pending tasks from the driver of node which already dead (killed head nodes), which is 2 mins timeout to confirm if the node is dead. The solution we proposed is when node is dead, we mark all the job submitted to that head node as "finished", so the RPC calls for the pending tasks will only applied to drivers of current head node which most likely to be alive => resulting no timeout.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
