### PR TITLE
[spark] Customize bazel test timeout for spark tests

### DIFF
--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -30,7 +30,7 @@ steps:
         --parallelism-per-worker 3
         --only-tags spark_plugin_tests
         --except-tags kubernetes
-        --test_timeout 1500
+        --test-timeout 1500
 
   - label: ":serverless: serverless: flaky tests"
     tags:

--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -29,7 +29,8 @@ steps:
         --test-env=RAY_ON_SPARK_RAY_WORKER_NODE_STARTUP_INTERVAL=5
         --parallelism-per-worker 3
         --only-tags spark_plugin_tests
-        --except-tags kubernetes 
+        --except-tags kubernetes
+        --test_timeout 1500
 
   - label: ":serverless: serverless: flaky tests"
     tags:

--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -30,7 +30,7 @@ steps:
         --parallelism-per-worker 3
         --only-tags spark_plugin_tests
         --except-tags kubernetes
-        --test-timeout 1500
+        --test-timeout=1500
 
   - label: ":serverless: serverless: flaky tests"
     tags:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Customize bazel test timeout for spark tests:
Spark tests runs for about nearly 900 seconds, it is close to upper bound of "large" size test, but much shorter than upper bound of "enormous" size test. So I customize its test timout to 1500 seconds.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
