### PR TITLE
[ci] Make manylinux build script re-executable

### DIFF
--- a/ci/build/build-manylinux-forge.sh
+++ b/ci/build/build-manylinux-forge.sh
@@ -34,7 +34,7 @@ nvm use "$NODE_VERSION"
 
 # Install bazel
 npm install -g @bazel/bazelisk
-ln -s "$(which bazelisk)" /usr/local/bin/bazel
+ln -sf "$(which bazelisk)" /usr/local/bin/bazel
 
 {
   echo "build --config=ci"


### PR DESCRIPTION
## Why are these changes needed?

During local development or re-used build server case wheel build shell script is executed more than one time. Such cases bazel link creation is failing with `File exists` error. In this PR I've fixed it by overwriting existing bazel link.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Manually locally and on custom build server
