### PR TITLE
[ci] move windows train tests to rayci

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -28,6 +28,11 @@ fi
 echo "Creating var/ artifact directory..."
 docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'chown -R 2000 /artifact-mount/' || true
 
+if [ "${OSTYPE}" = msys ]; then
+  # Disable Windows Defender real-time monitoring. This is neccessary to avoid
+  # docker build significant slow down
+  powershell -Command "Set-MpPreference -DisableRealtimeMonitoring 1"
+fi
 
 RAYCI_CHECKOUT_DIR="$(pwd)"
 export RAYCI_CHECKOUT_DIR

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -213,6 +213,19 @@ steps:
         --only-tags ptl_v2
     depends_on: [ "mllightning2gpubuild", "forge" ]
 
+  - label: ":train: ml: :windows: tests"
+    tags:
+      - train
+    job_env: WINDOWS
+    instance_type: windows
+    commands:
+      - bash ci/ray_ci/install_windows_tools.sh
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train:test_windows ml
+        --operating-system windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE="$${USERPROFILE}"
+
   - label: ":train: ml: flaky tests"
     tags: 
       - train
@@ -254,11 +267,3 @@ steps:
         --only-tags gpu,gpu_only
     depends_on: [ "mlgpubuild", "forge" ]
     soft_fail: true
-
-  - label: ":windows: train tests"
-    tags:
-      - train
-    job_env: WINDOWS
-    instance_type: windows
-    commands:
-      - bash /c/workdir/.buildkite/windows_ci.sh test_train_windows

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -322,6 +322,7 @@ if __name__ == "__main__":
                 or changed_file == ".buildkite/pipeline.build.yml"
                 or changed_file == ".buildkite/pipeline.ml.yml"
                 or changed_file == ".buildkite/hooks/post-command"
+                or changed_file == ".buildkite/hooks/pre-command"
             ):
                 # These scripts are always run as part of the build process
                 RAY_CI_TOOLS_AFFECTED = 1

--- a/ci/pipeline/fix-windows-recycle.ps1
+++ b/ci/pipeline/fix-windows-recycle.ps1
@@ -1,0 +1,1 @@
+Remove-Item -Path $env:TEMP\* -Recurse -Force -ErrorAction SilentlyContinue

--- a/ci/ray_ci/build_ray_windows.sh
+++ b/ci/ray_ci/build_ray_windows.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ex
+
+git config --global core.symlinks true
+git config --global core.autocrlf false
+mkdir -p /c/rayci
+git clone . /c/rayci
+cd /c/rayci
+
+powershell ci/pipeline/fix-windows-bazel.ps1
+
+{
+  echo "build --announce_rc";  
+  echo "build --config=ci";
+  echo "startup --output_user_root=c:/tmp";
+  echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}";
+} >> ~/.bazelrc
+
+# Build ray
+conda init 
+pip install -U --ignore-installed  \
+  -c python/requirements_compiled.txt \
+  -r python/requirements.txt \
+  -r python/requirements/test-requirements.txt
+pip install -v -e python
+
+# Clean up temp files to speed up docker build
+pip cache purge
+bazel clean --expunge
+powershell ci/pipeline/fix-windows-recycle.ps1

--- a/ci/ray_ci/install_windows_tools.sh
+++ b/ci/ray_ci/install_windows_tools.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+# Install Bazel
+powershell ci/pipeline/fix-windows-bazel.ps1
+
+# Install Docker
+mkdir -p /c/tools
+wget -P /c/tools https://download.docker.com/win/static/stable/x86_64/docker-20.10.10.zip
+unzip /c/tools/docker-20.10.10.zip -d /c/tools
+rm /c/tools/docker-20.10.10.zip
+mv /c/tools/docker/* /c/bazel/

--- a/ci/ray_ci/requirements.in
+++ b/ci/ray_ci/requirements.in
@@ -1,3 +1,4 @@
 click
+colorama
 pytest
 pyyaml

--- a/ci/ray_ci/requirements.txt
+++ b/ci/ray_ci/requirements.txt
@@ -8,6 +8,10 @@ click==8.1.6 \
     --hash=sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd \
     --hash=sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5
     # via -r ci/ray_ci/requirements.in
+colorama==0.4.6 \
+    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+    # via -r ci/ray_ci/requirements.in
 exceptiongroup==1.1.2 \
     --hash=sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5 \
     --hash=sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -35,7 +35,7 @@ def test_get_container() -> None:
         "ci.ray_ci.tester_container.TesterContainer.install_ray",
         return_value=None,
     ):
-        container = _get_container("core", 3, 1, 2, 0)
+        container = _get_container("core", 3, 1, 2, "linux", 0)
         assert container.docker_tag == "corebuild"
         assert container.shard_count == 6
         assert container.shard_ids == [2, 3]

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -15,6 +15,7 @@ class TesterContainer(Container):
     def __init__(
         self,
         docker_tag: str,
+        operating_system: str = "linux",
         shard_count: int = 1,
         gpus: int = 0,
         test_envs: Optional[List[str]] = None,
@@ -32,10 +33,13 @@ class TesterContainer(Container):
         super().__init__(
             docker_tag,
             envs=test_envs,
+            operating_system=operating_system,
             volumes=[
                 f"{os.environ.get('RAYCI_CHECKOUT_DIR')}:/ray-mount",
                 "/var/run/docker.sock:/var/run/docker.sock",
-            ],
+            ]
+            if operating_system == "linux"
+            else [],
         )
         self.shard_count = shard_count
         self.shard_ids = shard_ids or []

--- a/ci/ray_ci/tests.windows.env.Dockerfile
+++ b/ci/ray_ci/tests.windows.env.Dockerfile
@@ -1,0 +1,15 @@
+FROM rayproject/buildenv:windows
+
+ENV BUILDKITE_BAZEL_CACHE_URL=https://bazel-cache-dev.s3.us-west-2.amazonaws.com
+ENV PYTHON=3.8
+ENV RAY_USE_RANDOM_PORTS=1
+ENV RAY_DEFAULT_BUILD=1
+ENV RAY_INSTALL_JAVA=0
+ENV RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
+COPY . .
+RUN bash ci/ray_ci/build_ray_windows.sh
+
+WORKDIR /rayci


### PR DESCRIPTION
Move windows train tests to the common rayci tool. This requires the following changes:
- Turn off virus scanning in windows, this slow down docker build significantly
- Add the `--operating-system` flag to rayci to have a few special logic for windows (added `--os` tag originally but the word `os` is ambiguous to another library in python)
- Clean up build artifacts aggressively to speed up docker build

Test:
- CI