### PR TITLE
[RLlib] Fix 3 test cases that broke in move to revert PPO to old API stack.

### DIFF
--- a/rllib/examples/action_masking.py
+++ b/rllib/examples/action_masking.py
@@ -109,7 +109,10 @@ if __name__ == "__main__":
         )
         # We need to disable preprocessing of observations, because preprocessing
         # would flatten the observation dict of the environment.
-        .experimental(_disable_preprocessor_api=True)
+        .experimental(
+            _enable_new_api_stack=True,
+            _disable_preprocessor_api=True,
+        )
         .framework(args.framework)
         .resources(
             # Use GPUs iff `RLLIB_NUM_GPUS` env var set to > 0.

--- a/rllib/examples/env/action_mask_env.py
+++ b/rllib/examples/env/action_mask_env.py
@@ -30,7 +30,8 @@ class ActionMaskEnv(RandomEnv):
         # Check whether action is valid.
         if not self.valid_actions[action]:
             raise ValueError(
-                f"Invalid action sent to env! " f"valid_actions={self.valid_actions}"
+                f"Invalid action ({action}) sent to env! "
+                f"valid_actions={self.valid_actions}"
             )
         obs, rew, done, truncated, info = super().step(action)
         self._fix_action_mask(obs)

--- a/rllib/examples/learner/train_w_bc_finetune_w_ppo.py
+++ b/rllib/examples/learner/train_w_bc_finetune_w_ppo.py
@@ -117,7 +117,7 @@ def train_ppo_agent_from_checkpointed_module(
 
     config = (
         PPOConfig()
-        .training()
+        .experimental(_enable_new_api_stack=True)
         .rl_module(rl_module_spec=module_spec_from_ckpt)
         .environment(GYM_ENV_NAME)
         .debugging(seed=0)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix 3 test cases that broke in move to revert PPO to old API stack.

- action_masking torch + tf2
- learner API bc example test

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
