### PR TITLE
[VC] auto scaling virtual clusters.

### DIFF
--- a/src/ray/common/virtual_cluster_bundle_spec.cc
+++ b/src/ray/common/virtual_cluster_bundle_spec.cc
@@ -23,7 +23,10 @@ std::optional<VirtualClusterBundleResourceLabel> VirtualClusterBundleResourceLab
   VirtualClusterBundleResourceLabel data;
   std::smatch match_groups;
 
-  static const std::regex wildcard_resource_pattern("^(.*)_vc_([0-9a-f]+)$");
+  // Greedy match.
+  // CPU_vc_123_vc_456 is parsed as
+  // {.original_resource="CPU_vc_123", .vc_id="456"}
+  static const std::regex wildcard_resource_pattern("^(.*?)_vc_([0-9a-f]+)$");
   if (std::regex_match(resource, match_groups, wildcard_resource_pattern) &&
       match_groups.size() == 3) {
     data.original_resource = match_groups[1].str();

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -506,6 +506,7 @@ void GcsServer::InitGcsVirtualClusterManager(const GcsInitData &gcs_init_data) {
   gcs_virtual_cluster_manager_ =
       std::make_shared<GcsVirtualClusterManager>(main_service_,
                                                  *gcs_node_manager_,
+                                                 *gcs_resource_manager_,
                                                  *cluster_resource_scheduler_,
                                                  raylet_client_pool_);
   virtual_cluster_info_service_.reset(new rpc::VirtualClusterInfoGrpcService(

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.cc
@@ -5,15 +5,128 @@
 namespace ray {
 namespace gcs {
 
+namespace {
+
+// Represents a parsed view of a resource shape.
+struct RenamedResources {
+  absl::flat_hash_map<VirtualClusterID, absl::flat_hash_map<std::string, int>>
+      vc_resources;
+  absl::flat_hash_map<std::string, int> vanilla_resources;
+
+  // Parses a resource shape of {name -> val} by parsing the names as VC renamed ones.
+  static RenamedResources Parse(const google::protobuf::Map<std::string, double> &shape) {
+    RenamedResources ret;
+    for (const auto &[name, val] : shape) {
+      auto label = VirtualClusterBundleResourceLabel::Parse(name);
+      if (label.has_value()) {
+        ret.vc_resources[label->vc_id][label->original_resource] = val;
+      } else {
+        ret.vanilla_resources[name] = val;
+      }
+    }
+    return ret;
+  }
+
+  int get_from_vanilla_or_zero(const std::string &name) const {
+    auto name_it = vanilla_resources.find(name);
+    if (name_it == vanilla_resources.end()) {
+      return 0;
+    }
+    return name_it->second;
+  }
+
+  int get_from_vc_or_zero(VirtualClusterID vc_id, const std::string &name) const {
+    auto it = vc_resources.find(vc_id);
+    if (it == vc_resources.end()) {
+      return 0;
+    }
+    const auto &map = it->second;
+    auto name_it = map.find(name);
+    if (name_it == map.end()) {
+      return 0;
+    }
+    return name_it->second;
+  }
+};
+
+// Figure out what to do with each demand.
+// Only supports demand that all resources are in a same VC.
+// Returns a schedule plan:
+// - If nullopt: nothing we can do (see below)
+// - If non null: plan to take these vc resources, and rename these vanilla resources.
+// NOTE: the return only contains *changes* or *delta* of the resources, not total.
+//
+// How we plan:
+// - If it can be fulilled by vc_available_resources alone: do nothing
+// - If it can be fulilled by vc_available_resources +
+// vanilla_available_resources: plan some renames
+// - If it can't be fulfilled -> do nothing. TODO: ask parent.
+std::optional<VirtualClusterBundleSpec> PlanForDemand(const rpc::ResourceDemand &demand,
+                                                      RenamedResources &availables) {
+  // Prevent accidental changing
+  const auto &const_availables = availables;
+  if (demand.shape().empty()) {
+    return std::nullopt;
+  }
+  auto parsed_demands = RenamedResources::Parse(demand.shape());
+  if (parsed_demands.vc_resources.size() == 0) {
+    // non-VC demand
+    return std::nullopt;
+  }
+  if (parsed_demands.vc_resources.size() > 1) {
+    // multi-VC demand, refuse to schedule and complain.
+    std::string all_vc_ids;
+    for (const auto &[vc_id, _] : parsed_demands.vc_resources) {
+      all_vc_ids.append(", ");
+      all_vc_ids.append(vc_id.Hex());
+    }
+    RAY_LOG(ERROR)
+        << "Refuse to schedule a demand with resources from more than 1 virtual "
+           "clusters: "
+        << all_vc_ids;
+    return std::nullopt;
+  }
+
+  // Single VC demand.
+  auto &[vc_id, vc_demands] = *parsed_demands.vc_resources.begin();
+  bool feasible = true;
+  for (const auto &[name, val] : vc_demands) {
+    if (const_availables.get_from_vc_or_zero(vc_id, name) +
+            const_availables.get_from_vanilla_or_zero(name) <
+        val) {
+      feasible = false;
+    }
+  }
+  if (!feasible) {
+    // TODO: ask parent for more
+    return std::nullopt;
+  }
+  rpc::VirtualClusterBundle bundle;
+  auto &resources = *bundle.mutable_resources();
+
+  for (const auto &[name, val] : vc_demands) {
+    int vc_planned = std::min(availables.get_from_vc_or_zero(vc_id, name), val);
+    if (vc_planned > 0) {
+      availables.vc_resources[vc_id][name] -= vc_planned;
+    }
+    int vanilla_planned = val - vc_planned;
+    RAY_CHECK(vanilla_planned >= 0);
+    if (vanilla_planned > 0) {
+      resources[name] = vanilla_planned;
+    }
+  }
+  return std::make_optional(VirtualClusterBundleSpec(std::move(bundle), vc_id));
+}
+
+}  // namespace
+
 GcsVirtualClusterManager::GcsVirtualClusterManager(
     instrumented_io_context &io_context,
     const gcs::GcsNodeManager &gcs_node_manager,
-    const GcsResourceManager &gcs_resource_manager,
     ClusterResourceScheduler &cluster_resource_scheduler,
     std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool)
     : io_context_(io_context),
       gcs_node_manager_(gcs_node_manager),
-      gcs_resource_manager_(gcs_resource_manager),
       cluster_resource_scheduler_(cluster_resource_scheduler),
       raylet_client_pool_(raylet_client_pool) {
   Tick();
@@ -38,8 +151,15 @@ void GcsVirtualClusterManager::HandleRemoveVirtualCluster(
     const auto lease_client = GetLeaseClientFromNode(entry.second);
     lease_client->ReturnVirtualClusterBundle(
         vc_id,
-        [](const Status &status, const rpc::ReturnVirtualClusterBundleReply &reply) {
-          RAY_CHECK(status.ok());
+        -1,  // all seqno for this vc id.
+        [request](const Status &status,
+                  const rpc::ReturnVirtualClusterBundleReply &reply) {
+          // TODO: error handling. One node may be already dead and return GrpcUnavailable
+          // which should be fine.
+          if (!status.ok()) {
+            RAY_LOG(WARNING) << "Remove virtual cluster failed" << status << " request "
+                             << request.DebugString();
+          }
         });
   }
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
@@ -47,6 +167,12 @@ void GcsVirtualClusterManager::HandleRemoveVirtualCluster(
 
 std::vector<rpc::PlacementGroupTableData>
 GcsVirtualClusterManager::GetVirtualClusterLoad() const {
+  if (!IsInited()) {
+    return {};
+  }
+  RAY_LOG(INFO) << "GetVirtualClusterLoad " << seqno_ << " pending count "
+                << pending_virtual_clusters_.size() << " ongoing count "
+                << ongoing_virtual_clusters_.size();
   std::vector<rpc::PlacementGroupTableData> load;
   for (const auto &request : pending_virtual_clusters_) {
     rpc::PlacementGroupTableData data;
@@ -56,6 +182,7 @@ GcsVirtualClusterManager::GetVirtualClusterLoad() const {
                                                   vc_bundle.resources().end());
     }
     data.set_strategy(rpc::PlacementStrategy::STRICT_SPREAD);
+    RAY_LOG(INFO) << "GetVirtualClusterLoad load" << data.DebugString();
     load.emplace_back(data);
   }
   return load;
@@ -72,12 +199,65 @@ void GcsVirtualClusterManager::Tick() {
 }
 
 void GcsVirtualClusterManager::ScaleExistingVirtualClustersHack() {
-  // TODO:
-  // - read loads and availablees from gcs_resource_manager_
-  // - calculate vc-renamed ones, compare with running_virtual_clusters
-  // - issue renames if needed, warning-and-ignore if rename failed (wait for next tick
-  // pls!)
-  (void)&gcs_resource_manager_;
+  // Current limitations:
+  // - on renames available resources, does not talk to parent/physical node to scale
+  // - doing per-node renaming. No "work stealing".
+  // - not respecting VC limitations (assumes infinite scaling up)
+  // - no scale downs
+  // - no fairness: just fulfill loads one by one
+  // - 1 demand only asks for 1 VC's resources
+  if (!IsInited()) {
+    return;
+  }
+
+  const auto &resources_report_by_node = gcs_resource_manager_->NodeResourceReportView();
+
+  RAY_LOG(INFO) << "resources_report_by_node " << resources_report_by_node.size();
+
+  for (const auto &[node_id, resources_data] : resources_report_by_node) {
+    // Current code: find vanilla availables, find renamed loads, make some renames if
+    // needed
+    auto available_resources =
+        RenamedResources::Parse(resources_data.resources_available());
+
+    RAY_LOG(INFO) << "available_resources "
+                  << available_resources.vanilla_resources.size();
+
+    for (const rpc::ResourceDemand &demand :
+         resources_data.resource_load_by_shape().resource_demands()) {
+      auto maybe_plan = PlanForDemand(demand, available_resources);
+      if (maybe_plan.has_value()) {
+        RAY_LOG(INFO) << "PlanForDemand " << maybe_plan->DebugString() << ", node id "
+                      << node_id;
+        NodeID node_id_copied = node_id;  // strange compiler hack
+        VirtualClusterID vc_id = maybe_plan->GetVirtualClusterId();
+        int64_t seqno = IncrementSeqno();
+        // TODO: make it a function
+        const auto lease_client =
+            GetLeaseClientFromNode(gcs_node_manager_.GetAliveNode(node_id).value());
+        lease_client->PrepareVirtualClusterBundle(
+            *maybe_plan,
+            seqno,
+            [vc_id, node_id_copied, seqno, this](
+                const Status &status,
+                const rpc::PrepareVirtualClusterBundleReply &reply) {
+              if (!reply.success()) {
+                // Unfortunate. Maybe print log. No need to return anything.
+                return;
+              }
+              const auto lease_client = GetLeaseClientFromNode(
+                  gcs_node_manager_.GetAliveNode(node_id_copied).value());
+              lease_client->CommitVirtualClusterBundle(
+                  vc_id,
+                  seqno,
+                  [](const Status &status,
+                     const rpc::CommitVirtualClusterBundleReply &reply) {
+                    RAY_CHECK(status.ok());
+                  });
+            });
+      }
+    }
+  }
 }
 
 void GcsVirtualClusterManager::CreateVirtualClusters() {
@@ -99,9 +279,17 @@ void GcsVirtualClusterManager::CreateVirtualClusters() {
     // wait until the next time.
     return;
   }
-
   pending_virtual_clusters_.pop_front();
+
+  if (node_to_bundle->empty()) {
+    // No resources needed. Just return.
+    return;
+  }
+
+  int64_t seqno = IncrementSeqno();
+
   ongoing_virtual_clusters_.emplace(vc_id, request);
+
   for (const auto &entry : *node_to_bundle) {
     NodeID node_id = entry.first;
     ongoing_virtual_clusters_.at(vc_id).nodes.emplace(node_id);
@@ -109,8 +297,9 @@ void GcsVirtualClusterManager::CreateVirtualClusters() {
         GetLeaseClientFromNode(gcs_node_manager_.GetAliveNode(node_id).value());
     lease_client->PrepareVirtualClusterBundle(
         entry.second,
-        [vc_id, this](const Status &status,
-                      const rpc::PrepareVirtualClusterBundleReply &reply) {
+        seqno,
+        [vc_id, seqno, this](const Status &status,
+                             const rpc::PrepareVirtualClusterBundleReply &reply) {
           auto &ongoing_virtual_cluster = ongoing_virtual_clusters_.at(vc_id);
           ongoing_virtual_cluster.num_replied_prepares++;
           if (!reply.success()) {
@@ -126,6 +315,7 @@ void GcsVirtualClusterManager::CreateVirtualClusters() {
                   GetLeaseClientFromNode(gcs_node_manager_.GetAliveNode(node_id).value());
               lease_client->ReturnVirtualClusterBundle(
                   vc_id,
+                  seqno,
                   [](const Status &status,
                      const rpc::ReturnVirtualClusterBundleReply &reply) {
                     RAY_CHECK(status.ok());
@@ -139,6 +329,7 @@ void GcsVirtualClusterManager::CreateVirtualClusters() {
                   GetLeaseClientFromNode(gcs_node_manager_.GetAliveNode(node_id).value());
               lease_client->CommitVirtualClusterBundle(
                   vc_id,
+                  seqno,
                   [](const Status &status,
                      const rpc::CommitVirtualClusterBundleReply &reply) {
                     RAY_CHECK(status.ok());
@@ -160,6 +351,9 @@ GcsVirtualClusterManager::Schedule(const rpc::CreateVirtualClusterRequest &reque
   for (int i = 0; i < request.virtual_cluster_spec().bundles_size(); i++) {
     bundles.emplace_back(request.virtual_cluster_spec().bundles(i), vc_id);
     resource_request_list.emplace_back(&bundles[i].GetRequiredResources());
+  }
+  if (resource_request_list.empty()) {
+    return {};
   }
   auto scheduling_result = cluster_resource_scheduler_.Schedule(
       resource_request_list, SchedulingOptions::BundleStrictSpread());

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.h
@@ -2,6 +2,7 @@
 
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/gcs/gcs_server/gcs_node_manager.h"
+#include "ray/gcs/gcs_server/gcs_resource_manager.h"
 #include "ray/raylet/scheduling/cluster_resource_scheduler.h"
 #include "ray/rpc/gcs_server/gcs_rpc_server.h"
 #include "ray/rpc/node_manager/node_manager_client_pool.h"
@@ -24,6 +25,7 @@ class GcsVirtualClusterManager : public rpc::VirtualClusterInfoHandler {
   GcsVirtualClusterManager(
       instrumented_io_context &io_context,
       const GcsNodeManager &gcs_node_manager,
+      const GcsResourceManager &gcs_resource_manager,
       ClusterResourceScheduler &cluster_resource_scheduler,
       std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool);
 
@@ -48,9 +50,11 @@ class GcsVirtualClusterManager : public rpc::VirtualClusterInfoHandler {
 
   void Tick();
   void CreateVirtualClusters();
+  void ScaleExistingVirtualClustersHack();
 
   instrumented_io_context &io_context_;
   const GcsNodeManager &gcs_node_manager_;
+  const GcsResourceManager &gcs_resource_manager_;
   ClusterResourceScheduler &cluster_resource_scheduler_;
   std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool_;
   std::deque<rpc::CreateVirtualClusterRequest> pending_virtual_clusters_;

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -555,6 +555,7 @@ message ResourcesData {
   // Total resource capacity configured for this node manager.
   map<string, double> resources_total = 4;
   // Aggregate outstanding resource load on this node manager.
+  // DEPRECATED in favor of resource_load_by_shape. Don't use.
   map<string, double> resource_load = 5;
   // The resource load on this node, sorted by resource shape.
   ResourceLoad resource_load_by_shape = 7;

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -122,6 +122,7 @@ message CancelResourceReserveReply {
 
 message PrepareVirtualClusterBundleRequest {
   bytes virtual_cluster_id = 1;
+  int64 seqno = 3; // Used to track each request.
   // 1 virtual cluster can only have 1 bundle on a node.
   VirtualClusterBundle bundle_spec = 2;
 }
@@ -133,12 +134,14 @@ message PrepareVirtualClusterBundleReply {
 
 message CommitVirtualClusterBundleRequest {
   bytes virtual_cluster_id = 1;
+  int64 seqno = 3; // Used to track each request.
 }
 
 message CommitVirtualClusterBundleReply {}
 
 message ReturnVirtualClusterBundleRequest {
   bytes virtual_cluster_id = 1;
+  int64 seqno = 3; // Used to track each request. Only returns so many things.
 }
 
 message ReturnVirtualClusterBundleReply {}

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1905,7 +1905,8 @@ void NodeManager::HandlePrepareVirtualClusterBundle(
   auto bundle_spec = VirtualClusterBundleSpec(request.bundle_spec(), vc_id);
   RAY_LOG(DEBUG) << "Request to prepare resources for virtual cluster bundle: "
                  << bundle_spec.DebugString();
-  bool prepared = virtual_cluster_resource_manager_->PrepareBundle(bundle_spec);
+  bool prepared =
+      virtual_cluster_resource_manager_->PrepareBundle(bundle_spec, request.seqno());
   reply->set_success(prepared);
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
@@ -1916,7 +1917,7 @@ void NodeManager::HandleCommitVirtualClusterBundle(
     rpc::SendReplyCallback send_reply_callback) {
   auto vc_id = VirtualClusterID::FromBinary(request.virtual_cluster_id());
   RAY_LOG(DEBUG) << "Request to commit resources for virtual cluster bundle: " << vc_id;
-  virtual_cluster_resource_manager_->CommitBundle(vc_id);
+  virtual_cluster_resource_manager_->CommitBundle(vc_id, request.seqno());
   send_reply_callback(Status::OK(), nullptr, nullptr);
   cluster_task_manager_->ScheduleAndDispatchTasks();
 }
@@ -1927,7 +1928,7 @@ void NodeManager::HandleReturnVirtualClusterBundle(
     rpc::SendReplyCallback send_reply_callback) {
   auto vc_id = VirtualClusterID::FromBinary(request.virtual_cluster_id());
   RAY_LOG(DEBUG) << "Request to return resources for virtual cluster bundle: " << vc_id;
-  virtual_cluster_resource_manager_->ReturnBundle(vc_id);
+  virtual_cluster_resource_manager_->ReturnBundle(vc_id, request.seqno());
   cluster_task_manager_->ScheduleAndDispatchTasks();
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }

--- a/src/ray/raylet/virtual_cluster_resource_manager.h
+++ b/src/ray/raylet/virtual_cluster_resource_manager.h
@@ -76,20 +76,20 @@ class VirtualClusterResourceManager {
   ///
   /// \param bundle_specs A set of bundles that waiting to be prepared.
   /// \return bool True if all bundles successfully reserved resources, otherwise false.
-  virtual bool PrepareBundle(const VirtualClusterBundleSpec &bundle_spec);
+  virtual bool PrepareBundle(const VirtualClusterBundleSpec &bundle_spec, int64_t seqno);
 
   /// Convert the required resources to virtual cluster resources(like CPU ->
   /// CPU_cluster_i). This is phase two of 2PC.
   ///
   /// \param bundle_spec Specification of bundle whose resources will be commited.
-  void CommitBundle(VirtualClusterID vc_id);
+  void CommitBundle(VirtualClusterID vc_id, int64_t seqno);
 
   /// Return back all the bundle resource.
   /// Removes the added renamed resources, releases the original resources, and erases the
   /// entry in `vc_bundles_`.
   ///
   /// \param bundle_spec Specification of bundle whose resources will be returned.
-  virtual void ReturnBundle(VirtualClusterID vc_id);
+  virtual void ReturnBundle(VirtualClusterID vc_id, int64_t seqno);
 
   /// Return back all the bundle(which is unused) resource.
   ///
@@ -107,7 +107,7 @@ class VirtualClusterResourceManager {
 
   /// Tracking virtual cluster bundles and their states. This mapping is the source of
   /// truth for the scheduler.
-  absl::flat_hash_map<VirtualClusterID,
+  absl::flat_hash_map<std::pair<VirtualClusterID, int64_t /*seqno*/>,
                       std::shared_ptr<VirtualClusterBundleTransactionState>>
       vc_bundles_;
 };

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -486,28 +486,34 @@ void raylet::RayletClient::ReleaseUnusedBundles(
 
 void raylet::RayletClient::PrepareVirtualClusterBundle(
     const VirtualClusterBundleSpec &bundle_spec,
+    int64_t seqno,
     const ray::rpc::ClientCallback<ray::rpc::PrepareVirtualClusterBundleReply>
         &callback) {
   rpc::PrepareVirtualClusterBundleRequest request;
   request.set_virtual_cluster_id(bundle_spec.GetVirtualClusterId().Binary());
   *request.mutable_bundle_spec() = bundle_spec.GetMessage();
+  request.set_seqno(seqno);
   grpc_client_->PrepareVirtualClusterBundle(request, callback);
 }
 
 void raylet::RayletClient::CommitVirtualClusterBundle(
     const VirtualClusterID &virtual_cluster_id,
+    int64_t seqno,
     const ray::rpc::ClientCallback<ray::rpc::CommitVirtualClusterBundleReply> &callback) {
   rpc::CommitVirtualClusterBundleRequest request;
   request.set_virtual_cluster_id(virtual_cluster_id.Binary());
+  request.set_seqno(seqno);
 
   grpc_client_->CommitVirtualClusterBundle(request, callback);
 }
 
 void raylet::RayletClient::ReturnVirtualClusterBundle(
     const VirtualClusterID &virtual_cluster_id,
+    int64_t seqno,
     const ray::rpc::ClientCallback<ray::rpc::ReturnVirtualClusterBundleReply> &callback) {
   rpc::ReturnVirtualClusterBundleRequest request;
   request.set_virtual_cluster_id(virtual_cluster_id.Binary());
+  request.set_seqno(seqno);
   grpc_client_->ReturnVirtualClusterBundle(request, callback);
 }
 

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -151,6 +151,7 @@ class ResourceReserveInterface {
   /// \return ray::Status
   virtual void PrepareVirtualClusterBundle(
       const VirtualClusterBundleSpec &bundle_spec,
+      int64_t seqno,
       const ray::rpc::ClientCallback<ray::rpc::PrepareVirtualClusterBundleReply>
           &callback) = 0;
 
@@ -160,6 +161,7 @@ class ResourceReserveInterface {
   /// ray::Status
   virtual void CommitVirtualClusterBundle(
       const VirtualClusterID &virtual_cluster_id,
+      int64_t seqno,
       const ray::rpc::ClientCallback<ray::rpc::CommitVirtualClusterBundleReply>
           &callback) = 0;
 
@@ -169,6 +171,7 @@ class ResourceReserveInterface {
   /// \return ray::Status
   virtual void ReturnVirtualClusterBundle(
       const VirtualClusterID &virtual_cluster_id,
+      int64_t seqno,
       const ray::rpc::ClientCallback<ray::rpc::ReturnVirtualClusterBundleReply>
           &callback) = 0;
 
@@ -503,18 +506,21 @@ class RayletClient : public RayletClientInterface {
   /// Implements PrepareVirtualClusterBundleInterface.
   void PrepareVirtualClusterBundle(
       const VirtualClusterBundleSpec &bundle_spec,
+      int64_t seqno,
       const ray::rpc::ClientCallback<ray::rpc::PrepareVirtualClusterBundleReply>
           &callback) override;
 
   /// Implements CommitVirtualClusterBundleInterface.
   void CommitVirtualClusterBundle(
       const VirtualClusterID &virtual_cluster_id,
+      int64_t seqno,
       const ray::rpc::ClientCallback<ray::rpc::CommitVirtualClusterBundleReply> &callback)
       override;
 
   /// Implements ReturnVirtualClusterBundleInterface.
   void ReturnVirtualClusterBundle(
       const VirtualClusterID &virtual_cluster_id,
+      int64_t seqno,
       const ray::rpc::ClientCallback<ray::rpc::ReturnVirtualClusterBundleReply> &callback)
       override;
 


### PR DESCRIPTION
With this PR, a virtual cluster can start from the initial shape and scale up to the whole cluster.

Limitations:
  - only renames available resources, does not talk to parent/physical node to autoscale
  - doing per-node renaming. No "work stealing".
  - no VC upper limits (assumes infinite scaling up)
  - no scale downs
  - no fairness: just fulfill loads one by one
  - 1 demand only asks for 1 VC's resources
  - not yet adopting the new proto design

For unknown reasons, now after submitting a job via `ray job submit`, and after the job finishes, the cluster downs with received SIGTERM. Not sure who or why.