### PR TITLE
add worker debugger port to the state support

### DIFF
--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -664,6 +664,21 @@ class GlobalState:
             worker_data.SerializeToString()
         )
 
+    def update_worker_debugger_port(self, worker_id, debugger_port):
+        """Update the debugger port of a worker.
+
+        Args:
+            worker_id: ID of this worker. Type is bytes.
+            debugger_port: Port of the debugger. Type is int.
+
+        Returns:
+             Is operation success
+        """
+        self._check_connected()
+        return self.global_state_accessor.update_worker_debugger_port(
+            worker_id, debugger_port
+        )
+
     def cluster_resources(self):
         """Get the current total cluster resources.
 
@@ -933,3 +948,16 @@ def available_resources():
             resource in the cluster.
     """
     return state.available_resources()
+
+
+def update_worker_debugger_port(worker_id, debugger_port):
+    """Update the debugger port of a worker.
+
+    Args:
+        worker_id: ID of this worker. Type is bytes.
+        debugger_port: Port of the debugger. Type is int.
+
+    Returns:
+         Is operation success
+    """
+    return state.update_worker_debugger_port(worker_id, debugger_port)

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -675,6 +675,12 @@ class GlobalState:
              Is operation success
         """
         self._check_connected()
+
+        assert worker_id is not None, "worker_id is not valid"
+        assert (
+            debugger_port is not None and debugger_port > 0
+        ), "debugger_port is not valid"
+
         return self.global_state_accessor.update_worker_debugger_port(
             worker_id, debugger_port
         )

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -467,6 +467,8 @@ class Worker:
         # different drivers that connect to the same Serve instance.
         # See https://github.com/ray-project/ray/pull/35070.
         self._filter_logs_by_job = True
+        # the debugger port for this worker
+        self._debugger_port = None
 
     @property
     def connected(self):
@@ -540,6 +542,16 @@ class Worker:
     def runtime_env(self):
         """Get the runtime env in json format"""
         return self.core_worker.get_current_runtime_env()
+
+    @property
+    def debugger_port(self):
+        """Get the debugger port for this worker"""
+        return self._debugger_port
+
+    def set_debugger_port(self, port):
+        worker_id = self.core_worker.get_worker_id()
+        ray._private.state.update_worker_debugger_port(worker_id, port)
+        self._debugger_port = port
 
     def set_err_file(self, err_file=Optional[IO[AnyStr]]) -> None:
         """Set the worker's err file where stderr is redirected to"""

--- a/python/ray/includes/global_state_accessor.pxd
+++ b/python/ray/includes/global_state_accessor.pxd
@@ -2,7 +2,7 @@ from libcpp.string cimport string as c_string
 from libcpp cimport bool as c_bool
 from libcpp.vector cimport vector as c_vector
 from libcpp.memory cimport unique_ptr
-from libc.stdint cimport int32_t as c_int32_t
+from libc.stdint cimport int32_t as c_int32_t, uint32_t as c_uint32_t
 from ray.includes.unique_ids cimport (
     CActorID,
     CJobID,
@@ -38,6 +38,8 @@ cdef extern from "ray/gcs/gcs_client/global_state_accessor.h" nogil:
         unique_ptr[c_string] GetWorkerInfo(const CWorkerID &worker_id)
         c_vector[c_string] GetAllWorkerInfo()
         c_bool AddWorkerInfo(const c_string &serialized_string)
+        c_bool UpdateWorkerDebuggerPort(const CWorkerID &worker_id,
+                                        const c_uint32_t debuger_port)
         unique_ptr[c_string] GetPlacementGroupInfo(
             const CPlacementGroupID &placement_group_id)
         unique_ptr[c_string] GetPlacementGroupByName(

--- a/python/ray/includes/global_state_accessor.pxi
+++ b/python/ray/includes/global_state_accessor.pxi
@@ -180,7 +180,8 @@ cdef class GlobalStateAccessor:
         cdef CWorkerID cworker_id = CWorkerID.FromBinary(worker_id.binary())
         cdef c_uint32_t cdebugger_port = debugger_port
         with nogil:
-            result = self.inner.get().UpdateWorkerDebuggerPort(cworker_id,
+            result = self.inner.get().UpdateWorkerDebuggerPort(
+                cworker_id,
                 cdebugger_port)
         return result
 

--- a/python/ray/includes/global_state_accessor.pxi
+++ b/python/ray/includes/global_state_accessor.pxi
@@ -24,7 +24,7 @@ from ray.includes.optional cimport (
     make_optional
 )
 
-
+from libc.stdint cimport uint32_t as c_uint32_t
 from libcpp.string cimport string as c_string
 from libcpp.memory cimport make_unique as c_make_unique
 
@@ -173,6 +173,14 @@ cdef class GlobalStateAccessor:
         cdef c_string cserialized_string = serialized_string
         with nogil:
             result = self.inner.get().AddWorkerInfo(cserialized_string)
+        return result
+
+    def update_worker_debugger_port(self, worker_id, debugger_port):
+        cdef c_bool result
+        cdef CWorkerID cworker_id = CWorkerID.FromBinary(worker_id.binary())
+        cdef c_uint32_t cdebugger_port = debugger_port
+        with nogil:
+            result = self.inner.get().UpdateWorkerDebuggerPort(cworker_id, cdebugger_port)
         return result
 
     def get_placement_group_table(self):

--- a/python/ray/includes/global_state_accessor.pxi
+++ b/python/ray/includes/global_state_accessor.pxi
@@ -180,7 +180,8 @@ cdef class GlobalStateAccessor:
         cdef CWorkerID cworker_id = CWorkerID.FromBinary(worker_id.binary())
         cdef c_uint32_t cdebugger_port = debugger_port
         with nogil:
-            result = self.inner.get().UpdateWorkerDebuggerPort(cworker_id, cdebugger_port)
+            result = self.inner.get().UpdateWorkerDebuggerPort(cworker_id,
+                cdebugger_port)
         return result
 
     def get_placement_group_table(self):

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -645,6 +645,8 @@ class WorkerState(StateSchema):
     end_time_ms: Optional[int] = state_column(
         filterable=False, detail=True, format_fn=Humanify.timestamp
     )
+    # the debugger port of the worker
+    debugger_port: Optional[int] = state_column(filterable=True, detail=True)
 
 
 @dataclass(init=not IS_PYDANTIC_2)

--- a/src/mock/ray/gcs/gcs_server/gcs_worker_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_worker_manager.h
@@ -41,6 +41,12 @@ class MockGcsWorkerManager : public GcsWorkerManager {
                rpc::AddWorkerInfoReply *reply,
                rpc::SendReplyCallback send_reply_callback),
               (override));
+  MOCK_METHOD(void,
+              HandleUpdateWorkerDebuggerPort,
+              (rpc::UpdateWorkerDebuggerPortRequest request,
+               rpc::UpdateWorkerDebuggerPortReply *reply,
+               rpc::SendReplyCallback send_reply_callback),
+              (override));
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -889,6 +889,24 @@ Status WorkerInfoAccessor::AsyncAdd(const std::shared_ptr<rpc::WorkerTableData> 
   return Status::OK();
 }
 
+Status WorkerInfoAccessor::AsyncUpdateDebuggerPort(const WorkerID &worker_id,
+                                                   uint32_t debugger_port,
+                                                   const StatusCallback &callback) {
+  rpc::UpdateWorkerDebuggerPortRequest request;
+  request.set_worker_id(worker_id.Binary());
+  request.set_debugger_port(debugger_port);
+  RAY_LOG(DEBUG) << "Updating the worker debugger port, worker id = " << worker_id
+                 << ", port = " << debugger_port << ".";
+  client_impl_->GetGcsRpcClient().UpdateWorkerDebuggerPort(
+      request,
+      [callback](const Status &status, const rpc::UpdateWorkerDebuggerPortReply &reply) {
+        if (callback) {
+          callback(status);
+        }
+      });
+  return Status::OK();
+}
+
 PlacementGroupInfoAccessor::PlacementGroupInfoAccessor(GcsClient *client_impl)
     : client_impl_(client_impl) {}
 

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -588,6 +588,16 @@ class WorkerInfoAccessor {
   virtual Status AsyncAdd(const std::shared_ptr<rpc::WorkerTableData> &data_ptr,
                           const StatusCallback &callback);
 
+  /// Update the worker debugger port in GCS asynchronously.
+  ///
+  /// \param worker_id The ID of worker to update in the GCS.
+  /// \param debugger_port The debugger port of worker to update in the GCS.
+  /// \param callback Callback that will be called after update finishes.
+  /// \return Status
+  virtual Status AsyncUpdateDebuggerPort(const WorkerID &worker_id,
+                                         uint32_t debugger_port,
+                                         const StatusCallback &callback);
+
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
   /// PubSub server restart will cause GCS server restart. In this case, we need to

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -243,6 +243,21 @@ bool GlobalStateAccessor::AddWorkerInfo(const std::string &serialized_string) {
   return true;
 }
 
+bool GlobalStateAccessor::UpdateWorkerDebuggerPort(const WorkerID &worker_id,
+                                                   const uint32_t debugger_port) {
+  std::promise<bool> promise;
+  {
+    absl::ReaderMutexLock lock(&mutex_);
+    RAY_CHECK_OK(gcs_client_->Workers().AsyncUpdateDebuggerPort(
+        worker_id, debugger_port, [&promise](const Status &status) {
+          RAY_CHECK_OK(status);
+          promise.set_value(true);
+        }));
+  }
+  promise.get_future().get();
+  return true;
+}
+
 std::vector<std::string> GlobalStateAccessor::GetAllPlacementGroupInfo() {
   std::vector<std::string> placement_group_table_data;
   std::promise<bool> promise;

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -133,6 +133,13 @@ class GlobalStateAccessor {
   /// deserialized with protobuf function.
   std::vector<std::string> GetAllWorkerInfo() ABSL_LOCKS_EXCLUDED(mutex_);
 
+  /// Update the worker debugger port in the GCS Service.
+  ///
+  /// \param worker_id The ID of worker to update in the GCS Service.
+  /// \param debugger_port The debugger port of worker to update in the GCS Service.
+  /// \return Is operation success.
+  bool UpdateWorkerDebuggerPort(const WorkerID &worker_id, const uint32_t debugger_port);
+
   /// Add information of a worker to GCS Service.
   ///
   /// \param serialized_string The serialized data of worker to be added in the GCS

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -240,6 +240,29 @@ TEST_P(GlobalStateAccessorTest, TestWorkerTable) {
   ASSERT_EQ(global_state_->GetAllWorkerInfo().size(), 2);
 }
 
+TEST_P(GlobalStateAccessorTest, TestUpdateWorkerDebuggerPort) {
+  ASSERT_EQ(global_state_->GetAllWorkerInfo().size(), 0);
+  // Add worker info
+  auto worker_table_data = Mocker::GenWorkerTableData();
+  worker_table_data->mutable_worker_address()->set_worker_id(
+      WorkerID::FromRandom().Binary());
+  ASSERT_TRUE(global_state_->AddWorkerInfo(worker_table_data->SerializeAsString()));
+
+  // Get worker info
+  auto worker_id = WorkerID::FromBinary(worker_table_data->worker_address().worker_id());
+  ASSERT_TRUE(global_state_->GetWorkerInfo(worker_id));
+
+  // Update the worker debugger port
+  auto debugger_port = 10000;
+  ASSERT_TRUE(global_state_->UpdateWorkerDebuggerPort(worker_id, debugger_port));
+
+  // Verify the debugger port
+  auto another_worker_table_data = Mocker::GenWorkerTableData();
+  auto worker_info = global_state_->GetWorkerInfo(worker_id);
+  ASSERT_TRUE(another_worker_table_data->ParseFromString(*worker_info));
+  ASSERT_EQ(another_worker_table_data->debugger_port(), debugger_port);
+}
+
 // TODO(sang): Add tests after adding asyncAdd
 TEST_P(GlobalStateAccessorTest, TestPlacementGroupTable) {
   ASSERT_EQ(global_state_->GetAllPlacementGroupInfo().size(), 0);

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.h
@@ -47,6 +47,11 @@ class GcsWorkerManager : public rpc::WorkerInfoHandler {
                            rpc::AddWorkerInfoReply *reply,
                            rpc::SendReplyCallback send_reply_callback) override;
 
+  void HandleUpdateWorkerDebuggerPort(
+      rpc::UpdateWorkerDebuggerPortRequest request,
+      rpc::UpdateWorkerDebuggerPortReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override;
+
   void AddWorkerDeadListener(
       std::function<void(std::shared_ptr<WorkerTableData>)> listener);
 

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -466,6 +466,8 @@ message WorkerTableData {
   // by a raylet. (I.e., driver worker won't have this value).
   // If the value doesn't present, it is -1.
   uint64 worker_launched_time_ms = 26;
+  // The debugger port on the worker process.
+  optional uint32 debugger_port = 27;
 }
 
 // Fields to publish when worker fails.

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -278,6 +278,17 @@ message AddWorkerInfoReply {
   GcsStatus status = 1;
 }
 
+message UpdateWorkerDebuggerPortRequest {
+  // ID of this worker.
+  bytes worker_id = 1;
+  // Debugger port
+  uint32 debugger_port = 2;
+}
+
+message UpdateWorkerDebuggerPortReply {
+  GcsStatus status = 1;
+}
+
 // Service for worker info access.
 service WorkerInfoGcsService {
   // Report a worker failure to GCS Service.
@@ -288,6 +299,9 @@ service WorkerInfoGcsService {
   rpc GetAllWorkerInfo(GetAllWorkerInfoRequest) returns (GetAllWorkerInfoReply);
   // Add worker information to GCS Service.
   rpc AddWorkerInfo(AddWorkerInfoRequest) returns (AddWorkerInfoReply);
+  // Update worker debugger port in the GCS Service.
+  rpc UpdateWorkerDebuggerPort(UpdateWorkerDebuggerPortRequest)
+      returns (UpdateWorkerDebuggerPortReply);
 }
 
 message CreateActorRequest {

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -409,6 +409,12 @@ class GcsRpcClient {
                              worker_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
+  /// Add worker debugger port
+  VOID_GCS_RPC_CLIENT_METHOD(WorkerInfoGcsService,
+                             UpdateWorkerDebuggerPort,
+                             worker_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
   /// Create placement group via GCS Service.
   VOID_GCS_RPC_CLIENT_METHOD(PlacementGroupInfoGcsService,
                              CreatePlacementGroup,

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -473,6 +473,10 @@ class WorkerInfoGcsServiceHandler {
   virtual void HandleAddWorkerInfo(AddWorkerInfoRequest request,
                                    AddWorkerInfoReply *reply,
                                    SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleUpdateWorkerDebuggerPort(UpdateWorkerDebuggerPortRequest request,
+                                              UpdateWorkerDebuggerPortReply *reply,
+                                              SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `WorkerInfoGcsService`.
@@ -496,6 +500,7 @@ class WorkerInfoGrpcService : public GrpcService {
     WORKER_INFO_SERVICE_RPC_HANDLER(GetWorkerInfo);
     WORKER_INFO_SERVICE_RPC_HANDLER(GetAllWorkerInfo);
     WORKER_INFO_SERVICE_RPC_HANDLER(AddWorkerInfo);
+    WORKER_INFO_SERVICE_RPC_HANDLER(UpdateWorkerDebuggerPort);
   }
 
  private:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add `debugger_port` to the state API, this will allow ray to track which worker have a debugger server running and what port is open on those worker.

## Manual test

I ran the following code.
```
import ray
ray.init()

@ray.remote
def test_task():
    print("Worker id: ", ray.WorkerID(ray._private.worker.global_worker.worker_id))
    ray._private.worker.global_worker.set_debugger_port(12345)
    import time
    time.sleep(60)
    return 1


result = test_task.remote()
print(ray.get(result))
```

and then did: 
```
(base) ray@g-e1d12ab7226970001:~/default$ ray get workers bf9e0104210d9ae55220c0740453adbd25d0e54e563de9ba09bf3445
---
-   worker_id: bf9e0104210d9ae55220c0740453adbd25d0e54e563de9ba09bf3445
    is_alive: true
    worker_type: WORKER
    exit_type: null
    node_id: 44f3b738208b5f78cccb50404046cef0ee632a2a0514205e60d22926
    ip: 10.0.0.102
    pid: 213374
    exit_detail: null
    worker_launch_time_ms: '2023-11-06 12:32:10.526000'
    worker_launched_time_ms: '2023-11-06 12:32:11.380000'
    start_time_ms: '2023-11-06 12:32:11.414000'
    end_time_ms: '1969-12-31 16:00:00'
    debugger_port: 12345
...
```

and verified that the debugger_port is assigned.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
