### PR TITLE
[ci] mark two core functions as flaky

### DIFF
--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -55,6 +55,10 @@ def test_client(address):
         assert builder.address == address.replace("ray://", "")
 
 
+@pytest.mark.skipif(
+    skip_flaky_test(),
+    reason="https://github.com/ray-project/ray/issues/38224",
+)
 def test_namespace(ray_start_cluster):
     """
     Most of the "checks" in this test case rely on the fact that

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -348,6 +348,10 @@ class TestGC:
         wait_for_condition(lambda: check_local_files_gced(cluster, whitelist=whitelist))
         print("check_local_files_gced passed wait_for_condition block.")
 
+    @pytest.mark.skipif(
+        skip_flaky_test(),
+        reason="https://github.com/ray-project/ray/issues/40781",
+    )
     def test_hit_cache_size_limit(
         self, start_cluster, URI_cache_10_MB, disable_temporary_uri_pinning
     ):


### PR DESCRIPTION
Mark two more functions as flaky. These functions are inside the flaky targets.

- https://buildkite.com/ray-project/postmerge/builds/1723#018bdcf2-1da6-4daf-9251-910cc716f729/438-585
- https://buildkite.com/ray-project/postmerge/builds/1722#018bdc69-2d92-42c2-b1ef-d70093a01bd8/317-1971

Test:
- CI