### PR TITLE
worker pool disconnect when worker exit

### DIFF
--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -361,6 +361,8 @@ message ExitRequest {
   /// Whether to force exit the worker, regardless of whether the core worker
   /// owns object.
   bool force_exit = 1;
+  bytes worker_id = 2;
+  bool disconnect = 3;
 }
 
 message ExitReply {

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1112,6 +1112,7 @@ void WorkerPool::KillIdleWorker(std::shared_ptr<WorkerInterface> idle_worker,
                   << idle_worker->WorkerId();
     request.set_force_exit(true);
   }
+  request.set_worker_id(idle_worker->WorkerId().Binary());
   rpc_client->Exit(
       request,
       [this, idle_worker, last_time_used_ms](const ray::Status &status,

--- a/src/ray/rpc/worker/core_worker_client_pool.cc
+++ b/src/ray/rpc/worker/core_worker_client_pool.cc
@@ -53,5 +53,21 @@ void CoreWorkerClientPool::Disconnect(ray::WorkerID id) {
   client_map_.erase(it);
 }
 
+void CoreWorkerClientPool::DisconnectAll(ray::WorkerID id) {
+  // disconnect
+  for (auto it : client_map_) {
+    auto conn = it->second;
+    rpc::ExitRequest request;
+    request.set_disconnect(true);
+    request.set_worker_id(id.Binary());
+    conn->Exit(request,
+    [this](const ray::Status &status, const rpc::ExitReply &r) {
+        if (!status.ok()) {
+          RAY_LOG(ERROR) << "Failed to send exit request: " << status.ToString();
+        }
+      })
+  }
+}
+
 }  // namespace rpc
 }  // namespace ray

--- a/src/ray/rpc/worker/core_worker_client_pool.h
+++ b/src/ray/rpc/worker/core_worker_client_pool.h
@@ -53,6 +53,8 @@ class CoreWorkerClientPool {
   /// be open until it's no longer used, at which time it will disconnect.
   void Disconnect(ray::WorkerID id);
 
+  void DisconnectAll(ray::WorkerID id);
+
  private:
   /// Provides the default client factory function. Providing this function to the
   /// construtor aids migration but is ultimately a thing that should be


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
memory leak cause by `client_map_`. Details: https://github.com/ray-project/ray/issues/41260

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
