### PR TITLE
[Data] Use reversed/items instead of list/[::-1] to iterate topology in reversed insert order

### DIFF
--- a/python/ray/data/_internal/execution/backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy.py
@@ -193,7 +193,7 @@ class StreamingOutputBackpressurePolicy(BackpressurePolicy):
     ) -> Dict["OpState", int]:
         max_blocks_to_read_per_op: Dict["OpState", int] = {}
         downstream_num_active_tasks = 0
-        for op, state in list(topology.items())[::-1]:
+        for op, state in reversed(topology.items()):
             max_blocks_to_read_per_op[state] = (
                 self._max_num_blocks_in_op_output_queue - state.outqueue_num_blocks()
             )

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -77,7 +77,7 @@ class TopologyResourceUsage:
         downstream_usage = {}
         cur_usage = ExecutionResources(0, 0, 0)
         # Iterate from last to first operator.
-        for op, state in list(topology.items())[::-1]:
+        for op, state in reversed(topology.items()):
             cur_usage = cur_usage.add(op.current_resource_usage())
             # Don't count input refs towards dynamic memory usage, as they have been
             # pre-created already outside this execution.


### PR DESCRIPTION
Ray >=2.8 will not support Python 3.7, so we can use reversed/items (introduced in [Python 3.8](https://docs.python.org/3/whatsnew/3.8.html#other-language-changes)) instead of list/[::-1] to avoid converting the whole topology dict into a list many times.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
