### PR TITLE
[data] disable `test_data_head` on osx

### DIFF
--- a/dashboard/modules/data/tests/test_data_head.py
+++ b/dashboard/modules/data/tests/test_data_head.py
@@ -1,7 +1,11 @@
 import ray
+import os
 import requests
 import sys
 import pytest
+
+# For local testing on a Macbook, set `export TEST_ON_DARWIN=1`.
+TEST_ON_DARWIN = os.environ.get("TEST_ON_DARWIN", "0") == "1"
 
 DATA_HEAD_URLS = {"GET": "http://localhost:8265/api/data/datasets"}
 
@@ -28,6 +32,9 @@ OPERATOR_SCHEMA = [
 ] + DATA_SCHEMA
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
 def test_get_datasets():
     ray.init()
     ds = ray.data.range(100, parallelism=20).map_batches(lambda x: x)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`test_data_head` has been flaky only on osx:
<img width="1118" alt="Screenshot 2023-11-30 at 9 57 25 AM" src="https://github.com/ray-project/ray/assets/39287272/9b01bd92-1a34-49bd-9139-0dfa6c52658f">

The [serve dashboard tests](https://github.com/ray-project/ray/blob/master/dashboard/modules/serve/tests/test_serve_dashboard.py) are also disabled on osx because of #30114 (which looks like its still unresolved?)

This pr adds a flag to skip this test on osx like in `test_serve_dashboard`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
