### PR TITLE
[ci] add group 993 for docker

### DIFF
--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -42,7 +42,8 @@ python -m pip install pip==23.2.1
 
 # Needs to be synchronized to the host group id as we map /var/run/docker.sock
 # into the container.
-addgroup --gid 1001 docker
+addgroup --gid 1001 docker0  # Used on old buildkite AMIs.
+addgroup --gid 993 docker
 
 # Install bazelisk
 npm install -g @bazel/bazelisk
@@ -50,6 +51,7 @@ ln -s /usr/local/bin/bazel /usr/local/bin/bazelisk
 
 # A non-root user. Use 2000, which is the same as our buildkite agent VM uses.
 adduser --home /home/forge --uid 2000 forge --gid 100
+usermod -a -G docker0 forge
 usermod -a -G docker forge
 
 EOF


### PR DESCRIPTION
required for upgrade buildkite stack and AMIs to 6.x

buildkite 5.x is deprecating around the end of this year.