### PR TITLE
[serve] Add `route_prefix` flag to serve run

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -359,6 +359,17 @@ def deploy(config_file_name: str, address: str):
         "app."
     ),
 )
+@click.option(
+    "--route-prefix",
+    required=False,
+    default="/",
+    type=str,
+    help=(
+        "Route prefix for the application. This should only be used "
+        "when running an application specified by import path, and "
+        "will be ignored if running a config file."
+    ),
+)
 def run(
     config_or_import_path: str,
     arguments: Tuple[str],
@@ -371,6 +382,7 @@ def run(
     port: int,
     blocking: bool,
     reload: bool,
+    route_prefix: str,
 ):
     if host is not None or port is not None:
         cli_logger.warning(
@@ -466,7 +478,7 @@ def run(
             client.deploy_apps(config, _blocking=False)
             cli_logger.success("Submitted deploy config successfully.")
         else:
-            serve.run(app, host=host, port=port)
+            serve.run(app, route_prefix=route_prefix, host=host, port=port)
             cli_logger.success("Deployed Serve app successfully.")
 
         if reload:
@@ -493,7 +505,7 @@ def run(
                     app = _private_api.call_app_builder_with_args_if_necessary(
                         import_attr(import_path, reload_module=True), args_dict
                     )
-                    serve.run(app, host=host, port=port)
+                    serve.run(app, route_prefix=route_prefix, host=host, port=port)
 
         if blocking:
             while True:

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -366,7 +366,7 @@ def deploy(config_file_name: str, address: str):
     type=str,
     help=(
         "Route prefix for the application. This should only be used "
-        "when running an application specified by import path, and "
+        "when running an application specified by import path and "
         "will be ignored if running a config file."
     ),
 )

--- a/python/ray/serve/tests/test_cli_2.py
+++ b/python/ray/serve/tests/test_cli_2.py
@@ -50,8 +50,9 @@ def ping_endpoint(endpoint: str, params: str = ""):
 
 
 def check_app_running(app_name: str):
-    status = serve.status().applications[app_name]
-    assert status.status == "RUNNING"
+    status_response = subprocess.check_output(["serve", "status"])
+    status = yaml.safe_load(status_response)["applications"]
+    assert status[app_name]["status"] == "RUNNING"
     return True
 
 

--- a/python/ray/serve/tests/test_cli_2.py
+++ b/python/ray/serve/tests/test_cli_2.py
@@ -41,10 +41,18 @@ CONNECTION_ERROR_MSG = "connection error"
 
 
 def ping_endpoint(endpoint: str, params: str = ""):
+    endpoint = endpoint.lstrip("/")
+
     try:
         return requests.get(f"http://localhost:8000/{endpoint}{params}").text
     except requests.exceptions.ConnectionError:
         return CONNECTION_ERROR_MSG
+
+
+def check_app_running(app_name: str):
+    status = serve.status().applications[app_name]
+    assert status.status == "RUNNING"
+    return True
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
@@ -196,14 +204,12 @@ def test_run_application(ray_start_stop, number_of_kill_signals):
     p = subprocess.Popen(
         ["serve", "run", "--address=auto", "ray.serve.tests.test_cli_2.parrot_node"]
     )
-    wait_for_condition(
-        lambda: ping_endpoint("parrot", params="?sound=squawk") == "squawk"
-    )
+    wait_for_condition(lambda: ping_endpoint("/", params="?sound=squawk") == "squawk")
     print("Run successful! Deployment is live and reachable over HTTP. Killing run.")
 
     p.send_signal(signal.SIGINT)  # Equivalent to ctrl-C
     p.wait()
-    assert ping_endpoint("parrot", params="?sound=squawk") == CONNECTION_ERROR_MSG
+    assert ping_endpoint("/", params="?sound=squawk") == CONNECTION_ERROR_MSG
     print("Kill successful! Deployment is not reachable over HTTP.")
 
 
@@ -274,10 +280,10 @@ def test_run_deployment_node(ray_start_stop):
             "ray.serve.tests.test_cli_2.molly_macaw",
         ]
     )
-    wait_for_condition(lambda: ping_endpoint("Macaw") == "Molly is green!", timeout=10)
+    wait_for_condition(lambda: ping_endpoint("/") == "Molly is green!", timeout=10)
     p.send_signal(signal.SIGINT)
     p.wait()
-    assert ping_endpoint("Macaw") == CONNECTION_ERROR_MSG
+    assert ping_endpoint("/") == CONNECTION_ERROR_MSG
 
 
 @serve.deployment
@@ -288,6 +294,9 @@ class Echo:
 
     def __call__(self, *args):
         return self._message
+
+
+echo_app = Echo.bind("hello")
 
 
 def build_echo_app(args):
@@ -327,7 +336,7 @@ def test_run_builder_with_args(ray_start_stop, import_path: str):
     wait_for_condition(lambda: ping_endpoint("") == "DEFAULT", timeout=10)
     p.send_signal(signal.SIGINT)
     p.wait()
-    assert ping_endpoint("") == CONNECTION_ERROR_MSG
+    assert ping_endpoint("/") == CONNECTION_ERROR_MSG
 
     # Now deploy passing a message as an argument, should get passed message.
     p = subprocess.Popen(
@@ -343,7 +352,7 @@ def test_run_builder_with_args(ray_start_stop, import_path: str):
 
     p.send_signal(signal.SIGINT)
     p.wait()
-    assert ping_endpoint("") == CONNECTION_ERROR_MSG
+    assert ping_endpoint("/") == CONNECTION_ERROR_MSG
 
 
 @serve.deployment
@@ -480,6 +489,38 @@ def test_run_teardown(ray_start_stop):
         timeout=30,
     ).decode()
     assert "Intentionally failing." in logs
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
+def test_run_route_prefix_default(ray_start_stop):
+    """Test `serve run` with route prefix option."""
+
+    p = subprocess.Popen(["serve", "run", "ray.serve.tests.test_cli_2.echo_app"])
+
+    wait_for_condition(check_app_running, app_name="default")
+    assert ping_endpoint("/") == "hello"
+    p.send_signal(signal.SIGINT)
+    p.wait()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
+def test_run_route_prefix_override(ray_start_stop):
+    """Test `serve run` with route prefix option."""
+
+    p = subprocess.Popen(
+        [
+            "serve",
+            "run",
+            "--route-prefix=/hello",
+            "ray.serve.tests.test_cli_2.echo_app",
+        ],
+    )
+
+    wait_for_condition(check_app_running, app_name="default")
+    assert "Path '/' not found" in ping_endpoint("/")
+    assert ping_endpoint("/hello") == "hello"
+    p.send_signal(signal.SIGINT)
+    p.wait()
 
 
 @serve.deployment


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
