### PR TITLE
[ci] upgrade miniconda for py311

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -50,7 +50,7 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
         openssh-client \
         gnupg; fi) \
     && if [[ "${PYTHON_VERSION}" = "3.11" || "${PYTHON_VERSION}" =~ ^3\.11\. ]]; then \
-            MINICONDA_VERSION="py310_23.3.1-0"; \
+            MINICONDA_VERSION="py311_23.10.0-1"; \
             LIBGCC=(libgcc-ng); \
         else \
             MINICONDA_VERSION="py37_23.1.0-1"; \


### PR DESCRIPTION
As title, upgrade miniconda for py311. The previous conda version doesn't work well with libgcc

Test:
- CI