### PR TITLE
[ci] rename core and serve civ1 test jobs

### DIFF
--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -5,8 +5,8 @@
     - ./java/test.sh
 
 # the bulk of serve tests are now run on civ2 infra, and defined in
-# pipeline.build_serve.yml
-- label: ":serverless: Serve HA Tests"
+# serve.rayci.yaml
+- label: "serve civ1 tests"
   conditions:
     [
         "RAY_CI_SERVE_AFFECTED",
@@ -29,7 +29,7 @@
       --test_tag_filters=-post_wheel_build,-gpu,xcommit
       python/ray/serve/tests/...
 
-- label: ":python: civ1 tests"
+- label: "core civ1 tests"
   conditions: ["RAY_CI_PYTHON_AFFECTED"]
   instance_size: medium
   commands:


### PR DESCRIPTION
Rename core and serve civ1 test jobs (to see easier what have been migrated vs. what could not be migrated)

Test:
- CI