### PR TITLE
[ci] add `triage` tag to release test failure issues

### DIFF
--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -205,7 +205,7 @@ class TestStateMachine:
         )
 
     def _create_github_issue(self) -> None:
-        labels = ["P0", "bug", "release-test", self.test.get_oncall()]
+        labels = ["P0", "bug", "release-test", "triage", self.test.get_oncall()]
         if not self.test.is_stable():
             labels.append("unstable-release-test")
         issue_number = self.ray_repo.create_issue(


### PR DESCRIPTION
Add `triage` tag so issues created for release test failures also go through the bug triage processes

Test:
- CI