### PR TITLE
[spark] Preallocate Ray worker port range for Ray head node

### DIFF
--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -268,7 +268,7 @@ _RAY_WORKER_NODE_STARTUP_INTERVAL = int(
 _RAY_CONNECT_CLUSTER_POLL_PROGRESS_TIMEOUT = 120
 
 
-def _prepare_for_ray_worker_node_startup():
+def _preallocate_ray_worker_port_range():
     """
     If we start multiple ray workers on a machine concurrently, some ray worker
     processes might fail due to ray port conflicts, this is because race condition
@@ -607,6 +607,11 @@ def _setup_ray_cluster(
         )
         ray_head_node_cmd = autoscaling_cluster.ray_head_node_cmd
     else:
+        (
+            worker_port_range_begin,
+            worker_port_range_end,
+        ) = _preallocate_ray_worker_port_range()
+
         ray_head_node_cmd = [
             sys.executable,
             "-m",
@@ -621,6 +626,8 @@ def _setup_ray_cluster(
             f"--num-gpus={num_gpus_head_node}",
             f"--memory={heap_memory_head_node}",
             f"--object-store-memory={object_store_memory_head_node}",
+            f"--min-worker-port={worker_port_range_begin}",
+            f"--max-worker-port={worker_port_range_end - 1}",
             *dashboard_options,
             *_convert_ray_node_options(head_node_options),
         ]
@@ -1273,7 +1280,7 @@ def _start_ray_worker_nodes(
         (
             worker_port_range_begin,
             worker_port_range_end,
-        ) = _prepare_for_ray_worker_node_startup()
+        ) = _preallocate_ray_worker_port_range()
 
         # Ray worker might run on a machine different with the head node, so create the
         # local log dir and temp dir again.
@@ -1509,6 +1516,11 @@ class AutoscalingCluster:
         with open(autoscale_config, "w") as f:
             f.write(json.dumps(self._config))
 
+        (
+            worker_port_range_begin,
+            worker_port_range_end,
+        ) = _preallocate_ray_worker_port_range()
+
         ray_head_node_cmd = [
             sys.executable,
             "-m",
@@ -1520,6 +1532,8 @@ class AutoscalingCluster:
             f"--port={ray_head_port}",
             f"--ray-client-server-port={ray_client_server_port}",
             f"--autoscaling-config={autoscale_config}",
+            f"--min-worker-port={worker_port_range_begin}",
+            f"--max-worker-port={worker_port_range_end - 1}",
             *dashboard_options,
         ]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Preallocate Ray worker port range for Ray head node:

On databricks cluster, multiple users might connect to the same databricks cluster and each user might create his own Ray head node. Then, to avoid Ray task that is scheduled to Ray head node gets port conflict, I preallocate the Ray task port range for each Ray head node.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
