### PR TITLE
[Serve] Fixed `_DeploymentHandleBase` to avoid regenerating `handle` tag every time `handle.options` is invoked

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -102,11 +102,13 @@ class _DeploymentHandleBase:
         _router: Optional[Router] = None,
         _request_counter: Optional[metrics.Counter] = None,
         _recorded_telemetry: bool = False,
+        _handle_id: str = get_random_letters(),
     ):
         self.deployment_id = DeploymentID(deployment_name, app_name)
         self.handle_options = handle_options or _HandleOptions()
         self._recorded_telemetry = _recorded_telemetry
         self._sync = sync
+        self._handle_id = _handle_id
 
         self.request_counter = _request_counter or metrics.Counter(
             "serve_handle_request_counter",
@@ -117,9 +119,9 @@ class _DeploymentHandleBase:
             tag_keys=("handle", "deployment", "route", "application"),
         )
         if app_name:
-            handle_tag = f"{app_name}#{deployment_name}#{get_random_letters()}"
+            handle_tag = f"{app_name}#{deployment_name}#{_handle_id}"
         else:
-            handle_tag = f"{deployment_name}#{get_random_letters()}"
+            handle_tag = f"{deployment_name}#{_handle_id}"
 
         # TODO(zcin): Separate deployment_id into deployment and application tags
         self.request_counter.set_default_tags(
@@ -229,6 +231,7 @@ class _DeploymentHandleBase:
             _router=None if _router_cls != DEFAULT.VALUE else self._router,
             _request_counter=self.request_counter,
             _recorded_telemetry=self._recorded_telemetry,
+            _handle_id=self._handle_id,
         )
 
     def _remote(

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -168,9 +168,7 @@ class _DeploymentHandleBase:
             return f"{deployment_name}#{handle_id}"
 
     @classmethod
-    def _create_request_counter(
-        cls, app_name, deployment_name, handle_id=get_random_letters()
-    ):
+    def _create_request_counter(cls, app_name, deployment_name):
         return metrics.Counter(
             "serve_handle_request_counter",
             description=(
@@ -181,7 +179,9 @@ class _DeploymentHandleBase:
         ).set_default_tags(
             # TODO(zcin): Separate deployment_id into deployment and application tags
             {
-                "handle": cls._gen_handle_tag(app_name, deployment_name, handle_id),
+                "handle": cls._gen_handle_tag(
+                    app_name, deployment_name, handle_id=get_random_letters()
+                ),
                 "deployment": deployment_name,
                 "application": app_name,
             }

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -186,16 +186,21 @@ def test_handle_option_chaining(serve_instance):
             return "__call__"
 
     handle1 = serve.run(MultiMethod.bind())
-    metrics = handle1.request_counter
+    counter = handle1.request_counter
+    counter_info = counter.info
     assert handle1.remote().result() == "__call__"
 
     handle2 = handle1.options(method_name="method_a")
+
     assert handle2.remote().result() == "method_a"
-    assert handle2.request_counter == metrics
+    assert handle2.request_counter == counter
+    assert handle2.request_counter.info == counter_info
 
     handle3 = handle1.options(method_name="method_b")
+
     assert handle3.remote().result() == "method_b"
-    assert handle3.request_counter == metrics
+    assert handle3.request_counter == counter
+    assert handle2.request_counter.info == counter_info
 
 
 def test_repeated_get_handle_cached(serve_instance):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Addresses https://github.com/ray-project/ray/issues/41282

This makes sure that since we're reusing the counter we also don't update its default tags set

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
