### PR TITLE
[cherry-pick][data] Improve stall detection for StreamingOutputsBackpressurePolicy

### DIFF
--- a/python/ray/data/_internal/execution/backpressure_policy/streaming_output_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/streaming_output_backpressure_policy.py
@@ -1,10 +1,17 @@
-from typing import TYPE_CHECKING, Dict
+import time
+from collections import defaultdict
+from typing import TYPE_CHECKING, Dict, Tuple
 
 import ray
 from .backpressure_policy import BackpressurePolicy
+from ray.data._internal.dataset_logger import DatasetLogger
 
 if TYPE_CHECKING:
+    from ray.data._internal.execution.interfaces import PhysicalOperator
     from ray.data._internal.execution.streaming_executor_state import OpState, Topology
+
+
+logger = DatasetLogger(__name__)
 
 
 class StreamingOutputBackpressurePolicy(BackpressurePolicy):
@@ -39,6 +46,10 @@ class StreamingOutputBackpressurePolicy(BackpressurePolicy):
         "backpressure_policies.streaming_output.max_blocks_in_op_output_queue"
     )
 
+    # If an operator has active tasks but no outputs for at least this time,
+    # we'll consider it as idle and temporarily unblock backpressure for its upstream.
+    MAX_OUTPUT_IDLE_SECONDS = 10
+
     def __init__(self, topology: "Topology"):
         data_context = ray.data.DataContext.get_current()
         self._max_num_blocks_in_streaming_gen_buffer = data_context.get_config(
@@ -59,28 +70,80 @@ class StreamingOutputBackpressurePolicy(BackpressurePolicy):
         )
         assert self._max_num_blocks_in_op_output_queue > 0
 
+        # Latest number of outputs and the last time when the number changed
+        # for each op.
+        self._last_num_outputs_and_time: Dict[
+            "PhysicalOperator", Tuple[int, float]
+        ] = defaultdict(lambda: (0, time.time()))
+        self._warning_printed = False
+
     def calculate_max_blocks_to_read_per_op(
         self, topology: "Topology"
     ) -> Dict["OpState", int]:
         max_blocks_to_read_per_op: Dict["OpState", int] = {}
-        downstream_num_active_tasks = 0
+
+        # Indicates if the immediate downstream operator is idle.
+        downstream_idle = False
+
         for op, state in reversed(topology.items()):
             max_blocks_to_read_per_op[state] = (
                 self._max_num_blocks_in_op_output_queue - state.outqueue_num_blocks()
             )
-            if downstream_num_active_tasks == 0:
-                # If all downstream operators are idle, it could be because no resources
-                # are available. In this case, we'll make sure to read at least one
-                # block to avoid deadlock.
-                # TODO(hchen): `downstream_num_active_tasks == 0` doesn't necessarily
-                # mean no enough resources. One false positive case is when the upstream
-                # op hasn't produced any blocks for the downstream op to consume.
-                # In this case, at least reading one block is fine.
-                # If there are other false positive cases, we may want to make this
-                # deadlock check more accurate by directly checking resources.
+
+            if downstream_idle:
                 max_blocks_to_read_per_op[state] = max(
                     max_blocks_to_read_per_op[state],
                     1,
                 )
-            downstream_num_active_tasks += len(op.get_active_tasks())
+
+            # An operator is considered idle if either of the following is true:
+            # - It has no active tasks.
+            #   - This can happen when all resources are used by upstream operators.
+            # - It has active tasks, but no outputs for at least
+            #   `MAX_OUTPUT_IDLE_SECONDS`.
+            #   - This can happen when non-Data code preempted cluster resources, and
+            #   - some of the active tasks don't actually have enough resources to run.
+            #
+            # If the operator is idle, we'll temporarily unblock backpressure by
+            # allowing reading at least one block from its upstream
+            # to avoid deadlock.
+            # NOTE, these 2 conditions don't necessarily mean deadlock.
+            # The first case can also happen when the upstream operator hasn't outputted
+            # any blocks yet. While the second case can also happen when the task is
+            # expected to output data slowly.
+            # The false postive cases are fine as we only allow reading one block
+            # each time.
+            downstream_idle = False
+            if op.num_active_tasks() == 0:
+                downstream_idle = True
+            else:
+                cur_num_outputs = state.op.metrics.num_outputs_generated
+                cur_time = time.time()
+                last_num_outputs, last_time = self._last_num_outputs_and_time[state.op]
+                if cur_num_outputs > last_num_outputs:
+                    self._last_num_outputs_and_time[state.op] = (
+                        cur_num_outputs,
+                        cur_time,
+                    )
+                else:
+                    if cur_time - last_time > self.MAX_OUTPUT_IDLE_SECONDS:
+                        downstream_idle = True
+                        self._print_warning(state.op, cur_time - last_time)
         return max_blocks_to_read_per_op
+
+    def _print_warning(self, op: "PhysicalOperator", idle_time: float):
+        if self._warning_printed:
+            return
+        self._warning_printed = True
+        msg = (
+            f"Operator {op} is running but has no outputs for {idle_time} seconds."
+            " Execution may be slower than expected.\n"
+            "Ignore this warning if your UDF is expected to be slow."
+            " Otherwise, this can happen when there are fewer cluster resources"
+            " available to Ray Data than expected."
+            " If you have non-Data tasks or actors running in the cluster, exclude"
+            " their resources from Ray Data with"
+            " `DataContext.get_current().execution_options.exclude_resources`."
+            " This message will only print once."
+        )
+        logger.get_logger().warning(msg)

--- a/python/ray/data/_internal/execution/interfaces/executor.py
+++ b/python/ray/data/_internal/execution/interfaces/executor.py
@@ -46,6 +46,7 @@ class Executor:
 
     def __init__(self, options: ExecutionOptions):
         """Create the executor."""
+        options.validate()
         self._options = options
 
     def execute(

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -73,6 +73,7 @@ class StreamingExecutor(Executor, threading.Thread):
 
         # The executor can be shutdown while still running.
         self._shutdown_lock = threading.RLock()
+        self._execution_started = False
         self._shutdown = False
 
         # Internal execution state shared across thread boundaries. We run the control
@@ -133,6 +134,7 @@ class StreamingExecutor(Executor, threading.Thread):
             self._get_operator_tags(),
         )
         self.start()
+        self._execution_started = True
 
         class StreamIterator(OutputIterator):
             def __init__(self, outer: Executor):
@@ -165,7 +167,7 @@ class StreamingExecutor(Executor, threading.Thread):
         global _num_shutdown
 
         with self._shutdown_lock:
-            if self._shutdown:
+            if not self._execution_started or self._shutdown:
                 return
             logger.get_logger().debug(f"Shutting down {self}.")
             _num_shutdown += 1
@@ -332,16 +334,26 @@ class StreamingExecutor(Executor, threading.Thread):
         autoscaling.
         """
         base = self._options.resource_limits
+        exclude = self._options.exclude_resources
         cluster = ray.cluster_resources()
-        return ExecutionResources(
-            cpu=base.cpu if base.cpu is not None else cluster.get("CPU", 0.0),
-            gpu=base.gpu if base.gpu is not None else cluster.get("GPU", 0.0),
-            object_store_memory=base.object_store_memory
-            if base.object_store_memory is not None
-            else round(
+
+        cpu = base.cpu
+        if cpu is None:
+            cpu = cluster.get("CPU", 0.0) - (exclude.cpu or 0.0)
+        gpu = base.gpu
+        if gpu is None:
+            gpu = cluster.get("GPU", 0.0) - (exclude.gpu or 0.0)
+        object_store_memory = base.object_store_memory
+        if object_store_memory is None:
+            object_store_memory = round(
                 DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION
                 * cluster.get("object_store_memory", 0.0)
-            ),
+            ) - (exclude.object_store_memory or 0)
+
+        return ExecutionResources(
+            cpu=cpu,
+            gpu=gpu,
+            object_store_memory=object_store_memory,
         )
 
     def _report_current_usage(

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1,6 +1,7 @@
 import collections
+import math
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,10 +19,12 @@ from ray.data._internal.execution.operators.map_transformer import (
     create_map_transformer_from_block_fn,
 )
 from ray.data._internal.execution.streaming_executor import (
+    StreamingExecutor,
     _debug_dump_topology,
     _validate_dag,
 )
 from ray.data._internal.execution.streaming_executor_state import (
+    DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION,
     AutoscalingState,
     DownstreamMemoryInfo,
     OpState,
@@ -696,6 +699,62 @@ def test_execution_allowed_nothrottle():
         ),
         ExecutionResources(object_store_memory=900),
     )
+
+
+def test_resource_limits():
+    cluster_resources = {"CPU": 10, "GPU": 5, "object_store_memory": 1000}
+    default_object_store_memory_limit = math.ceil(
+        cluster_resources["object_store_memory"]
+        * DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION
+    )
+
+    with patch("ray.cluster_resources", return_value=cluster_resources):
+        # Test default resource limits.
+        # When no resource limits are set, the resource limits should default to
+        # the cluster resources for CPU/GPU, and
+        # DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION of cluster object store memory.
+        options = ExecutionOptions()
+        executor = StreamingExecutor(options, "")
+        expected = ExecutionResources(
+            cpu=cluster_resources["CPU"],
+            gpu=cluster_resources["GPU"],
+            object_store_memory=default_object_store_memory_limit,
+        )
+        assert executor._get_or_refresh_resource_limits() == expected
+
+        # Test setting resource_limits
+        options = ExecutionOptions()
+        options.resource_limits = ExecutionResources(
+            cpu=1, gpu=2, object_store_memory=100
+        )
+        executor = StreamingExecutor(options, "")
+        expected = ExecutionResources(
+            cpu=1,
+            gpu=2,
+            object_store_memory=100,
+        )
+        assert executor._get_or_refresh_resource_limits() == expected
+
+        # Test setting exclude_resources
+        # The actual limit should be the default limit minus the excluded resources.
+        options = ExecutionOptions()
+        options.exclude_resources = ExecutionResources(
+            cpu=1, gpu=2, object_store_memory=100
+        )
+        executor = StreamingExecutor(options, "")
+        expected = ExecutionResources(
+            cpu=cluster_resources["CPU"] - 1,
+            gpu=cluster_resources["GPU"] - 2,
+            object_store_memory=default_object_store_memory_limit - 100,
+        )
+        assert executor._get_or_refresh_resource_limits() == expected
+
+        # Test that we don't support setting both resource_limits and exclude_resources.
+        with pytest.raises(ValueError):
+            options = ExecutionOptions()
+            options.resource_limits = ExecutionResources(cpu=2)
+            options.exclude_resources = ExecutionResources(cpu=1)
+            options.validate()
 
 
 @pytest.mark.parametrize(

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Literal, Optional, Union
 import ray
 from ray.actor import ActorHandle
 from ray.data import DataIterator, Dataset, ExecutionOptions, NodeIdStr
+from ray.data._internal.execution.interfaces.execution_options import ExecutionResources
 from ray.data.preprocessor import Preprocessor
 
 # TODO(justinvyu): Fix the circular import error
@@ -94,21 +95,14 @@ class DataConfig:
             ds = ds.copy(ds)
             ds.context.execution_options = copy.deepcopy(self._execution_options)
 
-            # If CPU or GPU resource limits are not set,
-            # exclude the resources used by training from the resource limits.
-            # TODO(hchen): We calculate the resource limits based on the current
-            # cluster resources here, which means that auto-scaling is not supported.
-            # This should be fixed when we want to support auto-scaling for Ray Train.
-            resource_limits = ds.context.execution_options.resource_limits
-            cluster_resources = ray.cluster_resources()
-            if resource_limits.cpu is None:
-                resource_limits.cpu = (
-                    cluster_resources.get("CPU", 0) - self._num_train_cpus
+            # Add training-reserved resources to Data's exclude_resources.
+            ds.context.execution_options.exclude_resources = (
+                ds.context.execution_options.exclude_resources.add(
+                    ExecutionResources(
+                        cpu=self._num_train_cpus, gpu=self._num_train_gpus
+                    )
                 )
-            if resource_limits.gpu is None:
-                resource_limits.gpu = (
-                    cluster_resources.get("GPU", 0) - self._num_train_gpus
-                )
+            )
 
             if name in datasets_to_split:
                 for i, split in enumerate(


### PR DESCRIPTION
Cherry-pick #41637 to 2.9 release branch. This is a stability fix for a new backpressure feature in Ray Data

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
