### PR TITLE
Relax check_version_info to check for bytecode compatibility

### DIFF
--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -401,14 +401,10 @@ def _generate_cluster_metadata(*, ray_init_cluster: bool):
     Params:
         ray_init_cluster: Whether the cluster is started by ray.init()
     """
-    ray_version, python_version = ray._private.utils.compute_version_info()
-    # These two metadata is necessary although usage report is not enabled
-    # to check version compatibility.
-    metadata = {
-        "ray_version": ray_version,
-        "python_version": python_version,
-        "ray_init_cluster": ray_init_cluster,
-    }
+    # These metadata items are recorded to check version compatibility.
+    # They are necessary whether or not usage stats are enabled.
+    metadata = asdict(ray._private.utils.compute_version_info())
+    metadata["ray_init_cluster"] = ray_init_cluster
     # Additional metadata is recorded only when usage stats are enabled.
     if usage_stats_enabled():
         metadata.update(
@@ -419,7 +415,7 @@ def _generate_cluster_metadata(*, ray_init_cluster: bool):
             }
         )
         if sys.platform == "linux":
-            # Record llibc version
+            # Record libc version
             (lib, ver) = platform.libc_ver()
             if not lib:
                 metadata.update({"libc_version": "NA"})

--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -853,8 +853,9 @@ def test_usage_lib_cluster_metadata_generation_usage_disabled(
         meta = ray_usage_lib._generate_cluster_metadata(ray_init_cluster=False)
         assert "ray_version" in meta
         assert "python_version" in meta
+        assert "python_magic_number" in meta
         assert "ray_init_cluster" in meta
-        assert len(meta) == 3
+        assert len(meta) == 4
 
 
 def test_usage_lib_get_total_num_running_jobs_to_report(
@@ -1167,9 +1168,9 @@ provider:
             print_dashboard_log()
             raise
         payload = usage_stats_server.report_payload
-        ray_version, python_version = ray._private.utils.compute_version_info()
-        assert payload["ray_version"] == ray_version
-        assert payload["python_version"] == python_version
+        version_info = ray._private.utils.compute_version_info()
+        assert payload["ray_version"] == version_info.ray_version
+        assert payload["python_version"] == version_info.python_version
         assert payload["schema_version"] == "0.1"
         assert payload["os"] == sys.platform
         if sys.platform != "linux":

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -122,7 +122,6 @@ class _ClientContext:
             conn_info,
             "Ray Client",
             raise_on_mismatch=not ignore_version,
-            python_version_match_level="minor",
         )
 
     def disconnect(self):


### PR DESCRIPTION
As discussed in #3988, the intention of check_version_info is to ensure that cloudpickle can transfer objects across the two Python interpreters. Because cloudpickle serializes Python bytecode, it is known to be incompatible across minor versions (e.g., 3.11 to 3.12) but should be compatible across patch versions (e.g., 3.12.0 to 3.12.1).

The intention of the CPython team is that bytecode should be compatible within patch releases to the same minor version. This was last broken in 3.5.3, which was regarded as a mistake: see the commit message of python/cpython@93602e3af70d3b9f98ae2da654b16b3382b68d50 (in 3.5.10), which implies that it is reasonable to "rel[y] on pre-cached bytecode remaining valid across maintenance releases."

The constant importlib.util.MAGIC_NUMBER is used by Python to identify bytecode compatibility (it is stored in .pyc files and checked when they are loaded). The unwanted change in 3.5.3 bumped MAGIC_NUMBER, but since then, it has only changed between minor versions. See the long comment in CPython's Lib/importlib/_bootstrap_external.py for a history of the changes.

So, the practical effect of checking MAGIC_NUMBER will generally be to enforce that nodes run the same minor version of Python, but if some future patch release unexpectedly does break bytecode compatibility, checking MAGIC_NUMBER will account for that.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This allows using interpreters at the same minor version but a different patch version, as requested in #3988.

## Related issue number

Closes #3988.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
  - but I ran `black` by hand
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [X] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - I did some manual tests and will let CI get the rest of it.
