### PR TITLE
[core][state][log] Enable following symlinks that point outside of the `root_log_dir` when resolving paths

### DIFF
--- a/dashboard/modules/log/log_agent.py
+++ b/dashboard/modules/log/log_agent.py
@@ -394,7 +394,7 @@ class LogAgentV1Grpc(dashboard_utils.DashboardAgentModule):
         else:
             filepath = Path(filename)
 
-        filepath = filepath.resolve()
+        filepath = os.path.abspath(filepath)
 
         if not filepath.is_file():
             raise FileNotFoundError(f"A file is not found at: {filepath}")

--- a/dashboard/modules/log/log_agent.py
+++ b/dashboard/modules/log/log_agent.py
@@ -394,9 +394,9 @@ class LogAgentV1Grpc(dashboard_utils.DashboardAgentModule):
         else:
             filepath = Path(filename)
 
-        # We want to allow following relative paths that include symlinks pointing
-        # outside of the `root_log_dir`, so use `os.path.abspath` instead of
-        # `Path.resolve()` because `os.path.abspath` does not resolve symlinks.
+        # We want to allow relative paths that include symlinks pointing outside of the
+        # `root_log_dir`, so use `os.path.abspath` instead of `Path.resolve()` because
+        # `os.path.abspath` does not resolve symlinks.
         filepath = Path(os.path.abspath(filepath))
 
         if not filepath.is_file():

--- a/dashboard/modules/log/log_agent.py
+++ b/dashboard/modules/log/log_agent.py
@@ -394,7 +394,10 @@ class LogAgentV1Grpc(dashboard_utils.DashboardAgentModule):
         else:
             filepath = Path(filename)
 
-        filepath = os.path.abspath(filepath)
+        # We want to allow following relative paths that include symlinks pointing
+        # outside of the `root_log_dir`, so use `os.path.abspath` instead of
+        # `Path.resolve()` because `os.path.abspath` does not resolve symlinks.
+        filepath = Path(os.path.abspath(filepath))
 
         if not filepath.is_file():
             raise FileNotFoundError(f"A file is not found at: {filepath}")
@@ -404,7 +407,8 @@ class LogAgentV1Grpc(dashboard_utils.DashboardAgentModule):
         except ValueError as e:
             raise FileNotFoundError(f"{filepath} not in {root_log_dir}: {e}")
 
-        return filepath
+        # Fully resolve the path before returning (including following symlinks).
+        return filepath.resolve()
 
     async def StreamLog(self, request, context):
         """

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -425,6 +425,9 @@ def test_log_agent_resolve_filename(temp_dir):
     file.touch()
     subdir = root / "subdir"
     subdir.mkdir()
+
+    # Create a directory in the root that contains a valid file and
+    # is symlinked to by a path in the subdir.
     symlinked_dir = root / "symlinked"
     symlinked_dir.mkdir()
     symlinked_file = symlinked_dir / "valid_file"

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -417,7 +417,7 @@ def test_log_agent_resolve_filename(temp_dir):
     2. Not able to resolve files outside of the temp dir root.
         - with a absolute path.
         - with a relative path recursive up.
-    3. Permits a file in a directory that's symlinked into the temp dir.
+    3. Permits a file in a directory that's symlinked into the root dir.
     """
     root = Path(temp_dir)
     # Create a file in the temp dir.

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -416,7 +416,8 @@ def test_log_agent_resolve_filename(temp_dir):
     1. Not possible to resolve a file that doesn't exist.
     2. Not able to resolve files outside of the temp dir root.
         - with a absolute path.
-        - with a relative path recursive up
+        - with a relative path recursive up.
+    3. Permits a file in a directory that's symlinked into the temp dir.
     """
     root = Path(temp_dir)
     # Create a file in the temp dir.
@@ -424,12 +425,18 @@ def test_log_agent_resolve_filename(temp_dir):
     file.touch()
     subdir = root / "subdir"
     subdir.mkdir()
+    symlinked_dir = root / "symlinked"
+    symlinked_dir.mkdir()
+    symlinked_file = symlinked_dir / "valid_file"
+    symlinked_file.touch()
+    symlinked_path_in_subdir = subdir / "symlink_to_outside_dir"
+    symlinked_path_in_subdir.symlink_to(symlinked_dir)
 
     # Test file doesn't exist
     with pytest.raises(FileNotFoundError):
         LogAgentV1Grpc._resolve_filename(root, "non-exist-file")
 
-    # Test absolute path outside of root is now allowed
+    # Test absolute path outside of root is not allowed
     with pytest.raises(FileNotFoundError):
         LogAgentV1Grpc._resolve_filename(subdir, root.resolve() / "valid_file")
 
@@ -437,9 +444,16 @@ def test_log_agent_resolve_filename(temp_dir):
     with pytest.raises(FileNotFoundError):
         LogAgentV1Grpc._resolve_filename(subdir, "../valid_file")
 
+    # Test relative path a valid file is allowed
     assert (
         LogAgentV1Grpc._resolve_filename(root, "valid_file")
         == (root / "valid_file").resolve()
+    )
+
+    # Test relative path to a valid file following a symlink is allowed
+    assert (
+        LogAgentV1Grpc._resolve_filename(subdir, "symlink_to_outside_dir/valid_file")
+        == (root / "symlinked" / "valid_file").resolve()
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Follow-up to: https://github.com/ray-project/ray/pull/41467. The change incidentally broke log retrieval on mac os because `/tmp` is a symlink to `/private/tmp`.

This PR avoids resolving the symlink until after we do the subdir check. This solves the mac os problem and generically enables file paths that contain symlinks outside of the `root_log_dir`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
