### PR TITLE
[Doc] Trim some toctrees to save build time

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -59,25 +59,33 @@ extensions = [
     "sphinx.ext.intersphinx",
 ]
 
+remove_from_toctrees = [
+    "cluster/running-applications/job-submission/doc/*",
+    "ray-observability/reference/doc/*",
+    "ray-core/api/doc/*",
+    "data/api/doc/*",
+    "train/api/doc/*",
+    "tune/api/doc/*",
+    "serve/api/doc/*",
+    "rllib/package_ref/algorithm/*",
+    "rllib/package_ref/policy/*",
+    "rllib/package_ref/models/*",
+    "rllib/package_ref/catalogs/*",
+    "rllib/package_ref/rl_modules/*",
+    "rllib/package_ref/learner/*",
+    "rllib/package_ref/evaluation/*",
+    "rllib/package_ref/replay-buffers/*",
+    "rllib/package_ref/utils/*",
+]
+
 # Prune deep toc-trees on demand for smaller html and faster builds.
 # This only effects the navigation bar, not the content.
 if os.getenv("FAST", False):
-    remove_from_toctrees = [
-        "data/api/doc/*",
-        "ray-air/api/doc/*",
-        "ray-core/api/doc/*",
+    remove_from_toctrees += [
         "ray-observability/api/state/doc/*",
-        "serve/api/doc/*",
-        "train/api/doc/*",
-        "tune/api/doc/*",
         "workflows/api/doc/*",
-        "cluster/running-applications/job-submission/doc/*",
         "serve/production-guide/*",
         "serve/tutorials/deployment-graph-patterns/*",
-        "rllib/package_ref/env/*",
-        "rllib/package_ref/policy/*",
-        "rllib/package_ref/evaluation/*",
-        "rllib/package_ref/utils/*",
         "workflows/api/*",
         "cluster/kubernetes/user-guides/*",
         "cluster/kubernetes/examples/*",


### PR DESCRIPTION
## Why are these changes needed?

This PR trims some documentation toctrees to save build time in places where it makes sense to do so. Mostly what has been removed has been references to autosummary-generated pages which are deeply nested.

This has the impact of removing the child elements of some of our dropdowns, all of which are very deeply nested and which do not appear on one line.

## Related issue number

The following are experiencing build time issues and would be helped by this PR:

- https://github.com/ray-project/ray/pull/41596
- https://github.com/ray-project/ray/pull/41682
- https://github.com/ray-project/ray/pull/41686

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(