### PR TITLE
[ci] always update apt in dashboard tests

### DIFF
--- a/dashboard/tests/run_ui_tests.sh
+++ b/dashboard/tests/run_ui_tests.sh
@@ -12,6 +12,7 @@ trap clean_up EXIT
 
 echo "Installing cypress"
 if [ -n "$BUILDKITE" ]; then
+  apt-get update -qq
   apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
   sudo npm install cypress
 else


### PR DESCRIPTION
As title, the test might fail if apt has been cached and not updated. Currently blocking release branch https://buildkite.com/ray-project/postmerge/builds/2005#018c4a89-ec04-4f3b-83de-744b6e85fe63/159-895

Test:
- CI