### PR TITLE
[data] add interval for iter metrics reporting

### DIFF
--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -26,6 +26,7 @@ from ray.data.block import Block, BlockMetadata, DataBatch
 from ray.data.context import DataContext
 from ray.types import ObjectRef
 
+# Interval for metrics update remote calls to _StatsActor during iteration.
 STATS_UPDATE_INTERVAL_SECONDS = 30
 
 

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -26,7 +26,7 @@ from ray.data.block import Block, BlockMetadata, DataBatch
 from ray.data.context import DataContext
 from ray.types import ObjectRef
 
-STATS_UPDATE_INTERVAL_SECONDS = 10
+STATS_UPDATE_INTERVAL_SECONDS = 30
 
 
 def iter_batches(

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -1,4 +1,5 @@
 import collections
+import time
 from contextlib import nullcontext
 from typing import Any, Callable, Dict, Iterator, Optional, Tuple
 
@@ -24,6 +25,8 @@ from ray.data._internal.util import make_async_gen
 from ray.data.block import Block, BlockMetadata, DataBatch
 from ray.data.context import DataContext
 from ray.types import ObjectRef
+
+STATS_UPDATE_INTERVAL_SECONDS = 10
 
 
 def iter_batches(
@@ -176,6 +179,7 @@ def iter_batches(
     async_batch_iter = make_async_gen(block_refs, fn=_async_iter_batches, num_workers=1)
     metrics_tag = {"dataset": dataset_tag}
 
+    last_stats_update_time = 0
     while True:
         with stats.iter_total_blocked_s.timer() if stats else nullcontext():
             try:
@@ -184,7 +188,10 @@ def iter_batches(
                 break
         with stats.iter_user_s.timer() if stats else nullcontext():
             yield next_batch
-        update_stats_actor_iter_metrics(stats, metrics_tag)
+
+        if time.time() - last_stats_update_time >= STATS_UPDATE_INTERVAL_SECONDS:
+            update_stats_actor_iter_metrics(stats, metrics_tag)
+            last_stats_update_time = time.time()
     clear_stats_actor_iter_metrics(metrics_tag)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After adding [iteration metrics](https://github.com/ray-project/ray/pull/40541) `test_batcher` runtime on premerge went from `20-25s` to `45-50s`. It also timed out on this [build](https://buildkite.com/ray-project/premerge/builds/10085#018b71c4-fcbc-45c8-a732-fe61ab8c7467).

We currently report metrics to the StatsActor after every batch, if batches are small, then there are too many calls.

This pr adds an minimum time interval for iteration metrics reporting of 30s.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
