### PR TITLE
[ci] use conda-forge to install libffi

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -29,9 +29,6 @@ RUN apt-get update -y \
 
 USER $RAY_UID
 ENV HOME=/home/ray
-# Todo (krfricke): Move to latest miniconda version once we stop building
-# images for Python 3.7.
-# https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${HOSTTYPE}.sh
 
 SHELL ["/bin/bash", "-c"]
 RUN sudo apt-get update -y && sudo apt-get upgrade -y \
@@ -49,22 +46,15 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
         netbase \
         openssh-client \
         gnupg; fi) \
-    && if [[ "${PYTHON_VERSION}" = "3.11" || "${PYTHON_VERSION}" =~ ^3\.11\. ]]; then \
-            MINICONDA_VERSION="py311_23.10.0-1"; \
-            LIBGCC=(libgcc-ng); \
-        else \
-            MINICONDA_VERSION="py37_23.1.0-1"; \
-            # TODO (can): Remove libffi=3.3 once #33299 is resolved
-            LIBGCC=(libgcc-ng libffi=3.3); \
-        fi \
     && wget --quiet \
-        "https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-${HOSTTYPE}.sh" \
+        "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.10.0-1-Linux-${HOSTTYPE}.sh" \
         -O /tmp/miniconda.sh \
     && /bin/bash /tmp/miniconda.sh -b -u -p $HOME/anaconda3 \
     && $HOME/anaconda3/bin/conda init \ 
     && echo 'export PATH=$HOME/anaconda3/bin:$PATH' >> /home/ray/.bashrc \
     && rm /tmp/miniconda.sh  \
-    && $HOME/anaconda3/bin/conda install -y "${LIBGCC[@]}" python=$PYTHON_VERSION \
+    && $HOME/anaconda3/bin/conda install -y libgcc-ng python=$PYTHON_VERSION \
+    && $HOME/anaconda3/bin/conda install -y -c conda-forge libffi=3.4.2 \
     && $HOME/anaconda3/bin/conda clean -y --all \
     && $HOME/anaconda3/bin/pip install --no-cache-dir \
         flatbuffers \


### PR DESCRIPTION
Install libffi from conda-forge; libfii from conda default is buggy (see: https://github.com/AnacondaRecipes/libffi-feedstock/issues/15#issuecomment-1607798561)

Test:
- CI