### PR TITLE
[ci] run flaky core tests serially on postmerge

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -205,8 +205,10 @@ steps:
   - label: ":ray: core: flaky tests"
     tags: python
     instance_type: large
+    # run only on postmerge
+    if: build.env("BUILDKITE_PIPELINE_ID") == "0189e759-8c96-4302-b6b5-b4274406bf89"
     soft_fail: true
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //... core --run-flaky-tests --parallelism-per-worker 3 --except-tags manual
+      - bazel run //ci/ray_ci:test_in_docker -- //... core --run-flaky-tests --except-tags manual
     depends_on: corebuild
     job_env: forge


### PR DESCRIPTION
We want to test out an experiment to see if run the existing flaky tests serially will make them much more reliable. But doing so will make the job more expensive to run. I chat with @rkooo567 and we make a decision to run them serially on post-merge only as an experiement.

Test:
- CI