### PR TITLE
[Doc] Fix algolia autocomplete overlap

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -58,11 +58,9 @@ tr.row-odd {
 }
 
 /* For Algolia search box
-    * overflow-y: to flow-over horizontally into main content
     * height: to prevent topbar overlap
 */
 #site-navigation {
-  overflow-y: auto;
   height: calc(100vh - var(--sidebar-top));
   position: sticky;
   top: var(--sidebar-top) !important;
@@ -127,12 +125,6 @@ tr.row-odd {
       margin-top: 20px;
     }
   }
-
-/* Make Algolia search box scrollable */
-.algolia-autocomplete .ds-dropdown-menu {
-    height: 60vh !important;
-    overflow-y: scroll !important;
-}
 
 .bd-sidebar__content {
   overflow-y: unset !important;
@@ -909,7 +901,7 @@ footer.col.footer > p {
 #kapa-widget-container figure {
     padding: 0 !important;
   }
-  
+
   .mantine-Modal-root figure {
     padding: 0 !important;
   }


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes an issue where the algolia searchbox autocomplete menu would be "overlapped" by the main content area of the page.

In actuality this was not a z-index issue, but an issue with the `overflow` style on the `#site-navigation` bar. A rule setting a fixed size for the autocomplete box was also removed, along with a rule forcing the autocomplete box to always be scrollable - neither of these is needed here.

## Related issue number

Closes https://github.com/ray-project/ray/issues/41143.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
