### PR TITLE
[Doc] Fix busted AI assistant CSS

### DIFF
--- a/doc/source/_static/css/assistant.css
+++ b/doc/source/_static/css/assistant.css
@@ -26,7 +26,7 @@
   transform: translate(-50%, -20%);
   width: 50%;
   height: 70%;
-  background-color: var(--pst-color-surface);
+  background-color: var(--pst-color-background);
   border: 1px solid var(--pst-color-border);
   border-radius: 10px;
   box-shadow: 0 5px 10px var(--pst-color-shadow);
@@ -69,7 +69,10 @@
 
 #searchBar {
   border: 1px solid var(--pst-color-border);
-  background-color: var(--pst-color-on-surface);
+  background-color: var(--pst-color-surface);
+  margin: 0em 1em 0em 0em;
+  border-radius: 4px;
+  color: var(--pst-color-text-base);
 }
 
 .chatHeader {
@@ -100,7 +103,7 @@
   border-radius: 10px;
   margin-top: 10px;
   margin-bottom: 10px;
-  background-color: var(--pst-color-on-surface);
+  background-color: var(--pst-color-surface);
   max-height: calc(100% - 20px);
   overflow-y: auto;
 }
@@ -112,8 +115,9 @@
   resize: none;
 }
 
-.searchBtn {
-    white-space: nowrap;
+#searchBtn {
+  white-space: nowrap;
+  border-radius: 4px;
 }
 
 .input-group {

--- a/doc/source/_static/js/assistant.js
+++ b/doc/source/_static/js/assistant.js
@@ -22,9 +22,7 @@ chatPopupDiv.innerHTML = `
   <div class="chatContentContainer">
     <div class="input-group">
       <textarea id="searchBar" class="input" rows="3" placeholder="Do not include any personal or confidential information."></textarea>
-      <div class="input-group-append">
-        <button id="searchBtn" class="btn btn-primary">Ask AI</button>
-      </div>
+      <button id="searchBtn" class="btn btn-primary">Ask AI</button>
     </div>
     <div id="result"></div>
   </div>


### PR DESCRIPTION
## Why are these changes needed?

The docs upgrade (#41115) broke light styles for the ray AI assistant. This PR fixes the styles to make the assistant usable again.

There are a few changes which would be nice to make but are more invasive, and therefore out of scope for this PR (such as centering the placeholder text in the `textarea` element, which really isn't possible unless you use an `input` or `div` instead; see https://github.com/ray-project/ray/blob/master/doc/source/ray-overview/examples.rst?plain=1 for an example of how to do this).

Light mode:

![image](https://github.com/ray-project/ray/assets/14017872/8b286920-aa8a-41d1-8aa7-cb5fef6a7674)

Dark mode:

![image](https://github.com/ray-project/ray/assets/14017872/a776af17-85a2-46c2-9bba-5d7c0feb63fd)

## Related issue number

Closes #41440.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
