### PR TITLE
[RLlib] Fix bug in SingleAgentEnvRunner: Calling `sample()` would always force-reset the vector env (even if episodes were not completed in a previous call).

### DIFF
--- a/rllib/algorithms/dreamerv3/utils/debugging.py
+++ b/rllib/algorithms/dreamerv3/utils/debugging.py
@@ -19,17 +19,22 @@ class CartPoleDebug(CartPoleEnv):
         self.observation_space = gym.spaces.Box(low, high, shape=(5,), dtype=np.float32)
 
         self.timesteps_ = 0
+        self._next_action = 0
+        self._seed = 1
 
     def reset(self, *, seed=None, options=None):
-        ret = super().reset()
+        ret = super().reset(seed=self._seed)
+        self._seed += 1
         self.timesteps_ = 0
+        self._next_action = 0
         obs = np.concatenate([np.array([self.timesteps_]), ret[0]])
         return obs, ret[1]
 
     def step(self, action):
-        ret = super().step(action)
+        ret = super().step(self._next_action)
 
         self.timesteps_ += 1
+        self._next_action = 0 if self._next_action else 1
 
         obs = np.concatenate([np.array([self.timesteps_]), ret[0]])
         reward = 0.1 * self.timesteps_

--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -439,8 +439,28 @@ class PPO(Algorithm):
                         worker_set=self.workers,
                         max_env_steps=self.config.train_batch_size,
                     )
+                # TEST
+                #import pickle
+                #import torch
+                #import os
+                #with open("train_batch.pkl", "wb") as file:
+                #    pickle.dump(train_batch, file)
+                #torch.save(self.workers.local_worker().policy_map["default_policy"].model.state_dict(), "model_weights.pth")
+                # END TEST
+
             # New Episode-returning EnvRunner API.
             else:
+                # TEST
+                #import pickle
+                #import torch
+                #import os
+                #from ray.rllib.utils.test_utils import check
+                #rw_path = "/Users/sven/ray_results/PPO_2023-11-15_13-28-16/PPO_CartPoleDebug_74001_00000_0_2023-11-15_13-28-16"
+                #with open(os.path.join(rw_path, "train_batch.pkl"), "rb") as file:
+                #    rw_train_batch = pickle.load(file)
+                #rw_state_dict = torch.load(os.path.join(rw_path, "model_weights.pth"))
+                #self.workers.local_worker().module.load_state_dict(rw_state_dict)
+                # END TEST
                 if self.workers.num_remote_workers() <= 0:
                     episodes: List[SingleAgentEpisode] = [
                         self.workers.local_worker().sample()
@@ -457,6 +477,9 @@ class PPO(Algorithm):
                 train_batch: SampleBatch = postprocess_episodes_to_sample_batch(
                     postprocessed_episodes
                 )
+                #check(train_batch["advantages"], rw_train_batch["default_policy"]["advantages"], rtol=0.000001)
+                #check(train_batch["vf_preds"], rw_train_batch["default_policy"]["vf_preds"])
+                #check(train_batch["value_targets"], rw_train_batch["default_policy"]["value_targets"])
 
         train_batch = train_batch.as_multi_agent()
         self._counters[NUM_AGENT_STEPS_SAMPLED] += train_batch.agent_steps()

--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -439,28 +439,8 @@ class PPO(Algorithm):
                         worker_set=self.workers,
                         max_env_steps=self.config.train_batch_size,
                     )
-                # TEST
-                #import pickle
-                #import torch
-                #import os
-                #with open("train_batch.pkl", "wb") as file:
-                #    pickle.dump(train_batch, file)
-                #torch.save(self.workers.local_worker().policy_map["default_policy"].model.state_dict(), "model_weights.pth")
-                # END TEST
-
             # New Episode-returning EnvRunner API.
             else:
-                # TEST
-                #import pickle
-                #import torch
-                #import os
-                #from ray.rllib.utils.test_utils import check
-                #rw_path = "/Users/sven/ray_results/PPO_2023-11-15_13-28-16/PPO_CartPoleDebug_74001_00000_0_2023-11-15_13-28-16"
-                #with open(os.path.join(rw_path, "train_batch.pkl"), "rb") as file:
-                #    rw_train_batch = pickle.load(file)
-                #rw_state_dict = torch.load(os.path.join(rw_path, "model_weights.pth"))
-                #self.workers.local_worker().module.load_state_dict(rw_state_dict)
-                # END TEST
                 if self.workers.num_remote_workers() <= 0:
                     episodes: List[SingleAgentEpisode] = [
                         self.workers.local_worker().sample()
@@ -477,9 +457,6 @@ class PPO(Algorithm):
                 train_batch: SampleBatch = postprocess_episodes_to_sample_batch(
                     postprocessed_episodes
                 )
-                #check(train_batch["advantages"], rw_train_batch["default_policy"]["advantages"], rtol=0.000001)
-                #check(train_batch["vf_preds"], rw_train_batch["default_policy"]["vf_preds"])
-                #check(train_batch["value_targets"], rw_train_batch["default_policy"]["value_targets"])
 
         train_batch = train_batch.as_multi_agent()
         self._counters[NUM_AGENT_STEPS_SAMPLED] += train_batch.agent_steps()

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -43,9 +43,8 @@ class SingleAgentEnvRunner(EnvRunner):
 
         # Register env for the local context.
         # Note, `gym.register` has to be called on each worker.
-        if (
-            isinstance(self.config.env, str)
-            and _global_registry.contains(ENV_CREATOR, self.config.env)
+        if isinstance(self.config.env, str) and _global_registry.contains(
+            ENV_CREATOR, self.config.env
         ):
             entry_point = partial(
                 _global_registry.get(ENV_CREATOR, self.config.env),
@@ -177,7 +176,7 @@ class SingleAgentEnvRunner(EnvRunner):
         if force_reset or self._needs_initial_reset:
             obs, infos = self.env.reset()
 
-            # We just reset'd the env. Don't have to force this again in the next
+            # We just reset the env. Don't have to force this again in the next
             # call to `self._sample_timesteps()`.
             self._needs_initial_reset = False
 

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -43,25 +43,28 @@ class SingleAgentEnvRunner(EnvRunner):
 
         # Register env for the local context.
         # Note, `gym.register` has to be called on each worker.
-        gym.register(
-            "custom-env-v0",
-            partial(
+        if (
+            isinstance(self.config.env, str)
+            and _global_registry.contains(ENV_CREATOR, self.config.env)
+        ):
+            entry_point = partial(
                 _global_registry.get(ENV_CREATOR, self.config.env),
                 self.config.env_config,
             )
-            if _global_registry.contains(ENV_CREATOR, self.config.env)
-            else partial(
+
+        else:
+            entry_point = partial(
                 _gym_env_creator,
                 env_context=self.config.env_config,
                 env_descriptor=self.config.env,
-            ),
-        )
+            )
+        gym.register("rllib-single-agent-env-runner-v0", entry_point=entry_point)
 
         # Create the vectorized gymnasium env.
         # Wrap into `VectorListInfo`` wrapper to get infos as lists.
         self.env: gym.Wrapper = gym.wrappers.VectorListInfo(
             gym.vector.make(
-                "custom-env-v0",
+                "rllib-single-agent-env-runner-v0",
                 num_envs=self.config.num_envs_per_worker,
                 asynchronous=self.config.remote_worker_envs,
             )
@@ -174,6 +177,10 @@ class SingleAgentEnvRunner(EnvRunner):
         if force_reset or self._needs_initial_reset:
             obs, infos = self.env.reset()
 
+            # We just reset'd the env. Don't have to force this again in the next
+            # call to `self._sample_timesteps()`.
+            self._needs_initial_reset = False
+
             self._episodes = [SingleAgentEpisode() for _ in range(self.num_envs)]
             states = initial_states
 
@@ -208,7 +215,6 @@ class SingleAgentEnvRunner(EnvRunner):
         # Loop through env in enumerate.(self._episodes):
         ts = 0
 
-        # print(f"EnvRunner {self.worker_index}: {self.module.weights[0][0][0]}")
         while ts < num_timesteps:
             # Act randomly.
             if random_actions:
@@ -244,6 +250,7 @@ class SingleAgentEnvRunner(EnvRunner):
                     states = fwd_out[STATE_OUT]
 
             obs, rewards, terminateds, truncateds, infos = self.env.step(actions)
+
             ts += self.num_envs
 
             for i in range(self.num_envs):
@@ -465,6 +472,7 @@ class SingleAgentEnvRunner(EnvRunner):
         # Compute per-episode metrics (only on already completed episodes).
         metrics = []
         for eps in self._done_episodes_for_metrics:
+            assert eps.is_done
             episode_length = len(eps)
             episode_reward = eps.get_return()
             # Don't forget about the already returned chunks of this episode.

--- a/rllib/env/single_agent_episode.py
+++ b/rllib/env/single_agent_episode.py
@@ -526,3 +526,6 @@ class SingleAgentEpisode:
             "first (after which `len(SingleAgentEpisode)` will be 0)."
         )
         return len(self.observations) - 1
+
+    def __repr__(self):
+        return f"SAEps({self.id_} len={len(self)})"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix bug in SingleAgentEnvRunner: Calling `sample()` repeatedly would always force-reset the vector env (even if episodes were not completed in a previous call).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
