### PR TITLE
[docs[core] fix broken link to set_trace on API summary page

### DIFF
--- a/doc/source/ray-core/api/utility.rst
+++ b/doc/source/ray-core/api/utility.rst
@@ -33,6 +33,6 @@ Debugging
    :nosignatures:
    :toctree: doc/
 
-   ray.util.pdb.set_trace
+   ray.util.rpdb.set_trace
    ray.util.inspect_serializability
    ray.timeline


### PR DESCRIPTION
Link referenced `ray.util.pdb.set_trace` but there is no ray/util/pdb.py module. Instead, ray.util.__init__.py aliases ray.util.rpdb as pdb. The reference is fixed by using `ray.util.rpdb.set_trace`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
