### PR TITLE
[serve] Fix `test_serve_dashboard`

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -96,7 +96,9 @@ steps:
     job_env: forge
 
   - label: ":ray-serve: serve: serve minimal"
-    tags: python
+    tags:
+      - serve
+      - python
     instance_type: small
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/tests/... serve 
@@ -109,6 +111,7 @@ steps:
 
   - label: ":ray-serve: serve: dashboard tests"
     tags: 
+      - serve
       - python
       - dashboard
     instance_type: medium

--- a/dashboard/modules/serve/tests/test_serve_dashboard.py
+++ b/dashboard/modules/serve/tests/test_serve_dashboard.py
@@ -26,7 +26,7 @@ from ray.serve.generated import serve_pb2, serve_pb2_grpc
 
 # For local testing. If you're running these tests locally on a Macbook, set
 # this variable to False to enable tests.
-DISABLE_DARWIN = True
+DISABLE_DARWIN = False
 
 
 SERVE_AGENT_URLs = {
@@ -297,7 +297,7 @@ def test_delete(ray_start_stop):
         "runtime_env": {
             "working_dir": (
                 "https://github.com/ray-project/test_dag/archive/"
-                "40d61c141b9c37853a7014b8659fc7f23c1d04f6.zip"
+                "1a0ca74268de85affc6ead99121e2de7a01fa360.zip"
             )
         },
         "deployments": [

--- a/dashboard/modules/serve/tests/test_serve_dashboard.py
+++ b/dashboard/modules/serve/tests/test_serve_dashboard.py
@@ -376,7 +376,7 @@ def test_delete_multi_app(ray_start_stop, urls):
                 "runtime_env": {
                     "working_dir": (
                         "https://github.com/ray-project/test_dag/archive/"
-                        "40d61c141b9c37853a7014b8659fc7f23c1d04f6.zip"
+                        "1a0ca74268de85affc6ead99121e2de7a01fa360.zip"
                     )
                 },
                 "deployments": [

--- a/dashboard/modules/serve/tests/test_serve_dashboard.py
+++ b/dashboard/modules/serve/tests/test_serve_dashboard.py
@@ -26,7 +26,7 @@ from ray.serve.generated import serve_pb2, serve_pb2_grpc
 
 # For local testing. If you're running these tests locally on a Macbook, set
 # this variable to False to enable tests.
-DISABLE_DARWIN = False
+DISABLE_DARWIN = True
 
 
 SERVE_AGENT_URLs = {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_serve_dashboard` was accidentally broken in https://github.com/ray-project/ray/pull/40625 because I didn't update the URI in the dashboard tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
