### PR TITLE
[Data] Fix timeout on `read_images_train_4_gpu_chaos` release test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5767,7 +5767,7 @@
     cluster_compute: multi_node_train_4_workers.yaml
 
   run:
-    timeout: 21600
+    timeout: 18000
     script: python multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu --num-epochs 3
 
   variations:
@@ -5791,8 +5791,8 @@
     cluster_compute: dataset/multi_node_train_4_workers.yaml
 
   run:
-    timeout: 21600
-    prepare: python setup_chaos.py --kill-workers --kill-interval 50 --max-to-kill 20 --task-names "ReadImage->Map(crop_and_flip_image)"
+    timeout: 18000
+    prepare: python setup_chaos.py --kill-workers --kill-interval 200 --max-to-kill 50 --task-names "ReadImage->Map(wnid_to_index)->Map(crop_and_flip_image)"
     script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu --num-epochs 3
 
   variations:
@@ -5816,7 +5816,7 @@
     cluster_compute: multi_node_train_16_workers.yaml
 
   run:
-    timeout: 21600
+    timeout: 18000
     script: python multi_node_train_benchmark.py --num-workers 16 --file-type image --use-gpu
 
   variations:
@@ -5840,7 +5840,7 @@
     cluster_compute: multi_node_train_16_workers.yaml
 
   run:
-    timeout: 21600
+    timeout: 18000
     script: python multi_node_train_benchmark.py --num-workers 16 --file-type image --preserve-order --use-gpu
 
   variations:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5791,9 +5791,9 @@
     cluster_compute: dataset/multi_node_train_4_workers.yaml
 
   run:
-    timeout: 3600
+    timeout: 21600
     prepare: python setup_chaos.py --kill-workers --kill-interval 50 --max-to-kill 20 --task-names "ReadImage->Map(crop_and_flip_image)"
-    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image
+    script: python dataset/multi_node_train_benchmark.py --num-workers 4 --file-type image --use-gpu --num-epochs 3
 
   variations:
     - __suffix__: aws


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Increase the timeout on the newly added `read_images_train_4_gpu_chaos` test, which is needed due to the changes made in https://github.com/ray-project/ray/pull/41034 (written/merged in parallel). More time is needed because the aforementioned PR adds a model to train in the training loop (previously just iterated over the dataset).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests https://buildkite.com/ray-project/release/builds/2176
   - [ ] This PR is not tested :(
