### PR TITLE
[ci] migrate team:none doctest to civ2 other jobs

### DIFF
--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -1,5 +1,10 @@
 group: others
 steps:
+  #build
+  - name: doctestbuild
+    wanda: ci/docker/doctest.build.wanda.yaml
+    depends_on: oss-ci-base_build
+
   # test
   - label: ":java: java tests"
     tags: java
@@ -10,4 +15,22 @@ steps:
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild /bin/bash -iecuo pipefail 
         "./java/test.sh"
     depends_on: corebuild
+    job_env: forge
+
+  - label: doc tests
+    instance_type: large
+    commands:
+      # doc tests
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/... //doc/... none
+        --build-name doctestbuild
+        --only-tags doctest
+        --except-tags gpu
+        --parallelism-per-worker 3
+      # doc examples
+      - bazel run //ci/ray_ci:test_in_docker -- //doc/... core
+        --build-name doctestbuild
+        --only-tags xcommit
+        --except-tags gpu
+        --skip-ray-installation
+    depends_on: doctestbuild
     job_env: forge

--- a/.buildkite/pipeline.build.yml
+++ b/.buildkite/pipeline.build.yml
@@ -39,22 +39,6 @@
       --test_env=DOCKER_TLS_CERTDIR=/certs
       -- python/ray/tests/...
 
-- label: ":book: civ1 doctest"
-  instance_size: large
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    # Todo (krfricke): Move mosaicml to train-test-requirements.txt
-    - pip install "mosaicml==0.12.1"
-    - DOC_TESTING=1 ./ci/env/install-dependencies.sh
-    # TODO(scottjlee): Move datasets to train/data-test-requirements.txt
-    # (see https://github.com/ray-project/ray/pull/38432/)
-    - pip install "datasets==2.14.0"
-    - ./ci/env/install-horovod.sh
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./scripts/bazel_export_options)
-      --test_tag_filters=doctest,-gpu,-team:core,-team:data,-team:ml,-team:rllib,-team:serve
-      python/ray/... doc/...
-
 - label: ":kubernetes: operator"
   conditions: ["RAY_CI_LINUX_WHEELS_AFFECTED"]
   instance_size: medium

--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -8,24 +8,6 @@
 #    - INSTALL_LUDWIG=1 INSTALL_HOROVOD=1 ./ci/env/install-dependencies.sh
 #    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/tests/ludwig/...
 
-- label: ":book: civ1 doc tests and examples"
-  # Todo: check if we can modify the examples to use Ray with fewer CPUs.
-  conditions:
-    ["RAY_CI_PYTHON_AFFECTED", "RAY_CI_TUNE_AFFECTED", "RAY_CI_DOC_AFFECTED", "RAY_CI_SERVE_AFFECTED", "RAY_CI_ML_AFFECTED"]
-  instance_size: large
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - DOC_TESTING=1 INSTALL_HOROVOD=1 ./ci/env/install-dependencies.sh
-    # TODO (shrekris-anyscale): Remove transformers after core transformer
-    # requirement is upgraded
-    # TODO(scottjlee): Move datasets to train/data-test-requirements.txt 
-    # (see https://github.com/ray-project/ray/pull/38432/)
-    - pip install "transformers==4.30.2" "datasets==2.14.0"
-    - ./ci/env/env_info.sh
-    - bazel test --config=ci $(./scripts/bazel_export_options)
-      --test_tag_filters=xcommit,-gpu
-      doc/...
-
 - label: ":exploding_death_star: RLlib Contrib: A2C Tests"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_CONTRIB_AFFECTED"]
   commands:

--- a/ci/docker/doctest.build.Dockerfile
+++ b/ci/docker/doctest.build.Dockerfile
@@ -1,0 +1,14 @@
+ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build
+FROM $DOCKER_IMAGE_BASE_BUILD
+
+# Unset dind settings; we are using the host's docker daemon.
+ENV DOCKER_TLS_CERTDIR=
+ENV DOCKER_HOST=
+ENV DOCKER_TLS_VERIFY=
+ENV DOCKER_CERT_PATH=
+
+SHELL ["/bin/bash", "-ice"]
+
+COPY . .
+
+RUN DOC_TESTING=1 INSTALL_HOROVOD=1 ./ci/env/install-dependencies.sh

--- a/ci/docker/doctest.build.wanda.yaml
+++ b/ci/docker/doctest.build.wanda.yaml
@@ -1,0 +1,21 @@
+name: "doctestbuild"
+froms: ["cr.ray.io/rayproject/oss-ci-base_build"]
+dockerfile: ci/docker/doctest.build.Dockerfile
+srcs:
+  - ci/env/install-dependencies.sh
+  - ci/env/install-horovod.sh
+  - python/requirements.txt
+  - python/requirements_compiled.txt
+  - python/requirements/test-requirements.txt
+  - python/requirements/ml/core-requirements.txt
+  - python/requirements/ml/dl-cpu-requirements.txt
+  - python/requirements/ml/train-requirements.txt
+  - python/requirements/ml/train-test-requirements.txt
+  - python/requirements/ml/tune-requirements.txt
+  - python/requirements/ml/tune-test-requirements.txt
+  - python/requirements/ml/data-requirements.txt
+  - python/requirements/ml/data-test-requirements.txt
+  - python/requirements/ml/rllib-requirements.txt
+  - python/requirements/ml/rllib-test-requirements.txt
+tags:
+  - cr.ray.io/rayproject/doctestbuild

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -156,7 +156,6 @@ if __name__ == "__main__":
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
             elif (
                 changed_file.startswith("python/ray/data")
-                or changed_file == ".buildkite/pipeline.ml.yml"
                 or changed_file == ".buildkite/data.rayci.yml"
                 or changed_file == "ci/docker/data.build.Dockerfile"
                 or changed_file == "ci/docker/datan.build.wanda.yaml"
@@ -288,6 +287,12 @@ if __name__ == "__main__":
                 # we pass, as the flag RAY_CI_DOC_AFFECTED is only
                 # used to indicate that tests/examples should be run
                 # (documentation will be built always)
+            elif (
+                changed_file == "ci/docker/doctest.build.Dockerfile"
+                or changed_file == "ci/docker/doctest.build.wanda.yaml"
+            ):
+                # common doctest always run without coverage
+                pass
             elif changed_file.startswith("release/") or changed_file.startswith(
                 ".buildkite/release"
             ):
@@ -309,6 +314,7 @@ if __name__ == "__main__":
                 changed_file.startswith("ci/pipeline")
                 or changed_file.startswith("ci/ray_ci")
                 or changed_file == ".buildkite/pipeline.build.yml"
+                or changed_file == ".buildkite/pipeline.ml.yml"
             ):
                 # These scripts are always run as part of the build process
                 RAY_CI_TOOLS_AFFECTED = 1

--- a/ci/ray_ci/none.tests.yml
+++ b/ci/ray_ci/none.tests.yml
@@ -1,0 +1,1 @@
+flaky_tests: []

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -146,22 +146,9 @@ py_test_run_all_subdirectory(
         "source/serve/doc_code/http_guide/streaming_example.py",
         "source/serve/doc_code/http_guide/websockets_example.py",
         "source/serve/doc_code/vllm_example.py",
-        "source/serve/doc_code/production_guide/text_ml.py",
-        "source/serve/doc_code/fake_email_creator.py",
     ],
     extra_srcs = [],
     tags = ["exclusive", "team:serve"],
-)
-
-py_test_run_all_subdirectory(
-    size = "medium",
-    include = [
-        "source/serve/doc_code/production_guide/text_ml.py",
-        "source/serve/doc_code/fake_email_creator.py",
-    ],
-    exclude = [],
-    extra_srcs = [],
-    tags = ["exclusive", "team:serve", "xcommit"],
 )
 
 py_test_run_all_subdirectory(


### PR DESCRIPTION
Migrate team:none doctest to civ2 other jobs. Remove serve doctest from `xcommit` now that they are fixed. Still keep the ray_oom as xcommit and run it serially in this other doc job.

Since we don't have information about this job coverage, always run it.

Test:
- CI