### PR TITLE
[ci] mark some core tests as flaky

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -67,7 +67,7 @@ steps:
         --parallelism-per-worker 3
       # doc examples
       - bazel run //ci/ray_ci:test_in_docker -- //doc/... core
-        --except-tags gpu,post_wheel_build,doctest
+        --except-tags gpu,post_wheel_build,xcommit,doctest
         --parallelism-per-worker 3
         --skip-ray-installation
     depends_on: corebuild

--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -71,6 +71,9 @@
     - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only
       --test_tag_filters=-timeseries_libs,-external,-ray_air,-gpu,-post_wheel_build,-doctest,-datasets_train,-highly_parallel,-team:core
       doc/...
+    - bazel test --config=ci $(./scripts/bazel_export_options)
+      --test_tag_filters=xcommit,-gpu
+      doc/...
 
 - label: ":book: Doc tests and examples with time series libraries"
   conditions:

--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -13,3 +13,4 @@ flaky_tests:
   - //python/ray/tests:test_unhandled_error
   - //python/ray/tests:test_state_api_log
   - //python/ray/tests:test_ray_init_2
+  - //python/ray/workflow:tests/test_http_events_2

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -113,11 +113,20 @@ py_test(
     tags = ["exclusive", "post_wheel_build", "team:serve"]
 )
 
+py_test(
+    name = "doc_code_ray_oom_prevention",
+    size = "medium",
+    main = "source/ray-core/doc_code/ray_oom_prevention.py",
+    srcs = ["source/ray-core/doc_code/ray_oom_prevention.py"],
+    tags = ["exclusive", "xcommit", "team:core"]
+)
+
 py_test_run_all_subdirectory(
     size = "medium",
     include = ["source/ray-core/doc_code/*.py"],
     exclude = ["source/ray-core/doc_code/runtime_env_example.py",
-               "source/ray-core/doc_code/cross_language.py"],
+               "source/ray-core/doc_code/cross_language.py",
+               "source/ray-core/doc_code/ray_oom_prevention.py"],
     extra_srcs = [],
     tags = ["exclusive", "team:core"],
 )


### PR DESCRIPTION
The following two core tests are very flaky. This PR alleviate it:
- //doc:source/ray-core/doc_code/ray_oom_prevention: move it back to civ1
- //python/ray/workflow:tests/test_http_events_2: mark it as flaky

Test:
- CI