### PR TITLE
[ci] move test_per_func_name_stats to flaky

### DIFF
--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -17,6 +17,7 @@ from ray._private.metrics_agent import PrometheusServiceDiscoveryWriter
 from ray._private.ray_constants import PROMETHEUS_SERVICE_DISCOVERY_FILE
 from ray._private.test_utils import (
     SignalActor,
+    skip_flaky_core_test_premerge,
     fetch_prometheus,
     fetch_prometheus_metrics,
     get_log_batch,
@@ -539,6 +540,7 @@ def test_operation_stats(monkeypatch, shutdown_only):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Not working in Windows.")
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/41548")
 def test_per_func_name_stats(shutdown_only):
     # Test operation stats are available when flag is on.
     comp_metrics = [


### PR DESCRIPTION
Test is flaky (failed on 3 recent runs). See https://github.com/ray-project/ray/issues/41548 for context.

Test:
- CI