### PR TITLE
[ci] fix gce tests

### DIFF
--- a/release/ray_release/command_runner/_anyscale_job_wrapper.py
+++ b/release/ray_release/command_runner/_anyscale_job_wrapper.py
@@ -81,9 +81,9 @@ def run_storage_cp(source: str, target: str):
             "bucket-owner-full-control",
         ]
     elif storage_service == "gs":
-        install_pip("gsutil")
         cp_cmd_args = [
-            "gsutil",
+            "gcloud",
+            "storage",
             "cp",
             source,
             target,


### PR DESCRIPTION
Fix forward of https://github.com/ray-project/ray/pull/41489. `gsutil` and `gcloud` don't share crendentials anymore in the new dataplane, so `gsutil` fails to upload data to gcp. Use `gcloud` instead.

Test:
- release