### PR TITLE
[data] fixed the columns when reading a partitioned parquet dataset with one file after filtering

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -213,10 +213,12 @@ class _ParquetDatasourceReader(Reader):
 
             filtered_paths = set(expanded_paths) - set(paths)
             if filtered_paths:
-                logger.info(f"Filtered out the following paths: {filtered_paths}")
+                logger.debug(f"Filtered out the following paths: {filtered_paths}")
 
-        if len(paths) == 1:
-            paths = paths[0]
+        else:
+            # When partition_filter is used, we do not need this for full paths
+            if len(paths) == 1:
+                paths = paths[0]
 
         dataset_kwargs = reader_args.pop("dataset_kwargs", {})
         try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Pyarrow's `ParquetDataset` in ParquetDatasource treats the following cases differently:
- a partitioned parquet dataset is filtered down to one file (a list of one path, e.g., `["base_dir/x=0/abc.parquet"]`)
- a folder (e.g., `"base_dir/"`)
- a single file with full path (one path, e.g., `"base_dir/x=0/abc.parquet"`)

However, the original code treats these cases the same, so that no partition column is included in the first case.

This PR fixes the first case so that a list of one path is provided to `ParquetDataset`.

This PR also changes one log line from INFO to DEBUG because it prints a lot of file names with a large dataset.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
