### PR TITLE
[data] add task filter for node killer, train benchmark node chaos release test

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1401,7 +1401,7 @@ class ResourceKillerActor:
         head_node_id,
         kill_interval_s: float = 60,
         max_to_kill: int = 2,
-        task_filter: Optional[Callable] = None,
+        kill_filter_fn: Optional[Callable] = None,
     ):
         self.kill_interval_s = kill_interval_s
         self.is_running = False
@@ -1409,7 +1409,7 @@ class ResourceKillerActor:
         self.killed = set()
         self.done = ray._private.utils.get_or_create_event_loop().create_future()
         self.max_to_kill = max_to_kill
-        self.task_filter = task_filter
+        self.kill_filter_fn = kill_filter_fn
         self.kill_immediately_after_found = False
         # -- logger. --
         logging.basicConfig(level=logging.INFO)
@@ -1464,6 +1464,8 @@ class NodeKillerActor(ResourceKillerActor):
         while node_to_kill_port is None and self.is_running:
             nodes = ray.nodes()
             alive_nodes = self._get_alive_nodes(nodes)
+            if self.kill_filter_fn is not None:
+                nodes = list(filter(self.kill_filter_fn(), nodes))
             for node in nodes:
                 node_id = node["NodeID"]
                 # make sure at least 1 worker node is alive.
@@ -1523,9 +1525,9 @@ class WorkerKillerActor(ResourceKillerActor):
         head_node_id,
         kill_interval_s: float = 60,
         max_to_kill: int = 2,
-        task_filter: Optional[Callable] = None,
+        kill_filter_fn: Optional[Callable] = None,
     ):
-        super().__init__(head_node_id, kill_interval_s, max_to_kill, task_filter)
+        super().__init__(head_node_id, kill_interval_s, max_to_kill, kill_filter_fn)
 
         # Kill worker immediately so that the task does
         # not finish successfully on its own.
@@ -1554,8 +1556,8 @@ class WorkerKillerActor(ResourceKillerActor):
                 options=self.task_options,
                 raise_on_missing_output=False,
             )
-            if self.task_filter is not None:
-                tasks = list(filter(self.task_filter, tasks))
+            if self.kill_filter_fn is not None:
+                tasks = list(filter(self.kill_filter_fn(), tasks))
 
             for task in tasks:
                 if task.worker_id is not None and task.node_id is not None:
@@ -1605,7 +1607,7 @@ def get_and_run_resource_killer(
     no_start=False,
     max_to_kill=2,
     kill_delay_s=0,
-    task_filter=None,
+    kill_filter_fn=None,
 ):
     assert ray.is_initialized(), "The API is only available when Ray is initialized."
     name = resource_killer_cls.__ray_actor_class__.__name__
@@ -1623,7 +1625,7 @@ def get_and_run_resource_killer(
         head_node_id,
         kill_interval_s=kill_interval_s,
         max_to_kill=max_to_kill,
-        task_filter=task_filter,
+        kill_filter_fn=kill_filter_fn,
     )
     print(f"Waiting for {name} to be ready...")
     ray.get(resource_killer.ready.remote())

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -63,10 +63,10 @@ def set_kill_interval(request):
         yield (lineage_reconstruction_enabled, kill_interval, cluster_fixture)
 
 
-# @pytest.mark.skip(
-#    reason="Skip until https://github.com/ray-project/ray/issues/20706 is fixed."
-# )
-# @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+@pytest.mark.skip(
+    reason="Skip until https://github.com/ray-project/ray/issues/20706 is fixed."
+)
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 @pytest.mark.parametrize(
     "set_kill_interval",
     [(True, None), (True, 20), (False, None), (False, 20)],

--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -617,7 +617,7 @@ def benchmark_code(
     # Report the average of per-epoch throughput, excluding the first epoch.
     epoch_tputs = []
     num_rows_per_epoch = sum(result.metrics["num_rows"])
-    for i in range(1, args.num_epochs + 1):
+    for i in range(0, args.num_epochs):
         time_start_epoch_i, time_end_epoch_i = zip(*result.metrics[f"epoch_{i}_times"])
         runtime_epoch_i = max(time_end_epoch_i) - min(time_start_epoch_i)
         tput_epoch_i = num_rows_per_epoch / runtime_epoch_i

--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -616,10 +616,10 @@ def benchmark_code(
 
     # Report the average of per-epoch throughput, excluding the first epoch.
     # Unless there is only one epoch.
-    skip_first_epoch = 0 if args.num_epochs == 1 else 1
+    start_epoch_tput = 0 if args.num_epochs == 1 else 1
     epoch_tputs = []
     num_rows_per_epoch = sum(result.metrics["num_rows"])
-    for i in range(skip_first_epoch, args.num_epochs):
+    for i in range(start_epoch_tput, args.num_epochs):
         time_start_epoch_i, time_end_epoch_i = zip(*result.metrics[f"epoch_{i}_times"])
         runtime_epoch_i = max(time_end_epoch_i) - min(time_start_epoch_i)
         tput_epoch_i = num_rows_per_epoch / runtime_epoch_i

--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -617,7 +617,7 @@ def benchmark_code(
     # Report the average of per-epoch throughput, excluding the first epoch.
     epoch_tputs = []
     num_rows_per_epoch = sum(result.metrics["num_rows"])
-    for i in range(1, args.num_epochs):
+    for i in range(1, args.num_epochs + 1):
         time_start_epoch_i, time_end_epoch_i = zip(*result.metrics[f"epoch_{i}_times"])
         runtime_epoch_i = max(time_end_epoch_i) - min(time_start_epoch_i)
         tput_epoch_i = num_rows_per_epoch / runtime_epoch_i

--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -615,9 +615,11 @@ def benchmark_code(
     data_benchmark_metrics = {}
 
     # Report the average of per-epoch throughput, excluding the first epoch.
+    # Unless there is only one epoch.
+    skip_first_epoch = 0 if args.num_epochs == 1 else 1
     epoch_tputs = []
     num_rows_per_epoch = sum(result.metrics["num_rows"])
-    for i in range(0, args.num_epochs):
+    for i in range(skip_first_epoch, args.num_epochs):
         time_start_epoch_i, time_end_epoch_i = zip(*result.metrics[f"epoch_{i}_times"])
         runtime_epoch_i = max(time_end_epoch_i) - min(time_start_epoch_i)
         tput_epoch_i = num_rows_per_epoch / runtime_epoch_i

--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -615,7 +615,8 @@ def benchmark_code(
     data_benchmark_metrics = {}
 
     # Report the average of per-epoch throughput, excluding the first epoch.
-    # Unless there is only one epoch.
+    # Unless there is only one epoch, in which case we report the epoch
+    # throughput directly.
     start_epoch_tput = 0 if args.num_epochs == 1 else 1
     epoch_tputs = []
     num_rows_per_epoch = sum(result.metrics["num_rows"])

--- a/release/nightly_tests/setup_chaos.py
+++ b/release/nightly_tests/setup_chaos.py
@@ -1,4 +1,6 @@
 import argparse
+from ray.util.state.api import StateApiClient
+from ray.util.state.common import ListApiOptions, StateResource
 import ray
 
 from ray._private.test_utils import (
@@ -44,13 +46,35 @@ def parse_script_args():
 
 
 def task_filter(task_names):
-    if task_names == []:
-        return lambda _: True
+    def _task_filter():
+        if task_names == []:
+            return lambda _: True
 
-    def _filter_fn(task):
-        return task.name in task_names
+        def _filter_fn(task):
+            return task.name in task_names
 
-    return _filter_fn
+        return _filter_fn
+
+    return _task_filter
+
+
+def task_node_filter(task_names):
+    def _task_node_filter():
+        if task_names == []:
+            return lambda _: True
+
+        tasks = StateApiClient().list(
+            StateResource.TASKS, options=ListApiOptions(), raise_on_missing_output=False
+        )
+        filtered_tasks = list(filter(lambda task: task.name in task_names, tasks))
+        nodes_with_filtered_tasks = {task.node_id for task in filtered_tasks}
+
+        def _filter_fn(node):
+            return node["NodeID"] in nodes_with_filtered_tasks
+
+        return _filter_fn
+
+    return _task_node_filter
 
 
 def main():
@@ -62,8 +86,10 @@ def main():
     ray.init(address="auto")
     if args.kill_workers:
         resource_killer_cls = WorkerKillerActor
+        kill_filter_fn = task_filter(args.task_names)
     else:
         resource_killer_cls = NodeKillerActor
+        kill_filter_fn = task_node_filter(args.task_names)
 
     get_and_run_resource_killer(
         resource_killer_cls,
@@ -73,7 +99,7 @@ def main():
         no_start=args.no_start,
         max_to_kill=args.max_to_kill,
         kill_delay_s=args.kill_delay,
-        task_filter=task_filter(args.task_names),
+        kill_filter_fn=kill_filter_fn,
     )
     print(
         f"Successfully deployed a {'worker' if args.kill_workers else 'node'} killer."

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5816,7 +5816,7 @@
 
   run:
     timeout: 18000
-    prepare: python setup_chaos.py --kill-interval 200 --max-to-kill 1 --task-names "TorchTrainer.train"
+    prepare: python setup_chaos.py --kill-interval 1000 --max-to-kill 3 --task-names "TorchTrainer.train"
     script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image
 
   variations:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5777,7 +5777,7 @@
       cluster:
         cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_2x2_gce.yaml
 
-- name: read_images_train_4_gpu_chaos
+- name: read_images_train_4_gpu_worker_chaos
   group: data-tests
   working_dir: nightly_tests
 
@@ -5793,6 +5793,31 @@
     timeout: 18000
     prepare: python setup_chaos.py --kill-workers --kill-interval 200 --max-to-kill 50 --task-names "ReadImage->Map(wnid_to_index)->Map(crop_and_flip_image)"
     script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu --num-epochs 3
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_compute: ../air_tests/air_benchmarks/compute_gpu_2x2_gce.yaml
+
+- name: read_images_train_4_gpu_node_chaos
+  group: data-tests
+  working_dir: nightly_tests
+
+  frequency: nightly
+  team: data
+  python: "3.8"
+  cluster:
+    byod:
+      type: gpu
+    cluster_compute: dataset/multi_node_train_4_workers.yaml
+
+  run:
+    timeout: 18000
+    prepare: python setup_chaos.py --kill-interval 200 --max-to-kill 1 --task-names "TorchTrainer.train"
+    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image
 
   variations:
     - __suffix__: aws

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5816,8 +5816,8 @@
 
   run:
     timeout: 18000
-    prepare: python setup_chaos.py --kill-interval 1000 --max-to-kill 3 --task-names "TorchTrainer.train"
-    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu
+    prepare: python setup_chaos.py --kill-interval 3000 --max-to-kill 3 --task-names "TorchTrainer.train"
+    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu --num-epochs 3
 
   variations:
     - __suffix__: aws

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5816,7 +5816,7 @@
 
   run:
     timeout: 18000
-    prepare: python setup_chaos.py --kill-interval 3000 --max-to-kill 3 --task-names "TorchTrainer.train"
+    prepare: python setup_chaos.py --kill-interval 3000 --max-to-kill 3 --task-names "_RayTrainWorker__execute.get_next"
     script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu --num-epochs 3
 
   variations:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5791,8 +5791,8 @@
 
   run:
     timeout: 18000
-    prepare: python setup_chaos.py --kill-workers --kill-interval 200 --max-to-kill 50 --task-names "ReadImage->Map(wnid_to_index)->Map(crop_and_flip_image)"
-    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu --num-epochs 3
+    prepare: python setup_chaos.py --kill-workers --kill-interval 100 --max-to-kill 3 --task-names "ReadImage->Map(wnid_to_index)->Map(crop_and_flip_image)"
+    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu --num-epochs 1
 
   variations:
     - __suffix__: aws
@@ -5816,8 +5816,8 @@
 
   run:
     timeout: 18000
-    prepare: python setup_chaos.py --kill-interval 3000 --max-to-kill 3 --task-names "_RayTrainWorker__execute.get_next"
-    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu --num-epochs 3
+    prepare: python setup_chaos.py --kill-interval 200 --max-to-kill 1 --task-names "_RayTrainWorker__execute.get_next"
+    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu --num-epochs 1
 
   variations:
     - __suffix__: aws

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5817,7 +5817,7 @@
   run:
     timeout: 18000
     prepare: python setup_chaos.py --kill-interval 1000 --max-to-kill 3 --task-names "TorchTrainer.train"
-    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image
+    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu
 
   variations:
     - __suffix__: aws


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a node filter to `NodeKillerActor` to target nodes with specific tasks running on them. Used for targeting data+train nodes for training benchmarks.

Example usage:
```
>>> python setup_chaos.py --task-names "ReadRange->MapBatches(<lambda>)"
...
>>> ray.data.range(...).map_batches(lambda x: x).materialize()
```

When running with release tests, we should try to keep the test short because this uses the state api to query running tasks, which have a limit of 10k tasks (#33547). So currently we only run this with our train benchmarks with `--num-epochs 1`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
