### PR TITLE
[data] add rss and runtime to op metrics

### DIFF
--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -213,6 +213,14 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
         pathParams: "orgId=1&theme=light&panelId=8",
       },
       {
+        title: "Task Runtime",
+        pathParams: "orgId=1&theme=light&panelId=12",
+      },
+      {
+        title: "Task RSS",
+        pathParams: "orgId=1&theme=light&panelId=13",
+      },
+      {
         title: "Iteration Blocked Time",
         pathParams: "orgId=1&theme=light&panelId=9",
       },

--- a/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -116,6 +116,50 @@ DATA_GRAFANA_PANELS = [
         ],
     ),
     Panel(
+        id=12,
+        title="Task Runtime",
+        description="Task runtime in seconds.",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_data_p50_task_runtime_seconds{{{global_filters}}}) by (dataset, operator)",
+                legend="P50 Task Runtime: {{dataset}}, {{operator}}",
+            ),
+            Target(
+                expr="sum(ray_data_p90_task_runtime_seconds{{{global_filters}}}) by (dataset, operator)",
+                legend="P90 Task Runtime: {{dataset}}, {{operator}}",
+            ),
+            Target(
+                expr="sum(ray_data_p99_task_runtime_seconds{{{global_filters}}}) by (dataset, operator)",
+                legend="P99 Task Runtime: {{dataset}}, {{operator}}",
+            ),
+        ],
+        fill=0,
+        stack=False,
+    ),
+    Panel(
+        id=13,
+        title="Task RSS",
+        description="Resident set size of tasks. May be an overestimate, as we don't differentiate from previous tasks on the same worker",
+        unit="bytes",
+        targets=[
+            Target(
+                expr="sum(ray_data_p50_task_rss_seconds{{{global_filters}}}) by (dataset, operator)",
+                legend="P50 Task RSS: {{dataset}}, {{operator}}",
+            ),
+            Target(
+                expr="sum(ray_data_p90_task_rss_seconds{{{global_filters}}}) by (dataset, operator)",
+                legend="P90 Task RSS: {{dataset}}, {{operator}}",
+            ),
+            Target(
+                expr="sum(ray_data_p99_task_rss_seconds{{{global_filters}}}) by (dataset, operator)",
+                legend="P99 Task RSS: {{dataset}}, {{operator}}",
+            ),
+        ],
+        fill=0,
+        stack=False,
+    ),
+    Panel(
         id=9,
         title="Iteration Blocked Time",
         description="Seconds user thread is blocked by iter_batches()",

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -37,7 +37,7 @@ class SlidingWindowMetric:
         self._window = deque()
         self._window_lock = threading.Lock()
         self._computed_percentiles = [
-            (percentile, -1) for percentile in SlidingWindowMetric.PERCENTILES
+            (percentile, 0) for percentile in SlidingWindowMetric.PERCENTILES
         ]
 
     def append(self, value):
@@ -52,7 +52,7 @@ class SlidingWindowMetric:
         results = []
         for percentile in SlidingWindowMetric.PERCENTILES:
             results.append(
-                (percentile, np.percentile(values, percentile) if values else -1)
+                (percentile, np.percentile(values, percentile) if values else 0)
             )
         self._computed_percentiles = results
         return results

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -17,7 +17,6 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
 )
 from ray.data._internal.execution.interfaces.op_runtime_metrics import (
-    OpRuntimeMetrics,
     SlidingWindowMetric,
 )
 from ray.data._internal.execution.operators.actor_pool_map_operator import (

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1264,19 +1264,15 @@ def test_op_metrics_logging():
     with patch.object(logger, "info") as mock_logger:
         ray.data.range(100).map_batches(lambda x: x).materialize()
         logs = [canonicalize(call.args[0]) for call in mock_logger.call_args_list]
-        input_str = (
-            "Operator InputDataBuffer[Input] completed. Operator Metrics:\n"
-            + gen_expected_metrics(is_map=False)
-        )
+        input_str = "Operator InputDataBuffer[Input] completed."
         map_str = (
             "Operator InputDataBuffer[Input] -> "
             "TaskPoolMapOperator[ReadRange->MapBatches(<lambda>)] completed. "
-            "Operator Metrics:\n"
-        ) + STANDARD_EXTRA_METRICS
+        )
 
         # Check that these strings are logged exactly once.
-        assert sum([log == input_str for log in logs]) == 1
-        assert sum([log == map_str for log in logs]) == 1
+        assert sum([log.startswith(input_str) for log in logs]) == 1
+        assert sum([log.startswith(map_str) for log in logs]) == 1
 
 
 def test_op_state_logging():

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -49,6 +49,12 @@ def gen_expected_metrics(
             "'num_tasks_have_outputs': N",
             "'num_tasks_finished': N",
             "'num_tasks_failed': Z",
+            "'task_runtime_pN': N",
+            "'task_runtime_pN': N",
+            "'task_runtime_pN': N",
+            "'task_rss_pN': N",
+            "'task_rss_pN': N",
+            "'task_rss_pN': N",
             "'obj_store_mem_alloc': N",
             "'obj_store_mem_freed': N",
             "'obj_store_mem_cur': Z",
@@ -122,7 +128,7 @@ def canonicalize(stats: str, filter_global_stats: bool = True) -> str:
     # Handle zero values specially so we can check for missing values.
     s4 = re.sub(" [0]+(\.[0])?", " Z", s3)
     # Other numerics.
-    s5 = re.sub("[0-9]+(\.[0-9]+)?", "N", s4)
+    s5 = re.sub("-?[0-9]+(\.[0-9]+)?", "N", s4)
     # Replace tabs with spaces.
     s6 = re.sub("\t", "    ", s5)
     if filter_global_stats:
@@ -539,6 +545,12 @@ def test_dataset__repr__(ray_start_regular_shared):
         "      num_tasks_have_outputs: N,\n"
         "      num_tasks_finished: N,\n"
         "      num_tasks_failed: Z,\n"
+        "      task_runtime_pN: N,\n"
+        "      task_runtime_pN: N,\n"
+        "      task_runtime_pN: N,\n"
+        "      task_rss_pN: N,\n"
+        "      task_rss_pN: N,\n"
+        "      task_rss_pN: N,\n"
         "      obj_store_mem_alloc: N,\n"
         "      obj_store_mem_freed: N,\n"
         "      obj_store_mem_cur: Z,\n"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Maintains the task rss/runtime of tasks in the last 10s in `OpRuntimeMetrics`. The percentiles of these metrics are computed each time when metrics are emitted to `_StatsActor` every 5s. Each time we compute the percentiles, the values are also stored and reused for other calls to `as_dict`

All percentiles for a single metric are displayed on the data dashboard in a single chart.
<img width="862" alt="Screenshot 2023-11-27 at 9 42 02 AM" src="https://github.com/ray-project/ray/assets/39287272/bfdfda06-431c-4f1c-a4d1-e877a3cb1f86">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #40943

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
