### PR TITLE
[Data] Fix unused `columns` parameter in `read_parquet_bulk`

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -955,14 +955,16 @@ def read_parquet_bulk(
     """
     if meta_provider is None:
         meta_provider = get_parquet_bulk_metadata_provider()
-    arrow_parquet_args = _resolve_parquet_args(
+    read_table_args = _resolve_parquet_args(
         tensor_column_schema,
         **arrow_parquet_args,
     )
+    if columns is not None:
+        read_table_args["columns"] = columns
 
     datasource = ParquetBaseDatasource(
         paths,
-        read_table_args=arrow_parquet_args,
+        read_table_args=read_table_args,
         filesystem=filesystem,
         open_stream_args=arrow_open_file_args,
         meta_provider=meta_provider,

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1208,6 +1208,12 @@ def test_parquet_read_spread(ray_start_cluster, tmp_path):
     assert set(locations) == {node1_id, node2_id}
 
 
+def test_parquet_bulk_columns(ray_start_regular_shared):
+    ds = ray.data.read_parquet_bulk("example://iris.parquet", columns=["variety"])
+
+    assert ds.columns() == ["variety"]
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

https://github.com/ray-project/ray/pull/40900 refactored the `read_parquet_bulk` implementation and introduced a regression where the `columns` parameter wasn't used. This PR fixes the bug.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
