### PR TITLE
[Core] Speed up single_client_tasks_sync

### DIFF
--- a/python/ray/tests/accelerators/test_intel_gpu.py
+++ b/python/ray/tests/accelerators/test_intel_gpu.py
@@ -5,14 +5,18 @@ from unittest.mock import patch
 
 import ray
 from ray._private.accelerators import IntelGPUAcceleratorManager as Accelerator
+from ray._private.accelerators import get_accelerator_manager_for_resource
 from ray.util.accelerators import INTEL_MAX_1550, INTEL_MAX_1100
 
 
 def test_visible_intel_gpu_ids(shutdown_only):
     with patch.object(Accelerator, "get_current_node_num_accelerators", return_value=4):
         os.environ["ONEAPI_DEVICE_SELECTOR"] = "level_zero:0,1,2"
+        # Delete the cache so it can be re-populated the next time
+        # we call get_accelerator_manager_for_resource
+        del get_accelerator_manager_for_resource._resource_name_to_accelerator_manager
         ray.init()
-        manager = ray._private.accelerators.get_accelerator_manager_for_resource("GPU")
+        manager = get_accelerator_manager_for_resource("GPU")
         assert manager.get_current_node_num_accelerators() == 4
         assert manager.__name__ == "IntelGPUAcceleratorManager"
         assert ray.available_resources()["GPU"] == 3
@@ -25,8 +29,9 @@ def test_visible_intel_gpu_type(shutdown_only):
         Accelerator, "get_current_node_accelerator_type", return_value=INTEL_MAX_1550
     ):
         os.environ["ONEAPI_DEVICE_SELECTOR"] = "level_zero:0,1,2"
+        del get_accelerator_manager_for_resource._resource_name_to_accelerator_manager
         ray.init()
-        manager = ray._private.accelerators.get_accelerator_manager_for_resource("GPU")
+        manager = get_accelerator_manager_for_resource("GPU")
         assert manager.get_current_node_accelerator_type() == INTEL_MAX_1550
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently `IntelGPUAcceleratorManager.get_current_node_num_accelerators()` will be called everytime we try to get accelerator manager for GPU resource. This is expensive and makes `single_client_tasks_sync` slower.  This PR changes to only call it once.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#41695
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
