### PR TITLE
block PUT and POST methods for /api calls for browsers

### DIFF
--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -147,6 +147,19 @@ class HttpServerDashboardHead:
         return await handler(request)
 
     @aiohttp.web.middleware
+    async def browsers_no_post_put_middleware(self, request, handler):
+        if (
+            request.path.startswith("/api")
+            and request.headers["User-Agent"].startswith("Mozilla")
+            and request.method in [hdrs.METH_POST, hdrs.METH_PUT]
+        ):
+            return aiohttp.web.Response(
+                status=405, text="Method Not Allowed for browser traffic."
+            )
+
+        return await handler(request)
+
+    @aiohttp.web.middleware
     async def metrics_middleware(self, request, handler):
         start_time = time.monotonic()
 
@@ -185,7 +198,11 @@ class HttpServerDashboardHead:
         # working_dir uploads for job submission can be up to 100MiB.
         app = aiohttp.web.Application(
             client_max_size=100 * 1024**2,
-            middlewares=[self.metrics_middleware, self.path_clean_middleware],
+            middlewares=[
+                self.metrics_middleware,
+                self.path_clean_middleware,
+                self.browsers_no_post_put_middleware,
+            ],
         )
         app.add_routes(routes=routes.bound_routes())
 

--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -149,8 +149,9 @@ class HttpServerDashboardHead:
     @aiohttp.web.middleware
     async def browsers_no_post_put_middleware(self, request, handler):
         if (
-            request.path.startswith("/api")
-            and request.headers["User-Agent"].startswith("Mozilla")
+            # A best effort test for browser traffic. All common browsers
+            # start with Mozilla at the time of writing.
+            request.headers["User-Agent"].startswith("Mozilla")
             and request.method in [hdrs.METH_POST, hdrs.METH_PUT]
         ):
             return aiohttp.web.Response(

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -19,7 +19,7 @@ import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.modules
 import ray.dashboard.utils as dashboard_utils
 from click.testing import CliRunner
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, HTTPError
 from ray._private import ray_constants
 from ray._private.ray_constants import (
     DEBUG_AUTOSCALING_ERROR,
@@ -362,6 +362,47 @@ def test_http_get(enable_test_module, ray_start_with_dashboard):
                 logger.info("failed response: %s", response.text)
                 raise ex
             assert dump_info["result"] is True
+            break
+        except (AssertionError, requests.exceptions.ConnectionError) as e:
+            logger.info("Retry because of %s", e)
+        finally:
+            if time.time() > start_time + timeout_seconds:
+                raise Exception("Timed out while testing.")
+
+
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
+def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
+    assert wait_until_server_available(ray_start_with_dashboard["webui_url"]) is True
+    webui_url = ray_start_with_dashboard["webui_url"]
+    webui_url = format_web_url(webui_url)
+
+    timeout_seconds = 30
+    start_time = time.time()
+    while True:
+        time.sleep(3)
+        try:
+            # Starting and getting jobs should be fine from API clients
+            response = requests.post(webui_url + "/api/jobs", json={"entrypoint": "ls"})
+            response.raise_for_status()
+            response = requests.get(webui_url + "/api/jobs")
+            response.raise_for_status()
+
+            # Starting job should be blocked for browsers
+            response = requests.post(
+                webui_url + "/api/jobs",
+                json={"entrypoint": "ls"},
+                headers={
+                    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+                },
+            )
+            with pytest.raises(HTTPError):
+                response.raise_for_status()
+
+            response = requests.get(webui_url + "/api/jobs")
+            response.raise_for_status()
             break
         except (AssertionError, requests.exceptions.ConnectionError) as e:
             logger.info("Retry because of %s", e)

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -385,7 +385,9 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
         time.sleep(3)
         try:
             # Starting and getting jobs should be fine from API clients
-            response = requests.post(webui_url + "/api/jobs/", json={"entrypoint": "ls"})
+            response = requests.post(
+                webui_url + "/api/jobs/", json={"entrypoint": "ls"}
+            )
             response.raise_for_status()
             response = requests.get(webui_url + "/api/jobs/")
             response.raise_for_status()

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -385,14 +385,14 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
         time.sleep(3)
         try:
             # Starting and getting jobs should be fine from API clients
-            response = requests.post(webui_url + "/api/jobs", json={"entrypoint": "ls"})
+            response = requests.post(webui_url + "/api/jobs/", json={"entrypoint": "ls"})
             response.raise_for_status()
-            response = requests.get(webui_url + "/api/jobs")
+            response = requests.get(webui_url + "/api/jobs/")
             response.raise_for_status()
 
             # Starting job should be blocked for browsers
             response = requests.post(
-                webui_url + "/api/jobs",
+                webui_url + "/api/jobs/",
                 json={"entrypoint": "ls"},
                 headers={
                     "User-Agent": (
@@ -406,7 +406,7 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
                 response.raise_for_status()
 
             # Getting jobs should be fine for browsers
-            response = requests.get(webui_url + "/api/jobs")
+            response = requests.get(webui_url + "/api/jobs/")
             response.raise_for_status()
             break
         except (AssertionError, requests.exceptions.ConnectionError) as e:

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -395,7 +395,11 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
                 webui_url + "/api/jobs",
                 json={"entrypoint": "ls"},
                 headers={
-                    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+                    "User-Agent": (
+                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        "Chrome/119.0.0.0 Safari/537.36"
+                    )
                 },
             )
             with pytest.raises(HTTPError):

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -401,6 +401,7 @@ def test_browser_no_post_no_put(enable_test_module, ray_start_with_dashboard):
             with pytest.raises(HTTPError):
                 response.raise_for_status()
 
+            # Getting jobs should be fine for browsers
             response = requests.get(webui_url + "/api/jobs")
             response.raise_for_status()
             break


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The dashboard UI only uses GET methods. No need to expose these other endpoints to browsers.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
