### PR TITLE
[data] fix flaky test_stats_manager

### DIFF
--- a/python/ray/data/_internal/execution/autoscaling_requester.py
+++ b/python/ray/data/_internal/execution/autoscaling_requester.py
@@ -106,6 +106,11 @@ class AutoscalingRequester:
         self._timeout = ttl
 
 
+# Creating/getting an actor from multiple threads is not safe.
+# https://github.com/ray-project/ray/issues/41324
+_autoscaling_requester_lock: threading.RLock = threading.RLock()
+
+
 def get_or_create_autoscaling_requester_actor():
     ctx = DataContext.get_current()
     scheduling_strategy = ctx.scheduling_strategy
@@ -117,10 +122,11 @@ def get_or_create_autoscaling_requester_actor():
         soft=True,
         _spill_on_unavailable=True,
     )
-    return AutoscalingRequester.options(
-        name="AutoscalingRequester",
-        namespace="AutoscalingRequester",
-        get_if_exists=True,
-        lifetime="detached",
-        scheduling_strategy=scheduling_strategy,
-    ).remote()
+    with _autoscaling_requester_lock:
+        return AutoscalingRequester.options(
+            name="AutoscalingRequester",
+            namespace="AutoscalingRequester",
+            get_if_exists=True,
+            lifetime="detached",
+            scheduling_strategy=scheduling_strategy,
+        ).remote()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I forgot to lock the `AutoscalingRequester` too as part of #41299.

Now `test_stats.py` hopefully shouldn't be flaky. It passed 14 times [here](https://buildkite.com/ray-project/premerge/builds/12882) (I temporarily added the flaky test back in this commit).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #41412

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
