### PR TITLE
[Train] Add a barrier in RayTrainReportCallback to ensure synchronous reporting.

### DIFF
--- a/python/ray/train/lightning/_lightning_utils.py
+++ b/python/ray/train/lightning/_lightning_utils.py
@@ -270,6 +270,9 @@ class RayTrainReportCallback(pl.callbacks.Callback):
         checkpoint = Checkpoint.from_directory(tmpdir)
         train.report(metrics=metrics, checkpoint=checkpoint)
 
+        # Add a barrier to ensure all workers finished reporting here
+        torch.distributed.barrier()
+
         if self.local_rank == 0:
             shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`ray.train.report` ensures that all workers enter at the same time, but there are no barriers preventing all workers from exiting at the same time. This could lead to an `FileNotFoundError` in `RayTrainReportCallback`, where local_rank_0 worker exit earlier, deleted the ckpt folder, while other workers are still uploading it.

This PR fixed this bug by adding a barrier call right after `ray.train.report`.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
