### PR TITLE
[Core] Move resource view sync message out of ResourcesData

### DIFF
--- a/src/mock/ray/raylet/node_manager.h
+++ b/src/mock/ray/raylet/node_manager.h
@@ -28,12 +28,6 @@ namespace raylet {
 class MockNodeManager : public NodeManager {
  public:
   MOCK_METHOD(void,
-              HandleUpdateResourceUsage,
-              (rpc::UpdateResourceUsageRequest request,
-               rpc::UpdateResourceUsageReply *reply,
-               rpc::SendReplyCallback send_reply_callback),
-              (override));
-  MOCK_METHOD(void,
               HandleGetResourceLoad,
               (rpc::GetResourceLoadRequest request,
                rpc::GetResourceLoadReply *reply,

--- a/src/mock/ray/raylet_client/raylet_client.h
+++ b/src/mock/ray/raylet_client/raylet_client.h
@@ -93,11 +93,6 @@ class MockRayletClientInterface : public RayletClientInterface {
               (const rpc::ClientCallback<rpc::GetSystemConfigReply> &callback),
               (override));
   MOCK_METHOD(void,
-              UpdateResourceUsage,
-              (std::string & serialized_resource_usage_batch,
-               const rpc::ClientCallback<rpc::UpdateResourceUsageReply> &callback),
-              (override));
-  MOCK_METHOD(void,
               GetResourceLoad,
               (const rpc::ClientCallback<rpc::GetResourceLoadReply> &callback),
               (override));

--- a/src/ray/common/ray_syncer/ray_syncer.h
+++ b/src/ray/common/ray_syncer/ray_syncer.h
@@ -30,6 +30,7 @@ namespace syncer {
 using ray::rpc::syncer::CommandsSyncMessage;
 using ray::rpc::syncer::MessageType;
 using ray::rpc::syncer::RaySyncMessage;
+using ray::rpc::syncer::ResourceViewSyncMessage;
 
 using ServerBidiReactor = grpc::ServerBidiReactor<RaySyncMessage, RaySyncMessage>;
 using ClientBidiReactor = grpc::ClientBidiReactor<RaySyncMessage, RaySyncMessage>;

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -598,14 +598,13 @@ TEST_P(GcsClientTest, TestGetAllAvailableResources) {
 
   // Report resource usage of a node to GCS.
   NodeID node_id = NodeID::FromBinary(node_info->node_id());
-  auto resource = std::make_shared<rpc::ResourcesData>();
-  resource->set_node_id(node_id.Binary());
+  syncer::ResourceViewSyncMessage resource;
   // Set this flag to indicate resources has changed.
-  (*resource->mutable_resources_available())["CPU"] = 1.0;
-  (*resource->mutable_resources_available())["GPU"] = 10.0;
-  (*resource->mutable_resources_total())["CPU"] = 1.0;
-  (*resource->mutable_resources_total())["GPU"] = 10.0;
-  gcs_server_->UpdateGcsResourceManagerInTest(*resource);
+  (*resource.mutable_resources_available())["CPU"] = 1.0;
+  (*resource.mutable_resources_available())["GPU"] = 10.0;
+  (*resource.mutable_resources_total())["CPU"] = 1.0;
+  (*resource.mutable_resources_total())["GPU"] = 10.0;
+  gcs_server_->UpdateGcsResourceManagerInTest(node_id, resource);
 
   // Assert get all available resources right.
   std::vector<rpc::AvailableResources> resources = GetAllAvailableResources();
@@ -745,17 +744,15 @@ TEST_P(GcsClientTest, TestNodeTableResubscribe) {
   ASSERT_TRUE(RegisterNode(*node_info));
   NodeID node_id = NodeID::FromBinary(node_info->node_id());
   std::string key = "CPU";
-  auto resources = std::make_shared<rpc::ResourcesData>();
-  resources->set_node_id(node_info->node_id());
-  gcs_server_->UpdateGcsResourceManagerInTest(*resources);
+  syncer::ResourceViewSyncMessage resources;
+  gcs_server_->UpdateGcsResourceManagerInTest(node_id, resources);
 
   RestartGcsServer();
 
   node_info = Mocker::GenNodeInfo(1);
   ASSERT_TRUE(RegisterNode(*node_info));
   node_id = NodeID::FromBinary(node_info->node_id());
-  resources->set_node_id(node_info->node_id());
-  gcs_server_->UpdateGcsResourceManagerInTest(*resources);
+  gcs_server_->UpdateGcsResourceManagerInTest(node_id, resources);
 
   WaitForExpectedCount(node_change_count, 2);
 }

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -190,9 +190,9 @@ TEST_P(GlobalStateAccessorTest, TestGetAllResourceUsage) {
 
   // Report resource usage first time.
   std::promise<bool> promise1;
-  auto resources1 = std::make_shared<rpc::ResourcesData>();
-  resources1->set_node_id(node_table_data->node_id());
-  gcs_server_->UpdateGcsResourceManagerInTest(*resources1);
+  syncer::ResourceViewSyncMessage resources1;
+  gcs_server_->UpdateGcsResourceManagerInTest(
+      NodeID::FromBinary(node_table_data->node_id()), resources1);
 
   resources = global_state_->GetAllResourceUsage();
   resource_usage_batch_data.ParseFromString(*resources.get());
@@ -200,13 +200,13 @@ TEST_P(GlobalStateAccessorTest, TestGetAllResourceUsage) {
 
   // Report changed resource usage.
   std::promise<bool> promise2;
-  auto heartbeat2 = std::make_shared<rpc::ResourcesData>();
-  heartbeat2->set_node_id(node_table_data->node_id());
-  (*heartbeat2->mutable_resources_total())["CPU"] = 1;
-  (*heartbeat2->mutable_resources_total())["GPU"] = 10;
-  (*heartbeat2->mutable_resources_available())["CPU"] = 1;
-  (*heartbeat2->mutable_resources_available())["GPU"] = 5;
-  gcs_server_->UpdateGcsResourceManagerInTest(*heartbeat2);
+  syncer::ResourceViewSyncMessage resources2;
+  (*resources2.mutable_resources_total())["CPU"] = 1;
+  (*resources2.mutable_resources_total())["GPU"] = 10;
+  (*resources2.mutable_resources_available())["CPU"] = 1;
+  (*resources2.mutable_resources_available())["GPU"] = 5;
+  gcs_server_->UpdateGcsResourceManagerInTest(
+      NodeID::FromBinary(node_table_data->node_id()), resources2);
 
   resources = global_state_->GetAllResourceUsage();
   resource_usage_batch_data.ParseFromString(*resources.get());

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -145,7 +145,7 @@ void GcsResourceManager::UpdateFromResourceView(
     return;
   }
   if (RayConfig::instance().gcs_actor_scheduling_enabled()) {
-    // TODO (jjyao) This is currently an no-op.
+    // TODO (jjyao) This is currently an no-op and is broken.
     // UpdateNodeNormalTaskResources(node_id, data);
   } else {
     // We will only update the node's resources if it's from resource view reports.

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -128,7 +128,7 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
   /// Update resource usage of given node.
   ///
   /// \param node_id Node id.
-  /// \param resources The resource usage of the node.
+  /// \param resource_view_sync_message The resource usage of the node.
   void UpdateNodeResourceUsage(
       const NodeID &node_id,
       const syncer::ResourceViewSyncMessage &resource_view_sync_message);
@@ -136,7 +136,8 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
   /// Process a new resource report from a node, independent of the rpc handler it came
   /// from.
   ///
-  /// \param data The resource report.
+  /// \param node_id Node id.
+  /// \param resource_view_sync_message The resource usage of the node.
   void UpdateFromResourceView(
       const NodeID &node_id,
       const syncer::ResourceViewSyncMessage &resource_view_sync_message);

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -129,18 +129,17 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
   ///
   /// \param node_id Node id.
   /// \param resources The resource usage of the node.
-  /// \param from_resource_view Whether the resource report is from resource view, i.e.
-  ///   syncer::MessageType::RESOURCE_VIEW.
-  void UpdateNodeResourceUsage(const NodeID &node_id,
-                               const rpc::ResourcesData &resources);
+  void UpdateNodeResourceUsage(
+      const NodeID &node_id,
+      const syncer::ResourceViewSyncMessage &resource_view_sync_message);
 
   /// Process a new resource report from a node, independent of the rpc handler it came
   /// from.
   ///
   /// \param data The resource report.
-  /// \param from_resource_view Whether the resource report is from resource view, i.e.
-  ///   syncer::MessageType::RESOURCE_VIEW.
-  void UpdateFromResourceView(const rpc::ResourcesData &data);
+  void UpdateFromResourceView(
+      const NodeID &node_id,
+      const syncer::ResourceViewSyncMessage &resource_view_sync_message);
 
   /// Update the resource usage of a node from syncer COMMANDS
   ///

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -109,9 +109,11 @@ class GcsServer {
   static constexpr char kInMemoryStorage[] = "memory";
   static constexpr char kRedisStorage[] = "redis";
 
-  void UpdateGcsResourceManagerInTest(const rpc::ResourcesData &resources) {
+  void UpdateGcsResourceManagerInTest(
+      const NodeID &node_id,
+      const syncer::ResourceViewSyncMessage &resource_view_sync_message) {
     RAY_CHECK(gcs_resource_manager_ != nullptr);
-    gcs_resource_manager_->UpdateFromResourceView(resources);
+    gcs_resource_manager_->UpdateFromResourceView(node_id, resource_view_sync_message);
   }
 
  protected:

--- a/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
@@ -72,7 +72,6 @@ class GcsAutoscalerStateManagerTest : public ::testing::Test {
  public:
   void AddNode(const std::shared_ptr<rpc::GcsNodeInfo> &node) {
     gcs_node_manager_->alive_nodes_[NodeID::FromBinary(node->node_id())] = node;
-    gcs_resource_manager_->OnNodeAdd(*node);
     gcs_autoscaler_state_manager_->OnNodeAdd(*node);
   }
 
@@ -81,7 +80,6 @@ class GcsAutoscalerStateManagerTest : public ::testing::Test {
     node->set_state(rpc::GcsNodeInfo::DEAD);
     gcs_node_manager_->alive_nodes_.erase(node_id);
     gcs_node_manager_->dead_nodes_[node_id] = node;
-    gcs_resource_manager_->OnNodeDead(node_id);
     gcs_autoscaler_state_manager_->OnNodeDead(node_id);
   }
 
@@ -159,7 +157,6 @@ class GcsAutoscalerStateManagerTest : public ::testing::Test {
                               total_resources,
                               idle_ms,
                               is_draining);
-    gcs_resource_manager_->UpdateNodeResourceUsage(node_id, resources_data);
     gcs_autoscaler_state_manager_->UpdateResourceLoadAndUsage(resources_data);
   }
 
@@ -236,16 +233,6 @@ class GcsAutoscalerStateManagerTest : public ::testing::Test {
       ASSERT_EQ(actual_requests_by_count[req.first], req.second)
           << "Request: " << req.first;
     }
-  }
-
-  void UpdatePlacementGroupLoad(const std::vector<rpc::PlacementGroupTableData> &data) {
-    std::shared_ptr<rpc::PlacementGroupLoad> load =
-        std::make_shared<rpc::PlacementGroupLoad>();
-    for (auto &d : data) {
-      load->add_placement_group_data()->CopyFrom(d);
-    }
-
-    gcs_resource_manager_->UpdatePlacementGroupLoad(load);
   }
 
   void GroupResourceRequestsByConstraintForPG(

--- a/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
@@ -41,14 +41,18 @@ class GcsResourceManagerTest : public ::testing::Test {
       const absl::flat_hash_map<std::string, double> &total_resources,
       int64_t idle_ms = 0,
       bool is_draining = false) {
-    rpc::ResourcesData resources_data;
-    Mocker::FillResourcesData(resources_data,
-                              node_id,
-                              available_resources,
-                              total_resources,
-                              idle_ms,
-                              is_draining);
-    gcs_resource_manager_->UpdateFromResourceView(resources_data);
+    syncer::ResourceViewSyncMessage resource_view_sync_message;
+    for (const auto &resource : available_resources) {
+      (*resource_view_sync_message.mutable_resources_available())[resource.first] =
+          resource.second;
+    }
+    for (const auto &resource : total_resources) {
+      (*resource_view_sync_message.mutable_resources_total())[resource.first] =
+          resource.second;
+    }
+    resource_view_sync_message.set_idle_duration_ms(idle_ms);
+    resource_view_sync_message.set_is_draining(is_draining);
+    gcs_resource_manager_->UpdateFromResourceView(node_id, resource_view_sync_message);
   }
 
   instrumented_io_context io_service_;
@@ -107,10 +111,10 @@ TEST_F(GcsResourceManagerTest, TestResourceUsageAPI) {
 
   gcs_resource_manager_->OnNodeAdd(*node);
 
-  rpc::ResourcesData resources_data;
-  (*resources_data.mutable_resources_available())["CPU"] = 2;
-  (*resources_data.mutable_resources_total())["CPU"] = 2;
-  gcs_resource_manager_->UpdateNodeResourceUsage(node_id, resources_data);
+  syncer::ResourceViewSyncMessage resource_view_sync_message;
+  (*resource_view_sync_message.mutable_resources_available())["CPU"] = 2;
+  (*resource_view_sync_message.mutable_resources_total())["CPU"] = 2;
+  gcs_resource_manager_->UpdateNodeResourceUsage(node_id, resource_view_sync_message);
 
   gcs_resource_manager_->HandleGetAllResourceUsage(
       get_all_request, &get_all_reply, send_reply_callback);
@@ -123,7 +127,7 @@ TEST_F(GcsResourceManagerTest, TestResourceUsageAPI) {
   ASSERT_EQ(get_all_reply2.resource_usage_data().batch().size(), 0);
 
   // This will be ignored since the node is dead.
-  gcs_resource_manager_->UpdateNodeResourceUsage(node_id, resources_data);
+  gcs_resource_manager_->UpdateNodeResourceUsage(node_id, resource_view_sync_message);
   rpc::GetAllResourceUsageReply get_all_reply3;
   gcs_resource_manager_->HandleGetAllResourceUsage(
       get_all_request, &get_all_reply3, send_reply_callback);
@@ -135,18 +139,17 @@ TEST_F(GcsResourceManagerTest, TestResourceUsageFromDifferentSyncMsgs) {
   node->mutable_resources_total()->insert({"CPU", 10});
   gcs_resource_manager_->OnNodeAdd(*node);
 
-  rpc::ResourcesData resources_data;
-  resources_data.set_node_id(node->node_id());
-  resources_data.mutable_resources_total()->insert({"CPU", 5});
-  resources_data.mutable_resources_available()->insert({"CPU", 5});
-  resources_data.set_cluster_full_of_actors_detected(false);
+  syncer::ResourceViewSyncMessage resource_view_sync_message;
+  resource_view_sync_message.mutable_resources_total()->insert({"CPU", 5});
+  resource_view_sync_message.mutable_resources_available()->insert({"CPU", 5});
 
   // Update resource usage from resource view.
   {
     ASSERT_FALSE(gcs_resource_manager_->NodeResourceReportView()
                      .at(NodeID::FromBinary(node->node_id()))
                      .cluster_full_of_actors_detected());
-    gcs_resource_manager_->UpdateFromResourceView(resources_data);
+    gcs_resource_manager_->UpdateFromResourceView(NodeID::FromBinary(node->node_id()),
+                                                  resource_view_sync_message);
     ASSERT_EQ(
         cluster_resource_manager_.GetNodeResources(scheduling::NodeID(node->node_id()))
             .total.GetResourceMap()
@@ -190,11 +193,10 @@ TEST_F(GcsResourceManagerTest, TestSetAvailableResourcesWhenNodeDead) {
   gcs_resource_manager_->OnNodeDead(node_id);
   ASSERT_EQ(cluster_resource_manager_.GetResourceView().size(), 0);
 
-  rpc::ResourcesData resources_data;
-  resources_data.set_node_id(node->node_id());
-  resources_data.mutable_resources_total()->insert({"CPU", 5});
-  resources_data.mutable_resources_available()->insert({"CPU", 5});
-  gcs_resource_manager_->UpdateFromResourceView(resources_data);
+  syncer::ResourceViewSyncMessage resource_view_sync_message;
+  resource_view_sync_message.mutable_resources_total()->insert({"CPU", 5});
+  resource_view_sync_message.mutable_resources_available()->insert({"CPU", 5});
+  gcs_resource_manager_->UpdateFromResourceView(node_id, resource_view_sync_message);
   ASSERT_EQ(cluster_resource_manager_.GetResourceView().size(), 0);
 }
 

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -279,13 +279,6 @@ struct GcsServerMocker {
     void GetSystemConfig(const ray::rpc::ClientCallback<ray::rpc::GetSystemConfigReply>
                              &callback) override {}
 
-    /// ResourceUsageInterface
-    void UpdateResourceUsage(
-        std::string &address,
-        const rpc::ClientCallback<rpc::UpdateResourceUsageReply> &callback) override {
-      RAY_CHECK(false) << "Unused";
-    };
-
     /// ShutdownRaylet
     void ShutdownRaylet(
         const NodeID &node_id,

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -546,7 +546,7 @@ message ResourceLoad {
 }
 
 message ResourcesData {
-  reserved 3, 8;
+  reserved 3, 8, 17;
   // Node id.
   bytes node_id = 1;
   // Resource capacity currently available on this node manager.
@@ -577,8 +577,6 @@ message ResourcesData {
   int64 idle_duration_ms = 15;
   // Whether the node is being drained.
   bool is_draining = 16;
-  // Why the node is not idle.
-  repeated string node_activity = 17;
 }
 
 message ResourceUsageBatchData {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -285,16 +285,6 @@ message GetSystemConfigReply {
   string system_config = 1;
 }
 
-message UpdateResourceUsageRequest {
-  // This is a serialized version of ResourceUsageBatchData. This extra layer of
-  // serialization allows the sender to cache the expensive operation of serializing a
-  // `ResourceUsageBatchData` when sending this request to all nodes.
-  bytes serialized_resource_usage_batch = 1;
-}
-
-message UpdateResourceUsageReply {
-}
-
 message GetTasksInfoRequest {
   // Maximum number of entries to return.
   // If not specified, return the whole entries without truncation.
@@ -363,8 +353,6 @@ message DrainRayletReply {
 
 // Service for inter-node-manager communication.
 service NodeManagerService {
-  // Update the node's view of the cluster resource usage.
-  rpc UpdateResourceUsage(UpdateResourceUsageRequest) returns (UpdateResourceUsageReply);
   // Handle the case when GCS restarted.
   rpc NotifyGCSRestart(NotifyGCSRestartRequest) returns (NotifyGCSRestartReply);
   // Get the resource load of the raylet.

--- a/src/ray/protobuf/ray_syncer.proto
+++ b/src/ray/protobuf/ray_syncer.proto
@@ -28,6 +28,24 @@ message CommandsSyncMessage {
   bool cluster_full_of_actors_detected = 2;
 }
 
+message ResourceViewSyncMessage {
+  // Resource capacity currently available on this node manager.
+  map<string, double> resources_available = 1;
+  // Total resource capacity configured for this node manager.
+  map<string, double> resources_total = 2;
+  // Whether this node has object pulls queued. This can happen if
+  // the node has more pull requests than available object store
+  // memory. This is a proxy for available object store memory.
+  bool object_pulls_queued = 3;
+  // The duration in ms during which all the node's resources are idle. If the
+  // node currently has any resource being used, this will be 0.
+  int64 idle_duration_ms = 4;
+  // Whether the node is being drained.
+  bool is_draining = 5;
+  // Why the node is not idle.
+  repeated string node_activity = 6;
+}
+
 message RaySyncMessage {
   // The version of the message. -1 means the version is not set.
   int64 version = 1;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -297,7 +297,9 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// \param id The ID of the node manager that sent the resources data.
   /// \param data The resources data including load information.
   /// \return Whether the node resource usage is updated.
-  bool UpdateResourceUsage(const NodeID &id, const rpc::ResourcesData &data);
+  bool UpdateResourceUsage(
+      const NodeID &id,
+      const syncer::ResourceViewSyncMessage &resource_view_sync_message);
 
   /// Handle a worker finishing its assigned task.
   ///

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -294,8 +294,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
 
   /// Handler for a resource usage notification from the GCS.
   ///
-  /// \param id The ID of the node manager that sent the resources data.
-  /// \param data The resources data including load information.
+  /// \param id The ID of the node manager that sent the resource usage.
+  /// \param resource_view_sync_message The resource usage data.
   /// \return Whether the node resource usage is updated.
   bool UpdateResourceUsage(
       const NodeID &id,

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -55,7 +55,8 @@ class ClusterResourceManager {
   ///
   /// \param node_id ID of the node which resoruces need to be updated.
   /// \param resource_data The node resource data.
-  bool UpdateNode(scheduling::NodeID node_id, const rpc::ResourcesData &resource_data);
+  bool UpdateNode(scheduling::NodeID node_id,
+                  const syncer::ResourceViewSyncMessage &resource_view_sync_message);
 
   /// Remove node from the cluster data structure. This happens
   /// when a node fails or it is removed from the cluster.

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -54,7 +54,7 @@ class ClusterResourceManager {
   /// Update node resources. This happens when a node resource usage updated.
   ///
   /// \param node_id ID of the node which resoruces need to be updated.
-  /// \param resource_data The node resource data.
+  /// \param resource_view_sync_message The node resource usage data.
   bool UpdateNode(scheduling::NodeID node_id,
                   const syncer::ResourceViewSyncMessage &resource_view_sync_message);
 

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -350,7 +350,16 @@ void ClusterTaskManager::FillResourceUsage(rpc::ResourcesData &data) {
   // This populates load information.
   scheduler_resource_reporter_.FillResourceUsage(data);
   // This populates usage information.
-  cluster_resource_scheduler_->GetLocalResourceManager().PopulateResourceUsage(data);
+  syncer::ResourceViewSyncMessage resource_view_sync_message;
+  cluster_resource_scheduler_->GetLocalResourceManager().PopulateResourceViewSyncMessage(
+      resource_view_sync_message);
+  (*data.mutable_resources_total()) =
+      std::move(resource_view_sync_message.resources_total());
+  (*data.mutable_resources_available()) =
+      std::move(resource_view_sync_message.resources_available());
+  data.set_object_pulls_queued(resource_view_sync_message.object_pulls_queued());
+  data.set_idle_duration_ms(resource_view_sync_message.idle_duration_ms());
+  data.set_is_draining(resource_view_sync_message.is_draining());
 }
 
 bool ClusterTaskManager::AnyPendingTasksForResourceAcquisition(

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -294,14 +294,13 @@ double LocalResourceManager::GetLocalAvailableCpus() const {
   return local_resources_.available.Sum(ResourceID::CPU()).Double();
 }
 
-void LocalResourceManager::PopulateResourceUsage(
-    rpc::ResourcesData &resources_data) const {
-  resources_data.set_node_id(local_node_id_.Binary());
-
+void LocalResourceManager::PopulateResourceViewSyncMessage(
+    syncer::ResourceViewSyncMessage &resource_view_sync_message) const {
   NodeResources resources = ToNodeResources();
 
   auto total = resources.total.GetResourceMap();
-  resources_data.mutable_resources_total()->insert(total.begin(), total.end());
+  resource_view_sync_message.mutable_resources_total()->insert(total.begin(),
+                                                               total.end());
 
   for (const auto &[resource_name, available] : resources.available.GetResourceMap()) {
     // Resource availability can be negative locally but treat it as 0
@@ -309,13 +308,13 @@ void LocalResourceManager::PopulateResourceUsage(
     // system assume resource availability cannot be negative and
     // there is no difference between negative and zero from other nodes
     // and gcs's point of view.
-    (*resources_data.mutable_resources_available())[resource_name] =
+    (*resource_view_sync_message.mutable_resources_available())[resource_name] =
         std::max(available, 0.0);
   }
 
   if (get_pull_manager_at_capacity_ != nullptr) {
     resources.object_pulls_queued = get_pull_manager_at_capacity_();
-    resources_data.set_object_pulls_queued(resources.object_pulls_queued);
+    resource_view_sync_message.set_object_pulls_queued(resources.object_pulls_queued);
   }
 
   auto idle_time = GetResourceIdleTime();
@@ -323,11 +322,11 @@ void LocalResourceManager::PopulateResourceUsage(
     // We round up the idle duration to the nearest millisecond such that the idle
     // reporting would be correct even if it's less than 1 millisecond.
     const auto now = absl::Now();
-    resources_data.set_idle_duration_ms(std::max(
+    resource_view_sync_message.set_idle_duration_ms(std::max(
         static_cast<int64_t>(1), absl::ToInt64Milliseconds(now - idle_time.value())));
   }
 
-  resources_data.set_is_draining(IsLocalNodeDraining());
+  resource_view_sync_message.set_is_draining(IsLocalNodeDraining());
 
   for (const auto &iter : last_idle_times_) {
     if (iter.second == absl::nullopt) {
@@ -335,7 +334,7 @@ void LocalResourceManager::PopulateResourceUsage(
       if (iter.first.index() == 0) {
         switch (std::get<WorkFootprint>(iter.first)) {
         case WorkFootprint::NODE_WORKERS:
-          resources_data.add_node_activity("Busy workers on node.");
+          resource_view_sync_message.add_node_activity("Busy workers on node.");
           break;
         default:
           UNREACHABLE;
@@ -345,7 +344,7 @@ void LocalResourceManager::PopulateResourceUsage(
         std::stringstream out;
         out << "Resource: " << std::get<ResourceID>(iter.first).Binary()
             << " currently in use.";
-        resources_data.add_node_activity(out.str());
+        resource_view_sync_message.add_node_activity(out.str());
       }
     }
   }
@@ -364,14 +363,14 @@ std::optional<syncer::RaySyncMessage> LocalResourceManager::CreateSyncMessage(
   }
 
   syncer::RaySyncMessage msg;
-  rpc::ResourcesData resources_data;
-  PopulateResourceUsage(resources_data);
+  syncer::ResourceViewSyncMessage resource_view_sync_message;
+  PopulateResourceViewSyncMessage(resource_view_sync_message);
 
   msg.set_node_id(local_node_id_.Binary());
   msg.set_version(version_);
   msg.set_message_type(message_type);
   std::string serialized_msg;
-  RAY_CHECK(resources_data.SerializeToString(&serialized_msg));
+  RAY_CHECK(resource_view_sync_message.SerializeToString(&serialized_msg));
   msg.set_sync_message(std::move(serialized_msg));
   return std::make_optional(std::move(msg));
 }

--- a/src/ray/raylet/scheduling/local_resource_manager.h
+++ b/src/ray/raylet/scheduling/local_resource_manager.h
@@ -141,8 +141,8 @@ class LocalResourceManager : public syncer::ReporterInterface {
   std::optional<syncer::RaySyncMessage> CreateSyncMessage(
       int64_t after_version, syncer::MessageType message_type) const override;
 
-  /// Populate resource usage.
-  void PopulateResourceUsage(rpc::ResourcesData &resources_data) const;
+  void PopulateResourceViewSyncMessage(
+      syncer::ResourceViewSyncMessage &resource_view_sync_message) const;
 
   /// Record the metrics.
   void RecordMetrics() const;

--- a/src/ray/raylet/scheduling/local_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager_test.cc
@@ -46,11 +46,11 @@ class LocalResourceManagerTest : public ::testing::Test {
     }
   }
 
-  rpc::ResourcesData GetSyncMessageForResourceReport() {
+  syncer::ResourceViewSyncMessage GetSyncMessageForResourceReport() {
     auto msg = manager->CreateSyncMessage(0, syncer::MessageType::RESOURCE_VIEW);
-    rpc::ResourcesData resources_data;
-    resources_data.ParseFromString(msg->sync_message());
-    return resources_data;
+    syncer::ResourceViewSyncMessage resource_view_sync_messge;
+    resource_view_sync_messge.ParseFromString(msg->sync_message());
+    return resource_view_sync_messge;
   }
 
   scheduling::NodeID local_node_id = scheduling::NodeID(0);
@@ -282,8 +282,8 @@ TEST_F(LocalResourceManagerTest, IdleResourceTimeTest) {
       auto idle_time = manager->GetResourceIdleTime();
       ASSERT_EQ(idle_time, absl::nullopt);
 
-      const auto &resources_data = GetSyncMessageForResourceReport();
-      ASSERT_EQ(resources_data.idle_duration_ms(), 0);
+      const auto &resource_view_sync_messge = GetSyncMessageForResourceReport();
+      ASSERT_EQ(resource_view_sync_messge.idle_duration_ms(), 0);
     }
 
     // Deallocate the resource
@@ -303,9 +303,9 @@ TEST_F(LocalResourceManagerTest, IdleResourceTimeTest) {
       ASSERT_GE(dur, absl::ZeroDuration());
       ASSERT_LE(dur, absl::Seconds(1));
 
-      const auto &resources_data = GetSyncMessageForResourceReport();
-      ASSERT_GE(resources_data.idle_duration_ms(), 0);
-      ASSERT_LE(resources_data.idle_duration_ms(), 1 * 1000);
+      const auto &resource_view_sync_messge = GetSyncMessageForResourceReport();
+      ASSERT_GE(resource_view_sync_messge.idle_duration_ms(), 0);
+      ASSERT_LE(resource_view_sync_messge.idle_duration_ms(), 1 * 1000);
     }
   }
 
@@ -316,8 +316,8 @@ TEST_F(LocalResourceManagerTest, IdleResourceTimeTest) {
     auto idle_time = manager->GetResourceIdleTime();
     ASSERT_EQ(idle_time, absl::nullopt);
 
-    const auto &resources_data = GetSyncMessageForResourceReport();
-    ASSERT_EQ(resources_data.idle_duration_ms(), 0);
+    const auto &resource_view_sync_messge = GetSyncMessageForResourceReport();
+    ASSERT_EQ(resource_view_sync_messge.idle_duration_ms(), 0);
   }
 
   // Free object store memory usage should make node resource idle.
@@ -330,8 +330,8 @@ TEST_F(LocalResourceManagerTest, IdleResourceTimeTest) {
     ASSERT_GE(dur, absl::ZeroDuration());
 
     // And syncer messages should be created correctly for resource reporting.
-    const auto &resources_data = GetSyncMessageForResourceReport();
-    ASSERT_GE(resources_data.idle_duration_ms(), 0);
+    const auto &resource_view_sync_messge = GetSyncMessageForResourceReport();
+    ASSERT_GE(resource_view_sync_messge.idle_duration_ms(), 0);
   }
 }
 
@@ -351,8 +351,8 @@ TEST_F(LocalResourceManagerTest, CreateSyncMessageNegativeResourceAvailability) 
   manager->SubtractResourceInstances(
       ResourceID::CPU(), {2.0}, /*allow_going_negative=*/true);
 
-  const auto &resources_data = GetSyncMessageForResourceReport();
-  ASSERT_EQ(resources_data.resources_available().at("CPU"), 0);
+  const auto &resource_view_sync_messge = GetSyncMessageForResourceReport();
+  ASSERT_EQ(resource_view_sync_messge.resources_available().at("CPU"), 0);
 }
 
 }  // namespace ray

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -531,14 +531,6 @@ void raylet::RayletClient::GlobalGC(
   grpc_client_->GlobalGC(request, callback);
 }
 
-void raylet::RayletClient::UpdateResourceUsage(
-    std::string &serialized_resource_usage_batch,
-    const rpc::ClientCallback<rpc::UpdateResourceUsageReply> &callback) {
-  rpc::UpdateResourceUsageRequest request;
-  request.set_serialized_resource_usage_batch(serialized_resource_usage_batch);
-  grpc_client_->UpdateResourceUsage(request, callback);
-}
-
 void raylet::RayletClient::GetResourceLoad(
     const rpc::ClientCallback<rpc::GetResourceLoadReply> &callback) {
   rpc::GetResourceLoadRequest request;

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -164,10 +164,6 @@ class DependencyWaiterInterface {
 /// Inteface for getting resource reports.
 class ResourceTrackingInterface {
  public:
-  virtual void UpdateResourceUsage(
-      std::string &serialized_resource_usage_batch,
-      const rpc::ClientCallback<rpc::UpdateResourceUsageReply> &callback) = 0;
-
   virtual void GetResourceLoad(
       const rpc::ClientCallback<rpc::GetResourceLoadReply> &callback) = 0;
 
@@ -478,10 +474,6 @@ class RayletClient : public RayletClientInterface {
       const rpc::ClientCallback<rpc::GetSystemConfigReply> &callback) override;
 
   void GlobalGC(const rpc::ClientCallback<rpc::GlobalGCReply> &callback);
-
-  void UpdateResourceUsage(
-      std::string &serialized_resource_usage_batch,
-      const rpc::ClientCallback<rpc::UpdateResourceUsageReply> &callback) override;
 
   void GetResourceLoad(
       const rpc::ClientCallback<rpc::GetResourceLoadReply> &callback) override;

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -79,12 +79,6 @@ class NodeManagerWorkerClient
 
   std::shared_ptr<grpc::Channel> Channel() const { return grpc_client_->Channel(); }
 
-  /// Update cluster resource usage.
-  VOID_RPC_CLIENT_METHOD(NodeManagerService,
-                         UpdateResourceUsage,
-                         grpc_client_,
-                         /*method_timeout_ms*/ -1, )
-
   /// Get a resource load
   VOID_RPC_CLIENT_METHOD(NodeManagerService,
                          GetResourceLoad,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
ResourcesData contains too many things, this PR simplifies it by moving resource view sync message into its own proto message. Eventually after autoscaler v2, we can completely remove ResourceData. This is a continuation of #40983
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
