### PR TITLE
[core] Deflakey ray syncer test - 1

### DIFF
--- a/src/ray/common/test/ray_syncer_test.cc
+++ b/src/ray/common/test/ray_syncer_test.cc
@@ -924,8 +924,8 @@ TEST_F(SyncerReactorTest, TestReactorFailure) {
   auto [node_s, node_c] = GetNodeID();
   ASSERT_TRUE(s != nullptr);
   ASSERT_TRUE(c != nullptr);
-  s->Finish(grpc::Status::CANCELLED);
   s->disconnected_ = true;
+  s->Finish(grpc::Status::CANCELLED);
   auto c_cleanup = client_cleanup.get_future().get();
   ASSERT_EQ(node_s, c_cleanup.first);
   ASSERT_EQ(true, c_cleanup.second);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixed one test. It seems it's still flakey, but hard to reproduce. Check in this first.

The issue here is that the flag need to be marked as true before calling finish. Otherwise, there is a race condition where it might be destructed twice.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
