### PR TITLE
[Doc] Make linkcheck less aggressive when run on PR branches

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -88,9 +88,9 @@ steps:
 
   - label: ":lint-roller: lint: linkcheck"
     instance_type: medium
-    command: make -C doc/ linkcheck
+    commands:
+      - if [[ ${BUILDKITE_BRANCH} == 'master' ]]; then make -C doc/ linkcheck_all; else make -C doc/ linkcheck; fi
     depends_on: docbuild
     job_env: docbuild
     tags:
       - oss
-      - skip-on-premerge

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -27,30 +27,31 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html       to make standalone HTML files"
-	@echo "  dirhtml    to make HTML files named index.html in directories"
-	@echo "  singlehtml to make a single large HTML file"
-	@echo "  pickle     to make pickle files"
-	@echo "  json       to make JSON files"
-	@echo "  htmlhelp   to make HTML files and a HTML help project"
-	@echo "  qthelp     to make HTML files and a qthelp project"
-	@echo "  applehelp  to make an Apple Help Book"
-	@echo "  devhelp    to make HTML files and a Devhelp project"
-	@echo "  epub       to make an epub"
-	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
-	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
-	@echo "  latexpdfja to make LaTeX files and run them through platex/dvipdfmx"
-	@echo "  text       to make text files"
-	@echo "  man        to make manual pages"
-	@echo "  texinfo    to make Texinfo files"
-	@echo "  info       to make Texinfo files and run them through makeinfo"
-	@echo "  gettext    to make PO message catalogs"
-	@echo "  changes    to make an overview of all changed/added/deprecated items"
-	@echo "  xml        to make Docutils-native XML files"
-	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
-	@echo "  linkcheck  to check all external links for integrity"
-	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
-	@echo "  coverage   to run coverage check of the documentation (if enabled)"
+	@echo "  html            to make standalone HTML files"
+	@echo "  dirhtml         to make HTML files named index.html in directories"
+	@echo "  singlehtml      to make a single large HTML file"
+	@echo "  pickle          to make pickle files"
+	@echo "  json            to make JSON files"
+	@echo "  htmlhelp        to make HTML files and a HTML help project"
+	@echo "  qthelp          to make HTML files and a qthelp project"
+	@echo "  applehelp       to make an Apple Help Book"
+	@echo "  devhelp         to make HTML files and a Devhelp project"
+	@echo "  epub            to make an epub"
+	@echo "  latex           to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
+	@echo "  latexpdf        to make LaTeX files and run them through pdflatex"
+	@echo "  latexpdfja      to make LaTeX files and run them through platex/dvipdfmx"
+	@echo "  text            to make text files"
+	@echo "  man             to make manual pages"
+	@echo "  texinfo         to make Texinfo files"
+	@echo "  info            to make Texinfo files and run them through makeinfo"
+	@echo "  gettext         to make PO message catalogs"
+	@echo "  changes         to make an overview of all changed/added/deprecated items"
+	@echo "  xml             to make Docutils-native XML files"
+	@echo "  pseudoxml       to make pseudoxml-XML files for display purposes"
+	@echo "  linkcheck       to check all external links for integrity"
+	@echo "  linkcheck_all   to check all external links for integrity"
+	@echo "  doctest         to run all doctests embedded in the documentation (if enabled)"
+	@echo "  coverage        to run coverage check of the documentation (if enabled)"
 
 clean:
 	rm -rf $(BUILDDIR)/*
@@ -183,6 +184,12 @@ changes:
 
 linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLLINKCHECKOPTS) $(BUILDDIR)/linkcheck
+	@echo
+	@echo "Link check complete; look for any errors in the above output " \
+	      "or in $(BUILDDIR)/linkcheck/output.txt."
+
+linkcheck_all:
+	LINKCHECK_ALL=1 $(SPHINXBUILD) -b linkcheck $(ALLLINKCHECKOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -223,41 +223,49 @@ todo_include_todos = False
 # and is slow (it needs to download the linked website).
 linkcheck_anchors = False
 
-# Only check external links, i.e. the ones starting with http:// or https://.
-linkcheck_ignore = [
-    r"^((?!http).)*$",  # exclude links not starting with http
-    "http://ala2017.it.nuigalway.ie/papers/ALA2017_Gupta.pdf",  # broken
-    "https://mvnrepository.com/artifact/*",  # working but somehow not with linkcheck
-    # This should be fixed -- is temporal the successor of cadence? Do the examples need to be updated?
-    "https://github.com/serverlessworkflow/specification/blob/main/comparisons/comparison-cadence.md",
-    # TODO(richardliaw): The following probably needs to be fixed in the tune_sklearn package
-    "https://scikit-optimize.github.io/stable/modules/",
-    "https://www.oracle.com/java/technologies/javase-jdk15-downloads.html",  # forbidden for client
-    "https://speakerdeck.com/*",  # forbidden for bots
-    r"https://huggingface.co/*",  # seems to be flaky
-    r"https://www.meetup.com/*",  # seems to be flaky
-    r"https://www.pettingzoo.ml/*",  # seems to be flaky
-    r"http://localhost[:/].*",  # Ignore localhost links
-    r"^http:/$",  # Ignore incomplete links
-    # 403 Client Error: Forbidden for url.
-    # They ratelimit bots.
-    "https://www.datanami.com/2018/02/01/rays-new-library-targets-high-speed-reinforcement-learning/",
-    # 403 Client Error: Forbidden for url.
-    # They ratelimit bots.
-    "https://www.researchgate.net/publication/222573328_Stochastic_Gradient_Boosting",
-    "https://www.datanami.com/2019/11/05/why-every-python-developer-will-love-ray/",
-    "https://dev.mysql.com/doc/connector-python/en/",
-    # Returning 522s intermittently.
-    "https://lczero.org/",
-    # Returns 406 but remains accessible
-    "https://www.uber.com/blog/elastic-xgboost-ray/",
-    # Aggressive anti-bot checks
-    "https://archive.vn/*",
-    "https://archive.is/*",
-    # 429: Rate limited
-    "https://medium.com/*",
-    "https://towardsdatascience.com/*",
-]
+if os.environ.get("LINKCHECK_ALL"):
+    # Only check external links, i.e. the ones starting with http:// or https://.
+    linkcheck_ignore = [
+        r"^((?!http).)*$",  # exclude links not starting with http
+        "http://ala2017.it.nuigalway.ie/papers/ALA2017_Gupta.pdf",  # broken
+        "https://mvnrepository.com/artifact/*",  # working but somehow not with linkcheck
+        # This should be fixed -- is temporal the successor of cadence? Do the examples need to be updated?
+        "https://github.com/serverlessworkflow/specification/blob/main/comparisons/comparison-cadence.md",
+        # TODO(richardliaw): The following probably needs to be fixed in the tune_sklearn package
+        "https://scikit-optimize.github.io/stable/modules/",
+        "https://www.oracle.com/java/technologies/javase-jdk15-downloads.html",  # forbidden for client
+        "https://speakerdeck.com/*",  # forbidden for bots
+        r"https://huggingface.co/*",  # seems to be flaky
+        r"https://www.meetup.com/*",  # seems to be flaky
+        r"https://www.pettingzoo.ml/*",  # seems to be flaky
+        r"http://localhost[:/].*",  # Ignore localhost links
+        r"^http:/$",  # Ignore incomplete links
+        # 403 Client Error: Forbidden for url.
+        # They ratelimit bots.
+        "https://www.datanami.com/2018/02/01/rays-new-library-targets-high-speed-reinforcement-learning/",
+        # 403 Client Error: Forbidden for url.
+        # They ratelimit bots.
+        "https://www.researchgate.net/publication/222573328_Stochastic_Gradient_Boosting",
+        "https://www.datanami.com/2019/11/05/why-every-python-developer-will-love-ray/",
+        "https://dev.mysql.com/doc/connector-python/en/",
+        # Returning 522s intermittently.
+        "https://lczero.org/",
+        # Returns 406 but remains accessible
+        "https://www.uber.com/blog/elastic-xgboost-ray/",
+        # Aggressive anti-bot checks
+        "https://archive.vn/*",
+        "https://archive.is/*",
+        # 429: Rate limited
+        "https://medium.com/*",
+        "https://towardsdatascience.com/*",
+    ]
+else:
+    # Only check links that point to the ray-project org on github, since those
+    # links are under our control and therefore much more likely to be real
+    # issues that we need to fix if they are broken.
+    linkcheck_ignore = [
+        r"^(?!https://(raw\.githubusercontent|github)\.com/ray-project/).*$"
+    ]
 
 # -- Options for HTML output ----------------------------------------------
 def render_svg_logo(path):

--- a/doc/source/ray-contribute/docs.ipynb
+++ b/doc/source/ray-contribute/docs.ipynb
@@ -261,7 +261,7 @@
     "\n",
     "To work off of an existing example, you could also have a look at the\n",
     "[Ray Tune Hyperopt example (`.ipynb`)](https://github.com/ray-project/ray/blob/master/doc/source/tune/examples/hyperopt_example.ipynb)\n",
-    "or the [Ray Serve guide for RLlib (`.md`)](https://github.com/ray-project/ray/blob/master/doc/source/serve/tutorials/rllib.md).\n",
+    "or the [Ray Serve guide for text classification (`.md`)](https://github.com/ray-project/ray/blob/master/doc/source/serve/tutorials/text-classification.md).\n",
     "We recommend that you start with an `.md` file and convert your file to an `.ipynb` notebook at the end of the process.\n",
     "We'll walk you through this process below.\n",
     "\n",


### PR DESCRIPTION
## Why are these changes needed?

This PR makes the linkcheck CI job only check the `ray-project` github URLs, since those are the ones we have control over. If these don't pass, chances are you can't even push. This should increase the success rate of the CI job, while still performing the most important checks that we need on the docs.

## Related issue number

Should resolve https://github.com/ray-project/ray/issues/34928.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
