### PR TITLE
[serve] Fix bug in deployment state machine (#41799)

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2152,7 +2152,6 @@ class DeploymentState:
                 # prioritized over this resource availability issue.
                 if self._curr_status_info.status != DeploymentStatus.UNHEALTHY:
                     self._curr_status_info = self._curr_status_info.update(
-                        status=DeploymentStatus.UPDATING,
                         message=message,
                     )
 
@@ -2170,7 +2169,6 @@ class DeploymentState:
                 # prioritized over this resource availability issue.
                 if self._curr_status_info.status != DeploymentStatus.UNHEALTHY:
                     self._curr_status_info = self._curr_status_info.update(
-                        status=DeploymentStatus.UPDATING,
                         message=message,
                     )
 

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -165,6 +165,10 @@ class MockReplicaActorWrapper:
     def log_file_path(self) -> Optional[str]:
         return None
 
+    @property
+    def placement_group_bundles(self) -> Optional[List[Dict[str, float]]]:
+        return None
+
     def set_ready(self, version: DeploymentVersion = None):
         self.ready = ReplicaStartupStatus.SUCCEEDED
         if version:
@@ -2253,7 +2257,7 @@ def test_autoscale(mock_deployment_state_manager_full, target_capacity_direction
     deployment_id = DeploymentID("test_deployment", "test_app")
 
     # Create deployment state manager
-    create_deployment_state_manager, _, _ = mock_deployment_state_manager_full
+    create_deployment_state_manager, timer, _ = mock_deployment_state_manager_full
     deployment_state_manager: DeploymentStateManager = create_deployment_state_manager()
 
     # Deploy deployment with 3 replicas
@@ -2309,18 +2313,39 @@ def test_autoscale(mock_deployment_state_manager_full, target_capacity_direction
             by_state=[(ReplicaState.RUNNING, 3), (ReplicaState.STARTING, 3)],
         )
         assert depstate.curr_status_info.status == DeploymentStatus.UPSCALING
+        assert (
+            depstate.curr_status_info.status_trigger
+            == DeploymentStatusTrigger.AUTOSCALING
+        )
+
+        # Advance timer by 60 seconds; this should exceed the slow startup
+        # warning threshold. The message should be updated, but the status
+        # should remain upscaling/autoscaling
+        timer.advance(60)
+        deployment_state_manager.update()
+        check_counts(
+            depstate,
+            total=6,
+            by_state=[(ReplicaState.RUNNING, 3), (ReplicaState.STARTING, 3)],
+        )
+        assert depstate.curr_status_info.status == DeploymentStatus.UPSCALING
+        assert (
+            depstate.curr_status_info.status_trigger
+            == DeploymentStatusTrigger.AUTOSCALING
+        )
+        assert "have taken more than" in depstate.curr_status_info.message
+
+        # Set replicas ready
+        for replica in depstate._replicas.get():
+            replica._actor.set_ready()
     else:
         check_counts(depstate, total=3, by_state=[(ReplicaState.STOPPING, 3)])
         assert depstate.curr_status_info.status == DeploymentStatus.DOWNSCALING
-    assert (
-        depstate.curr_status_info.status_trigger == DeploymentStatusTrigger.AUTOSCALING
-    )
-
-    # Set replicas ready and check statuses
-    for replica in depstate._replicas.get():
-        if target_capacity_direction == "up":
-            replica._actor.set_ready()
-        else:
+        assert (
+            depstate.curr_status_info.status_trigger
+            == DeploymentStatusTrigger.AUTOSCALING
+        )
+        for replica in depstate._replicas.get():
             replica._actor.set_done_stopping()
 
     # status=HEALTHY, status_trigger=UPSCALE/DOWNSCALE


### PR DESCRIPTION
If a deployment is autoscaling and replicas take a long time to start, there is a bug that makes the state transition to (UPDATING, AUTOSCALING) which is a combination that should never occur. Instead, we should just update the message but not the status.

---------

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Cherry pick https://github.com/ray-project/ray/pull/41799

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
