### PR TITLE
[2.9.0 Release] Add release logs for 2.9.0

### DIFF
--- a/release/release_logs/2.9.0/benchmarks/many_actors.json
+++ b/release/release_logs/2.9.0/benchmarks/many_actors.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 536.94464,
+    "_dashboard_test_success": true,
+    "_peak_memory": 5.84,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n208\t1.65GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1601\t0.89GiB\tpython distributed/test_many_actors.py\n343\t0.43GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n506\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n1419\t0.07GiB\tray::JobSupervisor\n1749\t0.06GiB\tray::DashboardTester.run\n80\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1660\t0.06GiB\tray::MemoryMonitorActor.run\n504\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n445\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/log_m",
+    "actors_per_second": 652.3025965764776,
+    "num_actors": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "actors_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 652.3025965764776
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 31.743
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1844.456
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4070.315
+        }
+    ],
+    "success": "1",
+    "time": 15.330308437347412
+}

--- a/release/release_logs/2.9.0/benchmarks/many_nodes.json
+++ b/release/release_logs/2.9.0/benchmarks/many_nodes.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 187.846656,
+    "_dashboard_test_success": true,
+    "_peak_memory": 12.91,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n208\t0.5GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n343\t0.16GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n1103\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1304\t0.07GiB\tray::StateAPIGeneratorActor.start\n922\t0.07GiB\tray::JobSupervisor\n503\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n80\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1163\t0.06GiB\tray::MemoryMonitorActor.run\n1250\t0.06GiB\tray::DashboardTester.run\n501\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen",
+    "num_tasks": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 316.6511158500481
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4.459
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 54.645
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 152.981
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 316.6511158500481,
+    "time": 303.15804982185364,
+    "used_cpus": 250.0
+}

--- a/release/release_logs/2.9.0/benchmarks/many_tasks.json
+++ b/release/release_logs/2.9.0/benchmarks/many_tasks.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 753.803264,
+    "_dashboard_test_success": true,
+    "_peak_memory": 14.79,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n208\t1.17GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n942\t0.72GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n343\t0.71GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n1136\t0.07GiB\tray::DashboardTester.run\n1204\t0.07GiB\tray::StateAPIGeneratorActor.start\n507\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n742\t0.07GiB\tray::JobSupervisor\n80\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1064\t0.06GiB\tray::MemoryMonitorActor.run\n505\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen",
+    "num_tasks": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 594.4121709556288
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2500.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 6.317
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 9619.014
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 12194.633
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 594.4121709556288,
+    "time": 316.82334327697754,
+    "used_cpus": 2500.0
+}

--- a/release/release_logs/2.9.0/microbenchmark.json
+++ b/release/release_logs/2.9.0/microbenchmark.json
@@ -1,0 +1,283 @@
+{
+    "1_1_actor_calls_async": [
+        8802.618688415567,
+        95.8260336482515
+    ],
+    "1_1_actor_calls_concurrent": [
+        5336.212996582152,
+        121.37338770631413
+    ],
+    "1_1_actor_calls_sync": [
+        2177.1619419194303,
+        46.39806923585727
+    ],
+    "1_1_async_actor_calls_async": [
+        3230.6142324554685,
+        49.16790108592347
+    ],
+    "1_1_async_actor_calls_sync": [
+        1383.0488502410044,
+        35.36605749915935
+    ],
+    "1_1_async_actor_calls_with_args_async": [
+        2352.5191874975103,
+        67.9964161472068
+    ],
+    "1_n_actor_calls_async": [
+        7769.431743767464,
+        722.0084137825218
+    ],
+    "1_n_async_actor_calls_async": [
+        7953.049246488258,
+        155.70806639810598
+    ],
+    "client__1_1_actor_calls_async": [
+        1071.4786362740724,
+        5.171723820339284
+    ],
+    "client__1_1_actor_calls_concurrent": [
+        1063.662350782696,
+        11.17077349412178
+    ],
+    "client__1_1_actor_calls_sync": [
+        560.1396067522019,
+        5.90551191553866
+    ],
+    "client__get_calls": [
+        1121.0271839374332,
+        42.99121313178227
+    ],
+    "client__put_calls": [
+        869.7936004582608,
+        53.1707608886498
+    ],
+    "client__put_gigabytes": [
+        0.12795432763592557,
+        0.004761341038550263
+    ],
+    "client__tasks_and_get_batch": [
+        0.982305256221986,
+        0.013114790442708612
+    ],
+    "client__tasks_and_put_batch": [
+        10306.863268325735,
+        200.6421018961668
+    ],
+    "multi_client_put_calls_Plasma_Store": [
+        11162.251480555622,
+        209.87350812201743
+    ],
+    "multi_client_put_gigabytes": [
+        35.91997590246238,
+        1.7588110946526256
+    ],
+    "multi_client_tasks_async": [
+        23547.65328133274,
+        1624.242933443766
+    ],
+    "n_n_actor_calls_async": [
+        27282.915588001837,
+        566.4813638171095
+    ],
+    "n_n_actor_calls_with_arg_async": [
+        2945.9103513380783,
+        6.958094784887208
+    ],
+    "n_n_async_actor_calls_async": [
+        23828.114331532583,
+        436.9338168408824
+    ],
+    "perf_metrics": [
+        {
+            "perf_metric_name": "single_client_get_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8572.421130502738
+        },
+        {
+            "perf_metric_name": "single_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5446.38813194616
+        },
+        {
+            "perf_metric_name": "multi_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 11162.251480555622
+        },
+        {
+            "perf_metric_name": "single_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 20.91024418565827
+        },
+        {
+            "perf_metric_name": "single_client_tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8.815387055138444
+        },
+        {
+            "perf_metric_name": "multi_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 35.91997590246238
+        },
+        {
+            "perf_metric_name": "single_client_get_object_containing_10k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 13.956647427325594
+        },
+        {
+            "perf_metric_name": "single_client_wait_1k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5.52902247411149
+        },
+        {
+            "perf_metric_name": "single_client_tasks_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 896.3011478159317
+        },
+        {
+            "perf_metric_name": "single_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8721.338552221338
+        },
+        {
+            "perf_metric_name": "multi_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 23547.65328133274
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2177.1619419194303
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8802.618688415567
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5336.212996582152
+        },
+        {
+            "perf_metric_name": "1_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 7769.431743767464
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 27282.915588001837
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_with_arg_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2945.9103513380783
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1383.0488502410044
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 3230.6142324554685
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_with_args_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2352.5191874975103
+        },
+        {
+            "perf_metric_name": "1_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 7953.049246488258
+        },
+        {
+            "perf_metric_name": "n_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 23828.114331532583
+        },
+        {
+            "perf_metric_name": "placement_group_create/removal",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 817.5855922503765
+        },
+        {
+            "perf_metric_name": "client__get_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1121.0271839374332
+        },
+        {
+            "perf_metric_name": "client__put_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 869.7936004582608
+        },
+        {
+            "perf_metric_name": "client__put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.12795432763592557
+        },
+        {
+            "perf_metric_name": "client__tasks_and_put_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10306.863268325735
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 560.1396067522019
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1071.4786362740724
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1063.662350782696
+        },
+        {
+            "perf_metric_name": "client__tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.982305256221986
+        }
+    ],
+    "placement_group_create/removal": [
+        817.5855922503765,
+        12.592262381497191
+    ],
+    "single_client_get_calls_Plasma_Store": [
+        8572.421130502738,
+        59.61762268987168
+    ],
+    "single_client_get_object_containing_10k_refs": [
+        13.956647427325594,
+        0.06484961742353296
+    ],
+    "single_client_put_calls_Plasma_Store": [
+        5446.38813194616,
+        43.416663342692104
+    ],
+    "single_client_put_gigabytes": [
+        20.91024418565827,
+        4.524247964547407
+    ],
+    "single_client_tasks_and_get_batch": [
+        8.815387055138444,
+        0.6107237701852521
+    ],
+    "single_client_tasks_async": [
+        8721.338552221338,
+        530.1170936795154
+    ],
+    "single_client_tasks_sync": [
+        896.3011478159317,
+        9.797638332767432
+    ],
+    "single_client_wait_1k_refs": [
+        5.52902247411149,
+        0.11923315386815697
+    ]
+}

--- a/release/release_logs/2.9.0/scalability/object_store.json
+++ b/release/release_logs/2.9.0/scalability/object_store.json
@@ -1,0 +1,13 @@
+{
+    "broadcast_time": 78.31477016299999,
+    "num_nodes": 50,
+    "object_size": 1073741824,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 78.31477016299999
+        }
+    ],
+    "success": "1"
+}

--- a/release/release_logs/2.9.0/scalability/single_node.json
+++ b/release/release_logs/2.9.0/scalability/single_node.json
@@ -1,0 +1,40 @@
+{
+    "args_time": 18.200371015,
+    "get_time": 24.40687068600002,
+    "large_object_size": 107374182400,
+    "large_object_time": 31.513478057999976,
+    "num_args": 10000,
+    "num_get_args": 10000,
+    "num_queued": 1000000,
+    "num_returns": 3000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "10000_args_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 18.200371015
+        },
+        {
+            "perf_metric_name": "3000_returns_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 6.287682662999998
+        },
+        {
+            "perf_metric_name": "10000_get_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 24.40687068600002
+        },
+        {
+            "perf_metric_name": "1000000_queued_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 185.55641146
+        },
+        {
+            "perf_metric_name": "107374182400_large_object_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 31.513478057999976
+        }
+    ],
+    "queued_time": 185.55641146,
+    "returns_time": 6.287682662999998,
+    "success": "1"
+}

--- a/release/release_logs/2.9.0/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.9.0/stress_tests/stress_test_dead_actors.json
@@ -1,0 +1,14 @@
+{
+    "avg_iteration_time": 1.5317100596427917,
+    "max_iteration_time": 3.2659718990325928,
+    "min_iteration_time": 0.7450485229492188,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1.5317100596427917
+        }
+    ],
+    "success": 1,
+    "total_time": 153.1712019443512
+}

--- a/release/release_logs/2.9.0/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.9.0/stress_tests/stress_test_many_tasks.json
@@ -1,0 +1,47 @@
+{
+    "perf_metrics": [
+        {
+            "perf_metric_name": "stage_0_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 12.985974550247192
+        },
+        {
+            "perf_metric_name": "stage_1_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 25.154193711280822
+        },
+        {
+            "perf_metric_name": "stage_2_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 58.53190121650696
+        },
+        {
+            "perf_metric_name": "stage_3_creation_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.8420045375823975
+        },
+        {
+            "perf_metric_name": "stage_3_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3146.527221918106
+        },
+        {
+            "perf_metric_name": "stage_4_spread",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.671871809148491
+        }
+    ],
+    "stage_0_time": 12.985974550247192,
+    "stage_1_avg_iteration_time": 25.154193711280822,
+    "stage_1_max_iteration_time": 27.2432963848114,
+    "stage_1_min_iteration_time": 23.776684761047363,
+    "stage_1_time": 251.5420491695404,
+    "stage_2_avg_iteration_time": 58.53190121650696,
+    "stage_2_max_iteration_time": 59.79744076728821,
+    "stage_2_min_iteration_time": 57.46649527549744,
+    "stage_2_time": 292.660617351532,
+    "stage_3_creation_time": 3.8420045375823975,
+    "stage_3_time": 3146.527221918106,
+    "stage_4_spread": 0.671871809148491,
+    "success": 1
+}

--- a/release/release_logs/2.9.0/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.9.0/stress_tests/stress_test_placement_group.json
@@ -1,0 +1,17 @@
+{
+    "avg_pg_create_time_ms": 0.9481992612621639,
+    "avg_pg_remove_time_ms": 0.9064963108115691,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_pg_create_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.9481992612621639
+        },
+        {
+            "perf_metric_name": "avg_pg_remove_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.9064963108115691
+        }
+    ],
+    "success": 1
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Adds performance logs for Ray 2.9.0. Taken from the tests at https://buildkite.com/ray-project/release-tests-branch/builds?branch=releases%2F2.9.0 for commit ebc97d5c5e718a64f9310f72fcb586193ded3d51 by running `python fetch_release_logs.py 2.9.0`.

Below I have included the result of running the regression script. From the release instructions: 
> This script will catch regressions in perf_metrics, **you still need to manually check other metrics (e.g. _peak_memory)**

I have not done the "manual check" and will leave that to the reviewers of this PR.
 
```
(base) architkulkarni@archit-Q4WXGF2WQY release_logs % python compare_perf_metrics 2.8.0 2.9.0                     
REGRESSION 22.84%: single_client_tasks_sync (THROUGHPUT) regresses from 1161.670131632561 to 896.3011478159317 (22.84%) in 2.9.0/microbenchmark.json
REGRESSION 18.91%: 1_n_actor_calls_async (THROUGHPUT) regresses from 9581.728569086026 to 7769.431743767464 (18.91%) in 2.9.0/microbenchmark.json
REGRESSION 13.46%: multi_client_tasks_async (THROUGHPUT) regresses from 27211.51041454346 to 23547.65328133274 (13.46%) in 2.9.0/microbenchmark.json
REGRESSION 13.42%: actors_per_second (THROUGHPUT) regresses from 753.4446893211699 to 652.3025965764776 (13.42%) in 2.9.0/benchmarks/many_actors.json
REGRESSION 11.72%: placement_group_create/removal (THROUGHPUT) regresses from 926.0840791839338 to 817.5855922503765 (11.72%) in 2.9.0/microbenchmark.json
REGRESSION 9.71%: client__tasks_and_put_batch (THROUGHPUT) regresses from 11415.752622212967 to 10306.863268325735 (9.71%) in 2.9.0/microbenchmark.json
REGRESSION 9.38%: n_n_actor_calls_async (THROUGHPUT) regresses from 30108.565209428394 to 27282.915588001837 (9.38%) in 2.9.0/microbenchmark.json
REGRESSION 8.69%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12224.373147431208 to 11162.251480555622 (8.69%) in 2.9.0/microbenchmark.json
REGRESSION 7.54%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 8601.993472120319 to 7953.049246488258 (7.54%) in 2.9.0/microbenchmark.json
REGRESSION 4.41%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5697.447666436941 to 5446.38813194616 (4.41%) in 2.9.0/microbenchmark.json
REGRESSION 3.70%: client__get_calls (THROUGHPUT) regresses from 1164.1583807193044 to 1121.0271839374332 (3.70%) in 2.9.0/microbenchmark.json
REGRESSION 1.90%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 24290.541801601616 to 23828.114331532583 (1.90%) in 2.9.0/microbenchmark.json
REGRESSION 1.65%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2213.6033025230176 to 2177.1619419194303 (1.65%) in 2.9.0/microbenchmark.json
REGRESSION 1.18%: multi_client_put_gigabytes (THROUGHPUT) regresses from 36.34816401372876 to 35.91997590246238 (1.18%) in 2.9.0/microbenchmark.json
REGRESSION 69.95%: stage_3_creation_time (LATENCY) regresses from 2.260662794113159 to 3.8420045375823975 (69.95%) in 2.9.0/stress_tests/stress_test_many_tasks.json
REGRESSION 63.82%: stage_0_time (LATENCY) regresses from 7.927043914794922 to 12.985974550247192 (63.82%) in 2.9.0/stress_tests/stress_test_many_tasks.json
REGRESSION 31.80%: dashboard_p99_latency_ms (LATENCY) regresses from 3088.301 to 4070.315 (31.80%) in 2.9.0/benchmarks/many_actors.json
REGRESSION 31.12%: dashboard_p95_latency_ms (LATENCY) regresses from 7335.859 to 9619.014 (31.12%) in 2.9.0/benchmarks/many_tasks.json
REGRESSION 14.96%: avg_pg_remove_time_ms (LATENCY) regresses from 0.7885501576572757 to 0.9064963108115691 (14.96%) in 2.9.0/stress_tests/stress_test_placement_group.json
REGRESSION 6.92%: stage_3_time (LATENCY) regresses from 2943.001654624939 to 3146.527221918106 (6.92%) in 2.9.0/stress_tests/stress_test_many_tasks.json
REGRESSION 6.91%: avg_pg_create_time_ms (LATENCY) regresses from 0.8868904699705661 to 0.9481992612621639 (6.91%) in 2.9.0/stress_tests/stress_test_placement_group.json
REGRESSION 6.58%: 3000_returns_time (LATENCY) regresses from 5.899374322999989 to 6.287682662999998 (6.58%) in 2.9.0/scalability/single_node.json
REGRESSION 3.06%: 10000_args_time (LATENCY) regresses from 17.66019733799999 to 18.200371015 (3.06%) in 2.9.0/scalability/single_node.json
REGRESSION 1.26%: 107374182400_large_object_time (LATENCY) regresses from 31.122242091999965 to 31.513478057999976 (1.26%) in 2.9.0/scalability/single_node.json
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
