### PR TITLE
[Data] Remove `FileBasedDatasoure._read_file` in favor of `_read_stream`

### DIFF
--- a/doc/source/train/examples/pytorch/torch_detection.ipynb
+++ b/doc/source/train/examples/pytorch/torch_detection.ipynb
@@ -246,7 +246,7 @@
                 "bounding boxes from XML files. Later, you'll read the corresponding images.\n",
                 "\n",
                 "To implement the datasource, extend the built-in `FileBasedDatasource` class\n",
-                "and override the `_read_file` method."
+                "and override the `_read_stream_` method."
             ]
         },
         {
@@ -256,7 +256,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "from typing import List, Tuple\n",
+                "from typing import Iterator, List, Tuple\n",
                 "\n",
                 "import xmltodict\n",
                 "import pandas as pd\n",
@@ -267,7 +267,7 @@
                 "\n",
                 "\n",
                 "class VOCAnnotationDatasource(FileBasedDatasource):\n",
-                "    def _read_file(self, f: pa.NativeFile, path: str) -> pd.DataFrame:\n",
+                "    def _read_stream(self, f: pa.NativeFile, path: str) -> Iterator[\"pd.DataFrame\"]:\n",
                 "        text = f.read().decode(\"utf-8\")\n",
                 "        annotation = xmltodict.parse(text)[\"annotation\"]\n",
                 "\n",
@@ -288,7 +288,7 @@
                 "\n",
                 "        filename = annotation[\"filename\"]\n",
                 "\n",
-                "        return pd.DataFrame(\n",
+                "        yield pd.DataFrame(\n",
                 "            {\n",
                 "                \"boxes\": TensorArray([boxes]),\n",
                 "                \"labels\": TensorArray([labels]),\n",

--- a/python/ray/data/datasource/binary_datasource.py
+++ b/python/ray/data/datasource/binary_datasource.py
@@ -24,7 +24,7 @@ class BinaryDatasource(FileBasedDatasource):
 
         self.include_paths = include_paths
 
-    def _read_file(self, f: "pyarrow.NativeFile", path: str):
+    def _read_stream(self, f: "pyarrow.NativeFile", path: str):
         data = f.readall()
 
         builder = ArrowBlockBuilder()
@@ -33,7 +33,7 @@ class BinaryDatasource(FileBasedDatasource):
         else:
             item = {self._COLUMN_NAME: data}
         builder.add(item)
-        return builder.build()
+        yield builder.build()
 
     def _rows_per_file(self):
         return 1

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -396,19 +396,12 @@ class FileBasedDatasource(Datasource):
         return None
 
     def _read_stream(self, f: "pyarrow.NativeFile", path: str) -> Iterator[Block]:
-        """Streaming read a single file, passing all kwargs to the reader.
-
-        By default, delegates to self._read_file().
-        """
-        yield self._read_file(f, path)
-
-    def _read_file(self, f: "pyarrow.NativeFile", path: str) -> Block:
-        """Reads a single file, passing all kwargs to the reader.
+        """Streaming read a single file.
 
         This method should be implemented by subclasses.
         """
         raise NotImplementedError(
-            "Subclasses of FileBasedDatasource must implement _read_file()."
+            "Subclasses of FileBasedDatasource must implement _read_stream()."
         )
 
     def on_write_start(

--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -1,13 +1,13 @@
 import io
 import logging
 import time
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.util import _check_import
-from ray.data.block import BlockMetadata
+from ray.data.block import Block, BlockMetadata
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 from ray.data.datasource.file_meta_provider import DefaultFileMetadataProvider
 from ray.util.annotations import DeveloperAPI
@@ -70,11 +70,11 @@ class ImageDatasource(FileBasedDatasource):
         else:
             self._encoding_ratio = IMAGE_ENCODING_RATIO_ESTIMATE_DEFAULT
 
-    def _read_file(
+    def _read_stream(
         self,
         f: "pyarrow.NativeFile",
         path: str,
-    ) -> "pyarrow.Table":
+    ) -> Iterator[Block]:
         from PIL import Image, UnidentifiedImageError
 
         data = f.readall()
@@ -99,7 +99,7 @@ class ImageDatasource(FileBasedDatasource):
         builder.add(item)
         block = builder.build()
 
-        return block
+        yield block
 
     def _rows_per_file(self):
         return 1

--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -33,7 +33,7 @@ class JSONDatasource(FileBasedDatasource):
         self.arrow_json_args = arrow_json_args
 
     # TODO(ekl) The PyArrow JSON reader doesn't support streaming reads.
-    def _read_file(self, f: "pyarrow.NativeFile", path: str):
+    def _read_stream(self, f: "pyarrow.NativeFile", path: str):
         from pyarrow import json
 
-        return json.read_json(f, read_options=self.read_options, **self.arrow_json_args)
+        yield json.read_json(f, read_options=self.read_options, **self.arrow_json_args)

--- a/python/ray/data/datasource/parquet_base_datasource.py
+++ b/python/ray/data/datasource/parquet_base_datasource.py
@@ -37,11 +37,11 @@ class ParquetBaseDatasource(FileBasedDatasource):
         """
         return "ParquetBulk"
 
-    def _read_file(self, f: "pyarrow.NativeFile", path: str):
+    def _read_stream(self, f: "pyarrow.NativeFile", path: str):
         import pyarrow.parquet as pq
 
         use_threads = self.read_table_args.pop("use_threads", False)
-        return pq.read_table(f, use_threads=use_threads, **self.read_table_args)
+        yield pq.read_table(f, use_threads=use_threads, **self.read_table_args)
 
     def _open_input_source(
         self,

--- a/python/ray/data/datasource/text_datasource.py
+++ b/python/ray/data/datasource/text_datasource.py
@@ -1,6 +1,7 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Iterator, List
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
+from ray.data.block import Block
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 from ray.util.annotations import PublicAPI
 
@@ -27,7 +28,7 @@ class TextDatasource(FileBasedDatasource):
         self.drop_empty_lines = drop_empty_lines
         self.encoding = encoding
 
-    def _read_file(self, f: "pyarrow.NativeFile", path: str) -> List[str]:
+    def _read_stream(self, f: "pyarrow.NativeFile", path: str) -> Iterator[Block]:
         data = f.readall()
 
         builder = DelegatingBlockBuilder()
@@ -40,4 +41,4 @@ class TextDatasource(FileBasedDatasource):
             builder.add(item)
 
         block = builder.build()
-        return block
+        yield block

--- a/python/ray/data/tests/test_file_based_datasource.py
+++ b/python/ray/data/tests/test_file_based_datasource.py
@@ -1,4 +1,5 @@
 import os
+from typing import Iterator
 from unittest import mock
 
 import pyarrow
@@ -16,10 +17,10 @@ from ray.data.datasource.path_util import _is_local_windows_path
 
 
 class MockFileBasedDatasource(FileBasedDatasource):
-    def _read_file(self, f: "pyarrow.NativeFile", path: str) -> Block:
+    def _read_stream(self, f: "pyarrow.NativeFile", path: str) -> Iterator[Block]:
         builder = DelegatingBlockBuilder()
         builder.add({"data": f.readall()})
-        return builder.build()
+        yield builder.build()
 
 
 def test_file_extensions(ray_start_regular_shared, tmp_path):

--- a/python/ray/data/tests/test_partitioning.py
+++ b/python/ray/data/tests/test_partitioning.py
@@ -1,7 +1,7 @@
 import json
 import os
 import posixpath
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
 import pandas as pd
 import pyarrow
@@ -38,16 +38,16 @@ class CSVDatasource(FileBasedDatasource):
 
         self._block_type = block_type
 
-    def _read_file(self, f: pa.NativeFile, path: str) -> Block:
+    def _read_stream(self, f: pa.NativeFile, path: str) -> Iterator[Block]:
         assert self._block_type in {pd.DataFrame, pa.Table}
 
         if self._block_type is pa.Table:
             from pyarrow import csv
 
-            return csv.read_csv(f)
+            yield csv.read_csv(f)
 
         if self._block_type is pd.DataFrame:
-            return pd.read_csv(f)
+            yield pd.read_csv(f)
 
 
 def write_csv(data: Dict[str, List[Any]], path: str) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you're reading a large file, `_read_file` might perform worse than `_read_stream`. To simplify the `FileBasedDatasource` interface, and to encourage users to write performant implementations, this PR removes `_read_file` in favor of `_read_stream`.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
