### PR TITLE
[CI] Fix the git hook is invalid if the project location changed

### DIFF
--- a/setup_hooks.sh
+++ b/setup_hooks.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
-chmod +x "$PWD"/ci/lint/pre-push
-ln -s "$PWD"/ci/lint/pre-push "$PWD"/.git/hooks/pre-push
-ln -s "$PWD"/ci/lint/prepare-commit-msg "$PWD"/.git/hooks/prepare-commit-msg
+set -eu
+
+# This stops git rev-parse from failing if we run this from the .git directory
+builtin cd "$(dirname "${BASH_SOURCE:-$0}")"
+
+ROOT="$(git rev-parse --show-toplevel)"
+builtin cd "${ROOT}"
+
+# If we change the lint location we should modify the path of lint relative .git
+RELATIVE_PATH="../../ci/lint"
+
+ln -sf "${RELATIVE_PATH}/pre-push" "${ROOT}/.git/hooks/pre-push"
+ln -sf "${RELATIVE_PATH}/prepare-commit-msg" "${ROOT}/.git/hooks/prepare-commit-msg"
+


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
In the ray project, we used the `setup_hooks.sh` to create the symbolic links to the relative hook script and these links used the absolute path, if the project location changed will cause can't find the real files.

Recommend to replace with the relative path.

## Related issue number

Closes #41435 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
