### PR TITLE
[kuberay][autoscaler] Update KubeRay version to v1.0.0

### DIFF
--- a/python/ray/autoscaler/kuberay/init-config.sh
+++ b/python/ray/autoscaler/kuberay/init-config.sh
@@ -2,8 +2,8 @@
 
 # Clone pinned Kuberay commit to temporary directory, copy the CRD definitions
 # into the autoscaler folder.
-KUBERAY_BRANCH="v1.0.0-rc.2"
-OPERATOR_TAG="v1.0.0-rc.2"
+KUBERAY_BRANCH="v1.0.0"
+OPERATOR_TAG="v1.0.0"
 
 # Requires Kustomize
 if ! command -v kustomize &> /dev/null

--- a/python/ray/autoscaler/kuberay/init-config.sh
+++ b/python/ray/autoscaler/kuberay/init-config.sh
@@ -2,8 +2,8 @@
 
 # Clone pinned Kuberay commit to temporary directory, copy the CRD definitions
 # into the autoscaler folder.
-KUBERAY_BRANCH="v0.6.0"
-OPERATOR_TAG="v0.6.0"
+KUBERAY_BRANCH="v1.0.0-rc.2"
+OPERATOR_TAG="v1.0.0-rc.2"
 
 # Requires Kustomize
 if ! command -v kustomize &> /dev/null

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -19,7 +19,6 @@ from ray.tests.kuberay.utils import (
     switch_to_ray_parent_dir,
     kubectl_exec_python_script,
     kubectl_logs,
-    kubectl_patch,
     kubectl_delete,
     wait_for_pods,
     wait_for_pod_to_start,
@@ -80,9 +79,8 @@ class KubeRayAutoscalingTest(unittest.TestCase):
         with open(EXAMPLE_CLUSTER_PATH) as ray_cr_config_file:
             ray_cr_config_str = ray_cr_config_file.read()
 
-        kuberay_crd_sets = set(["RayCluster", "RayJob", "RayService"])
         for k8s_object in yaml.safe_load_all(ray_cr_config_str):
-            if k8s_object['kind'] in kuberay_crd_sets:
+            if k8s_object['kind'] in ["RayCluster", "RayJob", "RayService"]:
                 config = k8s_object
                 break
         head_group = config["spec"]["headGroupSpec"]

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -80,7 +80,7 @@ class KubeRayAutoscalingTest(unittest.TestCase):
             ray_cr_config_str = ray_cr_config_file.read()
 
         for k8s_object in yaml.safe_load_all(ray_cr_config_str):
-            if k8s_object['kind'] in ["RayCluster", "RayJob", "RayService"]:
+            if k8s_object["kind"] in ["RayCluster", "RayJob", "RayService"]:
                 config = k8s_object
                 break
         head_group = config["spec"]["headGroupSpec"]

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -47,7 +47,7 @@ logger.info(f"Using pull policy `{PULL_POLICY}` for all images.")
 
 # Path to example config rel RAY_PARENT
 EXAMPLE_CLUSTER_PATH = (
-    "ray/python/ray/autoscaler/kuberay/config/samples/ray-cluster.autoscaler.yaml"
+    "ray/python/ray/tests/kuberay/test_files/ray-cluster.autoscaler-template.yaml"
 )
 
 HEAD_SERVICE = "raycluster-autoscaler-head-svc"
@@ -79,7 +79,12 @@ class KubeRayAutoscalingTest(unittest.TestCase):
         """
         with open(EXAMPLE_CLUSTER_PATH) as ray_cr_config_file:
             ray_cr_config_str = ray_cr_config_file.read()
-        config = yaml.safe_load(ray_cr_config_str)
+
+        kuberay_crd_sets = set(["RayCluster", "RayJob", "RayService"])
+        for k8s_object in yaml.safe_load_all(ray_cr_config_str):
+            if k8s_object['kind'] in kuberay_crd_sets:
+                config = k8s_object
+                break
         head_group = config["spec"]["headGroupSpec"]
         head_group["rayStartParams"][
             "resources"

--- a/python/ray/tests/kuberay/test_files/ray-cluster.autoscaler-template.yaml
+++ b/python/ray/tests/kuberay/test_files/ray-cluster.autoscaler-template.yaml
@@ -1,5 +1,8 @@
 # `ray-cluster.autoscaler-template.yaml` is a template for the RayCluster CR and
 # is used by the function `_get_ray_cr_config` in `test_autoscaling_e2e.py`.
+# [Note]
+# (1) The VM test runner only has 4 CPUs, so we lower the CPU requests.
+# (2) `test_autoscaling_e2e.py` assumes that each Ray Pod has 1 logical CPU.
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
@@ -35,6 +38,7 @@ spec:
             name: dashboard
           - containerPort: 10001
             name: client
+          imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
               exec:
@@ -44,7 +48,7 @@ spec:
               cpu: "1"
               memory: "2G"
             requests:
-              cpu: "1"
+              cpu: "500m"
               memory: "2G"
   workerGroupSpecs:
   - replicas: 1
@@ -61,10 +65,11 @@ spec:
             preStop:
               exec:
                 command: ["/bin/sh","-c","ray stop"]
+          imagePullPolicy: IfNotPresent
           resources:
             limits:
               cpu: "1"
               memory: "1G"
             requests:
-              cpu: "1"
+              cpu: "500m"
               memory: "1G"

--- a/python/ray/tests/kuberay/test_files/ray-cluster.autoscaler-template.yaml
+++ b/python/ray/tests/kuberay/test_files/ray-cluster.autoscaler-template.yaml
@@ -1,0 +1,70 @@
+# `ray-cluster.autoscaler-template.yaml` is a template for the RayCluster CR and
+# is used by the function `_get_ray_cr_config` in `test_autoscaling_e2e.py`.
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: raycluster-autoscaler
+spec:
+  # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
+  rayVersion: '2.7.0'
+  # If `enableInTreeAutoscaling` is true, the Autoscaler sidecar will be added to the Ray head pod.
+  # Ray Autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
+  enableInTreeAutoscaling: true
+  autoscalerOptions:
+    upscalingMode: Default
+    idleTimeoutSeconds: 60
+    imagePullPolicy: IfNotPresent
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+      requests:
+        cpu: "500m"
+        memory: "512Mi"
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.7.0
+          ports:
+          - containerPort: 6379
+            name: gcs
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          resources:
+            limits:
+              cpu: "1"
+              memory: "2G"
+            requests:
+              cpu: "1"
+              memory: "2G"
+  workerGroupSpecs:
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 10
+    groupName: small-group
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:2.7.0
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1G"
+            requests:
+              cpu: "1"
+              memory: "1G"

--- a/release/k8s_tests/run_gcs_ft_on_k8s.py
+++ b/release/k8s_tests/run_gcs_ft_on_k8s.py
@@ -51,7 +51,7 @@ def generate_cluster_variable():
 
 def check_kuberay_installed():
     # Make sure the ray namespace exists
-    KUBERAY_VERSION = "v1.0.0-rc.2"
+    KUBERAY_VERSION = "v1.0.0"
     uri = (
         "github.com/ray-project/kuberay/manifests"
         f"/base?ref={KUBERAY_VERSION}&timeout=90s"

--- a/release/k8s_tests/run_gcs_ft_on_k8s.py
+++ b/release/k8s_tests/run_gcs_ft_on_k8s.py
@@ -51,7 +51,7 @@ def generate_cluster_variable():
 
 def check_kuberay_installed():
     # Make sure the ray namespace exists
-    KUBERAY_VERSION = "v0.6.0"
+    KUBERAY_VERSION = "v1.0.0-rc.2"
     uri = (
         "github.com/ray-project/kuberay/manifests"
         f"/base?ref={KUBERAY_VERSION}&timeout=90s"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Create a YAML file `ray-cluster.autoscaler-template.yaml` for testing instead of using the YAML file `ray-cluster.autoscaler.yaml` in the KubeRay repository.
   * Note that the tests assume that both head and worker Pods have exactly 1 CPU. Hence, if we set `num-cpus: "0"` in the head's `rayStartParams`, the current test logic would not work. 

* Why do I remove the test for "Confirming that the operator and autoscaler ignore pods marked for termination"?
  * KubeRay tries to ensure the number of `runningPods`, but the definition of `runningPods` is a bit different from different KubeRay versions.
    * Definition 1: For KubeRay v0.6.0 and older, the definition of `runningPods` is the Pods that are running or pending and not terminating.
    * Definition 2: For KubeRay v1.0.0, the definition of `runningPods` becomes that Pods that their Ray containers are not actually terminated. See https://github.com/ray-project/kuberay/pull/1386 for more details.
    * That is, in definition 1, KubeRay may create new Pods if some Pods are in the terminating process. Hence, it is possible to have more than `maxReplicas` Pods & Ray nodes from both Kubernetes and Ray perspectives. In definition 2, KubeRay only creates new Pods when the Ray nodes are actually terminated.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

* CI tests pass
  * https://buildkite.com/ray-project/oss-ci-build-pr/builds/40875#018ba315-b595-468e-9161-2e0455072833
  * https://buildkite.com/ray-project/oss-ci-build-pr/builds/40875#018ba315-a4c6-4a3c-a86f-79afe2fb2731 
