### PR TITLE
[Dashboard] Should specify the time range in job detail page for load the cluster status and scale metrics

### DIFF
--- a/dashboard/client/src/pages/job/JobDetail.tsx
+++ b/dashboard/client/src/pages/job/JobDetail.tsx
@@ -180,7 +180,7 @@ export const JobDetailChartsPage = () => {
           alignItems="stretch"
           className={classes.autoscalerSection}
         >
-          <NodeCountCard className={classes.nodeCountCard} />
+          <NodeCountCard className={classes.nodeCountCard} job={job} />
           <Section flex="1 1 500px">
             <NodeStatusCard clusterStatus={clusterStatus} />
           </Section>

--- a/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
+++ b/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
@@ -4,6 +4,7 @@ import makeStyles from "@mui/styles/makeStyles";
 import classNames from "classnames";
 import React, { useContext } from "react";
 import { GlobalContext } from "../../../App";
+import { UnifiedJob } from "../../../type/job";
 import { GrafanaNotRunningAlert } from "../../metrics";
 import { LinkWithArrow, OverviewCard } from "./OverviewCard";
 
@@ -35,9 +36,10 @@ const useStyles = makeStyles((theme) =>
 
 type NodeCountCardProps = {
   className?: string;
+  job?: UnifiedJob;
 };
 
-export const NodeCountCard = ({ className }: NodeCountCardProps) => {
+export const NodeCountCard = ({ className, job }: NodeCountCardProps) => {
   const classes = useStyles();
 
   const {
@@ -51,7 +53,9 @@ export const NodeCountCard = ({ className }: NodeCountCardProps) => {
   const grafanaDefaultDashboardUid =
     dashboardUids?.default ?? "rayDefaultDashboard";
   const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=1&theme=light&panelId=24&var-datasource=${dashboardDatasource}`;
-  const timeRangeParams = "&from=now-30m&to=now";
+  const timeRangeParams = `&from=${job ? job.start_time : "now-30m"}&to=${
+    job ? job.end_time || "now" : "now-30m"
+  }`;
 
   if (!metricsContextLoaded || grafanaHost === "DISABLED") {
     return null;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In Job Detail Page display the cluster status and autoscaler metrics, and the time range is `&from=now-30m&to=now` which makes it impossible to display the cluster status of the job at that time. So I think we should replace the range to `&from={start_time}&to={end_time}`, if the job is running the `to` param is `now`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #41781

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
