### PR TITLE
[data] Deflake test_large_e2e_backpressure

### DIFF
--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -300,31 +300,38 @@ class TestStreamOutputBackpressurePolicy(unittest.TestCase):
 
 def test_large_e2e_backpressure(shutdown_only, restore_data_context):  # noqa: F811
     """Test backpressure on a synthetic large-scale workload."""
-    # The cluster has 10 CPUs and 2GB object store memory.
-    # The dataset will have 2GB * 25% = 512MB memory budget.
+    # The cluster has 10 CPUs and 200MB object store memory.
+    # The dataset will have 200MB * 25% = 50MB memory budget.
     #
-    # Each produce task generates 10 blocks, each of which has 0.1GB data.
+    # Each produce task generates 10 blocks, each of which has 10MB data.
     #
     # Without any backpressure, the producer tasks will output at most
-    # 10 * 10 * 0.1GB = 10GB data.
+    # 10 * 10 * 10MB = 1000MB data.
     #
     # With StreamingOutputBackpressurePolicy and the following configuration,
     # the executor will still schedule 10 produce tasks, but only the first task is
     # allowed to output all blocks. The total size of pending blocks will be
-    # (10 + 9 * 1 + 1) * 0.1GB = 2GB,
-    # where
+    # (10 + 9 * 1 + 1) * 10MB = 200MB, where
     # - 10 is the number of blocks in the first task.
     # - 9 * 1 is the number of blocks pending at the streaming generator level of
     #   the other 15 tasks.
     # - 1 is the number of blocks pending at the output queue.
-    max_pending_block_bytes = int(2 * 1024**3)
 
-    ray.init(num_cpus=10, object_store_memory=2 * 1024 * 1024 * 1024)
-
+    NUM_CPUS = 10
     NUM_ROWS_PER_TASK = 10
     NUM_TASKS = 20
     NUM_ROWS_TOTAL = NUM_ROWS_PER_TASK * NUM_TASKS
-    BLOCK_SIZE = 100 * 1024 * 1024
+    BLOCK_SIZE = 10 * 1024 * 1024
+    STREMING_GEN_BUFFER_SIZE = 1
+    OP_OUTPUT_QUEUE_SIZE = 1
+    max_pending_block_bytes = (
+        NUM_ROWS_PER_TASK
+        + (NUM_CPUS - 1) * STREMING_GEN_BUFFER_SIZE
+        + OP_OUTPUT_QUEUE_SIZE
+    ) * BLOCK_SIZE
+    print(f"max_pending_block_bytes: {max_pending_block_bytes/1024/1024}MB")
+
+    ray.init(num_cpus=NUM_CPUS, object_store_memory=200 * 1024 * 1024)
 
     def produce(batch):
         print("Produce task started", batch["id"])
@@ -349,10 +356,12 @@ def test_large_e2e_backpressure(shutdown_only, restore_data_context):  # noqa: F
         ],
     )
     data_context.set_config(
-        StreamingOutputBackpressurePolicy.MAX_BLOCKS_IN_OP_OUTPUT_QUEUE_CONFIG_KEY, 1
+        StreamingOutputBackpressurePolicy.MAX_BLOCKS_IN_OP_OUTPUT_QUEUE_CONFIG_KEY,
+        OP_OUTPUT_QUEUE_SIZE,
     )
     data_context.set_config(
-        StreamingOutputBackpressurePolicy.MAX_BLOCKS_IN_GENERATOR_BUFFER_CONFIG_KEY, 1
+        StreamingOutputBackpressurePolicy.MAX_BLOCKS_IN_GENERATOR_BUFFER_CONFIG_KEY,
+        STREMING_GEN_BUFFER_SIZE,
     )
     data_context.execution_options.verbose_progress = True
     data_context.target_max_block_size = BLOCK_SIZE


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This test may timeout in CI because CI machines have very slow disks. Reduce the size of data to deflake this test.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
