### PR TITLE
[ci] run data arrow nightly tests only on postmerge

### DIFF
--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -54,6 +54,8 @@ steps:
     tags: 
       - python
       - data
+    # run only on postmerge
+    if: build.env("BUILDKITE_PIPELINE_ID") == "0189e759-8c96-4302-b6b5-b4274406bf89"
     instance_type: medium
     parallelism: 2
     commands:


### PR DESCRIPTION
The data arrow nightly tests are failing on premerge. Also this test depends on changes outside of a PR so ideally it should not run be a PR test.

Test:
- CI