### PR TITLE
add worker num paused tasks api

### DIFF
--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -196,6 +196,12 @@ class StateAPIManager:
                         match = datum[filter_column] == convert_string_to_type(
                             filter_value, bool
                         )
+                    elif isinstance(filter_value, str) and isinstance(
+                        datum[filter_column], int
+                    ):
+                        match = datum[filter_column] == convert_string_to_type(
+                            filter_value, int
+                        )
                     else:
                         match = datum[filter_column] == filter_value
                 elif filter_predicate == "!=":

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -685,6 +685,40 @@ class GlobalState:
             worker_id, debugger_port
         )
 
+    def get_worker_debugger_port(self, worker_id):
+        """Get the debugger port of a worker.
+
+        Args:
+            worker_id: ID of this worker. Type is bytes.
+
+        Returns:
+             Debugger port of the worker.
+        """
+        self._check_connected()
+
+        assert worker_id is not None, "worker_id is not valid"
+
+        return self.global_state_accessor.get_worker_debugger_port(worker_id)
+
+    def update_worker_num_paused_threads(self, worker_id, num_paused_threads_delta):
+        """Updates the number of paused threads of a worker.
+
+        Args:
+            worker_id: ID of this worker. Type is bytes.
+            num_paused_threads_delta: The delta of the number of paused threads.
+
+        Returns:
+             Is operation success
+        """
+        self._check_connected()
+
+        assert worker_id is not None, "worker_id is not valid"
+        assert num_paused_threads_delta is not None, "worker_id is not valid"
+
+        return self.global_state_accessor.update_worker_num_paused_threads(
+            worker_id, num_paused_threads_delta
+        )
+
     def cluster_resources(self):
         """Get the current total cluster resources.
 
@@ -967,3 +1001,28 @@ def update_worker_debugger_port(worker_id, debugger_port):
          Is operation success
     """
     return state.update_worker_debugger_port(worker_id, debugger_port)
+
+
+def update_worker_num_paused_threads(worker_id, num_paused_threads_delta):
+    """Update the number of paused threads of a worker.
+
+    Args:
+        worker_id: ID of this worker. Type is bytes.
+        num_paused_threads_delta: The delta of the number of paused threads.
+
+    Returns:
+         Is operation success
+    """
+    return state.update_worker_num_paused_threads(worker_id, num_paused_threads_delta)
+
+
+def get_worker_debugger_port(worker_id):
+    """Get the debugger port of a worker.
+
+    Args:
+        worker_id: ID of this worker. Type is bytes.
+
+    Returns:
+         Debugger port of the worker.
+    """
+    return state.get_worker_debugger_port(worker_id)

--- a/python/ray/includes/global_state_accessor.pxd
+++ b/python/ray/includes/global_state_accessor.pxd
@@ -40,6 +40,9 @@ cdef extern from "ray/gcs/gcs_client/global_state_accessor.h" nogil:
         c_bool AddWorkerInfo(const c_string &serialized_string)
         c_bool UpdateWorkerDebuggerPort(const CWorkerID &worker_id,
                                         const c_uint32_t debuger_port)
+        c_bool UpdateWorkerNumPausedThreads(const CWorkerID &worker_id,
+                                            const c_int32_t num_paused_threads_delta)
+        c_uint32_t GetWorkerDebuggerPort(const CWorkerID &worker_id)
         unique_ptr[c_string] GetPlacementGroupInfo(
             const CPlacementGroupID &placement_group_id)
         unique_ptr[c_string] GetPlacementGroupByName(

--- a/python/ray/includes/global_state_accessor.pxi
+++ b/python/ray/includes/global_state_accessor.pxi
@@ -24,7 +24,7 @@ from ray.includes.optional cimport (
     make_optional
 )
 
-from libc.stdint cimport uint32_t as c_uint32_t
+from libc.stdint cimport uint32_t as c_uint32_t, int32_t as c_int32_t
 from libcpp.string cimport string as c_string
 from libcpp.memory cimport make_unique as c_make_unique
 
@@ -175,6 +175,13 @@ cdef class GlobalStateAccessor:
             result = self.inner.get().AddWorkerInfo(cserialized_string)
         return result
 
+    def get_worker_debugger_port(self, worker_id):
+        cdef c_uint32_t result
+        cdef CWorkerID cworker_id = CWorkerID.FromBinary(worker_id.binary())
+        with nogil:
+            result = self.inner.get().GetWorkerDebuggerPort(cworker_id)
+        return result
+
     def update_worker_debugger_port(self, worker_id, debugger_port):
         cdef c_bool result
         cdef CWorkerID cworker_id = CWorkerID.FromBinary(worker_id.binary())
@@ -183,6 +190,16 @@ cdef class GlobalStateAccessor:
             result = self.inner.get().UpdateWorkerDebuggerPort(
                 cworker_id,
                 cdebugger_port)
+        return result
+
+    def update_worker_num_paused_threads(self, worker_id, num_paused_threads_delta):
+        cdef c_bool result
+        cdef CWorkerID cworker_id = CWorkerID.FromBinary(worker_id.binary())
+        cdef c_int32_t cnum_paused_threads_delta = num_paused_threads_delta
+
+        with nogil:
+            result = self.inner.get().UpdateWorkerNumPausedThreads(
+                cworker_id, cnum_paused_threads_delta)
         return result
 
     def get_placement_group_table(self):

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -130,6 +130,7 @@ py_test_module_list(
     "test_nested_task.py",
     "test_metrics.py",
     "test_task_events.py",
+    "test_worker_state.py",
     "test_task_events_2.py",
     "test_task_metrics.py",
     "test_task_metrics_reconstruction.py",

--- a/python/ray/tests/test_worker_state.py
+++ b/python/ray/tests/test_worker_state.py
@@ -1,0 +1,165 @@
+import os
+import pytest
+import sys
+import threading
+
+import ray
+from ray._private.test_utils import (
+    wait_for_condition,
+)
+from ray.util.state import list_workers
+
+
+_SYSTEM_CONFIG = {
+    "task_events_report_interval_ms": 100,
+    "metrics_report_interval_ms": 200,
+    "enable_timeline": False,
+    "gcs_mark_task_failed_on_job_done_delay_ms": 1000,
+}
+
+
+def test_worker_paused(shutdown_only):
+    ray.init(num_cpus=1, _system_config=_SYSTEM_CONFIG)
+
+    @ray.remote(max_retries=0)
+    def f():
+        import time
+
+        # Pause 5 seconds inside debugger
+        with ray._private.worker.global_worker.worker_paused_by_debugger():
+            time.sleep(5)
+
+    def verify(num_paused):
+        workers = list_workers(
+            filters=[("num_paused_threads", "=", num_paused)], detail=True
+        )
+        if len(workers) == 0:
+            return False
+        worker = workers[0]
+        return worker.num_paused_threads == num_paused
+
+    f_task = f.remote()  # noqa
+
+    wait_for_condition(
+        verify,
+        timeout=20,
+        retry_interval_ms=100,
+        num_paused=1,
+    )
+    wait_for_condition(
+        verify,
+        timeout=20,
+        retry_interval_ms=100,
+        num_paused=0,
+    )
+
+
+@pytest.mark.parametrize("actor_concurrency", [1, 3])
+def test_worker_paused_actor(shutdown_only, actor_concurrency):
+    ray.init(_system_config=_SYSTEM_CONFIG)
+
+    @ray.remote
+    class TestActor:
+        def main_task(self, i):
+            if i == 0:
+                import time
+
+                # Pause 5 seconds inside debugger
+                with ray._private.worker.global_worker.worker_paused_by_debugger():
+                    time.sleep(5)
+
+    def verify(num_paused):
+        workers = list_workers(
+            filters=[("num_paused_threads", "=", num_paused)], detail=True
+        )
+        if len(workers) == 0:
+            return False
+        worker = workers[0]
+        return worker.num_paused_threads == num_paused
+
+    test_actor = TestActor.options(max_concurrency=actor_concurrency).remote()
+    refs = [  # noqa
+        test_actor.main_task.options(name=f"TestActor.main_task_{i}").remote(i)
+        for i in range(20)
+    ]
+
+    wait_for_condition(verify, num_paused=1)
+
+
+@pytest.mark.parametrize("actor_concurrency", [1, 3])
+def test_worker_paused_threaded_actor(shutdown_only, actor_concurrency):
+    ray.init(_system_config=_SYSTEM_CONFIG)
+
+    @ray.remote
+    class ThreadedActor:
+        def main_task(self):
+            def thd_task():
+                import time
+
+                # Pause 5 seconds inside debugger
+                with ray._private.worker.global_worker.worker_paused_by_debugger():  # noqa: E501
+                    time.sleep(5)
+
+            # create and start 10 threads
+            thds = []
+            for _ in range(10):
+                thd = threading.Thread(target=thd_task)
+                thd.start()
+                thds.append(thd)
+
+            # wait for all threads to finish
+            for thd in thds:
+                thd.join()
+
+    def verify(num_paused):
+        workers = list_workers(
+            filters=[("num_paused_threads", "=", num_paused)], detail=True
+        )
+        if len(workers) == 0:
+            return False
+        worker = workers[0]
+        return worker.num_paused_threads == num_paused
+
+    threaded_actor = ThreadedActor.options(max_concurrency=actor_concurrency).remote()
+    # this one call will create 10 threads and all of them will be paused
+    threaded_actor.main_task.options(name="ThreadedActor.main_task").remote()
+    wait_for_condition(verify, num_paused=10)
+
+    # After waiting for 10 threads to finish, there should be no paused threads
+    wait_for_condition(verify, num_paused=0)
+
+
+@pytest.mark.parametrize("actor_concurrency", [1, 3])
+def test_worker_paused_async_actor(shutdown_only, actor_concurrency):
+    ray.init(_system_config=_SYSTEM_CONFIG)
+
+    @ray.remote
+    class AsyncActor:
+        async def main_task(self):
+            import time
+
+            # Pause 5 seconds inside debugger
+            with ray._private.worker.global_worker.worker_paused_by_debugger():
+                time.sleep(5)
+
+    def verify(num_paused):
+        workers = list_workers(
+            filters=[("num_paused_threads", "=", num_paused)], detail=True
+        )
+        if len(workers) == 0:
+            return False
+        worker = workers[0]
+        return worker.num_paused_threads == num_paused
+
+    async_actor = AsyncActor.options(max_concurrency=actor_concurrency).remote()
+    refs = [async_actor.main_task.remote() for i in range(20)]  # noqa
+
+    # This actor runs on a single thread, so num_paused should be 1
+    wait_for_condition(verify, num_paused=1)
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -647,6 +647,8 @@ class WorkerState(StateSchema):
     )
     # the debugger port of the worker
     debugger_port: Optional[int] = state_column(filterable=True, detail=True)
+    # the number of threads paused in this worker
+    num_paused_threads: Optional[int] = state_column(filterable=True, detail=True)
 
 
 @dataclass(init=not IS_PYDANTIC_2)

--- a/src/mock/ray/gcs/gcs_server/gcs_worker_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_worker_manager.h
@@ -47,6 +47,12 @@ class MockGcsWorkerManager : public GcsWorkerManager {
                rpc::UpdateWorkerDebuggerPortReply *reply,
                rpc::SendReplyCallback send_reply_callback),
               (override));
+  MOCK_METHOD(void,
+              HandleUpdateWorkerNumPausedThreads,
+              (rpc::UpdateWorkerNumPausedThreadsRequest request,
+               rpc::UpdateWorkerNumPausedThreadsReply *reply,
+               rpc::SendReplyCallback send_reply_callback),
+              (override));
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -887,6 +887,26 @@ Status WorkerInfoAccessor::AsyncUpdateDebuggerPort(const WorkerID &worker_id,
   return Status::OK();
 }
 
+Status WorkerInfoAccessor::AsyncUpdateWorkerNumPausedThreads(
+    const WorkerID &worker_id,
+    const int num_paused_threads_delta,
+    const StatusCallback &callback) {
+  rpc::UpdateWorkerNumPausedThreadsRequest request;
+  request.set_worker_id(worker_id.Binary());
+  request.set_num_paused_threads_delta(num_paused_threads_delta);
+  RAY_LOG(DEBUG) << "Update the num paused threads on worker id = " << worker_id
+                 << " by delta = " << num_paused_threads_delta << ".";
+  client_impl_->GetGcsRpcClient().UpdateWorkerNumPausedThreads(
+      request,
+      [callback](const Status &status,
+                 const rpc::UpdateWorkerNumPausedThreadsReply &reply) {
+        if (callback) {
+          callback(status);
+        }
+      });
+  return Status::OK();
+}
+
 PlacementGroupInfoAccessor::PlacementGroupInfoAccessor(GcsClient *client_impl)
     : client_impl_(client_impl) {}
 

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -587,6 +587,15 @@ class WorkerInfoAccessor {
                                          uint32_t debugger_port,
                                          const StatusCallback &callback);
 
+  /// Update the number of worker's paused threads in GCS asynchronously.
+  ///
+  /// \param worker_id The ID of worker to update in the GCS.
+  /// \param num_paused_threads_delta The number of paused threads to update in the GCS.
+  /// \param callback Callback that will be called after update finishes.
+  /// \return Status
+  virtual Status AsyncUpdateWorkerNumPausedThreads(const WorkerID &worker_id,
+                                                   int num_paused_threads_delta,
+                                                   const StatusCallback &callback);
   /// Reestablish subscription.
   /// This should be called when GCS server restarts from a failure.
   /// PubSub server restart will cause GCS server restart. In this case, we need to

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -125,12 +125,26 @@ class GlobalStateAccessor {
   /// deserialized with protobuf function.
   std::vector<std::string> GetAllWorkerInfo() ABSL_LOCKS_EXCLUDED(mutex_);
 
+  /// Get the worker debugger port from the GCS Service.
+  ///
+  /// \param worker_id The ID of worker to look up in the GCS Service.
+  /// \return The worker debugger port.
+  uint32_t GetWorkerDebuggerPort(const WorkerID &worker_id);
+
   /// Update the worker debugger port in the GCS Service.
   ///
   /// \param worker_id The ID of worker to update in the GCS Service.
   /// \param debugger_port The debugger port of worker to update in the GCS Service.
   /// \return Is operation success.
   bool UpdateWorkerDebuggerPort(const WorkerID &worker_id, const uint32_t debugger_port);
+
+  /// Update the worker num of paused threads in the GCS Service.
+  ///
+  /// \param worker_id The ID of worker to update in the GCS Service.
+  /// \param num_paused_threads_delta The delta of paused threads of worker to update in
+  /// the GCS Service. \return Is operation success.
+  bool UpdateWorkerNumPausedThreads(const WorkerID &worker_id,
+                                    const int num_paused_threads_delta);
 
   /// Add information of a worker to GCS Service.
   ///
@@ -239,6 +253,12 @@ class GlobalStateAccessor {
 
   // protects is_connected_ and gcs_client_
   mutable absl::Mutex mutex_;
+
+  // protects debugger port related operations
+  mutable absl::Mutex debugger_port_mutex_;
+
+  // protects debugger tasks related operations
+  mutable absl::Mutex debugger_threads_mutex_;
 
   /// Whether this client is connected to gcs server.
   bool is_connected_ ABSL_GUARDED_BY(mutex_) = false;

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.h
@@ -52,6 +52,11 @@ class GcsWorkerManager : public rpc::WorkerInfoHandler {
       rpc::UpdateWorkerDebuggerPortReply *reply,
       rpc::SendReplyCallback send_reply_callback) override;
 
+  void HandleUpdateWorkerNumPausedThreads(
+      rpc::UpdateWorkerNumPausedThreadsRequest request,
+      rpc::UpdateWorkerNumPausedThreadsReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override;
+
   void AddWorkerDeadListener(
       std::function<void(std::shared_ptr<WorkerTableData>)> listener);
 

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -465,6 +465,8 @@ message WorkerTableData {
   uint64 worker_launched_time_ms = 26;
   // The debugger port on the worker process.
   optional uint32 debugger_port = 27;
+  // The number of paused threads in this worker process
+  optional uint32 num_paused_threads = 28;
 }
 
 // Fields to publish when worker fails.

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -280,6 +280,17 @@ message UpdateWorkerDebuggerPortReply {
   GcsStatus status = 1;
 }
 
+message UpdateWorkerNumPausedThreadsRequest {
+  // ID of this worker.
+  bytes worker_id = 1;
+  // The delta of the number of paused threads.
+  int32 num_paused_threads_delta = 2;
+}
+
+message UpdateWorkerNumPausedThreadsReply {
+  GcsStatus status = 1;
+}
+
 // Service for worker info access.
 service WorkerInfoGcsService {
   // Report a worker failure to GCS Service.
@@ -293,6 +304,9 @@ service WorkerInfoGcsService {
   // Update worker debugger port in the GCS Service.
   rpc UpdateWorkerDebuggerPort(UpdateWorkerDebuggerPortRequest)
       returns (UpdateWorkerDebuggerPortReply);
+  // Update the worker number of paused threads in the GCS Service.
+  rpc UpdateWorkerNumPausedThreads(UpdateWorkerNumPausedThreadsRequest)
+      returns (UpdateWorkerNumPausedThreadsReply);
 }
 
 message CreateActorRequest {

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -409,6 +409,12 @@ class GcsRpcClient {
                              worker_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
+  /// Update the worker number of paused threads delta
+  VOID_GCS_RPC_CLIENT_METHOD(WorkerInfoGcsService,
+                             UpdateWorkerNumPausedThreads,
+                             worker_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
   /// Create placement group via GCS Service.
   VOID_GCS_RPC_CLIENT_METHOD(PlacementGroupInfoGcsService,
                              CreatePlacementGroup,

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -425,6 +425,11 @@ class WorkerInfoGcsServiceHandler {
   virtual void HandleUpdateWorkerDebuggerPort(UpdateWorkerDebuggerPortRequest request,
                                               UpdateWorkerDebuggerPortReply *reply,
                                               SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleUpdateWorkerNumPausedThreads(
+      UpdateWorkerNumPausedThreadsRequest request,
+      UpdateWorkerNumPausedThreadsReply *reply,
+      SendReplyCallback send_reply_callback) = 0;
 };
 
 /// The `GrpcService` for `WorkerInfoGcsService`.
@@ -449,6 +454,7 @@ class WorkerInfoGrpcService : public GrpcService {
     WORKER_INFO_SERVICE_RPC_HANDLER(GetAllWorkerInfo);
     WORKER_INFO_SERVICE_RPC_HANDLER(AddWorkerInfo);
     WORKER_INFO_SERVICE_RPC_HANDLER(UpdateWorkerDebuggerPort);
+    WORKER_INFO_SERVICE_RPC_HANDLER(UpdateWorkerNumPausedThreads);
   }
 
  private:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This is added to give the debugger another API to signal paused workloads without reliably depending on Ray having a valid task Id, this is needed for cases where manual threads are created by the user.

This work also solidify the `debugger_port` reading and writing to be thread safe.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
