### PR TITLE
[core] Fix the crash when the GCS address is not valid.

### DIFF
--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -375,9 +375,6 @@ cdef extern from "ray/gcs/gcs_client/gcs_client.h" nogil:
         UNIMPLEMENTED "grpc::StatusCode::UNIMPLEMENTED",
 
     cdef cppclass CGcsClientOptions "ray::gcs::GcsClientOptions":
-        CGcsClientOptions(const c_string &gcs_address)
-
-    cdef cppclass CGcsClientOptions "ray::gcs::GcsClientOptions":
         CGcsClientOptions(const c_string &gcs_address, int port)
 
     cdef cppclass CPythonGcsClient "ray::gcs::PythonGcsClient":

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -377,6 +377,9 @@ cdef extern from "ray/gcs/gcs_client/gcs_client.h" nogil:
     cdef cppclass CGcsClientOptions "ray::gcs::GcsClientOptions":
         CGcsClientOptions(const c_string &gcs_address)
 
+    cdef cppclass CGcsClientOptions "ray::gcs::GcsClientOptions":
+        CGcsClientOptions(const c_string &gcs_address, int port)
+
     cdef cppclass CPythonGcsClient "ray::gcs::PythonGcsClient":
         CPythonGcsClient(const CGcsClientOptions &options)
 

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -27,7 +27,7 @@ cdef class GcsClientOptions:
             ip, port = gcs_address.split(":")
             port = int(port)
             self.inner.reset(
-                new CGcsClientOptions(ip, port)
+                new CGcsClientOptions(ip, port))
         except Exception:
             raise ValueError(f"Invalid gcs_address: {gcs_address}")
         return self

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -25,7 +25,6 @@ cdef class GcsClientOptions:
         self = GcsClientOptions()
         try:
             ip, port = gcs_address.split(":", 2)
-            print("DBG>>", ip, port)
             port = int(port)
             self.inner.reset(
                 new CGcsClientOptions(ip, port))

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -24,7 +24,8 @@ cdef class GcsClientOptions:
     def from_gcs_address(cls, gcs_address):
         self = GcsClientOptions()
         try:
-            ip, port = gcs_address.split(":")
+            ip, port = gcs_address.split(":", 2)
+            print("DBG>>", ip, port)
             port = int(port)
             self.inner.reset(
                 new CGcsClientOptions(ip, port))

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -23,8 +23,13 @@ cdef class GcsClientOptions:
     @classmethod
     def from_gcs_address(cls, gcs_address):
         self = GcsClientOptions()
-        self.inner.reset(
-            new CGcsClientOptions(gcs_address.encode("ascii")))
+        try:
+            ip, port = gcs_address.split(":")
+            port = int(port)
+            self.inner.reset(
+                new CGcsClientOptions(ip, port)
+        except Exception:
+            raise ValueError(f"Invalid gcs_address: {gcs_address}")
         return self
 
     cdef CGcsClientOptions* native(self):

--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -9,6 +9,7 @@ import json
 from subprocess import Popen, PIPE, STDOUT, list2cmdline
 from typing import List
 from pathlib import Path
+import pytest
 
 import ray
 from ray._private.test_utils import (
@@ -39,6 +40,17 @@ def execute_driver(commands: List[str], input: bytes = None):
                 p.kill()
             except Exception:
                 pass
+
+
+def test_invalid_gcs_address():
+    with pytest.raises(ValueError):
+        JobSubmissionClient("foobar")
+
+    with pytest.raises(ValueError):
+        JobSubmissionClient("")
+
+    with pytest.raises(ValueError):
+        JobSubmissionClient("abc:abc")
 
 
 def test_job_isolation(call_ray_start):
@@ -323,7 +335,6 @@ ray.get(f.remote())
 
 
 if __name__ == "__main__":
-    import pytest
 
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -42,6 +42,9 @@ namespace gcs {
 /// password.
 class GcsClientOptions {
  public:
+  GcsClientOptions(const std::string gcs_address, int port)
+      : gcs_address_(gcs_address), gcs_port_(port) {}
+
   /// Constructor of GcsClientOptions from gcs address
   ///
   /// \param gcs_address gcs address, including port


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR fix the issue when GCS address is not valid the driver will crash. It only verify the address simply. But so far good enough for the issue.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/41076

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
