### PR TITLE
[data] refactor `StageSummaryStats` for stage deprecation

### DIFF
--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -217,7 +217,7 @@ def _get_initial_stats_from_plan(plan: ExecutionPlan) -> DatasetStats:
     # stats, see `StreamingExecutor._generate_stats`.
     # TODO(hchen): Unify the logic by saving the initial stats in `InputDataBuffer
     if isinstance(plan._in_blocks, LazyBlockList):
-        return DatasetStats(stages={}, parent=None)
+        return DatasetStats(metadata={}, parent=None)
     else:
         return plan._in_stats
 

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -419,6 +419,7 @@ def _map_task(
         # TODO(Clark): Add input file propagation from input blocks.
         m_out = BlockAccessor.for_block(b_out).get_metadata([], None)
         m_out.exec_stats = stats.build()
+        m_out.exec_stats.task_idx = ctx.task_idx
         yield b_out
         yield m_out
         stats = BlockExecStats.builder()

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -230,12 +230,12 @@ class StreamingExecutor(Executor, threading.Thread):
 
     def _generate_stats(self) -> DatasetStats:
         """Create a new stats object reflecting execution status so far."""
-        stats = self._initial_stats or DatasetStats(stages={}, parent=None)
+        stats = self._initial_stats or DatasetStats(metadata={}, parent=None)
         for op in self._topology:
             if isinstance(op, InputDataBuffer):
                 continue
             builder = stats.child_builder(op.name, override_start_time=self._start_time)
-            stats = builder.build_multistage(op.get_stats())
+            stats = builder.build_multioperator(op.get_stats())
             stats.extra_metrics = op.metrics.as_dict()
         return stats
 

--- a/python/ray/data/_internal/fast_repartition.py
+++ b/python/ray/data/_internal/fast_repartition.py
@@ -27,7 +27,7 @@ def fast_repartition(
     wrapped_ds = Dataset(
         ExecutionPlan(
             blocks,
-            DatasetStats(stages={}, parent=None),
+            DatasetStats(metadata={}, parent=None),
             run_by_consumer=blocks._owned_by_consumer,
         ),
         logical_plan=logical_plan,

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -66,7 +66,7 @@ class StreamSplitDataIterator(DataIterator):
         self._coord_actor = coord_actor
         self._output_split_idx = output_split_idx
         self._world_size = world_size
-        self._iter_stats = DatasetStats(stages={}, parent=None)
+        self._iter_stats = DatasetStats(metadata={}, parent=None)
 
     def _to_block_iterator(
         self,

--- a/python/ray/data/_internal/lazy_block_list.py
+++ b/python/ray/data/_internal/lazy_block_list.py
@@ -126,7 +126,7 @@ class LazyBlockList(BlockList):
         """Create DatasetStats for this LazyBlockList."""
         return DatasetStats(
             # Make a copy of metadata, as the DatasetStats may mutate it in-place.
-            stages={"Read": self.get_metadata(fetch_if_missing=False).copy()},
+            metadata={"Read": self.get_metadata(fetch_if_missing=False).copy()},
             parent=None,
             needs_stats_actor=True,
             stats_uuid=self._stats_uuid,

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -661,7 +661,7 @@ class ExecutionPlan:
                         blocks, clear_input_blocks, self._run_by_consumer
                     )
                     if stage_info:
-                        stats = stats_builder.build_multistage(stage_info)
+                        stats = stats_builder.build_multioperator(stage_info)
                     else:
                         stats = stats_builder.build(blocks)
                     stats.dataset_uuid = self._dataset_uuid
@@ -740,7 +740,7 @@ class ExecutionPlan:
         If the plan isn't executed, an empty stats object will be returned.
         """
         if not self._snapshot_stats:
-            return DatasetStats(stages={}, parent=None)
+            return DatasetStats(metadata={}, parent=None)
         return self._snapshot_stats
 
     def stats_summary(self) -> DatasetStatsSummary:
@@ -1318,7 +1318,7 @@ def _rewrite_read_stage(
         TaskPoolStrategy(),
         remote_args,
     )
-    stats = DatasetStats(stages={}, parent=None)
+    stats = DatasetStats(metadata={}, parent=None)
     stages.insert(0, stage)
     return block_list, stats, stages
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -93,36 +93,36 @@ class _DatasetStatsBuilder:
 
     def __init__(
         self,
-        stage_name: str,
+        operator_name: str,
         parent: "DatasetStats",
         override_start_time: Optional[float],
     ):
-        self.stage_name = stage_name
+        self.operator_name = operator_name
         self.parent = parent
         self.start_time = override_start_time or time.perf_counter()
 
-    def build_multistage(self, stages: StatsDict) -> "DatasetStats":
-        stage_infos = {}
-        for i, (k, v) in enumerate(stages.items()):
+    def build_multioperator(self, metadata: StatsDict) -> "DatasetStats":
+        op_metadata = {}
+        for i, (k, v) in enumerate(metadata.items()):
             capped_k = capfirst(k)
-            if len(stages) > 1:
+            if len(metadata) > 1:
                 if i == 0:
-                    stage_infos[self.stage_name + capped_k] = v
+                    op_metadata[self.operator_name + capped_k] = v
                 else:
-                    stage_infos[self.stage_name.split("->")[-1] + capped_k] = v
+                    op_metadata[self.operator_name.split("->")[-1] + capped_k] = v
             else:
-                stage_infos[self.stage_name] = v
+                op_metadata[self.operator_name] = v
         stats = DatasetStats(
-            stages=stage_infos,
+            metadata=op_metadata,
             parent=self.parent,
-            base_name=self.stage_name,
+            base_name=self.operator_name,
         )
         stats.time_total_s = time.perf_counter() - self.start_time
         return stats
 
     def build(self, final_blocks: BlockList) -> "DatasetStats":
         stats = DatasetStats(
-            stages={self.stage_name: final_blocks.get_metadata()},
+            metadata={self.operator_name: final_blocks.get_metadata()},
             parent=self.parent,
         )
         stats.time_total_s = time.perf_counter() - self.start_time
@@ -552,7 +552,7 @@ class DatasetStats:
     def __init__(
         self,
         *,
-        stages: StatsDict,
+        metadata: StatsDict,
         parent: Union[Optional["DatasetStats"], List["DatasetStats"]],
         needs_stats_actor: bool = False,
         stats_uuid: str = None,
@@ -561,7 +561,7 @@ class DatasetStats:
         """Create dataset stats.
 
         Args:
-            stages: Dict of stages used to create this Dataset from the
+            metadata: Dict of operators used to create this Dataset from the
                 previous one. Typically one entry, e.g., {"map": [...]}.
             parent: Reference to parent Dataset's stats, or a list of parents
                 if there are multiple.
@@ -570,10 +570,10 @@ class DatasetStats:
                 lazy datasource (i.e. a LazyBlockList).
             stats_uuid: The uuid for the stats, used to fetch the right stats
                 from the stats actor.
-            base_name: The name of the base operation for a multi-stage operation.
+            base_name: The name of the base operation for a multi-operator operation.
         """
 
-        self.stages: StatsDict = stages
+        self.metadata: StatsDict = metadata
         if parent is not None and not isinstance(parent, list):
             parent = [parent]
         self.parents: List["DatasetStats"] = parent or []
@@ -627,12 +627,12 @@ class DatasetStats:
 
     def child_TODO(self, name: str) -> "DatasetStats":
         """Placeholder for child ops not yet instrumented."""
-        return DatasetStats(stages={name + "_TODO": []}, parent=self)
+        return DatasetStats(metadata={name + "_TODO": []}, parent=self)
 
     @staticmethod
     def TODO():
         """Placeholder for ops not yet instrumented."""
-        return DatasetStats(stages={"TODO": []}, parent=None)
+        return DatasetStats(metadata={"TODO": []}, parent=None)
 
     def to_summary(self) -> "DatasetStatsSummary":
         """Generate a `DatasetStatsSummary` object from the given `DatasetStats`
@@ -643,19 +643,19 @@ class DatasetStats:
             stats_map, self.time_total_s = ray.get(ac.get.remote(self.stats_uuid))
             # Only populate stats when stats from all read tasks are ready at
             # stats actor.
-            if len(stats_map.items()) == len(self.stages["Read"]):
-                self.stages["Read"] = []
+            if len(stats_map.items()) == len(self.metadata["Read"]):
+                self.metadata["Read"] = []
                 for _, blocks_metadata in sorted(stats_map.items()):
-                    self.stages["Read"] += blocks_metadata
+                    self.metadata["Read"] += blocks_metadata
 
-        stages_stats = []
-        is_substage = len(self.stages) > 1
-        for stage_name, metadata in self.stages.items():
-            stages_stats.append(
-                StageStatsSummary.from_block_metadata(
-                    metadata,
-                    stage_name,
-                    is_substage=is_substage,
+        operator_stats = []
+        is_sub_operator = len(self.metadata) > 1
+        for name, meta in self.metadata.items():
+            operator_stats.append(
+                OperatorStatsSummary.from_block_metadata(
+                    name,
+                    meta,
+                    is_sub_operator=is_sub_operator,
                 )
             )
 
@@ -677,7 +677,7 @@ class DatasetStats:
         if self.parents is not None:
             stats_summary_parents = [p.to_summary() for p in self.parents]
         return DatasetStatsSummary(
-            stages_stats,
+            operator_stats,
             iter_stats,
             stats_summary_parents,
             self.number,
@@ -694,7 +694,7 @@ class DatasetStats:
 @DeveloperAPI
 @dataclass
 class DatasetStatsSummary:
-    stages_stats: List["StageStatsSummary"]
+    operator_stats: List["OperatorStatsSummary"]
     iter_stats: "IterStatsSummary"
     parents: List["DatasetStatsSummary"]
     number: int
@@ -715,10 +715,10 @@ class DatasetStatsSummary:
         """Return a human-readable summary of this Dataset's stats.
 
         Args:
-            already_printed: Set of stage IDs that have already had its stats printed
+            already_printed: Set of operator IDs that have already had its stats printed
             out.
             include_parent: If true, also include parent stats summary; otherwise, only
-            log stats of the latest stage.
+            log stats of the latest operator.
             add_global_stats: If true, includes global stats to this summary.
         Returns:
             String with summary statistics for executing the Dataset.
@@ -733,44 +733,46 @@ class DatasetStatsSummary:
                 if parent_sum:
                     out += parent_sum
                     out += "\n"
-        stage_stats_summary = None
-        if len(self.stages_stats) == 1:
-            stage_stats_summary = self.stages_stats[0]
-            stage_name = stage_stats_summary.stage_name
-            stage_uuid = self.dataset_uuid + stage_name
-            out += "Stage {} {}: ".format(self.number, stage_name)
-            if stage_uuid in already_printed:
+        operator_stats_summary = None
+        if len(self.operator_stats) == 1:
+            operator_stats_summary = self.operator_stats[0]
+            operator_name = operator_stats_summary.operator_name
+            operator_uuid = self.dataset_uuid + operator_name
+            out += "Operator {} {}: ".format(self.number, operator_name)
+            if operator_uuid in already_printed:
                 out += "[execution cached]\n"
             else:
-                already_printed.add(stage_uuid)
-                out += str(stage_stats_summary)
-        elif len(self.stages_stats) > 1:
+                already_printed.add(operator_uuid)
+                out += str(operator_stats_summary)
+        elif len(self.operator_stats) > 1:
             rounded_total = round(self.time_total_s, 2)
             if rounded_total <= 0:
                 # Handle -0.0 case.
                 rounded_total = 0
-            out += "Stage {} {}: executed in {}s\n".format(
+            out += "Operator {} {}: executed in {}s\n".format(
                 self.number, self.base_name, rounded_total
             )
-            for n, stage_stats_summary in enumerate(self.stages_stats):
-                stage_name = stage_stats_summary.stage_name
-                stage_uuid = self.dataset_uuid + stage_name
+            for n, operator_stats_summary in enumerate(self.operator_stats):
+                operator_name = operator_stats_summary.operator_name
+                operator_uuid = self.dataset_uuid + operator_name
                 out += "\n"
-                out += "\tSubstage {} {}: ".format(n, stage_name)
-                if stage_uuid in already_printed:
+                out += "\tSuboperator {} {}: ".format(n, operator_name)
+                if operator_uuid in already_printed:
                     out += "\t[execution cached]\n"
                 else:
-                    already_printed.add(stage_uuid)
-                    out += str(stage_stats_summary)
+                    already_printed.add(operator_uuid)
+                    out += str(operator_stats_summary)
         if self.extra_metrics:
             indent = (
-                "\t" if stage_stats_summary and stage_stats_summary.is_substage else ""
+                "\t"
+                if operator_stats_summary and operator_stats_summary.is_sub_operator
+                else ""
             )
             out += indent
             out += "* Extra metrics: " + str(self.extra_metrics) + "\n"
         out += str(self.iter_stats)
 
-        if len(self.stages_stats) > 0 and add_global_stats:
+        if len(self.operator_stats) > 0 and add_global_stats:
             mb_spilled = round(self.global_bytes_spilled / 1e6)
             mb_restored = round(self.global_bytes_restored / 1e6)
             if mb_spilled or mb_restored:
@@ -787,7 +789,9 @@ class DatasetStatsSummary:
 
     def __repr__(self, level=0) -> str:
         indent = leveled_indent(level)
-        stage_stats = "\n".join([ss.__repr__(level + 2) for ss in self.stages_stats])
+        operator_stats = "\n".join(
+            [ss.__repr__(level + 2) for ss in self.operator_stats]
+        )
         parent_stats = "\n".join([ps.__repr__(level + 2) for ps in self.parents])
         extra_metrics = "\n".join(
             f"{leveled_indent(level + 2)}{k}: {v},"
@@ -795,7 +799,7 @@ class DatasetStatsSummary:
         )
 
         # Handle formatting case for empty outputs.
-        stage_stats = f"\n{stage_stats},\n{indent}   " if stage_stats else ""
+        operator_stats = f"\n{operator_stats},\n{indent}   " if operator_stats else ""
         parent_stats = f"\n{parent_stats},\n{indent}   " if parent_stats else ""
         extra_metrics = f"\n{extra_metrics}\n{indent}   " if extra_metrics else ""
         return (
@@ -804,7 +808,7 @@ class DatasetStatsSummary:
             f"{indent}   base_name={self.base_name},\n"
             f"{indent}   number={self.number},\n"
             f"{indent}   extra_metrics={{{extra_metrics}}},\n"
-            f"{indent}   stage_stats=[{stage_stats}],\n"
+            f"{indent}   operator_stats=[{operator_stats}],\n"
             f"{indent}   iter_stats={self.iter_stats.__repr__(level+1)},\n"
             f"{indent}   global_bytes_spilled={self.global_bytes_spilled / 1e6}MB,\n"
             f"{indent}   global_bytes_restored={self.global_bytes_restored / 1e6}MB,\n"
@@ -817,39 +821,40 @@ class DatasetStatsSummary:
         parent_wall_times = [p.get_total_wall_time() for p in self.parents]
         parent_max_wall_time = max(parent_wall_times) if parent_wall_times else 0
         return parent_max_wall_time + sum(
-            ss.wall_time.get("max", 0) for ss in self.stages_stats
+            ss.wall_time.get("max", 0) for ss in self.operator_stats
         )
 
     def get_total_cpu_time(self) -> float:
         parent_sum = sum(p.get_total_cpu_time() for p in self.parents)
-        return parent_sum + sum(ss.cpu_time.get("sum", 0) for ss in self.stages_stats)
+        return parent_sum + sum(ss.cpu_time.get("sum", 0) for ss in self.operator_stats)
 
     def get_max_heap_memory(self) -> float:
         parent_memory = [p.get_max_heap_memory() for p in self.parents]
         parent_max = max(parent_memory) if parent_memory else 0
-        if not self.stages_stats:
+        if not self.operator_stats:
             return parent_max
 
         return max(
             parent_max,
-            *[ss.memory.get("max", 0) for ss in self.stages_stats],
+            *[ss.memory.get("max", 0) for ss in self.operator_stats],
         )
 
 
 @dataclass
-class StageStatsSummary:
-    stage_name: str
-    # Whether the stage associated with this StageStatsSummary object is a substage
-    is_substage: bool
-    # This is the total walltime of the entire stage, typically obtained from
+class OperatorStatsSummary:
+    operator_name: str
+    # Whether the operator associated with this OperatorStatsSummary object
+    # is a suboperator
+    is_sub_operator: bool
+    # This is the total walltime of the entire operator, typically obtained from
     # `DatasetStats.time_total_s`. An important distinction is that this is the
-    # overall runtime of the stage, pulled from the stats actor, whereas the
-    # computed walltimes in `self.wall_time` are calculated on a substage level.
+    # overall runtime of the operator, pulled from the stats actor, whereas the
+    # computed walltimes in `self.wall_time` are calculated on a operator level.
     time_total_s: float
-    # String summarizing high-level statistics from executing the stage
+    # String summarizing high-level statistics from executing the operator
     block_execution_summary_str: str
     # The fields below are dicts with stats aggregated across blocks
-    # processed in this stage. For example:
+    # processed in this operator. For example:
     # {"min": ..., "max": ..., "mean": ..., "sum": ...}
     wall_time: Optional[Dict[str, float]] = None
     cpu_time: Optional[Dict[str, float]] = None
@@ -859,37 +864,36 @@ class StageStatsSummary:
     output_size_bytes: Optional[Dict[str, float]] = None
     # node_count: "count" stat instead of "sum"
     node_count: Optional[Dict[str, float]] = None
+    task_rows: Optional[Dict[str, float]] = None
 
     @classmethod
     def from_block_metadata(
         cls,
+        operator_name: str,
         block_metas: List[BlockMetadata],
-        stage_name: str,
-        is_substage: bool,
-    ) -> "StageStatsSummary":
-        """Calculate the stats for a stage from a given list of blocks,
-        and generates a `StageStatsSummary` object with the results.
+        is_sub_operator: bool,
+    ) -> "OperatorStatsSummary":
+        """Calculate the stats for a operator from a given list of blocks,
+        and generates a `OperatorStatsSummary` object with the results.
 
         Args:
             block_metas: List of `BlockMetadata` to calculate stats of
-            stage_name: Name of stage associated with `blocks`
-            is_substage: Whether this set of blocks belongs to a substage.
+            operator_name: Name of operator associated with `blocks`
+            is_sub_operator: Whether this set of blocks belongs to a sub operator.
         Returns:
-            A `StageStatsSummary` object initialized with the calculated statistics
+            A `OperatorStatsSummary` object initialized with the calculated statistics
         """
         exec_stats = [m.exec_stats for m in block_metas if m.exec_stats is not None]
         rounded_total = 0
         time_total_s = 0
 
-        if is_substage:
-            exec_summary_str = "{}/{} blocks executed\n".format(
-                len(exec_stats), len(block_metas)
-            )
+        if is_sub_operator:
+            exec_summary_str = "{} blocks produced\n".format(len(exec_stats))
         else:
             if exec_stats:
-                # Calculate the total execution time of stage as
+                # Calculate the total execution time of operator as
                 # the difference between the latest end time and
-                # the earliest start time of all blocks in the stage.
+                # the earliest start time of all blocks in the operator.
                 earliest_start_time = min(s.start_time_s for s in exec_stats)
                 latest_end_time = max(s.end_time_s for s in exec_stats)
                 time_total_s = latest_end_time - earliest_start_time
@@ -898,21 +902,28 @@ class StageStatsSummary:
                 if rounded_total <= 0:
                     # Handle -0.0 case.
                     rounded_total = 0
-                exec_summary_str = "{}/{} blocks executed in {}s".format(
-                    len(exec_stats), len(block_metas), rounded_total
+                exec_summary_str = "{} blocks produced in {}s".format(
+                    len(exec_stats), rounded_total
                 )
             else:
                 exec_summary_str = ""
-            if len(exec_stats) < len(block_metas):
-                if exec_stats:
-                    exec_summary_str += ", "
-                num_inherited = len(block_metas) - len(exec_stats)
-                exec_summary_str += "{}/{} blocks split from parent".format(
-                    num_inherited, len(block_metas)
-                )
-                if not exec_stats:
-                    exec_summary_str += " in {}s".format(rounded_total)
             exec_summary_str += "\n"
+
+        task_rows = collections.defaultdict(int)
+        for meta in block_metas:
+            if meta.num_rows is not None and meta.exec_stats is not None:
+                task_rows[meta.exec_stats.task_idx] += meta.num_rows
+        task_rows_stats = None
+        if len(task_rows) > 0:
+            task_rows_stats = {
+                "min": min(task_rows.values()),
+                "max": max(task_rows.values()),
+                "mean": int(np.mean(list(task_rows.values()))),
+                "count": len(task_rows),
+            }
+            exec_summary_str = "{} tasks executed, {}".format(
+                len(task_rows), exec_summary_str
+            )
 
         wall_time_stats = None
         if exec_stats:
@@ -965,9 +976,11 @@ class StageStatsSummary:
 
         node_counts_stats = None
         if exec_stats:
-            node_counts = collections.defaultdict(int)
+            node_tasks = collections.defaultdict(set)
             for s in exec_stats:
-                node_counts[s.node_id] += 1
+                node_tasks[s.node_id].add(s.task_idx)
+
+            node_counts = {node: len(tasks) for node, tasks in node_tasks.items()}
             node_counts_stats = {
                 "min": min(node_counts.values()),
                 "max": max(node_counts.values()),
@@ -975,9 +988,9 @@ class StageStatsSummary:
                 "count": len(node_counts),
             }
 
-        return StageStatsSummary(
-            stage_name=stage_name,
-            is_substage=is_substage,
+        return OperatorStatsSummary(
+            operator_name=operator_name,
+            is_sub_operator=is_sub_operator,
             time_total_s=time_total_s,
             block_execution_summary_str=exec_summary_str,
             wall_time=wall_time_stats,
@@ -986,17 +999,18 @@ class StageStatsSummary:
             output_num_rows=output_num_rows_stats,
             output_size_bytes=output_size_bytes_stats,
             node_count=node_counts_stats,
+            task_rows=task_rows_stats,
         )
 
     def __str__(self) -> str:
-        """For a given (pre-calculated) `StageStatsSummary` object (e.g. generated from
-        `StageStatsSummary.from_block_metadata()`), returns a human-friendly string
-        that summarizes stage execution statistics.
+        """For a given (pre-calculated) `OperatorStatsSummary` object (e.g. generated from
+        `OperatorStatsSummary.from_block_metadata()`), returns a human-friendly string
+        that summarizes operator execution statistics.
 
         Returns:
-            String with summary statistics for executing the given stage.
+            String with summary statistics for executing the given operator.
         """
-        indent = "\t" if self.is_substage else ""
+        indent = "\t" if self.is_sub_operator else ""
         out = self.block_execution_summary_str
 
         wall_time_stats = self.wall_time
@@ -1031,7 +1045,9 @@ class StageStatsSummary:
         output_num_rows_stats = self.output_num_rows
         if output_num_rows_stats:
             out += indent
-            out += "* Output num rows: {} min, {} max, {} mean, {} total\n".format(
+            out += (
+                "* Output num rows per block: {} min, {} max, {} mean, {} total\n"
+            ).format(
                 output_num_rows_stats["min"],
                 output_num_rows_stats["max"],
                 output_num_rows_stats["mean"],
@@ -1041,11 +1057,25 @@ class StageStatsSummary:
         output_size_bytes_stats = self.output_size_bytes
         if output_size_bytes_stats:
             out += indent
-            out += "* Output size bytes: {} min, {} max, {} mean, {} total\n".format(
+            out += (
+                "* Output size bytes per block: {} min, {} max, {} mean, {} total\n"
+            ).format(
                 output_size_bytes_stats["min"],
                 output_size_bytes_stats["max"],
                 output_size_bytes_stats["mean"],
                 output_size_bytes_stats["sum"],
+            )
+
+        task_rows = self.task_rows
+        if task_rows:
+            out += indent
+            out += (
+                "* Output rows per task: {} min, {} max, {} mean, {} tasks used\n"
+            ).format(
+                task_rows["min"],
+                task_rows["max"],
+                task_rows["mean"],
+                task_rows["count"],
             )
 
         node_count_stats = self.node_count
@@ -1060,15 +1090,15 @@ class StageStatsSummary:
         return out
 
     def __repr__(self, level=0) -> str:
-        """For a given (pre-calculated) `StageStatsSummary` object (e.g. generated from
-        `StageStatsSummary.from_block_metadata()`), returns a human-friendly string
-        that summarizes stage execution statistics.
+        """For a given (pre-calculated) `OperatorStatsSummary` object (e.g. generated from
+        `OperatorStatsSummary.from_block_metadata()`), returns a human-friendly string
+        that summarizes operator execution statistics.
 
         Returns:
-            String with summary statistics for executing the given stage.
+            String with summary statistics for executing the given operator.
         """
         indent = leveled_indent(level)
-        indent += leveled_indent(1) if self.is_substage else ""
+        indent += leveled_indent(1) if self.is_sub_operator else ""
 
         wall_time_stats = {k: fmt(v) for k, v in (self.wall_time or {}).items()}
         cpu_stats = {k: fmt(v) for k, v in (self.cpu_time or {}).items()}
@@ -1081,9 +1111,9 @@ class StageStatsSummary:
         }
         node_conut_stats = {k: fmt(v) for k, v in (self.node_count or {}).items()}
         out = (
-            f"{indent}StageStatsSummary(\n"
-            f"{indent}   stage_name='{self.stage_name}',\n"
-            f"{indent}   is_substage={self.is_substage},\n"
+            f"{indent}OperatorStatsSummary(\n"
+            f"{indent}   operator_name='{self.operator_name}',\n"
+            f"{indent}   is_suboperator={self.is_sub_operator},\n"
             f"{indent}   time_total_s={fmt(self.time_total_s)},\n"
             # block_execution_summary_str already ends with \n
             f"{indent}   block_execution_summary_str={self.block_execution_summary_str}"

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -139,6 +139,7 @@ class BlockExecStats:
         # Max memory usage. May be an overestimate since we do not
         # differentiate from previous tasks on the same worker.
         self.max_rss_bytes: int = 0
+        self.task_idx: Optional[int] = None
 
     @staticmethod
     def builder() -> "_BlockExecStatsBuilder":

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1652,7 +1652,7 @@ class Dataset:
         splits = []
 
         for bs, ms in zip(blocks, metadata):
-            stats = DatasetStats(stages={"Split": ms}, parent=parent_stats)
+            stats = DatasetStats(metadata={"Split": ms}, parent=parent_stats)
             stats.time_total_s = split_duration
 
             split_block_list = BlockList(
@@ -1917,7 +1917,7 @@ class Dataset:
                 logical_plan = LogicalPlan(op)
 
         stats = DatasetStats(
-            stages={"Union": []},
+            metadata={"Union": []},
             parent=[d._plan.stats() for d in datasets],
         )
         stats.time_total_s = time.perf_counter() - start_time

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -180,7 +180,7 @@ def from_items(
     return MaterializedDataset(
         ExecutionPlan(
             BlockList(blocks, metadata, owned_by_consumer=False),
-            DatasetStats(stages={"FromItems": metadata}, parent=None),
+            DatasetStats(metadata={"FromItems": metadata}, parent=None),
             run_by_consumer=False,
         ),
         logical_plan,
@@ -2145,7 +2145,7 @@ def from_pandas_refs(
         return MaterializedDataset(
             ExecutionPlan(
                 BlockList(dfs, metadata, owned_by_consumer=False),
-                DatasetStats(stages={"FromPandas": metadata}, parent=None),
+                DatasetStats(metadata={"FromPandas": metadata}, parent=None),
                 run_by_consumer=False,
             ),
             logical_plan,
@@ -2160,7 +2160,7 @@ def from_pandas_refs(
     return MaterializedDataset(
         ExecutionPlan(
             BlockList(blocks, metadata, owned_by_consumer=False),
-            DatasetStats(stages={"FromPandas": metadata}, parent=None),
+            DatasetStats(metadata={"FromPandas": metadata}, parent=None),
             run_by_consumer=False,
         ),
         logical_plan,
@@ -2247,7 +2247,7 @@ def from_numpy_refs(
     return MaterializedDataset(
         ExecutionPlan(
             BlockList(blocks, metadata, owned_by_consumer=False),
-            DatasetStats(stages={"FromNumpy": metadata}, parent=None),
+            DatasetStats(metadata={"FromNumpy": metadata}, parent=None),
             run_by_consumer=False,
         ),
         logical_plan,
@@ -2327,7 +2327,7 @@ def from_arrow_refs(
     return MaterializedDataset(
         ExecutionPlan(
             BlockList(tables, metadata, owned_by_consumer=False),
-            DatasetStats(stages={"FromArrow": metadata}, parent=None),
+            DatasetStats(metadata={"FromArrow": metadata}, parent=None),
             run_by_consumer=False,
         ),
         logical_plan,

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -458,6 +458,7 @@ def stage_two_block():
         "wall_time": [5, 10],
         "cpu_time": [1.2, 3.4],
         "node_id": ["a1", "b2"],
+        "task_idx": [0, 1],
     }
 
     block_delay = 20
@@ -473,6 +474,7 @@ def stage_two_block():
         block_exec_stats.cpu_time_s = block_params["cpu_time"][i]
         block_exec_stats.node_id = block_params["node_id"][i]
         block_exec_stats.max_rss_bytes = block_params["max_rss_bytes"][i]
+        block_exec_stats.task_idx = block_params["task_idx"][i]
         block_meta_list.append(
             BlockMetadata(
                 num_rows=block_params["num_rows"][i],

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -422,11 +422,11 @@ def test_repartition_e2e(
         ds_stats: DatasetStats = ds._plan.stats()
         if shuffle:
             assert ds_stats.base_name == "ReadRange->Repartition"
-            assert "ReadRange->RepartitionMap" in ds_stats.stages
+            assert "ReadRange->RepartitionMap" in ds_stats.metadata
         else:
             assert ds_stats.base_name == "Repartition"
-            assert "RepartitionSplit" in ds_stats.stages
-        assert "RepartitionReduce" in ds_stats.stages
+            assert "RepartitionSplit" in ds_stats.metadata
+        assert "RepartitionReduce" in ds_stats.metadata
 
     ds = ray.data.range(10000, parallelism=10).repartition(20, shuffle=shuffle)
     assert ds.num_blocks() == 20, ds.num_blocks()
@@ -840,8 +840,8 @@ def test_read_map_batches_operator_fusion_with_random_shuffle_operator(
     ds = ds.map_batches(fn, batch_size=None)
     ds = ds.random_shuffle()
     assert set(extract_values("id", ds.take_all())) == set(range(2, n + 2))
-    assert "Stage 1 ReadRange->MapBatches(fn)->RandomShuffle" in ds.stats()
-    assert "Stage 2 MapBatches(fn)->RandomShuffle" in ds.stats()
+    assert "Operator 1 ReadRange->MapBatches(fn)->RandomShuffle" in ds.stats()
+    assert "Operator 2 MapBatches(fn)->RandomShuffle" in ds.stats()
     _check_usage_record(["ReadRange", "RandomShuffle", "MapBatches"])
 
     # Check the case where the upstream map function returns multiple blocks.
@@ -854,9 +854,9 @@ def test_read_map_batches_operator_fusion_with_random_shuffle_operator(
 
     ds = ray.data.range(10)
     ds = ds.repartition(2).map(fn).random_shuffle().materialize()
-    assert "Stage 1 ReadRange" in ds.stats()
-    assert "Stage 2 Repartition" in ds.stats()
-    assert "Stage 3 Map(fn)->RandomShuffle" in ds.stats()
+    assert "Operator 1 ReadRange" in ds.stats()
+    assert "Operator 2 Repartition" in ds.stats()
+    assert "Operator 3 Map(fn)->RandomShuffle" in ds.stats()
     _check_usage_record(["ReadRange", "RandomShuffle", "Map"])
 
     ctx.target_max_block_size = old_target_max_block_size
@@ -1503,7 +1503,7 @@ def test_execute_to_legacy_block_list(
         assert row["id"] == i
 
     assert ds._plan._snapshot_stats is not None
-    assert "ReadRange" in ds._plan._snapshot_stats.stages
+    assert "ReadRange" in ds._plan._snapshot_stats.metadata
     assert ds._plan._snapshot_stats.time_total_s > 0
 
 
@@ -1518,7 +1518,7 @@ def test_execute_to_legacy_block_iterator(
         assert batch is not None
 
     assert ds._plan._snapshot_stats is not None
-    assert "ReadRange" in ds._plan._snapshot_stats.stages
+    assert "ReadRange" in ds._plan._snapshot_stats.metadata
     assert ds._plan._snapshot_stats.time_total_s > 0
 
 

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -1007,7 +1007,7 @@ def test_actor_pool_strategy_bundles_to_max_actors(shutdown_only):
     # TODO(https://github.com/ray-project/ray/issues/31723): implement the feature
     # of capping bundle size by actor pool size, and then re-enable this test.
     if not DataContext.get_current().new_execution_backend:
-        assert f"{max_size}/{max_size} blocks" in ds.stats()
+        assert f"{max_size} blocks" in ds.stats()
 
     # Check batch size is still respected.
     ds = (
@@ -1016,7 +1016,7 @@ def test_actor_pool_strategy_bundles_to_max_actors(shutdown_only):
         .materialize()
     )
 
-    assert "1/1 blocks" in ds.stats()
+    assert "1 blocks" in ds.stats()
 
 
 def test_nonserializable_map_batches(shutdown_only):

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -390,7 +390,7 @@ def test_push_based_shuffle_stats(ray_start_cluster):
 
         # Check all merge tasks are included in stats.
         internal_stats = ds._plan.stats()
-        num_merge_tasks = len(internal_stats.stages["RandomShuffleMerge"])
+        num_merge_tasks = len(internal_stats.metadata["RandomShuffleMerge"])
         # Merge factor is 2 for random_shuffle ops.
         merge_factor = 2
         assert (

--- a/python/ray/data/tests/test_splitblocks.py
+++ b/python/ray/data/tests/test_splitblocks.py
@@ -56,7 +56,7 @@ def test_small_file_split(ray_start_10_cpus_shared, restore_data_context):
     )
 
     stats = materialized_ds.stats()
-    assert "Stage 1 ReadCSV->MapBatches" in stats, stats
+    assert "Operator 1 ReadCSV->MapBatches" in stats, stats
 
     ds = ray.data.read_csv("example://iris.csv", parallelism=10)
     assert ds.num_blocks() == 1
@@ -89,8 +89,8 @@ def test_small_file_split(ray_start_10_cpus_shared, restore_data_context):
 
     ds = ds.map_batches(lambda x: x).materialize()
     stats = ds.stats()
-    assert "Stage 1 ReadCSV->SplitBlocks(100)" in stats, stats
-    assert "Stage 2 MapBatches" in stats, stats
+    assert "Operator 1 ReadCSV->SplitBlocks(100)" in stats, stats
+    assert "Operator 2 MapBatches" in stats, stats
 
     ctx = ray.data.context.DataContext.get_current()
     # Smaller than a single row.

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -109,6 +109,8 @@ Dataset memory:
 * Spilled to disk: M
 """
 
+EXECUTION_STRING = "N tasks executed, N blocks produced in T"
+
 
 def canonicalize(stats: str, filter_global_stats: bool = True) -> str:
     # Dataset UUID expression.
@@ -178,16 +180,17 @@ def test_streaming_split_stats(ray_start_regular_shared):
     )
     assert (
         canonicalize(stats)
-        == f"""Stage N ReadRange->MapBatches(dummy_map_batches): N/N blocks executed in T
+        == f"""Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
-Stage N split(N, equal=False): \n"""
+Operator N split(N, equal=False): \n"""
         # Workaround to preserve trailing whitespace in the above line without
         # causing linter failures.
         f"""* Extra metrics: {extra_metrics}\n"""
@@ -213,21 +216,23 @@ def test_large_args_scheduling_strategy(ray_start_regular_shared):
     stats = ds.stats()
     assert (
         canonicalize(stats)
-        == f"""Stage N ReadRange: N/N blocks executed in T
+        == f"""Operator N ReadRange: {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
-Stage N MapBatches(dummy_map_batches): N/N blocks executed in T
+Operator N MapBatches(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {LARGE_ARGS_EXTRA_METRICS}
 """
@@ -265,12 +270,13 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
             if context.new_execution_backend:
                 assert (
                     canonicalize(logger_args[0])
-                    == f"""Stage N ReadRange->MapBatches(dummy_map_batches): N/N blocks executed in T
+                    == f"""Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 """
@@ -278,12 +284,13 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
             else:
                 assert (
                     canonicalize(logger_args[0])
-                    == """Stage N Read->MapBatches(dummy_map_batches): N/N blocks executed in T
+                    == """Operator N Read->MapBatches(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 """
                 )
@@ -295,12 +302,13 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
             if context.new_execution_backend:
                 assert (
                     canonicalize(logger_args[0])
-                    == f"""Stage N Map(dummy_map_batches): N/N blocks executed in T
+                    == f"""Operator N Map(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 """
@@ -308,12 +316,13 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
             else:
                 assert (
                     canonicalize(logger_args[0])
-                    == """Stage N Map(dummy_map_batches): N/N blocks executed in T
+                    == """Operator N Map(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 """
                 )
@@ -325,21 +334,23 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
         if context.use_streaming_executor:
             assert (
                 stats
-                == f"""Stage N ReadRange->MapBatches(dummy_map_batches): N/N blocks executed in T
+                == f"""Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
-Stage N Map(dummy_map_batches): N/N blocks executed in T
+Operator N Map(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
@@ -359,21 +370,23 @@ Dataset iterator time breakdown:
         else:
             assert (
                 stats
-                == f"""Stage N ReadRange->MapBatches(dummy_map_batches): N/N blocks executed in T
+                == f"""Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
-Stage N Map(dummy_map_batches): N/N blocks executed in T
+Operator N Map(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
@@ -393,21 +406,23 @@ Dataset iterator time breakdown:
         if context.use_streaming_executor:
             assert (
                 stats
-                == f"""Stage N ReadRange->MapBatches(dummy_map_batches): N/N blocks executed in T
+                == f"""Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
-Stage N Map(dummy_map_batches): N/N blocks executed in T
+Operator N Map(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
@@ -427,20 +442,22 @@ Dataset iterator time breakdown:
         else:
             assert (
                 stats
-                == """Stage N Read->MapBatches(dummy_map_batches): N/N blocks executed in T
+                == """Operator N Read->MapBatches(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N Map(dummy_map_batches): N/N blocks executed in T
+Operator N Map(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 
 Dataset iterator time breakdown:
@@ -466,12 +483,12 @@ def test_dataset__repr__(ray_start_regular_shared):
         "   base_name=None,\n"
         "   number=N,\n"
         "   extra_metrics={},\n"
-        "   stage_stats=[\n"
-        "      StageStatsSummary(\n"
-        "         stage_name='Read',\n"
-        "         is_substage=False,\n"
+        "   operator_stats=[\n"
+        "      OperatorStatsSummary(\n"
+        "         operator_name='Read',\n"
+        "         is_suboperator=False,\n"
         "         time_total_s=T,\n"
-        "         block_execution_summary_str=N/N blocks executed in T\n"
+        f"         block_execution_summary_str={EXECUTION_STRING}\n"
         "         wall_time={'min': 'T', 'max': 'T', 'mean': 'T', 'sum': 'T'},\n"
         "         cpu_time={'min': 'T', 'max': 'T', 'mean': 'T', 'sum': 'T'},\n"
         "         memory={'min': 'T', 'max': 'T', 'mean': 'T'},\n"
@@ -549,12 +566,12 @@ def test_dataset__repr__(ray_start_regular_shared):
         "      gpu_usage: Z,\n"
         "      ray_remote_args: {'num_cpus': N, 'scheduling_strategy': 'SPREAD'},\n"
         "   },\n"
-        "   stage_stats=[\n"
-        "      StageStatsSummary(\n"
-        "         stage_name='MapBatches(<lambda>)',\n"
-        "         is_substage=False,\n"
+        "   operator_stats=[\n"
+        "      OperatorStatsSummary(\n"
+        "         operator_name='MapBatches(<lambda>)',\n"
+        "         is_suboperator=False,\n"
         "         time_total_s=T,\n"
-        "         block_execution_summary_str=N/N blocks executed in T\n"
+        f"         block_execution_summary_str={EXECUTION_STRING}\n"
         "         wall_time={'min': 'T', 'max': 'T', 'mean': 'T', 'sum': 'T'},\n"
         "         cpu_time={'min': 'T', 'max': 'T', 'mean': 'T', 'sum': 'T'},\n"
         "         memory={'min': 'T', 'max': 'T', 'mean': 'T'},\n"
@@ -583,12 +600,12 @@ def test_dataset__repr__(ray_start_regular_shared):
         "         base_name=None,\n"
         "         number=N,\n"
         "         extra_metrics={},\n"
-        "         stage_stats=[\n"
-        "            StageStatsSummary(\n"
-        "               stage_name='Read',\n"
-        "               is_substage=False,\n"
+        "         operator_stats=[\n"
+        "            OperatorStatsSummary(\n"
+        "               operator_name='Read',\n"
+        "               is_suboperator=False,\n"
         "               time_total_s=T,\n"
-        "               block_execution_summary_str=N/N blocks executed in T\n"
+        f"               block_execution_summary_str={EXECUTION_STRING}\n"
         "               wall_time={'min': 'T', 'max': 'T', 'mean': 'T', 'sum': 'T'},\n"
         "               cpu_time={'min': 'T', 'max': 'T', 'mean': 'T', 'sum': 'T'},\n"
         "               memory={'min': 'T', 'max': 'T', 'mean': 'T'},\n"
@@ -637,41 +654,45 @@ def test_dataset_stats_shuffle(ray_start_regular_shared):
     stats = canonicalize(ds.materialize().stats())
     assert (
         stats
-        == f"""Stage N ReadRange->RandomShuffle: executed in T
+        == f"""Operator N ReadRange->RandomShuffle: executed in T
 
-    Substage Z ReadRange->RandomShuffleMap: N/N blocks executed
+    Suboperator Z ReadRange->RandomShuffleMap: N tasks executed, N blocks produced
     * Remote wall time: T min, T max, T mean, T total
     * Remote cpu time: T min, T max, T mean, T total
     * Peak heap memory usage (MiB): N min, N max, N mean
-    * Output num rows: N min, N max, N mean, N total
-    * Output size bytes: N min, N max, N mean, N total
+    * Output num rows per block: N min, N max, N mean, N total
+    * Output size bytes per block: N min, N max, N mean, N total
+    * Output rows per task: N min, N max, N mean, N tasks used
     * Tasks per node: N min, N max, N mean; N nodes used
 
-    Substage N RandomShuffleReduce: N/N blocks executed
+    Suboperator N RandomShuffleReduce: N tasks executed, N blocks produced
     * Remote wall time: T min, T max, T mean, T total
     * Remote cpu time: T min, T max, T mean, T total
     * Peak heap memory usage (MiB): N min, N max, N mean
-    * Output num rows: N min, N max, N mean, N total
-    * Output size bytes: N min, N max, N mean, N total
+    * Output num rows per block: N min, N max, N mean, N total
+    * Output size bytes per block: N min, N max, N mean, N total
+    * Output rows per task: N min, N max, N mean, N tasks used
     * Tasks per node: N min, N max, N mean; N nodes used
     * Extra metrics: {gen_expected_metrics(is_map=False)}
 
-Stage N Repartition: executed in T
+Operator N Repartition: executed in T
 
-    Substage Z RepartitionMap: N/N blocks executed
+    Suboperator Z RepartitionMap: N tasks executed, N blocks produced
     * Remote wall time: T min, T max, T mean, T total
     * Remote cpu time: T min, T max, T mean, T total
     * Peak heap memory usage (MiB): N min, N max, N mean
-    * Output num rows: N min, N max, N mean, N total
-    * Output size bytes: N min, N max, N mean, N total
+    * Output num rows per block: N min, N max, N mean, N total
+    * Output size bytes per block: N min, N max, N mean, N total
+    * Output rows per task: N min, N max, N mean, N tasks used
     * Tasks per node: N min, N max, N mean; N nodes used
 
-    Substage N RepartitionReduce: N/N blocks executed
+    Suboperator N RepartitionReduce: N tasks executed, N blocks produced
     * Remote wall time: T min, T max, T mean, T total
     * Remote cpu time: T min, T max, T mean, T total
     * Peak heap memory usage (MiB): N min, N max, N mean
-    * Output num rows: N min, N max, N mean, N total
-    * Output size bytes: N min, N max, N mean, N total
+    * Output num rows per block: N min, N max, N mean, N total
+    * Output size bytes per block: N min, N max, N mean, N total
+    * Output rows per task: N min, N max, N mean, N tasks used
     * Tasks per node: N min, N max, N mean; N nodes used
     * Extra metrics: {gen_expected_metrics(is_map=False)}
 """
@@ -723,12 +744,13 @@ def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
     if context.new_execution_backend:
         assert (
             stats
-            == f"""Stage N ReadParquet->Map(<lambda>): N/N blocks executed in T
+            == f"""Operator N ReadParquet->Map(<lambda>): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 """
@@ -736,12 +758,13 @@ def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
     else:
         assert (
             stats
-            == """Stage N Read->Map(<lambda>): N/N blocks executed in T
+            == """Operator N Read->Map(<lambda>): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 """
         )
@@ -758,29 +781,32 @@ def test_dataset_split_stats(ray_start_regular_shared, tmp_path):
         if context.new_execution_backend:
             assert (
                 stats
-                == f"""Stage N ReadRange->Map(<lambda>): N/N blocks executed in T
+                == f"""Operator N ReadRange->Map(<lambda>): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
-Stage N Split: N/N blocks executed in T
+Operator N Split: {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N Map(<lambda>): N/N blocks executed in T
+Operator N Map(<lambda>): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 """
@@ -788,28 +814,31 @@ Stage N Map(<lambda>): N/N blocks executed in T
         else:
             assert (
                 stats
-                == """Stage N Read->Map(<lambda>): N/N blocks executed in T
+                == """Operator N Read->Map(<lambda>): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N Split: N/N blocks executed in T
+Operator N Split: {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 
-Stage N Map(<lambda>): N/N blocks executed in T
+Operator N Map(<lambda>): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 """
             )
@@ -821,10 +850,10 @@ def test_calculate_blocks_stats(ray_start_regular_shared, stage_two_block):
 
     block_params, block_meta_list = stage_two_block
     stats = DatasetStats(
-        stages={"Read": block_meta_list},
+        metadata={"Read": block_meta_list},
         parent=None,
     )
-    calculated_stats = stats.to_summary().stages_stats[0]
+    calculated_stats = stats.to_summary().operator_stats[0]
 
     assert calculated_stats.output_num_rows == {
         "min": min(block_params["num_rows"]),
@@ -866,7 +895,7 @@ def test_summarize_blocks(ray_start_regular_shared, stage_two_block):
 
     block_params, block_meta_list = stage_two_block
     stats = DatasetStats(
-        stages={"Read": block_meta_list},
+        metadata={"Read": block_meta_list},
         parent=None,
     )
     stats.dataset_uuid = "test-uuid"
@@ -877,7 +906,7 @@ def test_summarize_blocks(ray_start_regular_shared, stage_two_block):
     latest_end_time = max(m.exec_stats.end_time_s for m in block_meta_list)
     earliest_start_time = min(m.exec_stats.start_time_s for m in block_meta_list)
     assert (
-        "Stage 0 Read: 2/2 blocks executed in {}s".format(
+        "Operator 0 Read: 2 tasks executed, 2 blocks produced in {}s".format(
             max(round(latest_end_time - earliest_start_time, 2), 0)
         )
         == summarized_lines[0]
@@ -909,7 +938,7 @@ def test_summarize_blocks(ray_start_regular_shared, stage_two_block):
         == summarized_lines[3]
     )
     assert (
-        "* Output num rows: {} min, {} max, {} mean, {} total".format(
+        "* Output num rows per block: {} min, {} max, {} mean, {} total".format(
             min(block_params["num_rows"]),
             max(block_params["num_rows"]),
             int(np.mean(block_params["num_rows"])),
@@ -918,13 +947,23 @@ def test_summarize_blocks(ray_start_regular_shared, stage_two_block):
         == summarized_lines[4]
     )
     assert (
-        "* Output size bytes: {} min, {} max, {} mean, {} total".format(
+        "* Output size bytes per block: {} min, {} max, {} mean, {} total".format(
             min(block_params["size_bytes"]),
             max(block_params["size_bytes"]),
             int(np.mean(block_params["size_bytes"])),
             sum(block_params["size_bytes"]),
         )
         == summarized_lines[5]
+    )
+
+    assert (
+        "* Output rows per task: {} min, {} max, {} mean, {} tasks used".format(
+            min(block_params["num_rows"]),
+            max(block_params["num_rows"]),
+            int(np.mean(list(block_params["num_rows"]))),
+            len(set(block_params["task_idx"])),
+        )
+        == summarized_lines[6]
     )
 
     node_counts = Counter(block_params["node_id"])
@@ -935,7 +974,7 @@ def test_summarize_blocks(ray_start_regular_shared, stage_two_block):
             int(np.mean(list(node_counts.values()))),
             len(node_counts),
         )
-        == summarized_lines[6]
+        == summarized_lines[7]
     )
 
 
@@ -950,12 +989,12 @@ def test_get_total_stats(ray_start_regular_shared, stage_two_block):
 
     block_params, block_meta_list = stage_two_block
     stats = DatasetStats(
-        stages={"Read": block_meta_list},
+        metadata={"Read": block_meta_list},
         parent=None,
     )
 
     dataset_stats_summary = stats.to_summary()
-    stage_stats = dataset_stats_summary.stages_stats[0]
+    stage_stats = dataset_stats_summary.operator_stats[0]
     wall_time_stats = stage_stats.wall_time
     assert dataset_stats_summary.get_total_wall_time() == wall_time_stats.get("max")
 
@@ -979,12 +1018,13 @@ def test_streaming_stats_full(ray_start_regular_shared, restore_data_context):
     stats = canonicalize(ds.stats())
     assert (
         stats
-        == f"""Stage N ReadRange->Map(<lambda>): N/N blocks executed in T
+        == f"""Operator N ReadRange->Map(<lambda>): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
@@ -1010,12 +1050,13 @@ def test_write_ds_stats(ray_start_regular_shared, tmp_path):
 
     assert (
         canonicalize(stats)
-        == f"""Stage N ReadRange->Write: N/N blocks executed in T
+        == f"""Operator N ReadRange->Write: {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 """
@@ -1029,21 +1070,23 @@ def test_write_ds_stats(ray_start_regular_shared, tmp_path):
 
     assert (
         canonicalize(stats)
-        == f"""Stage N ReadRange->MapBatches(<lambda>): N/N blocks executed in T
+        == f"""Operator N ReadRange->MapBatches(<lambda>): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
-Stage N Write: N/N blocks executed in T
+Operator N Write: {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 """
@@ -1101,12 +1144,13 @@ def test_spilled_stats(shutdown_only):
 
     assert (
         canonicalize(ds.stats(), filter_global_stats=False)
-        == f"""Stage N ReadRange->MapBatches(<lambda>): N/N blocks executed in T
+        == f"""Operator N ReadRange->MapBatches(<lambda>): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows: N min, N max, N mean, N total
-* Output size bytes: N min, N max, N mean, N total
+* Output num rows per block: N min, N max, N mean, N total
+* Output size bytes per block: N min, N max, N mean, N total
+* Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
 * Extra metrics: {MEM_SPILLED_EXTRA_METRICS}
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -483,7 +483,7 @@ def test_dataset__repr__(ray_start_regular_shared):
         "   base_name=None,\n"
         "   number=N,\n"
         "   extra_metrics={},\n"
-        "   operator_stats=[\n"
+        "   operators_stats=[\n"
         "      OperatorStatsSummary(\n"
         "         operator_name='Read',\n"
         "         is_suboperator=False,\n"
@@ -566,7 +566,7 @@ def test_dataset__repr__(ray_start_regular_shared):
         "      gpu_usage: Z,\n"
         "      ray_remote_args: {'num_cpus': N, 'scheduling_strategy': 'SPREAD'},\n"
         "   },\n"
-        "   operator_stats=[\n"
+        "   operators_stats=[\n"
         "      OperatorStatsSummary(\n"
         "         operator_name='MapBatches(<lambda>)',\n"
         "         is_suboperator=False,\n"
@@ -600,7 +600,7 @@ def test_dataset__repr__(ray_start_regular_shared):
         "         base_name=None,\n"
         "         number=N,\n"
         "         extra_metrics={},\n"
-        "         operator_stats=[\n"
+        "         operators_stats=[\n"
         "            OperatorStatsSummary(\n"
         "               operator_name='Read',\n"
         "               is_suboperator=False,\n"
@@ -853,7 +853,7 @@ def test_calculate_blocks_stats(ray_start_regular_shared, stage_two_block):
         metadata={"Read": block_meta_list},
         parent=None,
     )
-    calculated_stats = stats.to_summary().operator_stats[0]
+    calculated_stats = stats.to_summary().operators_stats[0]
 
     assert calculated_stats.output_num_rows == {
         "min": min(block_params["num_rows"]),
@@ -994,7 +994,7 @@ def test_get_total_stats(ray_start_regular_shared, stage_two_block):
     )
 
     dataset_stats_summary = stats.to_summary()
-    stage_stats = dataset_stats_summary.operator_stats[0]
+    stage_stats = dataset_stats_summary.operators_stats[0]
     wall_time_stats = stage_stats.wall_time
     assert dataset_stats_summary.get_total_wall_time() == wall_time_stats.get("max")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Updates execution summary string to be `N tasks executed, N blocks produced`. The "total" blocks was removed since it was incorrect.

Fix `tasks per node`. Previously we were assuming tasks produce one block, so we were outputting blocks per node.

Adds `rows per task` to the output

Renames `StageStatsSummary` to `OperatorStatsSummary`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #41280

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
