### PR TITLE
Adapt the joblib backend for compatibility with `return_as=generator`

### DIFF
--- a/python/ray/util/joblib/ray_backend.py
+++ b/python/ray/util/joblib/ray_backend.py
@@ -17,6 +17,8 @@ class RayBackend(MultiprocessingBackend):
     More info about Ray is available here: https://docs.ray.io.
     """
 
+    supports_return_generator = True
+
     def __init__(
         self,
         nesting_level: Optional[int] = None,


### PR DESCRIPTION
## Context

From the latest 1.3.x releases on, `joblib.Parallel` supports returning the results as a generator so users can consume an output as soon as it's ready, as opposed to the default, historical behavior that waits that all computations are done and returns all results in a list. It can prevent accumulation in memory. [Usage example](https://joblib.readthedocs.io/en/stable/auto_examples/parallel_generator.html#sphx-glr-auto-examples-parallel-generator-py).

(nb: 1.3.x introduced `return_as=generator`, and `return_as=generator_unordered` will also be available when 1.4.x is released ([preview example](https://joblib.readthedocs.io/en/latest/auto_examples/parallel_generator.html#further-memory-efficiency-for-commutative-aggregation)) )

## Why are these changes needed

If users run custom code containing `joblib.Parallel` calls using RayBackend, they currently can't use the `return_as=generator` feature that was introduced in 1.3.x, or have an error that says that RayBackend doesn't support it.

Backends that worked with `1.2.x` still work with `1.3.x`, but must be adapted to support the parameter `return_as=generator`. We did adapt MultiprocessingBackend, that is shipped with joblib, so the Ray backend, that inherits from it, is also naturally compatible. However [some tests](https://github.com/joblib/joblib/blob/bfd14ebc16ef36fde57b25654a10d5b21ca441d9/joblib/test/test_parallel.py#L1306-L1321) exposed instability (deadlocks) in edge cases linked to garbage collection when using `return_as=generator` with MultiprocessingBackend so we deactivated it. We assume instability comes from issues with the multiprocessing library itself (in the near future we don't plan to fix it since the backend is maintained for compatibility, the default backend for processes being loky and it's stable)

This PR overrides the enabling parameter in MultiprocessingBackend to activate `return_as=generator` support for RayBackend. I ran the tests locally, and I couldn't showcase any evidence of instability for the RayBackend like we see on the MultiprocessingBackend. I add the particular test that causes deadlocks with the MultiprocessingBackend to ray test suite, it shows that it's stable.

For the time being `return_as=generator` is not used in scikit-learn and will not be before joblib 1.2.x support is dropped but eventually it could become necessary to remain compatible with some estimators in the long term.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
