### PR TITLE
[Serve] fix flaky telemetry test

### DIFF
--- a/python/ray/serve/tests/test_telemetry.py
+++ b/python/ray/serve/tests/test_telemetry.py
@@ -43,12 +43,15 @@ def test_fastapi_detected(manage_ray_with_telemetry):
     )
 
     # Check that telemetry related to FastAPI app is not set
-    report = ray.get(storage_handle.get_report.remote())
-    assert ServeUsageTag.FASTAPI_USED.get_value_from_report(report) is None
-    assert ServeUsageTag.API_VERSION.get_value_from_report(report) == "v2"
-    assert int(ServeUsageTag.NUM_APPS.get_value_from_report(report)) == 1
-    assert int(ServeUsageTag.NUM_DEPLOYMENTS.get_value_from_report(report)) == 1
-    assert int(ServeUsageTag.NUM_GPU_DEPLOYMENTS.get_value_from_report(report)) == 0
+    def check_report_before_fastapi():
+        report = ray.get(storage_handle.get_report.remote())
+        assert ServeUsageTag.FASTAPI_USED.get_value_from_report(report) is None
+        assert ServeUsageTag.API_VERSION.get_value_from_report(report) == "v2"
+        assert int(ServeUsageTag.NUM_APPS.get_value_from_report(report)) == 1
+        assert int(ServeUsageTag.NUM_DEPLOYMENTS.get_value_from_report(report)) == 1
+        assert int(ServeUsageTag.NUM_GPU_DEPLOYMENTS.get_value_from_report(report)) == 0
+        return True
+    wait_for_condition(check_report_before_fastapi)
 
     app = FastAPI()
 

--- a/python/ray/serve/tests/test_telemetry.py
+++ b/python/ray/serve/tests/test_telemetry.py
@@ -51,6 +51,7 @@ def test_fastapi_detected(manage_ray_with_telemetry):
         assert int(ServeUsageTag.NUM_DEPLOYMENTS.get_value_from_report(report)) == 1
         assert int(ServeUsageTag.NUM_GPU_DEPLOYMENTS.get_value_from_report(report)) == 0
         return True
+
     wait_for_condition(check_report_before_fastapi)
 
     app = FastAPI()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It might take some time for the app to start up before the telemetry show up. Use `wait_for_condition` to ensure all required telemetries are logged before starting fastapi app.

## Related issue number

deflaky [windows://python/ray/serve/tests:test_telemetry](https://buildkite.com/ray-project/oss-ci-build-branch/builds/6839#018bb592-b81b-4cb7-becd-3fd200582449)

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
