### PR TITLE
[Data] Introduce `concurrency` argument to replace ComputeStrategy in map-like APIs

### DIFF
--- a/doc/source/data/examples/gptj_batch_prediction.ipynb
+++ b/doc/source/data/examples/gptj_batch_prediction.ipynb
@@ -230,19 +230,19 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "chengsu-dev",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.9.12 (main, Jun  1 2022, 06:36:29) \n[Clang 12.0.0 ]"
+   "version": "3.8.10 (default, Nov 14 2022, 12:59:47) \n[GCC 9.4.0]"
   },
   "orig_nbformat": 4,
   "orphan": true,
   "vscode": {
    "interpreter": {
-    "hash": "3b44a7d2c450ab056127801905451322f87b40fc6c413ff43ea831cf972c26cb"
+    "hash": "3c0d54d489a08ae47a06eae2fd00ff032d6cddb527c382959b7b2575f6a8167f"
    }
   }
  },

--- a/doc/source/data/examples/gptj_batch_prediction.ipynb
+++ b/doc/source/data/examples/gptj_batch_prediction.ipynb
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](stateful_transformation). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
+    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](stateful_transforms). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
    ]
   },
   {

--- a/doc/source/data/examples/gptj_batch_prediction.ipynb
+++ b/doc/source/data/examples/gptj_batch_prediction.ipynb
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](transforming_with_python_class). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
+    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](stateful_transformation). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
    ]
   },
   {

--- a/doc/source/data/examples/gptj_batch_prediction.ipynb
+++ b/doc/source/data/examples/gptj_batch_prediction.ipynb
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](transforming_data_actors). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
+    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](transforming_with_python_class). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
    ]
   },
   {
@@ -230,19 +230,19 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "chengsu-dev",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.8.10 (default, Nov 14 2022, 12:59:47) \n[GCC 9.4.0]"
+   "version": "3.9.12 (main, Jun  1 2022, 06:36:29) \n[Clang 12.0.0 ]"
   },
   "orig_nbformat": 4,
   "orphan": true,
   "vscode": {
    "interpreter": {
-    "hash": "3c0d54d489a08ae47a06eae2fd00ff032d6cddb527c382959b7b2575f6a8167f"
+    "hash": "3b44a7d2c450ab056127801905451322f87b40fc6c413ff43ea831cf972c26cb"
    }
   }
  },

--- a/doc/source/data/examples/stablediffusion_batch_prediction.ipynb
+++ b/doc/source/data/examples/stablediffusion_batch_prediction.ipynb
@@ -230,19 +230,19 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "chengsu-dev",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.9.12 (main, Jun  1 2022, 06:36:29) \n[Clang 12.0.0 ]"
+   "version": "3.8.10 (default, Nov 14 2022, 12:59:47) \n[GCC 9.4.0]"
   },
   "orig_nbformat": 4,
   "orphan": true,
   "vscode": {
    "interpreter": {
-    "hash": "3b44a7d2c450ab056127801905451322f87b40fc6c413ff43ea831cf972c26cb"
+    "hash": "3c0d54d489a08ae47a06eae2fd00ff032d6cddb527c382959b7b2575f6a8167f"
    }
   }
  },

--- a/doc/source/data/examples/stablediffusion_batch_prediction.ipynb
+++ b/doc/source/data/examples/stablediffusion_batch_prediction.ipynb
@@ -89,7 +89,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](transforming_data_actors). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
+    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](transforming_with_python_class). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
    ]
   },
   {
@@ -230,19 +230,19 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "chengsu-dev",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.8.10 (default, Nov 14 2022, 12:59:47) \n[GCC 9.4.0]"
+   "version": "3.9.12 (main, Jun  1 2022, 06:36:29) \n[Clang 12.0.0 ]"
   },
   "orig_nbformat": 4,
   "orphan": true,
   "vscode": {
    "interpreter": {
-    "hash": "3c0d54d489a08ae47a06eae2fd00ff032d6cddb527c382959b7b2575f6a8167f"
+    "hash": "3b44a7d2c450ab056127801905451322f87b40fc6c413ff43ea831cf972c26cb"
    }
   }
  },

--- a/doc/source/data/examples/stablediffusion_batch_prediction.ipynb
+++ b/doc/source/data/examples/stablediffusion_batch_prediction.ipynb
@@ -89,7 +89,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](stateful_transformation). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
+    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](stateful_transforms). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
    ]
   },
   {

--- a/doc/source/data/examples/stablediffusion_batch_prediction.ipynb
+++ b/doc/source/data/examples/stablediffusion_batch_prediction.ipynb
@@ -89,7 +89,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](transforming_with_python_class). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
+    "Since we will be using a pretrained model from Hugging Face hub, the simplest way is to use {meth}`map_batches <ray.data.Dataset.map_batches>` with a [callable class UDF](stateful_transformation). This will allow us to save time by initializing a model just once and then feed it multiple batches of data."
    ]
   },
   {

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -164,10 +164,10 @@ program might run out of memory. If you encounter an out-of-memory error, decrea
 Stateful Transforms
 ==============================
 
-If your transform is stateful to require expensive setup such as downloading
-model weights, use a callable Python class instead of a function. When a Python class
+If your transform requires expensive setup such as downloading
+model weights, use a callable Python class instead of a function to make the transform stateful. When a Python class
 is used, the ``__init__`` method is called to perform setup exactly once on each worker.
-In contrast, function is stateless, so any setup must be performed for each data item.
+In contrast, functions are stateless, so any setup must be performed for each data item.
 
 Internally, Ray Data uses tasks to execute functions, and uses actors to execute classes.
 To learn more about tasks and actors, read the

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -14,7 +14,7 @@ This guide shows you how to:
 
 * :ref:`Transform rows <transforming_rows>`
 * :ref:`Transform batches <transforming_batches>`
-* :ref:`Transform with Python Class <transforming_with_python_class>`
+* :ref:`Stateful Transformation <stateful_transformation>`
 * :ref:`Groupby and transform groups <transforming_groupby>`
 * :ref:`Shuffle rows <shuffling_rows>`
 * :ref:`Repartition data <repartitioning_data>`
@@ -159,14 +159,16 @@ program might run out of memory. If you encounter an out-of-memory error, decrea
     the default batch size is 4096. If you're using GPUs, you must specify an explicit
     batch size.
 
-.. _transforming_with_python_class:
+.. _stateful_transformation:
 
-Transforming with Python Class
+Stateful Transformation
 ==============================
 
-If your transformation requires expensive setup like downloading model weights, use
-Python class instead of function. Python class performs setup exactly once for all data.
-In contrast, function is stateless and doesn't have a way to perform setup.
+If your transformation is stateful to require expensive setup such as downloading
+model weights, use a callable Python class instead of a function. When a Python class
+is used, the `__init__` method will be called to perform setup exactly once on each
+worker. In contrast, function is stateless and doesn't have a way to perform setup
+before transforming data.
 
 Internally, Ray Data uses tasks to execute function, and uses actors to execute class.
 To learn more about tasks and actors, read the
@@ -177,10 +179,10 @@ To transform data with Python class, complete these steps:
 1. Implement a class. Perform setup in ``__init__`` and transform data in ``__call__``.
 
 2. Configure ``concurrency`` with the number of concurrent workers. Each worker
-transforms a partition of data.
+   transforms a partition of data.
 
-3. Call :meth:`~ray.data.Dataset.map_batches`,
-:meth:`~ray.data.Dataset.map`, or :meth:`~ray.data.Dataset.flat_map`.
+3. Call :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.map`, or
+   :meth:`~ray.data.Dataset.flat_map`.
 
 .. tab-set::
 

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -166,11 +166,10 @@ Stateful Transformation
 
 If your transformation is stateful to require expensive setup such as downloading
 model weights, use a callable Python class instead of a function. When a Python class
-is used, the `__init__` method will be called to perform setup exactly once on each
-worker. In contrast, function is stateless and doesn't have a way to perform setup
-before transforming data.
+is used, the `__init__` method is called to perform setup exactly once on each worker.
+In contrast, function is stateless, so any setup must be performed for each data item..
 
-Internally, Ray Data uses tasks to execute function, and uses actors to execute class.
+Internally, Ray Data uses tasks to execute functions, and uses actors to execute classes.
 To learn more about tasks and actors, read the
 :ref:`Ray Core Key Concepts <core-key-concepts>`.
 
@@ -179,7 +178,8 @@ To transform data with Python class, complete these steps:
 1. Implement a class. Perform setup in ``__init__`` and transform data in ``__call__``.
 
 2. Configure ``concurrency`` with the number of concurrent workers. Each worker
-   transforms a partition of data.
+   transforms a partition of data in parallel. You can also pass a tuple of
+   ``(min, max)`` to allow Ray Data to autoscale the number of concurrent workers.
 
 3. Call :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.map`, or
    :meth:`~ray.data.Dataset.flat_map`.

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -166,7 +166,7 @@ Transforming with Python Class
 
 If your transformation requires expensive setup like downloading model weights, use
 Python class instead of function. Python class performs setup exactly once for all data.
-In contrast, function is stateless and does not have a way to perform setup.
+In contrast, function is stateless and doesn't have a way to perform setup.
 
 Internally, Ray Data uses tasks to execute function, and uses actors to execute class.
 To learn more about tasks and actors, read the

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -14,7 +14,7 @@ This guide shows you how to:
 
 * :ref:`Transform rows <transforming_rows>`
 * :ref:`Transform batches <transforming_batches>`
-* :ref:`Stateful Transformation <stateful_transformation>`
+* :ref:`Stateful Transforms <stateful_transforms>`
 * :ref:`Groupby and transform groups <transforming_groupby>`
 * :ref:`Shuffle rows <shuffling_rows>`
 * :ref:`Repartition data <repartitioning_data>`
@@ -159,15 +159,15 @@ program might run out of memory. If you encounter an out-of-memory error, decrea
     the default batch size is 4096. If you're using GPUs, you must specify an explicit
     batch size.
 
-.. _stateful_transformation:
+.. _stateful_transforms:
 
-Stateful Transformation
+Stateful Transforms
 ==============================
 
-If your transformation is stateful to require expensive setup such as downloading
+If your transform is stateful to require expensive setup such as downloading
 model weights, use a callable Python class instead of a function. When a Python class
-is used, the `__init__` method is called to perform setup exactly once on each worker.
-In contrast, function is stateless, so any setup must be performed for each data item..
+is used, the ``__init__`` method is called to perform setup exactly once on each worker.
+In contrast, function is stateless, so any setup must be performed for each data item.
 
 Internally, Ray Data uses tasks to execute functions, and uses actors to execute classes.
 To learn more about tasks and actors, read the
@@ -177,13 +177,11 @@ To transform data with Python class, complete these steps:
 
 1. Implement a class. Perform setup in ``__init__`` and transform data in ``__call__``.
 
-2. Configure ``concurrency`` with the number of concurrent workers. Each worker
-   transforms a partition of data in parallel. You can also pass a tuple of
-   ``(min, max)`` to allow Ray Data to automatically scale the number of concurrent
-   workers.
-
-3. Call :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.map`, or
-   :meth:`~ray.data.Dataset.flat_map`.
+2. Call :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.map`, or
+   :meth:`~ray.data.Dataset.flat_map`. Configure ``concurrency`` with the number of
+   concurrent workers. Each worker transforms a partition of data in parallel.
+   You can also pass a tuple of ``(min, max)`` to allow Ray Data to automatically
+   scale the number of concurrent workers.
 
 .. tab-set::
 

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -178,9 +178,8 @@ To transform data with a Python class, complete these steps:
 1. Implement a class. Perform setup in ``__init__`` and transform data in ``__call__``.
 
 2. Call :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.map`, or
-   :meth:`~ray.data.Dataset.flat_map`. Configure ``concurrency`` with the number of
-   concurrent workers. Each worker transforms a partition of data in parallel.
-   You can also pass a tuple of ``(min, max)`` to allow Ray Data to automatically
+   :meth:`~ray.data.Dataset.flat_map`. Pass the number of concurrent workers to use with the ``concurrency`` argument. Each worker transforms a partition of data in parallel.
+   Fixing the number of concurrent workers gives the most predictable performance, but you can also pass a tuple of ``(min, max)`` to allow Ray Data to automatically
    scale the number of concurrent workers.
 
 .. tab-set::

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -179,7 +179,8 @@ To transform data with Python class, complete these steps:
 
 2. Configure ``concurrency`` with the number of concurrent workers. Each worker
    transforms a partition of data in parallel. You can also pass a tuple of
-   ``(min, max)`` to allow Ray Data to autoscale the number of concurrent workers.
+   ``(min, max)`` to allow Ray Data to automatically scale the number of concurrent
+   workers.
 
 3. Call :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.map`, or
    :meth:`~ray.data.Dataset.flat_map`.

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -173,7 +173,7 @@ Internally, Ray Data uses tasks to execute functions, and uses actors to execute
 To learn more about tasks and actors, read the
 :ref:`Ray Core Key Concepts <core-key-concepts>`.
 
-To transform data with Python class, complete these steps:
+To transform data with a Python class, complete these steps:
 
 1. Implement a class. Perform setup in ``__init__`` and transform data in ``__call__``.
 

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -124,10 +124,10 @@ To transform batches with actors, complete these steps:
 
 1. Implement a class. Perform setup in ``__init__`` and transform data in ``__call__``.
 
-2. Create an :class:`~ray.data.ActorPoolStrategy` and configure the number of concurrent
-   workers. Each worker transforms a partition of data.
+2. Configure ``concurrency`` with the number of concurrent workers. Each worker
+transforms a partition of data.
 
-3. Call :meth:`~ray.data.Dataset.map_batches` and pass your ``ActorPoolStrategy`` to ``compute``.
+3. Call :meth:`~ray.data.Dataset.map_batches`.
 
 .. tab-set::
 
@@ -154,7 +154,7 @@ To transform batches with actors, complete these steps:
 
             ds = (
                 ray.data.from_numpy(np.ones((32, 100)))
-                .map_batches(TorchPredictor, compute=ray.data.ActorPoolStrategy(size=2))
+                .map_batches(TorchPredictor, concurrency=2)
             )
 
         .. testcode::
@@ -188,7 +188,7 @@ To transform batches with actors, complete these steps:
                 .map_batches(
                     TorchPredictor,
                     # Two workers with one GPU each
-                    compute=ray.data.ActorPoolStrategy(size=2),
+                    concurrency=2,
                     # Batch size is required if you're using GPUs.
                     batch_size=4,
                     num_gpus=1

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -243,7 +243,7 @@ Finally, call :meth:`Dataset.map_batches() <ray.data.Dataset.map_batches>`.
 
 For more information on performing inference, see
 :ref:`End-to-end: Offline Batch Inference <batch_inference_home>`
-and :ref:`Stateful Transformation <stateful_transformation>`.
+and :ref:`Stateful Transforms <stateful_transforms>`.
 
 .. _saving_images:
 

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -243,7 +243,7 @@ Finally, call :meth:`Dataset.map_batches() <ray.data.Dataset.map_batches>`.
 
 For more information on performing inference, see
 :ref:`End-to-end: Offline Batch Inference <batch_inference_home>`
-and :ref:`Transforming batches with actors <transforming_data_actors>`.
+and :ref:`Transforming with Python Class <transforming_with_python_class>`.
 
 .. _saving_images:
 

--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -243,7 +243,7 @@ Finally, call :meth:`Dataset.map_batches() <ray.data.Dataset.map_batches>`.
 
 For more information on performing inference, see
 :ref:`End-to-end: Offline Batch Inference <batch_inference_home>`
-and :ref:`Transforming with Python Class <transforming_with_python_class>`.
+and :ref:`Stateful Transformation <stateful_transformation>`.
 
 .. _saving_images:
 

--- a/doc/source/data/working-with-text.rst
+++ b/doc/source/data/working-with-text.rst
@@ -169,7 +169,7 @@ that sets up and invokes a model. Then, call
 
 For more information on performing inference, see
 :ref:`End-to-end: Offline Batch Inference <batch_inference_home>`
-and :ref:`Stateful Transformation <stateful_transformation>`.
+and :ref:`Stateful Transforms <stateful_transforms>`.
 
 .. _saving-text:
 

--- a/doc/source/data/working-with-text.rst
+++ b/doc/source/data/working-with-text.rst
@@ -169,7 +169,7 @@ that sets up and invokes a model. Then, call
 
 For more information on performing inference, see
 :ref:`End-to-end: Offline Batch Inference <batch_inference_home>`
-and :ref:`Transforming with Python Class <transforming_with_python_class>`.
+and :ref:`Stateful Transformation <stateful_transformation>`.
 
 .. _saving-text:
 

--- a/doc/source/data/working-with-text.rst
+++ b/doc/source/data/working-with-text.rst
@@ -169,7 +169,7 @@ that sets up and invokes a model. Then, call
 
 For more information on performing inference, see
 :ref:`End-to-end: Offline Batch Inference <batch_inference_home>`
-and :ref:`Transforming batches with actors <transforming_data_actors>`.
+and :ref:`Transforming with Python Class <transforming_with_python_class>`.
 
 .. _saving-text:
 

--- a/doc/source/ray-core/_examples/datasets_train/datasets_train.py
+++ b/doc/source/ray-core/_examples/datasets_train/datasets_train.py
@@ -263,12 +263,18 @@ class DataPreprocessor:
 
 
 def inference(
-    dataset, model_cls: type, batch_size: int, result_path: str, use_gpu: bool
+    dataset,
+    load_model_func,
+    model_cls: type,
+    batch_size: int,
+    result_path: str,
+    use_gpu: bool
 ):
     print("inferencing...")
     num_gpus = 1 if use_gpu else 0
     dataset.map_batches(
         model_cls,
+        fn_constructor_args=[load_model_func],
         compute=ray.data.ActorPoolStrategy(),
         batch_size=batch_size,
         batch_format="pandas",
@@ -699,7 +705,8 @@ if __name__ == "__main__":
     )
     inference(
         inference_dataset,
-        BatchInferModel(load_model_func),
+        load_model_func,
+        BatchInferModel,
         100,
         inference_output_path,
         use_gpu,

--- a/doc/source/ray-core/_examples/datasets_train/datasets_train.py
+++ b/doc/source/ray-core/_examples/datasets_train/datasets_train.py
@@ -268,7 +268,7 @@ def inference(
     model_cls: type,
     batch_size: int,
     result_path: str,
-    use_gpu: bool
+    use_gpu: bool,
 ):
     print("inferencing...")
     num_gpus = 1 if use_gpu else 0

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -31,7 +31,6 @@ from ray.data._internal.memory_tracing import trace_allocation
 from ray.data._internal.plan import AllToAllStage, ExecutionPlan, OneToOneStage, Stage
 from ray.data._internal.stage_impl import LimitStage, RandomizeBlocksStage
 from ray.data._internal.stats import DatasetStats, StatsDict
-from ray.data._internal.util import validate_compute
 from ray.data.block import Block, BlockMetadata, CallableClass, List
 from ray.data.context import DataContext
 from ray.data.datasource import ReadTask
@@ -266,7 +265,6 @@ def _stage_to_operator(stage: Stage, input_op: PhysicalOperator) -> PhysicalOper
 
     if isinstance(stage, OneToOneStage):
         compute = get_compute(stage.compute)
-        validate_compute(stage.fn, compute)
 
         block_fn = stage.block_fn
         if stage.fn:

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -30,7 +30,7 @@ from ray.data._internal.logical.operators.map_operator import (
     MapRows,
 )
 from ray.data._internal.numpy_support import is_valid_udf_return
-from ray.data._internal.util import _truncated_repr, validate_compute
+from ray.data._internal.util import _truncated_repr
 from ray.data.block import (
     Block,
     BlockAccessor,
@@ -51,7 +51,6 @@ def plan_udf_map_op(
     """
 
     compute = get_compute(op._compute)
-    validate_compute(op._fn, compute)
     fn, init_fn = _parse_op_fn(op)
 
     if isinstance(op, MapBatches):

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 import logging
 import os
 import pathlib
@@ -531,13 +532,17 @@ def get_compute_strategy(
 
     if isinstance(fn, CallableClass):
         is_callable_class = True
-    else:
+    elif inspect.isfunction(fn):
         is_callable_class = False
         if fn_constructor_args is not None:
             raise ValueError(
                 "``fn_constructor_args`` can only be specified if providing a "
-                f"CallableClass instance for ``fn``, but got: {fn}"
+                f"CallableClass instance for ``fn``, but got: {fn}."
             )
+    else:
+        raise ValueError(
+            "``fn`` can only be either function or callable class, but got: " f"{fn}."
+        )
 
     if compute is not None:
         # Legacy code path to support `compute` argument.

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -569,12 +569,12 @@ def get_compute_strategy(
             if not is_callable_class:
                 # Currently do not support concurrency control with function,
                 # i.e., running with Ray Tasks (`TaskPoolMapOperator`).
-                logger.warning(
+                raise ValueError(
                     "``concurrency`` is specified as: {concurrency}, "
                     "but ``fn`` is not a CallableClass: {fn}. The setting of "
-                    "``concurrency`` is only supported when ``fn`` is a CallableClass."
+                    "``concurrency`` is only supported when ``fn`` is a CallableClass. "
+                    "This can be supported in future releases."
                 )
-                return TaskPoolStrategy()
 
             if isinstance(concurrency, tuple):
                 assert (

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -574,6 +574,7 @@ def get_compute_strategy(
                     f"{fn}. Non-default values of ``concurrency`` are currently only "
                     "supported when ``fn`` is a CallableClass."
                 )
+                return TaskPoolStrategy()
 
             if isinstance(concurrency, tuple):
                 if (

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 import logging
 import os
 import pathlib
@@ -527,17 +528,19 @@ def get_compute_strategy(
     """
     # Lazily import these objects to avoid circular imports.
     from ray.data._internal.compute import ActorPoolStrategy, TaskPoolStrategy
-    from ray.data.block import CallableClass
 
-    if isinstance(fn, CallableClass):
-        is_callable_class = True
-    else:
+    # Check if `fn` is a function or not.
+    # NOTE: use `inspect.isfunction(fn)` instead of `instanceof(fn, CallableClass)`,
+    # because latter returns False for an object instance of callable class.
+    if inspect.isfunction(fn):
         is_callable_class = False
         if fn_constructor_args is not None:
             raise ValueError(
                 "``fn_constructor_args`` can only be specified if providing a "
                 f"CallableClass instance for ``fn``, but got: {fn}"
             )
+    else:
+        is_callable_class = True
 
     if compute is not None:
         # Legacy code path to support `compute` argument.

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1,5 +1,4 @@
 import importlib
-import inspect
 import logging
 import os
 import pathlib

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -528,19 +528,17 @@ def get_compute_strategy(
     """
     # Lazily import these objects to avoid circular imports.
     from ray.data._internal.compute import ActorPoolStrategy, TaskPoolStrategy
+    from ray.data.block import CallableClass
 
-    # Check if `fn` is a function or not.
-    # NOTE: use `inspect.isfunction(fn)` instead of `instanceof(fn, CallableClass)`,
-    # because latter returns False for an object instance of callable class.
-    if inspect.isfunction(fn):
+    if isinstance(fn, CallableClass):
+        is_callable_class = True
+    else:
         is_callable_class = False
         if fn_constructor_args is not None:
             raise ValueError(
                 "``fn_constructor_args`` can only be specified if providing a "
                 f"CallableClass instance for ``fn``, but got: {fn}"
             )
-    else:
-        is_callable_class = True
 
     if compute is not None:
         # Legacy code path to support `compute` argument.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -338,8 +338,6 @@ class Dataset:
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
-                ``None`` by default autoscales from 1 to the max number of workers allowed
-                in cluster.
             ray_remote_args: Additional resource requirements to request from
                 Ray for each map worker.
 
@@ -566,9 +564,6 @@ class Dataset:
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
-                ``None`` by default autoscales from 1 to the max number of workers allowed
-                in cluster.
-
             ray_remote_args: Additional resource requirements to request from
                 ray for each map worker.
 
@@ -725,8 +720,7 @@ class Dataset:
             concurrency: The number of Ray workers to use concurrently. For a
                 fixed-sized worker pool of size ``n``, specify ``concurrency=n``. For
                 an autoscaling worker pool from ``m`` to ``n`` workers, specify
-                ``concurrency=(m, n)``. `None`` by default autoscales from 1 to the max
-                number of workers allowed in cluster.
+                ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """
@@ -790,8 +784,6 @@ class Dataset:
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
-                `None`` by default autoscales from 1 to the max number of workers allowed
-                in cluster.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """  # noqa: E501
@@ -851,8 +843,6 @@ class Dataset:
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
-                `None`` by default autoscales from 1 to the max number of workers allowed
-                in cluster.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """  # noqa: E501
@@ -945,8 +935,7 @@ class Dataset:
             concurrency: The number of Ray workers to use concurrently. For a
                 fixed-sized worker pool of size ``n``, specify ``concurrency=n``.
                 For an autoscaling worker pool from ``m`` to ``n`` workers, specify
-                ``concurrency=(m, n)``. `None`` by default autoscales from 1 to the max
-                number of workers allowed in cluster.
+                ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
                 ray for each map worker.
 
@@ -1040,8 +1029,7 @@ class Dataset:
             concurrency: The number of Ray workers to use concurrently. For a
                 fixed-sized worker pool of size ``n``, specify ``concurrency=n``.
                 For an autoscaling worker pool from ``m`` to ``n`` workers, specify
-                ``concurrency=(m, n)``. `None`` by default autoscales from 1 to the max
-                number of workers allowed in cluster.
+                ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -279,6 +279,11 @@ class Dataset:
         Use this method to transform your data. To learn more, see
         :ref:`Transforming rows <transforming_rows>`.
 
+        You can use either a function or a callable class to perform the transformation.
+        For functions, Ray Data uses stateless Ray tasks. For classes, Ray Data uses
+        stateful Ray actors. For more information, see
+        :ref:`Stateful Transformation <stateful_transformation>`.
+
         .. tip::
 
             If your transformation is vectorized like most NumPy or pandas operations,
@@ -314,8 +319,7 @@ class Dataset:
 
         Args:
             fn: The function to apply to each row, or a class type
-                that can be instantiated to create such a callable. Callable classes are
-                only supported for the actor compute strategy.
+                that can be instantiated to create such a callable.
             compute: The compute strategy, either None (default) to use Ray
                 tasks, ``ray.data.ActorPoolStrategy(size=n)`` to use a fixed-size actor
                 pool, or ``ray.data.ActorPoolStrategy(min_size=m, max_size=n)`` for an
@@ -432,10 +436,10 @@ class Dataset:
         This method is useful for preprocessing data and performing inference. To learn
         more, see :ref:`Transforming batches <transforming_batches>`.
 
-        You can use either function or class to perform the transformation. For
-        function, Ray Data uses Tasks. For class, Ray Data uses To use Actors.
-        For more information, see
-        :ref:`Transforming with Python Class <transforming_with_python_class>`.
+        You can use either a function or a callable class to perform the transformation.
+        For functions, Ray Data uses stateless Ray tasks. For classes, Ray Data uses
+        stateful Ray actors. For more information, see
+        :ref:`Stateful Transformation <stateful_transformation>`.
 
         .. tip::
             If ``fn`` doesn't mutate its input, set ``zero_copy_batch=True`` to improve
@@ -494,8 +498,7 @@ class Dataset:
 
         Args:
             fn: The function or generator to apply to a record batch, or a class type
-                that can be instantiated to create such a callable. Callable classes are
-                only supported for the actor compute strategy. Note ``fn`` must be
+                that can be instantiated to create such a callable. Note ``fn`` must be
                 pickle-able.
             batch_size: The desired number of rows in each batch, or ``None`` to use
                 entire blocks as batches (blocks may contain different numbers of rows).
@@ -866,6 +869,11 @@ class Dataset:
         Use this method if your transformation returns multiple rows for each input
         row.
 
+        You can use either a function or a callable class to perform the transformation.
+        For functions, Ray Data uses stateless Ray tasks. For classes, Ray Data uses
+        stateful Ray actors. For more information, see
+        :ref:`Stateful Transformation <stateful_transformation>`.
+
         .. tip::
             :meth:`~Dataset.map_batches` can also modify the number of rows. If your
             transformation is vectorized like most NumPy and pandas operations,
@@ -895,8 +903,7 @@ class Dataset:
 
         Args:
             fn: The function or generator to apply to each record, or a class type
-                that can be instantiated to create such a callable. Callable classes are
-                only supported for the actor compute strategy.
+                that can be instantiated to create such a callable.
             compute: The compute strategy, either "tasks" (default) to use Ray
                 tasks, ``ray.data.ActorPoolStrategy(size=n)`` to use a fixed-size actor
                 pool, or ``ray.data.ActorPoolStrategy(min_size=m, max_size=n)`` for an
@@ -987,6 +994,11 @@ class Dataset:
     ) -> "Dataset":
         """Filter out rows that don't satisfy the given predicate.
 
+        You can use either a function or a callable class to perform the transformation.
+        For functions, Ray Data uses stateless Ray tasks. For classes, Ray Data uses
+        stateful Ray actors. For more information, see
+        :ref:`Stateful Transformation <stateful_transformation>`.
+
         .. tip::
             If you can represent your predicate with NumPy or pandas operations,
             :meth:`Dataset.map_batches` might be faster. You can implement filter by
@@ -1003,8 +1015,7 @@ class Dataset:
 
         Args:
             fn: The predicate to apply to each row, or a class type
-                that can be instantiated to create such a callable. Callable classes are
-                only supported for the actor compute strategy.
+                that can be instantiated to create such a callable.
             compute: The compute strategy, either "tasks" (default) to use Ray
                 tasks, ``ray.data.ActorPoolStrategy(size=n)`` to use a fixed-size actor
                 pool, or ``ray.data.ActorPoolStrategy(min_size=m, max_size=n)`` for an

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -336,8 +336,8 @@ class Dataset:
                 example, specify `num_gpus=1` to request 1 GPU for each parallel map
                 worker.
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
-                workers pool of size ``n``, specify ``concurrency=n``. For a autoscaling
-                workers pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
+                worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
+                worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
                 ``None`` to use the default value of system.
             ray_remote_args: Additional resource requirements to request from
                 Ray for each map worker.
@@ -692,8 +692,8 @@ class Dataset:
                 autoscaling actor pool. This argument is deprecated. Please use
                 ``concurrency`` argument instead.
             concurrency: The number of Ray workers to use concurrently. For a
-                fixed-sized workers pool of size ``n``, specify ``concurrency=n``.
-                For a autoscaling workers pool from ``m`` to ``n`` workers, specify
+                fixed-sized worker pool of size ``n``, specify ``concurrency=n``. For
+                an autoscaling worker pool from ``m`` to ``n`` workers, specify
                 ``concurrency=(m, n)``. ``None`` to use the default value of system.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
@@ -760,8 +760,8 @@ class Dataset:
                 autoscaling actor pool. This argument is deprecated. Please use
                 ``concurrency`` argument instead.
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
-                workers pool of size ``n``, specify ``concurrency=n``. For a autoscaling
-                workers pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
+                worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
+                worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
                 ``None`` to use the default value of system.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
@@ -824,8 +824,8 @@ class Dataset:
                 autoscaling actor pool. This argument is deprecated. Please use
                 ``concurrency`` argument instead.
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
-                workers pool of size ``n``, specify ``concurrency=n``. For a autoscaling
-                workers pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
+                worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
+                worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
                 ``None`` to use the default value of system.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
@@ -917,8 +917,8 @@ class Dataset:
                 example, specify `num_gpus=1` to request 1 GPU for each parallel map
                 worker.
             concurrency: The number of Ray workers to use concurrently. For a
-                fixed-sized workers pool of size ``n``, specify ``concurrency=n``.
-                For a autoscaling workers pool from ``m`` to ``n`` workers, specify
+                fixed-sized worker pool of size ``n``, specify ``concurrency=n``.
+                For an autoscaling worker pool from ``m`` to ``n`` workers, specify
                 ``concurrency=(m, n)``. ``None`` to use the default value of system.
             ray_remote_args: Additional resource requirements to request from
                 ray for each map worker.
@@ -1011,8 +1011,8 @@ class Dataset:
                 autoscaling actor pool. This argument is deprecated. Please use
                 ``concurrency`` argument instead.
             concurrency: The number of Ray workers to use concurrently. For a
-                fixed-sized workers pool of size ``n``, specify ``concurrency=n``.
-                For a autoscaling workers pool from ``m`` to ``n`` workers, specify
+                fixed-sized worker pool of size ``n``, specify ``concurrency=n``.
+                For an autoscaling worker pool from ``m`` to ``n`` workers, specify
                 ``concurrency=(m, n)``. ``None`` to use the default value of system.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -282,7 +282,7 @@ class Dataset:
         You can use either a function or a callable class to perform the transformation.
         For functions, Ray Data uses stateless Ray tasks. For classes, Ray Data uses
         stateful Ray actors. For more information, see
-        :ref:`Stateful Transformation <stateful_transformation>`.
+        :ref:`Stateful Transforms <stateful_transforms>`.
 
         .. tip::
 
@@ -320,11 +320,7 @@ class Dataset:
         Args:
             fn: The function to apply to each row, or a class type
                 that can be instantiated to create such a callable.
-            compute: The compute strategy, either None (default) to use Ray
-                tasks, ``ray.data.ActorPoolStrategy(size=n)`` to use a fixed-size actor
-                pool, or ``ray.data.ActorPoolStrategy(min_size=m, max_size=n)`` for an
-                autoscaling actor pool. This argument is deprecated. Please use
-                ``concurrency`` argument instead.
+            compute: This argument is deprecated. Please use ``concurrency`` argument.
             fn_args: Positional arguments to pass to ``fn`` after the first argument.
                 These arguments are top-level arguments to the underlying Ray task.
             fn_kwargs: Keyword arguments to pass to ``fn``. These arguments are
@@ -342,7 +338,7 @@ class Dataset:
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
-                ``None`` by default autoscales from 1 to maximum number of workers allowed
+                ``None`` by default autoscales from 1 to the max number of workers allowed
                 in cluster.
             ray_remote_args: Additional resource requirements to request from
                 Ray for each map worker.
@@ -440,7 +436,7 @@ class Dataset:
         You can use either a function or a callable class to perform the transformation.
         For functions, Ray Data uses stateless Ray tasks. For classes, Ray Data uses
         stateful Ray actors. For more information, see
-        :ref:`Stateful Transformation <stateful_transformation>`.
+        :ref:`Stateful Transforms <stateful_transforms>`.
 
         .. tip::
             If ``fn`` doesn't mutate its input, set ``zero_copy_batch=True`` to improve
@@ -570,7 +566,7 @@ class Dataset:
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
-                ``None`` by default autoscales from 1 to maximum number of workers allowed
+                ``None`` by default autoscales from 1 to the max number of workers allowed
                 in cluster.
 
             ray_remote_args: Additional resource requirements to request from
@@ -725,15 +721,11 @@ class Dataset:
                 column is overwritten.
             fn: Map function generating the column values given a batch of
                 records in pandas format.
-            compute: The compute strategy, either "tasks" (default) to use Ray
-                tasks, ``ray.data.ActorPoolStrategy(size=n)`` to use a fixed-size actor
-                pool, or ``ray.data.ActorPoolStrategy(min_size=m, max_size=n)`` for an
-                autoscaling actor pool. This argument is deprecated. Please use
-                ``concurrency`` argument instead.
+            compute: This argument is deprecated. Please use ``concurrency`` argument.
             concurrency: The number of Ray workers to use concurrently. For a
                 fixed-sized worker pool of size ``n``, specify ``concurrency=n``. For
                 an autoscaling worker pool from ``m`` to ``n`` workers, specify
-                ``concurrency=(m, n)``. `None`` by default autoscales from 1 to maximum
+                ``concurrency=(m, n)``. `None`` by default autoscales from 1 to the max
                 number of workers allowed in cluster.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
@@ -794,15 +786,11 @@ class Dataset:
         Args:
             cols: Names of the columns to drop. If any name does not exist,
                 an exception is raised.
-            compute: The compute strategy, either "tasks" (default) to use Ray
-                tasks, ``ray.data.ActorPoolStrategy(size=n)`` to use a fixed-size actor
-                pool, or ``ray.data.ActorPoolStrategy(min_size=m, max_size=n)`` for an
-                autoscaling actor pool. This argument is deprecated. Please use
-                ``concurrency`` argument instead.
+            compute: This argument is deprecated. Please use ``concurrency`` argument.
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
-                `None`` by default autoscales from 1 to maximum number of workers allowed
+                `None`` by default autoscales from 1 to the max number of workers allowed
                 in cluster.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
@@ -859,15 +847,11 @@ class Dataset:
         Args:
             cols: Names of the columns to select. If a name isn't in the
                 dataset schema, an exception is raised.
-            compute: The compute strategy, either "tasks" (default) to use Ray
-                tasks, ``ray.data.ActorPoolStrategy(size=n)`` to use a fixed-size actor
-                pool, or ``ray.data.ActorPoolStrategy(min_size=m, max_size=n)`` for an
-                autoscaling actor pool. This argument is deprecated. Please use
-                ``concurrency`` argument instead.
+            compute: This argument is deprecated. Please use ``concurrency`` argument.
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
-                `None`` by default autoscales from 1 to maximum number of workers allowed
+                `None`` by default autoscales from 1 to the max number of workers allowed
                 in cluster.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
@@ -911,7 +895,7 @@ class Dataset:
         You can use either a function or a callable class to perform the transformation.
         For functions, Ray Data uses stateless Ray tasks. For classes, Ray Data uses
         stateful Ray actors. For more information, see
-        :ref:`Stateful Transformation <stateful_transformation>`.
+        :ref:`Stateful Transforms <stateful_transforms>`.
 
         .. tip::
             :meth:`~Dataset.map_batches` can also modify the number of rows. If your
@@ -943,11 +927,7 @@ class Dataset:
         Args:
             fn: The function or generator to apply to each record, or a class type
                 that can be instantiated to create such a callable.
-            compute: The compute strategy, either "tasks" (default) to use Ray
-                tasks, ``ray.data.ActorPoolStrategy(size=n)`` to use a fixed-size actor
-                pool, or ``ray.data.ActorPoolStrategy(min_size=m, max_size=n)`` for an
-                autoscaling actor pool. This argument is deprecated. Please use
-                ``concurrency`` argument instead.
+            compute: This argument is deprecated. Please use ``concurrency`` argument.
             fn_args: Positional arguments to pass to ``fn`` after the first argument.
                 These arguments are top-level arguments to the underlying Ray task.
             fn_kwargs: Keyword arguments to pass to ``fn``. These arguments are
@@ -965,7 +945,7 @@ class Dataset:
             concurrency: The number of Ray workers to use concurrently. For a
                 fixed-sized worker pool of size ``n``, specify ``concurrency=n``.
                 For an autoscaling worker pool from ``m`` to ``n`` workers, specify
-                ``concurrency=(m, n)``. `None`` by default autoscales from 1 to maximum
+                ``concurrency=(m, n)``. `None`` by default autoscales from 1 to the max
                 number of workers allowed in cluster.
             ray_remote_args: Additional resource requirements to request from
                 ray for each map worker.
@@ -1037,7 +1017,7 @@ class Dataset:
         You can use either a function or a callable class to perform the transformation.
         For functions, Ray Data uses stateless Ray tasks. For classes, Ray Data uses
         stateful Ray actors. For more information, see
-        :ref:`Stateful Transformation <stateful_transformation>`.
+        :ref:`Stateful Transforms <stateful_transforms>`.
 
         .. tip::
             If you can represent your predicate with NumPy or pandas operations,
@@ -1056,15 +1036,11 @@ class Dataset:
         Args:
             fn: The predicate to apply to each row, or a class type
                 that can be instantiated to create such a callable.
-            compute: The compute strategy, either "tasks" (default) to use Ray
-                tasks, ``ray.data.ActorPoolStrategy(size=n)`` to use a fixed-size actor
-                pool, or ``ray.data.ActorPoolStrategy(min_size=m, max_size=n)`` for an
-                autoscaling actor pool. This argument is deprecated. Please use
-                ``concurrency`` argument instead.
+            compute: This argument is deprecated. Please use ``concurrency`` argument.
             concurrency: The number of Ray workers to use concurrently. For a
                 fixed-sized worker pool of size ``n``, specify ``concurrency=n``.
                 For an autoscaling worker pool from ``m`` to ``n`` workers, specify
-                ``concurrency=(m, n)``. `None`` by default autoscales from 1 to maximum
+                ``concurrency=(m, n)``. `None`` by default autoscales from 1 to the max
                 number of workers allowed in cluster.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -487,8 +487,8 @@ class Dataset:
                     .map_batches(map_fn_with_large_output)
                 )
 
-            If you require stateful transfomation such as offline model inference,
-            use Python callable class.
+            If you require stateful transfomation,
+            use Python callable class. Here is an example showing how to use stateful transforms to create model inference workers, without having to reload the model on each call.
 
             .. testcode::
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -432,9 +432,10 @@ class Dataset:
         This method is useful for preprocessing data and performing inference. To learn
         more, see :ref:`Transforming batches <transforming_batches>`.
 
-        You can use either Ray Tasks or Ray Actors to perform the transformation. By
-        default, Ray Data uses Tasks. To use Actors, see
-        :ref:`Transforming batches with actors <transforming_data_actors>`.
+        You can use either function or class to perform the transformation. For
+        function, Ray Data uses Tasks. For class, Ray Data uses To use Actors.
+        For more information, see
+        :ref:`Transforming with Python Class <transforming_with_python_class>`.
 
         .. tip::
             If ``fn`` doesn't mutate its input, set ``zero_copy_batch=True`` to improve
@@ -530,8 +531,8 @@ class Dataset:
             num_gpus: The number of GPUs to reserve for each parallel map worker. For
                 example, specify `num_gpus=1` to request 1 GPU for each parallel map worker.
             concurrency: The number of Ray workers to use concurrently. For a fixed-sized
-                workers pool of size ``n``, specify ``concurrency=n``. For a autoscaling
-                workers pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
+                worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
+                worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
                 ``None`` to use the default value of system.
             ray_remote_args: Additional resource requirements to request from
                 ray for each map worker.

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -633,6 +633,7 @@ class TestAutoscalingPolicy:
     def test_start_actor_timeout(ray_start_regular_shared):
         """Tests that ActorPoolMapOperator raises an exception on
         timeout while waiting for actors."""
+
         class UDFClass:
             def __call__(self, x):
                 return x

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -633,6 +633,10 @@ class TestAutoscalingPolicy:
     def test_start_actor_timeout(ray_start_regular_shared):
         """Tests that ActorPoolMapOperator raises an exception on
         timeout while waiting for actors."""
+        class UDFClass:
+            def __call__(self, x):
+                return x
+
         from ray.data._internal.execution.operators import actor_pool_map_operator
         from ray.exceptions import GetTimeoutError
 
@@ -649,7 +653,7 @@ class TestAutoscalingPolicy:
             # Specify an unachievable resource requirement to ensure
             # we timeout while waiting for actors.
             ray.data.range(10).map_batches(
-                lambda x: x,
+                UDFClass,
                 batch_size=1,
                 compute=ray.data.ActorPoolStrategy(size=5),
                 num_gpus=100,

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -225,25 +225,18 @@ def test_concurrency(shutdown_only):
         def __call__(self, x):
             return x
 
-    class UDFClass2:
-        def __init__(self, y):
-            self._y = y
-
-        def __call__(self, x):
-            return x
-
-    # Test function, class, and object of class.
-    for fn in [udf, UDFClass, UDFClass2(1)]:
+    # Test function and class.
+    for fn in [udf, UDFClass]:
         # Test concurrency with None, single integer and a tuple of integers.
         for concurrency in [None, 2, (2, 4)]:
             result = ds.map(fn, concurrency=concurrency).take_all()
             assert sorted(extract_values("id", result)) == list(range(10)), result
 
     # Test concurrency with an illegal value.
-    for fn in [UDFClass, UDFClass2(1)]:
-        for concurrency in ["dummy", (1, 3, 5)]:
-            with pytest.raises(ValueError):
-                ds.map(fn, concurrency=concurrency).take_all()
+    error_message = "``concurrency`` is expected to be set a"
+    for concurrency in ["dummy", (1, 3, 5)]:
+        with pytest.raises(ValueError, match=error_message):
+            ds.map(UDFClass, concurrency=concurrency).take_all()
 
 
 def test_flat_map_generator(ray_start_regular_shared):

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -238,6 +238,11 @@ def test_concurrency(shutdown_only):
         with pytest.raises(ValueError, match=error_message):
             ds.map(UDFClass, concurrency=concurrency).take_all()
 
+    # Test an illegal value for fn.
+    error_message = "``fn`` can only be either function or callable class"
+    with pytest.raises(ValueError, match=error_message):
+        ds.map(UDFClass(), concurrency=concurrency).take_all()
+
 
 def test_flat_map_generator(ray_start_regular_shared):
     ds = ray.data.range(3)

--- a/python/ray/data/tests/util.py
+++ b/python/ray/data/tests/util.py
@@ -47,6 +47,14 @@ def column_udf(col, udf):
     return wraps
 
 
+def column_udf_class(col, udf):
+    class UDFClass:
+        def __call__(self, row):
+            return {col: udf(row[col])}
+
+    return UDFClass
+
+
 # Ex: named_values("id", [1, 2, 3])
 # Ex: named_values(["id", "id2"], [(1, 1), (2, 2), (3, 3)])
 def named_values(col_names, tuples):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Generated doc for review - https://anyscale-ray--41461.com.readthedocs.build/en/41461/data/transforming-data.html#transforming-with-python-class .

This PR is to add an extra `concurrency` argument into all map-like APIs (`map_batches`, `map`, `filter`, `flat_map`, `add_column`, `drop_columns`, `select_columns`), with the motivation to deprecate `compute` argument.

The typing for new `concurrency` is
```
Optional[Union[int, Tuple[int, int]]]
```

So it allows user to set a fixed-sized actors pool, or an auto-scaling actors pool. For 2.9, the `compute` argument would still work, but will print out a warning message for users to migrate to use `concurrency`. So this PR does not break any existing code and maintains backward compatibility.

Several other alternatives:
* Use two arguments `min_concurrency`, `max_concurrency`: `max_concurrency` is already a reserved parameter for Ray Core. This represents the number of concurrent actor tasks in Ray Core. So this would introduce extra confusion for users. In addition, we are recommending our users to use a fixed-sized actors pool for now. These two arguments are only useful for auto-scaling actors pool.

* Introduce a class like `ConcurrencyOption`: Do not see a need right now, and it would go back to have same issue with `ActorPoolStrategy`. We can always overload the type of `concurrency` and add more new types later, without breaking backward compatibility.

* Overload the type of existing argument `compute`: This would also work and requires minimal change from user side. The naming of `compute` is more vague than `concurrency` though.

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/40725

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
