### PR TITLE
[ci] mark pip-compile as soft fail

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -99,5 +99,6 @@ steps:
       - rm ./python/requirements_compiled.txt
       - ./ci/ci.sh compile_pip_dependencies
       - cp -f ./python/requirements_compiled.txt /artifact-mount/
+    soft_fail: true
     depends_on:
       - forge

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -303,7 +303,10 @@ if __name__ == "__main__":
             ):
                 # These scripts are always run as part of the build process
                 RAY_CI_TOOLS_AFFECTED = 1
-            elif changed_file.endswith("build-docker-images.py"):
+            elif (
+                changed_file.endswith("build-docker-images.py")
+                or changed_file == ".buildkite/build.rayci.yml"
+            ):
                 RAY_CI_DOCKER_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_TOOLS_AFFECTED = 1


### PR DESCRIPTION
The pip-compile job has been failing due to the internet and blocking people in several cases, so mark it as soft fail. It should not be PR-blocking for most cases.

Test:
- CI