### PR TITLE
Revert "[core] on plasma server, ref count fds to each client, and re…

### DIFF
--- a/python/ray/tests/test_plasma_unlimited.py
+++ b/python/ray/tests/test_plasma_unlimited.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import platform
 import pytest
-import psutil
 
 import ray
 from ray._private.test_utils import (
@@ -71,42 +70,6 @@ def test_fallback_when_spilling_impossible_on_get():
         check_spilled_mb(address, spilled=800, restored=800, fallback=400)
         del x1p
         del x2p
-    finally:
-        ray.shutdown()
-
-
-def fallback_allocation_mmaps():
-    p = psutil.Process()
-    return [
-        mmap
-        for mmap in p.memory_maps(grouped=False)
-        if mmap.path.startswith("/tmp/ray/plasma")
-    ]
-
-
-@pytest.mark.skipif(
-    platform.system() != "Linux", reason="Using the Linux psutil.Process.memory_maps()"
-)
-def test_core_worker_fallback_allocations_munmap():
-    try:
-        address = _init_ray()
-        x1 = ray.put(np.zeros(400 * MB, dtype=np.uint8))
-        # x1 will be spilled.
-        x2 = ray.put(np.zeros(400 * MB, dtype=np.uint8))
-        check_spilled_mb(address, spilled=400)
-        # x1 will be restored, x2 will be spilled.
-        x1p = ray.get(x1)
-        check_spilled_mb(address, spilled=800, restored=400)
-        # No fallback allocations yet
-        assert len(fallback_allocation_mmaps()) == 0, fallback_allocation_mmaps()
-        # x2 will be restored, triggering a fallback allocation.
-        x2p = ray.get(x2)
-        check_spilled_mb(address, spilled=800, restored=800, fallback=400)
-        assert len(fallback_allocation_mmaps()) == 1, fallback_allocation_mmaps()
-        del x1p
-        del x2p
-        # after the del, the fallback allocation should be unmapped.
-        assert len(fallback_allocation_mmaps()) == 0, fallback_allocation_mmaps()
     finally:
         ray.shutdown()
 

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -330,8 +330,6 @@ Status PlasmaClient::Impl::HandleCreateReply(const ObjectID &object_id,
   if (object.device_num == 0) {
     // The metadata should come right after the data.
     RAY_CHECK(object.metadata_offset == object.data_offset + object.data_size);
-    RAY_LOG(DEBUG) << "GetStoreFdAndMmap " << store_fd.first << ", " << store_fd.second
-                   << ", size " << mmap_size << " for object id " << id;
     *data = std::make_shared<PlasmaMutableBuffer>(
         shared_from_this(),
         GetStoreFdAndMmap(store_fd, mmap_size) + object.data_offset,
@@ -505,9 +503,6 @@ Status PlasmaClient::Impl::GetBuffers(
   // in the subsequent loop based on just the store file descriptor and without
   // having to know the relevant file descriptor received from recv_fd.
   for (size_t i = 0; i < store_fds.size(); i++) {
-    RAY_LOG(DEBUG) << "GetStoreFdAndMmap " << store_fds[i].first << ", "
-                   << store_fds[i].second << ", size " << mmap_sizes[i]
-                   << " for object id " << received_object_ids[i];
     GetStoreFdAndMmap(store_fds[i], mmap_sizes[i]);
   }
 
@@ -586,37 +581,16 @@ Status PlasmaClient::Impl::Release(const ObjectID &object_id) {
   if (!store_conn_) {
     return Status::OK();
   }
-  const auto object_entry = objects_in_use_.find(object_id);
+  auto object_entry = objects_in_use_.find(object_id);
   RAY_CHECK(object_entry != objects_in_use_.end());
 
   object_entry->second->count -= 1;
   RAY_CHECK(object_entry->second->count >= 0);
   // Check if the client is no longer using this object.
   if (object_entry->second->count == 0) {
-    // object_entry is invalidated in MarkObjectUnused, need to read the fd beforehand.
-    MEMFD_TYPE fd = object_entry->second->object.store_fd;
     // Tell the store that the client no longer needs the object.
     RAY_RETURN_NOT_OK(MarkObjectUnused(object_id));
     RAY_RETURN_NOT_OK(SendReleaseRequest(store_conn_, object_id));
-    std::vector<uint8_t> buffer;
-    RAY_RETURN_NOT_OK(
-        PlasmaReceive(store_conn_, MessageType::PlasmaReleaseReply, &buffer));
-    ObjectID released_object_id;
-
-    // `should_unmap` is set to true by the plasma server, when the mmap section is
-    // fallback-allocated and is no longer used. i.e. if the object ID is in the main
-    // memory, this boolean is always false.
-    bool should_unmap;
-    RAY_RETURN_NOT_OK(ReadReleaseReply(
-        buffer.data(), buffer.size(), &released_object_id, &should_unmap));
-    if (should_unmap) {
-      auto mmap_entry = mmap_table_.find(fd);
-      // Release call is idempotent: if we already released, it's ok.
-      if (mmap_entry != mmap_table_.end()) {
-        mmap_table_.erase(mmap_entry);
-      }
-    }
-
     auto iter = deletion_cache_.find(object_id);
     if (iter != deletion_cache_.end()) {
       deletion_cache_.erase(object_id);

--- a/src/ray/object_manager/plasma/connection.h
+++ b/src/ray/object_manager/plasma/connection.h
@@ -23,9 +23,8 @@ class ClientInterface {
 
   virtual ray::Status SendFd(MEMFD_TYPE fd) = 0;
   virtual const std::unordered_set<ray::ObjectID> &GetObjectIDs() = 0;
-  virtual void MarkObjectAsUsed(const ray::ObjectID &object_id,
-                                std::optional<MEMFD_TYPE> fallback_allocated_fd) = 0;
-  virtual bool MarkObjectAsUnused(const ray::ObjectID &object_id) = 0;
+  virtual void MarkObjectAsUsed(const ray::ObjectID &object_id) = 0;
+  virtual void MarkObjectAsUnused(const ray::ObjectID &object_id) = 0;
 };
 
 /// Contains all information that is associated with a Plasma store client.
@@ -38,66 +37,12 @@ class Client : public ray::ClientConnection, public ClientInterface {
 
   const std::unordered_set<ray::ObjectID> &GetObjectIDs() override { return object_ids; }
 
-  // Holds the object ID. If the object ID has a fallback-allocated fd, adds the ref count
-  // to that fd. Note: used_fds_ is not updated. rather, it's updated in SendFd().
-  //
-  // Idempotency: only increments ref count if the object ID was not held. Note that a
-  // second call for a same `object_id` must come with the same `fallback_allocated_fd`.
-  virtual void MarkObjectAsUsed(
-      const ray::ObjectID &object_id,
-      std::optional<MEMFD_TYPE> fallback_allocated_fd) override {
-    const auto [_, inserted] = object_ids.insert(object_id);
-    if (inserted) {
-      // new insertion
-      RAY_CHECK(!object_ids_to_fallback_allocated_fds_.contains(object_id));
-
-      if (fallback_allocated_fd.has_value()) {
-        MEMFD_TYPE fd = fallback_allocated_fd.value();
-        object_ids_to_fallback_allocated_fds_[object_id] = fd;
-        fallback_allocated_fds_ref_count_[fd] += 1;
-      }
-    } else {
-      // Already inserted, idempotent call.
-      // Assert the fd parameter == the fd used in the last call, or they are both none.
-      const auto iter = object_ids_to_fallback_allocated_fds_.find(object_id);
-      if (fallback_allocated_fd.has_value()) {
-        RAY_CHECK(iter != object_ids_to_fallback_allocated_fds_.end() &&
-                  iter->second == fallback_allocated_fd.value());
-      } else {
-        RAY_CHECK(iter == object_ids_to_fallback_allocated_fds_.end());
-      }
-    }
+  virtual void MarkObjectAsUsed(const ray::ObjectID &object_id) override {
+    object_ids.insert(object_id);
   }
 
-  // Removes object ID's ref to the fd, if any. If the fd's refcnt goes to 0, also remove
-  // the fd from used_fds_ and return true, directing the client to unmap it.
-  //
-  // Returns: bool, client should unmap.
-  // Idempotency: only decrements ref count if the object ID was held.
-  virtual bool MarkObjectAsUnused(const ray::ObjectID &object_id) override {
-    size_t erased = object_ids.erase(object_id);
-    if (erased == 0) {
-      return false;
-    }
-    auto fd_iter = object_ids_to_fallback_allocated_fds_.find(object_id);
-    if (fd_iter == object_ids_to_fallback_allocated_fds_.end()) {
-      return false;
-    }
-    MEMFD_TYPE fd = fd_iter->second;
-    object_ids_to_fallback_allocated_fds_.erase(fd_iter);
-
-    auto ref_cnt_iter = fallback_allocated_fds_ref_count_.find(fd);
-    // If fd existed before from object_ids_to_fds_ the ref count should have been > 0
-    RAY_CHECK(ref_cnt_iter != fallback_allocated_fds_ref_count_.end());
-    size_t &ref_cnt = ref_cnt_iter->second;
-    RAY_CHECK_GT(ref_cnt, static_cast<size_t>(0));
-    ref_cnt -= 1;
-    if (ref_cnt == 0) {
-      fallback_allocated_fds_ref_count_.erase(ref_cnt_iter);
-      used_fds_.erase(fd);  // Next SendFd call will send this fd again.
-      return true;
-    }
-    return false;
+  virtual void MarkObjectAsUnused(const ray::ObjectID &object_id) override {
+    object_ids.erase(object_id);
   }
 
   std::string name = "anonymous_client";
@@ -110,13 +55,6 @@ class Client : public ray::ClientConnection, public ClientInterface {
 
   /// Object ids that are used by this client.
   std::unordered_set<ray::ObjectID> object_ids;
-
-  // Records each fd sent to the client and which object IDs are in this fd.
-  // Only tracks fallback-allocated fds. This means the main memory is not tracked, and we
-  // won't tell client to unmap the main memory. Incremented by `Get`, Decremented by
-  // `Release`. If an FD is emptied out, the fd can be unmapped on the client side.
-  absl::flat_hash_map<MEMFD_TYPE, size_t> fallback_allocated_fds_ref_count_;
-  absl::flat_hash_map<ray::ObjectID, MEMFD_TYPE> object_ids_to_fallback_allocated_fds_;
 };
 
 std::ostream &operator<<(std::ostream &os, const std::shared_ptr<Client> &client);

--- a/src/ray/object_manager/plasma/get_request_queue.cc
+++ b/src/ray/object_manager/plasma/get_request_queue.cc
@@ -64,15 +64,9 @@ void GetRequestQueue::AddRequest(const std::shared_ptr<ClientInterface> &client,
     auto entry = object_lifecycle_mgr_.GetObject(object_id);
     if (entry && entry->Sealed()) {
       // Update the get request to take into account the present object.
-      auto *plasma_object = &get_request->objects[object_id];
-      entry->ToPlasmaObject(plasma_object, /* checksealed */ true);
+      entry->ToPlasmaObject(&get_request->objects[object_id], /* checksealed */ true);
       get_request->num_unique_objects_satisfied += 1;
-
-      std::optional<MEMFD_TYPE> fallback_allocated_fd = std::nullopt;
-      if (entry->GetAllocation().fallback_allocated) {
-        fallback_allocated_fd = entry->GetAllocation().fd;
-      }
-      object_satisfied_callback_(object_id, fallback_allocated_fd, get_request);
+      object_satisfied_callback_(object_id, get_request);
     } else {
       // Add a placeholder plasma object to the get request to indicate that the
       // object is not present. This will be parsed by the client. We set the
@@ -170,15 +164,9 @@ void GetRequestQueue::MarkObjectSealed(const ObjectID &object_id) {
     auto get_request = get_requests[index];
     auto entry = object_lifecycle_mgr_.GetObject(object_id);
     RAY_CHECK(entry != nullptr);
-    auto *plasma_object = &get_request->objects[object_id];
-    entry->ToPlasmaObject(plasma_object, /* check sealed */ true);
+    entry->ToPlasmaObject(&get_request->objects[object_id], /* check sealed */ true);
     get_request->num_unique_objects_satisfied += 1;
-
-    std::optional<MEMFD_TYPE> fallback_allocated_fd = std::nullopt;
-    if (entry->GetAllocation().fallback_allocated) {
-      fallback_allocated_fd = entry->GetAllocation().fd;
-    }
-    object_satisfied_callback_(object_id, fallback_allocated_fd, get_request);
+    object_satisfied_callback_(object_id, get_request);
     // If this get request is done, reply to the client.
     if (get_request->num_unique_objects_satisfied ==
         get_request->num_unique_objects_to_wait_for) {

--- a/src/ray/object_manager/plasma/get_request_queue.h
+++ b/src/ray/object_manager/plasma/get_request_queue.h
@@ -21,10 +21,8 @@
 
 namespace plasma {
 struct GetRequest;
-using ObjectReadyCallback =
-    std::function<void(const ObjectID &object_id,
-                       std::optional<MEMFD_TYPE> fallback_allocated_fd,
-                       const std::shared_ptr<GetRequest> &get_request)>;
+using ObjectReadyCallback = std::function<void(
+    const ObjectID &object_id, const std::shared_ptr<GetRequest> &get_request)>;
 using AllObjectReadyCallback =
     std::function<void(const std::shared_ptr<GetRequest> &get_request)>;
 

--- a/src/ray/object_manager/plasma/plasma.fbs
+++ b/src/ray/object_manager/plasma/plasma.fbs
@@ -236,8 +236,6 @@ table PlasmaReleaseRequest {
 table PlasmaReleaseReply {
   // ID of the object that was released.
   object_id: string;
-  // Client should unmap the mmap section for this object_id.
-  should_unmap: bool;
   // Error code.
   error: PlasmaError;
 }

--- a/src/ray/object_manager/plasma/protocol.cc
+++ b/src/ray/object_manager/plasma/protocol.cc
@@ -395,23 +395,18 @@ Status ReadReleaseRequest(uint8_t *data, size_t size, ObjectID *object_id) {
 
 Status SendReleaseReply(const std::shared_ptr<Client> &client,
                         ObjectID object_id,
-                        bool should_unmap,
                         PlasmaError error) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = fb::CreatePlasmaReleaseReply(
-      fbb, fbb.CreateString(object_id.Binary()), should_unmap, error);
+  auto message =
+      fb::CreatePlasmaReleaseReply(fbb, fbb.CreateString(object_id.Binary()), error);
   return PlasmaSend(client, MessageType::PlasmaReleaseReply, &fbb, message);
 }
 
-Status ReadReleaseReply(uint8_t *data,
-                        size_t size,
-                        ObjectID *object_id,
-                        bool *should_unmap) {
+Status ReadReleaseReply(uint8_t *data, size_t size, ObjectID *object_id) {
   RAY_DCHECK(data);
   auto message = flatbuffers::GetRoot<fb::PlasmaReleaseReply>(data);
   RAY_DCHECK(VerifyFlatbuffer(message, data, size));
   *object_id = ObjectID::FromBinary(message->object_id()->str());
-  *should_unmap = message->should_unmap();
   return PlasmaErrorStatus(message->error());
 }
 

--- a/src/ray/object_manager/plasma/protocol.h
+++ b/src/ray/object_manager/plasma/protocol.h
@@ -172,13 +172,9 @@ Status ReadReleaseRequest(uint8_t *data, size_t size, ObjectID *object_id);
 
 Status SendReleaseReply(const std::shared_ptr<Client> &client,
                         ObjectID object_id,
-                        bool should_unmap,
                         PlasmaError error);
 
-Status ReadReleaseReply(uint8_t *data,
-                        size_t size,
-                        ObjectID *object_id,
-                        bool *should_unmap);
+Status ReadReleaseReply(uint8_t *data, size_t size, ObjectID *object_id);
 
 /* Plasma Delete objects message functions. */
 

--- a/src/ray/object_manager/plasma/shared_memory.cc
+++ b/src/ray/object_manager/plasma/shared_memory.cc
@@ -19,20 +19,19 @@ ClientMmapTableEntry::ClientMmapTableEntry(MEMFD_TYPE fd, int64_t map_size)
   // in fake_mmap in malloc.h, to make map_size page-aligned again.
   length_ = map_size - kMmapRegionsGap;
 #ifdef _WIN32
-  pointer_ = MapViewOfFile(fd.first, FILE_MAP_ALL_ACCESS, 0, 0, length_);
+  pointer_ = reinterpret_cast<uint8_t *>(
+      MapViewOfFile(fd.first, FILE_MAP_ALL_ACCESS, 0, 0, length_));
   // TODO(pcm): Don't fail here, instead return a Status.
   if (pointer_ == NULL) {
     RAY_LOG(FATAL) << "mmap failed";
   }
   CloseHandle(fd.first);  // Closing this fd has an effect on performance.
 #else
-  pointer_ = mmap(NULL, length_, PROT_READ | PROT_WRITE, MAP_SHARED, fd.first, 0);
+  pointer_ = reinterpret_cast<uint8_t *>(
+      mmap(NULL, length_, PROT_READ | PROT_WRITE, MAP_SHARED, fd.first, 0));
   // TODO(pcm): Don't fail here, instead return a Status.
   if (pointer_ == MAP_FAILED) {
     RAY_LOG(FATAL) << "mmap failed";
-  } else {
-    RAY_LOG(DEBUG) << "ClientMmapTableEntry ctor mmaped " << fd_.first << ", "
-                   << fd_.second << ", addr " << pointer_ << ", size " << length_;
   }
   close(fd.first);  // Closing this fd has an effect on performance.
 
@@ -76,9 +75,6 @@ ClientMmapTableEntry::~ClientMmapTableEntry() {
 #endif
   if (r != 0) {
     RAY_LOG(ERROR) << "munmap returned " << r << ", errno = " << errno;
-  } else {
-    RAY_LOG(DEBUG) << "ClientMmapTableEntry dtor munmaped " << fd_.first << ", "
-                   << fd_.second << ", addr " << pointer_ << ", size " << length_;
   }
 }
 

--- a/src/ray/object_manager/plasma/shared_memory.h
+++ b/src/ray/object_manager/plasma/shared_memory.h
@@ -15,7 +15,7 @@ class ClientMmapTableEntry {
 
   ~ClientMmapTableEntry();
 
-  uint8_t *pointer() { return reinterpret_cast<uint8_t *>(pointer_); }
+  uint8_t *pointer() { return pointer_; }
 
   MEMFD_TYPE fd() { return fd_; }
 
@@ -23,7 +23,7 @@ class ClientMmapTableEntry {
   /// The associated file descriptor on the client.
   MEMFD_TYPE fd_;
   /// The result of mmap for this file descriptor.
-  void *pointer_;
+  uint8_t *pointer_;
   /// The length of the memory-mapped file.
   size_t length_;
 

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -105,12 +105,11 @@ PlasmaStore::PlasmaStore(instrumented_io_context &main_service,
           io_context_,
           object_lifecycle_mgr_,
           // absl failed to check thread safety for lambda
-          [this](const ObjectID &object_id,
-                 std::optional<MEMFD_TYPE> fallback_allocated_fd,
-                 const auto &request) ABSL_NO_THREAD_SAFETY_ANALYSIS {
-            mutex_.AssertHeld();
-            this->AddToClientObjectIds(object_id, fallback_allocated_fd, request->client);
-          },
+          [this](const ObjectID &object_id, const auto &request)
+              ABSL_NO_THREAD_SAFETY_ANALYSIS {
+                mutex_.AssertHeld();
+                this->AddToClientObjectIds(object_id, request->client);
+              },
           [this](const auto &request) { this->ReturnFromGet(request); }) {
   if (RayConfig::instance().event_stats_print_interval_ms() > 0 &&
       RayConfig::instance().event_stats()) {
@@ -135,7 +134,6 @@ void PlasmaStore::Stop() { acceptor_.close(); }
 // If this client is not already using the object, add the client to the
 // object's list of clients, otherwise do nothing.
 void PlasmaStore::AddToClientObjectIds(const ObjectID &object_id,
-                                       std::optional<MEMFD_TYPE> fallback_allocated_fd,
                                        const std::shared_ptr<ClientInterface> &client) {
   // Check if this client is already using the object.
   auto &object_ids = client->GetObjectIDs();
@@ -144,7 +142,7 @@ void PlasmaStore::AddToClientObjectIds(const ObjectID &object_id,
   }
   RAY_CHECK(object_lifecycle_mgr_.AddReference(object_id));
   // Add object id to the list of object ids that this client is using.
-  client->MarkObjectAsUsed(object_id, fallback_allocated_fd);
+  client->MarkObjectAsUsed(object_id);
 }
 
 PlasmaError PlasmaStore::HandleCreateObjectRequest(const std::shared_ptr<Client> &client,
@@ -185,11 +183,7 @@ PlasmaError PlasmaStore::CreateObject(const ray::ObjectInfo &object_info,
   }
   entry->ToPlasmaObject(result, /* check sealed */ false);
   // Record that this client is using this object.
-  std::optional<MEMFD_TYPE> fallback_allocated_fd = std::nullopt;
-  if (entry->GetAllocation().fallback_allocated) {
-    fallback_allocated_fd = entry->GetAllocation().fd;
-  }
-  AddToClientObjectIds(object_info.object_id, fallback_allocated_fd, client);
+  AddToClientObjectIds(object_info.object_id, client);
   return PlasmaError::OK;
 }
 
@@ -246,32 +240,30 @@ void PlasmaStore::ProcessGetRequest(const std::shared_ptr<Client> &client,
   get_request_queue_.AddRequest(client, object_ids, timeout_ms, is_from_worker);
 }
 
-bool PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
-                                            const std::shared_ptr<Client> &client) {
+int PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
+                                           const std::shared_ptr<Client> &client) {
   auto &object_ids = client->GetObjectIDs();
   auto it = object_ids.find(object_id);
   if (it != object_ids.end()) {
-    bool should_unmap = client->MarkObjectAsUnused(*it);
-    RAY_LOG(DEBUG) << "Object " << object_id
-                   << " no longer in use by client, should_unmap = " << should_unmap;
+    client->MarkObjectAsUnused(*it);
+    RAY_LOG(DEBUG) << "Object " << object_id << " no longer in use by client";
     // Decrease reference count.
     object_lifecycle_mgr_.RemoveReference(object_id);
-    // Return true to indicate that the client should unmap the fd for this object_id.
-    return should_unmap;
+    // Return 1 to indicate that the client was removed.
+    return 1;
   } else {
-    // No mmap sections applicable.
-    return false;
+    // Return 0 to indicate that the client was not removed.
+    return 0;
   }
 }
 
-bool PlasmaStore::ReleaseObject(const ObjectID &object_id,
+void PlasmaStore::ReleaseObject(const ObjectID &object_id,
                                 const std::shared_ptr<Client> &client) {
   auto entry = object_lifecycle_mgr_.GetObject(object_id);
   if (entry != nullptr) {
     // Remove the client from the object's array of clients.
-    return RemoveFromClientObjectIds(object_id, client);
+    RemoveFromClientObjectIds(object_id, client);
   }
-  return false;
 }
 
 void PlasmaStore::SealObjects(const std::vector<ObjectID> &object_ids) {
@@ -417,8 +409,7 @@ Status PlasmaStore::ProcessMessage(const std::shared_ptr<Client> &client,
   } break;
   case fb::MessageType::PlasmaReleaseRequest: {
     RAY_RETURN_NOT_OK(ReadReleaseRequest(input, input_size, &object_id));
-    bool should_unmap = ReleaseObject(object_id, client);
-    RAY_RETURN_NOT_OK(SendReleaseReply(client, object_id, should_unmap, PlasmaError::OK));
+    ReleaseObject(object_id, client);
   } break;
   case fb::MessageType::PlasmaDeleteRequest: {
     std::vector<ObjectID> object_ids;

--- a/src/ray/object_manager/plasma/store.h
+++ b/src/ray/object_manager/plasma/store.h
@@ -178,8 +178,7 @@ class PlasmaStore {
   ///
   /// \param object_id The object ID of the object that is being released.
   /// \param client The client making this request.
-  /// \return bool The client should unmap the mmap section for this object.
-  bool ReleaseObject(const ObjectID &object_id, const std::shared_ptr<Client> &client)
+  void ReleaseObject(const ObjectID &object_id, const std::shared_ptr<Client> &client)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Connect a new client to the PlasmaStore.
@@ -209,15 +208,13 @@ class PlasmaStore {
                            uint64_t req_id) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   void AddToClientObjectIds(const ObjectID &object_id,
-                            std::optional<MEMFD_TYPE> fallback_allocated_fd,
                             const std::shared_ptr<ClientInterface> &client)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   void ReturnFromGet(const std::shared_ptr<GetRequest> &get_request);
 
-  // Returns: the client should unmap the mmap section for this object.
-  bool RemoveFromClientObjectIds(const ObjectID &object_id,
-                                 const std::shared_ptr<Client> &client)
+  int RemoveFromClientObjectIds(const ObjectID &object_id,
+                                const std::shared_ptr<Client> &client)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   // Start listening for clients.

--- a/src/ray/object_manager/test/create_request_queue_test.cc
+++ b/src/ray/object_manager/test/create_request_queue_test.cc
@@ -25,10 +25,8 @@ class MockClient : public ClientInterface {
  public:
   MOCK_METHOD1(SendFd, Status(MEMFD_TYPE));
   MOCK_METHOD0(GetObjectIDs, const std::unordered_set<ray::ObjectID> &());
-  MOCK_METHOD2(MarkObjectAsUsed,
-               void(const ObjectID &object_id,
-                    std::optional<MEMFD_TYPE> fallback_allocated_fd));
-  MOCK_METHOD1(MarkObjectAsUnused, bool(const ObjectID &object_id));
+  MOCK_METHOD1(MarkObjectAsUsed, void(const ObjectID &object_id));
+  MOCK_METHOD1(MarkObjectAsUnused, void(const ObjectID &object_id));
 };
 
 #define ASSERT_REQUEST_UNFINISHED(queue, req_id)                    \

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2724,8 +2724,6 @@ void NodeManager::TriggerGlobalGC() {
 }
 
 void NodeManager::Stop() {
-  // This never fails.
-  RAY_CHECK_OK(store_client_.Disconnect());
   object_manager_.Stop();
   dashboard_agent_manager_.reset();
   runtime_env_agent_manager_.reset();


### PR DESCRIPTION

<img width="544" alt="Screen Shot 2023-10-30 at 11 41 36 AM" src="https://github.com/ray-project/ray/assets/18510752/559ce761-a96c-4c19-9084-ec2cefa2e8ca">
…quest unmaps on release. (#40370)"

This reverts commit d3567e0036c2970017029f192e4e962812b4d189.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
