### PR TITLE
[serve] Fix Java Replica shutdown error

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -690,13 +690,7 @@ class ActorReplicaWrapper:
 
         Returns the timeout after which to kill the actor.
         """
-        try:
-            handle = ray.get_actor(self._actor_name, namespace=SERVE_NAMESPACE)
-            self._graceful_shutdown_ref = handle.prepare_for_shutdown.remote()
-        except ValueError:
-            # ValueError thrown from ray.get_actor means actor has already been deleted.
-            pass
-
+        self._graceful_shutdown_ref = self._actor_handle.prepare_for_shutdown.remote()
         return self.graceful_shutdown_timeout_s
 
     def check_stopped(self) -> bool:

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -698,6 +698,7 @@ class ActorReplicaWrapper:
         except ValueError:
             # ValueError thrown from ray.get_actor means actor has already been deleted.
             pass
+
         return self.graceful_shutdown_timeout_s
 
     def check_stopped(self) -> bool:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

During the shutdown of the Java replica, exceptions are observed in the logs:

```
ERROR 2023-11-27 17:05:03,198 controller 17683 deployment_state.py:711 - Exception when trying to gracefully shutdown replica:
Traceback (most recent call last):
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/_private/deployment_state.py", line 709, in check_stopped
    ray.get(self._graceful_shutdown_ref)
  File "/Users/liuyang/Codes/ray-as/python/ray/_private/auto_init_hook.py", line 24, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/Users/liuyang/Codes/ray-as/python/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
  File "/Users/liuyang/Codes/ray-as/python/ray/_private/worker.py", line 2597, in get
    raise value
ray.exceptions.CrossLanguageError: An exception raised from JAVA:
io.ray.api.exception.RayTaskException: (pid=17696, ip=30.231.36.240) Function io.ray.serve.replica.RayServeWrappedReplica.prepare_for_shutdown.0 of task 3199ac5176bb979606c69ce885352107c6ad320901000000 doesn't exist
	at io.ray.runtime.task.TaskExecutor.execute(TaskExecutor.java:210)
	at io.ray.runtime.RayNativeRuntime.nativeRunTaskExecutor(Native Method)
	at io.ray.runtime.RayNativeRuntime.run(RayNativeRuntime.java:231)
	at io.ray.runtime.runner.worker.DefaultWorker.main(DefaultWorker.java:15)
Caused by: java.lang.NullPointerException
	at io.ray.runtime.functionmanager.FunctionManager$JobFunctionTable.getFunction(FunctionManager.java:173)
	at io.ray.runtime.functionmanager.FunctionManager.getFunction(FunctionManager.java:100)
	at io.ray.runtime.task.TaskExecutor.getRayFunction(TaskExecutor.java:66)
	at io.ray.runtime.task.TaskExecutor.execute(TaskExecutor.java:116)
	... 3 more

Traceback (most recent call last):
  File "/Users/liuyang/Codes/ray-as/python/ray/serve/_private/deployment_state.py", line 709, in check_stopped
    ray.get(self._graceful_shutdown_ref)
  File "/Users/liuyang/Codes/ray-as/python/ray/_private/auto_init_hook.py", line 24, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/Users/liuyang/Codes/ray-as/python/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
  File "/Users/liuyang/Codes/ray-as/python/ray/_private/worker.py", line 2597, in get
    raise value
ray.exceptions.CrossLanguageError: An exception raised from JAVA:
io.ray.api.exception.RayTaskException: (pid=17696, ip=30.231.36.240) Function io.ray.serve.replica.RayServeWrappedReplica.prepare_for_shutdown.0 of task 3199ac5176bb979606c69ce885352107c6ad320901000000 doesn't exist
	at io.ray.runtime.task.TaskExecutor.execute(TaskExecutor.java:210)
	at io.ray.runtime.RayNativeRuntime.nativeRunTaskExecutor(Native Method)
	at io.ray.runtime.RayNativeRuntime.run(RayNativeRuntime.java:231)
	at io.ray.runtime.runner.worker.DefaultWorker.main(DefaultWorker.java:15)
Caused by: java.lang.NullPointerException
	at io.ray.runtime.functionmanager.FunctionManager$JobFunctionTable.getFunction(FunctionManager.java:173)
	at io.ray.runtime.functionmanager.FunctionManager.getFunction(FunctionManager.java:100)
	at io.ray.runtime.task.TaskExecutor.getRayFunction(TaskExecutor.java:66)
	at io.ray.runtime.task.TaskExecutor.execute(TaskExecutor.java:116)
	... 3 more
```

While there is a fallback actor kill logic in place, the Java replica is not being prepared for shutdown. This PR addresses this issue and fixes it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
