### PR TITLE
[data] fix flaky stats manager test

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -497,9 +497,13 @@ class _StatsManager:
             if dataset_tag in self._last_execution_stats:
                 del self._last_execution_stats[dataset_tag]
 
-        self._stats_actor(create_if_not_exists=False).clear_execution_metrics.remote(
-            dataset_tag, operator_tags
-        )
+        try:
+            self._stats_actor(
+                create_if_not_exists=False
+            ).clear_execution_metrics.remote(dataset_tag, operator_tags)
+        except Exception:
+            # Cluster may be shut down.
+            pass
 
     # Iteration methods
 
@@ -513,9 +517,13 @@ class _StatsManager:
             if dataset_tag in self._last_iteration_stats:
                 del self._last_iteration_stats[dataset_tag]
 
-        self._stats_actor(create_if_not_exists=False).clear_iteration_metrics.remote(
-            dataset_tag
-        )
+        try:
+            self._stats_actor(
+                create_if_not_exists=False
+            ).clear_iteration_metrics.remote(dataset_tag)
+        except Exception:
+            # Cluster may be shut down.
+            pass
 
     # Other methods
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -497,7 +497,9 @@ class _StatsManager:
             if dataset_tag in self._last_execution_stats:
                 del self._last_execution_stats[dataset_tag]
 
-        self._stats_actor().clear_execution_metrics.remote(dataset_tag, operator_tags)
+        self._stats_actor(create_if_not_exists=False).clear_execution_metrics.remote(
+            dataset_tag, operator_tags
+        )
 
     # Iteration methods
 
@@ -511,7 +513,9 @@ class _StatsManager:
             if dataset_tag in self._last_iteration_stats:
                 del self._last_iteration_stats[dataset_tag]
 
-        self._stats_actor().clear_iteration_metrics.remote(dataset_tag)
+        self._stats_actor(create_if_not_exists=False).clear_iteration_metrics.remote(
+            dataset_tag
+        )
 
     # Other methods
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -346,7 +346,7 @@ class _StatsActor:
 
 # Creating/getting an actor from multiple threads is not safe.
 # https://github.com/ray-project/ray/issues/41324
-_stats_actor_lock: threading.Lock = threading.Lock()
+_stats_actor_lock: threading.RLock = threading.RLock()
 
 
 def _get_or_create_stats_actor():

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -417,13 +417,13 @@ class _StatsManager:
             self._stats_actor_handle is None
             or self._stats_actor_cluster_id != current_cluster_id
         ):
-            self._stats_actor_cluster_id = current_cluster_id
             if create_if_not_exists:
                 self._stats_actor_handle = _get_or_create_stats_actor()
             else:
                 self._stat_actor_handle = ray.get_actor(
                     name=STATS_ACTOR_NAME, namespace=STATS_ACTOR_NAMESPACE
                 )
+            self._stats_actor_cluster_id = current_cluster_id
         return self._stats_actor_handle
 
     def _start_thread_if_not_running(self):

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -850,8 +850,12 @@ class DataIterator(abc.ABC):
         )
 
     def __del__(self):
-        # Clear metrics on deletion in case the iterator was not fully consumed.
-        StatsManager.clear_iteration_metrics(self._get_dataset_tag())
+        try:
+            # Clear metrics on deletion in case the iterator was not fully consumed.
+            StatsManager.clear_iteration_metrics(self._get_dataset_tag())
+        except Exception:
+            # This may be run after the cluster is shutdown.
+            pass
 
 
 # Backwards compatibility alias.

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -850,12 +850,8 @@ class DataIterator(abc.ABC):
         )
 
     def __del__(self):
-        try:
-            # Clear metrics on deletion in case the iterator was not fully consumed.
-            StatsManager.clear_iteration_metrics(self._get_dataset_tag())
-        except Exception:
-            # This may be run after the cluster is shutdown.
-            pass
+        # Clear metrics on deletion in case the iterator was not fully consumed.
+        StatsManager.clear_iteration_metrics(self._get_dataset_tag())
 
 
 # Backwards compatibility alias.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Concurrently creating or getting an actor can cause errors (#41324). This pr puts a lock on `_get_or_create_stats_actor`.

Also catches any exceptions raised by `DataIterator.__del__` since this can be called after driver exits or cluster is shutdown.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
