### PR TITLE
[Serve] Add `--name` option to `serve run`

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -23,6 +23,7 @@ from ray.serve._private.constants import (
     DEFAULT_GRPC_PORT,
     DEFAULT_HTTP_HOST,
     DEFAULT_HTTP_PORT,
+    SERVE_DEFAULT_APP_NAME,
     SERVE_NAMESPACE,
 )
 from ray.serve._private.deployment_graph_build import build as pipeline_build
@@ -371,6 +372,17 @@ def deploy(config_file_name: str, address: str):
         "will be ignored if running a config file."
     ),
 )
+@click.option(
+    "--name",
+    required=False,
+    default=SERVE_DEFAULT_APP_NAME,
+    type=str,
+    help=(
+        "Name of the application. This should only be used "
+        "when running an application specified by import path and "
+        "will be ignored if running a config file."
+    ),
+)
 def run(
     config_or_import_path: str,
     arguments: Tuple[str],
@@ -384,6 +396,7 @@ def run(
     blocking: bool,
     reload: bool,
     route_prefix: str,
+    name: str,
 ):
     if host is not None or port is not None:
         cli_logger.warning(
@@ -479,7 +492,7 @@ def run(
             client.deploy_apps(config, _blocking=False)
             cli_logger.success("Submitted deploy config successfully.")
         else:
-            serve.run(app, route_prefix=route_prefix, host=host, port=port)
+            serve.run(app, name=name, route_prefix=route_prefix, host=host, port=port)
             cli_logger.success("Deployed Serve app successfully.")
 
         if reload:
@@ -506,7 +519,9 @@ def run(
                     app = _private_api.call_app_builder_with_args_if_necessary(
                         import_attr(import_path, reload_module=True), args_dict
                     )
-                    serve.run(app, route_prefix=route_prefix, host=host, port=port)
+                    serve.run(
+                        app, name=name, route_prefix=route_prefix, host=host, port=port
+                    )
 
         if blocking:
             while True:

--- a/python/ray/serve/tests/test_cli_2.py
+++ b/python/ray/serve/tests/test_cli_2.py
@@ -493,19 +493,19 @@ def test_run_teardown(ray_start_stop):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
-def test_run_route_prefix_default(ray_start_stop):
-    """Test `serve run` with route prefix option."""
+def test_run_route_prefix_and_name_default(ray_start_stop):
+    """Test `serve run` without route_prefix and name options."""
 
     p = subprocess.Popen(["serve", "run", "ray.serve.tests.test_cli_2.echo_app"])
 
-    wait_for_condition(check_app_running, app_name="default")
+    wait_for_condition(check_app_running, app_name=SERVE_DEFAULT_APP_NAME)
     assert ping_endpoint("/") == "hello"
     p.send_signal(signal.SIGINT)
     p.wait()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
-def test_run_route_prefix_override(ray_start_stop):
+def test_run_route_prefix_and_name_override(ray_start_stop):
     """Test `serve run` with route prefix option."""
 
     p = subprocess.Popen(
@@ -513,11 +513,12 @@ def test_run_route_prefix_override(ray_start_stop):
             "serve",
             "run",
             "--route-prefix=/hello",
+            "--name=hello_app",
             "ray.serve.tests.test_cli_2.echo_app",
         ],
     )
 
-    wait_for_condition(check_app_running, app_name="default")
+    wait_for_condition(check_app_running, app_name="hello_app")
     assert "Path '/' not found" in ping_endpoint("/")
     assert ping_endpoint("/hello") == "hello"
     p.send_signal(signal.SIGINT)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

As a follow-up to #41011, this change adds the `--name` option to `serve run`, which lets users name their Serve app.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #41003.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds checks to existing unit tests.
