### PR TITLE
[Doc] Elide long autosummary API names

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -218,3 +218,15 @@ table.autosummary {
 table.autosummary .row-odd {
   background-color: var(--pst-color-surface);
 }
+
+/* Ensure that long function names get elided and show ellipses to not overflow their bounding boxes  */
+table.autosummary tr > td:first-child > p > a > code {
+  max-width: 100%;
+  width: fit-content;
+  display: block;
+}
+table.autosummary tr > td:first-child > p > a > code > span {
+  display: block;
+  overflow: clip;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
## Why are these changes needed?

In the current docs, `sphinx.ext.autosummary` produces links which overflow their bounding boxes for functions with really long names. This PR fixes that, using ellipses to elide the part of the function name that would overflow its bounding box. You can still see the full name if you hover over the link (a little popup appears, or you can just look at the link name).

Before:
![image](https://github.com/ray-project/ray/assets/14017872/2e694351-122b-4c9d-b9e7-abbc1945f69d)

After:
![image](https://github.com/ray-project/ray/assets/14017872/2cbfe0e4-6eee-46a1-8e56-00f895165179)
 
## Related issue number

Closes #41145.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
