### PR TITLE
[data] Cache cluster_resources

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -35,6 +35,7 @@ from ray.data._internal.execution.streaming_executor_state import (
 )
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.stats import DatasetStats, StatsManager
+from ray.data._internal.util import cluster_resources
 from ray.data.context import DataContext
 
 logger = DatasetLogger(__name__)
@@ -335,7 +336,7 @@ class StreamingExecutor(Executor, threading.Thread):
         """
         base = self._options.resource_limits
         exclude = self._options.exclude_resources
-        cluster = ray.cluster_resources()
+        cluster = cluster_resources()
 
         cpu = base.cpu
         if cpu is None:

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -4,7 +4,6 @@ import time
 import uuid
 from typing import Dict, Iterator, List, Optional
 
-import ray
 from ray.data._internal.dataset_logger import DatasetLogger
 from ray.data._internal.execution.autoscaling_requester import (
     get_or_create_autoscaling_requester_actor,

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -55,6 +55,25 @@ LazyModule = Union[None, bool, ModuleType]
 _pyarrow_dataset: LazyModule = None
 
 
+cached_cluster_resources = {}
+cluster_resources_last_fetch_time = 0
+CLUSTER_RESOURCES_FETCH_INTERVAL_SECONDS = 10
+
+
+def cluster_resources():
+    """Fetch Ray cluster resources with cache."""
+    global cached_cluster_resources
+    global cluster_resources_last_fetch_time
+    now = time.time()
+    if (
+        now - cluster_resources_last_fetch_time
+        > CLUSTER_RESOURCES_FETCH_INTERVAL_SECONDS
+    ):
+        cached_cluster_resources = ray.cluster_resources()
+        cluster_resources_last_fetch_time = now
+    return cached_cluster_resources
+
+
 def _lazy_import_pyarrow_dataset() -> LazyModule:
     global _pyarrow_dataset
     if _pyarrow_dataset is None:

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -13,6 +13,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
     Iterable,
     Iterator,
     List,
@@ -60,7 +61,7 @@ cluster_resources_last_fetch_time = 0
 CLUSTER_RESOURCES_FETCH_INTERVAL_SECONDS = 10
 
 
-def cluster_resources():
+def cluster_resources() -> Dict[str, float]:
     """Fetch Ray cluster resources with cache."""
     global cached_cluster_resources
     global cluster_resources_last_fetch_time

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -109,6 +110,32 @@ def get_parquet_read_logical_op(
         **read_kwargs,
     )
     return read_op
+
+
+def test_cluster_resources():
+    """Test ray.data._internal.util.cluster_resources()."""
+    resources = {"CPU": 4, "GPU": 1}
+    cache_interval_s = 0.1
+    with patch.object(
+        ray.data._internal.util,
+        "CLUSTER_RESOURCES_FETCH_INTERVAL_SECONDS",
+        cache_interval_s,
+    ):
+        with patch(
+            "ray.cluster_resources",
+            return_value=resources,
+        ) as ray_cluster_resources:
+            # The first call should call ray.cluster_resources().
+            assert ray.data._internal.util.cluster_resources() == resources
+            assert ray_cluster_resources.call_count == 1
+            # The second call should return the cached value.
+            assert ray.data._internal.util.cluster_resources() == resources
+            assert ray_cluster_resources.call_count == 1
+            time.sleep(cache_interval_s)
+            # After the cache interval, the third call should call
+            # ray.cluster_resources() again.
+            assert ray.data._internal.util.cluster_resources() == resources
+            assert ray_cluster_resources.call_count == 2
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any, Dict, Optional
 from unittest.mock import patch
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`cluster_resources()` will be cached in each scheduling iteration. I found this became the bottleneck for training ingestion workloads. Cache the result to reduce the overheads. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
