### PR TITLE
[Data] Fix flaky `test_file_based_datasource` test

### DIFF
--- a/python/ray/data/tests/test_file_based_datasource.py
+++ b/python/ray/data/tests/test_file_based_datasource.py
@@ -33,7 +33,7 @@ def test_file_extensions(ray_start_regular_shared, tmp_path):
 
     datasource = MockFileBasedDatasource([csv_path, txt_path], file_extensions=None)
     ds = ray.data.read_datasource(datasource)
-    assert ds.input_files() == [csv_path, txt_path]
+    assert sorted(ds.input_files()) == sorted([csv_path, txt_path])
 
     datasource = MockFileBasedDatasource([csv_path, txt_path], file_extensions=["csv"])
     ds = ray.data.read_datasource(datasource)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

#41120 introduced a flaky test. It asserts that one list equals another, but the order of the first list isn't deterministic.

https://github.com/ray-project/ray/blob/372befbdfdf8191cb0c6b4207fe38c7f187dbc64/python/ray/data/tests/test_file_based_datasource.py#L36

This PR makes the test deterministic by sorting the lists.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/41169

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
