### PR TITLE
[data] log progress bar to data logs

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -421,7 +421,7 @@ def _debug_dump_topology(topology: Topology, log_to_stdout: bool = True) -> None
     Args:
         topology: The topology to debug.
     """
-    logger.get_logger(log_to_stdout).info("Scheduling Trace:")
+    logger.get_logger(log_to_stdout).info("Execution Progress:")
     for i, (op, state) in enumerate(topology.items()):
         logger.get_logger(log_to_stdout).info(
             f"{i}: {state.summary_str()}, "

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -421,10 +421,10 @@ def _debug_dump_topology(topology: Topology, log_to_stdout: bool = True) -> None
     Args:
         topology: The topology to debug.
     """
-    logger.get_logger(log_to_stdout).info("vvv scheduling trace vvv")
+    logger.get_logger(log_to_stdout).info("Scheduling Trace:")
     for i, (op, state) in enumerate(topology.items()):
         logger.get_logger(log_to_stdout).info(
             f"{i}: {state.summary_str()}, "
             f"Blocks Outputted: {state.num_completed_tasks}/{op.num_outputs_total()}"
         )
-    logger.get_logger(log_to_stdout).info("^^^ scheduling trace ^^^")
+    logger.get_logger(log_to_stdout).info("")

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1301,7 +1301,7 @@ def test_op_state_logging():
         logs = [canonicalize(call.args[0]) for call in mock_logger.call_args_list]
 
         for i, log in enumerate(logs):
-            if log == "vvv scheduling trace vvv":
+            if log == "Scheduling Trace:":
                 assert "Input" in logs[i + 1]
                 assert "ReadRange->MapBatches(<lambda>)" in logs[i + 2]
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1292,6 +1292,20 @@ def test_op_metrics_logging():
         assert sum([log == map_str for log in logs]) == 1
 
 
+def test_progress_bar_logging():
+    logger = DatasetLogger(
+        "ray.data._internal.execution.streaming_executor"
+    ).get_logger()
+    with patch.object(logger, "info") as mock_logger:
+        ray.data.range(100).map_batches(lambda x: x).materialize()
+        logs = [canonicalize(call.args[0]) for call in mock_logger.call_args_list]
+
+        for log in logs:
+            if log.startswith("Execution Progress Status:"):
+                assert "Input" in log
+                assert "ReadRange->MapBatches(<lambda>)" in log
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1293,17 +1293,22 @@ def test_op_metrics_logging():
 
 
 def test_progress_bar_logging():
-    logger = DatasetLogger(
-        "ray.data._internal.execution.streaming_executor"
-    ).get_logger()
-    with patch.object(logger, "info") as mock_logger:
-        ray.data.range(100).map_batches(lambda x: x).materialize()
-        logs = [canonicalize(call.args[0]) for call in mock_logger.call_args_list]
+    def _test_progress_bar_logging():
+        logger = DatasetLogger(
+            "ray.data._internal.execution.streaming_executor"
+        ).get_logger()
+        with patch.object(logger, "info") as mock_logger:
+            ray.data.range(100).map_batches(lambda x: x).materialize()
+            logs = [canonicalize(call.args[0]) for call in mock_logger.call_args_list]
 
-        for log in logs:
-            if log.startswith("Execution Progress Status:"):
-                assert "Input" in log
-                assert "ReadRange->MapBatches(<lambda>)" in log
+            for log in logs:
+                if log.startswith("Execution Progress Status:"):
+                    assert "Input" in log
+                    assert "ReadRange->MapBatches(<lambda>)" in log
+
+    _test_progress_bar_logging()
+    with patch("ray.data._internal.execution.streaming_executor.tqdm", new=None):
+        _test_progress_bar_logging()
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1302,8 +1302,8 @@ def test_op_state_logging():
 
         for i, log in enumerate(logs):
             if log == "vvv scheduling trace vvv":
-                assert "Input" in logs[i+1]
-                assert "ReadRange->MapBatches(<lambda>)" in logs[i+2]
+                assert "Input" in logs[i + 1]
+                assert "ReadRange->MapBatches(<lambda>)" in logs[i + 2]
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1300,10 +1300,13 @@ def test_op_state_logging():
         ray.data.range(100).map_batches(lambda x: x).materialize()
         logs = [canonicalize(call.args[0]) for call in mock_logger.call_args_list]
 
+        times_asserted = 0
         for i, log in enumerate(logs):
-            if log == "Scheduling Trace:":
+            if log == "Execution Progress:":
+                times_asserted += 1
                 assert "Input" in logs[i + 1]
                 assert "ReadRange->MapBatches(<lambda>)" in logs[i + 2]
+        assert times_asserted > 0
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1292,23 +1292,18 @@ def test_op_metrics_logging():
         assert sum([log == map_str for log in logs]) == 1
 
 
-def test_progress_bar_logging():
-    def _test_progress_bar_logging():
-        logger = DatasetLogger(
-            "ray.data._internal.execution.streaming_executor"
-        ).get_logger()
-        with patch.object(logger, "info") as mock_logger:
-            ray.data.range(100).map_batches(lambda x: x).materialize()
-            logs = [canonicalize(call.args[0]) for call in mock_logger.call_args_list]
+def test_op_state_logging():
+    logger = DatasetLogger(
+        "ray.data._internal.execution.streaming_executor"
+    ).get_logger()
+    with patch.object(logger, "info") as mock_logger:
+        ray.data.range(100).map_batches(lambda x: x).materialize()
+        logs = [canonicalize(call.args[0]) for call in mock_logger.call_args_list]
 
-            for log in logs:
-                if log.startswith("Execution Progress Status:"):
-                    assert "Input" in log
-                    assert "ReadRange->MapBatches(<lambda>)" in log
-
-    _test_progress_bar_logging()
-    with patch("ray.data._internal.execution.streaming_executor.tqdm", new=None):
-        _test_progress_bar_logging()
+        for i, log in enumerate(logs):
+            if log == "vvv scheduling trace vvv":
+                assert "Input" in logs[i+1]
+                assert "ReadRange->MapBatches(<lambda>)" in logs[i+2]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Log each operator's progress bar to `ray-data.log` after each `_scheduling_loop_step` if `DEBUG_TRACE_SCHEDULING` is not set.

Example: `ray.data.range(100).map_batches(lambda x: x).materialize()`:
```
2023-10-31 15:41:26,646 INFO streaming_executor.py:424 -- Execution Progress:
2023-10-31 15:41:26,646 INFO streaming_executor.py:426 -- 0: - Input: 0 active, 0 queued, 0.0 MiB objects, Blocks Outputted: 20/20
2023-10-31 15:41:26,646 INFO streaming_executor.py:426 -- 1: - ReadRange->MapBatches(<lambda>): 10 active, 10 queued, 0.02 MiB objects, Blocks Outputted: 0/20
2023-10-31 15:41:26,646 INFO streaming_executor.py:430 --
2023-10-31 15:41:26,646 INFO streaming_executor.py:312 -- Operator InputDataBuffer[Input] completed. Operator Metrics:
{'num_inputs_received': 20, 'bytes_inputs_received': 45900, 'num_outputs_taken': 20, 'bytes_outputs_taken': 45900, 'cpu_usage': 0, 'gpu_usage': 0}
2023-10-31 15:41:26,757 INFO streaming_executor.py:424 -- Execution Progress:
2023-10-31 15:41:26,757 INFO streaming_executor.py:426 -- 0: - Input: 0 active, 0 queued, 0.0 MiB objects, Blocks Outputted: 20/20
2023-10-31 15:41:26,757 INFO streaming_executor.py:426 -- 1: - ReadRange->MapBatches(<lambda>): 10 active, 9 queued, 0.02 MiB objects, Blocks Outputted: 1/20
2023-10-31 15:41:26,757 INFO streaming_executor.py:430 --
2023-10-31 15:41:26,866 INFO streaming_executor.py:424 -- Execution Progress:
2023-10-31 15:41:26,866 INFO streaming_executor.py:426 -- 0: - Input: 0 active, 0 queued, 0.0 MiB objects, Blocks Outputted: 20/20
2023-10-31 15:41:26,866 INFO streaming_executor.py:426 -- 1: - ReadRange->MapBatches(<lambda>): 10 active, 8 queued, 0.02 MiB objects, Blocks Outputted: 2/20
2023-10-31 15:41:26,866 INFO streaming_executor.py:430 --
2023-10-31 15:41:26,972 INFO streaming_executor.py:424 -- Execution Progress:
2023-10-31 15:41:26,972 INFO streaming_executor.py:426 -- 0: - Input: 0 active, 0 queued, 0.0 MiB objects, Blocks Outputted: 20/20
2023-10-31 15:41:26,972 INFO streaming_executor.py:426 -- 1: - ReadRange->MapBatches(<lambda>): 10 active, 7 queued, 0.02 MiB objects, Blocks Outputted: 3/20
2023-10-31 15:41:26,972 INFO streaming_executor.py:430 --
2023-10-31 15:41:27,079 INFO streaming_executor.py:424 -- Execution Progress:
2023-10-31 15:41:27,079 INFO streaming_executor.py:426 -- 0: - Input: 0 active, 0 queued, 0.0 MiB objects, Blocks Outputted: 20/20
2023-10-31 15:41:27,079 INFO streaming_executor.py:426 -- 1: - ReadRange->MapBatches(<lambda>): 10 active, 6 queued, 0.02 MiB objects, Blocks Outputted: 4/20
2023-10-31 15:41:27,079 INFO streaming_executor.py:430 --
2023-10-31 15:41:27,187 INFO streaming_executor.py:424 -- Execution Progress:
2023-10-31 15:41:27,188 INFO streaming_executor.py:426 -- 0: - Input: 0 active, 0 queued, 0.0 MiB objects, Blocks Outputted: 20/20
2023-10-31 15:41:27,188 INFO streaming_executor.py:426 -- 1: - ReadRange->MapBatches(<lambda>): 10 active, 5 queued, 0.02 MiB objects, Blocks Outputted: 5/20
2023-10-31 15:41:27,188 INFO streaming_executor.py:430 --
2023-10-31 15:41:27,290 INFO streaming_executor.py:424 -- Execution Progress:
2023-10-31 15:41:27,290 INFO streaming_executor.py:426 -- 0: - Input: 0 active, 0 queued, 0.0 MiB objects, Blocks Outputted: 20/20
2023-10-31 15:41:27,290 INFO streaming_executor.py:426 -- 1: - ReadRange->MapBatches(<lambda>): 5 active, 0 queued, 0.01 MiB objects, Blocks Outputted: 15/20
2023-10-31 15:41:27,290 INFO streaming_executor.py:430 --
2023-10-31 15:41:27,293 INFO streaming_executor.py:424 -- Execution Progress:
2023-10-31 15:41:27,293 INFO streaming_executor.py:426 -- 0: - Input: 0 active, 0 queued, 0.0 MiB objects, Blocks Outputted: 20/20
2023-10-31 15:41:27,293 INFO streaming_executor.py:426 -- 1: - ReadRange->MapBatches(<lambda>): 0 active, 0 queued, 0.0 MiB objects, Blocks Outputted: 20/20
2023-10-31 15:41:27,293 INFO streaming_executor.py:430 --
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
