### PR TITLE
[Data] Get updated stats after execution for read-only plans

### DIFF
--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -37,7 +37,7 @@ class UnionOperator(NAryOperator):
         self._input_idx_to_output = 0
 
         self._output_buffer: List[RefBundle] = []
-        self._stats: StatsDict = {}
+        self._stats: StatsDict = {"Union": []}
         super().__init__(*input_ops)
 
     def start(self, options: ExecutionOptions):

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -706,7 +706,11 @@ class ExecutionPlan:
             if self.is_read_only():
                 self._in_blocks = blocks
         if _is_lazy(self._snapshot_blocks) and force_read:
-            self._snapshot_blocks = self._snapshot_blocks.compute_to_blocklist()
+            executed_blocks = self._snapshot_blocks.compute_to_blocklist()
+            # After executing the snapshot blocks, get its updated stats.
+            # The snapshot blocks after execution will contain the execution stats.
+            self._snapshot_stats = self._snapshot_blocks.stats()
+            self._snapshot_blocks = executed_blocks
             # When force-read is enabled, we similarly update self._in_blocks.
             if self.is_read_only():
                 self._in_blocks = self._snapshot_blocks

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -454,50 +454,6 @@ Dataset iterator time breakdown:
             )
 
 
-def test_dataset_stats_stage_execution_time(ray_start_regular_shared):
-    # Disable stage/operator fusion in order to test the stats
-    # of two different map_batches operators without fusing them together,
-    # so that we can observe different execution times for each.
-    ctx = ray.data.DataContext.get_current()
-    curr_optimizer_enabled = ctx.optimizer_enabled
-    curr_optimize_fuse_stages = ctx.optimize_fuse_stages
-    ctx.optimize_fuse_stages = False
-    ctx.optimizer_enabled = False
-
-    sleep_1 = 1
-    sleep_2 = 3
-    ds = (
-        ray.data.range(100, parallelism=1)
-        .map_batches(lambda batch: map_batches_sleep(batch, sleep_1))
-        .map_batches(lambda batch: map_batches_sleep(batch, sleep_2))
-        .materialize()
-    )
-
-    # Check that each map_batches operator has the corresponding execution time.
-    map_batches_1_stats = ds._get_stats_summary().parents[0].stages_stats[0]
-    map_batches_2_stats = ds._get_stats_summary().stages_stats[0]
-    assert sleep_1 <= map_batches_1_stats.time_total_s
-    assert sleep_2 <= map_batches_2_stats.time_total_s
-
-    ctx.optimize_fuse_stages = curr_optimize_fuse_stages
-    ctx.optimizer_enabled = curr_optimizer_enabled
-
-    # The following case runs 2 tasks with 1 CPU, with each task sleeping for
-    # `sleep_2` seconds. We expect the overall reported stage time to be
-    # at least `2 * sleep_2` seconds`, and less than the total elapsed time.
-    num_tasks = 2
-    ds = ray.data.range(100, parallelism=num_tasks).map_batches(
-        lambda batch: map_batches_sleep(batch, sleep_2)
-    )
-    start_time = time.time()
-    ds.take_all()
-    end_time = time.time()
-
-    stage_stats = ds._get_stats_summary().stages_stats[0]
-    stage_time = stage_stats.time_total_s
-    assert num_tasks * sleep_2 <= stage_time <= end_time - start_time
-
-
 def test_dataset__repr__(ray_start_regular_shared):
     n = 100
     ds = ray.data.range(n)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
- Get the updated stats after execution for read-only plans from the input LazyBlockList, not the resulting BlockList after fully executing which does not contain stats for the read operation.
- Also fix a bug in Union operator with initializing stats.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
