### PR TITLE
[Serve] Support automatic conversion for Pydantic 2 models in the args builder

### DIFF
--- a/python/ray/_private/pydantic_compat.py
+++ b/python/ray/_private/pydantic_compat.py
@@ -24,6 +24,7 @@ if not PYDANTIC_INSTALLED:
     ValidationError = None
     root_validator = None
     validator = None
+    is_subclass_of_base_model = lambda obj: False
 # In pydantic <1.9.0, __version__ attribute is missing, issue ref:
 # https://github.com/pydantic/pydantic/issues/2572, so we need to check
 # the existence prior to comparison.
@@ -43,6 +44,10 @@ elif hasattr(pydantic, "__version__") and packaging.version.parse(
         root_validator,
         validator,
     )
+
+    def is_subclass_of_base_model(obj):
+        return issubclass(obj, BaseModel)
+
 else:
     IS_PYDANTIC_2 = True
     from pydantic.v1 import (
@@ -57,6 +62,12 @@ else:
         root_validator,
         validator,
     )
+
+    def is_subclass_of_base_model(obj):
+        from pydantic import BaseModel as BaseModelV2
+        from pydantic.v1 import BaseModel as BaseModelV1
+
+        return issubclass(obj, BaseModelV1) or issubclass(obj, BaseModelV2)
 
 
 def register_pydantic_serializers(serialization_context):

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -4,7 +4,7 @@ from types import FunctionType
 from typing import Any, Dict, Tuple, Union
 
 import ray
-from ray._private.pydantic_compat import BaseModel
+from ray._private.pydantic_compat import is_subclass_of_base_model
 from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
 from ray._private.usage import usage_lib
 from ray.actor import ActorHandle
@@ -340,7 +340,9 @@ def call_app_builder_with_args_if_necessary(
     # that model. This will perform standard pydantic validation (e.g., raise an
     # exception if required fields are missing).
     param = signature.parameters[list(signature.parameters.keys())[0]]
-    if inspect.isclass(param.annotation) and issubclass(param.annotation, BaseModel):
+    if inspect.isclass(param.annotation) and is_subclass_of_base_model(
+        param.annotation
+    ):
         args = param.annotation.parse_obj(args)
 
     app = builder(args)

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -773,7 +773,7 @@ class TestAppBuilder:
             call_app_builder_with_args_if_necessary(
                 check_missing_required, {"num_replicas": "10"}
             )
-    
+
     def test_pydantic_version_compatibility(self):
         """Check compatibility with different pydantic versions."""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Users can annotate their args builder with a Pydantic model to automatically convert config args to a Pydantic model. However, if they use a Pydantic v2 model, the config args will not be converted to a model. The args remain a `dict`.

This change makes the args builder automatically convert the `dict` to a model, no matter what Pydantic version the model was defined in.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds tests to `test_api.py`.