### PR TITLE
[Data] Partial fix for Dataset.context not being sealed after creation

### DIFF
--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -115,6 +115,7 @@ class ExecutionPlan:
         stats: DatasetStats,
         *,
         run_by_consumer: bool,
+        data_context: Optional[DataContext] = None,
     ):
         """Create a plan with no transformation stages.
 
@@ -143,9 +144,12 @@ class ExecutionPlan:
         self._run_by_consumer = run_by_consumer
         self._dataset_name = None
 
-        # Snapshot the current context, so that the config of Datasets is always
-        # determined by the config at the time it was created.
-        self._context = copy.deepcopy(DataContext.get_current())
+        if data_context is None:
+            # Snapshot the current context, so that the config of Datasets is always
+            # determined by the config at the time it was created.
+            self._context = copy.deepcopy(DataContext.get_current())
+        else:
+            self._context = data_context
 
     def __repr__(self) -> str:
         return (
@@ -330,7 +334,10 @@ class ExecutionPlan:
             A shallow copy of this execution plan.
         """
         plan_copy = ExecutionPlan(
-            self._in_blocks, self._in_stats, run_by_consumer=self._run_by_consumer
+            self._in_blocks,
+            self._in_stats,
+            run_by_consumer=self._run_by_consumer,
+            data_context=self._context,
         )
         if self._snapshot_blocks is not None:
             # Copy over the existing snapshot.

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -545,32 +545,6 @@ def test_streaming_fault_tolerance(ray_start_10_cpus_shared, restore_data_contex
         ds2.take_all()
 
 
-def test_streaming_split_with_custom_data_context(
-    ray_start_10_cpus_shared, restore_data_context
-):
-    # Tests that custom DataContext can be properly propagated
-    # when using `streaming_split()`.
-    block_size = 123 * 1024 * 1024
-    data_context = DataContext.get_current()
-    data_context.target_max_block_size = block_size
-    data_context.set_config("foo", "bar")
-
-    def f(x):
-        assert DataContext.get_current().target_max_block_size == block_size
-        assert DataContext.get_current().get_config("foo") == "bar"
-        return x
-
-    num_splits = 2
-    splits = ray.data.range(10, parallelism=10).map(f).streaming_split(num_splits)
-
-    @ray.remote
-    def consume(split):
-        for _ in split.iter_rows():
-            pass
-
-    assert ray.get([consume.remote(split) for split in splits]) == [None] * num_splits
-
-
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`Dataset.context` should be sealed the first time the Dataset is created. But if a new operator is applied to the dataset, the new global DataContext will be saved again to the Dataset. 

This bug prevents using different DataContexts for training and validation datasets in a training job.

Note this PR only fixes the issue when multiple datasets are created in the process but will be running in different processes. If they run in the same process, it's still a bug, see https://github.com/ray-project/ray/issues/41573.

## Related issue number

https://github.com/ray-project/ray/issues/41573

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
