### PR TITLE
[train] update config dataclass repr to check against None

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -71,11 +71,20 @@ def _repr_dataclass(obj, *, default_values: Optional[Dict[str, Any]] = None) -> 
 
     non_default_values = {}  # Maps field name to value.
 
+    def equals(value, default_value):
+        # We need to special case None because of a bug in pyarrow:
+        # https://github.com/apache/arrow/issues/38535
+        if value is None and default_value is None:
+            return True
+        if value is None or default_value is None:
+            return False
+        return value == default_value
+
     for field in fields(obj):
         value = getattr(obj, field.name)
         default_value = default_values.get(field.name, field.default)
         is_required = isinstance(field.default, _MISSING_TYPE)
-        if is_required or value != default_value:
+        if is_required or not equals(value, default_value):
             non_default_values[field.name] = value
 
     string = f"{obj.__class__.__name__}("

--- a/python/ray/air/tests/test_configs.py
+++ b/python/ray/air/tests/test_configs.py
@@ -31,10 +31,12 @@ def test_repr(config):
     assert eval(representation) == config
     assert len(representation) < MAX_REPR_LENGTH
 
+
 def test_storage_filesystem_repr():
     config = RunConfig(storage_filesystem=pyarrow.fs.S3FileSystem())
     representation = repr(config)
     assert len(representation) < MAX_REPR_LENGTH
+
 
 def test_failure_config_init():
     FailureConfig(fail_fast=True)

--- a/python/ray/air/tests/test_configs.py
+++ b/python/ray/air/tests/test_configs.py
@@ -1,5 +1,7 @@
 import pytest
 
+import pyarrow.fs
+
 from ray.train import (
     ScalingConfig,
     FailureConfig,
@@ -21,6 +23,7 @@ from ray.air.constants import MAX_REPR_LENGTH
         RunConfig(),
         RunConfig(name="experiment"),
         RunConfig(failure_config=FailureConfig()),
+        RunConfig(storage_filesystem=pyarrow.fs.S3FileSystem()),
     ],
 )
 def test_repr(config):

--- a/python/ray/air/tests/test_configs.py
+++ b/python/ray/air/tests/test_configs.py
@@ -23,7 +23,6 @@ from ray.air.constants import MAX_REPR_LENGTH
         RunConfig(),
         RunConfig(name="experiment"),
         RunConfig(failure_config=FailureConfig()),
-        RunConfig(storage_filesystem=pyarrow.fs.S3FileSystem()),
     ],
 )
 def test_repr(config):
@@ -32,6 +31,10 @@ def test_repr(config):
     assert eval(representation) == config
     assert len(representation) < MAX_REPR_LENGTH
 
+def test_storage_filesystem_repr():
+    config = RunConfig(storage_filesystem=pyarrow.fs.S3FileSystem())
+    representation = repr(config)
+    assert len(representation) < MAX_REPR_LENGTH
 
 def test_failure_config_init():
     FailureConfig(fail_fast=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This is needed because custom pyarrow filesystems will raise a SIGSEGV if checking equality against None.

**Context:** https://ray-distributed.slack.com/archives/CSX7HVB5L/p1698796987044039

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/apache/arrow/issues/38535

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
