### PR TITLE
[data] add data worker killer, train benchmark worker chaos release test

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1389,6 +1389,13 @@ def teardown_tls(key_filepath, cert_filepath, temp_dir):
 
 
 class ResourceKillerActor:
+    """Abstract base class used to implement resource killers for chaos testing.
+
+    Subclasses should implement _find_resource_to_kill, which should find a resource
+    to kill. This method should return the args to _kill_resource, which is another
+    abstract method that should kill the resource and add it to the `killed` set.
+    """
+
     def __init__(
         self,
         head_node_id,

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1575,10 +1575,10 @@ class WorkerKillerActor(ResourceKillerActor):
         if process_to_kill_pid is not None:
 
             @ray.remote
-            def kill_process():
+            def kill_process(pid):
                 import psutil
 
-                proc = psutil.Process(process_to_kill_pid)
+                proc = psutil.Process(pid)
                 proc.kill()
 
             scheduling_strategy = (
@@ -1587,7 +1587,9 @@ class WorkerKillerActor(ResourceKillerActor):
                     soft=False,
                 )
             )
-            kill_process.options(scheduling_strategy=scheduling_strategy).remote()
+            kill_process.options(scheduling_strategy=scheduling_strategy).remote(
+                process_to_kill_pid
+            )
             logging.info(
                 f"Killing pid {process_to_kill_pid} on node {process_to_kill_node_id}"
             )

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -24,6 +24,8 @@ import uuid
 from dataclasses import dataclass
 
 import requests
+from ray.util.state.common import ListApiOptions, StateResource
+from ray.util.state.api import StateApiClient
 from ray._raylet import Config
 
 import psutil  # We must import psutil after ray because we bundle it with ray.
@@ -1388,136 +1390,221 @@ def teardown_tls(key_filepath, cert_filepath, temp_dir):
     del os.environ["RAY_TLS_CA_CERT"]
 
 
-def get_and_run_node_killer(
-    node_kill_interval_s,
+class ResourceKillerActor:
+    def __init__(
+        self,
+        head_node_id,
+        kill_interval_s: float = 60,
+        max_to_kill: int = 2,
+        task_filter: Optional[Callable] = None,
+    ):
+        self.kill_interval_s = kill_interval_s
+        self.is_running = False
+        self.head_node_id = head_node_id
+        self.killed = set()
+        self.done = ray._private.utils.get_or_create_event_loop().create_future()
+        self.max_to_kill = max_to_kill
+        self.task_filter = task_filter
+        # -- logger. --
+        logging.basicConfig(level=logging.INFO)
+
+    def ready(self):
+        pass
+
+    async def run(self):
+        self.is_running = True
+        while self.is_running:
+            to_kill = await self._find_resource_to_kill()
+
+            if not self.is_running:
+                break
+
+            sleep_interval = random.random() * self.kill_interval_s
+            time.sleep(sleep_interval)
+
+            self._kill_resource(*to_kill)
+            await asyncio.sleep(self.kill_interval_s - sleep_interval)
+
+        self.done.set_result(True)
+
+    async def _find_resource_to_kill(self):
+        raise NotImplementedError
+
+    def _kill_resource(self, *args):
+        raise NotImplementedError
+
+    async def stop_run(self):
+        was_running = self.is_running
+        self.is_running = False
+        return was_running
+
+    async def get_total_killed(self):
+        """Get the total number of killed resources"""
+        await self.done
+        return self.killed
+
+
+@ray.remote(num_cpus=0)
+class NodeKillerActor(ResourceKillerActor):
+    async def _find_resource_to_kill(self):
+        node_to_kill_ip = None
+        node_to_kill_port = None
+        node_id = None
+        while node_to_kill_port is None and self.is_running:
+            nodes = ray.nodes()
+            alive_nodes = self._get_alive_nodes(nodes)
+            for node in nodes:
+                node_id = node["NodeID"]
+                # make sure at least 1 worker node is alive.
+                if (
+                    node["Alive"]
+                    and node_id != self.head_node_id
+                    and node_id not in self.killed
+                    and alive_nodes > 2
+                ):
+                    node_to_kill_ip = node["NodeManagerAddress"]
+                    node_to_kill_port = node["NodeManagerPort"]
+                    break
+            # Give the cluster some time to start.
+            await asyncio.sleep(0.1)
+
+        return node_id, node_to_kill_ip, node_to_kill_port
+
+    def _kill_resource(self, node_id, node_to_kill_ip, node_to_kill_port):
+        if node_to_kill_port is not None:
+            try:
+                self._kill_raylet(node_to_kill_ip, node_to_kill_port, graceful=False)
+            except Exception:
+                pass
+            logging.info(
+                f"Killed node {node_id} at address: "
+                f"{node_to_kill_ip}, port: {node_to_kill_port}"
+            )
+            self.killed.add(node_id)
+
+    def _kill_raylet(self, ip, port, graceful=False):
+        import grpc
+        from grpc._channel import _InactiveRpcError
+        from ray.core.generated import node_manager_pb2_grpc
+
+        raylet_address = f"{ip}:{port}"
+        channel = grpc.insecure_channel(raylet_address)
+        stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
+        try:
+            stub.ShutdownRaylet(
+                node_manager_pb2.ShutdownRayletRequest(graceful=graceful)
+            )
+        except _InactiveRpcError:
+            assert not graceful
+
+    def _get_alive_nodes(self, nodes):
+        alive_nodes = 0
+        for node in nodes:
+            if node["Alive"]:
+                alive_nodes += 1
+        return alive_nodes
+
+
+@ray.remote(num_cpus=0)
+class WorkerKillerActor(ResourceKillerActor):
+    async def _find_resource_to_kill(self):
+        process_to_kill_task_id = None
+        process_to_kill_pid = None
+        process_to_kill_node_id = None
+        while process_to_kill_pid is None and self.is_running:
+            client = StateApiClient()
+            tasks = client.list(
+                StateResource.TASKS,
+                options=ListApiOptions(
+                    filters=[
+                        ("state", "=", "RUNNING"),
+                        ("name", "!=", "WorkerKillActor.run"),
+                    ]
+                ),
+                raise_on_missing_output=False,
+            )
+            workers = {
+                worker.worker_id: worker
+                for worker in client.list(
+                    StateResource.WORKERS,
+                    options=ListApiOptions(filters=[("is_alive", "=", "True")]),
+                    raise_on_missing_output=False,
+                )
+            }
+            if self.task_filter is not None:
+                tasks = list(filter(self.task_filter, tasks))
+            for task in tasks:
+                if task.worker_id in workers:
+                    process_to_kill_task_id = task.task_id
+                    process_to_kill_pid = task.worker_pid
+                    process_to_kill_node_id = task.node_id
+                    break
+
+            # Give the cluster some time to start.
+            await asyncio.sleep(0.1)
+
+        return process_to_kill_task_id, process_to_kill_pid, process_to_kill_node_id
+
+    def _kill_resource(
+        self, process_to_kill_task_id, process_to_kill_pid, process_to_kill_node_id
+    ):
+        if process_to_kill_pid is not None:
+
+            @ray.remote
+            def kill_process():
+                import psutil
+
+                proc = psutil.Process(process_to_kill_pid)
+                proc.kill()
+
+            scheduling_strategy = (
+                ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
+                    node_id=process_to_kill_node_id,
+                    soft=False,
+                )
+            )
+            kill_process.options(scheduling_strategy=scheduling_strategy).remote()
+            logging.info(
+                f"Killing pid {process_to_kill_pid} on node {process_to_kill_node_id}"
+            )
+            self.killed.add(process_to_kill_task_id)
+
+
+def get_and_run_resource_killer(
+    resource_killer_cls,
+    kill_interval_s,
     namespace=None,
     lifetime=None,
     no_start=False,
-    max_nodes_to_kill=2,
-    node_kill_delay_s=0,
+    max_to_kill=2,
+    kill_delay_s=0,
+    task_filter=None,
 ):
     assert ray.is_initialized(), "The API is only available when Ray is initialized."
-
-    @ray.remote(num_cpus=0)
-    class NodeKillerActor:
-        def __init__(
-            self,
-            head_node_id,
-            node_kill_interval_s: float = 60,
-            max_nodes_to_kill: int = 2,
-        ):
-            self.node_kill_interval_s = node_kill_interval_s
-            self.is_running = False
-            self.head_node_id = head_node_id
-            self.killed_nodes = set()
-            self.done = ray._private.utils.get_or_create_event_loop().create_future()
-            self.max_nodes_to_kill = max_nodes_to_kill
-            # -- logger. --
-            logging.basicConfig(level=logging.INFO)
-
-        def ready(self):
-            pass
-
-        async def run(self):
-            self.is_running = True
-            while self.is_running:
-                node_to_kill_ip = None
-                node_to_kill_port = None
-                while node_to_kill_port is None and self.is_running:
-                    nodes = ray.nodes()
-                    alive_nodes = self._get_alive_nodes(nodes)
-                    for node in nodes:
-                        node_id = node["NodeID"]
-                        # make sure at least 1 worker node is alive.
-                        if (
-                            node["Alive"]
-                            and node_id != self.head_node_id
-                            and node_id not in self.killed_nodes
-                            and alive_nodes > 2
-                        ):
-                            node_to_kill_ip = node["NodeManagerAddress"]
-                            node_to_kill_port = node["NodeManagerPort"]
-                            break
-                    # Give the cluster some time to start.
-                    await asyncio.sleep(0.1)
-
-                if not self.is_running:
-                    break
-
-                sleep_interval = random.random() * self.node_kill_interval_s
-                time.sleep(sleep_interval)
-
-                if node_to_kill_port is not None:
-                    try:
-                        self._kill_raylet(
-                            node_to_kill_ip, node_to_kill_port, graceful=False
-                        )
-                    except Exception:
-                        pass
-                    logging.info(
-                        f"Killed node {node_id} at address: "
-                        f"{node_to_kill_ip}, port: {node_to_kill_port}"
-                    )
-                    self.killed_nodes.add(node_id)
-                if len(self.killed_nodes) >= self.max_nodes_to_kill:
-                    break
-                await asyncio.sleep(self.node_kill_interval_s - sleep_interval)
-
-            self.done.set_result(True)
-
-        async def stop_run(self):
-            was_running = self.is_running
-            self.is_running = False
-            return was_running
-
-        async def get_total_killed_nodes(self):
-            """Get the total number of killed nodes"""
-            await self.done
-            return self.killed_nodes
-
-        def _kill_raylet(self, ip, port, graceful=False):
-            import grpc
-            from grpc._channel import _InactiveRpcError
-            from ray.core.generated import node_manager_pb2_grpc
-
-            raylet_address = f"{ip}:{port}"
-            channel = grpc.insecure_channel(raylet_address)
-            stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
-            try:
-                stub.ShutdownRaylet(
-                    node_manager_pb2.ShutdownRayletRequest(graceful=graceful)
-                )
-            except _InactiveRpcError:
-                assert not graceful
-
-        def _get_alive_nodes(self, nodes):
-            alive_nodes = 0
-            for node in nodes:
-                if node["Alive"]:
-                    alive_nodes += 1
-            return alive_nodes
+    name = resource_killer_cls.__ray_actor_class__().__class__.__name__
 
     head_node_id = ray.get_runtime_context().get_node_id()
     # Schedule the actor on the current node.
-    node_killer = NodeKillerActor.options(
+    resource_killer = resource_killer_cls.options(
         scheduling_strategy=NodeAffinitySchedulingStrategy(
             node_id=head_node_id, soft=False
         ),
         namespace=namespace,
-        name="node_killer",
+        name=name,
         lifetime=lifetime,
     ).remote(
         head_node_id,
-        node_kill_interval_s=node_kill_interval_s,
-        max_nodes_to_kill=max_nodes_to_kill,
+        kill_interval_s=kill_interval_s,
+        max_to_kill=max_to_kill,
+        task_filter=task_filter,
     )
-    print("Waiting for node killer actor to be ready...")
-    ray.get(node_killer.ready.remote())
-    print("Node killer actor is ready now.")
+    print(f"Waiting for {name} to be ready...")
+    ray.get(resource_killer.ready.remote())
+    print(f"{name} is ready now.")
     if not no_start:
-        time.sleep(node_kill_delay_s)
-        node_killer.run.remote()
-    return node_killer
+        time.sleep(kill_delay_s)
+        resource_killer.run.remote()
+    return resource_killer
 
 
 @contextmanager

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1619,7 +1619,7 @@ def get_and_run_resource_killer(
     ray.get(resource_killer.ready.remote())
     print(f"{name} is ready now.")
     if not no_start:
-        time.sleep(kill_delay_s)
+        time.sleep(kill_delay)
         resource_killer.run.remote()
     return resource_killer
 

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1533,7 +1533,6 @@ class WorkerKillerActor(ResourceKillerActor):
                 ("name", "!=", "WorkerKillActor.run"),
             ]
         )
-        self.worker_options = ListApiOptions(filters=[("is_alive", "=", "True")])
 
     async def _find_resource_to_kill(self):
         from ray.util.state.common import StateResource
@@ -1547,18 +1546,11 @@ class WorkerKillerActor(ResourceKillerActor):
                 options=self.task_options,
                 raise_on_missing_output=False,
             )
-            workers = {
-                worker.worker_id: worker
-                for worker in self.client.list(
-                    StateResource.WORKERS,
-                    options=self.worker_options,
-                    raise_on_missing_output=False,
-                )
-            }
             if self.task_filter is not None:
                 tasks = list(filter(self.task_filter, tasks))
+
             for task in tasks:
-                if task.worker_id in workers:
+                if task.worker_id is not None and task.node_id is not None:
                     process_to_kill_task_id = task.task_id
                     process_to_kill_pid = task.worker_pid
                     process_to_kill_node_id = task.node_id

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1581,7 +1581,7 @@ def get_and_run_resource_killer(
     task_filter=None,
 ):
     assert ray.is_initialized(), "The API is only available when Ray is initialized."
-    name = resource_killer_cls.__ray_actor_class__().__class__.__name__
+    name = resource_killer_cls.__ray_actor_class__.__name__
 
     head_node_id = ray.get_runtime_context().get_node_id()
     # Schedule the actor on the current node.

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1619,7 +1619,7 @@ def get_and_run_resource_killer(
     ray.get(resource_killer.ready.remote())
     print(f"{name} is ready now.")
     if not no_start:
-        time.sleep(kill_delay)
+        time.sleep(kill_delay_s)
         resource_killer.run.remote()
     return resource_killer
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -25,7 +25,7 @@ from ray._private.runtime_env.pip import PipProcessor
 from ray._private.runtime_env.plugin_schema_manager import RuntimeEnvPluginSchemaManager
 
 from ray._private.test_utils import (
-    get_and_run_node_killer,
+    get_and_run_resource_killer,
     init_error_pubsub,
     init_log_pubsub,
     setup_tls,
@@ -37,6 +37,7 @@ from ray._private.test_utils import (
     find_available_port,
     wait_for_condition,
     find_free_port,
+    NodeKillerActor,
 )
 from ray.cluster_utils import AutoscalingCluster, Cluster, cluster_not_supported
 
@@ -909,7 +910,7 @@ def _ray_start_chaos_cluster(request):
     assert len(nodes) == 1
 
     if kill_interval is not None:
-        node_killer = get_and_run_node_killer(kill_interval)
+        node_killer = get_and_run_resource_killer(NodeKillerActor, kill_interval)
 
     yield cluster
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -916,7 +916,7 @@ def _ray_start_chaos_cluster(request):
 
     if kill_interval is not None:
         ray.get(node_killer.stop_run.remote())
-        killed = ray.get(node_killer.get_total_killed_nodes.remote())
+        killed = ray.get(node_killer.get_total_killed.remote())
         assert len(killed) > 0
         died = {node["NodeID"] for node in ray.nodes() if not node["Alive"]}
         assert died.issubset(

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -11,8 +11,15 @@ from ray.experimental import shuffle
 from ray.tests.conftest import _ray_start_chaos_cluster
 from ray.data._internal.progress_bar import ProgressBar
 from ray.util.placement_group import placement_group
-from ray._private.test_utils import get_log_message
+from ray._private.test_utils import (
+    get_log_message,
+    get_and_run_resource_killer,
+    WorkerKillerActor,
+    wait_for_condition,
+)
 from ray.exceptions import RayTaskError, ObjectLostError
+from ray.util.state.common import ListApiOptions, StateResource
+from ray.util.state.api import StateApiClient
 
 
 def assert_no_system_failure(p, timeout):
@@ -242,6 +249,58 @@ def test_streaming_shuffle(set_kill_interval):
 
         # TODO(swang): Enable this once we implement support ray.put.
         # assert not lineage_reconstruction_enabled
+
+
+def test_worker_killer():
+    ray.init()
+
+    task_name = "worker_to_kill"
+
+    @ray.remote
+    def worker_to_kill():
+        time.sleep(3)
+
+    # Run WorkerKillerActor to kill 3 tasks, and run remote "worker_to_kill"
+    # task with max_retires=3. 4 tasks in total (1 initial + 3 retries).
+    # First 3 tasks will be killed, the last retry will succeed.
+    worker_killer = get_and_run_resource_killer(
+        WorkerKillerActor,
+        1,
+        max_to_kill=3,
+        task_filter=lambda task: task.name == task_name,
+    )
+    worker_to_kill.options(name=task_name, max_retries=3).remote()
+
+    def check():
+        tasks = StateApiClient().list(
+            StateResource.TASKS,
+            options=ListApiOptions(filters=[("name", "=", task_name)]),
+            raise_on_missing_output=False,
+        )
+        failed = 0
+        finished = 0
+        for task in tasks:
+            if task.state == "FAILED":
+                failed += 1
+            elif task.state == "FINISHED":
+                finished += 1
+        return failed == 3 and finished == 1
+
+    wait_for_condition(check, timeout=20)
+
+    killed_tasks = ray.get(worker_killer.get_total_killed.remote())
+    assert len(killed_tasks) == 3
+
+    tasks = StateApiClient().list(
+        StateResource.TASKS,
+        options=ListApiOptions(filters=[("name", "=", task_name)]),
+        raise_on_missing_output=False,
+    )
+    for task in tasks:
+        if task.state == "FAILED":
+            assert (task.task_id, task.worker_pid) in killed_tasks
+
+    ray.shutdown()
 
 
 if __name__ == "__main__":

--- a/release/nightly_tests/chaos_test/test_chaos_basic.py
+++ b/release/nightly_tests/chaos_test/test_chaos_basic.py
@@ -210,10 +210,7 @@ def main():
     node_killer.run.remote()
     workload(total_num_cpus, args.smoke)
     print(f"Runtime when there are many failures: {time.time() - start}")
-    print(
-        f"Total node failures: "
-        f"{ray.get(node_killer.get_total_killed_nodes.remote())}"
-    )
+    print(f"Total node failures: " f"{ray.get(node_killer.get_total_killed.remote())}")
     node_killer.stop_run.remote()
     used_gb, usage = ray.get(monitor_actor.get_peak_memory_info.remote())
     print("Memory usage with failures.")
@@ -224,7 +221,7 @@ def main():
     ray.get(monitor_actor.stop_run.remote())
     print(
         "Total number of killed nodes: "
-        f"{ray.get(node_killer.get_total_killed_nodes.remote())}"
+        f"{ray.get(node_killer.get_total_killed.remote())}"
     )
     with open(os.environ["TEST_OUTPUT_JSON"], "w") as f:
         f.write(

--- a/release/nightly_tests/setup_chaos.py
+++ b/release/nightly_tests/setup_chaos.py
@@ -27,7 +27,7 @@ def parse_script_args():
         ),
     )
     parser.add_argument(
-        "--node-kill-delay",
+        "--kill-delay",
         type=int,
         default=0,
         help=(

--- a/release/nightly_tests/setup_chaos.py
+++ b/release/nightly_tests/setup_chaos.py
@@ -1,24 +1,29 @@
 import argparse
 import ray
 
-from ray._private.test_utils import get_and_run_node_killer
+from ray._private.test_utils import (
+    get_and_run_resource_killer,
+    NodeKillerActor,
+    WorkerKillerActor,
+)
 
 
 def parse_script_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--node-kill-interval", type=int, default=60)
-    parser.add_argument("--max-nodes-to-kill", type=int, default=2)
+    parser.add_argument("--kill-workers", action="store_true", default=False)
+    parser.add_argument("--kill-interval", type=int, default=60)
+    parser.add_argument("--max-to-kill", type=int, default=2)
     parser.add_argument(
         "--no-start",
         action="store_true",
         default=False,
         help=(
-            "If set, node killer won't be starting to kill nodes when "
+            "If set, resource killer won't be starting to kill resources when "
             "the script is done. Driver needs to manually "
-            "obtain the node killer handle and invoke run method to "
+            "obtain the resource killer handle and invoke run method to "
             "start killing nodes. If not set, as soon as "
-            "the script is done, nodes will be killed every "
-            "--node-kill-interval seconds."
+            "the script is done, resources will be killed every "
+            "--kill-interval seconds."
         ),
     )
     parser.add_argument(
@@ -30,7 +35,22 @@ def parse_script_args():
             "'no-start' is set.",
         ),
     )
+    parser.add_argument(
+        "--task-names",
+        nargs="*",
+        default=[],
+    )
     return parser.parse_known_args()
+
+
+def task_filter(task_names):
+    if task_names == []:
+        return lambda _: True
+
+    def _filter_fn(task):
+        return task.name in task_names
+
+    return _filter_fn
 
 
 def main():
@@ -40,15 +60,24 @@ def main():
     """
     args, _ = parse_script_args()
     ray.init(address="auto")
-    get_and_run_node_killer(
-        args.node_kill_interval,
+    if args.kill_workers:
+        resource_killer_cls = WorkerKillerActor
+    else:
+        resource_killer_cls = NodeKillerActor
+
+    get_and_run_resource_killer(
+        resource_killer_cls,
+        args.kill_interval,
         namespace="release_test_namespace",
         lifetime="detached",
         no_start=args.no_start,
-        max_nodes_to_kill=args.max_nodes_to_kill,
-        node_kill_delay_s=args.node_kill_delay,
+        max_to_kill=args.max_to_kill,
+        kill_delay=args.kill_delay,
+        task_filter=task_filter(args.task_names),
     )
-    print("Successfully deployed a node killer.")
+    print(
+        f"Successfully deployed a {'worker' if args.kill_workers else 'node'} killer."
+    )
 
 
 main()

--- a/release/nightly_tests/setup_chaos.py
+++ b/release/nightly_tests/setup_chaos.py
@@ -72,7 +72,7 @@ def main():
         lifetime="detached",
         no_start=args.no_start,
         max_to_kill=args.max_to_kill,
-        kill_delay=args.kill_delay,
+        kill_delay_s=args.kill_delay,
         task_filter=task_filter(args.task_names),
     )
     print(

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5793,7 +5793,7 @@
 
   run:
     timeout: 3600
-    prepare: python setup_chaos.py --kill-workers --kill-interval 10 --max-to-kill 10 --task-names "ReadImage->Map(crop_and_flip_image)"
+    prepare: python setup_chaos.py --kill-workers --kill-interval 50 --max-to-kill 20 --task-names "ReadImage->Map(crop_and_flip_image)"
     script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image
 
   variations:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -211,7 +211,7 @@
 
   run:
     timeout: 1000
-    prepare: python setup_chaos.py --max-nodes-to-kill 2 --node-kill-delay 30
+    prepare: python setup_chaos.py --max-to-kill 2 --kill-delay 30
     script: python dataset/gpu_batch_inference.py --data-directory 300G-image-data-synthetic-raw --data-format raw
 
     wait_for_nodes:
@@ -6250,7 +6250,7 @@
     timeout: 7200
     wait_for_nodes:
       num_nodes: 21
-    prepare: python setup_chaos.py --node-kill-interval 100
+    prepare: python setup_chaos.py --kill-interval 100
     script: python dask_on_ray/large_scale_test.py --num_workers 20 --worker_obj_store_size_in_gb
       20 --error_rate 0  --data_save_path /tmp/ray
 
@@ -6280,7 +6280,7 @@
     timeout: 7200
     wait_for_nodes:
       num_nodes: 21
-    prepare: python setup_chaos.py --node-kill-interval 100
+    prepare: python setup_chaos.py --kill-interval 100
     script: python dask_on_ray/large_scale_test.py --num_workers 150 --worker_obj_store_size_in_gb
       70 --error_rate 0  --data_save_path /tmp/ray
 
@@ -6311,7 +6311,7 @@
 
   run:
     timeout: 7200
-    prepare: ' python setup_chaos.py --node-kill-interval 1200 --max-nodes-to-kill 3'
+    prepare: ' python setup_chaos.py --kill-interval 1200 --max-to-kill 3'
     script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9
     wait_for_nodes:
       num_nodes: 20
@@ -6341,7 +6341,7 @@
 
   run:
     timeout: 7200
-    prepare: 'python setup_chaos.py --node-kill-interval 900 --max-nodes-to-kill 3'
+    prepare: 'python setup_chaos.py --kill-interval 900 --max-to-kill 3'
     script: python dataset/sort.py --num-partitions=1000 --partition-size=1e9
     wait_for_nodes:
       num_nodes: 20
@@ -6374,7 +6374,7 @@
 
   run:
     timeout: 7200
-    prepare: ' python setup_chaos.py --node-kill-interval 600 --max-nodes-to-kill 2'
+    prepare: ' python setup_chaos.py --kill-interval 600 --max-to-kill 2'
     script: python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20
@@ -6405,7 +6405,7 @@
 
   run:
     timeout: 7200
-    prepare: ' python setup_chaos.py --node-kill-interval 600 --max-nodes-to-kill 2'
+    prepare: ' python setup_chaos.py --kill-interval 600 --max-to-kill 2'
     script: RAY_DATA_PUSH_BASED_SHUFFLE=1 python dataset/sort.py --num-partitions=1000 --partition-size=1e9 --shuffle
     wait_for_nodes:
       num_nodes: 20

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5779,6 +5779,31 @@
       cluster:
         cluster_compute: ../../air_tests/air_benchmarks/compute_gpu_2x2_gce.yaml
 
+- name: read_images_train_4_gpu_chaos
+  group: data-tests
+  working_dir: nightly_tests
+
+  frequency: nightly
+  team: data
+  python: "3.8"
+  cluster:
+    byod:
+      type: gpu
+    cluster_compute: dataset/multi_node_train_4_workers.yaml
+
+  run:
+    timeout: 3600
+    prepare: python setup_chaos.py --kill-workers --kill-interval 10 --max-to-kill 10 --task-names "ReadImage->Map(crop_and_flip_image)"
+    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image
+
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_compute: ../air_tests/air_benchmarks/compute_gpu_2x2_gce.yaml
+
 - name: read_images_train_16_gpu
   group: data-tests
   working_dir: nightly_tests/dataset


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a `WorkerKillerActor`, similar to `NodeKillerActor` (now both extending a `ResourceKillerActor` base class) that targets worker processes instead of nodes for more fine grained chaos testing.

This actor uses the state api to look for specific tasks/workers that we are targeting and kills them using psutil with a remote task running on the targeted node. 

This is intended to be used for targeting data workers in data+train workloads to test fault tolerance for data.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
