### PR TITLE
[Serve] Fix duplicated pymodules in the serve details

### DIFF
--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -121,7 +121,6 @@ class LoggingConfig(BaseModel):
 
     @validator("encoding")
     def valid_encoding_format(cls, v):
-
         if v not in list(EncodingType):
             raise ValueError(
                 f"Got '{v}' for encoding. Encoding must be one "
@@ -227,7 +226,7 @@ class RayActorOptionsSchema(BaseModel):
             return
 
         uris = v.get("py_modules", [])
-        if "working_dir" in v:
+        if "working_dir" in v and v["working_dir"] not in uris:
             uris.append(v["working_dir"])
 
         for uri in uris:
@@ -509,7 +508,7 @@ class ServeApplicationSchema(BaseModel):
             return
 
         uris = v.get("py_modules", [])
-        if "working_dir" in v:
+        if "working_dir" in v and v["working_dir"] not in uris:
             uris.append(v["working_dir"])
 
         for uri in uris:

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import sys
 from typing import Dict, List, Optional, Union
@@ -133,7 +134,13 @@ class TestRayActorOptionsSchema:
 
         ray_actor_options_schema = self.get_valid_ray_actor_options_schema()
         ray_actor_options_schema["runtime_env"] = env
-        RayActorOptionsSchema.parse_obj(ray_actor_options_schema)
+        schema = RayActorOptionsSchema.parse_obj(ray_actor_options_schema)
+
+        original_runtime_env = copy.deepcopy(schema.runtime_env)
+        # Make sure "working_dir" is only added once.
+        for _ in range(5):
+            schema = RayActorOptionsSchema.parse_obj(schema)
+            assert schema.runtime_env == original_runtime_env
 
     @pytest.mark.parametrize("env", get_invalid_runtime_envs())
     def test_ray_actor_options_invalid_runtime_env(self, env):
@@ -395,7 +402,13 @@ class TestServeApplicationSchema:
 
         serve_application_schema = self.get_valid_serve_application_schema()
         serve_application_schema["runtime_env"] = env
-        ServeApplicationSchema.parse_obj(serve_application_schema)
+        schema = ServeApplicationSchema.parse_obj(serve_application_schema)
+
+        original_runtime_env = copy.deepcopy(schema.runtime_env)
+        # Make sure "working_dir" is only added once.
+        for _ in range(5):
+            schema = ServeApplicationSchema.parse_obj(schema)
+            assert schema.runtime_env == original_runtime_env
 
     @pytest.mark.parametrize("env", get_invalid_runtime_envs())
     def test_serve_application_invalid_runtime_env(self, env):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Whenever we construct the runtime_env in `RayActorOptionsSchema` or  `ServeApplicationSchema`, and working_dir is set, the value will be added into `py_modules`. (e.g. calling ServeApplicationSchema.parse_obj(config)) it ends up having duplicated items inside the list. 
This pr is to avoid the scenario.

## Related issue number
Closes #41690 https://github.com/ray-project/ray/issues/41690

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
