### PR TITLE
[core][CI] On Mac machines add timeouts to obejct spilling tests

### DIFF
--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -26,6 +26,10 @@ from ray.tests.conftest import (
     mock_distributed_fs_object_spilling_config,
 )
 
+# Note: Disk write speed can be as low as 6 MiB/s in AWS Mac instances, so we have to
+# increase the timeout.
+pytestmark = [pytest.mark.timeout(900 if platform.system() == "Darwin" else 180)]
+
 
 def run_basic_workload():
     """Run the workload that requires spilling."""

--- a/python/ray/tests/test_object_spilling_2.py
+++ b/python/ray/tests/test_object_spilling_2.py
@@ -17,6 +17,11 @@ from ray._private.external_storage import (
 )
 
 
+# Note: Disk write speed can be as low as 6 MiB/s in AWS Mac instances, so we have to
+# increase the timeout.
+pytestmark = [pytest.mark.timeout(900 if platform.system() == "Darwin" else 180)]
+
+
 def test_delete_objects(object_spilling_config, shutdown_only):
     # Limit our object store to 75 MiB of memory.
     object_spilling_config, temp_folder = object_spilling_config

--- a/python/ray/tests/test_object_spilling_3.py
+++ b/python/ray/tests/test_object_spilling_3.py
@@ -16,6 +16,10 @@ from ray._private.test_utils import wait_for_condition
 from ray.cluster_utils import Cluster, cluster_not_supported
 from ray.tests.test_object_spilling import assert_no_thrashing, is_dir_empty
 
+# Note: Disk write speed can be as low as 6 MiB/s in AWS Mac instances, so we have to
+# increase the timeout.
+pytestmark = [pytest.mark.timeout(900 if platform.system() == "Darwin" else 180)]
+
 
 @pytest.mark.skipif(platform.system() in ["Windows"], reason="Failing on Windows.")
 def test_multiple_directories(tmp_path, shutdown_only):


### PR DESCRIPTION
Those tests have been flaky on CI Mac tests for a while. Looks like it's possibly due to AWS Mac instances being bad in disk writes, from time to time. This PR increases the timeout of each case to 900s.

Fixes #41676