### PR TITLE
[data] test exactly-once row processing

### DIFF
--- a/python/ray/data/tests/test_batcher.py
+++ b/python/ray/data/tests/test_batcher.py
@@ -222,6 +222,31 @@ def test_shuffling_batcher_grid(batch_size, local_shuffle_buffer_size):
     assert count == 10000
 
 
+@pytest.mark.parametrize(
+    "batch_size,local_shuffle_buffer_size",
+    [(1, 1), (10, 1), (1, 10), (10, 100), (100, 10)],
+)
+def test_local_shuffle_determinism(batch_size, local_shuffle_buffer_size):
+    # Preserve order so that the blocks are in the same order prior to shuffling.
+    ctx = ray.data.DataContext.get_current()
+    ctx.execution_options.preserve_order = True
+    TEST_ITERATIONS = 10
+
+    ds = ray.data.range(1000)
+    batch_map = {}
+    for i in range(TEST_ITERATIONS):
+        for batch in ds.iter_batches(
+            batch_size=batch_size,
+            local_shuffle_buffer_size=local_shuffle_buffer_size,
+            local_shuffle_seed=0,
+        ):
+            if i == 0:
+                batch_map[batch["id"][0]] = batch
+            else:
+                # Check that batch is the same as the first dataset's batch
+                assert all(batch_map[batch["id"][0]]["id"] == batch["id"])
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add tests:
- Checks if dynamic block splitting is deterministic
- Checks if local shuffling is deterministic

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
