### PR TITLE
[Jobs] [Doc] Add note about trailing slash for REST API

### DIFF
--- a/doc/source/cluster/running-applications/job-submission/rest.rst
+++ b/doc/source/cluster/running-applications/job-submission/rest.rst
@@ -16,7 +16,7 @@ Continue on for examples, or jump to the :ref:`OpenAPI specification <ray-job-re
     import time
 
     resp = requests.post(
-        "http://127.0.0.1:8265/api/jobs/",
+        "http://127.0.0.1:8265/api/jobs/", # Don't forget the trailing slash!
         json={
             "entrypoint": "echo hello",
             "runtime_env": {},


### PR DESCRIPTION
It's a common mistake to forget the trailing slash in the URL for the REST API request, and the resulting error is not clear.  This PR adds a brief reminder in the docs about the slash.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
