### PR TITLE
[ci] move //:gcs_placement_group_manager_test to flaky

### DIFF
--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -1,3 +1,4 @@
 flaky_tests:
   - //python/ray/tests:test_client_library_integration
   - //src/ray/common/test:ray_syncer_test
+  - //:gcs_placement_group_manager_test


### PR DESCRIPTION
This test has gone bad, blocking postmerge at least 4 times now.

Open issue: https://github.com/ray-project/ray/issues/41215

<img width="1422" alt="Screenshot 2023-11-16 at 12 19 25 PM" src="https://github.com/ray-project/ray/assets/128072568/3cf9f422-3183-484d-b564-8f61dee3c841">

Test:
- CI