### PR TITLE
[data] Ray Data jobs detail table

### DIFF
--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -93,6 +93,18 @@ steps:
     depends_on: datamongobuild
     job_env: forge
 
+  - label: ":database: data: dashboard tests"
+    tags:
+      - python
+      - dashboard
+    instance_type: small
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- python/ray/dashboard/... data
+        --build-name datanbuild
+        --parallelism-per-worker 3
+    depends_on: datanbuild
+    job_env: forge
+
   - label: ":database: data: flaky tests"
     tags: 
       - python

--- a/dashboard/BUILD
+++ b/dashboard/BUILD
@@ -97,7 +97,7 @@ py_test(
 )
 
 py_test(
-    name = "test_data_dashboard",
+    name = "test_data_head",
     size = "small",
     srcs = ["modules/data/tests/test_data_head.py"],
     tags = ["team:data"],

--- a/dashboard/BUILD
+++ b/dashboard/BUILD
@@ -95,3 +95,10 @@ py_test(
     srcs = ["modules/serve/tests/test_serve_dashboard.py"],
     tags = ["team:serve"],
 )
+
+py_test(
+    name = "test_data_dashboard",
+    size = "small",
+    srcs = ["modules/data/tests/test_data_head.py"],
+    tags = ["team:data"],
+)

--- a/dashboard/client/src/components/DataOverviewTable.tsx
+++ b/dashboard/client/src/components/DataOverviewTable.tsx
@@ -47,7 +47,15 @@ const DataOverviewTable = ({
     { label: "Start Time" },
     { label: "End Time" },
     { label: "Bytes Outputted" },
-    { label: "Memory Usage (Current / Max)" },
+    {
+      label: "Memory Usage (Current / Max)",
+      helpInfo: (
+        <Typography>
+          Amount of object store memory used by a dataset. Includes spilled
+          objects.
+        </Typography>
+      ),
+    },
     {
       label: "Bytes Spilled",
       helpInfo: (

--- a/dashboard/client/src/components/DataOverviewTable.tsx
+++ b/dashboard/client/src/components/DataOverviewTable.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  InputAdornment,
   Table,
   TableBody,
   TableCell,
@@ -23,6 +22,36 @@ import StateCounter from "./StatesCounter";
 import { StatusChip } from "./StatusChip";
 import { HelpInfo } from "./Tooltip";
 
+const columns = [
+  { label: "Dataset" },
+  {
+    label: "Progress",
+    helpInfo: <Typography>Blocks outputted by output operator.</Typography>,
+  },
+  { label: "State" },
+  { label: "Start Time" },
+  { label: "End Time" },
+  { label: "Bytes Outputted" },
+  {
+    label: "Memory Usage (Current / Max)",
+    helpInfo: (
+      <Typography>
+        Amount of object store memory used by a dataset. Includes spilled
+        objects.
+      </Typography>
+    ),
+  },
+  {
+    label: "Bytes Spilled",
+    helpInfo: (
+      <Typography>
+        Set "enable_get_object_locations_for_metrics" in DataContext to True to
+        collect spill stats.
+      </Typography>
+    ),
+  },
+];
+
 const DataOverviewTable = ({
   datasets = [],
 }: {
@@ -30,42 +59,13 @@ const DataOverviewTable = ({
 }) => {
   const [pageNo, setPageNo] = useState(1);
   const { changeFilter, filterFunc } = useFilter();
-  const [pageSize, setPageSize] = useState(10);
+  const pageSize = 10;
   const datasetList = datasets.filter(filterFunc);
 
   const list = datasetList.slice((pageNo - 1) * pageSize, pageNo * pageSize);
 
   const classes = rowStyles();
 
-  const columns = [
-    { label: "Dataset" },
-    {
-      label: "Progress",
-      helpInfo: <Typography>Blocks outputted by output operator.</Typography>,
-    },
-    { label: "State" },
-    { label: "Start Time" },
-    { label: "End Time" },
-    { label: "Bytes Outputted" },
-    {
-      label: "Memory Usage (Current / Max)",
-      helpInfo: (
-        <Typography>
-          Amount of object store memory used by a dataset. Includes spilled
-          objects.
-        </Typography>
-      ),
-    },
-    {
-      label: "Bytes Spilled",
-      helpInfo: (
-        <Typography>
-          Set "enable_get_object_locations_for_metrics" in DataContext to True
-          to collect spill stats.
-        </Typography>
-      ),
-    },
-  ];
   return (
     <div>
       <div style={{ flex: 1, display: "flex", alignItems: "center" }}>
@@ -78,19 +78,6 @@ const DataOverviewTable = ({
           renderInput={(params: TextFieldProps) => (
             <TextField {...params} label="Dataset" />
           )}
-        />
-        <TextField
-          style={{ margin: 8, width: 120 }}
-          label="Page Size"
-          size="small"
-          InputProps={{
-            onChange: ({ target: { value } }) => {
-              setPageSize(Math.min(Number(value), 500) || 10);
-            },
-            endAdornment: (
-              <InputAdornment position="end">Per Page</InputAdornment>
-            ),
-          }}
         />
       </div>
       <div style={{ display: "flex", alignItems: "center" }}>

--- a/dashboard/client/src/components/DataOverviewTable.tsx
+++ b/dashboard/client/src/components/DataOverviewTable.tsx
@@ -1,0 +1,178 @@
+import {
+  Box,
+  InputAdornment,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  TextFieldProps,
+  Typography,
+} from "@material-ui/core";
+import Autocomplete from "@material-ui/lab/Autocomplete";
+import Pagination from "@material-ui/lab/Pagination";
+import React, { useState } from "react";
+import { formatDateFromTimeMs } from "../common/formatUtils";
+import rowStyles from "../common/RowStyles";
+import { TaskProgressBar } from "../pages/job/TaskProgressBar";
+import { DatasetMetrics } from "../type/data";
+import { memoryConverter } from "../util/converter";
+import { useFilter } from "../util/hook";
+import StateCounter from "./StatesCounter";
+import { StatusChip } from "./StatusChip";
+import { HelpInfo } from "./Tooltip";
+
+const DataOverviewTable = ({
+  datasets = [],
+}: {
+  datasets: DatasetMetrics[];
+}) => {
+  const [pageNo, setPageNo] = useState(1);
+  const { changeFilter, filterFunc } = useFilter();
+  const [pageSize, setPageSize] = useState(10);
+  const datasetList = datasets.filter(filterFunc);
+
+  const list = datasetList.slice((pageNo - 1) * pageSize, pageNo * pageSize);
+
+  const classes = rowStyles();
+
+  const columns = [
+    { label: "Dataset" },
+    {
+      label: "Progress",
+      helpInfo: <Typography>Blocks outputted by output operator.</Typography>,
+    },
+    { label: "State" },
+    { label: "Start Time" },
+    { label: "End Time" },
+    { label: "Bytes Outputted" },
+    { label: "Memory Usage (Current / Max)" },
+    {
+      label: "Bytes Spilled",
+      helpInfo: (
+        <Typography>
+          Set "enable_get_object_locations_for_metrics" in DataContext to True
+          to collect spill stats.
+        </Typography>
+      ),
+    },
+  ];
+  return (
+    <div>
+      <div style={{ flex: 1, display: "flex", alignItems: "center" }}>
+        <Autocomplete
+          style={{ margin: 8, width: 120 }}
+          options={Array.from(new Set(datasets.map((e) => e.dataset)))}
+          onInputChange={(_: any, value: string) => {
+            changeFilter("dataset", value.trim());
+          }}
+          renderInput={(params: TextFieldProps) => (
+            <TextField {...params} label="Dataset" />
+          )}
+        />
+        <TextField
+          style={{ margin: 8, width: 120 }}
+          label="Page Size"
+          size="small"
+          InputProps={{
+            onChange: ({ target: { value } }) => {
+              setPageSize(Math.min(Number(value), 500) || 10);
+            },
+            endAdornment: (
+              <InputAdornment position="end">Per Page</InputAdornment>
+            ),
+          }}
+        />
+      </div>
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <div>
+          <Pagination
+            page={pageNo}
+            onChange={(e, num) => setPageNo(num)}
+            count={Math.ceil(datasetList.length / pageSize)}
+          />
+        </div>
+        <div>
+          <StateCounter type="task" list={datasetList} />
+        </div>
+      </div>
+      <div className={classes.tableContainer}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              {columns.map(({ label, helpInfo }) => (
+                <TableCell align="center" key={label}>
+                  <Box
+                    display="flex"
+                    justifyContent="center"
+                    alignItems="center"
+                  >
+                    {label}
+                    {helpInfo && (
+                      <HelpInfo className={classes.helpInfo}>
+                        {helpInfo}
+                      </HelpInfo>
+                    )}
+                  </Box>
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {list.map(
+              ({
+                dataset,
+                state,
+                ray_data_current_bytes,
+                ray_data_output_bytes,
+                ray_data_spilled_bytes,
+                progress,
+                total,
+                start_time,
+                end_time,
+              }) => (
+                <TableRow key={dataset}>
+                  <TableCell align="center">{dataset}</TableCell>
+                  <TableCell align="center">
+                    <TaskProgressBar
+                      numFinished={progress}
+                      numRunning={
+                        state === "RUNNING" ? total - progress : undefined
+                      }
+                      numCancelled={
+                        state === "FAILED" ? total - progress : undefined
+                      }
+                      total={total}
+                    />
+                  </TableCell>
+                  <TableCell align="center">
+                    <StatusChip type="task" status={state} />
+                  </TableCell>
+                  <TableCell align="center">
+                    {formatDateFromTimeMs(start_time * 1000)}
+                  </TableCell>
+                  <TableCell align="center">
+                    {end_time && formatDateFromTimeMs(end_time * 1000)}
+                  </TableCell>
+                  <TableCell align="center">
+                    {memoryConverter(Number(ray_data_output_bytes.max))}
+                  </TableCell>
+                  <TableCell align="center">
+                    {memoryConverter(Number(ray_data_current_bytes.value))}/
+                    {memoryConverter(Number(ray_data_current_bytes.max))}
+                  </TableCell>
+                  <TableCell align="center">
+                    {memoryConverter(Number(ray_data_spilled_bytes.max))}
+                  </TableCell>
+                </TableRow>
+              ),
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+};
+
+export default DataOverviewTable;

--- a/dashboard/client/src/components/DataOverviewTable.tsx
+++ b/dashboard/client/src/components/DataOverviewTable.tsx
@@ -45,8 +45,9 @@ const columns = [
     label: "Bytes Spilled",
     helpInfo: (
       <Typography>
-        Set "enable_get_object_locations_for_metrics" in DataContext to True to
-        collect spill stats.
+        Set
+        "ray.data.context.DataContext.get_current().enable_get_object_locations_for_metrics
+        = True" to collect spill stats.
       </Typography>
     ),
   },

--- a/dashboard/client/src/components/DataOverviewTable.tsx
+++ b/dashboard/client/src/components/DataOverviewTable.tsx
@@ -29,8 +29,6 @@ const columns = [
     helpInfo: <Typography>Blocks outputted by output operator.</Typography>,
   },
   { label: "State" },
-  { label: "Start Time" },
-  { label: "End Time" },
   { label: "Bytes Outputted" },
   {
     label: "Memory Usage (Current / Max)",
@@ -51,6 +49,8 @@ const columns = [
       </Typography>
     ),
   },
+  { label: "Start Time" },
+  { label: "End Time" },
 ];
 
 const DataOverviewTable = ({
@@ -146,12 +146,6 @@ const DataOverviewTable = ({
                     <StatusChip type="task" status={state} />
                   </TableCell>
                   <TableCell align="center">
-                    {formatDateFromTimeMs(start_time * 1000)}
-                  </TableCell>
-                  <TableCell align="center">
-                    {end_time && formatDateFromTimeMs(end_time * 1000)}
-                  </TableCell>
-                  <TableCell align="center">
                     {memoryConverter(Number(ray_data_output_bytes.max))}
                   </TableCell>
                   <TableCell align="center">
@@ -160,6 +154,12 @@ const DataOverviewTable = ({
                   </TableCell>
                   <TableCell align="center">
                     {memoryConverter(Number(ray_data_spilled_bytes.max))}
+                  </TableCell>
+                  <TableCell align="center">
+                    {formatDateFromTimeMs(start_time * 1000)}
+                  </TableCell>
+                  <TableCell align="center">
+                    {end_time && formatDateFromTimeMs(end_time * 1000)}
                   </TableCell>
                 </TableRow>
               ),

--- a/dashboard/client/src/pages/data/DataOverview.component.test.tsx
+++ b/dashboard/client/src/pages/data/DataOverview.component.test.tsx
@@ -1,66 +1,50 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import { getDataDatasets } from "../../service/data";
 import { TEST_APP_WRAPPER } from "../../util/test-utils";
 import DataOverview from "./DataOverview";
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useParams: jest.fn(),
-}));
-jest.mock("../../service/data");
-
-const mockGetDataDatasets = jest.mocked(getDataDatasets);
-
 describe("DataOverview", () => {
   it("renders table with dataset metrics", async () => {
-    mockGetDataDatasets.mockResolvedValue({
-      data: {
-        datasets: [
-          {
-            dataset: "test_ds1",
-            state: "RUNNING",
-            progress: 50,
-            total: 100,
-            start_time: 0,
-            end_time: undefined,
-            ray_data_output_bytes: {
-              max: 10,
-            },
-            ray_data_spilled_bytes: {
-              max: 20,
-            },
-            ray_data_current_bytes: {
-              value: 30,
-              max: 40,
-            },
-          },
-          {
-            dataset: "test_ds2",
-            state: "FINISHED",
-            progress: 200,
-            total: 200,
-            start_time: 1,
-            end_time: 2,
-            ray_data_output_bytes: {
-              max: 50,
-            },
-            ray_data_spilled_bytes: {
-              max: 60,
-            },
-            ray_data_current_bytes: {
-              value: 70,
-              max: 80,
-            },
-          },
-        ],
+    const datasets = [
+      {
+        dataset: "test_ds1",
+        state: "RUNNING",
+        progress: 50,
+        total: 100,
+        start_time: 0,
+        end_time: undefined,
+        ray_data_output_bytes: {
+          max: 10,
+        },
+        ray_data_spilled_bytes: {
+          max: 20,
+        },
+        ray_data_current_bytes: {
+          value: 30,
+          max: 40,
+        },
       },
-    } as any);
+      {
+        dataset: "test_ds2",
+        state: "FINISHED",
+        progress: 200,
+        total: 200,
+        start_time: 1,
+        end_time: 2,
+        ray_data_output_bytes: {
+          max: 50,
+        },
+        ray_data_spilled_bytes: {
+          max: 60,
+        },
+        ray_data_current_bytes: {
+          value: 70,
+          max: 80,
+        },
+      },
+    ];
 
-    render(<DataOverview />, { wrapper: TEST_APP_WRAPPER });
-
-    // Wait for "TOTALx 2" to show up
-    await screen.findByText("x 2");
+    render(<DataOverview datasets={datasets} />, { wrapper: TEST_APP_WRAPPER });
 
     // First Dataset
     expect(screen.getByText("test_ds1")).toBeVisible();

--- a/dashboard/client/src/pages/data/DataOverview.component.test.tsx
+++ b/dashboard/client/src/pages/data/DataOverview.component.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { getDataDatasets } from "../../service/data";
+import { TEST_APP_WRAPPER } from "../../util/test-utils";
+import DataOverview from "./DataOverview";
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: jest.fn(),
+}));
+jest.mock("../../service/data");
+
+const mockGetDataDatasets = jest.mocked(getDataDatasets);
+
+describe("DataOverview", () => {
+  it("renders table with dataset metrics", async () => {
+    mockGetDataDatasets.mockResolvedValue({
+      data: {
+        datasets: [
+          {
+            dataset: "test_ds1",
+            state: "RUNNING",
+            progress: 50,
+            total: 100,
+            start_time: 0,
+            end_time: undefined,
+            ray_data_output_bytes: {
+              max: 10,
+            },
+            ray_data_spilled_bytes: {
+              max: 20,
+            },
+            ray_data_current_bytes: {
+              value: 30,
+              max: 40,
+            },
+          },
+          {
+            dataset: "test_ds2",
+            state: "FINISHED",
+            progress: 200,
+            total: 200,
+            start_time: 1,
+            end_time: 2,
+            ray_data_output_bytes: {
+              max: 50,
+            },
+            ray_data_spilled_bytes: {
+              max: 60,
+            },
+            ray_data_current_bytes: {
+              value: 70,
+              max: 80,
+            },
+          },
+        ],
+      },
+    } as any);
+
+    render(<DataOverview />, { wrapper: TEST_APP_WRAPPER });
+
+    // Wait for "TOTALx 2" to show up
+    await screen.findByText("x 2");
+
+    // First Dataset
+    expect(screen.getByText("test_ds1")).toBeVisible();
+    expect(screen.getByText("Total: 100")).toBeVisible();
+    expect(screen.getByText("Finished: 50")).toBeVisible();
+    expect(screen.getByText("Running: 50")).toBeVisible();
+    expect(screen.getByText("1969/12/31 16:00:00")).toBeVisible();
+    expect(screen.getByText("10.0000B")).toBeVisible();
+    expect(screen.getByText("20.0000B")).toBeVisible();
+    expect(screen.getByText("30.0000B/40.0000B")).toBeVisible();
+
+    // Second Dataset
+    expect(screen.getByText("test_ds2")).toBeVisible();
+    expect(screen.getByText("Total: 200")).toBeVisible();
+    expect(screen.getByText("Finished: 200")).toBeVisible();
+    expect(screen.getByText("1969/12/31 16:00:01")).toBeVisible();
+    expect(screen.getByText("1969/12/31 16:00:02")).toBeVisible();
+    expect(screen.getByText("50.0000B")).toBeVisible();
+    expect(screen.getByText("60.0000B")).toBeVisible();
+    expect(screen.getByText("70.0000B/80.0000B")).toBeVisible();
+  });
+});

--- a/dashboard/client/src/pages/data/DataOverview.tsx
+++ b/dashboard/client/src/pages/data/DataOverview.tsx
@@ -1,23 +1,11 @@
 import { Grid } from "@material-ui/core";
 import dayjs from "dayjs";
 import React, { useState } from "react";
-import useSWR from "swr";
 import DataOverviewTable from "../../components/DataOverviewTable";
-import { getDataDatasets } from "../../service/data";
+import { DatasetMetrics } from "../../type/data";
 
-const DataOverview = () => {
+const DataOverview = ({ datasets = [] }: { datasets: DatasetMetrics[] }) => {
   const [timeStamp] = useState(dayjs());
-  const { data } = useSWR(
-    "useDataDatasets",
-    async () => {
-      const rsp = await getDataDatasets();
-
-      if (rsp) {
-        return rsp.data;
-      }
-    },
-    { refreshInterval: 1000 },
-  );
 
   return (
     <div>
@@ -26,7 +14,7 @@ const DataOverview = () => {
           Last updated: {timeStamp.format("YYYY-MM-DD HH:mm:ss")}
         </Grid>
       </Grid>
-      <DataOverviewTable datasets={data?.datasets || []} />
+      <DataOverviewTable datasets={datasets || []} />
     </div>
   );
 };

--- a/dashboard/client/src/pages/data/DataOverview.tsx
+++ b/dashboard/client/src/pages/data/DataOverview.tsx
@@ -1,20 +1,11 @@
-import { Grid } from "@material-ui/core";
-import dayjs from "dayjs";
-import React, { useState } from "react";
+import React from "react";
 import DataOverviewTable from "../../components/DataOverviewTable";
 import { DatasetMetrics } from "../../type/data";
 
 const DataOverview = ({ datasets = [] }: { datasets: DatasetMetrics[] }) => {
-  const [timeStamp] = useState(dayjs());
-
   return (
     <div>
-      <Grid container alignItems="center">
-        <Grid item>
-          Last updated: {timeStamp.format("YYYY-MM-DD HH:mm:ss")}
-        </Grid>
-      </Grid>
-      <DataOverviewTable datasets={datasets || []} />
+      <DataOverviewTable datasets={datasets} />
     </div>
   );
 };

--- a/dashboard/client/src/pages/data/DataOverview.tsx
+++ b/dashboard/client/src/pages/data/DataOverview.tsx
@@ -1,0 +1,34 @@
+import { Grid } from "@material-ui/core";
+import dayjs from "dayjs";
+import React, { useState } from "react";
+import useSWR from "swr";
+import DataOverviewTable from "../../components/DataOverviewTable";
+import { getDataDatasets } from "../../service/data";
+
+const DataOverview = () => {
+  const [timeStamp] = useState(dayjs());
+  const { data } = useSWR(
+    "useDataDatasets",
+    async () => {
+      const rsp = await getDataDatasets();
+
+      if (rsp) {
+        return rsp.data;
+      }
+    },
+    { refreshInterval: 1000 },
+  );
+
+  return (
+    <div>
+      <Grid container alignItems="center">
+        <Grid item>
+          Last updated: {timeStamp.format("YYYY-MM-DD HH:mm:ss")}
+        </Grid>
+      </Grid>
+      <DataOverviewTable datasets={data?.datasets || []} />
+    </div>
+  );
+};
+
+export default DataOverview;

--- a/dashboard/client/src/pages/job/JobDetail.tsx
+++ b/dashboard/client/src/pages/job/JobDetail.tsx
@@ -11,6 +11,7 @@ import { StatusChip } from "../../components/StatusChip";
 import TitleCard from "../../components/TitleCard";
 import { NestedJobProgressLink } from "../../type/job";
 import ActorList from "../actor/ActorList";
+import DataOverview from "../data/DataOverview";
 import { NodeCountCard } from "../overview/cards/NodeCountCard";
 import PlacementGroupList from "../state/PlacementGroup";
 import TaskList from "../state/task";
@@ -207,6 +208,14 @@ export const JobDetailChartsPage = () => {
           >
             <Section>
               <PlacementGroupList jobId={job.job_id} />
+            </Section>
+          </CollapsibleSection>
+          <CollapsibleSection
+            title="Ray Data Overview"
+            className={classes.section}
+          >
+            <Section>
+              <DataOverview />
             </Section>
           </CollapsibleSection>
         </React.Fragment>

--- a/dashboard/client/src/pages/job/JobDetail.tsx
+++ b/dashboard/client/src/pages/job/JobDetail.tsx
@@ -119,6 +119,17 @@ export const JobDetailChartsPage = () => {
     <div className={classes.root}>
       <JobMetadataSection job={job} />
 
+      {data?.datasets && data.datasets.length > 0 && (
+        <CollapsibleSection
+          title="Ray Data Overview"
+          className={classes.section}
+        >
+          <Section>
+            <DataOverview datasets={data.datasets} />
+          </Section>
+        </CollapsibleSection>
+      )}
+
       <CollapsibleSection
         title="Tasks/actor overview (beta)"
         startExpanded
@@ -176,17 +187,6 @@ export const JobDetailChartsPage = () => {
           </Section>
         </Box>
       </CollapsibleSection>
-
-      {data?.datasets && data.datasets.length > 0 && (
-        <CollapsibleSection
-          title="Ray Data Overview"
-          className={classes.section}
-        >
-          <Section>
-            <DataOverview datasets={data.datasets} />
-          </Section>
-        </CollapsibleSection>
-      )}
 
       {job.job_id && (
         <React.Fragment>

--- a/dashboard/client/src/pages/job/JobDetail.tsx
+++ b/dashboard/client/src/pages/job/JobDetail.tsx
@@ -1,5 +1,6 @@
 import { Box, makeStyles } from "@material-ui/core";
 import React, { useRef, useState } from "react";
+import useSWR from "swr";
 import { CollapsibleSection } from "../../common/CollapsibleSection";
 import { Section } from "../../common/Section";
 import {
@@ -9,6 +10,7 @@ import {
 import Loading from "../../components/Loading";
 import { StatusChip } from "../../components/StatusChip";
 import TitleCard from "../../components/TitleCard";
+import { getDataDatasets } from "../../service/data";
 import { NestedJobProgressLink } from "../../type/job";
 import ActorList from "../actor/ActorList";
 import DataOverview from "../data/DataOverview";
@@ -53,6 +55,18 @@ export const JobDetailChartsPage = () => {
   const [actorTableExpanded, setActorTableExpanded] = useState(false);
   const actorTableRef = useRef<HTMLDivElement>(null);
   const { cluster_status } = useRayStatus();
+
+  const { data } = useSWR(
+    "useDataDatasets",
+    async () => {
+      const rsp = await getDataDatasets();
+
+      if (rsp) {
+        return rsp.data;
+      }
+    },
+    { refreshInterval: 1000 },
+  );
 
   if (!job) {
     return (
@@ -163,6 +177,17 @@ export const JobDetailChartsPage = () => {
         </Box>
       </CollapsibleSection>
 
+      {data?.datasets && data.datasets.length > 0 && (
+        <CollapsibleSection
+          title="Ray Data Overview"
+          className={classes.section}
+        >
+          <Section>
+            <DataOverview datasets={data.datasets} />
+          </Section>
+        </CollapsibleSection>
+      )}
+
       {job.job_id && (
         <React.Fragment>
           <CollapsibleSection
@@ -208,14 +233,6 @@ export const JobDetailChartsPage = () => {
           >
             <Section>
               <PlacementGroupList jobId={job.job_id} />
-            </Section>
-          </CollapsibleSection>
-          <CollapsibleSection
-            title="Ray Data Overview"
-            className={classes.section}
-          >
-            <Section>
-              <DataOverview />
             </Section>
           </CollapsibleSection>
         </React.Fragment>

--- a/dashboard/client/src/pages/job/JobDetail.tsx
+++ b/dashboard/client/src/pages/job/JobDetail.tsx
@@ -65,7 +65,7 @@ export const JobDetailChartsPage = () => {
         return rsp.data;
       }
     },
-    { refreshInterval: 1000 },
+    { refreshInterval: 5000 },
   );
 
   if (!job) {

--- a/dashboard/client/src/pages/job/JobDetail.tsx
+++ b/dashboard/client/src/pages/job/JobDetail.tsx
@@ -131,7 +131,7 @@ export const JobDetailChartsPage = () => {
       )}
 
       <CollapsibleSection
-        title="Tasks/actor overview (beta)"
+        title="Ray Core Overview"
         startExpanded
         className={classes.section}
       >

--- a/dashboard/client/src/pages/job/TaskProgressBar.tsx
+++ b/dashboard/client/src/pages/job/TaskProgressBar.tsx
@@ -20,6 +20,7 @@ export const TaskProgressBar = ({
   numPendingNodeAssignment = 0,
   numSubmittedToWorker = 0,
   numFailed = 0,
+  numCancelled = 0,
   numUnknown = 0,
   showAsComplete = false,
   showTooltip = true,
@@ -54,6 +55,11 @@ export const TaskProgressBar = ({
       label: "Waiting for dependencies",
       value: numPendingArgsAvail,
       color: "#f79e02",
+    },
+    {
+      label: "Cancelled",
+      value: numCancelled,
+      color: theme.palette.grey.A100,
     },
     {
       label: "Unknown",

--- a/dashboard/client/src/service/data.ts
+++ b/dashboard/client/src/service/data.ts
@@ -1,0 +1,6 @@
+import { DatasetResponse } from "../type/data";
+import { get } from "./requestHandlers";
+
+export const getDataDatasets = () => {
+  return get<DatasetResponse>("api/data/datasets");
+};

--- a/dashboard/client/src/type/data.ts
+++ b/dashboard/client/src/type/data.ts
@@ -1,0 +1,22 @@
+export type DatasetResponse = {
+  datasets: DatasetMetrics[];
+};
+
+export type DatasetMetrics = {
+  dataset: string;
+  state: string;
+  ray_data_current_bytes: {
+    value: number;
+    max: number;
+  };
+  ray_data_output_bytes: {
+    max: number;
+  };
+  ray_data_spilled_bytes: {
+    max: number;
+  };
+  progress: number;
+  total: number;
+  start_time: number;
+  end_time: number | undefined;
+};

--- a/dashboard/client/src/type/job.ts
+++ b/dashboard/client/src/type/job.ts
@@ -97,6 +97,7 @@ export type TaskProgress = {
   numRunning?: number;
   numPendingNodeAssignment?: number;
   numFailed?: number;
+  numCancelled?: number;
   numUnknown?: number;
 };
 

--- a/dashboard/modules/data/data_head.py
+++ b/dashboard/modules/data/data_head.py
@@ -55,6 +55,7 @@ class DataHead(dashboard_utils.DashboardHeadModule):
                     datasets[dataset][metric] = {query.value[0]: 0 for query in queries}
             # Query dataset metric values from prometheus
             try:
+                # TODO (Zandew): store results of completed datasets in stats actor.
                 for metric, queries in DATASET_METRICS.items():
                     for query in queries:
                         result = await self._query_prometheus(
@@ -65,7 +66,7 @@ class DataHead(dashboard_utils.DashboardHeadModule):
                             if dataset in datasets:
                                 datasets[dataset][metric][query.value[0]] = value
             except Exception:
-                # Prometheus server is not running,
+                # Prometheus server may not be running,
                 # leave these values blank and return other data
                 pass
             # Flatten response

--- a/dashboard/modules/data/data_head.py
+++ b/dashboard/modules/data/data_head.py
@@ -64,7 +64,7 @@ class DataHead(dashboard_utils.DashboardHeadModule):
                             dataset, value = res["metric"]["dataset"], res["value"][1]
                             if dataset in datasets:
                                 datasets[dataset][metric][query.value[0]] = value
-            except PrometheusQueryError:
+            except Exception:
                 # Prometheus server is not running,
                 # leave these values blank and return other data
                 pass

--- a/dashboard/modules/data/data_head.py
+++ b/dashboard/modules/data/data_head.py
@@ -1,0 +1,95 @@
+import json
+import os
+from enum import Enum
+import aiohttp
+from aiohttp.web import Request, Response
+import ray.dashboard.optional_utils as optional_utils
+import ray.dashboard.utils as dashboard_utils
+from ray.data._internal.stats import _get_or_create_stats_actor
+from ray.dashboard.modules.metrics.metrics_head import (
+    PROMETHEUS_HOST_ENV_VAR,
+    DEFAULT_PROMETHEUS_HOST,
+    PrometheusQueryError,
+)
+from urllib.parse import quote
+import ray
+
+
+MAX_TIME_WINDOW = "1h"
+SAMPLE_RATE = "1s"
+
+
+class PrometheusQuery(Enum):
+    VALUE = ("value", "sum({}) by (dataset)")
+    MAX = (
+        "max",
+        "max_over_time(sum({}) by (dataset)[" + f"{MAX_TIME_WINDOW}:{SAMPLE_RATE}])",
+    )
+
+
+DATASET_METRICS = {
+    "ray_data_output_bytes": (PrometheusQuery.MAX,),
+    "ray_data_spilled_bytes": (PrometheusQuery.MAX,),
+    "ray_data_current_bytes": (PrometheusQuery.VALUE, PrometheusQuery.MAX),
+}
+
+
+class DataHead(dashboard_utils.DashboardHeadModule):
+    def __init__(self, dashboard_head):
+        super().__init__(dashboard_head)
+        self.http_session = aiohttp.ClientSession()
+        self.prometheus_host = os.environ.get(
+            PROMETHEUS_HOST_ENV_VAR, DEFAULT_PROMETHEUS_HOST
+        )
+
+    @optional_utils.DashboardHeadRouteTable.get("/api/data/datasets")
+    @optional_utils.init_ray_and_catch_exceptions()
+    async def get_datasets(self, req: Request) -> Response:
+        try:
+            _stats_actor = _get_or_create_stats_actor()
+            datasets = ray.get(_stats_actor.get_datasets.remote())
+            # Initializes dataset metric values
+            for dataset in datasets:
+                for metric, queries in DATASET_METRICS.items():
+                    datasets[dataset][metric] = {query.value[0]: 0 for query in queries}
+            # Query dataset metric values from prometheus
+            for metric, queries in DATASET_METRICS.items():
+                for query in queries:
+                    result = await self._query_prometheus(query.value[1].format(metric))
+                    for res in result["data"]["result"]:
+                        dataset, value = res["metric"]["dataset"], res["value"][1]
+                        if dataset in datasets:
+                            datasets[dataset][metric][query.value[0]] = value
+            # Flatten response
+            datasets = list(
+                map(lambda item: {"dataset": item[0], **item[1]}, datasets.items())
+            )
+            # Sort by descending start time
+            datasets = sorted(datasets, key=lambda x: x["start_time"], reverse=True)
+            return Response(
+                text=json.dumps({"datasets": datasets}),
+                content_type="application/json",
+            )
+        except Exception as e:
+            return Response(
+                status=503,
+                text=str(e),
+            )
+
+    async def run(self, server):
+        pass
+
+    @staticmethod
+    def is_minimal_module():
+        return False
+
+    async def _query_prometheus(self, query):
+        async with self.http_session.get(
+            f"{self.prometheus_host}/api/v1/query?query={quote(query)}"
+        ) as resp:
+            if resp.status == 200:
+                prom_data = await resp.json()
+                return prom_data
+
+            message = await resp.text()
+            raise PrometheusQueryError(resp.status, message)

--- a/dashboard/modules/data/tests/test_data_head.py
+++ b/dashboard/modules/data/tests/test_data_head.py
@@ -1,0 +1,42 @@
+import ray
+import requests
+
+DATA_HEAD_URLS = {"GET": "http://localhost:8265/api/data/datasets"}
+
+RESPONSE_SCHEMA = [
+    "dataset",
+    "state",
+    "progress",
+    "start_time",
+    "end_time",
+    "total",
+    "ray_data_output_bytes",
+    "ray_data_spilled_bytes",
+    "ray_data_current_bytes",
+]
+
+
+def test_get_datasets():
+    ray.init()
+    ds = ray.data.range(1).map_batches(lambda x: x)
+    ds._set_name("data_head_test")
+    ds.materialize()
+
+    data = requests.get(DATA_HEAD_URLS["GET"]).json()
+
+    assert len(data["datasets"]) == 1
+    assert sorted(data["datasets"][0].keys()) == sorted(RESPONSE_SCHEMA)
+
+    dataset = data["datasets"][0]
+    assert dataset["dataset"].startswith("data_head_test")
+    assert dataset["state"] == "FINISHED"
+    assert dataset["end_time"] is not None
+
+    ds.map_batches(lambda x: x).materialize()
+    data = requests.get(DATA_HEAD_URLS["GET"]).json()
+
+    assert len(data["datasets"]) == 2
+    dataset = data["datasets"][1]
+    assert dataset["dataset"].startswith("data_head_test")
+    assert dataset["state"] == "FINISHED"
+    assert dataset["end_time"] is not None

--- a/dashboard/modules/data/tests/test_data_head.py
+++ b/dashboard/modules/data/tests/test_data_head.py
@@ -1,5 +1,7 @@
 import ray
 import requests
+import sys
+import pytest
 
 DATA_HEAD_URLS = {"GET": "http://localhost:8265/api/data/datasets"}
 
@@ -40,3 +42,7 @@ def test_get_datasets():
     assert dataset["dataset"].startswith("data_head_test")
     assert dataset["state"] == "FINISHED"
     assert dataset["end_time"] is not None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -252,7 +252,7 @@ class _StatsActor:
         self,
         op_metrics: List[Dict[str, Union[int, float]]],
         tags_list: List[Dict[str, str]],
-         state: Dict[str, Any],
+        state: Dict[str, Any],
     ):
         for stats, tags in zip(op_metrics, tags_list):
             self.bytes_spilled.set(stats.get("obj_store_mem_spilled", 0), tags)
@@ -340,7 +340,9 @@ def _check_cluster_stats_actor():
 
 
 def update_stats_actor_metrics(
-    op_metrics: List[OpRuntimeMetrics], tags_list: List[Dict[str, str]], state: Dict[str, Any],
+    op_metrics: List[OpRuntimeMetrics],
+    tags_list: List[Dict[str, str]],
+    state: Dict[str, Any],
 ):
     global _stats_actor
     _check_cluster_stats_actor()

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1287,7 +1287,7 @@ def test_op_metrics_logging():
         ray.data.range(100).map_batches(lambda x: x).materialize()
         logs = [canonicalize(call.args[0]) for call in mock_logger.call_args_list]
         input_str = (
-            "Operator InputDataBuffer[Input] completed. Operatorh Metrics:\n"
+            "Operator InputDataBuffer[Input] completed. Operator Metrics:\n"
             + gen_expected_metrics(is_map=False)
         )
         map_str = (

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -11,7 +11,11 @@ import pytest
 import ray
 from ray._private.test_utils import wait_for_condition
 from ray.data._internal.dataset_logger import DatasetLogger
-from ray.data._internal.stats import DatasetStats, _StatsActor
+from ray.data._internal.stats import (
+    DatasetStats,
+    _get_or_create_stats_actor,
+    _StatsActor,
+)
 from ray.data.block import BlockMetadata
 from ray.data.context import DataContext
 from ray.data.tests.util import column_udf
@@ -1283,7 +1287,7 @@ def test_op_metrics_logging():
         ray.data.range(100).map_batches(lambda x: x).materialize()
         logs = [canonicalize(call.args[0]) for call in mock_logger.call_args_list]
         input_str = (
-            "Operator InputDataBuffer[Input] completed. Operator Metrics:\n"
+            "Operator InputDataBuffer[Input] completed. Operatorh Metrics:\n"
             + gen_expected_metrics(is_map=False)
         )
         map_str = (
@@ -1312,6 +1316,23 @@ def test_op_state_logging():
                 assert "Input" in logs[i + 1]
                 assert "ReadRange->MapBatches(<lambda>)" in logs[i + 2]
         assert times_asserted > 0
+
+
+def test_stats_actor_datasets(ray_start_cluster):
+    ds = ray.data.range(100, parallelism=20).map_batches(lambda x: x)
+    ds._set_name("test_stats_actor_datasets")
+    ds.materialize()
+    stats_actor = _get_or_create_stats_actor()
+
+    datasets = ray.get(stats_actor.get_datasets.remote())
+    dataset_name = list(filter(lambda x: x.startswith(ds._name), datasets))
+    assert len(dataset_name) == 1
+    dataset_name = dataset_name[0]
+
+    assert datasets[dataset_name]["state"] == "FINISHED"
+    assert datasets[dataset_name]["progress"] == 20
+    assert datasets[dataset_name]["total"] == 20
+    assert datasets[dataset_name]["end_time"] is not None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Creates a table under the jobs page to display dataset-level metrics.

The `_StatsActor` now stores dataset metadata like `state`, `progress` and `start/end_time` for each executed dataset, that is directly queried by the new `data_head` dashboard api. This api also makes requests to the prometheus server to get other metrics that are displayed.

<img width="1726" alt="Screenshot 2023-10-31 at 4 39 10 PM" src="https://github.com/ray-project/ray/assets/39287272/8bf5a485-f756-495a-86ee-070a6f7c4aa7">


cluster env: `jobs-data-overview` to test on workspaces.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
