### PR TITLE
[Data] Skip `test_client_compat.py::test_client_data_get` unit test

### DIFF
--- a/python/ray/tests/test_client_compat.py
+++ b/python/ray/tests/test_client_compat.py
@@ -8,11 +8,13 @@ try:
 except ImportError:
     pyspark = None
 
-from ray._private.test_utils import (
-    skip_flaky_core_test_premerge,
+
+@pytest.mark.skip(
+    reason=(
+        "Ray Client not supported with Ray Data streaming execution, "
+        "which is enabled for all datasets by default in Ray 2.9."
+    )
 )
-
-
 @pytest.mark.skipif(pyspark is None, reason="PySpark dependency not found")
 @pytest.mark.parametrize(
     "call_ray_start",
@@ -22,7 +24,6 @@ from ray._private.test_utils import (
     ],
     indirect=True,
 )
-@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/41620")
 def test_client_data_get(call_ray_start):
     """PySpark import changes NamedTuple pickling behavior, leading
     to inconpatibilities with the Ray client and Ray Data. This test


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
https://github.com/ray-project/ray/pull/41466 enables Ray Data streaming executor by default for all datasets. As a result, the Ray Data execution in `test_client_data_get` test is now executed through the streaming executor, which is known to have many incompatibilities since Ray 2.7. So, we skip the test which checks compatibility between Ray Client and Ray Data, until we have a future Ray Client implementation which can better support Ray Data usage.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #41620

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
