### PR TITLE
[ci] move //python/ray/data:test_file_based_datasource to flaky

### DIFF
--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -161,6 +161,7 @@ if __name__ == "__main__":
                 or changed_file == "ci/docker/datan.build.wanda.yaml"
                 or changed_file == "ci/docker/data6.build.wanda.yaml"
                 or changed_file == "ci/docker/data12.build.wanda.yaml"
+                or changed_file == "ci/ray_ci/data.tests.yml"
             ):
                 RAY_CI_DATA_AFFECTED = 1
                 RAY_CI_ML_AFFECTED = 1

--- a/ci/ray_ci/data.tests.yml
+++ b/ci/ray_ci/data.tests.yml
@@ -1,3 +1,4 @@
 flaky_tests:
   - //python/ray/data:test_streaming_integration
   - //python/ray/data:test_split
+  - //python/ray/data:test_file_based_datasource


### PR DESCRIPTION
As title, the test has became flaky recently

Test:
- CI

<img width="1806" alt="Screenshot 2023-11-15 at 11 31 46 AM" src="https://github.com/ray-project/ray/assets/128072568/b8e0cf52-0e1a-443b-95bd-7b39680d9530">
