### PR TITLE
[GCS FT] Mark old head node as dead after pod restart

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -1038,7 +1038,6 @@ def test_job_finished_after_head_node_restart(
     # restart head node
     new_head_node = cluster.add_node()
     ray.init(cluster.address)
-    new_gcs_address = new_head_node.address
 
     # verify if job is finished, which marked is_dead
     def _check_job_is_dead(submission_id: str) -> bool:

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -1011,9 +1011,16 @@ def test_job_finished_after_gcs_server_restart(ray_start_regular_with_external_r
         import asyncio
 
         asyncio.set_event_loop(asyncio.new_event_loop())
-        all_job_info = get_or_create_event_loop().run_until_complete(async_get_all_job_info())
-        return list(filter(lambda job_info: 'job_submission_id' in job_info.config.metadata \
-            and job_info.config.metadata['job_submission_id'] == job_id, list(all_job_info.values())))
+        all_job_info = get_or_create_event_loop().run_until_complete(
+            async_get_all_job_info()
+        )
+        return list(
+            filter(
+                lambda job_info: "job_submission_id" in job_info.config.metadata
+                and job_info.config.metadata["job_submission_id"] == job_id,
+                list(all_job_info.values()),
+            )
+        )
 
     # verify if job is finished, which marked is_dead
     def _check_job_is_dead(job_id: str) -> bool:

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -1012,7 +1012,7 @@ def test_job_finished_after_head_node_restart(
             )
         )
 
-    def _check_job_running(client: JobSubmissionClient, submission_id: str) -> bool:
+    def _check_job_running(submission_id: str) -> bool:
         job_infos = get_job_info(submission_id)
         if len(job_infos) == 0:
             return False
@@ -1020,9 +1020,7 @@ def test_job_finished_after_head_node_restart(
         return job_info.status == JobStatus.RUNNING
 
     # wait until job info is written in redis
-    wait_for_condition(
-        _check_job_running, client=client, submission_id=submission_id, timeout=10
-    )
+    wait_for_condition(_check_job_running, submission_id=submission_id, timeout=10)
 
     # kill head node
     ray.shutdown()
@@ -1036,7 +1034,7 @@ def test_job_finished_after_head_node_restart(
     wait_for_pid_to_exit(gcs_server_pid, 1000)
 
     # restart head node
-    new_head_node = cluster.add_node()
+    cluster.add_node()
     ray.init(cluster.address)
 
     # verify if job is finished, which marked is_dead

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -11,7 +11,6 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 import ray._private.gcs_utils as gcs_utils
 from ray._private import ray_constants
 from ray._private.test_utils import (
-    format_web_url,
     convert_actor_state,
     enable_external_redis,
     generate_system_config_map,
@@ -19,7 +18,7 @@ from ray._private.test_utils import (
     wait_for_pid_to_exit,
     run_string_as_driver,
 )
-from ray.job_submission import JobStatus, JobSubmissionClient
+from ray.job_submission import JobSubmissionClient
 
 import psutil
 
@@ -993,7 +992,7 @@ def test_job_finished_after_gcs_server_restart(ray_start_regular_with_external_r
 
     # submit job
     job_id = client.submit_job(
-        entrypoint="python -c 'import ray; ray.init(); print(ray.cluster_resources());'",
+        entrypoint="python -c 'import ray; ray.init(); print(ray.cluster_resources());'"
     )
     # restart the gcs server
     ray._private.worker._global_node.kill_gcs_server()

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -1020,7 +1020,9 @@ def test_job_finished_after_head_node_restart(
         return job_info.status == JobStatus.RUNNING
 
     # wait until job info is written in redis
-    wait_for_condition(_check_job_running, client=client, submission_id=submission_id, timeout=10)
+    wait_for_condition(
+        _check_job_running, client=client, submission_id=submission_id, timeout=10
+    )
 
     # kill head node
     ray.shutdown()

--- a/python/ray/tests/test_gcs_ha_e2e.py
+++ b/python/ray/tests/test_gcs_ha_e2e.py
@@ -32,10 +32,7 @@ print(sum([1 if n["Alive"] else 0 for n in ray.nodes()]))
 
     head.restart()
     # When GCS restarts, a new raylet is added
-    # and the old dead raylet is going to take a while to be marked dead.
-    # So there should be 3 alive nodes
-    wait_for_condition(check_alive, timeout=10, n=3)
-    # Later, GCS detect the old raylet dead and the alive nodes will be 2
+    # GCS mark the old raylet as dead so the alive nodes will be 2
     wait_for_condition(check_alive, timeout=30, n=2)
 
 

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -222,7 +222,7 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
                        << WorkerID::FromBinary(data.second.driver_address().worker_id());
         client->NumPendingTasks(
             std::move(request),
-            [reply, i, num_processed_jobs, try_send_reply](
+            [data, reply, i, num_processed_jobs, try_send_reply](
                 const Status &status,
                 const rpc::NumPendingTasksReply &num_pending_tasks_reply) {
               RAY_LOG(DEBUG) << "SendNumPendingTaskReply: "

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -218,13 +218,13 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
         auto client = core_worker_clients_.GetOrConnect(data.second.driver_address());
         std::unique_ptr<rpc::NumPendingTasksRequest> request(
             new rpc::NumPendingTasksRequest());
-        RAY_LOG(DEBUG) << "SendNumPendingTask: " << worker_id;
+        RAY_LOG(DEBUG) << "Send NumPendingTasksRequest to worker " << worker_id;
         client->NumPendingTasks(
             std::move(request),
             [worker_id, reply, i, num_processed_jobs, try_send_reply](
                 const Status &status,
                 const rpc::NumPendingTasksReply &num_pending_tasks_reply) {
-              RAY_LOG(DEBUG) << "SendNumPendingTaskReply: " << worker_id;
+              RAY_LOG(DEBUG) << "Received NumPendingTasksReply from worker " << worker_id;
               if (!status.ok()) {
                 RAY_LOG(WARNING) << "Failed to get is_running_tasks from core worker: "
                                  << status.ToString();

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -222,12 +222,13 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
                        << WorkerID::FromBinary(data.second.driver_address().worker_id());
         client->NumPendingTasks(
             std::move(request),
-            [data, reply, i, num_processed_jobs, try_send_reply](
-                const Status &status,
-                const rpc::NumPendingTasksReply &num_pending_tasks_reply) {
-              RAY_LOG(DEBUG) << "SendNumPendingTaskReply: "
-                             << WorkerID::FromBinary(
-                                    data.second.driver_address().worker_id());
+            [worker_id = data.second.driver_address().worker_id(),
+             reply,
+             i,
+             num_processed_jobs,
+             try_send_reply](const Status &status,
+                             const rpc::NumPendingTasksReply &num_pending_tasks_reply) {
+              RAY_LOG(DEBUG) << "SendNumPendingTaskReply: " << worker_id;
               if (!status.ok()) {
                 RAY_LOG(WARNING) << "Failed to get is_running_tasks from core worker: "
                                  << status.ToString();

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -299,21 +299,21 @@ std::shared_ptr<rpc::JobConfig> GcsJobManager::GetJobConfig(const JobID &job_id)
 
 void GcsJobManager::OnNodeDead(const NodeID &node_id) {
   RAY_LOG(INFO) << "Node " << node_id
-              << " failed, mark all jobs from this node as finished";
+                << " failed, mark all jobs from this node as finished";
 
-  auto on_done = [this, node_id](
-    const absl::flat_hash_map<JobID, JobTableData> &result) {
-      // If job is not dead and from driver in current node, then mark it as finished
-      for (auto &data : result) {
-        if (!data.second.is_dead() && NodeID::FromBinary(data.second.driver_address().raylet_id()) == node_id) {
-          RAY_LOG(INFO) << "marking job: " << data.first << "as finished";
-          MarkJobAsFinished(data.second, [data](Status status) {
-              if (!status.ok()) {
-                RAY_LOG(WARNING) << "Failed to mark job as finished";
-              }
-          });
-        }
+  auto on_done = [this, node_id](const absl::flat_hash_map<JobID, JobTableData> &result) {
+    // If job is not dead and from driver in current node, then mark it as finished
+    for (auto &data : result) {
+      if (!data.second.is_dead() &&
+          NodeID::FromBinary(data.second.driver_address().raylet_id()) == node_id) {
+        RAY_LOG(DEBUG) << "Marking job: " << data.first << " as finished";
+        MarkJobAsFinished(data.second, [data](Status status) {
+          if (!status.ok()) {
+            RAY_LOG(WARNING) << "Failed to mark job as finished";
+          }
+        });
       }
+    }
   };
 
   // make all jobs in current node to finished

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -314,7 +314,7 @@ void GcsJobManager::OnNodeDead(const NodeID &node_id) {
         RAY_LOG(DEBUG) << "Marking job: " << data.first << " as finished";
         MarkJobAsFinished(data.second, [data](Status status) {
           if (!status.ok()) {
-            RAY_LOG(WARNING) << "Failed to mark job as finished";
+            RAY_LOG(WARNING) << "Failed to mark job as finished. Status: " << status;
           }
         });
       }

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -218,11 +218,13 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
         auto client = core_worker_clients_.GetOrConnect(data.second.driver_address());
         std::unique_ptr<rpc::NumPendingTasksRequest> request(
             new rpc::NumPendingTasksRequest());
+        RAY_LOG(DEBUG) << "SendNumPendingTask: " << WorkerID::FromBinary(data.second.driver_address().worker_id());
         client->NumPendingTasks(
             std::move(request),
             [reply, i, num_processed_jobs, try_send_reply](
                 const Status &status,
                 const rpc::NumPendingTasksReply &num_pending_tasks_reply) {
+              RAY_LOG(DEBUG) << "SendNumPendingTaskReply: " << WorkerID::FromBinary(data.second.driver_address().worker_id());
               if (!status.ok()) {
                 RAY_LOG(WARNING) << "Failed to get is_running_tasks from core worker: "
                                  << status.ToString();
@@ -299,21 +301,21 @@ std::shared_ptr<rpc::JobConfig> GcsJobManager::GetJobConfig(const JobID &job_id)
 
 void GcsJobManager::OnNodeDead(const NodeID &node_id) {
   RAY_LOG(INFO) << "Node " << node_id
-                << " failed, mark all jobs from this node as finished";
+              << " failed, mark all jobs from this node as finished";
 
-  auto on_done = [this, node_id](const absl::flat_hash_map<JobID, JobTableData> &result) {
-    // If job is not dead and from driver in current node, then mark it as finished
-    for (auto &data : result) {
-      if (!data.second.is_dead() &&
-          NodeID::FromBinary(data.second.driver_address().raylet_id()) == node_id) {
-        RAY_LOG(DEBUG) << "Marking job: " << data.first << " as finished";
-        MarkJobAsFinished(data.second, [data](Status status) {
-          if (!status.ok()) {
-            RAY_LOG(WARNING) << "Failed to mark job as finished";
-          }
-        });
+  auto on_done = [this, node_id](
+    const absl::flat_hash_map<JobID, JobTableData> &result) {
+      // If job is not dead and from driver in current node, then mark it as finished
+      for (auto &data : result) {
+        if (!data.second.is_dead() && NodeID::FromBinary(data.second.driver_address().raylet_id()) == node_id) {
+          RAY_LOG(DEBUG) << "Marking job: " << data.first << " as finished";
+          MarkJobAsFinished(data.second, [data](Status status) {
+              if (!status.ok()) {
+                RAY_LOG(WARNING) << "Failed to mark job as finished";
+              }
+          });
+        }
       }
-    }
   };
 
   // make all jobs in current node to finished

--- a/src/ray/gcs/gcs_server/gcs_job_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.h
@@ -79,6 +79,12 @@ class GcsJobManager : public rpc::JobInfoHandler {
 
   std::shared_ptr<rpc::JobConfig> GetJobConfig(const JobID &job_id) const;
 
+  /// Handle a node death. This will marks all jobs associated with the
+  /// specified node id as finished.
+  ///
+  /// \param node_id The specified node id.
+  void OnNodeDead(const NodeID &node_id);
+
  private:
   std::shared_ptr<GcsTableStorage> gcs_table_storage_;
   std::shared_ptr<GcsPublisher> gcs_publisher_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -740,6 +740,7 @@ void GcsServer::InstallEventListeners() {
         gcs_resource_manager_->OnNodeDead(node_id);
         gcs_placement_group_manager_->OnNodeDead(node_id);
         gcs_actor_manager_->OnNodeDead(node_id, node_ip_address);
+        gcs_job_manager_->OnNodeDead(node_id);
         raylet_client_pool_->Disconnect(node_id);
         gcs_healthcheck_manager_->RemoveNode(node_id);
         pubsub_handler_->RemoveSubscriberFrom(node_id.Binary());

--- a/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
@@ -594,13 +594,13 @@ TEST_F(GcsJobManagerTest, TestNodeFailure) {
 
   // Check if all job are not dead
   gcs_job_manager.HandleGetAllJobInfo(
-    all_job_info_request,
-    &all_job_info_reply,
-    [&all_job_info_promise](Status, std::function<void()>, std::function<void()>) {
-      all_job_info_promise.set_value(true);
-    });
+      all_job_info_request,
+      &all_job_info_reply,
+      [&all_job_info_promise](Status, std::function<void()>, std::function<void()>) {
+        all_job_info_promise.set_value(true);
+      });
   all_job_info_promise.get_future().get();
-  for(auto job_info: all_job_info_reply.job_info_list()){
+  for (auto job_info : all_job_info_reply.job_info_list()) {
     ASSERT_TRUE(!job_info.is_dead());
   }
 
@@ -611,27 +611,27 @@ TEST_F(GcsJobManagerTest, TestNodeFailure) {
 
   // Test get all jobs with limit larger than the number of jobs.
   auto condition = [&gcs_job_manager, node_id]() -> bool {
-      rpc::GetAllJobInfoRequest all_job_info_request2;
-      rpc::GetAllJobInfoReply all_job_info_reply2;
-      std::promise<bool> all_job_info_promise2;
-      gcs_job_manager.HandleGetAllJobInfo(
-          all_job_info_request2,
-          &all_job_info_reply2,
-          [&all_job_info_promise2](Status, std::function<void()>, std::function<void()>) {
-            all_job_info_promise2.set_value(true);
-          });
-      all_job_info_promise2.get_future().get();
+    rpc::GetAllJobInfoRequest all_job_info_request2;
+    rpc::GetAllJobInfoReply all_job_info_reply2;
+    std::promise<bool> all_job_info_promise2;
+    gcs_job_manager.HandleGetAllJobInfo(
+        all_job_info_request2,
+        &all_job_info_reply2,
+        [&all_job_info_promise2](Status, std::function<void()>, std::function<void()>) {
+          all_job_info_promise2.set_value(true);
+        });
+    all_job_info_promise2.get_future().get();
 
-      auto job_info1 = all_job_info_reply2.job_info_list().Get(0);
-      auto job_info2 = all_job_info_reply2.job_info_list().Get(1);
+    auto job_info1 = all_job_info_reply2.job_info_list().Get(0);
+    auto job_info2 = all_job_info_reply2.job_info_list().Get(1);
 
-      bool job_condition = true;
-      // job1 from the current node should dead, while job2 is still alive
-      for(auto job_info: all_job_info_reply2.job_info_list()){
-        auto job_node_id = NodeID::FromBinary(job_info.driver_address().raylet_id());
-        job_condition = job_condition && (job_info.is_dead() == (job_node_id == node_id));
-      }
-      return job_condition;
+    bool job_condition = true;
+    // job1 from the current node should dead, while job2 is still alive
+    for (auto job_info : all_job_info_reply2.job_info_list()) {
+      auto job_node_id = NodeID::FromBinary(job_info.driver_address().raylet_id());
+      job_condition = job_condition && (job_info.is_dead() == (job_node_id == node_id));
+    }
+    return job_condition;
   };
 
   EXPECT_TRUE(WaitForCondition(condition, 2000));

--- a/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
@@ -553,6 +553,93 @@ TEST_F(GcsJobManagerTest, TestPreserveDriverInfo) {
   ASSERT_EQ(data.driver_pid(), 8264);
 }
 
+TEST_F(GcsJobManagerTest, TestNodeFailure) {
+  gcs::GcsJobManager gcs_job_manager(gcs_table_storage_,
+                                     gcs_publisher_,
+                                     runtime_env_manager_,
+                                     *function_manager_,
+                                     *fake_kv_,
+                                     client_factory_);
+
+  auto job_id1 = JobID::FromInt(1);
+  auto job_id2 = JobID::FromInt(2);
+  gcs::GcsInitData gcs_init_data(gcs_table_storage_);
+  gcs_job_manager.Initialize(/*init_data=*/gcs_init_data);
+
+  rpc::AddJobReply empty_reply;
+  std::promise<bool> promise1;
+  std::promise<bool> promise2;
+
+  auto add_job_request1 = Mocker::GenAddJobRequest(job_id1, "namespace_1");
+  gcs_job_manager.HandleAddJob(
+      *add_job_request1,
+      &empty_reply,
+      [&promise1](Status, std::function<void()>, std::function<void()>) {
+        promise1.set_value(true);
+      });
+  promise1.get_future().get();
+
+  auto add_job_request2 = Mocker::GenAddJobRequest(job_id2, "namespace_2");
+  gcs_job_manager.HandleAddJob(
+      *add_job_request2,
+      &empty_reply,
+      [&promise2](Status, std::function<void()>, std::function<void()>) {
+        promise2.set_value(true);
+      });
+  promise2.get_future().get();
+
+  rpc::GetAllJobInfoRequest all_job_info_request;
+  rpc::GetAllJobInfoReply all_job_info_reply;
+  std::promise<bool> all_job_info_promise;
+
+  // Check if all job are not dead
+  gcs_job_manager.HandleGetAllJobInfo(
+    all_job_info_request,
+    &all_job_info_reply,
+    [&all_job_info_promise](Status, std::function<void()>, std::function<void()>) {
+      all_job_info_promise.set_value(true);
+    });
+  all_job_info_promise.get_future().get();
+  for(auto job_info: all_job_info_reply.job_info_list()){
+    ASSERT_TRUE(!job_info.is_dead());
+  }
+
+  // Remove node and then check that the job is dead.
+  auto address = all_job_info_reply.job_info_list().Get(0).driver_address();
+  auto node_id = NodeID::FromBinary(address.raylet_id());
+  
+  std::promise<bool> on_node_dead_promise;
+  io_service_.post(
+    [&gcs_job_manager, node_id, &on_node_dead_promise]() {
+      gcs_job_manager.OnNodeDead(node_id);
+      on_node_dead_promise.set_value(true);
+    },
+    "test");
+  ASSERT_TRUE(on_node_dead_promise.get_future().get());
+
+  // Test get all jobs with limit larger than the number of jobs.
+  rpc::GetAllJobInfoRequest all_job_info_request2;
+  rpc::GetAllJobInfoReply all_job_info_reply2;
+  std::promise<bool> all_job_info_promise2;
+  gcs_job_manager.HandleGetAllJobInfo(
+      all_job_info_request2,
+      &all_job_info_reply2,
+      [&all_job_info_promise2](Status, std::function<void()>, std::function<void()>) {
+        all_job_info_promise2.set_value(true);
+      });
+  all_job_info_promise2.get_future().get();
+
+  ASSERT_EQ(all_job_info_reply2.job_info_list().size(), 2);
+  auto job_info1 = all_job_info_reply2.job_info_list().Get(0);
+  auto job_info2 = all_job_info_reply2.job_info_list().Get(1);
+
+  // job1 from the current node should dead, while job2 is still alive
+  for(auto job_info: all_job_info_reply2.job_info_list()){
+    auto job_node_id = NodeID::FromBinary(job_info.driver_address().raylet_id());
+    ASSERT_EQ(job_info.is_dead(), job_node_id == node_id);
+  }
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
@@ -609,7 +609,7 @@ TEST_F(GcsJobManagerTest, TestNodeFailure) {
   auto node_id = NodeID::FromBinary(address.raylet_id());
   gcs_job_manager.OnNodeDead(node_id);
 
-  // Test get all jobs with limit larger than the number of jobs.
+  // Test get all jobs and check if killed node jobs marked as finished
   auto condition = [&gcs_job_manager, node_id]() -> bool {
     rpc::GetAllJobInfoRequest all_job_info_request2;
     rpc::GetAllJobInfoReply all_job_info_reply2;
@@ -621,9 +621,6 @@ TEST_F(GcsJobManagerTest, TestNodeFailure) {
           all_job_info_promise2.set_value(true);
         });
     all_job_info_promise2.get_future().get();
-
-    auto job_info1 = all_job_info_reply2.job_info_list().Get(0);
-    auto job_info2 = all_job_info_reply2.job_info_list().Get(1);
 
     bool job_condition = true;
     // job1 from the current node should dead, while job2 is still alive


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, `ray list nodes` shows two alive head nodes after restarting pod. The reason is the old head node failure is not detected by GCS health manager until 15 seconds timeout. So, we mark old head node as dead when we register new head node to guarantee only 1 head node alive at a time.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
