### PR TITLE
[GCS FT] Update Redis connection configs

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -321,9 +321,9 @@ RAY_CONFIG(int, worker_oom_score_adjustment, 1000)
 /// NOTE: Linux, Unix and MacOS only.
 RAY_CONFIG(int, worker_niceness, 15)
 
-/// Allow up to 60 seconds for connecting to Redis.
-RAY_CONFIG(int64_t, redis_db_connect_retries, 600)
-RAY_CONFIG(int64_t, redis_db_connect_wait_milliseconds, 100)
+/// Allow at least 60 seconds for connecting to Redis.
+RAY_CONFIG(int64_t, redis_db_connect_retries, 120)
+RAY_CONFIG(int64_t, redis_db_connect_wait_milliseconds, 500)
 
 /// Number of retries for a redis request failure.
 RAY_CONFIG(size_t, num_redis_request_retries, 5)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```
RAY_CONFIG(int64_t, redis_db_connect_retries, 120)
RAY_CONFIG(int64_t, redis_db_connect_wait_milliseconds, 500)
```

`redis_db_connect_retries * redis_db_connect_wait_milliseconds` is not the upper bound but the lower bound for the timeout of reconnection. Check the function [ConnectWithRetries](https://sourcegraph.com/github.com/ray-project/ray@ray-2.7.1/-/blob/src/ray/gcs/redis_context.cc?L360) for more details.

In my experiments, the combination of `redis_db_connect_retries = 600` and `redis_db_connect_wait_milliseconds = 100` takes 13 mins to fail. See [this gist](https://gist.github.com/kevin85421/271841ddc5816340765a44520de834c1) for more details about the experiment. The combination of `redis_db_connect_retries = 120` and `redis_db_connect_wait_milliseconds = 500` takes 3m10s to fail. See [this gist](https://gist.github.com/kevin85421/63fc2936430472213396c59e1a8a7783) for more details.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
