### PR TITLE
[Data] Fix metrics reporting for `torch_batch_inference` release tests

### DIFF
--- a/release/nightly_tests/dataset/benchmark.py
+++ b/release/nightly_tests/dataset/benchmark.py
@@ -19,6 +19,9 @@ class BenchmarkMetric(Enum):
     THROUGHPUT = "tput"
     ACCURACY = "accuracy"
 
+    # Extra metrics not matching the above categories/keys, stored as a Dict[str, Any].
+    EXTRA_METRICS = "extra_metrics"
+
 
 class Benchmark:
     """Utility class used for Ray Data release tests and benchmarks, which works
@@ -150,12 +153,13 @@ class Benchmark:
             BenchmarkMetric.RUNTIME.value: duration,
         }
         if isinstance(fn_output, dict):
-            # Filter out metrics which are not in BenchmarkMetric,
-            # to ensure proper format of outputs.
-            for m in BenchmarkMetric:
-                metric_value = fn_output.get(m.value)
-                if metric_value:
-                    curr_case_metrics[m.value] = metric_value
+            extra_metrics = {}
+            for metric_key, metric_val in fn_output:
+                if metric_key in BenchmarkMetric.__members__:
+                    curr_case_metrics[metric_key] = metric_val
+                else:
+                    extra_metrics[metric_key] = metric_val
+            curr_case_metrics[BenchmarkMetric.EXTRA_METRICS.value] = extra_metrics
 
         self.result[name] = curr_case_metrics
         print(f"Result of case {name}: {curr_case_metrics}")

--- a/release/nightly_tests/dataset/benchmark.py
+++ b/release/nightly_tests/dataset/benchmark.py
@@ -154,7 +154,7 @@ class Benchmark:
         }
         if isinstance(fn_output, dict):
             extra_metrics = {}
-            for metric_key, metric_val in fn_output:
+            for metric_key, metric_val in fn_output.items():
                 if metric_key in BenchmarkMetric.__members__:
                     curr_case_metrics[metric_key] = metric_val
                 else:

--- a/release/nightly_tests/dataset/benchmark.py
+++ b/release/nightly_tests/dataset/benchmark.py
@@ -43,7 +43,7 @@ class Benchmark:
 
     # Writes a JSON with metrics of the form:
     # {"case-1": {...}, "case-2": {...}, "case-3": {...}}
-    benchmark.write_result("output.json")
+    benchmark.write_result()
 
     See example usage in ``aggregate_benchmark.py``.
     """
@@ -155,8 +155,8 @@ class Benchmark:
         if isinstance(fn_output, dict):
             extra_metrics = {}
             for metric_key, metric_val in fn_output.items():
-                if metric_key in BenchmarkMetric.__members__:
-                    curr_case_metrics[metric_key] = metric_val
+                if isinstance(metric_key, BenchmarkMetric):
+                    curr_case_metrics[metric_key.value] = metric_val
                 else:
                     extra_metrics[metric_key] = metric_val
             curr_case_metrics[BenchmarkMetric.EXTRA_METRICS.value] = extra_metrics

--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -127,6 +127,4 @@ def main(data_directory: str, data_format: str, smoke_test: bool):
 if __name__ == "__main__":
     benchmark = Benchmark("gpu-batch-inference")
     benchmark.run_fn("batch-inference", main)
-
-    test_output_json = os.environ.get("TEST_OUTPUT_JSON", "/tmp/release_test_out.json")
-    benchmark.write_result(test_output_json)
+    benchmark.write_result(os.environ.get("TEST_OUTPUT_JSON"))

--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -117,8 +117,8 @@ def main(data_directory: str, data_format: str, smoke_test: bool):
         "data_format": data_format,
         BenchmarkMetric.RUNTIME.value: total_time,
         BenchmarkMetric.THROUGHPUT.value: throughput,
-        "total_time_s_w/o_metadata_fetch": total_time_without_metadata_fetch,
-        "throughput_images_s_w/o_metadata_fetch": throughput_without_metadata_fetch,
+        "total_time_s_wo_metadata_fetch": total_time_without_metadata_fetch,
+        "throughput_images_s_wo_metadata_fetch": throughput_without_metadata_fetch,
     }
 
     return results

--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -112,14 +112,13 @@ def main(data_directory: str, data_format: str, smoke_test: bool):
 
     # For structured output integration with internal tooling
     results = {
-        "data_directory": data_directory,
-        "data_format": data_format,
         BenchmarkMetric.RUNTIME.value: total_time,
         BenchmarkMetric.THROUGHPUT.value: throughput,
+        "data_directory": data_directory,
+        "data_format": data_format,
         "total_time_s_wo_metadata_fetch": total_time_without_metadata_fetch,
         "throughput_images_s_wo_metadata_fetch": throughput_without_metadata_fetch,
     }
-    print("===> results in main:", results)
 
     return results
 
@@ -127,5 +126,4 @@ def main(data_directory: str, data_format: str, smoke_test: bool):
 if __name__ == "__main__":
     benchmark = Benchmark("gpu-batch-inference")
     benchmark.run_fn("batch-inference", main)
-    print("===> benchmark results:", benchmark.result)
     benchmark.write_result()

--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -119,6 +119,7 @@ def main(data_directory: str, data_format: str, smoke_test: bool):
         "total_time_s_wo_metadata_fetch": total_time_without_metadata_fetch,
         "throughput_images_s_wo_metadata_fetch": throughput_without_metadata_fetch,
     }
+    print("===> results in main:", results)
 
     return results
 
@@ -126,5 +127,5 @@ def main(data_directory: str, data_format: str, smoke_test: bool):
 if __name__ == "__main__":
     benchmark = Benchmark("gpu-batch-inference")
     benchmark.run_fn("batch-inference", main)
+    print("===> benchmark results:", benchmark.result)
     benchmark.write_result()
-    print("===> Finished running test, exiting")

--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -1,7 +1,6 @@
 from typing import Dict
 import click
 import time
-import os
 
 import numpy as np
 import torch
@@ -127,4 +126,5 @@ def main(data_directory: str, data_format: str, smoke_test: bool):
 if __name__ == "__main__":
     benchmark = Benchmark("gpu-batch-inference")
     benchmark.run_fn("batch-inference", main)
-    benchmark.write_result(os.environ.get("TEST_OUTPUT_JSON"))
+    benchmark.write_result()
+    print("===> Finished running test, exiting")

--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 from torchvision.models import resnet50, ResNet50_Weights
 
-from benchmark import Benchmark
+from benchmark import Benchmark, BenchmarkMetric
 import ray
 from ray.data import ActorPoolStrategy
 
@@ -112,28 +112,13 @@ def main(data_directory: str, data_format: str, smoke_test: bool):
     )
 
     # For structured output integration with internal tooling
-    results = {"data_directory": data_directory, "data_format": data_format}
-    results["perf_metrics"] = {
-        "total_time_s": {
-            "perf_metric_name": "total_time_s",
-            "perf_metric_value": total_time,
-            "perf_metric_type": "LATENCY",
-        },
-        "throughput_images_s": {
-            "perf_metric_name": "throughput_images_s",
-            "perf_metric_value": throughput,
-            "perf_metric_type": "THROUGHPUT",
-        },
-        "total_time_s_w/o_metadata_fetch": {
-            "perf_metric_name": "total_time_s_w/o_metadata_fetch",
-            "perf_metric_value": total_time_without_metadata_fetch,
-            "perf_metric_type": "LATENCY",
-        },
-        "throughput_images_s_w/o_metadata_fetch": {
-            "perf_metric_name": "throughput_images_s_w/o_metadata_fetch",
-            "perf_metric_value": throughput_without_metadata_fetch,
-            "perf_metric_type": "THROUGHPUT",
-        },
+    results = {
+        "data_directory": data_directory,
+        "data_format": data_format,
+        BenchmarkMetric.RUNTIME.value: total_time,
+        BenchmarkMetric.THROUGHPUT.value: throughput,
+        "total_time_s_w/o_metadata_fetch": total_time_without_metadata_fetch,
+        "throughput_images_s_w/o_metadata_fetch": throughput_without_metadata_fetch,
     }
 
     return results

--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -627,7 +627,7 @@ def benchmark_code(
     print("Averaged per-epoch throughput:", avg_per_epoch_tput, "img/s")
     data_benchmark_metrics.update(
         {
-            BenchmarkMetric.THROUGHPUT.value: avg_per_epoch_tput,
+            BenchmarkMetric.THROUGHPUT: avg_per_epoch_tput,
         }
     )
 
@@ -639,7 +639,7 @@ def benchmark_code(
         print(f"Final epoch accuracy: {final_epoch_acc * 100:.3f}%")
         data_benchmark_metrics.update(
             {
-                BenchmarkMetric.ACCURACY.value: final_epoch_acc,
+                BenchmarkMetric.ACCURACY: final_epoch_acc,
             }
         )
     return data_benchmark_metrics


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Followup to https://github.com/ray-project/ray/pull/39889, add an option to include additional metrics from `Benchmark.run_fn()` which do not exactly conform to standard metrics defined in `BenchmarkMetrics` class. This allows us to report additional metrics originally included in the `torch_batch_inference` related release tests, and fixes the metrics reporting issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests https://buildkite.com/ray-project/release/builds/2535#_
   - [ ] This PR is not tested :(
