### PR TITLE
[ci] turn off verbose mode when zipping logs

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -24,7 +24,7 @@ prelude_commands: &prelude_commands |-
 epilogue_commands: &epilogue_commands |-
   # Persist ray logs
   mkdir -p /tmp/artifacts/.ray/
-  tar -cvzf /tmp/artifacts/.ray/logs.tgz /tmp/ray
+  tar -czf /tmp/artifacts/.ray/logs.tgz /tmp/ray
   # Cleanup runtime environment to save storage
   rm -rf /tmp/ray || true
   # Cleanup local caches - this should not clean up global disk cache


### PR DESCRIPTION
As title, the tar command is spamming a lot of logs

Test:
- CI