### PR TITLE
[spark] Ray on spark: Support ray-client-server-port in `setup_ray_cluster` API

### DIFF
--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -11,7 +11,7 @@ import uuid
 import warnings
 import requests
 from packaging.version import Version
-from typing import Optional, Dict, Type
+from typing import Optional, Dict, Tuple, Type
 
 import ray
 import ray._private.services
@@ -834,7 +834,7 @@ def setup_ray_cluster(
     autoscale_upscaling_speed: Optional[float] = 1.0,
     autoscale_idle_timeout_minutes: Optional[float] = 1.0,
     **kwargs,
-) -> str:
+) -> Tuple[str, str]:
     """
     Set up a ray cluster on the spark cluster by starting a ray head node in the
     spark application's driver side node.

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -535,7 +535,10 @@ def _setup_ray_cluster(
             "--include-dashboard=false",
         ]
 
-    _logger.info(f"Ray head hostname {ray_head_ip}, port {ray_head_port}")
+    _logger.info(
+        f"Ray head hostname: {ray_head_ip}, port: {ray_head_port}, "
+        f"ray client server port: {ray_client_server_port}."
+    )
 
     cluster_unique_id = uuid.uuid4().hex[:8]
 

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -90,6 +90,7 @@ class RayClusterOnSpark:
         start_hook,
         ray_dashboard_port,
         spark_job_server,
+        ray_client_server_port,
     ):
         self.autoscale = autoscale
         self.address = address
@@ -101,6 +102,7 @@ class RayClusterOnSpark:
         self.start_hook = start_hook
         self.ray_dashboard_port = ray_dashboard_port
         self.spark_job_server = spark_job_server
+        self.ray_client_server_port = ray_client_server_port
 
         self.is_shutdown = False
         self.spark_job_is_canceled = False
@@ -482,6 +484,14 @@ def _setup_ray_cluster(
     include_dashboard = head_node_options.pop("include_dashboard", None)
     ray_dashboard_port = head_node_options.pop("dashboard_port", None)
 
+    ray_client_server_port = get_random_unused_port(
+        ray_head_ip,
+        min_port=9000,
+        max_port=10000,
+        exclude_list=port_exclude_list,
+    )
+    port_exclude_list.append(ray_client_server_port)
+
     if autoscale:
         spark_job_server_port = get_random_unused_port(
             ray_head_ip,
@@ -586,6 +596,7 @@ def _setup_ray_cluster(
         ray_head_proc, tail_output_deque = autoscaling_cluster.start(
             ray_head_ip,
             ray_head_port,
+            ray_client_server_port,
             ray_temp_dir,
             dashboard_options,
             head_node_options,
@@ -602,6 +613,7 @@ def _setup_ray_cluster(
             "--head",
             f"--node-ip-address={ray_head_ip}",
             f"--port={ray_head_port}",
+            f"--ray-client-server-port={ray_client_server_port}",
             f"--num-cpus={num_cpus_head_node}",
             f"--num-gpus={num_gpus_head_node}",
             f"--memory={heap_memory_head_node}",
@@ -654,6 +666,7 @@ def _setup_ray_cluster(
         start_hook=start_hook,
         ray_dashboard_port=ray_dashboard_port,
         spark_job_server=spark_job_server,
+        ray_client_server_port=ray_client_server_port,
     )
 
     if not autoscale:
@@ -921,7 +934,14 @@ def setup_ray_cluster(
             Default value is 1.0, minimum value is 0
 
     Returns:
-        The address of the initiated Ray cluster on spark.
+        A tuple of (address, remote_connection_address)
+        "address" is in format of "<ray_head_node_ip>:<port>"
+        "remote_connection_address" is in format of
+        "ray://<ray_head_node_ip>:<ray-client-server-port>",
+        if your client runs on a machine that also hosts a Ray cluster node locally,
+        you can connect to the Ray cluster via ``ray.init(address)``,
+        otherwise you can connect to the Ray cluster via
+        ``ray.init(remote_connection_address)``.
     """
     global _active_ray_cluster
 
@@ -1197,7 +1217,10 @@ def setup_ray_cluster(
         # If connect cluster successfully, set global _active_ray_cluster to be the
         # started cluster.
         _active_ray_cluster = cluster
-    return cluster.address
+
+    head_ip = cluster.address.split(":")[0]
+    remote_connection_address = f"ray://{head_ip}:{cluster.ray_client_server_port}"
+    return cluster.address, remote_connection_address
 
 
 def _start_ray_worker_nodes(
@@ -1462,6 +1485,7 @@ class AutoscalingCluster:
         self,
         ray_head_ip,
         ray_head_port,
+        ray_client_server_port,
         ray_temp_dir,
         dashboard_options,
         head_node_options,
@@ -1492,6 +1516,7 @@ class AutoscalingCluster:
             "--head",
             f"--node-ip-address={ray_head_ip}",
             f"--port={ray_head_port}",
+            f"--ray-client-server-port={ray_client_server_port}",
             f"--autoscaling-config={autoscale_config}",
             *dashboard_options,
         ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Ray on spark: Support ray-client-server-port in `setup_ray_cluster` API.

API update:

```
def setup_ray_cluster(...):
    """
    Args:
        ....
    Returns:
        A tuple of (address, remote_connection_address)
        "address" is in format of "<ray_head_node_ip>:<port>"
        "remote_connection_address" is in format of
        "ray://<ray_head_node_ip>:<ray-client-server-port>",
        if your client runs on a machine that also hosts a Ray cluster node locally,
        you can connect to the Ray cluster via ``ray.init(address)``,
        otherwise you can connect to the Ray cluster via
        ``ray.init(remote_connection_address)``.
    """

```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
