### PR TITLE
[ci] fix forge dependencies

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -15,7 +15,6 @@ steps:
     depends_on:
       - manylinux
       - forge
-    job_env: forge
 
   - label: ":tapioca: build: wheel {{matrix}} (aarch64)"
     tags:
@@ -44,7 +43,6 @@ steps:
     depends_on:
       - manylinux
       - forge
-    job_env: forge
 
   - label: ":windows: wheel {{matrix}}"
     # we have linux/mac wheels tag, but do not have a windows wheels tag..
@@ -80,8 +78,9 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- doc
-    depends_on: docbuild
-    job_env: forge
+    depends_on:
+      - docbuild
+      - forge
 
   - label: ":tapioca: build: ray py{{matrix}} docker (x86_64)"
     tags:
@@ -100,7 +99,6 @@ steps:
       - forge
       - raycudabase
       - raycpubase
-    job_env: forge
     matrix:
       - "3.8"
       - "3.9"
@@ -148,7 +146,6 @@ steps:
       - forge
       - ray-mlcudabase
       - ray-mlcpubase
-    job_env: forge
     matrix:
       - "3.8"
       - "3.9"

--- a/.buildkite/cicd.rayci.yml
+++ b/.buildkite/cicd.rayci.yml
@@ -1,15 +1,15 @@
 group: CI/CD infra
+depends_on:
+  - forge
 steps:
   - label: "CI/CD: ray_ci tooling"
     commands:
       # TODO(aslonnie): wrap this in a script, and upload test telemetry.
       - bazel test --test_tag_filters=ci_unit //ci/ray_ci/...
     instance_type: small
-    depends_on: forge
 
   - label: "CI/CD: release test infra"
     commands:
       # TODO(aslonnie): wrap this in a script, and upload test telemetry.
       - bazel test --test_tag_filters=release_unit //release/...
     instance_type: small
-    depends_on: forge

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -1,14 +1,15 @@
 group: core tests
+depends_on:
+  - forge
+  - oss-ci-base_build
 steps:
   # builds
   - name: corebuild
     wanda: ci/docker/core.build.wanda.yaml
-    depends_on: oss-ci-base_build
 
   - name: minbuild-core
     label: "wanda: minbuild-core-py{{matrix}}"
     wanda: ci/docker/min.build.wanda.yaml
-    depends_on: oss-ci-base_build
     matrix:
       - "3.8"
       - "3.9"
@@ -17,6 +18,8 @@ steps:
     env:
       PYTHON_VERSION: "{{matrix}}"
       EXTRA_DEPENDENCY: core
+
+  - wait: ~
 
   # tests
   - label: ":ray: core: python tests"
@@ -27,8 +30,6 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core 
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --except-tags debug_tests,asan_tests,post_wheel_build,xcommit,manual
-    depends_on: corebuild
-    job_env: forge
 
   - label: ":ray: core: redis tests"
     tags: python
@@ -39,8 +40,6 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --test-env=TEST_EXTERNAL_REDIS=1
         --except-tags debug_tests,asan_tests,post_wheel_build,xcommit,manual
-    depends_on: corebuild
-    job_env: forge
 
   - label: ":ray: core: workflow tests"
     tags: 
@@ -57,8 +56,6 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --skip-ray-installation
         --only-tags use_all_core
-    depends_on: data14build
-    job_env: forge
 
   - label: ":ray: core: doc tests"
     tags: 
@@ -75,8 +72,6 @@ steps:
         --except-tags gpu,post_wheel_build,xcommit,doctest
         --parallelism-per-worker 3
         --skip-ray-installation
-    depends_on: corebuild
-    job_env: forge
 
   - label: ":ray: core: data tests"
     tags: python
@@ -86,8 +81,9 @@ steps:
         python/ray/util/dask/... python/ray/tests/modin/... core
         --build-name data14build
         --parallelism-per-worker 2
-    depends_on: data14build
-    job_env: forge
+    depends_on:
+      - data14build
+      - forge
 
   - label: ":ray: core: dashboard tests"
     tags: 
@@ -101,8 +97,6 @@ steps:
       - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild /bin/bash -iecuo pipefail 
         "./dashboard/tests/run_ui_tests.sh"
-    depends_on: corebuild
-    job_env: forge
 
   - label: ":ray: core: debug test"
     tags: python
@@ -113,8 +107,6 @@ steps:
         --parallelism-per-worker 3
         --only-tags debug_tests
         --except-tags kubernetes,manual
-    depends_on: corebuild
-    job_env: forge
 
   - label: ":ray: core: asan tests"
     tags: python
@@ -125,8 +117,6 @@ steps:
         --parallelism-per-worker 2
         --only-tags asan_tests
         --except-tags kubernetes,manual
-    depends_on: corebuild
-    job_env: forge
 
   - label: ":ray: core: wheel tests"
     tags: linux_wheels
@@ -137,10 +127,10 @@ steps:
         --parallelism-per-worker 3
         --only-tags post_wheel_build
         --test-env=RAY_CI_POST_WHEEL_TESTS=True
-    depends_on: 
+    depends_on:
       - manylinux
       - corebuild
-    job_env: forge
+      - forge
 
   - label: ":ray: core: wheel-aarch64 tests"
     tags: linux_wheels
@@ -155,6 +145,7 @@ steps:
     depends_on: 
       - manylinux-aarch64
       - oss-ci-base_build-aarch64
+      - forge-aarch64
     job_env: forge-aarch64
 
   - label: ":ray: core: minimal tests {{matrix}}"
@@ -196,8 +187,6 @@ steps:
         --test-env=RAY_MINIMAL=1
         --only-tags minimal
         --skip-ray-installation
-    depends_on: minbuild-core
-    job_env: forge
     matrix:
       - "3.8"
       - "3.9"
@@ -205,23 +194,12 @@ steps:
       - "3.11"
 
   # cpp tests
-  - label: ":ray: core: cpp worker tests"
-    tags: core_cpp
-    instance_type: small
-    commands:
-      - ci/ci.sh build
-      - ci/ci.sh test_cpp
-    depends_on: oss-ci-base_build
-    job_env: oss-ci-base_build
-
   - label: ":ray: core: cpp tests"
     tags: core_cpp
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type clang
         --parallelism-per-worker 2
-    depends_on: corebuild
-    job_env: forge
 
   - label: ":ray: core: cpp asan tests"
     tags: core_cpp
@@ -229,8 +207,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type asan-clang
         --parallelism-per-worker 2
-    depends_on: corebuild
-    job_env: forge
 
   - label: ":ray: core: cpp ubsan tests"
     tags: core_cpp
@@ -239,8 +215,6 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type ubsan
         --except-tags no_ubsan
         --parallelism-per-worker 2
-    depends_on: corebuild
-    job_env: forge
 
   - label: ":ray: core: cpp tsan tests"
     tags: core_cpp
@@ -249,8 +223,6 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type tsan-clang
         --except-tags no_tsan
         --parallelism-per-worker 2
-    depends_on: corebuild
-    job_env: forge
 
   - label: ":ray: core: flaky tests"
     tags:
@@ -269,8 +241,15 @@ steps:
         //python/ray/tests:test_object_assign_owner_client_mode core 
         --test-env CI_SKIP_FLAKY_TEST=0
         --skip-ray-installation
-    depends_on: corebuild
-    job_env: forge
+
+  - label: ":ray: core: cpp worker tests"
+    tags: core_cpp
+    instance_type: small
+    commands:
+      - ci/ci.sh build
+      - ci/ci.sh test_cpp
+    depends_on: oss-ci-base_build
+    job_env: oss-ci-base_build
 
   - label: ":windows: python tests"
     tags:

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -1,21 +1,20 @@
 group: data tests
+depends_on:
+  - forge
+  - oss-ci-base_ml
 steps:
   # builds
   - name: data6build
     wanda: ci/docker/data6.build.wanda.yaml
-    depends_on: oss-ci-base_ml
 
   - name: data14build
     wanda: ci/docker/data14.build.wanda.yaml
-    depends_on: oss-ci-base_ml
 
   - name: datanbuild
     wanda: ci/docker/datan.build.wanda.yaml
-    depends_on: oss-ci-base_ml
 
   - name: datamongobuild
     wanda: ci/docker/datamongo.build.wanda.yaml
-    depends_on: oss-ci-base_ml
 
   # tests
   - label: ":database: data: arrow 6 tests"
@@ -32,7 +31,6 @@ steps:
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
         --except-tags data_integration,doctest
     depends_on: data6build
-    job_env: forge
 
   - label: ":database: data: arrow 14 tests"
     tags: 
@@ -48,7 +46,6 @@ steps:
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
         --except-tags data_integration,doctest
     depends_on: data14build
-    job_env: forge
 
   - label: ":database: data: arrow nightly tests"
     tags: 
@@ -65,7 +62,6 @@ steps:
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1
         --except-tags data_integration,doctest
     depends_on: datanbuild
-    job_env: forge
 
   - label: ":database: data: doc tests"
     tags: 
@@ -86,7 +82,6 @@ steps:
         --parallelism-per-worker 2
         --skip-ray-installation
     depends_on: data14build
-    job_env: forge
 
   - label: ":database: data: doc gpu tests"
     tags: 
@@ -107,7 +102,6 @@ steps:
         --only-tags gpu
         --skip-ray-installation
     depends_on: docgpubuild
-    job_env: forge
 
   - label: ":database: data: integration tests"
     tags:
@@ -121,7 +115,6 @@ steps:
         --only-tags data_integration
         --except-tags doctest
     depends_on: datamongobuild
-    job_env: forge
 
   - label: ":database: data: dashboard tests"
     tags:
@@ -133,7 +126,6 @@ steps:
         --build-name data14build
         --parallelism-per-worker 3
     depends_on: data14build
-    job_env: forge
 
   - label: ":database: data: flaky tests"
     tags: 
@@ -147,4 +139,3 @@ steps:
         --test-env RAY_DATA_USE_STREAMING_EXECUTOR=1 --parallelism-per-worker 3
         --build-name data14build
     depends_on: data14build
-    job_env: forge

--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -1,74 +1,63 @@
 group: lint
+depends_on:
+  - forge
 steps:
   - label: ":lint-roller: lint: clang format"
     commands:
       - pip install -c python/requirements_compiled.txt clang-format
       - ./ci/lint/check-git-clang-format-output.sh
-    depends_on: forge
 
   - label: ":lint-roller: lint: code format"
     commands:
       - pip install -c python/requirements_compiled.txt -r python/requirements/lint-requirements.txt
       - FORMAT_SH_PRINT_DIFF=1 ./ci/lint/format.sh --all-scripts
-    depends_on: forge
 
   - label: ":lint-roller: lint: untested code snippet"
     commands:
       - pip install -c python/requirements_compiled.txt semgrep
       - semgrep ci --config semgrep.yml
-    depends_on: forge
 
   - label: ":lint-roller: lint: banned words"
     commands:
       - ./ci/lint/check-banned-words.sh
-    depends_on: forge
 
   - label: ":lint-roller: lint: doc readme"
     commands:
       - pip install -c python/requirements_compiled.txt docutils
       - cd python && python setup.py check --restructuredtext --strict --metadata
-    depends_on: forge
 
   - label: ":lint-roller: lint: dashboard format"
     commands:
       - ./ci/lint/check-dashboard-format.sh
-    depends_on: forge
 
   - label: ":lint-roller: lint: copyright format"
     commands:
       - ./ci/lint/copyright-format.sh -c
-    depends_on: forge
 
   - label: ":lint-roller: lint: bazel team"
     commands:
       - bazel query 'kind("cc_test", //...)' --output=xml | python ./ci/lint/check-bazel-team-owner.py
       - bazel query 'kind("py_test", //...)' --output=xml | python ./ci/lint/check-bazel-team-owner.py
-    depends_on: forge
 
   - label: ":lint-roller: lint: bazel buildifier"
     commands:
       - ./ci/lint/check-bazel-buildifier.sh
-    depends_on: forge
 
   - label: ":lint-roller: lint: pytest format"
     commands:
       - pip install -c python/requirements_compiled.txt yq
       - ./ci/lint/check-pytest-format.sh
-    depends_on: forge
 
   - label: ":lint-roller: lint: test coverage"
     commands:
       - python ci/pipeline/check-test-run.py
-    depends_on: forge
 
   - label: ":lint-roller: lint: api annotations"
     instance_type: medium
     commands:
       - RAY_DISABLE_EXTRA_CPP=1 pip install -e python/[all]
       - ./ci/lint/check_api_annotations.py
-    depends_on: forge
 
   - label: ":lint-roller: lint: documentation style"
     commands:
       - ./ci/lint/check-documentation-style.sh
-    depends_on: forge

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -1,22 +1,13 @@
 group: others
+depends_on:
+  - oss-ci-base_build
+  - forge
 steps:
   #build
   - name: doctestbuild
     wanda: ci/docker/doctest.build.wanda.yaml
-    depends_on: oss-ci-base_build
 
   # test
-  - label: ":java: java tests"
-    tags: java
-    instance_type: medium
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //... core --build-only
-      - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
-        "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild /bin/bash -iecuo pipefail 
-        "./java/test.sh"
-    depends_on: corebuild
-    job_env: forge
-
   - label: doc tests
     instance_type: large
     commands:
@@ -33,4 +24,13 @@ steps:
         --except-tags gpu
         --skip-ray-installation
     depends_on: doctestbuild
-    job_env: forge
+
+  - label: ":java: java tests"
+    tags: java
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //... core --build-only
+      - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
+        "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild /bin/bash -iecuo pipefail 
+        "./java/test.sh"
+    depends_on: [ "corebuild", "forge" ]

--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -9,7 +9,6 @@ steps:
       - forge
       - raycudabase
       - raycpubase
-    job_env: forge
     matrix:
       - "3.8"
       - "3.9"
@@ -23,7 +22,6 @@ steps:
       - manylinux
       - forge
       - ray-mlcudabase
-    job_env: forge
     matrix:
       - "3.8"
       - "3.9"

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -1,4 +1,6 @@
 group: rllib tests
+depends_on:
+  - forge
 steps:
   # builds
   - name: rllibbuild
@@ -28,7 +30,6 @@ steps:
         --except-tags learning_tests,memory_leak_tests,examples,tests_dir,documentation,multi_gpu,no_cpu,torch_2.x_only_benchmark,manual
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: learning tests tf2-static-graph"
     tags: rllib
@@ -41,7 +42,6 @@ steps:
         --except-tags torch_only,tf2_only,no_tf_static_graph,multi_gpu
         --test-arg --framework=tf
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: learning tests pytorch"
     tags: rllib
@@ -54,7 +54,6 @@ steps:
         --except-tags tf_only,tf2_only,multi_gpu
         --test-arg --framework=torch
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: examples"
     tags: rllib
@@ -67,7 +66,6 @@ steps:
         --except-tags multi_gpu,gpu 
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: learning tests tf2-eager-tracing"
     tags: rllib
@@ -80,7 +78,6 @@ steps:
         --except-tags fake_gpus,torch_only,multi_gpu,no_tf_eager_tracing
         --test-arg --framework=tf2
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: tests dir"
     tags: rllib_directly
@@ -93,7 +90,6 @@ steps:
         --except-tags multi_gpu,manual
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: gpu tests"
     tags: 
@@ -109,7 +105,6 @@ steps:
         --test-env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 
         --test-env=RLLIB_NUM_GPUS=1
     depends_on: rllibgpubuild
-    job_env: forge
 
   - label: ":brain: rllib: rlmodule tests"
     tags: rllib_directly
@@ -121,7 +116,6 @@ steps:
         --test-env RLLIB_ENABLE_RL_MODULE=1
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: data tests"
     if: build.branch != "master"
@@ -150,7 +144,6 @@ steps:
         --except-tags learning_tests_with_ray_data,multi_gpu,gpu
         --skip-ray-installation # reuse the same docker image as the previous run
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: benchmarks"
     tags: rllib
@@ -158,7 +151,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --only-tags torch_2.x_only_benchmark
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: memory leak tf2-eager-tracing tests"
     tags: rllib
@@ -169,7 +161,6 @@ steps:
         --except-tags flaky
         --test-arg --framework=tf2
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: memory leak pytorch tests"
     tags: rllib
@@ -180,7 +171,6 @@ steps:
         --except-tags flaky
         --test-arg --framework=torch
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: doc tests"
     tags: 
@@ -203,7 +193,6 @@ steps:
         --parallelism-per-worker 2
         --skip-ray-installation
     depends_on: rllibbuild
-    job_env: forge
 
   - label: ":brain: rllib: multi-gpu tests"
     tags: 
@@ -217,7 +206,6 @@ steps:
         --build-name rllibgpubuild
         --only-tags multi_gpu
     depends_on: rllibgpubuild
-    job_env: forge
 
   - label: ":brain: rllib: flaky multi-gpu tests"
     tags: 
@@ -233,7 +221,6 @@ steps:
         --only-tags multi_gpu
     depends_on: rllibgpubuild
     soft_fail: true
-    job_env: forge
 
   - label: ":brain: rllib: flaky tests (learning tests)"
     tags: 
@@ -262,7 +249,6 @@ steps:
         --skip-ray-installation # reuse the same docker image as the previous run
     depends_on: rllibbuild
     soft_fail: true
-    job_env: forge
 
   - label: ":brain: rllib: flaky tests (examples/rlmodule/models/tests_dir)"
     tags: 
@@ -297,7 +283,6 @@ steps:
         --skip-ray-installation # reuse the same docker image as the previous run
     depends_on: rllibbuild
     soft_fail: true
-    job_env: forge
 
   - label: ":brain: rllib: flaky tests (memory leak)"
     tags: 
@@ -312,4 +297,3 @@ steps:
         --test-arg --framework=tf2
     depends_on: rllibbuild
     soft_fail: true
-    job_env: forge

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -1,17 +1,17 @@
 group: serve tests
+depends_on:
+  - forge
+  - oss-ci-base_build
 steps:
   # builds
   - name: servebuild
     wanda: ci/docker/serve.build.wanda.yaml
-    depends_on: oss-ci-base_build
 
   - name: servepydantic1build
     wanda: ci/docker/servepydantic1.build.wanda.yaml
-    depends_on: oss-ci-base_build
 
   - name: servepython311build
     wanda: ci/docker/servepython311.build.wanda.yaml
-    depends_on: oss-ci-base_build
 
   # tests
   - label: ":ray-serve: serve: tests"
@@ -25,8 +25,7 @@ steps:
         --except-tags post_wheel_build,gpu,worker-container,xcommit
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name servebuild --test-env=EXPECTED_PYTHON_VERSION=3.8
-    depends_on: servebuild
-    job_env: forge
+    depends_on: "servebuild"
 
   - label: ":ray-serve: serve: pydantic < 2.0 tests"
     parallelism: 2
@@ -41,7 +40,6 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name servepydantic1build --test-env=EXPECTED_PYTHON_VERSION=3.8 --test-env=EXPECTED_PYDANTIC_VERSION=1.10.12
     depends_on: servepydantic1build
-    job_env: forge
 
   - label: ":ray-serve: serve: Python 3.11 tests"
     parallelism: 2
@@ -57,7 +55,6 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name servepython311build --test-env=EXPECTED_PYTHON_VERSION=3.11
     depends_on: servepython311build
-    job_env: forge
 
   - label: ":ray-serve: serve: release tests"
     tags:
@@ -67,7 +64,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //release/... serve --parallelism-per-worker 3
     depends_on: servebuild
-    job_env: forge
 
   - label: ":ray-serve: serve: wheel tests"
     tags: linux_wheels
@@ -81,6 +77,7 @@ steps:
     depends_on: 
       - manylinux
       - servebuild
+      - forge
 
   - label: ":ray-serve: serve: wheel-aarch64 tests"
     tags: linux_wheels
@@ -95,6 +92,7 @@ steps:
     depends_on: 
       - manylinux-aarch64
       - oss-ci-base_build-aarch64
+      - forge-aarch64
     job_env: forge-aarch64
 
   - label: ":ray-serve: serve: doc tests"
@@ -113,7 +111,6 @@ steps:
         --parallelism-per-worker 3
         --skip-ray-installation
     depends_on: servebuild
-    job_env: forge
 
   - label: ":ray-serve: serve: default minimal"
     tags: python
@@ -125,7 +122,6 @@ steps:
         --test-env=RAY_DEFAULT=1
         --only-tags minimal
     depends_on: minbuild-serve
-    job_env: forge
 
   - label: ":ray-serve: serve: serve minimal"
     tags:
@@ -139,7 +135,6 @@ steps:
         --test-env=RAY_DEFAULT=1
         --only-tags minimal
     depends_on: minbuild-serve
-    job_env: forge
 
   - label: ":ray-serve: serve: dashboard tests"
     tags: 
@@ -151,7 +146,6 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- python/ray/dashboard/... serve 
         --parallelism-per-worker 3
     depends_on: servebuild
-    job_env: forge
 
   - label: ":ray-serve: serve: doc gpu tests"
     tags: 
@@ -164,7 +158,6 @@ steps:
         --build-name docgpubuild
         --only-tags gpu
     depends_on: docgpubuild
-    job_env: forge
   
   - label: ":ray-serve: serve: flaky tests"
     tags: 
@@ -176,12 +169,10 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //... serve --run-flaky-tests --parallelism-per-worker 3
     depends_on: servebuild
-    job_env: forge
 
   - name: minbuild-serve
     label: "wanda: minbuild-{{matrix}}-py38"
     wanda: ci/docker/min.build.wanda.yaml
-    depends_on: oss-ci-base_build
     matrix:
       - serve
       - default

--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -5,6 +5,11 @@ steps:
     wanda: ci/docker/serverless.build.wanda.yaml
     depends_on: oss-ci-base_build
 
+  - wait: ~
+    depends_on:
+    - serverlessbuild
+    - forge
+
   # tests
   - label: ":serverless: serverless: python tests"
     tags: python
@@ -13,8 +18,6 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless 
         --parallelism-per-worker 3
         --except-tags manual,kuberay_operator,spark_plugin_tests
-    depends_on: serverlessbuild
-    job_env: forge
 
   - label: ":serverless: serverless: spark tests"
     tags: python
@@ -27,8 +30,15 @@ steps:
         --parallelism-per-worker 3
         --only-tags spark_plugin_tests
         --except-tags kubernetes 
-    depends_on: serverlessbuild
-    job_env: forge
+
+  - label: ":serverless: serverless: flaky tests"
+    tags:
+      - python
+      - skip-on-premerge
+    instance_type: medium
+    soft_fail: true
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //... serverless --run-flaky-tests  --parallelism-per-worker 3
 
   - label: ":serverless: serverless: ml tests"
     tags: python
@@ -39,16 +49,4 @@ steps:
         --parallelism-per-worker 2
         --only-tags client
         --test-env=RAY_CLIENT_MODE=1
-    depends_on: mlbuild
-    job_env: forge
-
-  - label: ":serverless: serverless: flaky tests"
-    tags: 
-      - python
-      - skip-on-premerge
-    instance_type: medium
-    soft_fail: true
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //... serverless --run-flaky-tests  --parallelism-per-worker 3
-    depends_on: serverlessbuild
-    job_env: forge
+    depends_on: [ "mlbuild", "forge" ]


### PR DESCRIPTION
jobs using forge needs to explicitly claim dependencies on the forge wanda buildkite job.

also `forge` is the default job env.

