### PR TITLE
[ci] fix python 311 dependencies

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -53,7 +53,7 @@ prometheus_client>=0.7.1
 requests
 pandas
 tensorboardX<=2.6.0,>=1.9  # >=2.6.1 uses protobuf>=4, and conflicts with other packages.
-aiohttp>=3.7
+aiohttp>=3.7,<3.9
 starlette
 typer
 fsspec

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -46,7 +46,7 @@ aiofiles==22.1.0
     #   aim
     #   gradio
     #   ypy-websocket
-aiohttp==3.9.0
+aiohttp==3.8.6
     # via
     #   -r /ray/ci/../python/requirements.txt
     #   aiobotocore
@@ -146,7 +146,7 @@ autorom==0.6.1 ; platform_machine != "arm64"
     # via -r /ray/ci/../python/requirements/ml/rllib-test-requirements.txt
 autorom-accept-rom-license==0.6.1
     # via autorom
-aws-sam-translator==1.80.0
+aws-sam-translator==1.81.0
     # via cfn-lint
 aws-xray-sdk==2.12.1
     # via moto
@@ -263,7 +263,9 @@ cffi==1.16.0
 cfn-lint==0.83.3
     # via moto
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   aiohttp
+    #   requests
 chess==1.7.0
     # via -r /ray/ci/../python/requirements/ml/rllib-test-requirements.txt
 chex==0.1.7
@@ -532,7 +534,7 @@ flatbuffers==2.0.7
     #   tf2onnx
 flax==0.7.2
     # via dopamine-rl
-fonttools==4.45.0
+fonttools==4.45.1
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
@@ -749,7 +751,7 @@ humanfriendly==10.0
     #   coloredlogs
 hyperopt==0.2.7
     # via -r /ray/ci/../python/requirements/ml/tune-requirements.txt
-idna==3.4
+idna==3.5
     # via
     #   anyio
     #   httpx
@@ -797,7 +799,7 @@ importlib-resources==5.13.0
     #   tensorflow-datasets
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.27.0
+ipykernel==6.26.0
     # via
     #   nbclassic
     #   notebook
@@ -969,7 +971,7 @@ jupyterlab==3.6.1
     # via
     #   -r /ray/ci/../python/requirements/anyscale-requirements.txt
     #   -r /ray/ci/../python/requirements/ml/tune-test-requirements.txt
-jupyterlab-pygments==0.2.2
+jupyterlab-pygments==0.3.0
     # via nbconvert
 jupyterlab-server==2.24.0
     # via jupyterlab
@@ -2044,7 +2046,7 @@ send2trash==1.8.2
     #   notebook
 sentencepiece==0.1.96
     # via -r /ray/ci/../python/requirements/ml/train-test-requirements.txt
-sentry-sdk==1.36.0
+sentry-sdk==1.37.1
     # via
     #   comet-ml
     #   wandb


### PR DESCRIPTION
Fix forward https://github.com/ray-project/ray/commit/b9932a8ee024647a93f320ddeb3734fb77f54f17 which broke all py311 release tests

Test:
- release