### PR TITLE
[serve] Ensure that the `target_capacity` field of the Serve REST API response is always set

### DIFF
--- a/dashboard/modules/serve/tests/test_serve_dashboard.py
+++ b/dashboard/modules/serve/tests/test_serve_dashboard.py
@@ -294,7 +294,13 @@ def test_delete_multi_app(ray_start_stop, url):
 def test_get_serve_instance_details_not_started(ray_start_stop, url):
     """Test REST API when Serve hasn't started yet."""
 
-    ServeInstanceDetails(**requests.get(url).json())
+    raw_json = requests.get(url).json()
+
+    # `target_capacity` should always be present in the response.
+    assert raw_json["target_capacity"] is None
+
+    # Parse the response to ensure it's formatted correctly.
+    ServeInstanceDetails(**raw_json)
 
 
 @pytest.mark.skipif(sys.platform == "darwin" and DISABLE_DARWIN, reason="Flaky on OSX.")
@@ -373,7 +379,11 @@ def test_get_serve_instance_details(ray_start_stop, f_deployment_options, url):
     wait_for_condition(applications_running, timeout=15)
     print("All applications are in a RUNNING state.")
 
-    serve_details = ServeInstanceDetails(**requests.get(url).json())
+    raw_json = requests.get(url).json()
+    # `target_capacity` should always be present in the response even when `None`.
+    assert raw_json["target_capacity"] is None
+
+    serve_details = ServeInstanceDetails(**raw_json)
     # CHECK: proxy location, HTTP host, and HTTP port
     assert serve_details.proxy_location == "HeadOnly"
     assert serve_details.http_options.host == "127.0.0.1"

--- a/dashboard/modules/serve/tests/test_serve_dashboard.py
+++ b/dashboard/modules/serve/tests/test_serve_dashboard.py
@@ -26,9 +26,8 @@ from ray.serve._private.common import (
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 
 
-# For local testing. If you're running these tests locally on a Macbook, set
-# this variable to False to enable tests.
-DISABLE_DARWIN = True
+# For local testing on a Macbook, set `export TEST_ON_DARWIN=1`.
+TEST_ON_DARWIN = os.environ.get("TEST_ON_DARWIN", "0") == "1"
 
 
 SERVE_AGENT_URL = "http://localhost:52365/api/serve/applications/"
@@ -41,7 +40,9 @@ def deploy_config_multi_app(config: Dict, url: str):
     print("PUT request sent successfully.")
 
 
-@pytest.mark.skipif(sys.platform == "darwin" and DISABLE_DARWIN, reason="Flaky on OSX.")
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
 @pytest.mark.parametrize("url", [SERVE_AGENT_URL, SERVE_HEAD_URL])
 def test_put_get_multi_app(ray_start_stop, url):
     pizza_import_path = (
@@ -138,7 +139,9 @@ def test_put_get_multi_app(ray_start_stop, url):
         print("Deployments are live and reachable over HTTP.\n")
 
 
-@pytest.mark.skipif(sys.platform == "darwin" and DISABLE_DARWIN, reason="Flaky on OSX.")
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
 @pytest.mark.parametrize(
     "put_url",
     [
@@ -153,7 +156,9 @@ def test_put_bad_schema(ray_start_stop, put_url: str):
     assert put_response.status_code == 400
 
 
-@pytest.mark.skipif(sys.platform == "darwin" and DISABLE_DARWIN, reason="Flaky on OSX.")
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
 @pytest.mark.parametrize("url", [SERVE_AGENT_URL, SERVE_HEAD_URL])
 def test_put_duplicate_apps(ray_start_stop, url):
     """If a config with duplicate app names is deployed, the PUT request should fail.
@@ -178,7 +183,9 @@ def test_put_duplicate_apps(ray_start_stop, url):
     assert put_response.status_code == 400 and "ValidationError" in put_response.text
 
 
-@pytest.mark.skipif(sys.platform == "darwin" and DISABLE_DARWIN, reason="Flaky on OSX.")
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
 @pytest.mark.parametrize("url", [SERVE_AGENT_URL, SERVE_HEAD_URL])
 def test_put_duplicate_routes(ray_start_stop, url):
     """If a config with duplicate routes is deployed, the PUT request should fail.
@@ -203,7 +210,9 @@ def test_put_duplicate_routes(ray_start_stop, url):
     assert put_response.status_code == 400 and "ValidationError" in put_response.text
 
 
-@pytest.mark.skipif(sys.platform == "darwin" and DISABLE_DARWIN, reason="Flaky on OSX.")
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
 @pytest.mark.parametrize("url", [SERVE_AGENT_URL, SERVE_HEAD_URL])
 def test_delete_multi_app(ray_start_stop, url):
     py_module = (
@@ -289,21 +298,19 @@ def test_delete_multi_app(ray_start_stop, url):
         print("Deployments have been deleted and are not reachable.\n")
 
 
-@pytest.mark.skipif(sys.platform == "darwin" and DISABLE_DARWIN, reason="Flaky on OSX.")
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
 @pytest.mark.parametrize("url", [SERVE_AGENT_URL, SERVE_HEAD_URL])
 def test_get_serve_instance_details_not_started(ray_start_stop, url):
     """Test REST API when Serve hasn't started yet."""
-
-    raw_json = requests.get(url).json()
-
-    # `target_capacity` should always be present in the response.
-    assert raw_json["target_capacity"] is None
-
     # Parse the response to ensure it's formatted correctly.
-    ServeInstanceDetails(**raw_json)
+    ServeInstanceDetails(**requests.get(url).json())
 
 
-@pytest.mark.skipif(sys.platform == "darwin" and DISABLE_DARWIN, reason="Flaky on OSX.")
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
 @pytest.mark.parametrize(
     "f_deployment_options",
     [
@@ -379,11 +386,7 @@ def test_get_serve_instance_details(ray_start_stop, f_deployment_options, url):
     wait_for_condition(applications_running, timeout=15)
     print("All applications are in a RUNNING state.")
 
-    raw_json = requests.get(url).json()
-    # `target_capacity` should always be present in the response even when `None`.
-    assert raw_json["target_capacity"] is None
-
-    serve_details = ServeInstanceDetails(**raw_json)
+    serve_details = ServeInstanceDetails(**requests.get(url).json())
     # CHECK: proxy location, HTTP host, and HTTP port
     assert serve_details.proxy_location == "HeadOnly"
     assert serve_details.http_options.host == "127.0.0.1"
@@ -453,7 +456,9 @@ def test_get_serve_instance_details(ray_start_stop, f_deployment_options, url):
     print("Finished checking application details.")
 
 
-@pytest.mark.skipif(sys.platform == "darwin" and DISABLE_DARWIN, reason="Flaky on OSX.")
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
 def test_serve_namespace(ray_start_stop):
     """Check that the driver can interact with Serve using the Python API."""
 
@@ -630,7 +635,9 @@ def test_default_dashboard_agent_listen_port():
     assert ray_constants.DEFAULT_DASHBOARD_AGENT_LISTEN_PORT == 52365
 
 
-@pytest.mark.skipif(sys.platform == "darwin" and DISABLE_DARWIN, reason="Flaky on OSX.")
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
 @pytest.mark.parametrize(
     "ray_start_regular_with_external_redis",
     [
@@ -665,6 +672,42 @@ def test_get_applications_while_gcs_down(
         assert requests.get(url, timeout=30).status_code == 200
 
     serve.shutdown()
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
+@pytest.mark.parametrize("url", [SERVE_AGENT_URL, SERVE_HEAD_URL])
+def test_target_capacity_field(ray_start_stop, url: str):
+    """Test that the `target_capacity` field is always populated as expected."""
+
+    raw_json = requests.get(url).json()
+
+    # `target_capacity` should be present in the response before deploying anything.
+    assert raw_json["target_capacity"] is None, raw_json
+
+    config_without_target_capacity = {
+        "http_options": {
+            "host": "127.0.0.1",
+            "port": 8000,
+        },
+        "applications": [],
+    }
+    deploy_config_multi_app(config_without_target_capacity, url)
+
+    raw_json = requests.get(url).json()
+
+    # `target_capacity` should be present in the response even if not set.
+    assert raw_json["target_capacity"] is None, raw_json
+
+    # Parse the response to ensure it's formatted correctly.
+    details = ServeInstanceDetails(**raw_json)
+    assert details.target_capacity is None
+    assert details.http_options.host == "127.0.0.1"
+    assert details.http_options.port == 8000
+    assert details.applications == {}
+
+    # TODO(edoakes): add test cases that set and update `target_capacity`.
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -834,6 +834,7 @@ class ServeController:
         http_options = HTTPOptionsSchema.parse_obj(http_config.dict(exclude_unset=True))
         grpc_options = gRPCOptionsSchema.parse_obj(grpc_config.dict(exclude_unset=True))
         return ServeInstanceDetails(
+            target_capacity=None,
             controller_info=self._actor_details,
             proxy_location=http_config.location,
             http_options=http_options,

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -972,6 +972,7 @@ class ServeInstanceDetails(BaseModel, extra=Extra.forbid):
             "controller_info": {},
             "proxies": {},
             "applications": {},
+            "target_capacity": None,
         }
 
     def _get_status(self) -> ServeStatus:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This field should be returned as `null` even when it's not set so we can differentiate between the response when it's not set vs. older versions of Serve where it isn't supported.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
