### PR TITLE
[docs] [data] fixing some hyperlinks

### DIFF
--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -12,11 +12,11 @@ to express a chain of computations.
 
 This guide shows you how to:
 
-* `Transform rows <#transforming-rows>`_
-* `Transform batches <#transforming-batches>`_
-* `Groupby and transform groups <#groupby-and-transforming-groups>`_
-* `Shuffle rows <#shuffling-rows>`_
-* `Repartition data <#repartitioning-data>`_
+* :ref:`Transform rows <transforming_rows>`
+* :ref:`Transform batches <transforming_batches>`
+* :ref:`Groupby and transform groups <transforming_groupby>`
+* :ref:`Shuffle rows <shuffling_rows>`
+* :ref:`Repartition data <repartitioning_data>`
 
 .. _transforming_rows:
 
@@ -311,6 +311,8 @@ To transform groups, call :meth:`~ray.data.Dataset.groupby` to group rows. Then,
                 .map_groups(normalize_features)
             )
 
+.. _shuffling_rows:
+
 Shuffling rows
 ==============
 
@@ -329,6 +331,8 @@ To randomly shuffle all rows, call :meth:`~ray.data.Dataset.random_shuffle`.
 
     :meth:`~ray.data.Dataset.random_shuffle` is slow. For better performance, try
     :ref:`Iterating over batches with shuffling <iterating-over-batches-with-shuffling>`.
+
+.. _repartitioning_data:
 
 Repartitioning data
 ===================


### PR DESCRIPTION
The `Transform batches` hyperlink under the `This guide shows you how to:`. The other links work, but the syntax is not consistent.  Re-doing the hyperlinks to have a consistent syntax.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
