### PR TITLE
[ci] run core flaky test functions

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -238,13 +238,21 @@ steps:
     job_env: forge
 
   - label: ":ray: core: flaky tests"
-    tags: python
+    tags: 
+      - python
+      - skip-on-premerge
     instance_type: large
-    # run only on postmerge
-    if: build.env("BUILDKITE_PIPELINE_ID") == "0189e759-8c96-4302-b6b5-b4274406bf89"
     soft_fail: true
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //... core 
         --run-flaky-tests  --build-type clang
+      - bazel run //ci/ray_ci:test_in_docker -- 
+        //python/ray/tests:test_placement_group
+        //python/ray/tests:test_runtime_env_working_dir_3 
+        //python/ray/tests:test_state_api_log
+        //python/ray/tests:test_client_builder
+        //python/ray/tests:test_object_assign_owner_client_mode core 
+        --test-env CI_SKIP_FLAKY_TEST=0
+        --skip-ray-installation
     depends_on: corebuild
     job_env: forge

--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -1,8 +1,3 @@
 flaky_tests:
-  - //python/ray/tests:test_placement_group
-  - //python/ray/tests:test_runtime_env_working_dir_3
-  - //python/ray/tests:test_state_api_log
-  - //python/ray/tests:test_client_builder
   - //python/ray/tests:test_client_library_integration
-  - //python/ray/tests:test_object_assign_owner_client_mode
   - //src/ray/common/test:ray_syncer_test


### PR DESCRIPTION
As a follow up of https://github.com/ray-project/ray/pull/41195/files, we remove core flaky test targets, and run flaky test functions in the flaky job

I switch off the postmerge only conditions for testing. Will undo that change before merging.

Test:
- CI