### PR TITLE
[Serve] Patching ActorProxyWrapper to properly handle is_drained RPC

### DIFF
--- a/python/ray/serve/tests/test_proxy_state.py
+++ b/python/ray/serve/tests/test_proxy_state.py
@@ -53,12 +53,14 @@ class FakeProxyWrapper(ProxyWrapper):
         self.actor_handle = FakeProxyActor(*args, **kwargs)
         self.ready = ProxyWrapperCallStatus.FINISHED_SUCCEED
         self.health = ProxyWrapperCallStatus.FINISHED_SUCCEED
+        self.drained = ProxyWrapperCallStatus.FINISHED_SUCCEED
         self.worker_id = "mock_worker_id"
         self.log_file_path = "mock_log_file_path"
         self.health_check_ongoing = False
         self.is_draining = False
         self.shutdown = False
         self.num_health_checks = 0
+        self.num_drain_checks = 0
 
     @property
     def actor_id(self) -> str:
@@ -74,7 +76,7 @@ class FakeProxyWrapper(ProxyWrapper):
         self.health_check_ongoing = True
 
     def start_new_drained_check(self):
-        pass
+        self.is_draining = True
 
     def is_ready(self) -> ProxyWrapperCallStatus:
         return self.ready
@@ -85,7 +87,9 @@ class FakeProxyWrapper(ProxyWrapper):
         return self.health
 
     def is_drained(self) -> ProxyWrapperCallStatus:
-        pass
+        self.num_drain_checks += 1
+        self.is_draining = False
+        return self.drained
 
     def is_shutdown(self):
         return self.shutdown
@@ -97,6 +101,9 @@ class FakeProxyWrapper(ProxyWrapper):
         self.shutdown = True
 
     def get_num_health_checks(self):
+        return self.num_health_checks
+
+    def get_num_drain_checks(self):
         return self.num_health_checks
 
 
@@ -800,6 +807,52 @@ def test_proxy_actor_unhealthy_during_draining(all_nodes, number_of_worker_nodes
 
     wait_for_condition(condition_predictor=check_worker_node_proxy_actor_is_removed)
     assert manager._proxy_states[HEAD_NODE_ID].status == ProxyStatus.HEALTHY
+
+
+@patch("ray.serve._private.proxy_state.PROXY_HEALTH_CHECK_PERIOD_S", 5)
+def test_proxy_state_reconcile_draining_success():
+    """Test that the proxy will remain DRAINING even if health check succeeds."""
+    timer = MockTimer(start_time=0)
+    # Start with HEALTHY state
+    proxy_state = _create_proxy_state(status=ProxyStatus.HEALTHY, timer=timer)
+    # Simulate health-checks passing
+    proxy_state._actor_proxy_wrapper.healthy = ProxyWrapperCallStatus.FINISHED_SUCCEED
+    # Simulate is_drained check returning false
+    proxy_state._actor_proxy_wrapper.drained = ProxyWrapperCallStatus.FINISHED_FAILED
+
+    for _ in range(10):
+        proxy_state.update(draining=True)
+        assert proxy_state.status == ProxyStatus.DRAINING
+        # Advance timer by 5 (to trigger new health-check, drain-check)
+        timer.advance(5)
+
+    # assert proxy_state._actor_proxy_wrapper.get_num_health_checks() == 10
+    # assert proxy_state._actor_proxy_wrapper.get_num_drain_checks() == 9
+
+    # Make sure the status is still DRAINING
+    assert proxy_state.status == ProxyStatus.DRAINING
+
+    # Simulate is_drained request to ProxyActor pending (for 5 iterations)
+    proxy_state._actor_proxy_wrapper.drained = ProxyWrapperCallStatus.PENDING
+
+    for _ in range(5):
+        proxy_state.update(draining=True)
+        assert proxy_state.status == ProxyStatus.DRAINING
+        # Advance timer by 5 (to trigger new health-check, drain-check)
+        timer.advance(5)
+
+    # assert proxy_state._actor_proxy_wrapper.get_num_health_checks() == 15
+    # No new drain checks will occur, since there's a pending one (not completed yet)
+    # assert proxy_state._actor_proxy_wrapper.get_num_drain_checks() == 14
+
+    # Simulate draining completed
+    proxy_state._actor_proxy_wrapper.drained = ProxyWrapperCallStatus.FINISHED_SUCCEED
+    # Advance timer by 5 (to trigger new health-check, drain-check on next iteration)
+    timer.advance(5)
+
+    proxy_state.update(draining=True)
+    # State should transition to DRAINED
+    assert proxy_state.status == ProxyStatus.DRAINED
 
 
 def test_is_ready_for_shutdown(all_nodes):


### PR DESCRIPTION
## Why are these changes needed?

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

This is a minified version of https://github.com/ray-project/ray/pull/41722/files, specifically put to be cherry-picked into 2.9

Addresses #41726

<!-- Please give a short summary of the change and the problem this solves. -->

Addresses following gaps:

 - Patches `ActorProxyWrapper.is_drained` method to handle RPC response properly
 - Cherry-picks a test from #41722 to validate draining sequence is correct


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
