### PR TITLE
[Data] Replace incorrect `write_datasource` calls with `write_datasink`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3004,7 +3004,7 @@ class Dataset:
             block_path_provider=block_path_provider,
             dataset_uuid=self._uuid,
         )
-        self.write_datasource(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
 
     @ConsumptionAPI
     def write_tfrecords(
@@ -3291,7 +3291,7 @@ class Dataset:
                 write tasks.
         """  # noqa: E501
         datasink = _SQLDatasink(sql=sql, connection_factory=connection_factory)
-        self.write_datasource(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
 
     @PublicAPI(stability="alpha")
     @ConsumptionAPI

--- a/python/ray/data/datasource/sql_datasink.py
+++ b/python/ray/data/datasource/sql_datasink.py
@@ -28,10 +28,10 @@ class _SQLDatasink(Datasink):
                     values.append(tuple(row.values()))
                     assert len(values) <= self._MAX_ROWS_PER_WRITE, len(values)
                     if len(values) == self._MAX_ROWS_PER_WRITE:
-                        cursor.executemany(sql, values)
+                        cursor.executemany(self.sql, values)
                         values = []
 
                 if values:
-                    cursor.executemany(sql, values)
+                    cursor.executemany(self.sql, values)
 
         return "ok"

--- a/python/ray/data/datasource/sql_datasink.py
+++ b/python/ray/data/datasource/sql_datasink.py
@@ -18,7 +18,6 @@ class _SQLDatasink(Datasink):
         self,
         blocks: Iterable[Block],
         ctx: TaskContext,
-        sql: str,
     ) -> Any:
         with _connect(self.connection_factory) as cursor:
             for block in blocks:

--- a/python/ray/data/tests/test_sql.py
+++ b/python/ray/data/tests/test_sql.py
@@ -70,3 +70,9 @@ def test_write_sql_nonexistant_table(temp_database: str):
         dataset.write_sql(
             "INSERT INTO test VALUES(?)", lambda: sqlite3.connect(temp_database)
         )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This bug fixes an issue where we call `write_datasource` instead of `write_datasink` in `write_sql` and `write_csv`. 

https://github.com/ray-project/ray/blob/c4179f70d5c9033564fa7203a26663d178e7159f/python/ray/data/dataset.py#L3007

The issue with `write_sql` wasn't caught because the SQL tests weren't running in CI (we forgot to call `pytest.main()`).

The issue with `write_csv` wasn't caught because the `write_datasource` and `write_datasink` implementations are similar, and for `write_csv` in particular it doesn't make a difference.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
