### PR TITLE
[core] Fix autoscaler v2 for gcs FT

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -128,7 +128,7 @@ def test_autoscaler_init(
     check that the removed node will die finally.
     """
     cluster = ray_start_cluster_head_with_external_redis
-    worker = cluster.add_node()
+    cluster.add_node()
     cluster.wait_for_nodes()
 
     # Make sure both head and worker node are alive.

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -113,6 +113,56 @@ def test_gcs_server_restart_during_actor_creation(
             health_check_initial_delay_ms=0,
             health_check_period_ms=1000,
             health_check_failure_threshold=3,
+            enable_autoscaler_v2=True,
+        ),
+    ],
+    indirect=True,
+)
+def test_autoscaler_init(
+    ray_start_cluster_head_with_external_redis,
+):
+    """Checks that the node failure detector is correct when gcs server restart.
+
+    We set the cluster to timeout nodes after 2 seconds of heartbeats. We then
+    kill gcs server and remove the worker node and restart gcs server again to
+    check that the removed node will die finally.
+    """
+    cluster = ray_start_cluster_head_with_external_redis
+    worker = cluster.add_node()
+    cluster.wait_for_nodes()
+
+    # Make sure both head and worker node are alive.
+    nodes = ray.nodes()
+    assert len(nodes) == 2
+    assert nodes[0]["alive"] and nodes[1]["alive"]
+
+    head_node = cluster.head_node
+    gcs_server_process = head_node.all_processes["gcs_server"][0].process
+    gcs_server_pid = gcs_server_process.pid
+    # Kill gcs server.
+    cluster.head_node.kill_gcs_server()
+    # Wait to prevent the gcs server process becoming zombie.
+    gcs_server_process.wait()
+    wait_for_pid_to_exit(gcs_server_pid, 1000)
+
+    # Restart gcs server process.
+    cluster.head_node.start_gcs_server()
+
+    from ray.autoscaler.v2.sdk import get_cluster_status
+
+    status = get_cluster_status(ray.get_runtime_context().gcs_address)
+    assert len(status.idle_nodes) == 2
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_external_redis",
+    [
+        generate_system_config_map(
+            gcs_failover_worker_reconnect_timeout=2,
+            gcs_rpc_server_reconnect_timeout_s=60,
+            health_check_initial_delay_ms=0,
+            health_check_period_ms=1000,
+            health_check_failure_threshold=3,
         ),
     ],
     indirect=True,

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -143,7 +143,7 @@ def test_autoscaler_init(
     cluster.head_node.kill_gcs_server()
     # Wait to prevent the gcs server process becoming zombie.
     gcs_server_process.wait()
-    wait_for_pid_to_exit(gcs_server_pid, 1000)
+    wait_for_pid_to_exit(gcs_server_pid, 300)
 
     # Restart gcs server process.
     cluster.head_node.start_gcs_server()

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -121,11 +121,8 @@ def test_gcs_server_restart_during_actor_creation(
 def test_autoscaler_init(
     ray_start_cluster_head_with_external_redis,
 ):
-    """Checks that the node failure detector is correct when gcs server restart.
-
-    We set the cluster to timeout nodes after 2 seconds of heartbeats. We then
-    kill gcs server and remove the worker node and restart gcs server again to
-    check that the removed node will die finally.
+    """
+    Checks that autoscaler initializes properly after GCS restarts.
     """
     cluster = ray_start_cluster_head_with_external_redis
     cluster.add_node()

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -231,6 +231,14 @@ GcsAutoscalerStateManager::GetAggregatedResourceLoad() const {
   return aggregate_load;
 };
 
+void GcsAutoscalerStateManager::Initialize(const GcsInitData &gcs_init_data) {
+  for (const auto &entry : gcs_init_data.Nodes()) {
+    if (entry.second.state() == rpc::GcsNodeInfo::ALIVE) {
+      OnNodeAdd(entry.second);
+    }
+  }
+}
+
 void GcsAutoscalerStateManager::GetPendingResourceRequests(
     rpc::autoscaler::ClusterResourceState *state) {
   auto aggregate_load = GetAggregatedResourceLoad();

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "ray/gcs/gcs_server/gcs_init_data.h"
 #include "ray/rpc/gcs_server/gcs_rpc_server.h"
 #include "ray/rpc/node_manager/node_manager_client_pool.h"
 #include "src/ray/protobuf/gcs.pb.h"
@@ -61,6 +62,8 @@ class GcsAutoscalerStateManager : public rpc::autoscaler::AutoscalerStateHandler
   void RecordMetrics() const { throw std::runtime_error("Unimplemented"); }
 
   std::string DebugString() const { throw std::runtime_error("Unimplemented"); }
+
+  void Initialize(const GcsInitData &gcs_init_data);
 
   void OnNodeAdd(const rpc::GcsNodeInfo &node);
 

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -234,7 +234,7 @@ void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
   InstallEventListeners();
 
   // Init autoscaling manager
-  InitGcsAutoscalerStateManager();
+  InitGcsAutoscalerStateManager(gcs_init_data);
 
   // Start RPC server when all tables have finished loading initial
   // data.
@@ -647,7 +647,7 @@ void GcsServer::InitGcsWorkerManager() {
   rpc_server_.RegisterService(*worker_info_service_);
 }
 
-void GcsServer::InitGcsAutoscalerStateManager() {
+void GcsServer::InitGcsAutoscalerStateManager(const GcsInitData &gcs_init_data) {
   RAY_CHECK(kv_manager_) << "kv_manager_ is not initialized.";
   auto v2_enabled = std::to_string(RayConfig::instance().enable_autoscaler_v2());
   RAY_LOG(INFO) << "Autoscaler V2 enabled: " << v2_enabled;
@@ -680,6 +680,7 @@ void GcsServer::InitGcsAutoscalerStateManager() {
                                                   *gcs_node_manager_,
                                                   *gcs_placement_group_manager_,
                                                   raylet_client_pool_);
+  gcs_autoscaler_state_manager_->Initialize(gcs_init_data);
 
   autoscaler_state_service_.reset(new rpc::autoscaler::AutoscalerStateGrpcService(
       main_service_, *gcs_autoscaler_state_manager_));

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -150,7 +150,7 @@ class GcsServer {
   void InitGcsTaskManager();
 
   /// Initialize gcs autoscaling manager.
-  void InitGcsAutoscalerStateManager();
+  void InitGcsAutoscalerStateManager(const GcsInitData &gcs_init_data);
 
   /// Initialize usage stats client.
   void InitUsageStatsClient();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

When recovering from Redis, we don't repopulate state in GcsAutoscalerStateManager (as it was stateless before). Since it is now stateful, fix this.

Verified that the added test fails on master.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
