### PR TITLE
[docs][cherry-pick] removal of some data, serve, and tune examples

### DIFF
--- a/doc/source/ray-overview/examples.rst
+++ b/doc/source/ray-overview/examples.rst
@@ -1123,34 +1123,6 @@ Ray Examples
 
         Speed up your web crawler by parallelizing it with Ray
 
-    .. grid-item-card:: :bdg-success:`Tutorial`
-        :class-item: gallery-item huggingface computer-vision data inference
-        :link: /data/examples/huggingface_vit_batch_prediction
-        :link-type: doc
-
-        Image Classification Batch Inference with Huggingface Vision Transformer
-
-    .. grid-item-card:: :bdg-success:`Tutorial`
-        :class-item: gallery-item pytorch computer-vision data inference
-        :link: /data/examples/pytorch_resnet_batch_prediction
-        :link-type: doc
-
-        Image Classification Batch Inference with PyTorch ResNet152
-
-    .. grid-item-card:: :bdg-success:`Tutorial`
-        :class-item: gallery-item pytorch computer-vision data inference
-        :link: /data/examples/batch_inference_object_detection
-        :link-type: doc
-
-        Object Detection Batch Inference with PyTorch FasterRCNN_ResNet50
-
-    .. grid-item-card:: :bdg-success:`Tutorial`
-        :class-item: gallery-item data data-processing training
-        :link: /data/examples/batch_training
-        :link-type: doc
-
-        Many Model Training with Ray Data
-
     .. grid-item-card:: :bdg-secondary:`Code example`
         :class-item: gallery-item core inference
         :link: /ray-core/examples/batch_prediction


### PR DESCRIPTION
Cherry-picking some docs updates that clean up the Examples Gallery:
* [[docs][data] Remove outdated Data examples](https://github.com/ray-project/ray/pull/41738#top)
* [[docs][serve][tune] Remove serve/tutorial/rllib and tune-sklearn examples](https://github.com/ray-project/ray/pull/41758#top)

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
