### PR TITLE
[vSphere] Add timestamp suffixes to the frozen VMs when they are deployed from OVF

### DIFF
--- a/python/ray/autoscaler/_private/vsphere/node_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/node_provider.py
@@ -32,7 +32,7 @@ from ray.autoscaler._private.vsphere.gpu_utils import (
 )
 from ray.autoscaler._private.vsphere.pyvmomi_sdk_provider import PyvmomiSdkProvider
 from ray.autoscaler._private.vsphere.scheduler import SchedulerFactory
-from ray.autoscaler._private.vsphere.utils import Constants, is_ipv4
+from ray.autoscaler._private.vsphere.utils import Constants, is_ipv4, now_ts
 from ray.autoscaler._private.vsphere.vsphere_sdk_provider import VsphereSdkProvider
 from ray.autoscaler.node_provider import NodeProvider
 from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME
@@ -471,7 +471,7 @@ class VsphereNodeProvider(NodeProvider):
                 node_config_frozen_vm = copy.deepcopy(node_config)
                 node_config_frozen_vm["host_id"] = host.host
 
-                frozen_vm_name = "{}-{}".format(name, host.name)
+                frozen_vm_name = "{}-{}-{}".format(name, host.name, now_ts())
                 vm_names.append(frozen_vm_name)
 
                 futures_frozen_vms.append(

--- a/python/ray/autoscaler/_private/vsphere/utils.py
+++ b/python/ray/autoscaler/_private/vsphere/utils.py
@@ -1,5 +1,6 @@
 import ipaddress
 import time
+from datetime import datetime
 from enum import Enum
 
 
@@ -49,3 +50,7 @@ def singleton_client(cls):
         return instances[cls][0]
 
     return get_instance
+
+
+def now_ts():
+    return datetime.now().strftime("%Y%m%d-%H%M%S")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This can help better versioning the frozen VMs deployed from OVF, otherwise the names are always the same.

## Test

![Screenshot 2023-11-23 at 09 33 56](https://github.com/ray-project/ray/assets/15973672/fb3a9a70-2367-4a3b-9fef-21040f5bbf10)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
