### PR TITLE
[Dashboard] Fix Path Resolution on Windows

### DIFF
--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -130,13 +130,15 @@ class HttpServerDashboardHead:
     @aiohttp.web.middleware
     async def path_clean_middleware(self, request, handler):
         if request.path.startswith("/static") or request.path.startswith("/logs"):
-            parent = pathlib.Path(
+            parent = pathlib.PurePosixPath(
                 "/logs" if request.path.startswith("/logs") else "/static"
             )
 
             # If the destination is not relative to the expected directory,
             # then the user is attempting path traversal, so deny the request.
-            request_path = pathlib.Path(request.path).resolve()
+            request_path = pathlib.PurePosixPath(
+                pathlib.posixpath.realpath(request.path)
+            )
             if request_path != parent and parent not in request_path.parents:
                 raise aiohttp.web.HTTPForbidden()
         return await handler(request)

--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -140,6 +140,9 @@ class HttpServerDashboardHead:
                 pathlib.posixpath.realpath(request.path)
             )
             if request_path != parent and parent not in request_path.parents:
+                logger.info(
+                    f"Rejecting {request_path=} because it is not relative to {parent=}"
+                )
                 raise aiohttp.web.HTTPForbidden()
         return await handler(request)
 


### PR DESCRIPTION
## Why are these changes needed?
https://github.com/ray-project/ray/pull/39018/ makes an implicit assumption that the host OS is **Posix** and that path resolution follows Posix convention. I don't actually need any of the 'host-specific' aspects of `pathlib` and only want the Pure Posix path semantics.

## Related issue number

Closes #41379

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
