### PR TITLE
[ci] Use release test pipeline v2

### DIFF
--- a/release/ray_release/byod/build_ray.py
+++ b/release/ray_release/byod/build_ray.py
@@ -19,8 +19,8 @@ def build_ray(tests: List[Test]) -> None:
     """
     Builds ray and ray-ml images for PR builds
     """
-    if not _is_pr():
-        logger.info("Not a PR, skipping build_ray")
+    if not _is_pr() or os.environ.get("RAYCI_V2"):
+        logger.info("Skip building Ray on PR builds and CIv2")
         return
     start = int(time.time())
     base_image = _get_docker_name()


### PR DESCRIPTION
In civ2, release test pipeline doesn't need to wait for external ray image since the image is built within the pipeline itself.

Use a special env-var to distinguish the two pipelines, to keep both pipeline function for now.

Test:
- CI
- Test pipeline on this PR: https://buildkite.com/ray-project/release/builds/25#_