### PR TITLE
[data] filter data_head queries by session name

### DIFF
--- a/dashboard/modules/data/data_head.py
+++ b/dashboard/modules/data/data_head.py
@@ -12,6 +12,10 @@ from ray.dashboard.modules.metrics.metrics_head import (
 )
 from urllib.parse import quote
 import ray
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 # Window and sampling rate used for certain Prometheus queries.
@@ -23,10 +27,11 @@ SAMPLE_RATE = "1s"
 class PrometheusQuery(Enum):
     """Enum to store types of Prometheus queries for a given metric and grouping."""
 
-    VALUE = ("value", "sum({}) by ({})")
+    VALUE = ("value", "sum({}{{SessionName='{}'}}) by ({})")
     MAX = (
         "max",
-        "max_over_time(sum({}) by ({})[" + f"{MAX_TIME_WINDOW}:{SAMPLE_RATE}])",
+        "max_over_time(sum({}{{SessionName='{}'}}) by ({})["
+        + f"{MAX_TIME_WINDOW}:{SAMPLE_RATE}])",
     )
 
 
@@ -43,6 +48,7 @@ class DataHead(dashboard_utils.DashboardHeadModule):
     def __init__(self, dashboard_head):
         super().__init__(dashboard_head)
         self.http_session = aiohttp.ClientSession()
+        self._session_name = dashboard_head.session_name
         self.prometheus_host = os.environ.get(
             PROMETHEUS_HOST_ENV_VAR, DEFAULT_PROMETHEUS_HOST
         )
@@ -71,7 +77,7 @@ class DataHead(dashboard_utils.DashboardHeadModule):
                         query_name, prom_query = query.value
                         # Dataset level
                         dataset_result = await self._query_prometheus(
-                            prom_query.format(metric, "dataset")
+                            prom_query.format(metric, self._session_name, "dataset")
                         )
                         for res in dataset_result["data"]["result"]:
                             dataset, value = res["metric"]["dataset"], res["value"][1]
@@ -80,7 +86,9 @@ class DataHead(dashboard_utils.DashboardHeadModule):
 
                         # Operator level
                         operator_result = await self._query_prometheus(
-                            prom_query.format(metric, "dataset, operator")
+                            prom_query.format(
+                                metric, self._session_name, "dataset, operator"
+                            )
                         )
                         for res in operator_result["data"]["result"]:
                             dataset, operator, value = (
@@ -101,7 +109,10 @@ class DataHead(dashboard_utils.DashboardHeadModule):
             except aiohttp.client_exceptions.ClientConnectorError:
                 # Prometheus server may not be running,
                 # leave these values blank and return other data
-                pass
+                logging.exception(
+                    "Exception occurred while querying Prometheus. "
+                    "The Prometheus server may not be running."
+                )
             # Flatten response
             for dataset in datasets:
                 datasets[dataset]["operators"] = list(

--- a/dashboard/modules/data/data_head.py
+++ b/dashboard/modules/data/data_head.py
@@ -131,6 +131,7 @@ class DataHead(dashboard_utils.DashboardHeadModule):
                 content_type="application/json",
             )
         except Exception as e:
+            logging.exception("Exception occured while getting datasets.")
             return Response(
                 status=503,
                 text=str(e),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds `SessionName` filter to prometheus queries from `data_head`. This table should only be showing datapoints from the current session.

Also adds some logging for exceptions.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
