### PR TITLE
[ci] special exit code for test failures

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -15,7 +15,7 @@ if [ -d "/tmp/artifacts/test-summaries" ] && [ "$(ls -A /tmp/artifacts/test-summ
     # Only upload annotations if there are at least 2 files in the directory:
     # 1 header and 1 failed test.
     if [ "$(find /tmp/artifacts/test-summaries -maxdepth 1 -name '*.txt' | wc -l)" -ge 2 ]; then
-      cat /tmp/artifacts/test-summaries/*.txt | buildkite-agent annotate --job "${BUILDKITE_JOB_ID}" --append --style error --context "${BUILDKITE_JOB_ID}"
+      cat /tmp/artifacts/test-summaries/*.txt | head -n 20 | buildkite-agent annotate --job "${BUILDKITE_JOB_ID}" --append --style error --context "${BUILDKITE_JOB_ID}"
     fi
 
     # Remove test summaries files (don't actually upload as artifacts)

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -316,6 +316,7 @@ if __name__ == "__main__":
                 or changed_file == "ci/docker/forge.aarch64.wanda.yaml"
                 or changed_file == ".buildkite/pipeline.build.yml"
                 or changed_file == ".buildkite/pipeline.ml.yml"
+                or changed_file == ".buildkite/hooks/post-command"
             ):
                 # These scripts are always run as part of the build process
                 RAY_CI_TOOLS_AFFECTED = 1

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -182,7 +182,7 @@ def main(
         get_flaky_tests=run_flaky_tests,
     )
     success = container.run_tests(test_targets, test_arg)
-    sys.exit(0 if success else 1)
+    sys.exit(0 if success else 42)
 
 
 def _add_default_except_tags(except_tags: str) -> str:


### PR DESCRIPTION
Return a special exit code on test failures. After this, let turn on auto-retries on non-test failures (those wheel, docker build are flaky too).

I fixed an issue where the job crashed when there are too many test failures as well. That errors will hinder the command exit code.

Test:
- CI