### PR TITLE
[data] allow ConcurrencyCapBackpressurePolicy._cap_multiplier to be set to 1.0 

### DIFF
--- a/python/ray/data/_internal/execution/backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy.py
@@ -114,7 +114,7 @@ class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
 
         assert self._init_cap > 0
         assert 0 < self._cap_multiply_threshold <= 1
-        assert self._cap_multiplier > 1
+        assert self._cap_multiplier >= 1
 
         logger.debug(
             "ConcurrencyCapBackpressurePolicy initialized with config: "
@@ -126,7 +126,7 @@ class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
 
     def can_add_input(self, op: "PhysicalOperator") -> bool:
         metrics = op.metrics
-        while metrics.num_tasks_finished >= (
+        while self._cap_multiplier > 1 and metrics.num_tasks_finished >= (
             self._concurrency_caps[op] * self._cap_multiply_threshold
         ):
             self._concurrency_caps[op] *= self._cap_multiplier


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Allow ConcurrencyCapBackpressurePolicy._cap_multiplier to be set to 1.0. This means that the concurrency will stay the same. No ramping up. This is because for some workloads, we need an upper bound of concurrency cap to make it stable. Before introducing new configs for control concurrency. Add this as a temporary workaround. 

## Related issue number

https://github.com/ray-project/ray/issues/41193

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
