### PR TITLE
[Core] Fix test_hpu.py

### DIFF
--- a/python/ray/tests/accelerators/test_hpu.py
+++ b/python/ray/tests/accelerators/test_hpu.py
@@ -8,7 +8,7 @@ from ray._private.accelerators import HPUAcceleratorManager
 from ray._private.accelerators import hpu
 
 
-def test_user_configured_more_than_visible(monkeypatch, shutdown_only):
+def test_user_configured_more_than_visible(monkeypatch, call_ray_stop_only):
     # Test more hpus are configured than visible.
     monkeypatch.setenv("HABANA_VISIBLE_MODULES", "0,1,2")
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, when Ray throws an exception in the middle of `Node` constructor, there can be leaked processes that can not be terminated by `ray.shutdown()` since `ray.shutdown()` relies on `_global_node = ray._private.node.Node(...)` to be set but it will be None if the constructor throws the exception. 

We need to have better handling of exceptions in this case but for now I just use `ray stop` to kill all processes.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #40866
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
