### PR TITLE
[Serve] Fix HTTP failure to Serve Java replica

### DIFF
--- a/java/serve/src/test/java/io/ray/serve/deployment/DeploymentTest.java
+++ b/java/serve/src/test/java/io/ray/serve/deployment/DeploymentTest.java
@@ -36,7 +36,7 @@ public class DeploymentTest extends BaseServeTest2 {
     Assert.assertTrue((boolean) handle.method("checkHealth").remote().result());
   }
 
-  @Test(enabled = false)
+  @Test
   public void httpExposeDeploymentTest() throws IOException {
     // Deploy deployment.
     String deploymentName = "exampleEcho";
@@ -91,8 +91,8 @@ public class DeploymentTest extends BaseServeTest2 {
   public void autoScaleTest() {
     String deploymentName = "exampleEcho";
     AutoscalingConfig autoscalingConfig = new AutoscalingConfig();
-    autoscalingConfig.setMinReplicas(2);
-    autoscalingConfig.setMaxReplicas(5);
+    autoscalingConfig.setMinReplicas(1);
+    autoscalingConfig.setMaxReplicas(3);
     autoscalingConfig.setTargetNumOngoingRequestsPerReplica(10);
     Application deployment =
         Serve.deployment()

--- a/java/serve/src/test/java/io/ray/serve/docdemo/test/HttpStrategyCalcOnRayServeTest.java
+++ b/java/serve/src/test/java/io/ray/serve/docdemo/test/HttpStrategyCalcOnRayServeTest.java
@@ -39,9 +39,7 @@ public class HttpStrategyCalcOnRayServeTest extends BaseServeTest {
     }
   }
 
-  @Test(
-      enabled = false,
-      groups = {"cluster"})
+  @Test(groups = {"cluster"})
   public void test() {
     String prefix = "HttpStrategyCalcOnRayServeTest";
     String bank1 = prefix + "_bank_1";

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -39,6 +39,7 @@ from ray.serve._private.utils import (
     override_runtime_envs_except_env_vars,
 )
 from ray.serve.exceptions import RayServeException
+from ray.serve.generated.serve_pb2 import DeploymentLanguage
 from ray.serve.schema import DeploymentDetails, ServeApplicationSchema
 from ray.types import ObjectRef
 
@@ -306,9 +307,16 @@ class ApplicationState:
             config = deployment_info.deployment_config
             self._endpoint_state.update_endpoint(
                 deployment_id,
+                # The current meaning of the "is_cross_language" field is ambiguous.
+                # We will work on optimizing and removing this field in the future.
+                # Instead of using the "is_cross_language" field, we will directly
+                # compare if the replica is Python, which will assist the Python
+                # router in determining if the replica invocation is a cross-language
+                # operation.
                 EndpointInfo(
                     route=deployment_info.route_prefix,
-                    app_is_cross_language=config.is_cross_language,
+                    app_is_cross_language=config.deployment_language
+                    != DeploymentLanguage.PYTHON,
                 ),
             )
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, the deployed Serve Java Application fails to be accessed via HTTP due to an issue with the use of `is_cross_language`. The Proxy Router does not correctly determine whether the replica invocation is cross-language or not.

```
ERROR 2023-11-27 14:55:04,648 proxy 127.0.0.1 235b4018-2a3e-4730-a692-b141441ed107 /exampleEcho default proxy.py:1028 - Streaming not supported for Java.
Traceback (most recent call last):
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/_private/proxy.py", line 962, in send_request_to_replica
    async for asgi_message_batch in response_generator:
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/_private/proxy_response_generator.py", line 111, in __anext__
    raise e from None
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/_private/proxy_response_generator.py", line 91, in __anext__
    result = await self._get_next_streaming_result()
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/_private/proxy_response_generator.py", line 134, in _get_next_streaming_result
    return next_result_task.result()
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/_private/proxy_response_generator.py", line 116, in _await_response_anext
    return await self._response.__anext__()
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/handle.py", line 777, in __anext__
    self._obj_ref_gen = await self._to_object_ref_gen(_record_telemetry=False)
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/handle.py", line 802, in _to_object_ref_gen
    return await self._to_object_ref_or_gen(_record_telemetry=_record_telemetry)
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/handle.py", line 520, in _to_object_ref_or_gen
    return await asyncio.wrap_future(self._object_ref_future)
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/_private/router.py", line 1023, in assign_request
    return await self._replica_scheduler.assign_replica(query)
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/_private/router.py", line 890, in assign_replica
    return replica.send_query(query)
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/_private/router.py", line 251, in send_query
    return self._send_query_java(query)
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/_private/router.py", line 217, in _send_query_java
    raise RuntimeError("Streaming not supported for Java.")
RuntimeError: Streaming not supported for Java.
ERROR:    ASGI callable returned without starting response.
```

This PR uses `deployment_language` for now to make the determination and will continue to optimize the use of `is_cross_language` in the future.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
