### PR TITLE
[ci] migrate rllib memory leak tests to civ2

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -1,31 +1,5 @@
 #ci:group=ML tests
 
-- label: ":brain: RLlib: Memory leak tests TF2-eager-tracing"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
-  instance_size: medium
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options)
-      --build_tests_only
-      --test_tag_filters=memory_leak_tests,-flaky
-      --test_arg=--framework=tf2
-      rllib/...
-
-- label: ":brain: RLlib: Memory leak tests PyTorch"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_AFFECTED"]
-  instance_size: medium
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - RLLIB_TESTING=1 ./ci/env/install-dependencies.sh
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./ci/run/bazel_export_options)
-      --build_tests_only
-      --test_tag_filters=memory_leak_tests,-flaky
-      --test_arg=--framework=torch
-      rllib/...
-
 # TODO(amogkam): Re-enable Ludwig tests after Ludwig supports Ray 2.0
 #- label: ":octopus: Ludwig tests and examples. Python 3.7"
 #  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_TUNE_AFFECTED"]

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -160,6 +160,28 @@ steps:
     depends_on: rllibbuild
     job_env: forge
 
+  - label: ":brain: rllib: memory leak tf2-eager-tracing tests"
+    tags: rllib
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --only-tags memory_leak_tests
+        --except-tags flaky
+        --test-arg --framework=tf2
+    depends_on: rllibbuild
+    job_env: forge
+
+  - label: ":brain: rllib: memory leak pytorch tests"
+    tags: rllib
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --only-tags memory_leak_tests
+        --except-tags flaky
+        --test-arg --framework=torch
+    depends_on: rllibbuild
+    job_env: forge
+
   - label: ":brain: rllib: doc tests"
     tags: 
       - rllib_directly
@@ -268,6 +290,19 @@ steps:
         --except-tags multi_gpu,manual
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
         --skip-ray-installation # reuse the same docker image as the previous run
+    depends_on: rllibbuild
+    soft_fail: true
+    job_env: forge
+
+  - label: ":brain: rllib: flaky tests (memory leak)"
+    tags: rllib
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --run-flaky-tests
+        --only-tags memory_leak_tests
+        --except-tags flaky
+        --test-arg --framework=tf2
     depends_on: rllibbuild
     soft_fail: true
     job_env: forge

--- a/ci/ray_ci/rllib.tests.yml
+++ b/ci/ray_ci/rllib.tests.yml
@@ -27,6 +27,7 @@ flaky_tests:
   - //rllib:examples/custom_recurrent_rnn_tokenizer_repeat_initial_obs_env_torch
   # memory leak tf2-eager-tracing
   - //rllib:test_memory_leak_ppo
+  - //rllib:test_memory_leak_appo
   - //rllib:test_memory_leak_sac
   - //rllib:test_memory_leak_impala
   - //rllib:test_memory_leak_a3c


### PR DESCRIPTION
Migrate the last rllib test jobs (memory leak) to civ2

Test:
- CI