### PR TITLE
[ci] fix gpu images

### DIFF
--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -89,6 +89,8 @@ class Container:
             "run",
             "-i",
             "--rm",
+            "--env",
+            "NVIDIA_DISABLE_REQUIRE=1",
             "--volume",
             "/tmp/artifacts:/artifact-mount",
         ]


### PR DESCRIPTION
cuda re-publishes its image recently that break all of our gpu build/test (https://buildkite.com/ray-project/postmerge/builds/1637#018bb8e5-bfd7-47d6-af25-a1effb77d5c8/6-90). It complains that the driver installed in the host machine is in-compatible with the image.

Simply disable that check and the tests run just fine. Use this as a work around for now and we'll investigate further next week

Test:
- CI: https://buildkite.com/ray-project/postmerge/builds/1641#_