### PR TITLE
Undeprecate InputNode

### DIFF
--- a/python/ray/dag/input_node.py
+++ b/python/ray/dag/input_node.py
@@ -3,18 +3,10 @@ from typing import Any, Dict, List, Union, Optional
 from ray.dag import DAGNode
 from ray.dag.format_utils import get_dag_node_str
 from ray.experimental.gradio_utils import type_to_string
-from ray.util.annotations import Deprecated
 
 IN_CONTEXT_MANAGER = "__in_context_manager__"
 
 
-@Deprecated(
-    message=(
-        "The DAG API is deprecated. Please use the recommended model "
-        "composition pattern instead (see "
-        "https://docs.ray.io/en/latest/serve/model_composition.html)."
-    )
-)
 class InputNode(DAGNode):
     r"""Ray dag node used in DAG building API to mark entrypoints of a DAG.
 
@@ -187,13 +179,6 @@ class InputNode(DAGNode):
             return self._bound_other_args_to_resolve["result_type_string"]
 
 
-@Deprecated(
-    message=(
-        "The DAG API is deprecated. Please use the recommended model "
-        "composition pattern instead (see "
-        "https://docs.ray.io/en/latest/serve/model_composition.html)."
-    )
-)
 class InputAttributeNode(DAGNode):
     """Represents partial access of user input based on an index (int),
      object attribute or dict key (str).
@@ -304,13 +289,6 @@ class InputAttributeNode(DAGNode):
             return self._bound_other_args_to_resolve["result_type_string"]
 
 
-@Deprecated(
-    message=(
-        "The DAG API is deprecated. Please use the recommended model "
-        "composition pattern instead (see "
-        "https://docs.ray.io/en/latest/serve/model_composition.html)."
-    )
-)
 class DAGInputData:
     """If user passed multiple args and kwargs directly to dag.execute(), we
     generate this wrapper for all user inputs as one object, accessible via

--- a/python/ray/dag/input_node.py
+++ b/python/ray/dag/input_node.py
@@ -3,10 +3,12 @@ from typing import Any, Dict, List, Union, Optional
 from ray.dag import DAGNode
 from ray.dag.format_utils import get_dag_node_str
 from ray.experimental.gradio_utils import type_to_string
+from ray.util.annotations import DeveloperAPI
 
 IN_CONTEXT_MANAGER = "__in_context_manager__"
 
 
+@DeveloperAPI
 class InputNode(DAGNode):
     r"""Ray dag node used in DAG building API to mark entrypoints of a DAG.
 
@@ -179,6 +181,7 @@ class InputNode(DAGNode):
             return self._bound_other_args_to_resolve["result_type_string"]
 
 
+@DeveloperAPI
 class InputAttributeNode(DAGNode):
     """Represents partial access of user input based on an index (int),
      object attribute or dict key (str).
@@ -289,6 +292,7 @@ class InputAttributeNode(DAGNode):
             return self._bound_other_args_to_resolve["result_type_string"]
 
 
+@DeveloperAPI
 class DAGInputData:
     """If user passed multiple args and kwargs directly to dag.execute(), we
     generate this wrapper for all user inputs as one object, accessible via


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

InputNode was deprecated in https://github.com/ray-project/ray/pull/40290, but it will continue to be used by APIs other than Serve, so we need to undeprecate it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
