### PR TITLE
[ci] move test_connect_to_cluster to flaky

### DIFF
--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -108,6 +108,9 @@ print("Current namespace:", ray.get_runtime_context().namespace)
     subprocess.check_output("ray stop --force", shell=True)
 
 
+@pytest.mark.skipif(
+    skip_flaky_test(), reason="https://github.com/ray-project/ray/issues/38224"
+)
 def test_connect_to_cluster(ray_start_regular_shared):
     server = ray_client_server.serve("localhost:50055")
     with ray.client("localhost:50055").connect() as client_context:


### PR DESCRIPTION
Have seen this test failing/flaky several times since yesterday: https://buildkite.com/ray-project/postmerge/builds/1759#018bf2cf-54e1-4180-8a93-1de10f914633/696-795

Test:
- CI