### PR TITLE
[data] assert metadata size_bytes is int

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -207,6 +207,8 @@ class BlockMetadata:
         if self.input_files is None:
             self.input_files = []
         if self.size_bytes is not None:
+            # Require size_bytes to be int, ray.util.metrics objects
+            # will not take other types like numpy.int64
             assert isinstance(self.size_bytes, int)
 
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -207,7 +207,7 @@ class BlockMetadata:
         if self.input_files is None:
             self.input_files = []
         if self.size_bytes is not None:
-            self.size_bytes = int(self.size_bytes)
+            assert isinstance(self.size_bytes, int)
 
 
 @DeveloperAPI

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -228,7 +228,7 @@ class _RangeDatasourceReader(Reader):
         tensor_shape: Tuple = (1,),
         column_name: Optional[str] = None,
     ):
-        self._n = n
+        self._n = int(n)
         self._block_format = block_format
         self._tensor_shape = tensor_shape
         self._column_name = column_name

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -293,7 +293,7 @@ class _RangeDatasourceReader(Reader):
         else:
             raise ValueError("Unsupported block type", block_format)
         if block_format == "tensor":
-            element_size = np.product(tensor_shape)
+            element_size = int(np.product(tensor_shape))
         else:
             element_size = 1
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1208,7 +1208,7 @@ def test_stats_actor_metrics():
 
 
 def test_stats_actor_iter_metrics():
-    ds = ray.data.range(100).map_batches(lambda x: x)
+    ds = ray.data.range(1e6).map_batches(lambda x: x)
     with patch_update_stats_actor_iter() as update_fn:
         ds.take_all()
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1208,7 +1208,7 @@ def test_stats_actor_metrics():
 
 
 def test_stats_actor_iter_metrics():
-    ds = ray.data.range(1e6).map_batches(lambda x: x)
+    ds = ray.data.range(100).map_batches(lambda x: x)
     with patch_update_stats_actor_iter() as update_fn:
         ds.take_all()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Follow up to #40819 

Asserts that `BlockMetadata.size_bytes` is an int, and updates the remaining references that pass an incorrect type.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
