### PR TITLE
[ci] move linux://python/ray/serve/tests:test_util to flaky

### DIFF
--- a/ci/ray_ci/serve.tests.yml
+++ b/ci/ray_ci/serve.tests.yml
@@ -1,1 +1,2 @@
-flaky_tests: []
+flaky_tests:
+  - //python/ray/serve/tests:test_util


### PR DESCRIPTION
See https://github.com/ray-project/ray/issues/41904, it's pretty flaky

Test:
- CI