### PR TITLE
[Data] Skip execution for `LogicalPlan`s with only `InputData` op

### DIFF
--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -119,6 +119,7 @@ steps:
   - label: ":database: data: dashboard tests"
     tags:
       - python
+      - data
       - dashboard
     instance_type: small
     commands:

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -30,6 +30,7 @@ from ray.data._internal.compute import (
 from ray.data._internal.dataset_logger import DatasetLogger
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.lazy_block_list import LazyBlockList
+from ray.data._internal.logical.operators.input_data_operator import InputData
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.rules.operator_fusion import _are_remote_args_compatible
 from ray.data._internal.logical.rules.set_read_parallelism import (
@@ -592,22 +593,31 @@ class ExecutionPlan:
                     execute_to_legacy_block_list,
                     get_legacy_lazy_block_list_read_only,
                 )
-                from ray.data._internal.execution.streaming_executor import (
-                    StreamingExecutor,
-                )
 
-                metrics_tag = create_dataset_tag(self._dataset_name, self._dataset_uuid)
-                executor = StreamingExecutor(
-                    copy.deepcopy(context.execution_options),
-                    metrics_tag,
-                )
-                if self.is_read_only():
+                if self._is_input_data_only():
+                    # No need to execute MaterializedDatasets with only an InputData
+                    # operator, since the data is already materialized. This also avoids
+                    # recording unnecessary metrics for an empty plan execution.
+                    blocks = self._in_blocks
+                    stats = _get_initial_stats_from_plan(self)
+                elif self.is_read_only():
                     # If the Dataset is read-only, get the LazyBlockList without
                     # executing the plan by only fetching metadata available from
                     # the input Datasource or Reader without executing its ReadTasks.
                     blocks = get_legacy_lazy_block_list_read_only(self)
                     stats = _get_initial_stats_from_plan(self)
                 else:
+                    from ray.data._internal.execution.streaming_executor import (
+                        StreamingExecutor,
+                    )
+
+                    metrics_tag = create_dataset_tag(
+                        self._dataset_name, self._dataset_uuid
+                    )
+                    executor = StreamingExecutor(
+                        copy.deepcopy(context.execution_options),
+                        metrics_tag,
+                    )
                     blocks = execute_to_legacy_block_list(
                         executor,
                         self,
@@ -843,6 +853,12 @@ class ExecutionPlan:
         """Return whether the underlying logical plan contains only a Read op."""
         root_op = self._logical_plan.dag
         return isinstance(root_op, Read) and len(root_op.input_dependencies) == 0
+
+    def _is_input_data_only(self) -> bool:
+        """Return whether the underlying logical plan contains only an InputData op
+        (e.g. in the case of a :class:`~ray.data.MaterializedDataset`)."""
+        root_op = self._logical_plan.dag
+        return isinstance(root_op, InputData) and len(root_op.input_dependencies) == 0
 
     def is_read_stage_equivalent(self) -> bool:
         """Return whether this plan can be executed as only a read stage."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

- After https://github.com/ray-project/ray/pull/41466, all Datasets are executed using the new streaming executor backend. There is an edge case that was not caught related to MaterializedDatasets, where executing the already materialized dataset caused extraneous (empty) metrics to be registered from these newly created datasets. This PR covers this edge case by skipping execution in the case where the Dataset's logical plan consists of only an `InputData` operator.
- Also enables Data dashboard tests to run for any data-related change, not just for dashboard related changes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
