### PR TITLE
[Core] gpu memory scheduling prototype

### DIFF
--- a/python/ray/_private/accelerators/accelerator.py
+++ b/python/ray/_private/accelerators/accelerator.py
@@ -136,3 +136,13 @@ class AcceleratorManager(ABC):
             Return None if it's unknown.
         """
         return None
+
+    @staticmethod
+    def get_current_node_accelerator_memory() -> int:
+        """Get the total number of accelerators of this family on the current node.
+
+        Returns:
+            The detected total number of accelerators of this family.
+            Return 0 if the current node doesn't contain accelerators of this family.
+        """
+        return 0

--- a/python/ray/_private/accelerators/accelerator.py
+++ b/python/ray/_private/accelerators/accelerator.py
@@ -146,3 +146,21 @@ class AcceleratorManager(ABC):
             Return 0 if the current node doesn't contain accelerators of this family.
         """
         return 0
+
+    @staticmethod
+    def get_ec2_instance_accelerator_memory(
+        instance_type: str, instances: dict
+    ) -> Optional[str]:
+        """Get the accelerator total memory of this family on the current node.
+
+        Args:
+            instance_type: The ec2 instance type.
+            instances: Map from ec2 instance type to instance metadata returned by
+                ec2 `describe-instance-types`.
+
+        Returns:
+            The accelerator total memory of this family in bytes on the ec2 instance
+            with given type.
+            Return None if it's unknown.
+        """
+        return None

--- a/python/ray/_private/accelerators/intel_gpu.py
+++ b/python/ray/_private/accelerators/intel_gpu.py
@@ -103,5 +103,5 @@ class IntelGPUAcceleratorManager(AcceleratorManager):
         ] = prefix + ",".join([str(i) for i in visible_xpu_devices])
 
     @staticmethod
-    def get_current_node_gpu_memory() -> int:
+    def get_current_node_accelerator_memory() -> int:
         return 0

--- a/python/ray/_private/accelerators/intel_gpu.py
+++ b/python/ray/_private/accelerators/intel_gpu.py
@@ -101,7 +101,7 @@ class IntelGPUAcceleratorManager(AcceleratorManager):
         os.environ[
             IntelGPUAcceleratorManager.get_visible_accelerator_ids_env_var()
         ] = prefix + ",".join([str(i) for i in visible_xpu_devices])
-    
+
     @staticmethod
     def get_current_node_gpu_memory() -> int:
         return 0

--- a/python/ray/_private/accelerators/intel_gpu.py
+++ b/python/ray/_private/accelerators/intel_gpu.py
@@ -101,3 +101,7 @@ class IntelGPUAcceleratorManager(AcceleratorManager):
         os.environ[
             IntelGPUAcceleratorManager.get_visible_accelerator_ids_env_var()
         ] = prefix + ",".join([str(i) for i in visible_xpu_devices])
+    
+    @staticmethod
+    def get_current_node_gpu_memory() -> int:
+        return 0

--- a/python/ray/_private/accelerators/nvidia_gpu.py
+++ b/python/ray/_private/accelerators/nvidia_gpu.py
@@ -122,7 +122,21 @@ class NvidiaGPUAcceleratorManager(AcceleratorManager):
             assert len(gpus) == 1
             return gpus[0]["Name"]
         return None
-    
+
     @staticmethod
     def get_current_node_gpu_memory() -> int:
-        return 1000
+        try:
+            pynvml.nvmlInit()
+        except pynvml.NVMLError:
+            return None  # pynvml init failed
+        device_count = pynvml.nvmlDeviceGetCount()
+        cuda_device_type = None
+        if device_count > 0:
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            cuda_device_type = (
+                NvidiaGPUAcceleratorManager._gpu_name_to_accelerator_type(
+                    pynvml.nvmlDeviceGetName(handle)
+                )
+            )
+        pynvml.nvmlShutdown()
+        return cuda_device_type

--- a/python/ray/_private/accelerators/nvidia_gpu.py
+++ b/python/ray/_private/accelerators/nvidia_gpu.py
@@ -130,13 +130,11 @@ class NvidiaGPUAcceleratorManager(AcceleratorManager):
         except pynvml.NVMLError:
             return 0  # pynvml init failed
         device_count = pynvml.nvmlDeviceGetCount()
-        cuda_device_type = None
+        cuda_device_memory = 0
         if device_count > 0:
             handle = pynvml.nvmlDeviceGetHandleByIndex(0)
-            cuda_device_type = (
-                NvidiaGPUAcceleratorManager._gpu_name_to_accelerator_type(
-                    pynvml.nvmlDeviceGetName(handle)
-                )
-            )
+            cuda_device_memory = int(pynvml.nvmlDeviceGetMemoryInfo(handle).total) // (
+                1024 * 1024
+            )  # in MB
         pynvml.nvmlShutdown()
-        return cuda_device_type
+        return cuda_device_memory

--- a/python/ray/_private/accelerators/nvidia_gpu.py
+++ b/python/ray/_private/accelerators/nvidia_gpu.py
@@ -122,3 +122,7 @@ class NvidiaGPUAcceleratorManager(AcceleratorManager):
             assert len(gpus) == 1
             return gpus[0]["Name"]
         return None
+    
+    @staticmethod
+    def get_current_node_gpu_memory() -> int:
+        return 1000

--- a/python/ray/_private/accelerators/nvidia_gpu.py
+++ b/python/ray/_private/accelerators/nvidia_gpu.py
@@ -136,3 +136,17 @@ class NvidiaGPUAcceleratorManager(AcceleratorManager):
             cuda_device_memory = int(pynvml.nvmlDeviceGetMemoryInfo(handle).total)
         pynvml.nvmlShutdown()
         return cuda_device_memory
+
+    @staticmethod
+    def get_ec2_instance_accelerator_memory(
+        instance_type: str, instances: dict
+    ) -> Optional[str]:
+        if instance_type not in instances:
+            return None
+
+        gpus = instances[instance_type].get("GpuInfo", {}).get("Gpus")
+        if gpus is not None:
+            # TODO(ameer): currently we support one gpu type per node.
+            assert len(gpus) == 1
+            return int(gpus[0]["MemoryInfo"]["SizeInMiB"]) * 1024 * 1024
+        return None

--- a/python/ray/_private/accelerators/nvidia_gpu.py
+++ b/python/ray/_private/accelerators/nvidia_gpu.py
@@ -133,8 +133,6 @@ class NvidiaGPUAcceleratorManager(AcceleratorManager):
         cuda_device_memory = 0
         if device_count > 0:
             handle = pynvml.nvmlDeviceGetHandleByIndex(0)
-            cuda_device_memory = int(pynvml.nvmlDeviceGetMemoryInfo(handle).total) // (
-                1024 * 1024
-            )  # in MB
+            cuda_device_memory = int(pynvml.nvmlDeviceGetMemoryInfo(handle).total)
         pynvml.nvmlShutdown()
         return cuda_device_memory

--- a/python/ray/_private/accelerators/nvidia_gpu.py
+++ b/python/ray/_private/accelerators/nvidia_gpu.py
@@ -124,11 +124,11 @@ class NvidiaGPUAcceleratorManager(AcceleratorManager):
         return None
 
     @staticmethod
-    def get_current_node_gpu_memory() -> int:
+    def get_current_node_accelerator_memory() -> int:
         try:
             pynvml.nvmlInit()
         except pynvml.NVMLError:
-            return None  # pynvml init failed
+            return 0  # pynvml init failed
         device_count = pynvml.nvmlDeviceGetCount()
         cuda_device_type = None
         if device_count > 0:

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -507,6 +507,7 @@ class Node:
             num_cpus = env_dict.pop("CPU", None)
             num_gpus = env_dict.pop("GPU", None)
             memory = env_dict.pop("memory", None)
+            gpu_memory = env_dict.pop("gpu_memory", None)
             object_store_memory = env_dict.pop("object_store_memory", None)
 
             result = params_dict.copy()
@@ -518,7 +519,7 @@ class Node:
                         "Autoscaler is overriding your resource:"
                         f"{key}: {params_dict[key]} with {env_dict[key]}."
                     )
-            return num_cpus, num_gpus, memory, object_store_memory, result
+            return num_cpus, num_gpus, memory, gpu_memory, object_store_memory, result
 
         if not self._resource_spec:
             env_resources = {}
@@ -534,13 +535,17 @@ class Node:
                 num_cpus,
                 num_gpus,
                 memory,
+                gpu_memory,
                 object_store_memory,
                 resources,
             ) = merge_resources(env_resources, self._ray_params.resources)
+            if num_gpus and gpu_memory and num_gpus != len(gpu_memory):
+                raise ValueError(f"Number of gpus specified: {gpu_memory} does not match specified num_gpus: {num_gpus}")
             self._resource_spec = ResourceSpec(
                 self._ray_params.num_cpus if num_cpus is None else num_cpus,
                 self._ray_params.num_gpus if num_gpus is None else num_gpus,
                 self._ray_params.memory if memory is None else memory,
+                self._ray_params.gpu_memory if gpu_memory is None else gpu_memory,
                 self._ray_params.object_store_memory
                 if object_store_memory is None
                 else object_store_memory,

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -543,7 +543,7 @@ class Node:
                 self._ray_params.num_cpus if num_cpus is None else num_cpus,
                 self._ray_params.num_gpus if num_gpus is None else num_gpus,
                 self._ray_params.memory if memory is None else memory,
-                self._ray_params.gpu_memory if gpu_memory is None else gpu_memory,
+                self._ray_params._gpu_memory if gpu_memory is None else gpu_memory,
                 self._ray_params.object_store_memory
                 if object_store_memory is None
                 else object_store_memory,

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -539,8 +539,6 @@ class Node:
                 object_store_memory,
                 resources,
             ) = merge_resources(env_resources, self._ray_params.resources)
-            if num_gpus and gpu_memory and num_gpus != len(gpu_memory):
-                raise ValueError(f"Number of gpus specified: {gpu_memory} does not match specified num_gpus: {num_gpus}")
             self._resource_spec = ResourceSpec(
                 self._ray_params.num_cpus if num_cpus is None else num_cpus,
                 self._ray_params.num_gpus if num_gpus is None else num_gpus,

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -33,7 +33,7 @@ class RayParams:
             of that resource available.
         labels: The key-value labels of the node.
         memory: Total available memory for workers requesting memory.
-        gpu_memory: Total available memory for each gpu from num_gpus.
+        _gpu_memory: Total available memory from all GPUs in MB.
         object_store_memory: The amount of memory (in bytes) to start the
             object store with.
         redis_max_memory: The max amount of memory (in bytes) to allow redis
@@ -142,7 +142,7 @@ class RayParams:
         resources: Optional[Dict[str, float]] = None,
         labels: Optional[Dict[str, str]] = None,
         memory: Optional[float] = None,
-        gpu_memory: Optional[List[float]] = None,
+        _gpu_memory: Optional[float] = None,
         object_store_memory: Optional[float] = None,
         redis_max_memory: Optional[float] = None,
         redis_port: Optional[int] = None,
@@ -200,7 +200,7 @@ class RayParams:
         self.num_cpus = num_cpus
         self.num_gpus = num_gpus
         self.memory = memory
-        self.gpu_memory = gpu_memory
+        self._gpu_memory = _gpu_memory
         self.object_store_memory = object_store_memory
         self.resources = resources
         self.redis_max_memory = redis_max_memory
@@ -443,7 +443,7 @@ class RayParams:
             assert "GPU" not in self.resources, build_error("GPU", "num_gpus")
             assert "memory" not in self.resources, build_error("memory", "memory")
             assert "gpu_memory" not in self.resources, build_error(
-                "gpu_memory", "gpu_memory"
+                "gpu_memory", "_gpu_memory"
             )
             assert "object_store_memory" not in self.resources, build_error(
                 "object_store_memory", "object_store_memory"

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -33,6 +33,7 @@ class RayParams:
             of that resource available.
         labels: The key-value labels of the node.
         memory: Total available memory for workers requesting memory.
+        gpu_memory: Total available memory for each gpu from num_gpus.
         object_store_memory: The amount of memory (in bytes) to start the
             object store with.
         redis_max_memory: The max amount of memory (in bytes) to allow redis
@@ -141,6 +142,7 @@ class RayParams:
         resources: Optional[Dict[str, float]] = None,
         labels: Optional[Dict[str, str]] = None,
         memory: Optional[float] = None,
+        gpu_memory: Optional[List[float]] = None,
         object_store_memory: Optional[float] = None,
         redis_max_memory: Optional[float] = None,
         redis_port: Optional[int] = None,
@@ -198,6 +200,7 @@ class RayParams:
         self.num_cpus = num_cpus
         self.num_gpus = num_gpus
         self.memory = memory
+        self.gpu_memory = gpu_memory
         self.object_store_memory = object_store_memory
         self.resources = resources
         self.redis_max_memory = redis_max_memory
@@ -439,6 +442,9 @@ class RayParams:
             assert "CPU" not in self.resources, build_error("CPU", "num_cpus")
             assert "GPU" not in self.resources, build_error("GPU", "num_gpus")
             assert "memory" not in self.resources, build_error("memory", "memory")
+            assert "gpu_memory" not in self.resources, build_error(
+                "gpu_memory", "gpu_memory"
+            )
             assert "object_store_memory" not in self.resources, build_error(
                 "object_store_memory", "object_store_memory"
             )

--- a/python/ray/_private/ray_option_utils.py
+++ b/python/ray/_private/ray_option_utils.py
@@ -125,6 +125,7 @@ _common_options = {
     "name": Option((str, type(None))),
     "num_cpus": _resource_option("num_cpus"),
     "num_gpus": _resource_option("num_gpus"),
+    "_gpu_memory": _resource_option("_gpu_memory"),
     "object_store_memory": _counting_option("object_store_memory", False),
     # TODO(suquark): "placement_group", "placement_group_bundle_index"
     # and "placement_group_capture_child_tasks" are deprecated,

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -223,7 +223,6 @@ class ResourceSpec(
                             * accelerator_manager.get_current_node_accelerator_memory()
                         )
                     )
-                    resources["gpu_memory"] = gpu_memory
                 else:
                     resources[accelerator_resource_name] = num_accelerators
 

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -40,7 +40,7 @@ class ResourceSpec(
         num_cpus: The CPUs allocated for this raylet.
         num_gpus: The GPUs allocated for this raylet.
         memory: The memory allocated for this raylet.
-        gpu_memory: The GPUs' memory allocated for this raylet.
+        gpu_memory: The total GPUs' memory allocated for this raylet.
         object_store_memory: The object store memory allocated for this raylet.
             Note that when calling to_resource_dict(), this will be scaled down
             by 30% to account for the global plasma LRU reserve.
@@ -215,7 +215,14 @@ class ResourceSpec(
             if num_accelerators:
                 if accelerator_resource_name == "GPU":
                     num_gpus = num_accelerators
-                    gpu_memory = num_accelerators * (self.gpu_memory if self.gpu_memory else accelerator_manager.get_current_node_gpu_memory())
+                    gpu_memory = (
+                        self.gpu_memory
+                        if self.gpu_memory
+                        else (
+                            num_accelerators
+                            * accelerator_manager.get_current_node_gpu_memory()
+                        )
+                    )
                     resources["gpu_memory"] = gpu_memory
                 else:
                     resources[accelerator_resource_name] = num_accelerators

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -220,7 +220,7 @@ class ResourceSpec(
                         if self.gpu_memory
                         else (
                             num_accelerators
-                            * accelerator_manager.get_current_node_gpu_memory()
+                            * accelerator_manager.get_current_node_accelerator_memory()
                         )
                     )
                     resources["gpu_memory"] = gpu_memory

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -216,11 +216,10 @@ class ResourceSpec(
                 if accelerator_resource_name == "GPU":
                     num_gpus = num_accelerators
                     gpu_memory = (
-                        self.gpu_memory
-                        if self.gpu_memory
-                        else (
-                            num_accelerators
-                            * accelerator_manager.get_current_node_accelerator_memory()
+                        num_accelerators * (
+                            self.gpu_memory if self.gpu_memory
+                            else 
+                            accelerator_manager.get_current_node_accelerator_memory()
                         )
                     )
                 else:

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -23,6 +23,7 @@ class ResourceSpec(
             "num_cpus",
             "num_gpus",
             "memory",
+            "gpu_memory",
             "object_store_memory",
             "resources",
             "redis_max_memory",
@@ -39,6 +40,7 @@ class ResourceSpec(
         num_cpus: The CPUs allocated for this raylet.
         num_gpus: The GPUs allocated for this raylet.
         memory: The memory allocated for this raylet.
+        gpu_memory: The GPUs' memory allocated for this raylet.
         object_store_memory: The object store memory allocated for this raylet.
             Note that when calling to_resource_dict(), this will be scaled down
             by 30% to account for the global plasma LRU reserve.
@@ -55,6 +57,7 @@ class ResourceSpec(
         num_cpus=None,
         num_gpus=None,
         memory=None,
+        gpu_memory=None,
         object_store_memory=None,
         resources=None,
         redis_max_memory=None,
@@ -64,6 +67,7 @@ class ResourceSpec(
             num_cpus,
             num_gpus,
             memory,
+            gpu_memory,
             object_store_memory,
             resources,
             redis_max_memory,
@@ -89,6 +93,7 @@ class ResourceSpec(
             CPU=self.num_cpus,
             GPU=self.num_gpus,
             memory=int(self.memory),
+            gpu_memory=int(self.gpu_memory),
             object_store_memory=int(self.object_store_memory),
         )
 
@@ -141,6 +146,7 @@ class ResourceSpec(
         assert "CPU" not in resources, resources
         assert "GPU" not in resources, resources
         assert "memory" not in resources, resources
+        assert "gpu_memory" not in resources, resources
         assert "object_store_memory" not in resources, resources
 
         if node_ip_address is None:
@@ -165,6 +171,7 @@ class ResourceSpec(
             num_cpus = ray._private.utils.get_num_cpus()
 
         num_gpus = 0
+        gpu_memory = 0
         for (
             accelerator_resource_name
         ) in ray._private.accelerators.get_all_accelerator_resource_names():
@@ -208,6 +215,8 @@ class ResourceSpec(
             if num_accelerators:
                 if accelerator_resource_name == "GPU":
                     num_gpus = num_accelerators
+                    gpu_memory = num_accelerators * (self.gpu_memory if self.gpu_memory else accelerator_manager.get_current_node_gpu_memory())
+                    resources["gpu_memory"] = gpu_memory
                 else:
                     resources[accelerator_resource_name] = num_accelerators
 
@@ -298,6 +307,7 @@ class ResourceSpec(
             num_cpus,
             num_gpus,
             memory,
+            gpu_memory,
             object_store_memory,
             resources,
             redis_max_memory,

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -361,15 +361,20 @@ def resources_from_ray_options(options_dict: Dict[str, Any]) -> Dict[str, Any]:
         raise ValueError(
             "The resources dictionary must not contain the key 'CPU' or 'GPU'"
         )
-    elif "memory" in resources or "object_store_memory" in resources:
+    elif (
+        "memory" in resources
+        or "object_store_memory" in resources
+        or "_gpu_memory" in resources
+    ):
         raise ValueError(
-            "The resources dictionary must not "
-            "contain the key 'memory' or 'object_store_memory'"
+            "The resources dictionary must not contain the key"
+            " 'memory' or 'object_store_memory' or '_gpu_memory'"
         )
 
     num_cpus = options_dict.get("num_cpus")
     num_gpus = options_dict.get("num_gpus")
     memory = options_dict.get("memory")
+    gpu_memory = options_dict.get("_gpu_memory")
     object_store_memory = options_dict.get("object_store_memory")
     accelerator_type = options_dict.get("accelerator_type")
 
@@ -381,6 +386,8 @@ def resources_from_ray_options(options_dict: Dict[str, Any]) -> Dict[str, Any]:
         resources["memory"] = int(memory)
     if object_store_memory is not None:
         resources["object_store_memory"] = object_store_memory
+    if gpu_memory is not None:
+        resources["gpu_memory"] = int(gpu_memory)
     if accelerator_type is not None:
         resources[
             f"{ray_constants.RESOURCE_CONSTRAINT_PREFIX}{accelerator_type}"

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1289,7 +1289,7 @@ def init(
         _memory: Amount of reservable memory resource in bytes rounded
             down to the nearest integer.
         _gpu_memory: The gpu memory request in megabytes for this task/actor
-            from a single gpu, rounded down to the nearest integer.
+            from a single gpu, rounded up to the nearest integer.
         _redis_password: Prevents external clients without the password
             from connecting to Redis if provided.
         _temp_dir: If provided, specifies the root temporary
@@ -3307,7 +3307,7 @@ def remote(
         memory: The heap memory request in bytes for this task/actor,
             rounded down to the nearest integer.
         _gpu_memory: The gpu memory request in megabytes for this task/actor
-            from a single gpu, rounded down to the nearest integer.
+            from a single gpu, rounded up to the nearest integer.
         max_calls: Only for *remote functions*. This specifies the
             maximum number of times that a given worker can execute
             the given remote function before it must exit

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1157,6 +1157,7 @@ def init(
     resources: Optional[Dict[str, float]] = None,
     labels: Optional[Dict[str, str]] = None,
     object_store_memory: Optional[int] = None,
+    _gpu_memory: Optional[int] = None,
     local_mode: bool = False,
     ignore_reinit_error: bool = False,
     include_dashboard: Optional[bool] = None,
@@ -1287,6 +1288,8 @@ def init(
         _driver_object_store_memory: Deprecated.
         _memory: Amount of reservable memory resource in bytes rounded
             down to the nearest integer.
+        _gpu_memory: The gpu memory request in megabytes for this task/actor
+            from a single gpu, rounded down to the nearest integer.
         _redis_password: Prevents external clients without the password
             from connecting to Redis if provided.
         _temp_dir: If provided, specifies the root temporary
@@ -1562,6 +1565,7 @@ def init(
             dashboard_host=dashboard_host,
             dashboard_port=dashboard_port,
             memory=_memory,
+            _gpu_memory=_gpu_memory,
             object_store_memory=object_store_memory,
             redis_max_memory=_redis_max_memory,
             plasma_store_socket_name=None,
@@ -1589,6 +1593,11 @@ def init(
             raise ValueError(
                 "When connecting to an existing cluster, num_cpus "
                 "and num_gpus must not be provided."
+            )
+        if _gpu_memory is not None:
+            raise ValueError(
+                "When connecting to an existing cluster, "
+                "_gpu_memory must not be provided."
             )
         if resources is not None:
             raise ValueError(
@@ -3127,6 +3136,7 @@ def remote(
     resources: Dict[str, float] = Undefined,
     accelerator_type: str = Undefined,
     memory: Union[int, float] = Undefined,
+    _gpu_memory: Union[int, float] = Undefined,
     max_calls: int = Undefined,
     max_restarts: int = Undefined,
     max_task_retries: int = Undefined,
@@ -3296,6 +3306,8 @@ def remote(
             See :ref:`accelerator types <accelerator_types>`.
         memory: The heap memory request in bytes for this task/actor,
             rounded down to the nearest integer.
+        _gpu_memory: The gpu memory request in megabytes for this task/actor
+            from a single gpu, rounded down to the nearest integer.
         max_calls: Only for *remote functions*. This specifies the
             maximum number of times that a given worker can execute
             the given remote function before it must exit

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1288,7 +1288,7 @@ def init(
         _driver_object_store_memory: Deprecated.
         _memory: Amount of reservable memory resource in bytes rounded
             down to the nearest integer.
-        _gpu_memory: The gpu memory request in megabytes for this task/actor
+        _gpu_memory: The gpu memory request in bytes for this task/actor
             from a single gpu, rounded up to the nearest integer.
         _redis_password: Prevents external clients without the password
             from connecting to Redis if provided.
@@ -3306,7 +3306,7 @@ def remote(
             See :ref:`accelerator types <accelerator_types>`.
         memory: The heap memory request in bytes for this task/actor,
             rounded down to the nearest integer.
-        _gpu_memory: The gpu memory request in megabytes for this task/actor
+        _gpu_memory: The gpu memory request in bytes for this task/actor
             from a single gpu, rounded up to the nearest integer.
         max_calls: Only for *remote functions*. This specifies the
             maximum number of times that a given worker can execute

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1431,7 +1431,7 @@ def _make_actor(cls, actor_options):
     Class = _modify_class(cls)
     _inject_tracing_into_class(Class)
 
-    if "_gpu_memory" in actor_options and "num_gpus" in actor_options:
+    if actor_options.get("_gpu_memory", None) and actor_options.get("num_gpus", None):
         raise ValueError(
             "Specifying both `num_gpus` and `_gpu_memory` is not allowed. "
             "See more at: (link TBD)"

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -350,8 +350,7 @@ class _ActorClassMetadata:
         num_gpus: The default number of GPUs required by the actor creation
             task.
         memory: The heap memory quota for this actor.
-        _gpu_memory: The gpu memory request in megabytes for this task/actor
-            from a single gpu, rounded down to the nearest integer.
+        _gpu_memory: The gpu memory request in megabytes for this actor.
         resources: The default resources required by the actor creation task.
         accelerator_type: The specified type of accelerator required for the
             node on which this actor runs.
@@ -600,7 +599,7 @@ class ActorClass:
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
             _gpu_memory: The gpu memory request in megabytes for this task/actor
-                from a single gpu, rounded down to the nearest integer.
+                from a single gpu, rounded up to the nearest integer.
             object_store_memory: The object store memory request for actors only.
             max_restarts: This specifies the maximum
                 number of times that the actor should be restarted when it dies

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -350,7 +350,7 @@ class _ActorClassMetadata:
         num_gpus: The default number of GPUs required by the actor creation
             task.
         memory: The heap memory quota for this actor.
-        _gpu_memory: The gpu memory request in megabytes for this actor.
+        _gpu_memory: The gpu memory request in bytes for this actor.
         resources: The default resources required by the actor creation task.
         accelerator_type: The specified type of accelerator required for the
             node on which this actor runs.
@@ -598,7 +598,7 @@ class ActorClass:
                 See :ref:`accelerator types <accelerator_types>`.
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
-            _gpu_memory: The gpu memory request in megabytes for this task/actor
+            _gpu_memory: The gpu memory request in bytes for this task/actor
                 from a single gpu, rounded up to the nearest integer.
             object_store_memory: The object store memory request for actors only.
             max_restarts: This specifies the maximum

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -662,6 +662,19 @@ class AWSNodeProvider(NodeProvider):
                             autodetected_resources[
                                 f"accelerator_type:{accelerator_type}"
                             ] = 1
+                        # autodetect gpu memory
+                        gpu_memory = (
+                            accelerator_manager.get_ec2_instance_accelerator_memory(
+                                instance_type, instances_dict
+                            )
+                        )
+                        if (
+                            accelerator_manager.get_resource_name() == "GPU"
+                            and gpu_memory
+                        ):
+                            autodetected_resources["gpu_memory"] = (
+                                num_accelerators * gpu_memory
+                            )
 
                 autodetected_resources.update(
                     available_node_types[node_type].get("resources", {})

--- a/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
@@ -316,7 +316,7 @@ class FakeMultiNodeProvider(NodeProvider):
                 num_cpus=resources.pop("CPU", 0),
                 num_gpus=resources.pop("GPU", 0),
                 object_store_memory=resources.pop("object_store_memory", None),
-                _gpu_memory=resources.pop("gpu_memory", 0),
+                _gpu_memory=resources.pop("gpu_memory", 0),  # gpu memory = 600,
                 resources=resources,
                 labels=labels,
                 redis_address="{}:6379".format(

--- a/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
@@ -316,6 +316,7 @@ class FakeMultiNodeProvider(NodeProvider):
                 num_cpus=resources.pop("CPU", 0),
                 num_gpus=resources.pop("GPU", 0),
                 object_store_memory=resources.pop("object_store_memory", None),
+                _gpu_memory=resources.pop("gpu_memory", 0),
                 resources=resources,
                 labels=labels,
                 redis_address="{}:6379".format(

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -546,11 +546,14 @@ class ResourceDemandScheduler:
                 node_type = tags[TAG_RAY_USER_NODE_TYPE]
                 ip = self.provider.internal_ip(node_id)
                 available_resources = copy.deepcopy(unused_resources_by_ip.get(ip))
-                available = self.node_types[node_type]["resources"]
-                if available_resources and "node:gpu_memory_per_gpu" in available:
-                    available_resources["node:gpu_memory_per_gpu"] = available[
+                available_node_type = self.node_types.get(node_type, {})
+                if (
+                    available_resources
+                    and "node:gpu_memory_per_gpu" in available_node_type["resources"]
+                ):
+                    available_resources[
                         "node:gpu_memory_per_gpu"
-                    ]
+                    ] = available_node_type["resources"]["node:gpu_memory_per_gpu"]
                 add_node(node_type, available_resources)
 
         for node_type, count in pending_nodes.items():

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -545,7 +545,12 @@ class ResourceDemandScheduler:
             if TAG_RAY_USER_NODE_TYPE in tags:
                 node_type = tags[TAG_RAY_USER_NODE_TYPE]
                 ip = self.provider.internal_ip(node_id)
-                available_resources = unused_resources_by_ip.get(ip)
+                available_resources = copy.deepcopy(unused_resources_by_ip.get(ip))
+                available = self.node_types[node_type]["resources"]
+                if available_resources and "node:gpu_memory_per_gpu" in available:
+                    available_resources["node:gpu_memory_per_gpu"] = available[
+                        "node:gpu_memory_per_gpu"
+                    ]
                 add_node(node_type, available_resources)
 
         for node_type, count in pending_nodes.items():

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -85,6 +85,8 @@ class AutoscalingCluster:
                     self._head_resources.pop("object_store_memory")
                 )
             )
+        if "gpu_memory" in self._head_resources:
+            cmd.append("--gpu-memory={}".format(self._head_resources.pop("gpu_memory")))
         if self._head_resources:
             cmd.append("--resources='{}'".format(json.dumps(self._head_resources)))
         if _system_config is not None:

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -56,7 +56,7 @@ class RemoteFunction:
             remote function.
         _memory: The heap memory request in bytes for this task/actor,
             rounded down to the nearest integer.
-        _gpu_memory: The gpu memory request in megabytes for this task/actor
+        _gpu_memory: The gpu memory request in bytes for this task/actor
             from a single gpu, rounded up to the nearest integer.
         _resources: The default custom resource requirements for invocations of
             this remote function.
@@ -186,7 +186,7 @@ class RemoteFunction:
                 See :ref:`accelerator types <accelerator_types>`.
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
-            _gpu_memory: The gpu memory request in megabytes for this task/actor
+            _gpu_memory: The gpu memory request in bytes for this task/actor
                 from a single gpu, rounded up to the nearest integer.
             object_store_memory: The object store memory request for actors only.
             max_calls: This specifies the

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -57,7 +57,7 @@ class RemoteFunction:
         _memory: The heap memory request in bytes for this task/actor,
             rounded down to the nearest integer.
         _gpu_memory: The gpu memory request in megabytes for this task/actor
-            from a single gpu, rounded down to the nearest integer.
+            from a single gpu, rounded up to the nearest integer.
         _resources: The default custom resource requirements for invocations of
             this remote function.
         _num_returns: The default number of return values for invocations
@@ -187,7 +187,7 @@ class RemoteFunction:
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
             _gpu_memory: The gpu memory request in megabytes for this task/actor
-            from a single gpu, rounded down to the nearest integer.
+                from a single gpu, rounded up to the nearest integer.
             object_store_memory: The object store memory request for actors only.
             max_calls: This specifies the
                 maximum number of times that a given worker can execute

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -56,6 +56,8 @@ class RemoteFunction:
             remote function.
         _memory: The heap memory request in bytes for this task/actor,
             rounded down to the nearest integer.
+        _gpu_memory: The gpu memory request in megabytes for this task/actor
+            from a single gpu, rounded down to the nearest integer.
         _resources: The default custom resource requirements for invocations of
             this remote function.
         _num_returns: The default number of return values for invocations
@@ -109,6 +111,13 @@ class RemoteFunction:
             num_gpus > 0 and self._default_options.get("max_calls", None) is None
         ) or "nsight" in (self._default_options.get("runtime_env") or {}):
             self._default_options["max_calls"] = 1
+
+        # Either num_gpus or gpu_memory can be specified, not both.
+        if num_gpus != 0 and self._default_options.get("_gpu_memory"):
+            raise ValueError(
+                "Specifying both `num_gpus` and `_gpu_memory` is not allowed. "
+                "See more at: (link TBD)"
+            )
 
         # TODO(suquark): This is a workaround for class attributes of options.
         # They are being used in some other places, mostly tests. Need cleanup later.
@@ -177,6 +186,8 @@ class RemoteFunction:
                 See :ref:`accelerator types <accelerator_types>`.
             memory: The heap memory request in bytes for this task/actor,
                 rounded down to the nearest integer.
+            _gpu_memory: The gpu memory request in megabytes for this task/actor
+            from a single gpu, rounded down to the nearest integer.
             object_store_memory: The object store memory request for actors only.
             max_calls: This specifies the
                 maximum number of times that a given worker can execute

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -382,6 +382,14 @@ def debug(address):
     "--num-gpus", required=False, type=int, help="the number of GPUs on this node"
 )
 @click.option(
+    "--gpu-memory",
+    required=False,
+    type=int,
+    help="The total amount of memory (in megabytes) to make available to workers. "
+    "By default, this is set to the sum of available memory "
+    "from the gpus detected gpus in the node.",
+)
+@click.option(
     "--resources",
     required=False,
     default="{}",
@@ -564,6 +572,7 @@ def start(
     redis_max_memory,
     num_cpus,
     num_gpus,
+    gpu_memory,
     resources,
     head,
     include_dashboard,
@@ -656,6 +665,7 @@ def start(
         redirect_output=redirect_output,
         num_cpus=num_cpus,
         num_gpus=num_gpus,
+        _gpu_memory=gpu_memory,
         resources=resources,
         labels=labels_dict,
         autoscaling_config=autoscaling_config,

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -385,7 +385,7 @@ def debug(address):
     "--gpu-memory",
     required=False,
     type=int,
-    help="The total amount of memory (in megabytes) to make available to workers. "
+    help="The total amount of memory (in bytes) to make available to workers. "
     "By default, this is set to the sum of available memory "
     "from the gpus detected gpus in the node.",
 )

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -385,9 +385,9 @@ def debug(address):
     "--gpu-memory",
     required=False,
     type=int,
-    help="The total amount of memory (in bytes) to make available to workers. "
-    "By default, this is set to the sum of available memory "
-    "from the gpus detected gpus in the node.",
+    help="The amount of GPU memory per GPU (in bytes) to make available to workers. "
+    "By default, this is set to the available memory "
+    "from the detected gpus in the node.",
 )
 @click.option(
     "--resources",

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -25,6 +25,7 @@ def test_fake_autoscaler_basic_e2e(shutdown_only):
                     "CPU": 2,
                     "GPU": 1,
                     "object_store_memory": 1024 * 1024 * 1024,
+                    "gpu_memory": 1000,
                 },
                 "node_config": {},
                 "min_workers": 0,
@@ -51,6 +52,11 @@ def test_fake_autoscaler_basic_e2e(shutdown_only):
         @ray.remote(num_gpus=1)
         def f():
             print("gpu ok")
+
+        # Triggers the addition of a GPU memory node.
+        @ray.remote(_gpu_memory=1000)
+        def f2():
+            print("gpu memory ok")
 
         # Triggers the addition of a CPU node.
         @ray.remote(num_cpus=3)

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -169,6 +169,7 @@ class AutoscalingConfigTest(unittest.TestCase):
             "CPU": 32,
             "memory": 183395103539,
             "GPU": 4,
+            "gpu_memory": 4 * 16160 * 1024 * 1024,
             "accelerator_type:V100": 1,
         }
         expected_available_node_types["neuron_core_inf_1_ondemand"]["resources"] = {
@@ -197,7 +198,15 @@ class AutoscalingConfigTest(unittest.TestCase):
                     "InstanceType": "p3.8xlarge",
                     "VCpuInfo": {"DefaultVCpus": 32},
                     "MemoryInfo": {"SizeInMiB": 249856},
-                    "GpuInfo": {"Gpus": [{"Name": "V100", "Count": 4}]},
+                    "GpuInfo": {
+                        "Gpus": [
+                            {
+                                "Name": "V100",
+                                "Count": 4,
+                                "MemoryInfo": {"SizeInMiB": 16160},
+                            }
+                        ]
+                    },
                 },
                 {
                     "InstanceType": "inf2.xlarge",
@@ -221,7 +230,6 @@ class AutoscalingConfigTest(unittest.TestCase):
             new_config = prepare_config(new_config)
             importer = _NODE_PROVIDERS.get(new_config["provider"]["type"])
             provider_cls = importer(new_config["provider"])
-
             try:
                 new_config = provider_cls.fillout_available_node_types_resources(
                     new_config

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -718,6 +718,12 @@ RAY_CONFIG(std::string, predefined_unit_instance_resources, "GPU")
 /// When set it to "neuron_cores,TPU,FPGA", we will also treat FPGA as unit_instance.
 RAY_CONFIG(std::string, custom_unit_instance_resources, "neuron_cores,TPU")
 
+/// The scheduler will treat these resource as resource which can be requested
+/// but not stored as NodeResources. The main reason is the resource is different
+/// representation of other resource stored in NodeResources.
+/// For example: gpu_memory and GPU.
+RAY_CONFIG(std::string, request_only_resources, "gpu_memory")
+
 // Maximum size of the batches when broadcasting resources to raylet.
 RAY_CONFIG(uint64_t, resource_broadcast_batch_size, 512)
 

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -57,11 +57,10 @@ NodeResources ResourceMapToNodeResources(
   auto resource_map_total_copy = resource_map_total;
   auto resource_map_available_copy = resource_map_available;
   auto node_labels_copy = node_labels;
-  // move gpu_memory to node labels
+
   if (resource_map_total.find("gpu_memory") != resource_map_total.end()) {
     node_labels_copy["gpu_memory"] = std::to_string(resource_map_total.at("gpu_memory") /
                                                     resource_map_total.at("GPU"));
-    // RAY_CHECK(std::stod(node_labels_copy.at("gpu_memory")) == 1000);
     resource_map_total_copy.erase("gpu_memory");
     resource_map_available_copy.erase("gpu_memory");
   } else {

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -59,10 +59,9 @@ NodeResources ResourceMapToNodeResources(
   auto node_labels_copy = node_labels;
   // move gpu_memory to node labels
   if (resource_map_total.find("gpu_memory") != resource_map_total.end()) {
-    RAY_LOG(INFO) << resource_map_total.at("gpu_memory");
-    node_labels_copy["gpu_memory"] =
-        std::to_string(resource_map_total.at("gpu_memory") / resource_map_total.at("GPU"));
-    //RAY_CHECK(std::stod(node_labels_copy.at("gpu_memory")) == 1000);
+    node_labels_copy["gpu_memory"] = std::to_string(resource_map_total.at("gpu_memory") /
+                                                    resource_map_total.at("GPU"));
+    // RAY_CHECK(std::stod(node_labels_copy.at("gpu_memory")) == 1000);
     resource_map_total_copy.erase("gpu_memory");
     resource_map_available_copy.erase("gpu_memory");
   } else {
@@ -152,6 +151,7 @@ const ResourceSet NodeResources::ConvertRelativeResource(
   if (resource.Has(ResourceID::GPU_Memory())) {
     double total_gpu_memory = 0;
     if (this->labels.find("gpu_memory") != this->labels.end()) {
+      // TODO: raise exception if this is not true
       total_gpu_memory = std::stod(this->labels.at("gpu_memory"));
     }
     double num_gpus_request = 0;

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -54,19 +54,22 @@ NodeResources ResourceMapToNodeResources(
     const absl::flat_hash_map<std::string, double> &resource_map_available,
     const absl::flat_hash_map<std::string, std::string> &node_labels) {
   NodeResources node_resources;
+  auto resource_map_total_copy = resource_map_total;
+  auto resource_map_available_copy = resource_map_available;
+  auto node_labels_copy = node_labels;
   // move gpu_memory to node labels
   if (resource_map_total.find("gpu_memory") != resource_map_total.end()) {
-    node_labels["gpu_memory"] =
-        resource_map_total["gpu_memory"] / resource_map_total["GPU"];
-    resource_map_total.erase("gpu_memory");
-    resource_map_available.erase("gpu_memory");
+    node_labels_copy["gpu_memory"] =
+        resource_map_total.at("gpu_memory") / resource_map_total.at("GPU");
+    resource_map_total_copy.erase("gpu_memory");
+    resource_map_available_copy.erase("gpu_memory");
   } else {
-    node_labels["gpu_memory"] = "0";
+    node_labels_copy["gpu_memory"] = "0";
   }
 
-  node_resources.total = NodeResourceSet(resource_map_total);
-  node_resources.available = NodeResourceSet(resource_map_available);
-  node_resources.labels = node_labels;
+  node_resources.total = NodeResourceSet(resource_map_total_copy);
+  node_resources.available = NodeResourceSet(resource_map_available_copy);
+  node_resources.labels = node_labels_copy;
 
   return node_resources;
 }
@@ -146,14 +149,14 @@ const ResourceSet NodeResources::ConvertRelativeResource(
   // convert gpu_memory to GPU
   if (resource.Has(ResourceID::GPU_Memory())) {
     double total_gpu_memory = 0;
-    if (this->labels.find("GPU_Memory") != this->labels.end()) {
-      total_gpu_mem = std::stod(this->labels["GPU_Memory"]);
+    if (this->labels.find("gpu_memory") != this->labels.end()) {
+      total_gpu_memory = std::stod(this->labels.at("gpu_memory"));
     }
     double num_gpus_request = 0;
-    if (total_gpu_mem > 0) {
+    if (total_gpu_memory > 0) {
       // round up to closes kResourceUnitScaling
       num_gpus_request =
-          (resource.Get(ResourceID::GPU_Memory()).Double() / total_gpu_mem) +
+          (resource.Get(ResourceID::GPU_Memory()).Double() / total_gpu_memory) +
           1 / static_cast<double>(2 * kResourceUnitScaling);
     }
     adjusted_resource.Set(ResourceID::GPU(), num_gpus_request);
@@ -195,14 +198,14 @@ const ResourceSet NodeResourceInstances::ConvertRelativeResource(
   // convert gpu_memory to GPU
   if (resource.Has(ResourceID::GPU_Memory())) {
     double total_gpu_memory = 0;
-    if (this->labels.find("GPU_Memory") != this->labels.end()) {
-      total_gpu_mem = std::stod(this->labels["GPU_Memory"]);
+    if (this->labels.find("gpu_memory") != this->labels.end()) {
+      total_gpu_memory = std::stod(this->labels.at("gpu_memory"));
     }
     double num_gpus_request = 0;
-    if (total_gpu_mem > 0) {
+    if (total_gpu_memory > 0) {
       // round up to closes kResourceUnitScaling
       num_gpus_request =
-          (resource.Get(ResourceID::GPU_Memory()).Double() / total_gpu_mem) +
+          (resource.Get(ResourceID::GPU_Memory()).Double() / total_gpu_memory) +
           1 / static_cast<double>(2 * kResourceUnitScaling);
     }
     adjusted_resource.Set(ResourceID::GPU(), num_gpus_request);

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -59,8 +59,10 @@ NodeResources ResourceMapToNodeResources(
   auto node_labels_copy = node_labels;
   // move gpu_memory to node labels
   if (resource_map_total.find("gpu_memory") != resource_map_total.end()) {
+    RAY_LOG(INFO) << resource_map_total.at("gpu_memory");
     node_labels_copy["gpu_memory"] =
-        resource_map_total.at("gpu_memory") / resource_map_total.at("GPU");
+        std::to_string(resource_map_total.at("gpu_memory") / resource_map_total.at("GPU"));
+    //RAY_CHECK(std::stod(node_labels_copy.at("gpu_memory")) == 1000);
     resource_map_total_copy.erase("gpu_memory");
     resource_map_available_copy.erase("gpu_memory");
   } else {

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -289,8 +289,8 @@ class TaskResourceInstances {
 class NodeResources {
  public:
   NodeResources() {}
-  NodeResources(const NodeResourceSet &resources)
-      : total(resources), available(resources) {}
+  NodeResources(const NodeResourceSet &resources);
+
   NodeResourceSet total;
   NodeResourceSet available;
   /// Only used by light resource report.

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -119,23 +119,6 @@ class ResourceRequest {
   bool requires_object_store_memory_ = false;
 };
 
-// update this and resource instance set,
-// two options, both same idea: map derived resource id to vector of resource id
-
-// option 1: update in taskresource instance, resourceinstance set to override Set, add,
-// etc for derived resource id for example Set(DerivedNodeID ,
-// abs::flat_hash_map<ResourceID, vector<FixedPoint>> base_resources) how to not expose
-// the base resource??
-
-// option 2: map derived resource id to its base resource ids outside Resource instance
-// problem: Tryallocate is hard to handle, esp need same index for all 3 resources
-// + need to free all when failed allocating
-
-// note: both no need to store DerivedResourceID => vector<FixedPoint>, as all stored as
-// base resource id
-
-// we might need to check if gpu_memory and gpu both exists here??
-
 /// Represents a resource set that contains the per-instance resource values.
 /// NOTE, unlike ResourceRequest, zero values won't be automatically removed in this
 /// class. Because otherwise we will lose the number of instances the set originally had

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -119,6 +119,21 @@ class ResourceRequest {
   bool requires_object_store_memory_ = false;
 };
 
+// update this and resource instance set, 
+// two options, both same idea: map derived resource id to vector of resource id
+
+// option 1: update in taskresource instance, resourceinstance set to override Set, add, etc for derived resource id
+// for example Set(DerivedNodeID , abs::flat_hash_map<ResourceID, vector<FixedPoint>> base_resources)
+// how to not expose the base resource??
+
+// option 2: map derived resource id to its base resource ids outside Resource instance
+// problem: Tryallocate is hard to handle, esp need same index for all 3 resources
+// + need to free all when failed allocating
+
+// note: both no need to store DerivedResourceID => vector<FixedPoint>, as all stored as base resource id
+
+// we might need to check if gpu_memory and gpu both exists here??
+
 /// Represents a resource set that contains the per-instance resource values.
 /// NOTE, unlike ResourceRequest, zero values won't be automatically removed in this
 /// class. Because otherwise we will lose the number of instances the set originally had
@@ -333,6 +348,9 @@ class NodeResources {
   std::string DebugString() const;
   /// Returns compact dict-like string.
   std::string DictString() const;
+  // Returns adjusted ResourceSet after converting resource relative to others.
+  // For example: gpu_memory => num_gpus = gpu_memory / total.gpu_memory.
+  const ResourceSet ProcessRelativeResource(const ResourceSet &resource) const;
 };
 
 /// Total and available capacities of each resource instance.
@@ -351,6 +369,10 @@ class NodeResourceInstances {
   bool operator==(const NodeResourceInstances &other);
   /// Returns human-readable string for these resources.
   [[nodiscard]] std::string DebugString() const;
+
+  // Returns adjusted ResourceSet after converting resource relative to others.
+  // For example: gpu_memory => num_gpus = gpu_memory / total.gpu_memory.
+  const ResourceSet ProcessRelativeResource(const ResourceSet &resource) const;
 };
 
 struct Node {

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -119,18 +119,20 @@ class ResourceRequest {
   bool requires_object_store_memory_ = false;
 };
 
-// update this and resource instance set, 
+// update this and resource instance set,
 // two options, both same idea: map derived resource id to vector of resource id
 
-// option 1: update in taskresource instance, resourceinstance set to override Set, add, etc for derived resource id
-// for example Set(DerivedNodeID , abs::flat_hash_map<ResourceID, vector<FixedPoint>> base_resources)
-// how to not expose the base resource??
+// option 1: update in taskresource instance, resourceinstance set to override Set, add,
+// etc for derived resource id for example Set(DerivedNodeID ,
+// abs::flat_hash_map<ResourceID, vector<FixedPoint>> base_resources) how to not expose
+// the base resource??
 
 // option 2: map derived resource id to its base resource ids outside Resource instance
 // problem: Tryallocate is hard to handle, esp need same index for all 3 resources
 // + need to free all when failed allocating
 
-// note: both no need to store DerivedResourceID => vector<FixedPoint>, as all stored as base resource id
+// note: both no need to store DerivedResourceID => vector<FixedPoint>, as all stored as
+// base resource id
 
 // we might need to check if gpu_memory and gpu both exists here??
 
@@ -350,7 +352,7 @@ class NodeResources {
   std::string DictString() const;
   // Returns adjusted ResourceSet after converting resource relative to others.
   // For example: gpu_memory => num_gpus = gpu_memory / total.gpu_memory.
-  const ResourceSet ProcessRelativeResource(const ResourceSet &resource) const;
+  const ResourceSet ConvertRelativeResource(const ResourceSet &resource) const;
 };
 
 /// Total and available capacities of each resource instance.
@@ -372,7 +374,7 @@ class NodeResourceInstances {
 
   // Returns adjusted ResourceSet after converting resource relative to others.
   // For example: gpu_memory => num_gpus = gpu_memory / total.gpu_memory.
-  const ResourceSet ProcessRelativeResource(const ResourceSet &resource) const;
+  const ResourceSet ConvertRelativeResource(const ResourceSet &resource) const;
 };
 
 struct Node {

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -335,7 +335,7 @@ class NodeResources {
   std::string DictString() const;
   // Returns adjusted ResourceSet after converting resource relative to others.
   // For example: gpu_memory => num_gpus = gpu_memory / total.gpu_memory.
-  const ResourceSet ConvertRelativeResource(const ResourceSet &resource) const;
+  const ResourceSet ConvertRelativeResources(const ResourceSet &resource) const;
 };
 
 /// Total and available capacities of each resource instance.
@@ -357,7 +357,7 @@ class NodeResourceInstances {
 
   // Returns adjusted ResourceSet after converting resource relative to others.
   // For example: gpu_memory => num_gpus = gpu_memory / total.gpu_memory.
-  const ResourceSet ConvertRelativeResource(const ResourceSet &resource) const;
+  const ResourceSet ConvertRelativeResources(const ResourceSet &resource) const;
 };
 
 struct Node {

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -93,7 +93,6 @@ bool NodeResourceInstanceSet::operator==(const NodeResourceInstanceSet &other) c
 std::optional<absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>>
 NodeResourceInstanceSet::TryAllocate(const ResourceSet &resource_demands) {
   absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> allocations;
-  // update this to TryAllocateBundle
   for (const auto &[resource_id, demand] : resource_demands.Resources()) {
     auto allocation = TryAllocate(resource_id, demand);
     if (allocation) {
@@ -135,8 +134,6 @@ std::optional<std::vector<FixedPoint>> NodeResourceInstanceSet::TryAllocate(
       return std::nullopt;
     }
   }
-  // need to update this to support instance > 1
-  // still unit tho, might need to create different TryAllocate function
 
   // If resources has multiple instances, each instance has total capacity of 1.
   //

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -22,8 +22,7 @@
 namespace ray {
 
 NodeResourceInstanceSet::NodeResourceInstanceSet(const NodeResourceSet &total) {
-  auto resource_ids = total.ExplicitResourceIds();
-  for (auto &resource_id : resource_ids) {
+  for (auto &resource_id : total.ExplicitResourceIds()) {
     std::vector<FixedPoint> instances;
     auto value = total.Get(resource_id);
     if (resource_id.IsUnitInstanceResource()) {
@@ -31,13 +30,6 @@ NodeResourceInstanceSet::NodeResourceInstanceSet(const NodeResourceSet &total) {
       for (size_t i = 0; i < num_instances; i++) {
         instances.push_back(1.0);
       };
-    } else if (resource_id == ResourceID::GPU_Memory() &&
-               resource_ids.find(ResourceID::GPU()) != resource_ids.end()) {
-      double num_gpus = total.Get(ResourceID::GPU()).Double();
-      for (size_t i = 0; i < static_cast<size_t>(num_gpus); i++) {
-        instances.push_back(value.Double() / num_gpus);
-      };
-
     } else {
       instances.push_back(value);
     }
@@ -101,6 +93,7 @@ bool NodeResourceInstanceSet::operator==(const NodeResourceInstanceSet &other) c
 std::optional<absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>>
 NodeResourceInstanceSet::TryAllocate(const ResourceSet &resource_demands) {
   absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> allocations;
+  // update this to TryAllocateBundle
   for (const auto &[resource_id, demand] : resource_demands.Resources()) {
     auto allocation = TryAllocate(resource_id, demand);
     if (allocation) {
@@ -142,6 +135,8 @@ std::optional<std::vector<FixedPoint>> NodeResourceInstanceSet::TryAllocate(
       return std::nullopt;
     }
   }
+  // need to update this to support instance > 1
+  // still unit tho, might need to create different TryAllocate function
 
   // If resources has multiple instances, each instance has total capacity of 1.
   //

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -22,7 +22,8 @@
 namespace ray {
 
 NodeResourceInstanceSet::NodeResourceInstanceSet(const NodeResourceSet &total) {
-  for (auto &resource_id : total.ExplicitResourceIds()) {
+  auto resource_ids = total.ExplicitResourceIds();
+  for (auto &resource_id : resource_ids) {
     std::vector<FixedPoint> instances;
     auto value = total.Get(resource_id);
     if (resource_id.IsUnitInstanceResource()) {
@@ -30,6 +31,13 @@ NodeResourceInstanceSet::NodeResourceInstanceSet(const NodeResourceSet &total) {
       for (size_t i = 0; i < num_instances; i++) {
         instances.push_back(1.0);
       };
+    } else if(resource_id == ResourceID::GPU_Memory() &&
+      resource_ids.find(ResourceID::GPU()) != resource_ids.end()){
+      double num_gpus = total.Get(ResourceID::GPU()).Double();
+      for (size_t i = 0; i < static_cast<size_t>(num_gpus); i++) {
+        instances.push_back(value.Double() / num_gpus);
+      };
+
     } else {
       instances.push_back(value);
     }

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -31,8 +31,8 @@ NodeResourceInstanceSet::NodeResourceInstanceSet(const NodeResourceSet &total) {
       for (size_t i = 0; i < num_instances; i++) {
         instances.push_back(1.0);
       };
-    } else if(resource_id == ResourceID::GPU_Memory() &&
-      resource_ids.find(ResourceID::GPU()) != resource_ids.end()){
+    } else if (resource_id == ResourceID::GPU_Memory() &&
+               resource_ids.find(ResourceID::GPU()) != resource_ids.end()) {
       double num_gpus = total.Get(ResourceID::GPU()).Double();
       for (size_t i = 0; i < static_cast<size_t>(num_gpus); i++) {
         instances.push_back(value.Double() / num_gpus);

--- a/src/ray/common/scheduling/scheduling_ids.cc
+++ b/src/ray/common/scheduling/scheduling_ids.cc
@@ -113,6 +113,25 @@ absl::flat_hash_set<int64_t> &ResourceID::UnitInstanceResources() {
   return set;
 }
 
+absl::flat_hash_set<int64_t> &ResourceID::RequestOnlyResources() {
+  static absl::flat_hash_set<int64_t> set{[]() {
+    absl::flat_hash_set<int64_t> res;
+
+    std::string request_only_resources = RayConfig::instance().request_only_resources();
+    if (!request_only_resources.empty()) {
+      std::vector<std::string> results;
+      boost::split(results, request_only_resources, boost::is_any_of(","));
+      for (std::string &result : results) {
+        int64_t resource_id = ResourceID(result).ToInt();
+        res.insert(resource_id);
+      }
+    }
+
+    return res;
+  }()};
+  return set;
+}
+
 }  // namespace scheduling
 
 }  // namespace ray

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -36,6 +36,7 @@ enum PredefinedResourcesEnum {
   CPU,
   MEM,
   GPU,
+  GPU_MEM,
   OBJECT_STORE_MEM,
   PredefinedResourcesEnum_MAX
 };
@@ -44,6 +45,7 @@ const std::string kCPU_ResourceLabel = "CPU";
 const std::string kGPU_ResourceLabel = "GPU";
 const std::string kObjectStoreMemory_ResourceLabel = "object_store_memory";
 const std::string kMemory_ResourceLabel = "memory";
+const std::string kGPU_Memory_ResourceLabel = "gpu_memory";
 const std::string kBundle_ResourceLabel = "bundle";
 
 /// Class to map string IDs to unique integer IDs and back.
@@ -149,7 +151,8 @@ inline StringIdMap &BaseSchedulingID<SchedulingIDTag::Resource>::GetMap() {
     map->InsertOrDie(kCPU_ResourceLabel, CPU)
         .InsertOrDie(kGPU_ResourceLabel, GPU)
         .InsertOrDie(kObjectStoreMemory_ResourceLabel, OBJECT_STORE_MEM)
-        .InsertOrDie(kMemory_ResourceLabel, MEM);
+        .InsertOrDie(kMemory_ResourceLabel, MEM)
+        .InsertOrDie(kGPU_Memory_ResourceLabel, GPU_MEM);
     return map;
   }()};
   return *map;
@@ -183,6 +186,9 @@ class ResourceID : public BaseSchedulingID<SchedulingIDTag::Resource> {
 
   /// Resource ID of GPU.
   static ResourceID GPU() { return ResourceID(PredefinedResourcesEnum::GPU); }
+
+  /// Resource ID of GPU memory.
+  static ResourceID GPU_Memory() { return ResourceID(PredefinedResourcesEnum::GPU_MEM); }
 
   /// Resource ID of object store memory.
   static ResourceID ObjectStoreMemory() {

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -178,6 +178,8 @@ class ResourceID : public BaseSchedulingID<SchedulingIDTag::Resource> {
     return !IsPredefinedResource() && absl::StartsWith(Binary(), kImplicitResourcePrefix);
   }
 
+  bool IsRequestOnlyResource() const { return RequestOnlyResources().contains(id_); }
+
   /// Resource ID of CPU.
   static ResourceID CPU() { return ResourceID(PredefinedResourcesEnum::CPU); }
 
@@ -203,6 +205,9 @@ class ResourceID : public BaseSchedulingID<SchedulingIDTag::Resource> {
  private:
   /// Return the IDs of all unit-instance resources.
   static absl::flat_hash_set<int64_t> &UnitInstanceResources();
+
+  /// Return the IDs of all request-only-instance resources.
+  static absl::flat_hash_set<int64_t> &RequestOnlyResources();
 };
 
 }  // namespace scheduling

--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -430,9 +430,9 @@ bool LocalTaskManager::PoppedWorkerHandler(
 
   const auto &required_resource =
       task.GetTaskSpecification().GetRequiredResources().GetResourceMap();
-  for (auto &entry : required_resource) {
+  for (auto &entry : required_resource) { // it fails here
     if (!cluster_resource_scheduler_->GetLocalResourceManager().ResourcesExist(
-            scheduling::ResourceID(entry.first))) {
+            scheduling::ResourceID(entry.first)) && entry.first != "gpu_memory") {
       RAY_CHECK(task.GetTaskSpecification().PlacementGroupBundleId().first !=
                 PlacementGroupID::Nil());
       RAY_LOG(DEBUG) << "The placement group: "

--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -430,9 +430,11 @@ bool LocalTaskManager::PoppedWorkerHandler(
 
   const auto &required_resource =
       task.GetTaskSpecification().GetRequiredResources().GetResourceMap();
-  for (auto &entry : required_resource) { // it fails here
+  for (auto &entry : required_resource) {
+    scheduling::ResourceID resource_id(entry.first);
     if (!cluster_resource_scheduler_->GetLocalResourceManager().ResourcesExist(
-            scheduling::ResourceID(entry.first)) && entry.first != "gpu_memory") {
+            resource_id) &&
+        !resource_id.IsRequestOnlyResource()) {
       RAY_CHECK(task.GetTaskSpecification().PlacementGroupBundleId().first !=
                 PlacementGroupID::Nil());
       RAY_LOG(DEBUG) << "The placement group: "

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -188,7 +188,7 @@ bool ClusterResourceManager::SubtractNodeAvailableResources(
 
   NodeResources *resources = it->second.GetMutableLocalView();
   const ResourceSet adjusted_resource_request =
-      resources.ConvertRelativeResource(resource_request.GetResourceSet());
+      resources->ConvertRelativeResource(resource_request.GetResourceSet());
 
   resources->available -= adjusted_resource_request;
   resources->available.RemoveNegative();

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -188,7 +188,7 @@ bool ClusterResourceManager::SubtractNodeAvailableResources(
 
   NodeResources *resources = it->second.GetMutableLocalView();
   const ResourceSet adjusted_resource_request =
-      resources->ConvertRelativeResource(resource_request.GetResourceSet());
+      resources->ConvertRelativeResources(resource_request.GetResourceSet());
 
   resources->available -= adjusted_resource_request;
   resources->available.RemoveNegative();
@@ -217,7 +217,7 @@ bool ClusterResourceManager::HasSufficientResource(
   }
 
   const ResourceSet adjusted_resource_request =
-      resources.ConvertRelativeResource(resource_request.GetResourceSet());
+      resources.ConvertRelativeResources(resource_request.GetResourceSet());
 
   return resources.available >= adjusted_resource_request;
 }

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -187,8 +187,10 @@ bool ClusterResourceManager::SubtractNodeAvailableResources(
   }
 
   NodeResources *resources = it->second.GetMutableLocalView();
+  const ResourceSet adjusted_resource_request =
+      resources.ConvertRelativeResource(resource_request.GetResourceSet());
 
-  resources->available -= resource_request.GetResourceSet();
+  resources->available -= adjusted_resource_request;
   resources->available.RemoveNegative();
 
   // TODO(swang): We should also subtract object store memory if the task has
@@ -214,7 +216,10 @@ bool ClusterResourceManager::HasSufficientResource(
     return false;
   }
 
-  return resources.available >= resource_request.GetResourceSet();
+  const ResourceSet adjusted_resource_request =
+      resources.ConvertRelativeResource(resource_request.GetResourceSet());
+
+  return resources.available >= adjusted_resource_request;
 }
 
 bool ClusterResourceManager::AddNodeAvailableResources(scheduling::NodeID node_id,

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -82,7 +82,8 @@ bool LocalResourceManager::AllocateTaskResourceInstances(
   RAY_CHECK(task_allocation != nullptr);
   const ResourceSet adjusted_resource_request =
       local_resources_.ConvertRelativeResource(resource_request.GetResourceSet());
-  if (resource_request.GetResourceSet().Has(ResourceID::GPU_Memory()) && adjusted_resource_request.Get(ResourceID::GPU()) > 1) {
+  if (resource_request.GetResourceSet().Has(ResourceID::GPU_Memory()) &&
+      adjusted_resource_request.Get(ResourceID::GPU()) > 1) {
     return false;
   }
   // add adjust_gpu_memory here, added to NodeInstanceResourceSet

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -80,17 +80,18 @@ bool LocalResourceManager::AllocateTaskResourceInstances(
     const ResourceRequest &resource_request,
     std::shared_ptr<TaskResourceInstances> task_allocation) {
   RAY_CHECK(task_allocation != nullptr);
-  const ResourceSet adjusted_resource_request =
+  const ResourceSet resource_request_adjusted =
       local_resources_.ConvertRelativeResources(resource_request.GetResourceSet());
+
   if (resource_request.GetResourceSet().Has(ResourceID::GPU_Memory()) &&
-      adjusted_resource_request.Get(ResourceID::GPU()) > 1) {
+      resource_request_adjusted.Get(ResourceID::GPU()) > 1) {
     return false;
   }
   // add adjust_gpu_memory here, added to NodeInstanceResourceSet
-  auto allocation = local_resources_.available.TryAllocate(adjusted_resource_request);
+  auto allocation = local_resources_.available.TryAllocate(resource_request_adjusted);
   if (allocation) {
     *task_allocation = TaskResourceInstances(*allocation);
-    for (const auto &resource_id : adjusted_resource_request.ResourceIds()) {
+    for (const auto &resource_id : resource_request_adjusted.ResourceIds()) {
       SetResourceNonIdle(resource_id);
     }
     return true;

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -81,7 +81,7 @@ bool LocalResourceManager::AllocateTaskResourceInstances(
     std::shared_ptr<TaskResourceInstances> task_allocation) {
   RAY_CHECK(task_allocation != nullptr);
   const ResourceSet adjusted_resource_request =
-      local_resources_.ConvertRelativeResource(resource_request.GetResourceSet());
+      local_resources_.ConvertRelativeResources(resource_request.GetResourceSet());
   if (resource_request.GetResourceSet().Has(ResourceID::GPU_Memory()) &&
       adjusted_resource_request.Get(ResourceID::GPU()) > 1) {
     return false;

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -82,6 +82,9 @@ bool LocalResourceManager::AllocateTaskResourceInstances(
   RAY_CHECK(task_allocation != nullptr);
   const ResourceSet adjusted_resource_request =
       local_resources_.ConvertRelativeResource(resource_request.GetResourceSet());
+  if (resource_request.GetResourceSet().Has(ResourceID::GPU_Memory()) && adjusted_resource_request.Get(ResourceID::GPU()) > 1) {
+    return false;
+  }
   // add adjust_gpu_memory here, added to NodeInstanceResourceSet
   auto allocation = local_resources_.available.TryAllocate(adjusted_resource_request);
   if (allocation) {

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -80,11 +80,13 @@ bool LocalResourceManager::AllocateTaskResourceInstances(
     const ResourceRequest &resource_request,
     std::shared_ptr<TaskResourceInstances> task_allocation) {
   RAY_CHECK(task_allocation != nullptr);
+  const ResourceSet adjusted_resource_request = local_resources_.ProcessRelativeResource(resource_request.GetResourceSet());
+  // add adjust_gpu_memory here, added to NodeInstanceResourceSet
   auto allocation =
-      local_resources_.available.TryAllocate(resource_request.GetResourceSet());
+      local_resources_.available.TryAllocate(adjusted_resource_request);
   if (allocation) {
     *task_allocation = TaskResourceInstances(*allocation);
-    for (const auto &resource_id : resource_request.ResourceIds()) {
+    for (const auto &resource_id : adjusted_resource_request.ResourceIds()) {
       SetResourceNonIdle(resource_id);
     }
     return true;

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -80,10 +80,10 @@ bool LocalResourceManager::AllocateTaskResourceInstances(
     const ResourceRequest &resource_request,
     std::shared_ptr<TaskResourceInstances> task_allocation) {
   RAY_CHECK(task_allocation != nullptr);
-  const ResourceSet adjusted_resource_request = local_resources_.ProcessRelativeResource(resource_request.GetResourceSet());
+  const ResourceSet adjusted_resource_request =
+      local_resources_.ConvertRelativeResource(resource_request.GetResourceSet());
   // add adjust_gpu_memory here, added to NodeInstanceResourceSet
-  auto allocation =
-      local_resources_.available.TryAllocate(adjusted_resource_request);
+  auto allocation = local_resources_.available.TryAllocate(adjusted_resource_request);
   if (allocation) {
     *task_allocation = TaskResourceInstances(*allocation);
     for (const auto &resource_id : adjusted_resource_request.ResourceIds()) {

--- a/src/ray/raylet/scheduling/policy/scorer.cc
+++ b/src/ray/raylet/scheduling/policy/scorer.cc
@@ -35,8 +35,11 @@ double LeastResourceScorer::Score(const ResourceRequest &required_resources,
   }
 
   double node_score = 0.;
-  for (auto &resource_id : required_resources.ResourceIds()) {
-    const auto &request_resource = required_resources.Get(resource_id);
+  const ResourceSet resource_request_adjusted =
+      node_resources_ptr->ConvertRelativeResources(required_resources.GetResourceSet());
+
+  for (auto &resource_id : resource_request_adjusted.ResourceIds()) {
+    const auto &request_resource = resource_request_adjusted.Get(resource_id);
     const auto &node_available_resource = node_resources_ptr->available.Get(resource_id);
     auto score = Calculate(request_resource, node_available_resource);
     if (score < 0.) {

--- a/src/ray/raylet/scheduling/scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/scheduling_policy.cc
@@ -24,7 +24,8 @@ namespace raylet_scheduling_policy {
 namespace {
 
 bool IsGPURequest(const ResourceRequest &resource_request) {
-  return resource_request.Has(ResourceID::GPU());
+  return resource_request.Has(ResourceID::GPU()) ||
+         resource_request.Has(ResourceID::GPU_Memory());
 }
 
 bool DoesNodeHaveGPUs(const NodeResources &resources) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
A prototype to allow user to specify `_gpu_memory` as alternative to specify fractional gpu to the remote function. The field `_gpu_memory` defined as "The gpu memory request in megabytes for this task/actor from a single gpu, rounded down to the nearest integer.".

```python
# Assume we have a single GPU with 1000mb total memory

@ray.remote(_gpu_memory=100 * 1024 * 1024) # allocate 100mb from a single gpu to this task
def task():
    # contains { 'GPU': [assigned_gpu_id]}
    resources = ray.get_runtime_context().get_resource_ids()

@ray.remote(_gpu_memory=1001  * 1024 * 1024) # task can't be scheduled due to requested memory > total gpu memory
def expensive_task():
    resources = ray.get_runtime_context().get_resource_ids()

@ray.remote(num_gpus=1, _gpu_memory=100  * 1024 * 1024) # task can't request both num_gpus and gpu_memory
def not_allowed_task():
    resources = ray.get_runtime_context().get_resource_ids()
```

Implementation detail: `_gpu_memory` will be converted to `num_gpus` before being scheduled where `num_gpus = _gpu_memory / gpu_total_memory` and we check if the `0 <= num_gpus <= 1` representing fractional GPU request.

### Implementation Detail
`_gpu_memory` is an alternative representation of `num_gpus` where `num_ gpus = _gpu_memory / node_total_ gpu_ memory` where `node_total_gpu_memory` is total gpu memory of the GPU type in the node.

Thus, we convert `gpu_memory` to `GPU` resource when scheduling depending on what GPU type the scheduled node has and update `GPU` resource value stored in `NodeResources`. Additionally, since `GPU` has precision of $10^{-4}$, we rounded up the converted `gpu_memory` resource with the `GPU` precision.

### Status
Currently working on cluster with multi-nodes setup, but not working with autoscaler yet.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #37574

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
