### PR TITLE
[core] Change `__import__` to `importlib.import_module` for MPI plugin.

### DIFF
--- a/python/ray/_private/runtime_env/mpi_runner.py
+++ b/python/ray/_private/runtime_env/mpi_runner.py
@@ -24,6 +24,6 @@ if __name__ == "__main__":
         spec.loader.exec_module(mod)
     else:
         module, func = args.worker_entry.rsplit(".", 1)
-        m = __import__(module)
+        m = importlib.import_module(module)
         f = getattr(m, func)
         f()


### PR DESCRIPTION
Signed-off-by: Yi Cheng <74173148+iycheng@users.noreply.github.com>

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`__import__` will only return the top module which is not what we want. Change it to import_module
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
