### PR TITLE
[Doc] Parallelize RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,14 +10,20 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  commands:
+    - pip install -r doc/requirements-doc.txt
+    - pip install readthedocs-sphinx-ext
+    - make -C doc/ html
+    - mkdir -p $READTHEDOCS_OUTPUT/
+    - mv doc/_build/html $READTHEDOCS_OUTPUT/
 
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-  configuration: doc/source/conf.py
-  fail_on_warning: true
+# # Build documentation in the docs/ directory with Sphinx
+# sphinx:
+#   configuration: doc/source/conf.py
+#   fail_on_warning: true
 
-# We recommend specifying your dependencies to enable reproducible builds:
-# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-  install:
-    - requirements: doc/requirements-doc.txt
+# # We recommend specifying your dependencies to enable reproducible builds:
+# # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#     - requirements: doc/requirements-doc.txt


### PR DESCRIPTION
## Why are these changes needed?

Building docs on RTD is incredibly slow because they do not parallelize by default. This PR forces the builder to run build jobs in parallel, speeding up the build.

## Related issue number

Closes #41456.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
