### PR TITLE
[Core] Fix dashboard tester failure due to deprecation of log_index API

### DIFF
--- a/release/benchmarks/distributed/dashboard_test.py
+++ b/release/benchmarks/distributed/dashboard_test.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import urllib
 from typing import Dict, Optional, List
 from pprint import pprint
 
@@ -41,7 +42,7 @@ endpoints = [
     "/api/cluster_status",
     "/events",
     "/api/jobs/",
-    "/log_index",
+    "/api/v0/logs",
     "/api/prometheus_health",
 ]
 
@@ -60,9 +61,21 @@ class DashboardTester:
 
     async def ping(self, endpoint):
         """Synchronously call an endpoint."""
+        node_id = ray.get_runtime_context().get_node_id()
         while True:
             start = time.monotonic()
-            resp = requests.get(self.dashboard_url + endpoint, timeout=30)
+            # for logs API, we should append node ID and glob.
+            if "/api/v0/logs" in endpoint:
+                glob_filter = "*"
+
+                options_dict = {"node_id": node_id, "glob": glob_filter}
+                url = (
+                    f"{self.dashboard_url}{endpoint}?"
+                    f"{urllib.parse.urlencode(options_dict)}")
+            else:
+                url = f"{self.dashboard_url}{endpoint}"
+
+            resp = requests.get(url, timeout=30)
             elapsed = time.monotonic() - start
 
             if resp.status_code == 200:

--- a/release/benchmarks/distributed/dashboard_test.py
+++ b/release/benchmarks/distributed/dashboard_test.py
@@ -71,7 +71,8 @@ class DashboardTester:
                 options_dict = {"node_id": node_id, "glob": glob_filter}
                 url = (
                     f"{self.dashboard_url}{endpoint}?"
-                    f"{urllib.parse.urlencode(options_dict)}")
+                    f"{urllib.parse.urlencode(options_dict)}"
+                )
             else:
                 url = f"{self.dashboard_url}{endpoint}"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

log_index is deprecated. We should use api/v0/logs

## Related issue number

Part of https://github.com/ray-project/ray/issues/41820

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
