### PR TITLE
[serve] Don't pass full `Request` object in release tests

### DIFF
--- a/release/serve_tests/workloads/autoscaling_multi_deployment.py
+++ b/release/serve_tests/workloads/autoscaling_multi_deployment.py
@@ -30,6 +30,9 @@ import click
 import logging
 import math
 import random
+from typing import Optional
+
+from starlette.requests import Request
 
 import ray
 from ray import serve
@@ -46,7 +49,6 @@ from serve_test_cluster_utils import (
     NUM_CPU_PER_NODE,
     NUM_CONNECTIONS,
 )
-from typing import Optional
 
 logger = logging.getLogger(__file__)
 
@@ -103,18 +105,18 @@ def setup_multi_deployment_replicas(min_replicas, max_replicas, num_deployments)
 
             return random.choice(self.all_app_async_handles)
 
-        async def handle_request(self, request, depth: int):
+        async def handle_request(self, body: bytes, depth: int):
             # Max recursive call depth reached
             if depth > 4:
                 return "hi"
 
             next_async_handle = await self.get_random_async_handle()
-            fut = next_async_handle.handle_request.remote(request, depth + 1)
+            fut = next_async_handle.handle_request.remote(body, depth + 1)
 
             return await fut
 
-        async def __call__(self, request):
-            return await self.handle_request(request, 0)
+        async def __call__(self, request: Request):
+            return await self.handle_request(await request.body(), 0)
 
     for name in all_app_names:
         serve.run(Echo.bind(), name=name, route_prefix=f"/{name}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is not expected to work; must pass the body or params directly.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
