### PR TITLE
[WIP] Unmark test_failure as flaky + use a dedicated decorator for skipping tests

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -2095,15 +2095,18 @@ def reset_autoscaler_v2_enabled_cache():
     u.cached_is_autoscaler_v2 = None
 
 
-def skip_flaky_test() -> bool:
+def skip_flaky_core_test_premerge(reason: str):
     """
-    Skip a test if it is flaky (e.g. in premerge)
+    Decorator to skip a test if it is flaky (e.g. in premerge)
 
     Default we will skip the flaky test if not specified otherwise in
     CI with CI_SKIP_FLAKY_TEST="0"
-
-
-    Returns:
-        bool: True if the test should be skipped
     """
-    return os.environ.get("CI_SKIP_FLAKY_TEST", "1") == "1"
+    import pytest
+
+    def wrapper(func):
+        return pytest.mark.skipif(
+            os.environ.get("CI_SKIP_FLAKY_TEST", "1") == "1", reason=reason
+        )(func)
+
+    return wrapper

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -13,7 +13,7 @@ from ray._private.test_utils import (
     run_string_as_driver,
     run_string_as_driver_nonblocking,
     wait_for_condition,
-    skip_flaky_test,
+    skip_flaky_core_test_premerge,
 )
 from ray.util.state import list_workers
 
@@ -55,10 +55,7 @@ def test_client(address):
         assert builder.address == address.replace("ray://", "")
 
 
-@pytest.mark.skipif(
-    skip_flaky_test(),
-    reason="https://github.com/ray-project/ray/issues/38224",
-)
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/38224")
 def test_namespace(ray_start_cluster):
     """
     Most of the "checks" in this test case rely on the fact that
@@ -108,9 +105,7 @@ print("Current namespace:", ray.get_runtime_context().namespace)
     subprocess.check_output("ray stop --force", shell=True)
 
 
-@pytest.mark.skipif(
-    skip_flaky_test(), reason="https://github.com/ray-project/ray/issues/38224"
-)
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/38224")
 def test_connect_to_cluster(ray_start_regular_shared):
     server = ray_client_server.serve("localhost:50055")
     with ray.client("localhost:50055").connect() as client_context:
@@ -335,9 +330,7 @@ def has_client_deprecation_warn(warning: Warning, expected_replacement: str) -> 
 @pytest.mark.filterwarnings(
     "default:Starting a connection through `ray.client` will be deprecated"
 )
-@pytest.mark.skipif(
-    skip_flaky_test(), reason="https://github.com/ray-project/ray/issues/38224"
-)
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/38224")
 def test_client_deprecation_warn():
     """
     Tests that calling ray.client directly raises a deprecation warning with

--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -16,7 +16,6 @@ from ray._private.test_utils import (
     wait_for_pid_to_exit,
     wait_for_condition,
     run_string_as_driver_nonblocking,
-    skip_flaky_test,
 )
 
 SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
@@ -240,10 +239,6 @@ def test_actor_failure_async_2(ray_start_regular, tmp_path):
     "ray_start_regular",
     [{"_system_config": {"timeout_ms_task_wait_for_death_info": 100000000}}],
     indirect=True,
-)
-@pytest.mark.skipif(
-    skip_flaky_test(),
-    reason="https://github.com/ray-project/ray/issues/41188",
 )
 def test_actor_failure_async_3(ray_start_regular):
     @ray.remote(max_restarts=1)

--- a/python/ray/tests/test_object_assign_owner.py
+++ b/python/ray/tests/test_object_assign_owner.py
@@ -3,7 +3,7 @@ import ray
 import time
 import numpy as np
 import os
-from ray._private.test_utils import skip_flaky_test
+from ray._private.test_utils import skip_flaky_core_test_premerge
 
 
 # https://github.com/ray-project/ray/issues/19659
@@ -155,10 +155,7 @@ def test_multiple_objects(ray_start_cluster):
     assert ray.get(owner.remote_get_object_refs.remote(borrower), timeout=60)
 
 
-# https://github.com/ray-project/ray/issues/30341
-@pytest.mark.skipif(
-    skip_flaky_test(), reason="https://github.com/ray-project/ray/issues/41175"
-)
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/41175")
 def test_owner_assign_inner_object(shutdown_only):
 
     ray.init()

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -8,7 +8,7 @@ import ray
 from ray._private.utils import get_ray_doc_version
 import ray.cluster_utils
 from ray._private.test_utils import placement_group_assert_no_leak
-from ray._private.test_utils import skip_flaky_test
+from ray._private.test_utils import skip_flaky_core_test_premerge
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
@@ -340,10 +340,7 @@ def test_placement_group_spread(
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
 @pytest.mark.parametrize("gcs_actor_scheduling_enabled", [False, True])
-@pytest.mark.skipif(
-    skip_flaky_test(),
-    reason="https://github.com/ray-project/ray/issues/38726",
-)
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/38726")
 def test_placement_group_strict_spread(
     ray_start_cluster, connect_to_client, gcs_actor_scheduling_enabled
 ):

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -12,7 +12,7 @@ import ray
 import ray.experimental.internal_kv as kv
 from ray._private.ray_constants import RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_ENV_VAR
 from ray._private.test_utils import chdir, check_local_files_gced, wait_for_condition
-from ray._private.test_utils import skip_flaky_test
+from ray._private.test_utils import skip_flaky_core_test_premerge
 from ray._private.utils import get_directory_size_bytes
 
 # This test requires you have AWS credentials set up (any AWS credentials will
@@ -250,10 +250,7 @@ class TestGC:
     @pytest.mark.parametrize(
         "source", [S3_PACKAGE_URI, lazy_fixture("tmp_working_dir")]
     )
-    @pytest.mark.skipif(
-        skip_flaky_test(),
-        reason="https://github.com/ray-project/ray/issues/40781",
-    )
+    @skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/40781")
     def test_detached_actor_gc(
         self,
         start_cluster,
@@ -348,10 +345,7 @@ class TestGC:
         wait_for_condition(lambda: check_local_files_gced(cluster, whitelist=whitelist))
         print("check_local_files_gced passed wait_for_condition block.")
 
-    @pytest.mark.skipif(
-        skip_flaky_test(),
-        reason="https://github.com/ray-project/ray/issues/40781",
-    )
+    @skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/40781")
     def test_hit_cache_size_limit(
         self, start_cluster, URI_cache_10_MB, disable_temporary_uri_pinning
     ):

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -20,7 +20,7 @@ from ray._private.test_utils import (
     format_web_url,
     wait_for_condition,
     wait_until_server_available,
-    skip_flaky_test,
+    skip_flaky_core_test_premerge,
 )
 
 from ray._private.ray_constants import (
@@ -1273,10 +1273,7 @@ def test_log_get(ray_start_cluster):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Windows has logging race from tasks."
 )
-@pytest.mark.skipif(
-    skip_flaky_test(),
-    reason="https://github.com/ray-project/ray/issues/40959",
-)
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/40959")
 def test_log_task(shutdown_only):
     from ray.runtime_env import RuntimeEnv
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Unmark test_failure as flaky + use a dedicated decorator for skipping tests

Waiting for CI to see if it works 

## Related issue number

Closes https://github.com/ray-project/ray/issues/41188

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
