### PR TITLE
[Dashboard] fix profiling and stack trace link naming

### DIFF
--- a/dashboard/client/src/common/ProfilingLink.tsx
+++ b/dashboard/client/src/common/ProfilingLink.tsx
@@ -56,7 +56,7 @@ export const TaskCpuStackTraceLink = ({
   );
 };
 
-export const CpuProfilingLink = ({
+export const CpuStackTraceLink = ({
   pid,
   ip,
   type = "",
@@ -76,7 +76,7 @@ export const CpuProfilingLink = ({
   );
 };
 
-export const CpuStackTraceLink = ({
+export const CpuProfilingLink = ({
   pid,
   ip,
   type = "",

--- a/dashboard/client/src/pages/actor/ActorDetail.tsx
+++ b/dashboard/client/src/pages/actor/ActorDetail.tsx
@@ -197,13 +197,13 @@ const ActorDetailPage = () => {
             label: "Actions",
             content: (
               <div>
-                <CpuProfilingLink
+                <CpuStackTraceLink
                   pid={actorDetail.pid}
                   ip={actorDetail.address?.ipAddress}
                   type=""
                 />
                 <br />
-                <CpuStackTraceLink
+                <CpuProfilingLink
                   pid={actorDetail.pid}
                   ip={actorDetail.address?.ipAddress}
                   type=""

--- a/dashboard/client/src/pages/job/JobDetailInfoPage.tsx
+++ b/dashboard/client/src/pages/job/JobDetailInfoPage.tsx
@@ -188,13 +188,13 @@ export const JobMetadataSection = ({ job }: JobMetadataSectionProps) => {
           label: "Actions",
           content: (
             <div>
-              <CpuProfilingLink
+              <CpuStackTraceLink
                 pid={job.driver_info?.pid}
                 ip={job.driver_info?.node_ip_address}
                 type="Driver"
               />
               <br />
-              <CpuStackTraceLink
+              <CpuProfilingLink
                 pid={job.driver_info?.pid}
                 ip={job.driver_info?.node_ip_address}
                 type="Driver"

--- a/dashboard/client/src/pages/job/JobRow.tsx
+++ b/dashboard/client/src/pages/job/JobRow.tsx
@@ -121,13 +121,13 @@ export const JobRow = ({ job }: JobRowProps) => {
             <br />
           </React.Fragment>
         )}
-        <CpuProfilingLink
+        <CpuStackTraceLink
           pid={job.driver_info?.pid}
           ip={job.driver_info?.node_ip_address}
           type="Driver"
         />
         <br />
-        <CpuStackTraceLink
+        <CpuProfilingLink
           pid={job.driver_info?.pid}
           ip={job.driver_info?.node_ip_address}
           type="Driver"

--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -280,9 +280,9 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
           Log
         </Link>
         <br />
-        <CpuStackTraceLink pid={pid} ip={ip} type="" />
-        <br />
         <CpuProfilingLink pid={pid} ip={ip} type="" />
+        <br />
+        <CpuStackTraceLink pid={pid} ip={ip} type="" />
         <br />
       </TableCell>
       <TableCell>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
stacktrace and cpu profile link naming is switched. So this PR is for switching the naming without switching the link order in the pages
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
