### PR TITLE
[core] Add __ray_call__ default actor method

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1419,13 +1419,15 @@ def _modify_class(cls):
             "'class ClassName(object):' instead of 'class ClassName:'."
         )
 
-    # Modify the class to have additional methods
-    # for checking actor alive status and to terminate the worker.
+    # Modify the class to have additional default methods.
     class Class(cls):
         __ray_actor_class__ = cls  # The original actor class
 
         def __ray_ready__(self):
             return True
+
+        def __ray_call__(self, fn, *args, **kwargs):
+            return fn(self, *args, **kwargs)
 
         def __ray_terminate__(self):
             worker = ray._private.worker.global_worker

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1135,8 +1135,8 @@ def test_actor_generic_call(ray_start_regular_shared):
         actor.__ray_call__()
 
     assert ray.get(actor.__ray_call__.remote(lambda self: 4)) == 4
-    assert ray.get(actor.__ray_call__.remote(lambda self, x: x * 2), 2) == 4
-    assert ray.get(actor.__ray_call__.remote(lambda self, x: x * 2), x=2) == 4
+    assert ray.get(actor.__ray_call__.remote(lambda self, x: x * 2, 2)) == 4
+    assert ray.get(actor.__ray_call__.remote(lambda self, x: x * 2, x=2)) == 4
 
 
 def test_return_actor_handle_from_actor(ray_start_regular_shared):

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1183,6 +1183,7 @@ def test_actor_autocomplete(ray_start_regular_shared):
         "__init__",
         "method_one",
         "__ray_ready__",
+        "__ray_call__",
         "__ray_terminate__",
     }
 

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1123,6 +1123,22 @@ def test_actor_ready(ray_start_regular_shared):
     assert ray.get(actor.__ray_ready__.remote())
 
 
+def test_actor_generic_call(ray_start_regular_shared):
+    @ray.remote
+    class Actor:
+        pass
+
+    actor = Actor.remote()
+
+    with pytest.raises(TypeError):
+        # Method can't be called directly
+        actor.__ray_call__()
+
+    assert ray.get(actor.__ray_call__.remote(lambda self: 4)) == 4
+    assert ray.get(actor.__ray_call__.remote(lambda self, x: x * 2), 2) == 4
+    assert ray.get(actor.__ray_call__.remote(lambda self, x: x * 2), x=2) == 4
+
+
 def test_return_actor_handle_from_actor(ray_start_regular_shared):
     @ray.remote
     class Inner:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Similar to `__ray_ready__`, this adds a developer method `__ray_call__(fn, *a, **kw)`  that can be used by library developers to run custom closures on actors.

For example, a common use case for an actor is to "get its current node id". Without this method, a library developer would have to tell users to add a special `get_node_id` method to their actor. With this new API, the library developer can instead run:

```
def fn(actor_self):
   return ray.get_runtime_context().get_node_id()

ray.get(actor.__ray_call__.remote(fn))
```
