### PR TITLE
[data] register arrow extension types in __init__

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -79,7 +79,7 @@ try:
         if parse_version(pyarrow_version) >= parse_version("14.0.1"):
             pa.PyExtensionType.set_auto_load(True)
         # Import these arrow extension types to ensure that they are registered.
-        from ray.data.extensions.tensor_extension import (  # noqa
+        from ray.air.util.tensor_extensions.arrow import (  # noqa
             ArrowTensorType,
             ArrowVariableShapedTensorType,
         )

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -75,8 +75,14 @@ try:
         # PyArrow is mocked in documentation builds. In this case, we don't need to do
         # anything.
         pass
-    elif parse_version(pyarrow_version) >= parse_version("14.0.1"):
-        pa.PyExtensionType.set_auto_load(True)
+    else:
+        if parse_version(pyarrow_version) >= parse_version("14.0.1"):
+            pa.PyExtensionType.set_auto_load(True)
+        # Import these arrow extension types to ensure that they are registered.
+        from ray.data.extensions.tensor_extension import (  # noqa
+            ArrowTensorType,
+            ArrowVariableShapedTensorType,
+        )
 except ModuleNotFoundError:
     pass
 

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -1,6 +1,9 @@
+import numpy as np
 import pyarrow as pa
 import pytest
 
+import ray
+from ray._private.test_utils import run_string_as_driver
 from ray.data._internal.arrow_block import ArrowBlockAccessor
 
 
@@ -14,6 +17,29 @@ def test_append_column(ray_start_regular_shared):
 
     expected_block = pa.Table.from_pydict({"animals": animals, "num_legs": num_legs})
     assert actual_block.equals(expected_block)
+
+
+def test_register_arrow_types(tmp_path):
+    # Test that our custom arrow extension types are registered on initialization.
+    ds = ray.data.from_items(np.zeros((8, 8, 8), dtype=np.int64))
+    tmp_file = f"{tmp_path}/test.parquet"
+    ds.write_parquet(tmp_file)
+
+    ds = ray.data.read_parquet(tmp_file)
+    schema = (
+        "Column  Type\n------  ----\nitem    numpy.ndarray(shape=(8, 8), dtype=int64)"
+    )
+    assert str(ds.schema()) == schema
+
+    # Also run in driver script to eliminate existing imports.
+    driver_script = """import ray
+ds = ray.data.read_parquet("{0}")
+schema = ds.schema()
+assert str(schema) == \"\"\"{1}\"\"\"
+""".format(
+        tmp_file, schema
+    )
+    run_string_as_driver(driver_script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
#41642 was reverted because it caused `distributed_sage_example.py` to fail with errors: 
```
(RayTrainWorker pid=4904) ../aten/src/ATen/native/cuda/Indexing.cu:1146: indexSelectLargeIndex: block: [32,0,0], thread: [96,0,0] Assertion `srcIndex < srcSelectDimSize` failed.
(RayTrainWorker pid=4904) ../aten/src/ATen/native/cuda/Indexing.cu:1146: indexSelectLargeIndex: block: [32,0,0], thread: [97,0,0] Assertion `srcIndex < srcSelectDimSize` failed.
(RayTrainWorker pid=4904) ../aten/src/ATen/native/cuda/Indexing.cu:1146: indexSelectLargeIndex: block: [32,0,0], thread: [98,0,0] Assertion `srcIndex < srcSelectDimSize` failed.
```

I'm not sure of the cause but it looks like importing the types directly from `ray.air.util.tensor_extensions.arrow` fixes this.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #41628 again.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
