### PR TITLE
[serve] Update `target_capacity=0` behavior to start no replicas

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1471,9 +1471,8 @@ class DeploymentState:
     ) -> int:
         """Return the target state `num_replicas` adjusted by the `target_capacity`.
 
-        The output will only ever be 0 if the passed `num_replicas` is 0. This is to
-        support autoscaling deployments using scale-to-zero (we assume that any other
-        deployment should always have at least 1 replica).
+        The output will only ever be 0 if `target_capacity` is 0 or `num_replicas` is
+        0 (to support autoscaling deployments using scale-to-zero).
 
         Rather than using the default `round` behavior in Python, which rounds half to
         even, uses the `decimal` module to round half up (standard rounding behavior).
@@ -1481,7 +1480,7 @@ class DeploymentState:
         if target_capacity is None or target_capacity == 100:
             return num_replicas
 
-        if num_replicas == 0:
+        if target_capacity == 0 or num_replicas == 0:
             return 0
 
         adjusted_num_replicas = Decimal(num_replicas * target_capacity) / Decimal(100.0)

--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -480,8 +480,9 @@ class TestInitialReplicasHandling:
             ],
         )
 
-        test_target_capacities = [0, 20, 60, 40, 30, 100, None]
+        test_target_capacities = [0, 1, 20, 60, 40, 30, 100, None]
         expected_num_replicas = [
+            0,
             1,
             2,
             6,
@@ -527,7 +528,7 @@ class TestInitialReplicasHandling:
             ],
         )
 
-        test_target_capacities = [0, 20, 60, 40, 30, 100, None]
+        test_target_capacities = [0, 1, 20, 60, 40, 30, 100, None]
         expected_num_replicas = [0] * len(test_target_capacities)
 
         for target_capacity, num_replicas in zip(

--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -312,6 +312,17 @@ def test_autoscaling_scale_to_zero(
         },
     )
 
+    # Increase to target_capacity 1, should remain at 0 replicas initially.
+    config.target_capacity = 1.0
+    client.deploy_apps(config)
+    wait_for_condition(lambda: serve.status().target_capacity == 1.0)
+    wait_for_condition(
+        check_expected_num_replicas,
+        deployment_to_num_replicas={
+            SCALE_TO_ZERO_DEPLOYMENT_NAME: 0,
+        },
+    )
+
     # Send a bunch of requests. Autoscaler will want to scale it up to max replicas,
     # but it should stay at one due to the target_capacity.
     handle = serve.get_app_handle(SERVE_DEFAULT_APP_NAME)

--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -96,10 +96,22 @@ def test_incremental_scale_up(shutdown_ray_and_serve, client: ServeControllerCli
         ]
     )
 
-    # Initially deploy at target_capacity 0, should have 1 replica of each.
+    # Initially deploy at target_capacity 0, should have no replicas.
     config.target_capacity = 0.0
     client.deploy_apps(config)
     wait_for_condition(lambda: serve.status().target_capacity == 0.0)
+    wait_for_condition(
+        check_expected_num_replicas,
+        deployment_to_num_replicas={
+            INGRESS_DEPLOYMENT_NAME: 0,
+            DOWNSTREAM_DEPLOYMENT_NAME: 0,
+        },
+    )
+
+    # Initially deploy at target_capacity 1, should have 1 replica of each.
+    config.target_capacity = 1.0
+    client.deploy_apps(config)
+    wait_for_condition(lambda: serve.status().target_capacity == 1.0)
     wait_for_condition(
         check_expected_num_replicas,
         deployment_to_num_replicas={
@@ -174,6 +186,18 @@ def test_incremental_scale_down(shutdown_ray_and_serve, client: ServeControllerC
         deployment_to_num_replicas={
             INGRESS_DEPLOYMENT_NAME: INGRESS_DEPLOYMENT_NUM_REPLICAS / 2,
             DOWNSTREAM_DEPLOYMENT_NAME: DOWNSTREAM_DEPLOYMENT_NUM_REPLICAS / 2,
+        },
+    )
+
+    # Decrease target_capacity to 1, both should fully scale down.
+    config.target_capacity = 1.0
+    client.deploy_apps(config)
+    wait_for_condition(lambda: serve.status().target_capacity == 1.0)
+    wait_for_condition(
+        check_expected_num_replicas,
+        deployment_to_num_replicas={
+            INGRESS_DEPLOYMENT_NAME: 1,
+            DOWNSTREAM_DEPLOYMENT_NAME: 1,
         },
     )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After further discussion, we've decided to update the semantics such that if `target_capacity=0`, no replicas of any application will be started. This is to enable leaving a head-only cluster as a "hot standby" for rolling back at the end of a rollout.

Behavior unchanged for all other cases.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
