### PR TITLE
[cd] unify image_exist

### DIFF
--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -74,7 +74,7 @@ def build_anyscale_custom_byod_image(test: Test) -> None:
         logger.info(f"Test {test.get_name()} does not require a custom byod image")
         return
     byod_image = test.get_anyscale_byod_image()
-    if _byod_image_exist(test, base_image=False):
+    if _image_exist(byod_image):
         logger.info(f"Image {byod_image} already exists")
         return
 
@@ -127,12 +127,12 @@ def build_anyscale_base_byod_images(tests: List[Test]) -> None:
             else:
                 byod_requirements = f"{REQUIREMENTS_BYOD}_{py_version}.txt"
 
-            if _byod_image_exist(test):
+            if _image_exist(byod_image):
                 logger.info(f"Image {byod_image} already exists")
                 built.add(byod_image)
                 continue
             ray_image = test.get_ray_image()
-            if not _ray_image_exist(ray_image):
+            if not _image_exist(ray_image):
                 # TODO(can): instead of waiting for the base image to be built, we can
                 #  build it ourselves
                 timeout = BASE_IMAGE_WAIT_TIMEOUT - (int(time.time()) - start)
@@ -244,36 +244,13 @@ def _download_dataplane_build_file() -> None:
         assert digest == DATAPLANE_DIGEST, "Mismatched dataplane digest found!"
 
 
-def _ray_image_exist(ray_image: str) -> bool:
+def _image_exist(image: str) -> bool:
     """
     Checks if the given image exists in Docker
     """
     p = subprocess.run(
-        ["docker", "manifest", "inspect", ray_image],
+        ["docker", "manifest", "inspect", image],
         stdout=sys.stderr,
         stderr=sys.stderr,
     )
     return p.returncode == 0
-
-
-def _byod_image_exist(test: Test, base_image: bool = True) -> bool:
-    """
-    Checks if the given Anyscale BYOD image exists.
-    """
-    if os.environ.get("BYOD_NO_CACHE", False):
-        return False
-    if test.is_gce():
-        # TODO(can): check image existence on GCE; without this, we'll always rebuild
-        return False
-    client = boto3.client("ecr", region_name="us-west-2")
-    image_tag = (
-        test.get_byod_base_image_tag() if base_image else test.get_byod_image_tag()
-    )
-    try:
-        client.describe_images(
-            repositoryName=test.get_byod_repo(),
-            imageIds=[{"imageTag": image_tag}],
-        )
-        return True
-    except client.exceptions.ImageNotFoundException:
-        return False

--- a/release/ray_release/tests/test_byod_build.py
+++ b/release/ray_release/tests/test_byod_build.py
@@ -85,15 +85,10 @@ def test_build_anyscale_custom_byod_image() -> None:
     ) -> None:
         cmds.append(cmd)
 
-    with patch(
-        "ray_release.byod.build._byod_image_exist", return_value=False
-    ), patch.dict(
+    with patch("ray_release.byod.build._image_exist", return_value=False), patch.dict(
         "os.environ",
         {"BUILDKITE_COMMIT": "abc123", "BUILDKITE_BRANCH": "master"},
-    ), patch(
-        "subprocess.check_call",
-        side_effect=_mock_check_call,
-    ), patch(
+    ), patch("subprocess.check_call", side_effect=_mock_check_call,), patch(
         "subprocess.check_output",
         return_value=b"abc123",
     ):
@@ -114,6 +109,9 @@ def test_build_anyscale_base_byod_images() -> None:
     def _mock_validate_and_push(image: str) -> None:
         images.append(image)
 
+    def _mock_image_exist(image: str) -> bool:
+        return "rayproject/ray" in image
+
     with patch(
         "ray_release.byod.build._download_dataplane_build_file", return_value=None
     ), patch(
@@ -122,9 +120,7 @@ def test_build_anyscale_base_byod_images() -> None:
     ), patch(
         "subprocess.check_call", return_value=None
     ), patch(
-        "ray_release.byod.build._byod_image_exist", return_value=False
-    ), patch(
-        "ray_release.byod.build._ray_image_exist", return_value=True
+        "ray_release.byod.build._image_exist", side_effect=_mock_image_exist
     ), patch(
         "ray_release.byod.build._validate_and_push", side_effect=_mock_validate_and_push
     ):


### PR DESCRIPTION
We have two different functions for checking if a docker image exist. Unify them into one (especially because one of them doesn't work for gcp).

Test:
- CI
- Release test