### PR TITLE
[data] Set map op block size to match downstream shuffle op

### DIFF
--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -93,6 +93,11 @@ class OperatorFusionRule(Rule):
     ) -> AllToAllOperator:
         """Starting at the given operator, traverses up the DAG of operators
         and recursively fuses compatible MapOperator -> AllToAllOperator pairs.
+
+        Also, sets the target block size of the immediately upstream map op to
+        match the shuffle block size. We use a larger block size for shuffles
+        because tiny blocks are bad for I/O performance.
+
         Returns the current (root) operator after completing upstream operator fusions.
         """
         upstream_ops = dag.input_dependencies
@@ -104,6 +109,7 @@ class OperatorFusionRule(Rule):
             if self._can_fuse(dag, upstream_ops[0]):
                 # Fuse operator with its upstream op.
                 dag = self._get_fused_all_to_all_operator(dag, upstream_ops[0])
+                upstream_ops = dag.input_dependencies
             else:
                 # Propagate target max block size to the upstream map op. This
                 # is necessary even when fusion is not allowed, so that the map
@@ -113,8 +119,7 @@ class OperatorFusionRule(Rule):
                 map_op._target_max_block_size = self._get_merged_target_max_block_size(
                     upstream_ops[0].target_max_block_size, dag.target_max_block_size
                 )
-
-            upstream_ops = dag.input_dependencies
+                break
 
         self._propagate_target_max_block_size_to_input(dag)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If there is a shuffle op, then the immediately upstream (unfused) map op should try to produce output blocks that match the shuffle block size. This is to make sure that once we run the shuffle, the blocks are large enough.

## Related issue number

Closes #38400.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
