### PR TITLE
[ci] remove common doc coverage for per-team changes

### DIFF
--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -174,7 +174,6 @@ if __name__ == "__main__":
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
             elif changed_file.startswith("python/ray/tune"):
                 RAY_CI_ML_AFFECTED = 1
-                RAY_CI_DOC_AFFECTED = 1
                 RAY_CI_TUNE_AFFECTED = 1
                 RAY_CI_RLLIB_AFFECTED = 1
                 RAY_CI_TRAIN_AFFECTED = 1
@@ -213,7 +212,6 @@ if __name__ == "__main__":
                 or changed_file == ".buildkite/serve.rayci.yml"
                 or changed_file == "ci/docker/serve.build.Dockerfile"
             ):
-                RAY_CI_DOC_AFFECTED = 1
                 RAY_CI_SERVE_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
@@ -240,7 +238,6 @@ if __name__ == "__main__":
                 RAY_CI_DASHBOARD_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
-                RAY_CI_DOC_AFFECTED = 1
                 # Python changes might impact cross language stack in Java.
                 # Java also depends on Python CLI to manage processes.
                 RAY_CI_JAVA_AFFECTED = 1
@@ -334,7 +331,6 @@ if __name__ == "__main__":
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
                 RAY_CI_DASHBOARD_AFFECTED = 1
-                RAY_CI_DOC_AFFECTED = 1
                 RAY_CI_RELEASE_TESTS_AFFECTED = 1
             else:
                 print(


### PR DESCRIPTION
Previously, because we have only one doc build for the entire OSS repository, any local ray change will trigger this doc build. In Civ2, we break doc build into per-team-doc build, so that only team-specific docs are run based on that team change.

The all-doc builds (in others) are still always run as usual. This will help some savings since the doc builds are costly.

Test:
- CI