### PR TITLE
[release infra] add `RAY_WANT_COMMIT_IN_IMAGE`

### DIFF
--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional, Dict
 
 import boto3
 import hashlib
@@ -217,11 +217,18 @@ def _validate_and_push(byod_image: str) -> None:
     )
 
 
-def _get_ray_commit() -> str:
-    return os.environ.get(
+def _get_ray_commit(envs: Optional[Dict[str, str]] = None) -> str:
+    if envs is None:
+        envs = os.environ
+    for key in [
+        "RAY_WANT_COMMIT_IN_IMAGE",
         "COMMIT_TO_TEST",
-        os.environ["BUILDKITE_COMMIT"],
-    )
+        "BUILDKITE_COMMIT",
+    ]:
+        commit = envs.get(key, "")
+        if commit:
+            return commit
+    return ""
 
 
 def _download_dataplane_build_file() -> None:

--- a/release/ray_release/tests/test_byod_build.py
+++ b/release/ray_release/tests/test_byod_build.py
@@ -12,7 +12,33 @@ from ray_release.byod.build import (
     build_anyscale_base_byod_images,
     build_champagne_image,
     DATAPLANE_FILENAME,
+    _get_ray_commit,
 )
+
+
+def test_get_ray_commit() -> None:
+    assert (
+        _get_ray_commit(
+            {
+                "RAY_WANT_COMMIT_IN_IMAGE": "abc123",
+                "COMMIT_TO_TEST": "def456",
+                "BUILDKITE_COMMIT": "987789",
+            }
+        )
+        == "abc123"
+    )
+
+    assert (
+        _get_ray_commit(
+            {
+                "COMMIT_TO_TEST": "def456",
+                "BUILDKITE_COMMIT": "987789",
+            }
+        )
+        == "def456"
+    )
+    assert _get_ray_commit({"BUILDKITE_COMMIT": "987789"}) == "987789"
+    assert _get_ray_commit({"PATH": "/usr/bin"}) == ""
 
 
 def test_build_anyscale_champagne_image() -> None:


### PR DESCRIPTION
allow setting the wanted commit in images via a new environment variable. useful for special cases where a different ray is installed in the image.
