### PR TITLE
[spark] Remove ray head node memory limitation if user set 'object_store_memory_head_node' argument

### DIFF
--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -1160,15 +1160,15 @@ def setup_ray_cluster(
                 f"Current value is {num_gpus_head_node}."
             )
 
-    if num_cpus_head_node == 0 and num_gpus_head_node == 0:
+    if (
+        num_cpus_head_node == 0
+        and num_gpus_head_node == 0
+        and object_store_memory_head_node is None
+    ):
         # Because tasks that require CPU or GPU resources are not scheduled to Ray
-        # head node, limit the heap memory and object store memory allocation to the
-        # head node.
-        if object_store_memory_head_node is not None:
-            raise ValueError(
-                "If you want to set 'object_store_memory_head_node', you should also "
-                "set num_cpus_head_node to >=1."
-            )
+        # head node, and user does not set `object_store_memory_head_node` explicitly,
+        # limit the heap memory and object store memory allocation to the
+        # head node, in order to save spark driver memory.
         heap_memory_head_node = 128 * 1024 * 1024
         object_store_memory_head_node = 128 * 1024 * 1024
     else:

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -1164,6 +1164,11 @@ def setup_ray_cluster(
         # Because tasks that require CPU or GPU resources are not scheduled to Ray
         # head node, limit the heap memory and object store memory allocation to the
         # head node.
+        if object_store_memory_head_node is not None:
+            raise ValueError(
+                "If you want to set 'object_store_memory_head_node', you should also "
+                "set num_cpus_head_node to >=1."
+            )
         heap_memory_head_node = 128 * 1024 * 1024
         object_store_memory_head_node = 128 * 1024 * 1024
     else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

It is a common case that user need to increase object_store_memory for head node (otherwise OOM occurs in some workloads), but currently, if user set object_store_memory, but does not set num_cpus_head_node / num_gpus_head_node, the head node memory limitation is still 128MB, this PR fixes the issue.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
