### PR TITLE
[ci] move //python/ray/data:test_backpressure_policies to flaky

### DIFF
--- a/ci/ray_ci/data.tests.yml
+++ b/ci/ray_ci/data.tests.yml
@@ -2,3 +2,4 @@ flaky_tests:
   - //python/ray/data:test_streaming_integration
   - //python/ray/data:test_split
   - //python/ray/data:test_stats
+  - //python/ray/data:test_backpressure_policies


### PR DESCRIPTION
As title

<img width="1424" alt="Screenshot 2023-11-29 at 4 38 56 PM" src="https://github.com/ray-project/ray/assets/128072568/e383e5a5-e17e-4796-80aa-5c3d0f05ca55">


Test:
- CI