### PR TITLE
[cd] tag anyscale image with all sort of aliases

### DIFF
--- a/ci/ray_ci/anyscale_docker_container.py
+++ b/ci/ray_ci/anyscale_docker_container.py
@@ -17,12 +17,20 @@ class AnyscaleDockerContainer(DockerContainer):
         anyscale_image = f"{ecr}/anyscale/{self.image_type}:{tag}"
         requirement = self._get_requirement_file()
 
-        self.run_script(
-            [
-                f"./ci/build/build-anyscale-docker.sh "
-                f"{ray_image} {anyscale_image} {requirement} {ecr}",
+        cmds = [
+            f"./ci/build/build-anyscale-docker.sh "
+            f"{ray_image} {anyscale_image} {requirement} {ecr}",
+        ]
+        # TODO(can): remove the alias when release test infra uses only the canonical
+        # tag
+        for alias in self._get_image_tags():
+            alias_image = f"{ecr}/anyscale/{self.image_type}:{alias}"
+            cmds += [
+                f"docker tag {anyscale_image} {alias_image}",
+                f"docker push {alias_image}",
             ]
-        )
+
+        self.run_script(cmds)
 
     def _get_requirement_file(self) -> str:
         prefix = "requirements" if self.image_type == "ray" else "requirements_ml"

--- a/ci/ray_ci/test_anyscale_docker_container.py
+++ b/ci/ray_ci/test_anyscale_docker_container.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from typing import List
 from unittest import mock
 
@@ -18,15 +19,22 @@ class TestAnyscaleDockerContainer(RayCITestBase):
         with mock.patch(
             "ci.ray_ci.docker_container.Container.run_script",
             side_effect=_mock_run_script,
-        ):
-            container = AnyscaleDockerContainer("3.8", "cu11.8.0", "ray")
+        ), mock.patch.dict(os.environ, {"BUILDKITE_BRANCH": "test_branch"}):
+            container = AnyscaleDockerContainer("3.9", "cu11.8.0", "ray-ml")
             container.run()
             cmd = self.cmds[-1]
+            ecr = "029272617770.dkr.ecr.us-west-2.amazonaws.com"
+            project = f"{ecr}/anyscale/ray-ml"
             assert cmd == [
-                "./ci/build/build-anyscale-docker.sh rayproject/ray:123456-py38-cu118 "
-                "029272617770.dkr.ecr.us-west-2.amazonaws.com"
-                "/anyscale/ray:123456-py38-cu118 requirements_byod_3.8.txt "
-                "029272617770.dkr.ecr.us-west-2.amazonaws.com",
+                "./ci/build/build-anyscale-docker.sh "
+                "rayproject/ray-ml:123456-py39-cu118 "
+                f"{project}:123456-py39-cu118 requirements_ml_byod_3.9.txt {ecr}",
+                f"docker tag {project}:123456-py39-cu118 {project}:123456-py39-cu118",
+                f"docker push {project}:123456-py39-cu118",
+                f"docker tag {project}:123456-py39-cu118 {project}:123456-py39-gpu",
+                f"docker push {project}:123456-py39-gpu",
+                f"docker tag {project}:123456-py39-cu118 {project}:123456-py39",
+                f"docker push {project}:123456-py39",
             ]
 
 


### PR DESCRIPTION
Build anyscale images with all possible alias tags. The release test infra uses some of the alias and not the canonical tag. I'll remove this alias logic once we can get release test infra to use only the canonical tag (needs to completely deprecate its old version first).

Test:
- CI