### PR TITLE
[Data] Check if BigQuery dataset exists before creation

### DIFF
--- a/python/ray/data/datasource/bigquery_datasink.py
+++ b/python/ray/data/datasource/bigquery_datasink.py
@@ -35,8 +35,8 @@ class _BigQueryDatasink(Datasink):
         self.max_retry_cnt = max_retry_cnt
 
     def on_write_start(self) -> None:
+        from google.api_core import exceptions
         from google.cloud import bigquery
-        from google.cloud.exceptions import NotFound
 
         if self.project_id is None or self.dataset is None:
             raise ValueError("project_id and dataset are required args")
@@ -50,7 +50,7 @@ class _BigQueryDatasink(Datasink):
                 f"Dataset {dataset_id} already exists. "
                 "The table will be overwritten if it already exists."
             )
-        except NotFound:
+        except exceptions.NotFound:
             client.create_dataset(f"{self.project_id}.{dataset_id}", timeout=30)
             logger.info("Created dataset " + dataset_id)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We found issue that user may not grant permission to create Google BigQuery dataset when using Ray Data `write_bigquery()` API. So the `client.create_dataset` call would fail with permission error:

```
Access Denied: Project ...: User does not have bigquery.datasets.create permission in project ...
```

So here we change to check if BigQuery dataset already exists, if not then trying to create it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
