### PR TITLE
[data] Revert default block size back to 512MiB

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -23,7 +23,7 @@ ESTIMATED_SAFE_MEMORY_FRACTION = 0.25
 # memory footprint will be about 2 * num_cpus * target_max_block_size ~= RAM *
 # DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION * 0.3 (default object store memory
 # fraction set by Ray core), assuming typical memory:core ratio of 4:1.
-DEFAULT_TARGET_MAX_BLOCK_SIZE = 128 * 1024 * 1024
+DEFAULT_TARGET_MAX_BLOCK_SIZE = 512 * 1024 * 1024
 
 # The max target block size in bytes for shuffle ops (random_shuffle, sort,
 # repartition). Set a higher target block size because we have to materialize

--- a/python/ray/data/tests/test_auto_parallelism.py
+++ b/python/ray/data/tests/test_auto_parallelism.py
@@ -136,8 +136,7 @@ def test_auto_parallelism_basic(shutdown_only):
     assert ds.num_blocks() == 16, ds
     # Block size bound.
     ds = ray.data.range_tensor(100000000, shape=(100,), parallelism=-1)
-    assert ds.num_blocks() >= 590, ds
-    assert ds.num_blocks() <= 600, ds
+    assert ds.num_blocks() == 150, ds
 
 
 def test_auto_parallelism_placement_group(shutdown_only):

--- a/python/ray/data/tests/test_auto_parallelism.py
+++ b/python/ray/data/tests/test_auto_parallelism.py
@@ -79,13 +79,13 @@ TEST_CASES = [
         avail_cpus=4,
         target_max_block_size=DataContext.get_current().target_max_block_size,
         data_size=1000 * GiB,
-        expected_parallelism=8000,  # MAX_BLOCK_SIZE has precedence
+        expected_parallelism=2000,  # MAX_BLOCK_SIZE has precedence
     ),
     TestCase(
         avail_cpus=4,
         target_max_block_size=DataContext.get_current().target_max_block_size,
         data_size=10000 * GiB,
-        expected_parallelism=80000,  # MAX_BLOCK_SIZE has precedence
+        expected_parallelism=20000,  # MAX_BLOCK_SIZE has precedence
     ),
     TestCase(
         avail_cpus=4,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This addresses #40759 and #38400 for the 2.8 release branch. This change OR reverting #40248 seems to fix #40759, but the root cause has not been identified yet. For #38400, we will merge a longer-term fix to master for 2.9.

This PR should be safe since it reverts Data block size back to the 2.7 default.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
