### PR TITLE
[docs] Fix broken Spotify link

### DIFF
--- a/doc/source/ray-air/getting-started.rst
+++ b/doc/source/ray-air/getting-started.rst
@@ -42,7 +42,7 @@ Example ML Platforms built on Ray
 
   Shopify's Merlin architecture built on Ray.
 
-Spotify `uses Ray for advanced applications <https://www.anyscale.com/ray-summit-2022/agenda/sessions/180>`_ that include personalizing content recommendations for home podcasts, and personalizing Spotify Radio track sequencing.
+Spotify `uses Ray for advanced applications <https://engineering.atspotify.com/2023/02/unleashing-ml-innovation-at-spotify-with-ray/>`_ that include personalizing content recommendations for home podcasts, and personalizing Spotify Radio track sequencing.
 
 .. figure:: /images/spotify.png
 


### PR DESCRIPTION
Link to Anyscale Summit no longer exists. Changing to Spotify blog for Ray.
Fixing linkcheck error.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
