### PR TITLE
[Serve] Update serve.start API from system_logging_config to logging_config

### DIFF
--- a/dashboard/modules/serve/serve_rest_api_impl.py
+++ b/dashboard/modules/serve/serve_rest_api_impl.py
@@ -176,7 +176,7 @@ def create_serve_rest_api(
                 client = await serve_start_async(
                     http_options=full_http_options,
                     grpc_options=grpc_options,
-                    system_logging_config=config.logging_config,
+                    global_logging_config=config.logging_config,
                 )
 
             # Serve ignores HTTP options if it was already running when
@@ -186,7 +186,7 @@ def create_serve_rest_api(
 
             try:
                 if config.logging_config:
-                    client.update_system_logging_config(config.logging_config)
+                    client.update_global_logging_config(config.logging_config)
                 client.deploy_apps(config)
                 record_extra_usage_tag(TagKey.SERVE_REST_API_VERSION, "v2")
             except RayTaskError as e:

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -111,7 +111,7 @@ def _check_http_options(
 def _start_controller(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
-    system_logging_config: Union[None, dict, LoggingConfig] = None,
+    global_logging_config: Union[None, dict, LoggingConfig] = None,
     **kwargs,
 ) -> Tuple[ActorHandle, str]:
     """Start Ray Serve controller.
@@ -157,16 +157,16 @@ def _start_controller(
     if isinstance(grpc_options, dict):
         grpc_options = gRPCOptions(**grpc_options)
 
-    if system_logging_config is None:
-        system_logging_config = LoggingConfig()
-    elif isinstance(system_logging_config, dict):
-        system_logging_config = LoggingConfig(**system_logging_config)
+    if global_logging_config is None:
+        global_logging_config = LoggingConfig()
+    elif isinstance(global_logging_config, dict):
+        global_logging_config = LoggingConfig(**global_logging_config)
 
     controller = ServeController.options(**controller_actor_options).remote(
         SERVE_CONTROLLER_NAME,
         http_config=http_options,
         grpc_options=grpc_options,
-        system_logging_config=system_logging_config,
+        global_logging_config=global_logging_config,
     )
 
     proxy_handles = ray.get(controller.get_proxies.remote())
@@ -186,7 +186,7 @@ def _start_controller(
 async def serve_start_async(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
-    system_logging_config: Union[None, dict, LoggingConfig] = None,
+    global_logging_config: Union[None, dict, LoggingConfig] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance asynchronously.
@@ -216,7 +216,7 @@ async def serve_start_async(
     controller, controller_name = (
         await ray.remote(_start_controller)
         .options(num_cpus=0)
-        .remote(http_options, grpc_options, system_logging_config, **kwargs)
+        .remote(http_options, grpc_options, global_logging_config, **kwargs)
     )
 
     client = ServeControllerClient(
@@ -231,7 +231,7 @@ async def serve_start_async(
 def serve_start(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
-    system_logging_config: Union[None, dict, LoggingConfig] = None,
+    global_logging_config: Union[None, dict, LoggingConfig] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance.
@@ -289,7 +289,7 @@ def serve_start(
         pass
 
     controller, controller_name = _start_controller(
-        http_options, grpc_options, system_logging_config, **kwargs
+        http_options, grpc_options, global_logging_config, **kwargs
     )
 
     client = ServeControllerClient(

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -590,6 +590,6 @@ class ServeControllerClient:
         self._controller.record_multiplexed_replica_info.remote(info)
 
     @_ensure_connected
-    def update_system_logging_config(self, logging_config: LoggingConfig):
+    def update_global_logging_config(self, logging_config: LoggingConfig):
         """Reconfigure the logging config for the controller & proxies."""
-        self._controller.reconfigure_system_logging_config.remote(logging_config)
+        self._controller.reconfigure_global_logging_config.remote(logging_config)

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -115,7 +115,7 @@ class ServeController:
         controller_name: str,
         *,
         http_config: HTTPOptions,
-        system_logging_config: LoggingConfig,
+        global_logging_config: LoggingConfig,
         grpc_options: Optional[gRPCOptions] = None,
     ):
         self._controller_node_id = ray.get_runtime_context().get_node_id()
@@ -135,11 +135,11 @@ class ServeController:
         # Try to read config from checkpoint
         # logging config from checkpoint take precedence over the one passed in
         # the constructor.
-        self.system_logging_config = None
+        self.global_logging_config = None
         log_config_checkpoint = self.kv_store.get(LOGGING_CONFIG_CHECKPOINT_KEY)
         if log_config_checkpoint is not None:
-            system_logging_config = pickle.loads(log_config_checkpoint)
-        self.reconfigure_system_logging_config(system_logging_config)
+            global_logging_config = pickle.loads(log_config_checkpoint)
+        self.reconfigure_global_logging_config(global_logging_config)
 
         configure_component_memory_profiler(
             component_name="controller", component_id=str(os.getpid())
@@ -163,7 +163,7 @@ class ServeController:
             http_config,
             self._controller_node_id,
             self.cluster_node_info_cache,
-            self.system_logging_config,
+            self.global_logging_config,
             grpc_options,
         )
 
@@ -223,29 +223,29 @@ class ServeController:
             description="The number of times that controller has started.",
         ).inc()
 
-    def reconfigure_system_logging_config(self, system_logging_config: LoggingConfig):
+    def reconfigure_global_logging_config(self, global_logging_config: LoggingConfig):
         if (
-            self.system_logging_config
-            and self.system_logging_config == system_logging_config
+            self.global_logging_config
+            and self.global_logging_config == global_logging_config
         ):
             return
         self.kv_store.put(
-            LOGGING_CONFIG_CHECKPOINT_KEY, pickle.dumps(system_logging_config)
+            LOGGING_CONFIG_CHECKPOINT_KEY, pickle.dumps(global_logging_config)
         )
-        self.system_logging_config = system_logging_config
+        self.global_logging_config = global_logging_config
 
         self.long_poll_host.notify_changed(
-            LongPollNamespace.SYSTEM_LOGGING_CONFIG,
-            system_logging_config,
+            LongPollNamespace.GLOBAL_LOGGING_CONFIG,
+            global_logging_config,
         )
         configure_component_logger(
             component_name="controller",
             component_id=str(os.getpid()),
-            logging_config=system_logging_config,
+            logging_config=global_logging_config,
         )
         logger.debug(
             "Configure the serve controller logger "
-            f"with logging config: {self.system_logging_config}"
+            f"with logging config: {self.global_logging_config}"
         )
 
     def check_alive(self) -> None:
@@ -513,7 +513,6 @@ class ServeController:
 
         checkpoint = self.kv_store.get(CONFIG_CHECKPOINT_KEY)
         if checkpoint is not None:
-
             (
                 deployment_time,
                 target_capacity,
@@ -1081,7 +1080,7 @@ class ServeController:
         for handler in logger.handlers:
             if isinstance(handler, logging.handlers.RotatingFileHandler):
                 log_file_path = handler.baseFilename
-        return self.system_logging_config, log_file_path
+        return self.global_logging_config, log_file_path
 
     def _get_target_capacity_direction(self) -> Optional[TargetCapacityDirection]:
         """Gets the controller's scale direction (for testing purposes)."""
@@ -1192,7 +1191,7 @@ class ServeControllerAvatar:
             ).remote(
                 controller_name,
                 http_config=http_config,
-                system_logging_config=logging_config,
+                global_logging_config=logging_config,
             )
 
     def check_alive(self) -> None:

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -40,7 +40,7 @@ class LongPollNamespace(Enum):
 
     RUNNING_REPLICAS = auto()
     ROUTE_TABLE = auto()
-    SYSTEM_LOGGING_CONFIG = auto()
+    GLOBAL_LOGGING_CONFIG = auto()
 
 
 @dataclass

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1115,7 +1115,7 @@ class ProxyActor:
         self.long_poll_client = long_poll_client or LongPollClient(
             ray.get_actor(controller_name, namespace=SERVE_NAMESPACE),
             {
-                LongPollNamespace.SYSTEM_LOGGING_CONFIG: self._update_logging_config,
+                LongPollNamespace.GLOBAL_LOGGING_CONFIG: self._update_logging_config,
             },
             call_in_event_loop=get_or_create_event_loop(),
         )

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -65,7 +65,7 @@ def start(
     http_options: Union[None, dict, HTTPOptions] = None,
     dedicated_cpu: bool = False,
     grpc_options: Union[None, dict, gRPCOptions] = None,
-    system_logging_config: Union[None, dict, LoggingConfig] = None,
+    logging_config: Union[None, dict, LoggingConfig] = None,
     **kwargs,
 ):
     """Start Serve on the cluster.
@@ -89,7 +89,7 @@ def start(
         grpc_options: [EXPERIMENTAL] gRPC config options for the proxies. These can
           be passed as an unstructured dictionary or the structured `gRPCOptions`
           class See `gRPCOptions` for supported options.
-        system_logging_config: logging config options for the serve component (
+        logging_config: logging config options for the serve component (
             controller & proxy).
     """
 
@@ -122,7 +122,7 @@ def start(
     _private_api.serve_start(
         http_options=http_options,
         grpc_options=grpc_options,
-        system_logging_config=system_logging_config,
+        global_logging_config=logging_config,
         **kwargs,
     )
 

--- a/python/ray/serve/tests/test_callback.py
+++ b/python/ray/serve/tests/test_callback.py
@@ -176,7 +176,7 @@ def test_callback_fail(ray_instance):
     handle = actor_def.remote(
         "controller",
         http_config={},
-        system_logging_config=LoggingConfig(),
+        global_logging_config=LoggingConfig(),
     )
     with pytest.raises(RayActorError, match="cannot be imported"):
         ray.get(handle.check_alive.remote())

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -420,7 +420,7 @@ def test_controller_crashes_with_logging_config(serve_instance):
     client = serve_instance
 
     # Update the logging config
-    client.update_system_logging_config(
+    client.update_global_logging_config(
         LoggingConfig(encoding="JSON", log_level="DEBUG")
     )
 

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -359,7 +359,7 @@ def check_log_file(log_file: str, expected_regex: list):
 
 class TestLoggingAPI:
     def test_start_serve_with_logging_config(self, serve_and_ray_shutdown):
-        serve.start(system_logging_config={"log_level": "DEBUG", "encoding": "JSON"})
+        serve.start(logging_config={"log_level": "DEBUG", "encoding": "JSON"})
         serve_log_dir = get_serve_logs_dir()
         # Check controller log
         actors = state_api.list_actors()
@@ -434,7 +434,6 @@ class TestLoggingAPI:
         check_log_file(resp["log_file"], expected_log_regex)
 
     def test_logs_dir(self, serve_and_ray_shutdown):
-
         logger = logging.getLogger("ray.serve")
 
         @serve.deployment


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently we have mismatch api logging_config and system_logging_config, change system_logging_config to logging_config to reduce the confusion since it will be applied to application & deployment too.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
