### PR TITLE
[Cherry-pick][Serve] allow gRPC deployment to use grpc context (#41667)

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -245,3 +245,6 @@ RAY_SERVE_ENABLE_CPU_PROFILING = (
 # precision up to 0.0001.
 # This limitation should be lifted in the long term.
 MAX_REPLICAS_PER_NODE_MAX_VALUE = 100
+
+# Argument name for passing in the gRPC context into a replica.
+GRPC_CONTEXT_ARG_NAME = "grpc_context"

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -616,6 +616,20 @@ class gRPCProxy(GenericProxy):
         )
 
     def service_handler_factory(self, service_method: str, stream: bool) -> Callable:
+        def set_grpc_code_and_details(
+            context: grpc._cython.cygrpc._ServicerContext, status: ResponseStatus
+        ):
+            # Only the latest code and details will take effect. If the user already
+            # set them to a truthy value in the context, skip setting them with Serve's
+            # default values. By default, if nothing is set, the code is 0 and the
+            # details is "", which both are falsy. So if the user did not set them or
+            # if they're explicitly set to falsy values, such as None, Serve will
+            # continue to set them with our default values.
+            if not context.code():
+                context.set_code(status.code)
+            if not context.details():
+                context.set_details(status.message)
+
         async def unary_unary(
             request_proto: Any, context: grpc._cython.cygrpc._ServicerContext
         ) -> bytes:
@@ -640,8 +654,8 @@ class gRPCProxy(GenericProxy):
                 else:
                     response = message
 
-            context.set_code(status.code)
-            context.set_details(status.message)
+            set_grpc_code_and_details(context, status)
+
             return response
 
         async def unary_stream(
@@ -668,8 +682,7 @@ class gRPCProxy(GenericProxy):
                 else:
                     yield message
 
-            context.set_code(status.code)
-            context.set_details(status.message)
+            set_grpc_code_and_details(context, status)
 
         return unary_stream if stream else unary_unary
 
@@ -702,6 +715,7 @@ class gRPCProxy(GenericProxy):
             "request_id": request_id,
             "app_name": app_name,
             "multiplexed_model_id": multiplexed_model_id,
+            "grpc_context": proxy_request.ray_serve_grpc_context,
         }
         ray.serve.context._serve_request_context.set(
             ray.serve.context._RequestContext(**request_context_info)
@@ -723,7 +737,8 @@ class gRPCProxy(GenericProxy):
         )
 
         try:
-            async for result in response_generator:
+            async for context, result in response_generator:
+                context.set_on_grpc_context(proxy_request.context)
                 yield result
 
             yield ResponseStatus(code=grpc.StatusCode.OK)

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -32,6 +32,7 @@ from ray.serve._private.common import (
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
     DEFAULT_LATENCY_BUCKET_MS,
+    GRPC_CONTEXT_ARG_NAME,
     HEALTH_CHECK_METHOD,
     RAY_SERVE_GAUGE_METRIC_SET_PERIOD_S,
     RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S,
@@ -63,6 +64,7 @@ from ray.serve._private.utils import (
 from ray.serve._private.version import DeploymentVersion
 from ray.serve.deployment import Deployment
 from ray.serve.exceptions import RayServeException
+from ray.serve.grpc_util import RayServegRPCContext
 from ray.serve.schema import LoggingConfig
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -713,6 +715,7 @@ class RayServeReplica:
                 request_metadata.request_id,
                 self.deployment_id.app,
                 request_metadata.multiplexed_model_id,
+                request_metadata.grpc_context,
             )
         )
 
@@ -758,7 +761,7 @@ class RayServeReplica:
 
     async def call_user_method_with_grpc_unary_stream(
         self, request_metadata: RequestMetadata, request: gRPCRequest
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[Tuple[RayServegRPCContext, bytes], None]:
         """Call a user method that is expected to be a generator.
 
         Deserializes gRPC request into protobuf object and pass into replica's runner
@@ -767,16 +770,22 @@ class RayServeReplica:
         async with self.wrap_user_method_call(request_metadata):
             user_method = self.get_runner_method(request_metadata)
             user_request = pickle.loads(request.grpc_user_request)
-            result_generator = user_method(user_request)
+            if GRPC_CONTEXT_ARG_NAME in inspect.signature(user_method).parameters:
+                result_generator = user_method(
+                    user_request,
+                    grpc_context=request_metadata.grpc_context,
+                )
+            else:
+                result_generator = user_method(user_request)
             if inspect.iscoroutine(result_generator):
                 result_generator = await result_generator
 
             if inspect.isgenerator(result_generator):
                 for result in result_generator:
-                    yield result.SerializeToString()
+                    yield request_metadata.grpc_context, result.SerializeToString()
             elif inspect.isasyncgen(result_generator):
                 async for result in result_generator:
-                    yield result.SerializeToString()
+                    yield request_metadata.grpc_context, result.SerializeToString()
             else:
                 raise TypeError(
                     "When using `stream=True`, the called method must be a generator "
@@ -785,7 +794,7 @@ class RayServeReplica:
 
     async def call_user_method_grpc_unary(
         self, request_metadata: RequestMetadata, request: gRPCRequest
-    ) -> bytes:
+    ) -> Tuple[RayServegRPCContext, bytes]:
         """Call a user method that is *not* expected to be a generator.
 
         Deserializes gRPC request into protobuf object and pass into replica's runner
@@ -806,8 +815,14 @@ class RayServeReplica:
 
             method_to_call = sync_to_async(runner_method)
 
-            result = await method_to_call(user_request)
-            return result.SerializeToString()
+            if GRPC_CONTEXT_ARG_NAME in inspect.signature(runner_method).parameters:
+                result = await method_to_call(
+                    user_request,
+                    grpc_context=request_metadata.grpc_context,
+                )
+            else:
+                result = await method_to_call(user_request)
+            return request_metadata.grpc_context, result.SerializeToString()
 
     async def call_user_method(
         self,

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -38,6 +38,7 @@ from ray.serve._private.long_poll import LongPollClient, LongPollNamespace
 from ray.serve._private.utils import JavaActorHandleProxy, MetricsPusher
 from ray.serve.generated.serve_pb2 import DeploymentRoute
 from ray.serve.generated.serve_pb2 import RequestMetadata as RequestMetadataProto
+from ray.serve.grpc_util import RayServegRPCContext
 from ray.util import metrics
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -63,6 +64,9 @@ class RequestMetadata:
 
     # The protocol to serve this request
     _request_protocol: RequestProtocol = RequestProtocol.UNDEFINED
+
+    # Serve's gRPC context associated with this request for getting and setting metadata
+    grpc_context: Optional[RayServegRPCContext] = None
 
     @property
     def is_http_request(self) -> bool:

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -14,6 +14,7 @@ from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import ReplicaTag
 from ray.serve._private.constants import SERVE_CONTROLLER_NAME, SERVE_NAMESPACE
 from ray.serve.exceptions import RayServeException
+from ray.serve.grpc_util import RayServegRPCContext
 from ray.util.annotations import DeveloperAPI
 
 logger = logging.getLogger(__file__)
@@ -166,6 +167,7 @@ class _RequestContext:
     request_id: str = ""
     app_name: str = ""
     multiplexed_model_id: str = ""
+    grpc_context: Optional[RayServegRPCContext] = None
 
 
 _serve_request_context = contextvars.ContextVar(

--- a/python/ray/serve/grpc_util.py
+++ b/python/ray/serve/grpc_util.py
@@ -1,0 +1,87 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+import grpc
+
+from ray.util.annotations import PublicAPI
+
+
+@PublicAPI(stability="beta")
+class RayServegRPCContext:
+    """Context manager to set and get gRPC context.
+
+    This class implements most of the methods from ServicerContext
+    (see: https://grpc.github.io/grpc/python/grpc.html#grpc.ServicerContext). It's
+    serializable and can be passed with the request to be used on the deployment.
+    """
+
+    def __init__(self, grpc_context: grpc._cython.cygrpc._ServicerContext):
+        self._auth_context = grpc_context.auth_context()
+        self._code = grpc_context.code()
+        self._details = grpc_context.details()
+        self._invocation_metadata = [
+            (key, value) for key, value in grpc_context.invocation_metadata()
+        ]
+        self._peer = grpc_context.peer()
+        self._peer_identities = grpc_context.peer_identities()
+        self._peer_identity_key = grpc_context.peer_identity_key()
+        self._trailing_metadata = [
+            (key, value) for key, value in grpc_context.trailing_metadata()
+        ]
+        self._compression = None
+
+    def auth_context(self) -> Dict[str, Any]:
+        return self._auth_context
+
+    def code(self) -> grpc.StatusCode:
+        return self._code
+
+    def details(self) -> str:
+        return self._details
+
+    def invocation_metadata(self) -> List[Tuple[str, str]]:
+        return self._invocation_metadata
+
+    def peer(self) -> str:
+        return self._peer
+
+    def peer_identities(self) -> Optional[bytes]:
+        return self._peer_identities
+
+    def peer_identity_key(self) -> Optional[str]:
+        return self._peer_identity_key
+
+    def trailing_metadata(self) -> List[Tuple[str, str]]:
+        return self._trailing_metadata
+
+    def set_code(self, code: grpc.StatusCode):
+        self._code = code
+
+    def set_compression(self, compression: grpc.Compression):
+        self._compression = compression
+
+    def set_details(self, details: str):
+        self._details = details
+
+    def _request_id_metadata(self) -> List[Tuple[str, str]]:
+        # Request id metadata should be carried over to the trailing metadata and passed
+        # back to the request client. This function helps pick it out if it exists.
+        for key, value in self._trailing_metadata:
+            if key == "request_id":
+                return [(key, value)]
+        return []
+
+    def set_trailing_metadata(self, trailing_metadata: List[Tuple[str, str]]):
+        self._trailing_metadata = self._request_id_metadata() + trailing_metadata
+
+    def set_on_grpc_context(self, grpc_context: grpc._cython.cygrpc._ServicerContext):
+        if self._code:
+            grpc_context.set_code(self._code)
+
+        if self._compression:
+            grpc_context.set_compression(self._compression)
+
+        if self._details:
+            grpc_context.set_details(self._details)
+
+        if self._trailing_metadata:
+            grpc_context.set_trailing_metadata(self._trailing_metadata)

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -265,6 +265,7 @@ class _DeploymentHandleBase:
             multiplexed_model_id=self.handle_options.multiplexed_model_id,
             is_streaming=self.handle_options.stream,
             _request_protocol=self.handle_options._request_protocol,
+            grpc_context=_request_context.grpc_context,
         )
         self.request_counter.inc(
             tags={

--- a/python/ray/serve/tests/common/utils.py
+++ b/python/ray/serve/tests/common/utils.py
@@ -236,16 +236,42 @@ async def send_signal_on_cancellation(signal_actor: ActorHandle):
 
 class FakeGrpcContext:
     def __init__(self):
-        self.code = None
-        self.details = None
-        self._trailing_metadata = None
+        self._auth_context = {"key": "value"}
+        self._invocation_metadata = [("key", "value")]
+        self._peer = "peer"
+        self._peer_identities = b"peer_identities"
+        self._peer_identity_key = "peer_identity_key"
+        self._code = None
+        self._details = None
+        self._trailing_metadata = []
         self._invocation_metadata = []
 
+    def auth_context(self):
+        return self._auth_context
+
+    def code(self):
+        return self._code
+
+    def details(self):
+        return self._details
+
+    def peer(self):
+        return self._peer
+
+    def peer_identities(self):
+        return self._peer_identities
+
+    def peer_identity_key(self):
+        return self._peer_identity_key
+
+    def trailing_metadata(self):
+        return self._trailing_metadata
+
     def set_code(self, code):
-        self.code = code
+        self._code = code
 
     def set_details(self, details):
-        self.details = details
+        self._details = details
 
     def set_trailing_metadata(self, trailing_metadata):
         self._trailing_metadata = trailing_metadata

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import Any
 
 import grpc
 
@@ -24,6 +25,9 @@ from ray.serve.tests.common.utils import (
     ping_grpc_streaming,
     send_signal_on_cancellation,
 )
+from ray.serve.config import gRPCOptions
+from ray.serve.generated import serve_pb2, serve_pb2_grpc
+from ray.serve.grpc_util import RayServegRPCContext
 from ray.serve.tests.test_config_files.grpc_deployment import g, g2
 
 
@@ -574,6 +578,232 @@ async def test_grpc_proxy_cancellation(ray_instance, ray_shutdown, streaming: bo
 
     with pytest.raises(grpc.FutureCancelledError):
         r.result()
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_using_grpc_context(ray_instance, ray_shutdown, streaming: bool):
+    """Test using gRPC context.
+
+    When the deployment sets code, details, and trailing metadata in the gRPC context,
+    the response will reflect those values.
+    """
+    grpc_port = 9000
+    grpc_servicer_functions = [
+        "ray.serve.generated.serve_pb2_grpc.add_UserDefinedServiceServicer_to_server",
+    ]
+
+    serve.start(
+        grpc_options=gRPCOptions(
+            port=grpc_port,
+            grpc_servicer_functions=grpc_servicer_functions,
+        ),
+    )
+    error_code = grpc.StatusCode.DATA_LOSS
+    error_message = "my specific error message"
+    trailing_metadata = ("foo", "bar")
+
+    @serve.deployment()
+    class HelloModel:
+        def __call__(
+            self,
+            user_message: serve_pb2.UserDefinedMessage,
+            grpc_context: RayServegRPCContext,
+        ):
+            grpc_context.set_code(error_code)
+            grpc_context.set_details(error_message)
+            grpc_context.set_trailing_metadata([trailing_metadata])
+            return serve_pb2.UserDefinedResponse(greeting="hello")
+
+        def Streaming(
+            self,
+            user_message: serve_pb2.UserDefinedMessage,
+            grpc_context: RayServegRPCContext,
+        ):
+            grpc_context.set_code(error_code)
+            grpc_context.set_details(error_message)
+            grpc_context.set_trailing_metadata([trailing_metadata])
+            yield serve_pb2.UserDefinedResponse(greeting="hello")
+
+    model = HelloModel.bind()
+    app_name = "app1"
+    serve.run(target=model, name=app_name)
+
+    channel = grpc.insecure_channel("localhost:9000")
+    stub = serve_pb2_grpc.UserDefinedServiceStub(channel)
+    request = serve_pb2.UserDefinedMessage(name="foo", num=30, foo="bar")
+
+    with pytest.raises(grpc.RpcError) as exception_info:
+        if streaming:
+            list(stub.Streaming(request=request))
+        else:
+            _ = stub.__call__(request=request)
+    rpc_error = exception_info.value
+
+    assert rpc_error.code() == error_code
+    assert error_message == rpc_error.details()
+    assert trailing_metadata in rpc_error.trailing_metadata()
+    # request_id should always be set in the trailing metadata.
+    assert any([key == "request_id" for key, _ in rpc_error.trailing_metadata()])
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_using_grpc_context_exception(ray_instance, ray_shutdown, streaming: bool):
+    """Test setting code on gRPC context then raised exception.
+
+    When the deployment in the gRPC context and then raised exception, the response
+    code should still be internal error instead of user defined error.
+    """
+    grpc_port = 9000
+    grpc_servicer_functions = [
+        "ray.serve.generated.serve_pb2_grpc.add_UserDefinedServiceServicer_to_server",
+    ]
+
+    serve.start(
+        grpc_options=gRPCOptions(
+            port=grpc_port,
+            grpc_servicer_functions=grpc_servicer_functions,
+        ),
+    )
+    user_defined_error_code = grpc.StatusCode.DATA_LOSS
+    real_error_message = "test error"
+
+    @serve.deployment()
+    class HelloModel:
+        def __call__(
+            self,
+            user_message: serve_pb2.UserDefinedMessage,
+            grpc_context: RayServegRPCContext,
+        ):
+            grpc_context.set_code(user_defined_error_code)
+            raise RuntimeError(real_error_message)
+
+        def Streaming(
+            self,
+            user_message: serve_pb2.UserDefinedMessage,
+            grpc_context: RayServegRPCContext,
+        ):
+            grpc_context.set_code(user_defined_error_code)
+            raise RuntimeError(real_error_message)
+
+    model = HelloModel.bind()
+    app_name = "app1"
+    serve.run(target=model, name=app_name)
+
+    channel = grpc.insecure_channel("localhost:9000")
+    stub = serve_pb2_grpc.UserDefinedServiceStub(channel)
+    request = serve_pb2.UserDefinedMessage(name="foo", num=30, foo="bar")
+
+    with pytest.raises(grpc.RpcError) as exception_info:
+        if streaming:
+            list(stub.Streaming(request=request))
+        else:
+            _ = stub.__call__(request=request)
+    rpc_error = exception_info.value
+
+    assert rpc_error.code() == grpc.StatusCode.INTERNAL
+    assert real_error_message in rpc_error.details()
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("issue", ["incorrect_spelling", "more_args"])
+def test_using_grpc_context_bad_function_signature(
+    ray_instance, ray_shutdown, streaming: bool, issue: str
+):
+    """Test using gRPC context with bad function signature.
+
+    When the deployment sets code, details, and trailing metadata in the gRPC context,
+    the response will reflect those values.
+    """
+    grpc_port = 9000
+    grpc_servicer_functions = [
+        "ray.serve.generated.serve_pb2_grpc.add_UserDefinedServiceServicer_to_server",
+    ]
+
+    serve.start(
+        grpc_options=gRPCOptions(
+            port=grpc_port,
+            grpc_servicer_functions=grpc_servicer_functions,
+        ),
+    )
+    error_code = grpc.StatusCode.DATA_LOSS
+    error_message = "my specific error message"
+    trailing_metadata = ("foo", "bar")
+
+    if issue == "incorrect_spelling":
+
+        @serve.deployment()
+        class HelloModel:
+            def __call__(
+                self,
+                user_message: serve_pb2.UserDefinedMessage,
+                grpc_context_incorrect_spelling: RayServegRPCContext,
+            ):
+                grpc_context_incorrect_spelling.set_code(error_code)
+                grpc_context_incorrect_spelling.set_details(error_message)
+                grpc_context_incorrect_spelling.set_trailing_metadata(
+                    [trailing_metadata]
+                )
+                return serve_pb2.UserDefinedResponse(greeting="hello")
+
+            def Streaming(
+                self,
+                user_message: serve_pb2.UserDefinedMessage,
+                grpc_context_incorrect_spelling: RayServegRPCContext,
+            ):
+                grpc_context_incorrect_spelling.set_code(error_code)
+                grpc_context_incorrect_spelling.set_details(error_message)
+                grpc_context_incorrect_spelling.set_trailing_metadata(
+                    [trailing_metadata]
+                )
+                yield serve_pb2.UserDefinedResponse(greeting="hello")
+
+    elif issue == "more_args":
+
+        @serve.deployment()
+        class HelloModel:
+            def __call__(
+                self,
+                user_message: serve_pb2.UserDefinedMessage,
+                grpc_context: RayServegRPCContext,
+                extra_required_arg: Any,
+            ):
+                grpc_context.set_code(error_code)
+                grpc_context.set_details(error_message)
+                grpc_context.set_trailing_metadata([trailing_metadata])
+                return serve_pb2.UserDefinedResponse(greeting="hello")
+
+            def Streaming(
+                self,
+                user_message: serve_pb2.UserDefinedMessage,
+                grpc_context: RayServegRPCContext,
+                extra_required_arg: Any,
+            ):
+                grpc_context.set_code(error_code)
+                grpc_context.set_details(error_message)
+                grpc_context.set_trailing_metadata([trailing_metadata])
+                yield serve_pb2.UserDefinedResponse(greeting="hello")
+
+    model = HelloModel.bind()
+    app_name = "app1"
+    serve.run(target=model, name=app_name)
+
+    channel = grpc.insecure_channel("localhost:9000")
+    stub = serve_pb2_grpc.UserDefinedServiceStub(channel)
+    request = serve_pb2.UserDefinedMessage(name="foo", num=30, foo="bar")
+
+    with pytest.raises(grpc.RpcError) as exception_info:
+        if streaming:
+            list(stub.Streaming(request=request))
+        else:
+            _ = stub.__call__(request=request)
+    rpc_error = exception_info.value
+
+    assert rpc_error.code() == grpc.StatusCode.INTERNAL
+    assert "missing 1 required positional argument:" in rpc_error.details()
+    if issue == "incorrect_spelling":
+        assert "grpc_context_incorrect_spelling" in rpc_error.details()
+    elif issue == "more_args":
+        assert "extra_required_arg" in rpc_error.details()
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -15,6 +15,7 @@ from ray.serve._private.common import DeploymentID
 from ray.serve._private.constants import SERVE_NAMESPACE
 from ray.serve.config import gRPCOptions
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
+from ray.serve.grpc_util import RayServegRPCContext
 from ray.serve.tests.common.utils import (
     ping_fruit_stand,
     ping_grpc_another_method,
@@ -25,9 +26,6 @@ from ray.serve.tests.common.utils import (
     ping_grpc_streaming,
     send_signal_on_cancellation,
 )
-from ray.serve.config import gRPCOptions
-from ray.serve.generated import serve_pb2, serve_pb2_grpc
-from ray.serve.grpc_util import RayServegRPCContext
 from ray.serve.tests.test_config_files.grpc_deployment import g, g2
 
 

--- a/python/ray/serve/tests/test_proxy.py
+++ b/python/ray/serve/tests/test_proxy.py
@@ -26,6 +26,7 @@ from ray.serve._private.proxy_request_response import ProxyRequest
 from ray.serve._private.proxy_router import ProxyRouter
 from ray.serve.generated import serve_pb2
 from ray.serve.tests.common.utils import FakeGrpcContext
+from ray.serve.grpc_util import RayServegRPCContext
 
 
 class FakeRef:
@@ -73,9 +74,10 @@ class FakeActorHandler:
 
 
 class FakeGrpcHandle:
-    def __init__(self, streaming: bool):
+    def __init__(self, streaming: bool, grpc_context: RayServegRPCContext):
         self.deployment_id = DeploymentID("fak_deployment_name", "fake_app_name")
         self.streaming = streaming
+        self.grpc_context = grpc_context
 
     async def remote(self, *args, **kwargs):
         def unary_call():
@@ -85,7 +87,10 @@ class FakeGrpcHandle:
             for i in range(10):
                 yield f"hello world: {i}"
 
-        return unary_call() if not self.streaming else streaming_call()
+        return (
+            self.grpc_context,
+            unary_call() if not self.streaming else streaming_call(),
+        )
 
     def options(self, *args, **kwargs):
         return self
@@ -304,13 +309,17 @@ class TestgRPCProxy:
         # Ensure the unary entry point returns the correct result and sets the
         # code and details on the grpc context object.
         grpc_proxy.proxy_router.route = "route"
-        grpc_proxy.proxy_router.handle = FakeGrpcHandle(streaming=False)
-        grpc_proxy.proxy_router.app_is_cross_language = False
         context = FakeGrpcContext()
+        serve_grpc_context = RayServegRPCContext(context)
+        grpc_proxy.proxy_router.handle = FakeGrpcHandle(
+            streaming=False,
+            grpc_context=serve_grpc_context,
+        )
+        grpc_proxy.proxy_router.app_is_cross_language = False
         result = await unary_entrypoint(request_proto=request_proto, context=context)
         assert result == "hello world"
-        assert context.code == grpc.StatusCode.OK
-        assert context.details == ""
+        assert context.code() == grpc.StatusCode.OK
+        assert context.details() == ""
 
         # Ensure gRPC streaming call uses the correct entry point.
         streaming_entrypoint = grpc_proxy.service_handler_factory(
@@ -321,13 +330,17 @@ class TestgRPCProxy:
         # Ensure the streaming entry point returns the correct result and sets the
         # code and details on the grpc context object.
         grpc_proxy.proxy_router.route = "route"
-        grpc_proxy.proxy_router.handle = FakeGrpcHandle(streaming=True)
-        grpc_proxy.proxy_router.app_is_cross_language = False
         context = FakeGrpcContext()
+        serve_grpc_context = RayServegRPCContext(context)
+        grpc_proxy.proxy_router.handle = FakeGrpcHandle(
+            streaming=True,
+            grpc_context=serve_grpc_context,
+        )
+        grpc_proxy.proxy_router.app_is_cross_language = False
         result = await unary_entrypoint(request_proto=request_proto, context=context)
         assert list(result) == [f"hello world: {i}" for i in range(10)]
-        assert context.code == grpc.StatusCode.OK
-        assert context.details == ""
+        assert context.code() == grpc.StatusCode.OK
+        assert context.details() == ""
 
 
 class TestHTTPProxy:

--- a/python/ray/serve/tests/test_proxy.py
+++ b/python/ray/serve/tests/test_proxy.py
@@ -25,8 +25,8 @@ from ray.serve._private.proxy import (
 from ray.serve._private.proxy_request_response import ProxyRequest
 from ray.serve._private.proxy_router import ProxyRouter
 from ray.serve.generated import serve_pb2
-from ray.serve.tests.common.utils import FakeGrpcContext
 from ray.serve.grpc_util import RayServegRPCContext
+from ray.serve.tests.common.utils import FakeGrpcContext
 
 
 class FakeRef:

--- a/python/ray/serve/tests/unit/test_grpc_util.py
+++ b/python/ray/serve/tests/unit/test_grpc_util.py
@@ -11,8 +11,8 @@ from ray.serve._private.grpc_util import (
     create_serve_grpc_server,
     gRPCServer,
 )
-from ray.serve._private.test_utils import FakeGrpcContext
 from ray.serve.grpc_util import RayServegRPCContext
+from ray.serve.tests.common.utils import FakeGrpcContext
 
 
 def fake_service_handler_factory(service_method: str, stream: bool) -> Callable:

--- a/python/ray/serve/tests/unit/test_proxy_request_response.py
+++ b/python/ray/serve/tests/unit/test_proxy_request_response.py
@@ -244,7 +244,9 @@ class TestgRPCProxyRequest:
         assert proxy_request.is_health_request is False
 
         proxy_request.send_request_id(request_id=request_id)
-        context.set_trailing_metadata.assert_called_with([("request_id", request_id)])
+        assert proxy_request.ray_serve_grpc_context.trailing_metadata() == [
+            ("request_id", request_id)
+        ]
 
         proxy_handle = MagicMock()
         request_object = proxy_request.request_object(proxy_handle=proxy_handle)


### PR DESCRIPTION
This PR passes a grpc_context to deployments if the deployment uses it to get gRPC request related info can use to set code, details, trailing metadata, and compression. The original grpc._cython.cygrpc._ServicerContext type is not serializable, so we created a RayServegRPCContext to be able to pass to the deployment. Will follow up with doc change.

---------

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Pick of https://github.com/ray-project/ray/pull/41667

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
