### PR TITLE
[ci] one job for one anyscale platform

### DIFF
--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -1,20 +1,28 @@
 group: build
 steps:
-  - label: ":tapioca: build: anyscale py{{matrix}} docker"
+  - label: ":tapioca: build: anyscale py{{matrix.python}}-{{matrix.platform}} docker"
     commands:
-      - bazel run //ci/ray_ci:build_in_docker -- anyscale --python-version {{matrix}}
-        --platform cu12.1.1 --platform cpu --image-type ray --upload
+      - bazel run //ci/ray_ci:build_in_docker -- anyscale 
+        --python-version {{matrix.python}} --platform {{matrix.platform}} 
+        --image-type ray --upload
     depends_on:
       - manylinux
       - forge
       - raycudabase
       - raycpubase
     matrix:
-      - "3.8"
-      - "3.9"
-      - "3.11"
+      setup:
+        python:
+          # This list should be kept in sync with the list of supported Python in 
+          # release test suite. We don't have release tests for Python 3.10 yet.
+          - "3.8"
+          - "3.9"
+          - "3.11"
+        platform:
+          - cu12.1.1
+          - cpu
 
-  - label: ":tapioca: build: anyscale-ml py{{matrix}} docker"
+  - label: ":tapioca: build: anyscale-ml py{{matrix}}-cu11.8.0 docker"
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- anyscale --python-version {{matrix}}
         --platform cu11.8.0 --image-type ray-ml --upload
@@ -23,5 +31,8 @@ steps:
       - forge
       - ray-mlcudabase
     matrix:
+      # This list should be kept in sync with the list of supported Python in 
+      # release test suite. We don't have ray-ml release tests for Python 3.10 and 3.11 
+      # yet.
       - "3.8"
       - "3.9"


### PR DESCRIPTION
Currently we build anyscale images for two platform in one job. That job is not very fast (40 minutes). Split them into two to speed up release test signal time.

Test:
- CI
- Release test