### PR TITLE
[train] Update TensorFlow ReportCheckpointCallback to delete temporary directory

### DIFF
--- a/python/ray/air/integrations/keras.py
+++ b/python/ray/air/integrations/keras.py
@@ -162,7 +162,8 @@ class ReportCheckpointCallback(_Callback):
         if should_checkpoint:
             checkpoint = TensorflowCheckpoint.from_model(self.model)
             ray.train.report(metrics, checkpoint=checkpoint)
-            shutil.rmtree(checkpoint.path)  # Clean up temporary checkpoint
+            # Clean up temporary checkpoint
+            shutil.rmtree(checkpoint.path, ignore_errors=True)
         else:
             ray.train.report(metrics, checkpoint=None)
 

--- a/python/ray/air/integrations/keras.py
+++ b/python/ray/air/integrations/keras.py
@@ -1,3 +1,4 @@
+import shutil
 from typing import Dict, List, Optional, Union
 
 from tensorflow.keras.callbacks import Callback as KerasCallback
@@ -158,10 +159,12 @@ class ReportCheckpointCallback(_Callback):
         metrics = self._get_reported_metrics(logs)
 
         should_checkpoint = when in self._checkpoint_on
-        checkpoint = None
         if should_checkpoint:
             checkpoint = TensorflowCheckpoint.from_model(self.model)
-        ray.train.report(metrics, checkpoint=checkpoint)
+            ray.train.report(metrics, checkpoint=checkpoint)
+            shutil.rmtree(checkpoint.path)  # Clean up temporary checkpoint
+        else:
+            ray.train.report(metrics, checkpoint=None)
 
     def _get_reported_metrics(self, logs: Dict) -> Dict:
         assert isinstance(self._metrics, (type(None), str, list, dict))

--- a/python/ray/air/tests/test_keras_callback.py
+++ b/python/ray/air/tests/test_keras_callback.py
@@ -1,5 +1,6 @@
 from typing import Dict, Tuple
 from unittest.mock import patch
+import os
 
 import pytest
 import numpy as np
@@ -137,6 +138,22 @@ class TestReportCheckpointCallback:
         # specified in `report_metrics_on`.
         assert second_metric == {"loss": 1}
         assert second_checkpoint is not None
+
+    @patch("ray.train.report")
+    def test_report_delete_tempdir(self, mock_report, model):
+        # This tests `ReportCheckpointCallback`. The test simulates the end of an epoch,
+        # and asserts that the temporary checkpoint directory is deleted afterwards.
+        callback = ReportCheckpointCallback()
+        callback.model = model
+
+        callback.on_epoch_end(0, {"loss": 0})
+
+        assert len(ray.train.report.call_args_list) == 1
+        metrics, checkpoint = self.parse_call(ray.train.report.call_args_list[0])
+        assert metrics == {"loss": 0}
+        assert checkpoint is not None
+        assert checkpoint.path is not None
+        assert not os.path.exists(checkpoint.path)
 
     def parse_call(self, call) -> Tuple[Dict, train.Checkpoint]:
         (metrics,), kwargs = call


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`ReportCheckpointCallback` creates a `TensorflowCheckpoint`, which will create a temporary directory to hold the checkpoint state. After `ReportCheckpointCallback` calls `train.report`, it should clean up this temporary directory, as the checkpoint is now persisted to the final storage location.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #40956

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
