### PR TITLE
[Serve] Fix batch disconnect issue

### DIFF
--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -228,7 +228,7 @@ class _BatchQueue:
                     results = await func_future
                     self._validate_results(results, len(batch))
                     for result, future in zip(results, futures):
-                        # The client can be dropped and the request is canceled.
+                        # If the client has disconnected, the future is canceled.
                         # We should only set result when the connection is still live.
                         if not future.cancelled():
                             future.set_result(result)

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -187,7 +187,10 @@ class _BatchQueue:
                         next_futures.append(FINISHED_TOKEN)
                     else:
                         next_future = get_or_create_event_loop().create_future()
-                        future.set_result(_GeneratorResult(result, next_future))
+                        # The client can be dropped and the request is canceled.
+                        # We should only set result when the connection is still live.
+                        if not future.cancelled():
+                            future.set_result(_GeneratorResult(result, next_future))
                         next_futures.append(next_future)
                 futures = next_futures
 
@@ -225,7 +228,10 @@ class _BatchQueue:
                     results = await func_future
                     self._validate_results(results, len(batch))
                     for result, future in zip(results, futures):
-                        future.set_result(result)
+                        # The client can be dropped and the request is canceled.
+                        # We should only set result when the connection is still live.
+                        if not future.cancelled():
+                            future.set_result(result)
                 except Exception as e:
                     for future in futures:
                         future.set_exception(e)

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -187,7 +187,7 @@ class _BatchQueue:
                         next_futures.append(FINISHED_TOKEN)
                     else:
                         next_future = get_or_create_event_loop().create_future()
-                        # The client can be dropped and the request is canceled.
+                        # If the client has disconnected, the future is canceled.
                         # We should only set result when the connection is still live.
                         if not future.cancelled():
                             future.set_result(_GeneratorResult(result, next_future))

--- a/python/ray/serve/tests/test_batching.py
+++ b/python/ray/serve/tests/test_batching.py
@@ -111,7 +111,7 @@ def test_batching_client_dropped_unary(serve_instance):
     url = "http://0.0.0.0:8000/"
 
     # Sending requests with clients that drops the connection.
-    for _ in range(10):
+    for _ in range(3):
         with pytest.raises(requests.exceptions.ReadTimeout):
             requests.get(url, timeout=0.005)
 
@@ -143,7 +143,7 @@ def test_batching_client_dropped_streaming(serve_instance):
     url = "http://0.0.0.0:8000/"
 
     # Sending requests with clients that drops the connection.
-    for _ in range(10):
+    for _ in range(3):
         with pytest.raises(
             (requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError)
         ):

--- a/python/ray/serve/tests/test_batching.py
+++ b/python/ray/serve/tests/test_batching.py
@@ -108,7 +108,7 @@ def test_batching_client_dropped_unary(serve_instance):
 
     serve.run(ModelUnary.bind())
 
-    url = "http://0.0.0.0:8000/"
+    url = "http://localhost:8000/"
 
     # Sending requests with clients that drops the connection.
     for _ in range(3):
@@ -140,7 +140,7 @@ def test_batching_client_dropped_streaming(serve_instance):
 
     serve.run(ModelStreaming.bind())
 
-    url = "http://0.0.0.0:8000/"
+    url = "http://localhost:8000/"
 
     # Sending requests with clients that drops the connection.
     for _ in range(3):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In batching requests, after the client dropped the connection and the future is canceled, we might still be calling `set_result` on the future object and cause the entire batching processing loop to terminate. This PR fixes it by only calling `set_result` on not canceled futures. Also, added tests for both unary and streaming cases. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/41057

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
