### PR TITLE
[data] fix split read output blocks

### DIFF
--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -750,7 +750,6 @@ class ExecutionPlan:
                 logical_op._parallelism,
                 logical_op._mem_size,
                 ctx.target_max_block_size,
-                cur_additional_split_factor=None,
             )
             if logical_op._parallelism == -1:
                 assert reason != ""

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -750,6 +750,7 @@ class ExecutionPlan:
                 logical_op._parallelism,
                 logical_op._mem_size,
                 ctx.target_max_block_size,
+                cur_additional_split_factor=None,
             )
             if logical_op._parallelism == -1:
                 assert reason != ""

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -921,7 +921,14 @@ def test_map_estimated_output_blocks():
     # 100 inputs -> 100 / 10 = 10 tasks -> 10 * 5 = 50 output blocks
     assert op._estimated_output_blocks == 50
 
+
+def test_map_estimated_blocks_split():
     # Test read output splitting
+    def yield_five(block_iter: Iterable[Block], ctx) -> Iterable[Block]:
+        for i in range(5):
+            yield pd.DataFrame({"id": [i]})
+
+    min_rows_per_bundle = 10
     input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
     op = MapOperator.create(
         create_map_transformer_from_block_fn(yield_five),

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -921,6 +921,28 @@ def test_map_estimated_output_blocks():
     # 100 inputs -> 100 / 10 = 10 tasks -> 10 * 5 = 50 output blocks
     assert op._estimated_output_blocks == 50
 
+    # Test read output splitting
+    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
+    op = MapOperator.create(
+        create_map_transformer_from_block_fn(yield_five),
+        input_op=input_op,
+        name="TestEstimatedNumBlocksSplit",
+        min_rows_per_bundle=min_rows_per_bundle,
+    )
+    op.set_additional_split_factor(2)
+
+    op.start(ExecutionOptions())
+    while input_op.has_next():
+        op.add_input(input_op.get_next(), 0)
+        if op.metrics.num_inputs_received % min_rows_per_bundle == 0:
+            # enough inputs for a task bundle
+            run_op_tasks_sync(op)
+            assert op._estimated_output_blocks == 100
+
+    op.all_inputs_done()
+    # Each output block is split in 2, so the number of blocks double.
+    assert op._estimated_output_blocks == 100
+
 
 def test_limit_estimated_output_blocks():
     # Test limit operator estimation


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I'm not sure why we were calling `_set_num_output_blocks` on the upstream input operator when we were splitting blocks for the downstream read map operator. The split happens in the read map operator, which shouldn't affect the input operator. 

Also adds a test for estimating output blocks with additional split factor.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
