### PR TITLE
[ci] Deflaky test_metrics_agent

### DIFF
--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -570,6 +570,9 @@ def test_per_func_name_stats(shutdown_only):
     a = Actor.remote()  # noqa
     b = ActorB.remote()
 
+    ray.get(a.__ray_ready__.remote())
+    ray.get(b.__ray_ready__.remote())
+
     def verify_components():
         metrics = raw_metrics(addr)
         metric_names = set(metrics.keys())
@@ -580,15 +583,13 @@ def test_per_func_name_stats(shutdown_only):
             for sample in samples:
                 components.add(sample.labels["Component"])
 
-        # NOTE: when Actor.__init__ runs slow, it might also show up
-        # in the metrics.
         assert {
             "raylet",
             "agent",
             "ray::Actor",
             "ray::ActorB",
             "ray::IDLE",
-        } in components
+        } == components
         return True
 
     wait_for_condition(verify_components, timeout=30)

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -17,7 +17,6 @@ from ray._private.metrics_agent import PrometheusServiceDiscoveryWriter
 from ray._private.ray_constants import PROMETHEUS_SERVICE_DISCOVERY_FILE
 from ray._private.test_utils import (
     SignalActor,
-    skip_flaky_core_test_premerge,
     fetch_prometheus,
     fetch_prometheus_metrics,
     get_log_batch,
@@ -581,7 +580,7 @@ def test_per_func_name_stats(shutdown_only):
             for sample in samples:
                 components.add(sample.labels["Component"])
 
-        # NOTE: when Actor.__init__ runs slow, it might also show up 
+        # NOTE: when Actor.__init__ runs slow, it might also show up
         # in the metrics.
         assert {
             "raylet",

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -540,7 +540,6 @@ def test_operation_stats(monkeypatch, shutdown_only):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Not working in Windows.")
-@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/41548")
 def test_per_func_name_stats(shutdown_only):
     # Test operation stats are available when flag is on.
     comp_metrics = [
@@ -581,13 +580,16 @@ def test_per_func_name_stats(shutdown_only):
             components = set()
             for sample in samples:
                 components.add(sample.labels["Component"])
+
+        # NOTE: when Actor.__init__ runs slow, it might also show up 
+        # in the metrics.
         assert {
             "raylet",
             "agent",
             "ray::Actor",
             "ray::ActorB",
             "ray::IDLE",
-        } == components
+        } in components
         return True
 
     wait_for_condition(verify_components, timeout=30)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When the init function runs slow enough, we will the the function name e.g. `Actor.__init__` shows up in the metrics component reporting as well. 

Changing the test function to adapt to this non-determinism. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
