### PR TITLE
[ci] fix docbuild

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -524,7 +524,8 @@ intersphinx_mapping = {
     "pyspark": ("https://spark.apache.org/docs/latest/api/python/", None),
     "python": ("https://docs.python.org/3", None),
     "pytorch_lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    # TODO(can-anyscale): undo this once scipy doc is back up
+    #    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "skopt": ("https://scikit-optimize.github.io/stable/", None),
     "tensorflow": (


### PR DESCRIPTION
https://docs.scipy.org/doc/scipy/ is down, which cause docbuild to fail. Better to have a doc without reference to scipy than nothing.

Error: https://buildkite.com/ray-project/premerge/builds/11904#018bd5a7-0219-481c-be19-4472c5028173

Test:
- CI