### PR TITLE
[Doc] Fix the missing ray module import in PyTorch Guide

### DIFF
--- a/doc/source/train/getting-started-pytorch.rst
+++ b/doc/source/train/getting-started-pytorch.rst
@@ -84,10 +84,11 @@ Compare a PyTorch training script with and without Ray Train.
     .. group-tab:: PyTorch + Ray Train
 
         .. code-block:: python
-            :emphasize-lines: 9, 10, 12, 17, 18, 26, 27, 41, 42, 44-49
+            :emphasize-lines: 3, 10, 11, 13, 18, 19, 27, 28, 42, 43, 45-50
 
             import tempfile
             import torch
+            import ray
             from torchvision.models import resnet18
             from torchvision.datasets import FashionMNIST
             from torchvision.transforms import ToTensor, Normalize, Compose


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Missing the ray module import in PyTorch Guide

## Related issue number

Closes #41291 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
