### PR TITLE
[data] create StatsManager to manage _StatsActor remote calls

### DIFF
--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -1,5 +1,4 @@
 import collections
-import time
 from contextlib import nullcontext
 from typing import Any, Callable, Dict, Iterator, Optional, Tuple
 
@@ -16,23 +15,15 @@ from ray.data._internal.block_batching.util import (
     resolve_block_refs,
 )
 from ray.data._internal.memory_tracing import trace_deallocation
-from ray.data._internal.stats import (
-    DatasetStats,
-    clear_stats_actor_iter_metrics,
-    update_stats_actor_iter_metrics,
-)
+from ray.data._internal.stats import DatasetStats
 from ray.data._internal.util import make_async_gen
 from ray.data.block import Block, BlockMetadata, DataBatch
 from ray.data.context import DataContext
 from ray.types import ObjectRef
 
-# Interval for metrics update remote calls to _StatsActor during iteration.
-STATS_UPDATE_INTERVAL_SECONDS = 30
-
 
 def iter_batches(
     block_refs: Iterator[Tuple[ObjectRef[Block], BlockMetadata]],
-    dataset_tag: str,
     *,
     stats: Optional[DatasetStats] = None,
     clear_block_after_read: bool = False,
@@ -178,9 +169,7 @@ def iter_batches(
     # Run everything in a separate thread to not block the main thread when waiting
     # for streaming results.
     async_batch_iter = make_async_gen(block_refs, fn=_async_iter_batches, num_workers=1)
-    metrics_tag = {"dataset": dataset_tag}
 
-    last_stats_update_time = 0
     while True:
         with stats.iter_total_blocked_s.timer() if stats else nullcontext():
             try:
@@ -189,11 +178,6 @@ def iter_batches(
                 break
         with stats.iter_user_s.timer() if stats else nullcontext():
             yield next_batch
-
-        if time.time() - last_stats_update_time >= STATS_UPDATE_INTERVAL_SECONDS:
-            update_stats_actor_iter_metrics(stats, metrics_tag)
-            last_stats_update_time = time.time()
-    clear_stats_actor_iter_metrics(metrics_tag)
 
 
 def _format_in_threadpool(

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -121,7 +121,9 @@ class StreamingExecutor(Executor, threading.Thread):
             self._global_info = ProgressBar("Running", dag.num_outputs_total())
 
         self._output_node: OpState = self._topology[dag]
-        StatsManager.register_dataset_to_stats_actor(self._dataset_tag, [tag["operator"] for tag in self._get_metrics_tags()])
+        StatsManager.register_dataset_to_stats_actor(
+            self._dataset_tag, [tag["operator"] for tag in self._get_metrics_tags()]
+        )
         self.start()
 
         class StreamIterator(OutputIterator):

--- a/python/ray/data/_internal/iterator/iterator_impl.py
+++ b/python/ray/data/_internal/iterator/iterator_impl.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Iterator, Optional, Tuple, Union
 
 from ray.data._internal.stats import DatasetStats
+from ray.data._internal.util import create_dataset_tag
 from ray.data.block import Block, BlockMetadata
 from ray.data.iterator import DataIterator
 from ray.types import ObjectRef
@@ -58,4 +59,6 @@ class DataIteratorImpl(DataIterator):
         raise AttributeError()
 
     def _get_dataset_tag(self):
-        return (self._base_dataset._plan._dataset_name or "") + self._base_dataset._uuid
+        return create_dataset_tag(
+            self._base_dataset._plan._dataset_name, self._base_dataset._uuid
+        )

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -11,6 +11,7 @@ from ray.data._internal.execution.legacy_compat import execute_to_legacy_bundle_
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter
 from ray.data._internal.execution.streaming_executor import StreamingExecutor
 from ray.data._internal.stats import DatasetStats, DatasetStatsSummary
+from ray.data._internal.util import create_dataset_tag
 from ray.data.block import Block, BlockMetadata
 from ray.data.iterator import DataIterator
 from ray.types import ObjectRef
@@ -110,6 +111,13 @@ class StreamSplitDataIterator(DataIterator):
     def world_size(self) -> int:
         """Returns the number of splits total."""
         return self._world_size
+
+    def _get_dataset_tag(self):
+        return create_dataset_tag(
+            self._base_dataset._plan._dataset_name,
+            self._base_dataset._uuid,
+            self._output_split_idx,
+        )
 
 
 @ray.remote(num_cpus=0)

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -39,7 +39,11 @@ from ray.data._internal.planner.plan_read_op import (
     apply_output_blocks_handling_to_read_task,
 )
 from ray.data._internal.stats import DatasetStats, DatasetStatsSummary
-from ray.data._internal.util import capitalize, unify_block_metadata_schema
+from ray.data._internal.util import (
+    capitalize,
+    create_dataset_tag,
+    unify_block_metadata_schema,
+)
 from ray.data.block import Block, BlockMetadata
 from ray.data.context import DataContext
 from ray.types import ObjectRef
@@ -532,9 +536,8 @@ class ExecutionPlan:
         )
         from ray.data._internal.execution.streaming_executor import StreamingExecutor
 
-        executor = StreamingExecutor(
-            copy.deepcopy(ctx.execution_options), self._dataset_uuid
-        )
+        metrics_tag = create_dataset_tag(self._dataset_name, self._dataset_uuid)
+        executor = StreamingExecutor(copy.deepcopy(ctx.execution_options), metrics_tag)
         block_iter = execute_to_legacy_block_iterator(
             executor,
             self,
@@ -591,7 +594,7 @@ class ExecutionPlan:
                     StreamingExecutor,
                 )
 
-                metrics_tag = (self._dataset_name or "dataset") + self._dataset_uuid
+                metrics_tag = create_dataset_tag(self._dataset_name, self._dataset_uuid)
                 executor = StreamingExecutor(
                     copy.deepcopy(context.execution_options),
                     metrics_tag,

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -864,3 +864,10 @@ def make_async_gen(
         num_threads_alive = num_workers - num_threads_finished
         if num_threads_alive > 0:
             output_queue.release(num_threads_alive)
+
+
+def create_dataset_tag(dataset_name: Optional[str], *args):
+    tag = dataset_name or "dataset"
+    for arg in args:
+        tag += f"_{arg}"
+    return tag

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -83,11 +83,7 @@ from ray.data._internal.stage_impl import (
     SortStage,
     ZipStage,
 )
-from ray.data._internal.stats import (
-    DatasetStats,
-    DatasetStatsSummary,
-    get_dataset_id_from_stats_actor,
-)
+from ray.data._internal.stats import DatasetStats, DatasetStatsSummary, StatsManager
 from ray.data._internal.util import (
     AllToAllAPI,
     ConsumptionAPI,
@@ -256,7 +252,7 @@ class Dataset:
         self._current_executor: Optional["Executor"] = None
         self._write_ds = None
 
-        self._set_uuid(get_dataset_id_from_stats_actor())
+        self._set_uuid(StatsManager.get_dataset_id_from_stats_actor())
 
     @staticmethod
     def copy(

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -850,6 +850,7 @@ class DataIterator(abc.ABC):
         )
 
     def __del__(self):
+        # Clear metrics on deletion in case the iterator was not fully consumed.
         StatsManager.clear_stats_actor_iter_metrics(
             {"dataset": self._get_dataset_tag()}
         )

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -179,11 +179,11 @@ class DataIterator(abc.ABC):
                 )
             )
 
-            metrics_tag = {"dataset": self._get_dataset_tag()}
+            dataset_tag = self._get_dataset_tag()
             for batch in iterator:
                 yield batch
-                StatsManager.update_stats_actor_iter_metrics(stats, metrics_tag)
-            StatsManager.clear_stats_actor_iter_metrics(metrics_tag)
+                StatsManager.update_iteration_metrics(stats, dataset_tag)
+            StatsManager.clear_iteration_metrics(dataset_tag)
 
             if stats:
                 stats.iter_total_s.add(time.perf_counter() - time_start)
@@ -851,9 +851,7 @@ class DataIterator(abc.ABC):
 
     def __del__(self):
         # Clear metrics on deletion in case the iterator was not fully consumed.
-        StatsManager.clear_stats_actor_iter_metrics(
-            {"dataset": self._get_dataset_tag()}
-        )
+        StatsManager.clear_iteration_metrics(self._get_dataset_tag())
 
 
 # Backwards compatibility alias.

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1353,6 +1353,7 @@ def test_stats_actor_datasets(ray_start_cluster):
 @patch.object(StatsManager, "_stats_actor_handle")
 @patch.object(StatsManager, "UPDATE_THREAD_INACTIVITY_LIMIT", new=1)
 def test_stats_manager(shutdown_only):
+    ray.init()
     num_threads = 10
 
     datasets = [None] * num_threads


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Creates a `StatsManager` class to manage remote calls to `_StatsActor`.

This singleton manager controls the time interval for reporting metrics to `_StatsActor`:
- Runs a single background thread that reports metrics to `_StatsActor` every 5s
- This thread is stopped after being inactive for too long, and will be restarted if there is a new update afterwards

Also logs op metrics for `_debug_dump_topology`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
