### PR TITLE
[Data] Fix `FileBasedDatasource` serialization

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -200,15 +200,15 @@ class FileBasedDatasource(Datasource):
         self._paths_ref = ray.put(paths)
         self._file_sizes_ref = ray.put(file_sizes)
 
-    def paths(self) -> List[str]:
+    def _paths(self) -> List[str]:
         return ray.get(self._paths_ref)
 
-    def file_sizes(self) -> List[float]:
+    def _file_sizes(self) -> List[float]:
         return ray.get(self._file_sizes_ref)
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
         total_size = 0
-        for sz in self.file_sizes():
+        for sz in self._file_sizes():
             if sz is not None:
                 total_size += sz
         return total_size
@@ -220,8 +220,8 @@ class FileBasedDatasource(Datasource):
         open_stream_args = self._open_stream_args
         partitioning = self._partitioning
 
-        paths = self.paths()
-        file_sizes = self.file_sizes()
+        paths = self._paths()
+        file_sizes = self._file_sizes()
 
         if self._file_metadata_shuffler is not None:
             files_metadata = list(zip(paths, file_sizes))

--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -124,7 +124,7 @@ class ImageDatasource(FileBasedDatasource):
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
         total_size = 0
-        for file_size in self._file_sizes:
+        for file_size in self.file_sizes():
             # NOTE: check if file size is not None, because some metadata provider
             # such as FastFileMetadataProvider does not provide file size information.
             if file_size is not None:
@@ -136,7 +136,7 @@ class ImageDatasource(FileBasedDatasource):
         start_time = time.perf_counter()
         # Filter out empty file to avoid noise.
         non_empty_path_and_size = list(
-            filter(lambda p: p[1] > 0, zip(self._paths, self._file_sizes))
+            filter(lambda p: p[1] > 0, zip(self.paths(), self.file_sizes()))
         )
         num_files = len(non_empty_path_and_size)
         if num_files == 0:

--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -124,7 +124,7 @@ class ImageDatasource(FileBasedDatasource):
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
         total_size = 0
-        for file_size in self.file_sizes():
+        for file_size in self._file_sizes():
             # NOTE: check if file size is not None, because some metadata provider
             # such as FastFileMetadataProvider does not provide file size information.
             if file_size is not None:
@@ -136,7 +136,7 @@ class ImageDatasource(FileBasedDatasource):
         start_time = time.perf_counter()
         # Filter out empty file to avoid noise.
         non_empty_path_and_size = list(
-            filter(lambda p: p[1] > 0, zip(self.paths(), self.file_sizes()))
+            filter(lambda p: p[1] > 0, zip(self._paths(), self._file_sizes()))
         )
         num_files = len(non_empty_path_and_size)
         if num_files == 0:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When you launch a read task generated by`FileBasedDatasource`, Ray serializes the `FileBasedDatasource` instance because the read task calls `FileBasedDatasource._read_stream`. This wasn't an issue before, because `FileBasedDatasource` was stateless and therefore quick to serialize. However, https://github.com/ray-project/ray/pull/40900 moved state like the input file paths from `_FileBasedDatasourceReader` to `FileBasedDatasource`. As a result, `FileBasedDatasource` is now slow to serialize and read tasks can be slow to launch.

To fix this issue, this PR stores paths and file sizes in the object store, as only stores references to them in `FileBasedDatasource`.

Successful run https://buildkite.com/ray-project/release/builds/860#018bb679-fa27-4dfa-a8fe-6271ce76fb43

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
