### PR TITLE
[data] Update default shuffle block size to 1GB

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -159,6 +159,13 @@ def _autodetect_parallelism(
             min_safe_parallelism,
             avail_cpus * 2,
         )
+        print(
+            "PARALLELISM",
+            min(ctx.min_parallelism, max_reasonable_parallelism),
+            min_safe_parallelism,
+            avail_cpus * 2,
+            parallelism,
+        )
 
         if parallelism == ctx.min_parallelism:
             reason = f"DataContext.get_current().min_parallelism={ctx.min_parallelism}"

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -159,13 +159,6 @@ def _autodetect_parallelism(
             min_safe_parallelism,
             avail_cpus * 2,
         )
-        print(
-            "PARALLELISM",
-            min(ctx.min_parallelism, max_reasonable_parallelism),
-            min_safe_parallelism,
-            avail_cpus * 2,
-            parallelism,
-        )
 
         if parallelism == ctx.min_parallelism:
             reason = f"DataContext.get_current().min_parallelism={ctx.min_parallelism}"

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -30,7 +30,7 @@ DEFAULT_TARGET_MAX_BLOCK_SIZE = 128 * 1024 * 1024
 # all input blocks anyway, so there is no performance advantage to having
 # smaller blocks. Setting a larger block size allows avoiding overhead from an
 # excessive number of partitions.
-# We choose 512MiB as 8x less than the typical memory:core ratio of 4:1.
+# We choose 1GiB as 4x less than the typical memory:core ratio (4:1).
 DEFAULT_SHUFFLE_TARGET_MAX_BLOCK_SIZE = 1024 * 1024 * 1024
 
 # Dataset will avoid creating blocks smaller than this size in bytes on read.

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -31,7 +31,7 @@ DEFAULT_TARGET_MAX_BLOCK_SIZE = 128 * 1024 * 1024
 # smaller blocks. Setting a larger block size allows avoiding overhead from an
 # excessive number of partitions.
 # We choose 512MiB as 8x less than the typical memory:core ratio of 4:1.
-DEFAULT_SHUFFLE_TARGET_MAX_BLOCK_SIZE = 512 * 1024 * 1024
+DEFAULT_SHUFFLE_TARGET_MAX_BLOCK_SIZE = 1024 * 1024 * 1024
 
 # Dataset will avoid creating blocks smaller than this size in bytes on read.
 # This takes precedence over DEFAULT_MIN_PARALLELISM.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With #40248, block sizes are now respected. This increases the default shuffle block size to 1GiB, which restores the previous behavior in the release test dataset_shuffle_sort_1tb. There is a possibility that this increases worker heap memory pressure during shuffle operations, but it can be resolved by overriding DataContext.

## Related issue number

Closes #38400.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
