### PR TITLE
added entrypoint_memory to openapi.yml

### DIFF
--- a/doc/source/cluster/running-applications/job-submission/openapi.yml
+++ b/doc/source/cluster/running-applications/job-submission/openapi.yml
@@ -411,6 +411,9 @@ components:
         entrypoint_num_gpus:
           type: number
           description: "Number of GPUs to allocate for the execution of the entrypoint command, separately from any Ray tasks or actors that are created by it."
+        entrypoint_memory:
+          type: integer
+          description: "The quantity of memory to reserve for the execution of the entrypoint command, separately from any tasks or actors launched by it."
         entrypoint_resources:
           type: object
           description: "The quantity of various custom resources to allocate for the execution of the entrypoint command, separately from any Ray tasks or actors that are created by it."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

for the openAPI the documentation was missing an input variable entrypoint_memory and a description of what that is, I used the info at [here](https://docs.ray.io/en/latest/cluster/running-applications/job-submission/doc/ray.job_submission.JobSubmissionClient.submit_job.html#ray-job-submission-jobsubmissionclient-submit-job) to create a descriptor.

## Related issue number

closes #41277

## Checks

- [ + ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ + ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ + ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ + ] This PR is not tested :(
   - ---> only because it's just a small edit to the openapi.yml
