### PR TITLE
[RLlib] Remove old `exec_plan` API code.

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -596,7 +596,6 @@ class Algorithm(Trainable, AlgorithmBase):
         ] = defaultdict(set)
 
         self.workers: Optional[WorkerSet] = None
-        self.train_exec_impl = None
 
         # Offline RL settings.
         input_evaluation = self.config.get("input_evaluation")
@@ -612,52 +611,19 @@ class Algorithm(Trainable, AlgorithmBase):
             )
             self.config.off_policy_estimation_methods = ope_dict
 
-        # Deprecated way of implementing Algorithm sub-classes (or "templates"
-        # via the `build_trainer` utility function).
-        # Instead, sub-classes should override the Trainable's `setup()`
-        # method and call super().setup() from within that override at some
-        # point.
-        # Old design: Override `Algorithm._init`.
-        _init = False
-        try:
-            self._init(self.config, self.env_creator)
-            _init = True
-        # New design: Override `Algorithm.setup()` (as indented by tune.Trainable)
-        # and do or don't call `super().setup()` from within your override.
-        # By default, `super().setup()` will create both worker sets:
-        # "rollout workers" for collecting samples for training and - if
-        # applicable - "evaluation workers" for evaluation runs in between or
-        # parallel to training.
-        # TODO: Deprecate `_init()` and remove this try/except block.
-        except NotImplementedError:
-            pass
+        # Create a set of env runner actors via a WorkerSet.
+        self.workers = WorkerSet(
+            env_creator=self.env_creator,
+            validate_env=self.validate_env,
+            default_policy_class=self.get_default_policy_class(self.config),
+            config=self.config,
+            num_workers=self.config.num_rollout_workers,
+            local_worker=True,
+            logdir=self.logdir,
+        )
 
-        # Only if user did not override `_init()`:
-        if _init is False:
-            # Create a set of env runner actors via a WorkerSet.
-            self.workers = WorkerSet(
-                env_creator=self.env_creator,
-                validate_env=self.validate_env,
-                default_policy_class=self.get_default_policy_class(self.config),
-                config=self.config,
-                num_workers=self.config.num_rollout_workers,
-                local_worker=True,
-                logdir=self.logdir,
-            )
-
-            # TODO (avnishn): Remove the execution plan API by q1 2023
-            # Function defining one single training iteration's behavior.
-            if self.config._disable_execution_plan_api:
-                # Ensure remote workers are initially in sync with the local worker.
-                self.workers.sync_weights()
-            # LocalIterator-creating "execution plan".
-            # Only call this once here to create `self.train_exec_impl`,
-            # which is a ray.util.iter.LocalIterator that will be `next`'d
-            # on each training iteration.
-            else:
-                self.train_exec_impl = self.execution_plan(
-                    self.workers, self.config, **self._kwargs_for_execution_plan()
-                )
+        # Ensure remote workers are initially in sync with the local worker.
+        self.workers.sync_weights()
 
         # Compile, validate, and freeze an evaluation config.
         self.evaluation_config = self.config.get_evaluation_config_object()
@@ -786,14 +752,6 @@ class Algorithm(Trainable, AlgorithmBase):
         # Run `on_algorithm_init` callback after initialization is done.
         self.callbacks.on_algorithm_init(algorithm=self)
 
-    # TODO: Deprecated: In your sub-classes of Algorithm, override `setup()`
-    #  directly and call super().setup() from within it if you would like the
-    #  default setup behavior plus some own setup logic.
-    #  If you don't need the env/workers/config/etc.. setup for you by super,
-    #  simply do not call super().setup() from your overridden method.
-    def _init(self, config: AlgorithmConfigDict, env_creator: EnvCreator) -> None:
-        raise NotImplementedError
-
     @OverrideToImplementCustomLogic
     @classmethod
     def get_default_policy_class(
@@ -870,19 +828,16 @@ class Algorithm(Trainable, AlgorithmBase):
                 workers=self.workers,
                 config=self.config,
             )
-            # TODO (avnishn): Remove the execution plan API by q1 2023
-            # Collect worker metrics and add combine them with `results`.
-            if self.config._disable_execution_plan_api:
-                episodes_this_iter = collect_episodes(
-                    self.workers,
-                    self._remote_worker_ids_for_metrics(),
-                    timeout_seconds=self.config.metrics_episode_collection_timeout_s,
-                )
-                results = self._compile_iteration_results(
-                    episodes_this_iter=episodes_this_iter,
-                    step_ctx=train_iter_ctx,
-                    iteration_results=results,
-                )
+            episodes_this_iter = collect_episodes(
+                self.workers,
+                self._remote_worker_ids_for_metrics(),
+                timeout_seconds=self.config.metrics_episode_collection_timeout_s,
+            )
+            results = self._compile_iteration_results(
+                episodes_this_iter=episodes_this_iter,
+                step_ctx=train_iter_ctx,
+                iteration_results=results,
+            )
 
         # Check `env_task_fn` for possible update of the env's task.
         if self.config.env_task_fn is not None:
@@ -1661,15 +1616,6 @@ class Algorithm(Trainable, AlgorithmBase):
             )
 
         return train_results
-
-    @staticmethod
-    def execution_plan(workers, config, **kwargs):
-        raise NotImplementedError(
-            "It is no longer supported to use the `Algorithm.execution_plan()` API!"
-            " Set `_disable_execution_plan_api=True` in your config and override the "
-            "`Algorithm.training_step()` method with your algo's custom "
-            "execution logic instead."
-        )
 
     # TODO (sven): Deprecate this API in favor of extracting the correct RLModule
     #  and simply calling `forward_inference()` on it (see DreamerV3 for an example).
@@ -2769,10 +2715,7 @@ class Algorithm(Trainable, AlgorithmBase):
         ):
             state["local_replay_buffer"] = self.local_replay_buffer.get_state()
 
-        if self.train_exec_impl is not None:
-            state["train_exec_impl"] = self.train_exec_impl.shared_metrics.get().save()
-        else:
-            state["counters"] = self._counters
+        state["counters"] = self._counters
         state["training_iteration"] = self.training_iteration
 
         return state
@@ -2832,9 +2775,7 @@ class Algorithm(Trainable, AlgorithmBase):
                     "data found in state!"
                 )
 
-        if self.train_exec_impl is not None:
-            self.train_exec_impl.shared_metrics.get().restore(state["train_exec_impl"])
-        elif "counters" in state:
+        if "counters" in state:
             self._counters = state["counters"]
 
         if "training_iteration" in state:
@@ -3007,13 +2948,6 @@ class Algorithm(Trainable, AlgorithmBase):
 
         return from_config(ReplayBuffer, config["replay_buffer_config"])
 
-    @DeveloperAPI
-    def _kwargs_for_execution_plan(self):
-        kwargs = {}
-        if self.local_replay_buffer is not None:
-            kwargs["local_replay_buffer"] = self.local_replay_buffer
-        return kwargs
-
     def _run_one_training_iteration(self) -> Tuple[ResultDict, "TrainIterCtx"]:
         """Runs one training iteration (self.iteration will be +1 after this).
 
@@ -3036,12 +2970,8 @@ class Algorithm(Trainable, AlgorithmBase):
             # when we have reached `min_time_s_per_iteration`).
             while not train_iter_ctx.should_stop(results):
                 # Try to train one step.
-                # TODO (avnishn): Remove the execution plan API by q1 2023
                 with self._timers[TRAINING_ITERATION_TIMER]:
-                    if self.config._disable_execution_plan_api:
-                        results = self.training_step()
-                    else:
-                        results = next(self.train_exec_impl)
+                    results = self.training_step()
 
         # With training step done. Try to bring failed workers back.
         self.restore_workers(self.workers)
@@ -3381,41 +3311,34 @@ class TrainIterCtx:
             return False
 
         # Stopping criteria.
-        elif self.algo.config._disable_execution_plan_api:
-            if self.algo.config.count_steps_by == "agent_steps":
-                self.sampled = (
-                    self.algo._counters[NUM_AGENT_STEPS_SAMPLED]
-                    - self.init_agent_steps_sampled
-                )
-                self.trained = (
-                    self.algo._counters[NUM_AGENT_STEPS_TRAINED]
-                    - self.init_agent_steps_trained
-                )
-            else:
-                self.sampled = (
-                    self.algo._counters[NUM_ENV_STEPS_SAMPLED]
-                    - self.init_env_steps_sampled
-                )
-                self.trained = (
-                    self.algo._counters[NUM_ENV_STEPS_TRAINED]
-                    - self.init_env_steps_trained
-                )
-
-            min_t = self.algo.config["min_time_s_per_iteration"]
-            min_sample_ts = self.algo.config["min_sample_timesteps_per_iteration"]
-            min_train_ts = self.algo.config["min_train_timesteps_per_iteration"]
-            # Repeat if not enough time has passed or if not enough
-            # env|train timesteps have been processed (or these min
-            # values are not provided by the user).
-            if (
-                (not min_t or time.time() - self.time_start >= min_t)
-                and (not min_sample_ts or self.sampled >= min_sample_ts)
-                and (not min_train_ts or self.trained >= min_train_ts)
-            ):
-                return True
-            else:
-                return False
-        # No errors (we got results != None) -> Return True
-        # (meaning: yes, should stop -> no further step attempts).
+        if self.algo.config.count_steps_by == "agent_steps":
+            self.sampled = (
+                self.algo._counters[NUM_AGENT_STEPS_SAMPLED]
+                - self.init_agent_steps_sampled
+            )
+            self.trained = (
+                self.algo._counters[NUM_AGENT_STEPS_TRAINED]
+                - self.init_agent_steps_trained
+            )
         else:
+            self.sampled = (
+                self.algo._counters[NUM_ENV_STEPS_SAMPLED] - self.init_env_steps_sampled
+            )
+            self.trained = (
+                self.algo._counters[NUM_ENV_STEPS_TRAINED] - self.init_env_steps_trained
+            )
+
+        min_t = self.algo.config["min_time_s_per_iteration"]
+        min_sample_ts = self.algo.config["min_sample_timesteps_per_iteration"]
+        min_train_ts = self.algo.config["min_train_timesteps_per_iteration"]
+        # Repeat if not enough time has passed or if not enough
+        # env|train timesteps have been processed (or these min
+        # values are not provided by the user).
+        if (
+            (not min_t or time.time() - self.time_start >= min_t)
+            and (not min_sample_ts or self.sampled >= min_sample_ts)
+            and (not min_train_ts or self.trained >= min_train_ts)
+        ):
             return True
+        else:
+            return False

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -478,7 +478,6 @@ class AlgorithmConfig(_Config):
         self._tf_policy_handles_more_than_one_loss = False
         self._disable_preprocessor_api = False
         self._disable_action_flattening = False
-        self._disable_execution_plan_api = True
         self._disable_initialize_loss_from_dummy_batch = False
 
         # Has this config object been frozen (cannot alter its attributes anymore).
@@ -517,6 +516,7 @@ class AlgorithmConfig(_Config):
         self.min_time_s_per_reporting = DEPRECATED_VALUE
         self.min_train_timesteps_per_reporting = DEPRECATED_VALUE
         self.min_sample_timesteps_per_reporting = DEPRECATED_VALUE
+        self._disable_execution_plan_api = DEPRECATED_VALUE
 
     def to_dict(self) -> AlgorithmConfigDict:
         """Converts all settings into a legacy config dict for backward compatibility.
@@ -2597,8 +2597,9 @@ class AlgorithmConfig(_Config):
         _tf_policy_handles_more_than_one_loss: Optional[bool] = NotProvided,
         _disable_preprocessor_api: Optional[bool] = NotProvided,
         _disable_action_flattening: Optional[bool] = NotProvided,
-        _disable_execution_plan_api: Optional[bool] = NotProvided,
         _disable_initialize_loss_from_dummy_batch: Optional[bool] = NotProvided,
+        # Deprecated args.
+        _disable_execution_plan_api=None,
     ) -> "AlgorithmConfig":
         """Sets the config's experimental settings.
 
@@ -2623,14 +2624,19 @@ class AlgorithmConfig(_Config):
                 - SampleCollectors: Have to store possibly nested action structs.
                 - Models that have the previous action(s) as part of their input.
                 - Algorithms reading from offline files (incl. action information).
-            _disable_execution_plan_api: Experimental flag.
-                If True, the execution plan API will not be used. Instead,
-                a Algorithm's `training_iteration` method will be called as-is each
-                training iteration.
 
         Returns:
             This updated AlgorithmConfig object.
         """
+        if _disable_execution_plan_api is not None:
+            deprecation_warning(
+                old="config.experimental(_disable_execution_plan_api=...)",
+                help="The execution plan API is no longer supported! Use subclassing "
+                "of the `Algorithm` class and override the "
+                "`Algorithm.training_step()` method instead.",
+                error=True,
+            )
+
         if _enable_new_api_stack is not NotProvided:
             self._enable_new_api_stack = _enable_new_api_stack
 
@@ -2656,8 +2662,6 @@ class AlgorithmConfig(_Config):
             self._disable_preprocessor_api = _disable_preprocessor_api
         if _disable_action_flattening is not NotProvided:
             self._disable_action_flattening = _disable_action_flattening
-        if _disable_execution_plan_api is not NotProvided:
-            self._disable_execution_plan_api = _disable_execution_plan_api
         if _disable_initialize_loss_from_dummy_batch is not NotProvided:
             self._disable_initialize_loss_from_dummy_batch = (
                 _disable_initialize_loss_from_dummy_batch

--- a/rllib/algorithms/random_agent/random_agent.py
+++ b/rllib/algorithms/random_agent/random_agent.py
@@ -57,14 +57,14 @@ class RandomAgent(Algorithm):
 
     @classmethod
     @override(Algorithm)
-    def get_default_config(cls) -> AlgorithmConfig:
-        config = AlgorithmConfig()
+    def get_default_config(cls) -> RandomAgentConfig:
+        config = RandomAgentConfig()
         config.rollouts_per_iteration = 10
         return config
 
     @override(Algorithm)
-    def _init(self, config, env_creator):
-        self.env = env_creator(config["env_config"])
+    def setup(self, config):
+        self.env = self.env_creator(config["env_config"])
 
     @override(Algorithm)
     def step(self):

--- a/rllib/execution/multi_gpu_learner_thread.py
+++ b/rllib/execution/multi_gpu_learner_thread.py
@@ -140,7 +140,12 @@ class MultiGPULearnerThread(LearnerThread):
 
     @override(LearnerThread)
     def step(self) -> None:
-        assert self.loader_thread.is_alive()
+        if not self.loader_thread.is_alive():
+            raise RuntimeError(
+                "The `_MultiGPULoaderThread` has died! Will therefore also terminate "
+                "the `MultiGPULearnerThread`."
+            )
+
         with self.load_wait_timer:
             buffer_idx, released = self.ready_tower_stacks_buffer.get()
 

--- a/rllib/utils/replay_buffers/replay_buffer.py
+++ b/rllib/utils/replay_buffers/replay_buffer.py
@@ -11,7 +11,6 @@ import psutil
 from ray.rllib.policy.sample_batch import SampleBatch, concat_samples
 from ray.rllib.utils.actor_manager import FaultAwareApply
 from ray.rllib.utils.annotations import override
-from ray.rllib.utils.deprecation import Deprecated
 from ray.rllib.utils.metrics.window_stat import WindowStat
 from ray.rllib.utils.replay_buffers.base import ReplayBufferInterface
 from ray.rllib.utils.typing import SampleBatchType
@@ -373,13 +372,3 @@ class ReplayBuffer(ReplayBufferInterface, FaultAwareApply):
             out = SampleBatch()
         out.decompress_if_needed()
         return out
-
-    @Deprecated(
-        help="ReplayBuffers could be iterated over by default before. "
-        "Making a buffer an iterator has been deprecated. Switch your Algorithm to "
-        "override the `training_step()` method (instead of `execution_plan()`) to "
-        "resolve this.",
-        error=True,
-    )
-    def make_iterator(self, num_items_to_replay: int):
-        pass


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Remove old `exec_plan` API code.

The execution plan API has been completely removed from RLlib and is no longer used by any of its supported algorithms. This PR removes the last remainders of it from the codebase.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
