### PR TITLE
[core] Fix the lifetime issue in Plasma server client releasing object.

### DIFF
--- a/src/ray/object_manager/plasma/connection.h
+++ b/src/ray/object_manager/plasma/connection.h
@@ -72,6 +72,10 @@ class Client : public ray::ClientConnection, public ClientInterface {
   // Removes object ID's ref to the fd, if any. If the fd's refcnt goes to 0, also remove
   // the fd from used_fds_ and return true, directing the client to unmap it.
   //
+  // Invalidates the corresponding iterator from GetObjectIDs() in the middle of
+  // execution. *Don't* pass in the object_id dererfenced from an iterator from
+  // GetObjectIDs().
+  //
   // Returns: bool, client should unmap.
   // Idempotency: only decrements ref count if the object ID was held.
   virtual bool MarkObjectAsUnused(const ray::ObjectID &object_id) override {

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -251,7 +251,7 @@ bool PlasmaStore::RemoveFromClientObjectIds(const ObjectID &object_id,
   auto &object_ids = client->GetObjectIDs();
   auto it = object_ids.find(object_id);
   if (it != object_ids.end()) {
-    bool should_unmap = client->MarkObjectAsUnused(*it);
+    bool should_unmap = client->MarkObjectAsUnused(object_id);
     RAY_LOG(DEBUG) << "Object " << object_id
                    << " no longer in use by client, should_unmap = " << should_unmap;
     // Decrease reference count.
@@ -298,7 +298,7 @@ int PlasmaStore::AbortObject(const ObjectID &object_id,
   }
   // The client requesting the abort is the creator. Free the object.
   RAY_CHECK(object_lifecycle_mgr_.AbortObject(object_id) == PlasmaError::OK);
-  client->MarkObjectAsUnused(*it);
+  client->MarkObjectAsUnused(object_id);
   return 1;
 }
 


### PR DESCRIPTION
When the PlasmaStore wants to remove a object reference from a client in `PlasmaStore::RemoveFromClientObjectIds`, it somehow uses the ObjectID from the iterator from the underlying hash map. In the function `MarkObjectAsUnused` the hash map (`object_ids`) is invalidated, causing the seemingly `const &` object ID to be cleared out, and hence the subsequent lookup (`object_ids_to_fallback_allocated_fds_.find()`) always returns "not found" and the mmaps are leaked. Further, when the same object ID is mapped again, a RAY_CHECK crashes Raylet because there should be no existing mmap but we have the leaked one. This issue should have been caught by the borrow checker, but we don't have Rust yet.

This PR fixes by not using the object ID from the iterator. It does not make much sense anyway.

Somehow, the failure in `python/ray/tests/test_plasma_unlimited.py` only manifests in the mac os but not in Linux. I guess they have a subtle different hash map so even though the iterator is invalidated in Linux you can still access it for a while.

Closes #40785.