### PR TITLE
[cd] migrate java tests to civ2

### DIFF
--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -1,0 +1,13 @@
+group: others
+steps:
+  # test
+  - label: ":java: java tests"
+    tags: java
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //... core --build-only
+      - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
+        "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild /bin/bash -iecuo pipefail 
+        "./java/test.sh"
+    depends_on: corebuild
+    job_env: forge

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -1,9 +1,3 @@
-- label: ":java: Java"
-  conditions: ["RAY_CI_JAVA_AFFECTED"]
-  instance_size: medium
-  commands:
-    - ./java/test.sh
-
 # the bulk of serve tests are now run on civ2 infra, and defined in
 # serve.rayci.yaml
 - label: "serve civ1 tests"

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -256,11 +256,13 @@ if __name__ == "__main__":
                 or changed_file == "ci/docker/min.build.Dockerfile"
                 or changed_file == "ci/docker/min.build.wanda.yaml"
                 or changed_file == ".buildkite/serverless.rayci.yml"
-                or changed_file == ".buildkite/pipeline.build.yml"
                 or changed_file == ".buildkite/pipeline.ml.yml"
             ):
                 RAY_CI_PYTHON_AFFECTED = 1
-            elif changed_file.startswith("java/"):
+            elif (
+                changed_file.startswith("java/")
+                or changed_file == ".buildkite/others.rayci.yml"
+            ):
                 RAY_CI_JAVA_AFFECTED = 1
             elif (
                 changed_file.startswith("cpp/")
@@ -301,8 +303,10 @@ if __name__ == "__main__":
             elif changed_file.startswith("ci/lint"):
                 # Linter will always be run
                 RAY_CI_TOOLS_AFFECTED = 1
-            elif changed_file.startswith("ci/pipeline") or changed_file.startswith(
-                "ci/ray_ci"
+            elif (
+                changed_file.startswith("ci/pipeline")
+                or changed_file.startswith("ci/ray_ci")
+                or changed_file == ".buildkite/pipeline.build.yml"
             ):
                 # These scripts are always run as part of the build process
                 RAY_CI_TOOLS_AFFECTED = 1

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -84,6 +84,13 @@ bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
     help=("Skip ray installation."),
 )
 @click.option(
+    "--build-only",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help=("Build ray only, skip running tests."),
+)
+@click.option(
     "--gpus",
     default=0,
     type=int,
@@ -135,6 +142,7 @@ def main(
     only_tags: str,
     run_flaky_tests: bool,
     skip_ray_installation: bool,
+    build_only: bool,
     gpus: int,
     test_env: Tuple[str],
     test_arg: Optional[str],
@@ -160,6 +168,8 @@ def main(
         build_type=build_type,
         skip_ray_installation=skip_ray_installation,
     )
+    if build_only:
+        sys.exit(0)
     test_targets = _get_test_targets(
         container,
         targets,


### PR DESCRIPTION
Migrate java tests to civ2. Add a flag to for rayci to produce the builds only, without running tests. Then use that build to run `java/test.sh` script.

Test:
- CI