### PR TITLE
[core][state][log] State API should not allow reading files outside of the ray log directory on all ray nodes.

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -180,6 +180,9 @@ class DashboardAgent:
         ), "Accessing unsupported API (GcsAioPublisher) in a minimal ray."
         return self.aio_publisher
 
+    def get_node_id(self) -> str:
+        return self.node_id
+
     async def run(self):
         # Start a grpc asyncio server.
         if self.server:

--- a/dashboard/modules/log/log_consts.py
+++ b/dashboard/modules/log/log_consts.py
@@ -3,7 +3,6 @@ MIME_TYPES = {
 }
 
 LOG_GRPC_ERROR = "log_grpc_status"
-FILE_NOT_FOUND = "LOG_GRPC_ERROR: file_not_found"
 
 # 10 seconds
 GRPC_TIMEOUT = 10

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -1261,6 +1261,12 @@ def temp_file(request):
         yield fp
 
 
+@pytest.fixture(scope="function")
+def temp_dir(request):
+    with tempfile.TemporaryDirectory("r+b") as d:
+        yield d
+
+
 @pytest.fixture(scope="module")
 def random_ascii_file(request):
     import random

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -410,6 +410,39 @@ async def test_log_agent_find_task_log_offsets(temp_file):
     assert start_offset == expected_start + len(exclude_tail_content)
 
 
+def test_log_agent_resolve_filename(temp_dir):
+    """
+    Test that LogAgentV1Grpc.resolve_filename(root, filename) works:
+    1. Not possible to resolve a file that doesn't exist.
+    2. Not able to resolve files outside of the temp dir root.
+        - with a absolute path.
+        - with a relative path recursive up
+    """
+    root = Path(temp_dir)
+    # Create a file in the temp dir.
+    file = root / "valid_file"
+    file.touch()
+    subdir = root / "subdir"
+    subdir.mkdir()
+
+    # Test file doesn't exist
+    with pytest.raises(FileNotFoundError):
+        LogAgentV1Grpc._resolve_filename(root, "non-exist-file")
+
+    # Test absolute path outside of root is now allowed
+    with pytest.raises(FileNotFoundError):
+        LogAgentV1Grpc._resolve_filename(subdir, root.resolve() / "valid_file")
+
+    # Test relative path recursive up is not allowed
+    with pytest.raises(FileNotFoundError):
+        LogAgentV1Grpc._resolve_filename(subdir, "../valid_file")
+
+    assert (
+        LogAgentV1Grpc._resolve_filename(root, "valid_file")
+        == (root / "valid_file").resolve()
+    )
+
+
 # Unit Tests (LogsManager)
 
 
@@ -1030,6 +1063,41 @@ def test_log_job(ray_start_with_dashboard):
         logs = "".join(get_log(submission_id=job_id, node_id=node_id))
         assert JOB_LOG + "\n" == logs
 
+        return True
+
+    wait_for_condition(verify)
+
+
+def test_log_get_invalid_filenames(ray_start_with_dashboard, temp_file):
+    assert (
+        wait_until_server_available(ray_start_with_dashboard.address_info["webui_url"])
+        is True
+    )
+    webui_url = ray_start_with_dashboard.address_info["webui_url"]
+    webui_url = format_web_url(webui_url)
+    node_id = list_nodes()[0]["node_id"]
+
+    # log_dir = ray._private.worker.global_worker.node.get_logs_dir_path()
+
+    def verify():
+        # Kind of hack that we know the file node_ip_address.json exists in ray.
+        with pytest.raises(RayStateApiException) as e:
+            logs = "".join(get_log(node_id=node_id, filename="../node_ip_address.json"))
+            print(logs)
+            assert "does not start with " in str(e.value)
+        return True
+
+    wait_for_condition(verify)
+
+    # Verify that reading file outside of the log directory is not allowed
+    # with absolute path.
+    def verify():
+        # Kind of hack that we know the file node_ip_address.json exists in ray.
+        temp_file_abs_path = str(Path(temp_file.name).resolve())
+        with pytest.raises(RayStateApiException) as e:
+            logs = "".join(get_log(node_id=node_id, filename=temp_file_abs_path))
+            print(logs)
+            assert "does not start with " in str(e.value)
         return True
 
     wait_for_condition(verify)

--- a/python/ray/util/state/api.py
+++ b/python/ray/util/state/api.py
@@ -1355,6 +1355,7 @@ def list_logs(
     r = requests.get(
         f"{api_server_url}/api/v0/logs?{urllib.parse.urlencode(options_dict)}"
     )
+    # TODO(rickyx): we could do better at error handling here.
     r.raise_for_status()
 
     response = r.json()

--- a/python/ray/util/state/state_manager.py
+++ b/python/ray/util/state/state_manager.py
@@ -477,6 +477,6 @@ class StateDataSourceClient:
             timeout=timeout,
         )
         metadata = await stream.initial_metadata()
-        if metadata.get(log_consts.LOG_GRPC_ERROR) == log_consts.FILE_NOT_FOUND:
-            raise ValueError(f'File "{log_file_name}" not found on node {node_id}')
+        if metadata.get(log_consts.LOG_GRPC_ERROR) is not None:
+            raise ValueError(metadata.get(log_consts.LOG_GRPC_ERROR))
         return stream


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
State API log retrieval has a bug where one could pass:
1. relative paths like "../../../xxx" to get file outside of ray's log dir
2. absolute path that's refers to other files to get file somewhere else. 

This PR fixes both issues such that one could only read logs under the ray logs directory.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
