### PR TITLE
[Core] Unflake memory pressure test

### DIFF
--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -19,7 +19,7 @@ from ray._private.state_api_test_utils import verify_failed_task
 from ray.util.state.state_manager import StateDataSourceClient
 
 
-memory_usage_threshold = 0.65
+memory_usage_threshold = 0.5
 task_oom_retries = 1
 memory_monitor_refresh_ms = 100
 expected_worker_eviction_message = (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Looks like the test allocates memory as much as 0.65 + 1 (75%) of total memory. And it seems like the actors are actually dead by system level OOM killer before Ray OOM killer kicks in. 

To avoid system OOM killer kicks in, I reduced the default threshold.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
