### PR TITLE
Refactor the vSphere sdk provider

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -233,6 +233,7 @@ test_python() {
       -python/ray/tests:test_tracing  # tracing not enabled on windows
       -python/ray/tests:kuberay/test_autoscaling_e2e # irrelevant on windows
       -python/ray/tests:vsphere/test_vsphere_node_provider # irrelevant on windows
+      -python/ray/tests:vsphere/test_vsphere_sdk_provider # irrelevant on windows
       -python/ray/tests/xgboost/... # Requires ML dependencies, should not be run on Windows
       -python/ray/tests/lightgbm/... # Requires ML dependencies, should not be run on Windows
       -python/ray/tests/horovod/... # Requires ML dependencies, should not be run on Windows

--- a/python/ray/autoscaler/_private/vsphere/ARCHITECTURE.md
+++ b/python/ray/autoscaler/_private/vsphere/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Optionally, the vSphere Node Provider can also take a content library item name,
 All the nodes are instantly cloned from the frozen VM. 
 
 #### Tag nodes with [vSphere Tags](#vsphere-tags)
-The nodes are tagged while their creation is in progress in an async way with `tag_vm` function.
+The nodes are tagged while their creation is in progress in an async way with `tag_new_vm_instantly` function.
 Post creation of the nodes, the tags on the nodes are updated. 
 
 ## Autoscaling

--- a/python/ray/autoscaler/_private/vsphere/node_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/node_provider.py
@@ -1,23 +1,12 @@
 import copy
 import logging
 import threading
-import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from threading import RLock
 from typing import Any, Dict
 
-import com.vmware.vapi.std.errors_client as ErrorClients
-from com.vmware.cis.tagging_client import CategoryModel
-from com.vmware.content.library_client import Item
-from com.vmware.vapi.std_client import DynamicID
-from com.vmware.vcenter.ovf_client import DiskProvisioningType, LibraryItem
-from com.vmware.vcenter.vm.hardware_client import Cpu, Memory
-from com.vmware.vcenter.vm_client import Power as HardPower
-from com.vmware.vcenter_client import VM, Host, ResourcePool
 from pyVmomi import vim
 
-from ray.autoscaler._private.cli_logger import cli_logger
 from ray.autoscaler._private.vsphere.config import (
     bootstrap_vsphere,
     is_dynamic_passthrough,
@@ -39,34 +28,14 @@ from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME
 logger = logging.getLogger(__name__)
 
 
-def is_powered_on_or_creating(power_status, vsphere_node_status):
-    return (
-        power_status.state == HardPower.State.POWERED_OFF
-        and vsphere_node_status == Constants.VsphereNodeStatus.CREATING.value
-    ) or (power_status.state == HardPower.State.POWERED_ON)
-
-
-def vsphere_tag_to_kv_pair(vsphere_tag):
-    if ":" in vsphere_tag:
-        items = vsphere_tag.split(":")
-        if len(items) == 2:
-            return items
-    return None
-
-
-def kv_pair_to_vsphere_tag(key, value):
-    return "{}:{}".format(key, value)
-
-
 class VsphereNodeProvider(NodeProvider):
     max_terminate_nodes = 1000
 
     def __init__(self, provider_config, cluster_name):
         NodeProvider.__init__(self, provider_config, cluster_name)
         self.frozen_vm_scheduler = None
-        vsphere_credentials = provider_config["vsphere_config"]["credentials"]
-        self.vsphere_credentials = vsphere_credentials
         self.vsphere_config = provider_config["vsphere_config"]
+        self.vsphere_credentials = provider_config["vsphere_config"]["credentials"]
 
         # The below cache will be a map, whose key is the Ray node and the value will
         # be a list of vSphere tags one that node. The reason for this cache is to
@@ -74,15 +43,14 @@ class VsphereNodeProvider(NodeProvider):
         # The cache will be filled when a Ray node is created and tagged.
         self.tag_cache = {}
         self.tag_cache_lock = threading.Lock()
-        self.lock = RLock()
 
-    def get_vsphere_sdk_client(self):
+    def get_vsphere_sdk_provider(self):
         return VsphereSdkProvider(
             self.vsphere_credentials["server"],
             self.vsphere_credentials["user"],
             self.vsphere_credentials["password"],
             Constants.SessionType.UNVERIFIED,
-        ).vsphere_sdk_client
+        )
 
     def get_pyvmomi_sdk_provider(self):
         return PyvmomiSdkProvider(
@@ -107,68 +75,13 @@ class VsphereNodeProvider(NodeProvider):
     def bootstrap_config(cluster_config):
         return bootstrap_vsphere(cluster_config)
 
-    def get_matched_tags(self, tag_filters, dynamic_id):
-        """
-        tag_filters will be a dict like {"tag_key1": "val1", "tag_key2": "val2"}
-        dynamic_id will be the vSphere object id
-        This function will list all the attached tags of the vSphere object, convert
-        the string formatted tag to k,v formatted. Then compare the attached tags to
-        the ones in the filters.
-        Return all the matched tags and all the tags the vSphere object has.
-        vsphere_tag_to_kv_pair will ignore the tags not convertable to k,v pairs.
-        """
-        matched_tags = {}
-        all_tags = {}
-
-        for tag_id in self.list_vm_tags(dynamic_id):
-            vsphere_vm_tag = (
-                self.get_vsphere_sdk_client().tagging.Tag.get(tag_id=tag_id).name
-            )
-            tag_key_value = vsphere_tag_to_kv_pair(vsphere_vm_tag)
-            if tag_key_value:
-                tag_key, tag_value = tag_key_value[0], tag_key_value[1]
-
-                if tag_key in tag_filters and tag_value == tag_filters[tag_key]:
-                    matched_tags[tag_key] = tag_value
-
-                all_tags[tag_key] = tag_value
-
-        return matched_tags, all_tags
-
     def non_terminated_nodes(self, tag_filters):
-        """
-        This function is going to find all the running vSphere VMs created by Ray via
-        the tag filters, the VMs should either be powered_on or be powered_off but has
-        a tag "vsphere-node-status:creating"
-        """
-        with self.lock:
-            nodes = []
-            vms = self.get_vsphere_sdk_client().vcenter.VM.list()
-            filters = tag_filters.copy()
-            if TAG_RAY_CLUSTER_NAME not in tag_filters:
-                filters[TAG_RAY_CLUSTER_NAME] = self.cluster_name
-            for vm in vms:
-                vm_id = vm.vm
-                dynamic_id = DynamicID(type=Constants.TYPE_OF_RESOURCE, id=vm.vm)
-
-                matched_tags, all_tags = self.get_matched_tags(filters, dynamic_id)
-                # Update the tag cache with latest tags
-                with self.tag_cache_lock:
-                    self.tag_cache[vm_id] = all_tags
-
-                if len(matched_tags) == len(filters):
-                    # All the tags in the filters are matched on this vm
-                    power_status = self.get_vsphere_sdk_client().vcenter.vm.Power.get(
-                        vm_id
-                    )
-
-                    # Return VMs in powered-on and creating state
-                    vsphere_node_status = all_tags.get(Constants.VSPHERE_NODE_STATUS)
-                    if is_powered_on_or_creating(power_status, vsphere_node_status):
-                        nodes.append(vm_id)
-
-            logger.debug(f"Non terminated nodes are {nodes}")
-            return nodes
+        nodes, tag_cache = self.get_vsphere_sdk_provider().non_terminated_nodes(
+            self.cluster_name, tag_filters
+        )
+        with self.tag_cache_lock:
+            self.tag_cache.update(tag_cache)
+        return nodes
 
     def is_running(self, node_id):
         return self.get_pyvmomi_sdk_provider().is_vm_power_on(node_id)
@@ -177,17 +90,10 @@ class VsphereNodeProvider(NodeProvider):
         if self.get_pyvmomi_sdk_provider().is_vm_power_on(node_id):
             return False
         else:
-            vns = Constants.VSPHERE_NODE_STATUS
-            matched_tags, _ = self.get_matched_tags(
-                {vns: Constants.VsphereNodeStatus.CREATING.value},
-                DynamicID(type=Constants.TYPE_OF_RESOURCE, id=node_id),
-            )
-            if matched_tags:
-                # If the node is not powered on but has the creating tag, then it could
-                # be under reconfiguration, such as plugging the GPU. In this case we
-                # should consider the node is not terminated, it will be turned on later
-                return False
-        return True
+            # If the node is not powered on but has the creating tag, then it could
+            # be under reconfiguration, such as plugging the GPU. In this case we
+            # should consider the node is not terminated, it will be turned on later
+            return not self.get_vsphere_sdk_provider().is_vm_creating(node_id)
 
     def node_tags(self, node_id):
         with self.tag_cache_lock:
@@ -202,27 +108,9 @@ class VsphereNodeProvider(NodeProvider):
         return self.get_pyvmomi_sdk_provider().get_vm_external_ip(node_id)
 
     def set_node_tags(self, node_id, tags):
-
         # This method gets called from the Ray and it passes
         # node_id which needs to be vm.vm and not vm.name
-        with self.lock:
-            category_id = self.get_category()
-            if not category_id:
-                category_id = self.create_category()
-
-            for key, value in tags.items():
-
-                tag = kv_pair_to_vsphere_tag(key, value)
-                tag_id = self.get_tag(tag, category_id)
-                if not tag_id:
-                    tag_id = self.create_node_tag(tag, category_id)
-
-                # If a tag with a key is present on the VM, then remove it
-                # before updating the key with a new value.
-                self.remove_tag_from_vm(key, node_id)
-
-                logger.debug(f"Attaching tag {tag} to {node_id}")
-                self.attach_tag(node_id, Constants.TYPE_OF_RESOURCE, tag_id=tag_id)
+        self.get_vsphere_sdk_provider().set_node_tags(node_id, tags)
 
     def create_node(self, node_config, tags, count) -> Dict[str, Any]:
         """Creates instances.
@@ -245,68 +133,6 @@ class VsphereNodeProvider(NodeProvider):
             )
 
         return created_nodes_dict
-
-    def attach_tag(self, vm_id, resource_type, tag_id):
-        dynamic_id = DynamicID(type=resource_type, id=vm_id)
-        try:
-            self.get_vsphere_sdk_client().tagging.TagAssociation.attach(
-                tag_id, dynamic_id
-            )
-            logger.debug(f"Tag {tag_id} attached on VM {dynamic_id}")
-        except Exception as e:
-            logger.warning(f"Check that the tag is attachable to {resource_type}")
-            raise e
-
-    # Example: If a tag called node-status:initializing is present on the VM.
-    # If we would like to add a new value called finished with the node-status key.
-    # We'll need to delete the older tag node-status:initializing first before creating
-    # node-status:finished
-    def remove_tag_from_vm(self, tag_key_to_remove, vm_id):
-        dynamic_id = DynamicID(type=Constants.TYPE_OF_RESOURCE, id=vm_id)
-
-        # List all the tags present on the VM.
-        for tag_id in self.list_vm_tags(dynamic_id):
-            vsphere_vm_tag = (
-                self.get_vsphere_sdk_client().tagging.Tag.get(tag_id=tag_id).name
-            )
-            tag_key_value = vsphere_tag_to_kv_pair(vsphere_vm_tag)
-            tag_key = tag_key_value[0] if tag_key_value else None
-            if tag_key == tag_key_to_remove:
-                # Remove the tag matching the key passed.
-                logger.debug("Removing tag {} from the VM {}".format(tag_key, vm_id))
-                self.get_vsphere_sdk_client().tagging.TagAssociation.detach(
-                    tag_id, dynamic_id
-                )
-                break
-
-    def list_vm_tags(self, vm_dynamic_id):
-        return self.get_vsphere_sdk_client().tagging.TagAssociation.list_attached_tags(
-            vm_dynamic_id
-        )
-
-    # This method is used to tag VMs as soon as they show up on vCenter.
-    def tag_vm(self, vm_name, tags):
-        names = {vm_name}
-        start = time.time()
-        # In most cases the instant clone VM will show up in several seconds.
-        # When the vCenter Server is busy, the time could be longer. We set a 120
-        # seconds timeout here. Because it's not used anywhere else, we don't make
-        # it as a formal constant.
-        while time.time() - start < Constants.CREATING_TAG_TIMEOUT:
-            time.sleep(0.5)
-            vms = self.get_vsphere_sdk_client().vcenter.VM.list(
-                VM.FilterSpec(names=names)
-            )
-
-            if len(vms) == 1:
-                vm_id = vms[0].vm
-                self.set_node_tags(vm_id, tags)
-                return
-            elif len(vms) > 1:
-                # This should never happen
-                raise RuntimeError("Duplicated VM with name {} found.".format(vm_name))
-
-        raise RuntimeError("VM {} could not be found.".format(vm_name))
 
     def create_instant_clone_node(
         self,
@@ -336,7 +162,10 @@ class VsphereNodeProvider(NodeProvider):
                 break
 
         tags[Constants.VSPHERE_NODE_STATUS] = Constants.VsphereNodeStatus.CREATING.value
-        threading.Thread(target=self.tag_vm, args=(target_vm_name, tags)).start()
+        threading.Thread(
+            target=self.get_vsphere_sdk_provider().tag_new_vm_instantly,
+            args=(target_vm_name, tags),
+        ).start()
         self.get_pyvmomi_sdk_provider().instance_clone_vm(
             parent_vm_name,
             target_vm_name,
@@ -348,25 +177,16 @@ class VsphereNodeProvider(NodeProvider):
             [vim.VirtualMachine], target_vm_name
         )
 
-        vsphere_sdk_vm_obj = self.get_vsphere_sdk_vm_obj(target_vm_id)
         if "CPU" in resources:
             # Update number of CPUs
-            update_spec = Cpu.UpdateSpec(count=resources["CPU"])
-            logger.debug(
-                "vm.hardware.Cpu.update({}, {})".format(target_vm_name, update_spec)
-            )
-            self.get_vsphere_sdk_client().vcenter.vm.hardware.Cpu.update(
-                vsphere_sdk_vm_obj.vm, update_spec
+            self.get_vsphere_sdk_provider().update_vm_cpu(
+                target_vm_id, resources["CPU"]
             )
 
         if "Memory" in resources:
             # Update Memory
-            update_spec = Memory.UpdateSpec(size_mib=resources["Memory"])
-            logger.debug(
-                "vm.hardware.Memory.update({}, {})".format(target_vm_name, update_spec)
-            )
-            self.get_vsphere_sdk_client().vcenter.vm.hardware.Memory.update(
-                vsphere_sdk_vm_obj.vm, update_spec
+            self.get_vsphere_sdk_provider().update_vm_memory(
+                target_vm_id, resources["Memory"]
             )
 
         if to_be_plugged_gpu:
@@ -378,7 +198,7 @@ class VsphereNodeProvider(NodeProvider):
                 is_dynamic,
             )
 
-        return vsphere_sdk_vm_obj
+        return self.get_vsphere_sdk_provider().get_vsphere_sdk_vm_obj(target_vm_id)
 
     def create_frozen_vm_on_each_host(self, node_config, name, resource_pool_name):
         """
@@ -388,15 +208,10 @@ class VsphereNodeProvider(NodeProvider):
         """
         exception_happened = False
         vm_names = []
-
-        resource_pool_obj = self.get_pyvmomi_sdk_provider().get_pyvmomi_obj(
-            [vim.ResourcePool], resource_pool_name
+        cluster_id = self.get_pyvmomi_sdk_provider().get_cluster_id_of_resource_pool(
+            resource_pool_name
         )
-
-        cluster = resource_pool_obj.parent.parent
-
-        host_filter_spec = Host.FilterSpec(clusters={cluster._moId})
-        hosts = self.get_vsphere_sdk_client().vcenter.Host.list(host_filter_spec)
+        hosts = self.get_vsphere_sdk_provider().list_all_hosts_in_cluster(cluster_id)
 
         futures_frozen_vms = []
         with ThreadPoolExecutor(max_workers=len(hosts)) as executor:
@@ -428,7 +243,9 @@ class VsphereNodeProvider(NodeProvider):
         if exception_happened:
             with ThreadPoolExecutor(max_workers=len(hosts)) as executor:
                 futures = [
-                    executor.submit(self.delete_vm, vm_names[i])
+                    executor.submit(
+                        self.get_vsphere_sdk_provider().delete_vm_by_name, vm_names[i]
+                    )
                     for i in range(len(futures_frozen_vms))
                 ]
             for future in futures:
@@ -448,18 +265,11 @@ class VsphereNodeProvider(NodeProvider):
         )
 
         if node_config.get("frozen_vm").get("resource_pool"):
-            rp_filter_spec = ResourcePool.FilterSpec(
-                names={node_config["frozen_vm"]["resource_pool"]}
-            )
-            resource_pool_summaries = (
-                self.get_vsphere_sdk_client().vcenter.ResourcePool.list(rp_filter_spec)
-            )
-            if not resource_pool_summaries:
-                raise ValueError(
-                    "Resource pool with name '{}' not found".format(rp_filter_spec)
+            resource_pool_id = (
+                self.get_vsphere_sdk_provider().get_resource_pool_id_by_name(
+                    node_config.get("frozen_vm").get("resource_pool")
                 )
-            resource_pool_id = resource_pool_summaries[0].resource_pool
-            logger.debug("Resource pool ID: {}".format(resource_pool_id))
+            )
         else:
             cluster_name = node_config.get("frozen_vm").get("cluster")
             if not cluster_name:
@@ -467,105 +277,23 @@ class VsphereNodeProvider(NodeProvider):
                     "The cluster name must be provided when deploying a single frozen"
                     " VM from OVF"
                 )
-            cluster_mo = self.get_pyvmomi_sdk_provider().get_pyvmomi_obj(
-                [vim.ClusterComputeResource], cluster_name
-            )
-            node_config["host_id"] = cluster_mo.host[0]._moId
-            resource_pool_id = cluster_mo.resourcePool._moId
-
-        # Find and use the OVF library item defined in the manifest file.
-        lib_item = node_config["frozen_vm"]["library_item"]
-        find_spec = Item.FindSpec(name=lib_item)
-        item_ids = self.get_vsphere_sdk_client().content.library.Item.find(find_spec)
-
-        if len(item_ids) < 1:
-            raise ValueError(
-                "Content library items with name '{}' not found".format(lib_item),
-            )
-        if len(item_ids) > 1:
-            logger.warning(
-                "Unexpected: found multiple content library items with name \
-                '{}'".format(
-                    lib_item
+            node_config[
+                "host_id"
+            ] = self.get_pyvmomi_sdk_provider().get_host_id_in_cluster(cluster_name)
+            resource_pool_id = (
+                self.get_pyvmomi_sdk_provider().get_resource_pool_id_in_cluster(
+                    cluster_name
                 )
             )
 
-        lib_item_id = item_ids[0]
-        deployment_target = LibraryItem.DeploymentTarget(
-            resource_pool_id=resource_pool_id,
-            host_id=node_config.get("host_id"),
+        vm_name = self.get_vsphere_sdk_provider().deploy_ovf(
+            node_config["frozen_vm"]["library_item"],
+            vm_name_target,
+            resource_pool_id,
+            node_config.get("host_id"),
+            datastore_id,
         )
-        ovf_summary = self.get_vsphere_sdk_client().vcenter.ovf.LibraryItem.filter(
-            ovf_library_item_id=lib_item_id, target=deployment_target
-        )
-        logger.info("Found an OVF template: {} to deploy.".format(ovf_summary.name))
-
-        # Build the deployment spec
-        deployment_spec = LibraryItem.ResourcePoolDeploymentSpec(
-            name=vm_name_target,
-            annotation=ovf_summary.annotation,
-            accept_all_eula=True,
-            network_mappings=None,
-            storage_mappings=None,
-            storage_provisioning=DiskProvisioningType.thin,
-            storage_profile_id=None,
-            locale=None,
-            flags=None,
-            additional_parameters=None,
-            default_datastore_id=datastore_id,
-        )
-
-        # Deploy the ovf template
-        result = self.get_vsphere_sdk_client().vcenter.ovf.LibraryItem.deploy(
-            lib_item_id,
-            deployment_target,
-            deployment_spec,
-            client_token=str(uuid.uuid4()),
-        )
-
-        logger.debug("result: {}".format(result))
-        # The type and ID of the target deployment is available in the
-        # deployment result.
-        if len(result.error.errors) > 0:
-            for error in result.error.errors:
-                logger.error("OVF error: {}".format(error))
-
-            raise ValueError(
-                "OVF deployment failed for VM {}, reason: {}".format(
-                    vm_name_target, result
-                )
-            )
-
-        logger.info(
-            'Deployment successful. VM Name: "{}", ID: "{}"'.format(
-                vm_name_target, result.resource_id.id
-            )
-        )
-        error = result.error
-        if error is not None:
-            for warning in error.warnings:
-                logger.warning("OVF warning: {}".format(warning.message))
-
-        vm_id = result.resource_id.id
-        vm = self.get_vsphere_sdk_vm_obj(vm_id)
-
-        return self.ensure_frozen_vm_status(vm.name)
-
-    def delete_vm(self, vm_name):
-        vms = self.get_vsphere_sdk_client().vcenter.VM.list(
-            VM.FilterSpec(names={vm_name})
-        )
-
-        if len(vms) > 0:
-            vm_id = vms[0].vm
-
-            status = self.get_vsphere_sdk_client().vcenter.vm.Power.get(vm_id)
-
-            if status.state != HardPower.State.POWERED_OFF:
-                self.get_vsphere_sdk_client().vcenter.vm.Power.stop(vm_id)
-
-            logger.info("Deleting VM {}".format(vm_name))
-            self.get_vsphere_sdk_client().vcenter.VM.delete(vm_id)
+        return self.ensure_frozen_vm_status(vm_name)
 
     def ensure_frozen_vms_status(self, reource_pool_name):
         rp_obj = self.get_pyvmomi_sdk_provider().get_pyvmomi_obj(
@@ -600,8 +328,6 @@ class VsphereNodeProvider(NodeProvider):
                     frozen_vm_config.get("name", "frozen-vm"),
                     frozen_vm_resource_pool_name,
                 )
-                frozen_vm_obj = self.frozen_vm_scheduler.next_frozen_vm()
-
             # If resource_pool config is not present then create a frozen VM
             # with name as specified.
             else:
@@ -616,7 +342,6 @@ class VsphereNodeProvider(NodeProvider):
             # present in the resource pool specified.
             if frozen_vm_resource_pool_name:
                 self.ensure_frozen_vms_status(frozen_vm_resource_pool_name)
-                frozen_vm_obj = self.frozen_vm_scheduler.next_frozen_vm()
             # If resource_pool is not present then select the frozen VM with
             # name as specified.
             else:
@@ -728,7 +453,9 @@ class VsphereNodeProvider(NodeProvider):
         if exception_happened:
             with ThreadPoolExecutor(max_workers=count) as executor:
                 futures = [
-                    executor.submit(self.delete_vm, vm_names[i])
+                    executor.submit(
+                        self.get_vsphere_sdk_provider().delete_vm_by_name, vm_names[i]
+                    )
                     for i in failed_vms_index
                 ]
             for future in futures:
@@ -739,76 +466,12 @@ class VsphereNodeProvider(NodeProvider):
 
         return created_nodes_dict
 
-    def get_tag(self, tag_name, category_id):
-        for id in self.get_vsphere_sdk_client().tagging.Tag.list_tags_for_category(
-            category_id
-        ):
-            if tag_name == self.get_vsphere_sdk_client().tagging.Tag.get(id).name:
-                return id
-        return None
-
-    def create_node_tag(self, ray_node_tag, category_id):
-        logger.debug(f"Creating {ray_node_tag} tag")
-        tag_spec = self.get_vsphere_sdk_client().tagging.Tag.CreateSpec(
-            ray_node_tag, "Ray node tag", category_id
-        )
-        tag_id = None
-        try:
-            tag_id = self.get_vsphere_sdk_client().tagging.Tag.create(tag_spec)
-        except ErrorClients.Unauthorized as e:
-            cli_logger.abort(f"Unauthorized to create the tag. Exception: {e}")
-        except Exception as e:
-            cli_logger.abort(e)
-
-        logger.debug(f"Tag {tag_id} created")
-        return tag_id
-
-    def get_category(self):
-        for id in self.get_vsphere_sdk_client().tagging.Category.list():
-            if (
-                self.get_vsphere_sdk_client().tagging.Category.get(id).name
-                == Constants.NODE_CATEGORY
-            ):
-                return id
-        return None
-
-    def create_category(self):
-        # Create RAY_NODE category. This category is associated with VMs and supports
-        # multiple tags e.g. "Ray-Head-Node, Ray-Worker-Node-1 etc."
-        cli_logger.info(f"Creating {Constants.NODE_CATEGORY} category")
-        category_spec = self.get_vsphere_sdk_client().tagging.Category.CreateSpec(
-            name=Constants.NODE_CATEGORY,
-            description="Identifies Ray head node and worker nodes",
-            cardinality=CategoryModel.Cardinality.MULTIPLE,
-            associable_types=set(),
-        )
-        category_id = None
-
-        try:
-            category_id = self.get_vsphere_sdk_client().tagging.Category.create(
-                category_spec
-            )
-        except ErrorClients.Unauthorized as e:
-            cli_logger.abort(f"Unauthorized to create the category. Exception: {e}")
-        except Exception as e:
-            cli_logger.abort(e)
-
-        cli_logger.info(f"Category {category_id} created")
-
-        return category_id
-
     def terminate_node(self, node_id):
         if node_id is None:
             return
 
-        status = self.get_vsphere_sdk_client().vcenter.vm.Power.get(node_id)
+        self.get_vsphere_sdk_provider().delete_vm_by_id(node_id)
 
-        if status.state != HardPower.State.POWERED_OFF:
-            self.get_vsphere_sdk_client().vcenter.vm.Power.stop(node_id)
-            logger.debug("vm.Power.stop({})".format(node_id))
-
-        self.get_vsphere_sdk_client().vcenter.VM.delete(node_id)
-        logger.info("Deleted vm {}".format(node_id))
         with self.tag_cache_lock:
             if node_id in self.tag_cache:
                 self.tag_cache.pop(node_id)
@@ -819,11 +482,3 @@ class VsphereNodeProvider(NodeProvider):
 
         for node_id in node_ids:
             self.terminate_node(node_id)
-
-    def get_vsphere_sdk_vm_obj(self, vm_id):
-        """Get the vm object by vSphere SDK with the vm id, such as 'vm-12'"""
-        vms = self.get_vsphere_sdk_client().vcenter.VM.list(VM.FilterSpec(vms={vm_id}))
-        if len(vms) == 0:
-            logger.warning("VM with name ({}) not found by vSphere sdk".format(vm_id))
-            return None
-        return vms[0]

--- a/python/ray/autoscaler/_private/vsphere/utils.py
+++ b/python/ray/autoscaler/_private/vsphere/utils.py
@@ -49,6 +49,17 @@ def singleton_client(cls):
                 instances[cls] = (instance, current_time)
         return instances[cls][0]
 
+    # For singleton-decorator, it can't direct access to the class object
+    # without decorator. So you cannot call methods using a class name in unit tests.
+    # It would not work because You Class actually contains a wrapper function but not
+    # your class object. This is a workaround solution for this issue. It uses a
+    # separate wrapper object for each decorated class and holds a class within
+    # __wrapped__ attribute so you can access the decorated class directly in your
+    # unit tests.
+    # Please refer to https://stackoverflow.com/questions/70958126
+    # /how-to-mock-a-method-inside-a-singleton-decorated-class-in-python
+    get_instance.__wrapped__ = cls
+
     return get_instance
 
 

--- a/python/ray/autoscaler/_private/vsphere/vsphere_sdk_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/vsphere_sdk_provider.py
@@ -1,8 +1,43 @@
+import logging
+import time
+import uuid
+from threading import RLock
+
+import com.vmware.vapi.std.errors_client as ErrorClients
 import requests
+from com.vmware.cis.tagging_client import CategoryModel
+from com.vmware.content.library_client import Item
 from com.vmware.vapi.std.errors_client import Unauthenticated
+from com.vmware.vapi.std_client import DynamicID
+from com.vmware.vcenter.ovf_client import DiskProvisioningType, LibraryItem
+from com.vmware.vcenter.vm.hardware_client import Cpu, Memory
+from com.vmware.vcenter.vm_client import Power as HardPower
+from com.vmware.vcenter_client import VM, Host, ResourcePool
 from vmware.vapi.vsphere.client import create_vsphere_client
 
 from ray.autoscaler._private.vsphere.utils import Constants, singleton_client
+from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME
+
+logger = logging.getLogger(__name__)
+
+
+def is_powered_on_or_creating(power_status, vsphere_node_status):
+    return (
+        power_status.state == HardPower.State.POWERED_OFF
+        and vsphere_node_status == Constants.VsphereNodeStatus.CREATING.value
+    ) or (power_status.state == HardPower.State.POWERED_ON)
+
+
+def vsphere_tag_to_kv_pair(vsphere_tag):
+    if ":" in vsphere_tag:
+        items = vsphere_tag.split(":")
+        if len(items) == 2:
+            return items
+    return None
+
+
+def kv_pair_to_vsphere_tag(key, value):
+    return "{}:{}".format(key, value)
 
 
 def get_unverified_session():
@@ -30,6 +65,7 @@ class VsphereSdkProvider:
         self.password = password
         self.session_type = session_type
         self.vsphere_sdk_client = self.get_client()
+        self.lock = RLock()
 
     def get_client(self):
         session = None
@@ -53,3 +89,393 @@ class VsphereSdkProvider:
             self.vsphere_sdk_client = self.get_client()
         except Exception as e:
             raise RuntimeError(f"failed to ensure the connect, exception: {e}")
+
+    def get_vsphere_sdk_vm_obj(self, vm_id):
+        """
+        This function will get the vm object by vSphere SDK with the vm id
+        """
+        vms = self.vsphere_sdk_client.vcenter.VM.list(VM.FilterSpec(vms={vm_id}))
+        if len(vms) == 0:
+            logger.warning("VM with name ({}) not found by vSphere sdk".format(vm_id))
+            return None
+        return vms[0]
+
+    def delete_vm_by_id(self, vm_id):
+        """
+        This function will delete the vm object by vSphere SDK with the vm id
+        """
+        status = self.vsphere_sdk_client.vcenter.vm.Power.get(vm_id)
+
+        if status.state != HardPower.State.POWERED_OFF:
+            self.vsphere_sdk_client.vcenter.vm.Power.stop(vm_id)
+
+        logger.info("Deleting VM {}".format(vm_id))
+        self.vsphere_sdk_client.vcenter.VM.delete(vm_id)
+
+    def delete_vm_by_name(self, vm_name):
+        """
+        This function will delete the vm object by vSphere SDK with the vm name
+        """
+        vms = self.vsphere_sdk_client.vcenter.VM.list(VM.FilterSpec(names={vm_name}))
+
+        if len(vms) > 0:
+            logger.info("Deleting VM {}".format(vm_name))
+            self.delete_vm_by_id(vms[0].vm)
+
+    def list_all_hosts_in_cluster(self, cluster_id):
+        """
+        This function will list all host objects in cluster with this cluster id
+        """
+        host_filter_spec = Host.FilterSpec(clusters={cluster_id})
+        return self.vsphere_sdk_client.vcenter.Host.list(host_filter_spec)
+
+    def get_resource_pool_id_by_name(self, rp_name):
+        """
+        This function will get the resource pool id by vSphere SDK with the
+        resource pool name
+        """
+        rp_filter_spec = ResourcePool.FilterSpec(names={rp_name})
+        resource_pool_summaries = self.vsphere_sdk_client.vcenter.ResourcePool.list(
+            rp_filter_spec
+        )
+        if not resource_pool_summaries:
+            raise ValueError(
+                "Resource pool with name '{}' not found".format(rp_filter_spec)
+            )
+        logger.debug(
+            "Resource pool ID: {}".format(resource_pool_summaries[0].resource_pool)
+        )
+        return resource_pool_summaries[0].resource_pool
+
+    def non_terminated_nodes(self, cluster_name, tag_filters):
+        """
+        This function is going to find all the running vSphere VMs created by Ray via
+        the tag filters, the VMs should either be powered_on or be powered_off but has
+        a tag "vsphere-node-status:creating"
+        """
+        with self.lock:
+            nodes = []
+            vms = self.vsphere_sdk_client.vcenter.VM.list()
+            filters = tag_filters.copy()
+            tag_cache = {}
+            if TAG_RAY_CLUSTER_NAME not in tag_filters:
+                filters[TAG_RAY_CLUSTER_NAME] = cluster_name
+            for vm in vms:
+                vm_id = vm.vm
+                dynamic_id = DynamicID(type=Constants.TYPE_OF_RESOURCE, id=vm_id)
+
+                matched_tags, all_tags = self.get_matched_tags(filters, dynamic_id)
+                # Update the tag cache with latest tags
+                tag_cache[vm_id] = all_tags
+
+                if len(matched_tags) == len(filters):
+                    # All the tags in the filters are matched on this vm
+                    power_status = self.vsphere_sdk_client.vcenter.vm.Power.get(vm_id)
+
+                    # Return VMs in powered-on and creating state
+                    vsphere_node_status = all_tags.get(Constants.VSPHERE_NODE_STATUS)
+                    if is_powered_on_or_creating(power_status, vsphere_node_status):
+                        nodes.append(vm_id)
+
+            logger.debug(f"Non terminated nodes are {nodes}")
+            return nodes, tag_cache
+
+    def is_vm_creating(self, vm_id):
+        """
+        This function will check if this vm is creating status
+        """
+        vns = Constants.VSPHERE_NODE_STATUS
+        matched_tags, _ = self.get_matched_tags(
+            {vns: Constants.VsphereNodeStatus.CREATING.value},
+            DynamicID(type=Constants.TYPE_OF_RESOURCE, id=vm_id),
+        )
+        if matched_tags:
+            return True
+        return False
+
+    def list_vm_tags(self, vm_id):
+        """
+        This function will list all the attached tags of vm
+        """
+        return self.vsphere_sdk_client.tagging.TagAssociation.list_attached_tags(vm_id)
+
+    def get_matched_tags(self, tag_filters, vm_id):
+        """
+        This function will list all the attached tags of the vSphere object, convert
+        the string formatted tag to k,v formatted. Then compare the attached tags to
+        the ones in the filters.
+
+        tag_filters will be a dict like {"tag_key1": "val1", "tag_key2": "val2"}
+        vm_id will be the vSphere vm object id
+
+        Return all the matched tags and all the tags the vSphere object has.
+        vsphere_tag_to_kv_pair will ignore the tags not convertable to k,v pairs.
+        """
+        matched_tags = {}
+        all_tags = {}
+
+        for tag_id in self.list_vm_tags(vm_id):
+            vsphere_vm_tag = self.vsphere_sdk_client.tagging.Tag.get(tag_id=tag_id).name
+            tag_key_value = vsphere_tag_to_kv_pair(vsphere_vm_tag)
+            if tag_key_value:
+                tag_key, tag_value = tag_key_value[0], tag_key_value[1]
+
+                if tag_key in tag_filters and tag_value == tag_filters[tag_key]:
+                    matched_tags[tag_key] = tag_value
+
+                all_tags[tag_key] = tag_value
+
+        return matched_tags, all_tags
+
+    def remove_tag_from_vm(self, tag_key_to_remove, vm_id):
+        """
+        This function will remove all tags of vm.
+        Example: If a tag called node-status:initializing is present on the VM.
+        If we would like to add a new value called finished with the node-status
+        key.We'll need to delete the older tag node-status:initializing first
+        before creating
+        node-status:finished
+        """
+        dynamic_id = DynamicID(type=Constants.TYPE_OF_RESOURCE, id=vm_id)
+
+        # List all the tags present on the VM.
+        for tag_id in self.list_vm_tags(dynamic_id):
+            vsphere_vm_tag = self.vsphere_sdk_client.tagging.Tag.get(tag_id=tag_id).name
+            tag_key_value = vsphere_tag_to_kv_pair(vsphere_vm_tag)
+            tag_key = tag_key_value[0] if tag_key_value else None
+            if tag_key == tag_key_to_remove:
+                # Remove the tag matching the key passed.
+                logger.debug("Removing tag {} from the VM {}".format(tag_key, vm_id))
+                self.vsphere_sdk_client.tagging.TagAssociation.detach(
+                    tag_id, dynamic_id
+                )
+                break
+
+    def get_tag_id_by_name(self, tag_name, category_id):
+        """
+        This function is used to get tag id
+        """
+        for id in self.vsphere_sdk_client.tagging.Tag.list_tags_for_category(
+            category_id
+        ):
+            if tag_name == self.vsphere_sdk_client.tagging.Tag.get(id).name:
+                return id
+        return None
+
+    def get_category(self):
+        """
+        This function is used to get RAY_NODE category
+        """
+        for id in self.vsphere_sdk_client.tagging.Category.list():
+            if (
+                self.vsphere_sdk_client.tagging.Category.get(id).name
+                == Constants.NODE_CATEGORY
+            ):
+                return id
+        return None
+
+    def create_category(self):
+        """
+        This function is used to create RAY_NODE category.
+        This category is associated with VMs and supports
+        multiple tags e.g. "Ray-Head-Node, Ray-Worker-Node-1 etc."
+        """
+        logger.info(f"Creating {Constants.NODE_CATEGORY} category")
+        category_spec = self.vsphere_sdk_client.tagging.Category.CreateSpec(
+            name=Constants.NODE_CATEGORY,
+            description="Identifies Ray head node and worker nodes",
+            cardinality=CategoryModel.Cardinality.MULTIPLE,
+            associable_types=set(),
+        )
+        category_id = None
+
+        try:
+            category_id = self.vsphere_sdk_client.tagging.Category.create(category_spec)
+        except ErrorClients.Unauthorized as e:
+            logger.critical(f"Unauthorized to create the category. Exception: {e}")
+            raise e
+        except Exception as e:
+            logger.critical(e)
+            raise e
+
+        logger.info(f"Category {category_id} created")
+
+        return category_id
+
+    def create_node_tag(self, ray_node_tag, category_id):
+        """
+        This function is used to create tag "ray_node_tag" under category "category_id"
+        """
+        logger.debug(f"Creating {ray_node_tag} tag")
+        tag_spec = self.vsphere_sdk_client.tagging.Tag.CreateSpec(
+            ray_node_tag, "Ray node tag", category_id
+        )
+        tag_id = None
+        try:
+            tag_id = self.vsphere_sdk_client.tagging.Tag.create(tag_spec)
+        except ErrorClients.Unauthorized as e:
+            logger.critical(f"Unauthorized to create the tag. Exception: {e}")
+            raise e
+        except Exception as e:
+            logger.critical(e)
+            raise e
+
+        logger.debug(f"Tag {tag_id} created")
+        return tag_id
+
+    def attach_tag(self, vm_id, resource_type, tag_id):
+        """
+        This function is used to attach tag to vm
+        """
+        dynamic_id = DynamicID(type=resource_type, id=vm_id)
+        try:
+            self.vsphere_sdk_client.tagging.TagAssociation.attach(tag_id, dynamic_id)
+            logger.debug(f"Tag {tag_id} attached on VM {dynamic_id}")
+        except Exception as e:
+            logger.warning(f"Check that the tag is attachable to {resource_type}")
+            raise e
+
+    def set_node_tags(self, vm_id, tags):
+        """
+        This function is used to create category if category is not exists,
+        crate tag if tag is not exists, and update the latest tag to VM.
+        """
+        with self.lock:
+            category_id = self.get_category()
+            if not category_id:
+                category_id = self.create_category()
+
+            for key, value in tags.items():
+                tag = kv_pair_to_vsphere_tag(key, value)
+                tag_id = self.get_tag_id_by_name(tag, category_id)
+                if not tag_id:
+                    tag_id = self.create_node_tag(tag, category_id)
+
+                # If a tag with a key is present on the VM, then remove it
+                # before updating the key with a new value.
+                self.remove_tag_from_vm(key, vm_id)
+
+                logger.debug(f"Attaching tag {tag} to {vm_id}")
+                self.attach_tag(vm_id, Constants.TYPE_OF_RESOURCE, tag_id=tag_id)
+
+    # This method is used to
+    def tag_new_vm_instantly(self, vm_name, tags):
+        """
+        This function is used to do tag VMs as soon as VM show up on vCenter.
+        """
+        names = {vm_name}
+        start = time.time()
+        # In most cases the instant clone VM will show up in several seconds.
+        # When the vCenter Server is busy, the time could be longer. We set a 120
+        # seconds timeout here. Because it's not used anywhere else, we don't make
+        # it as a formal constant.
+        while time.time() - start < Constants.CREATING_TAG_TIMEOUT:
+            time.sleep(0.5)
+            vms = self.vsphere_sdk_client.vcenter.VM.list(VM.FilterSpec(names=names))
+
+            if len(vms) == 1:
+                vm_id = vms[0].vm
+                self.set_node_tags(vm_id, tags)
+                return
+            elif len(vms) > 1:
+                # This should never happen
+                raise RuntimeError("Duplicated VM with name {} found.".format(vm_name))
+
+        raise RuntimeError("VM {} could not be found.".format(vm_name))
+
+    def update_vm_cpu(self, vm_id, cpu_count):
+        """
+        This function helps to Update CPUs Number of VM
+        """
+        update_spec = Cpu.UpdateSpec(count=cpu_count)
+        logger.debug("vm.hardware.Cpu.update({}, {})".format(vm_id, update_spec))
+        self.vsphere_sdk_client.vcenter.vm.hardware.Cpu.update(vm_id, update_spec)
+
+    def update_vm_memory(self, vm_id, memory):
+        """
+        This function helps to Update Memory of VM
+        """
+        update_spec = Memory.UpdateSpec(size_mib=memory)
+        logger.debug("vm.hardware.Memory.update({}, {})".format(vm_id, update_spec))
+        self.vsphere_sdk_client.vcenter.vm.hardware.Memory.update(vm_id, update_spec)
+
+    def deploy_ovf(
+        self, lib_item, vm_name_target, resource_pool_id, host_id, datastore_id
+    ):
+        """
+        This function is used to deploy vm from OVF
+        """
+        find_spec = Item.FindSpec(name=lib_item)
+        item_ids = self.vsphere_sdk_client.content.library.Item.find(find_spec)
+
+        if len(item_ids) < 1:
+            raise ValueError(
+                "Content library items with name '{}' not found".format(lib_item),
+            )
+        if len(item_ids) > 1:
+            logger.warning(
+                "Unexpected: found multiple content library items with name \
+                '{}'".format(
+                    lib_item
+                )
+            )
+
+        lib_item_id = item_ids[0]
+        deployment_target = LibraryItem.DeploymentTarget(
+            resource_pool_id=resource_pool_id,
+            host_id=host_id,
+        )
+        ovf_summary = self.vsphere_sdk_client.vcenter.ovf.LibraryItem.filter(
+            ovf_library_item_id=lib_item_id, target=deployment_target
+        )
+        logger.info("Found an OVF template: {} to deploy.".format(ovf_summary.name))
+
+        # Build the deployment spec
+        deployment_spec = LibraryItem.ResourcePoolDeploymentSpec(
+            name=vm_name_target,
+            annotation=ovf_summary.annotation,
+            accept_all_eula=True,
+            network_mappings=None,
+            storage_mappings=None,
+            storage_provisioning=DiskProvisioningType.thin,
+            storage_profile_id=None,
+            locale=None,
+            flags=None,
+            additional_parameters=None,
+            default_datastore_id=datastore_id,
+        )
+
+        # Deploy the ovf template
+        result = self.vsphere_sdk_client.vcenter.ovf.LibraryItem.deploy(
+            lib_item_id,
+            deployment_target,
+            deployment_spec,
+            client_token=str(uuid.uuid4()),
+        )
+
+        logger.debug("result: {}".format(result))
+        # The type and ID of the target deployment is available in the
+        # deployment result.
+        if len(result.error.errors) > 0:
+            for error in result.error.errors:
+                logger.error("OVF error: {}".format(error))
+
+            raise ValueError(
+                "OVF deployment failed for VM {}, reason: {}".format(
+                    vm_name_target, result
+                )
+            )
+
+        logger.info(
+            'Deployment successful. VM Name: "{}", ID: "{}"'.format(
+                vm_name_target, result.resource_id.id
+            )
+        )
+        error = result.error
+        if error is not None:
+            for warning in error.warnings:
+                logger.warning("OVF warning: {}".format(warning.message))
+
+        vm_id = result.resource_id.id
+        vm = self.get_vsphere_sdk_vm_obj(vm_id)
+        return vm.name

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -544,7 +544,7 @@ py_test(
 )
 
 py_test(
-    name = "vsphere/test_vsphere_sdk_provider.py",
+    name = "vsphere/test_vsphere_sdk_provider",
     size = "small",
     srcs = ["vsphere/test_vsphere_sdk_provider.py"],
     tags = ["exclusive", "small_size_python_tests", "team:serverless"],

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -543,6 +543,14 @@ py_test(
     deps = ["//:ray_lib", ":conftest"],
 )
 
+py_test(
+    name = "vsphere/test_vsphere_sdk_provider.py",
+    size = "small",
+    srcs = ["vsphere/test_vsphere_sdk_provider.py"],
+    tags = ["exclusive", "small_size_python_tests", "team:serverless"],
+    deps = ["//:ray_lib", ":conftest"],
+)
+
 # Note(simon): typing tests are not included in module list
 #    because they requires globs and it might be refactored in the future.
 py_test(

--- a/python/ray/tests/vsphere/test_vsphere_node_provider.py
+++ b/python/ray/tests/vsphere/test_vsphere_node_provider.py
@@ -1,13 +1,10 @@
 import copy
 import time
-from threading import RLock
 import pytest
 import threading
 from unittest.mock import MagicMock, patch
 
 from ray.autoscaler._private.vsphere.node_provider import VsphereNodeProvider
-from com.vmware.vcenter_client import VM
-from com.vmware.vcenter.vm_client import Power as HardPower
 from ray.autoscaler._private.vsphere.config import (
     update_vsphere_configs,
     validate_frozen_vm_configs,
@@ -40,7 +37,7 @@ def mock_vsphere_node_provider():
         self.vsphere_credentials = vsphere_credentials
         self.vsphere_config = provider_config["vsphere_config"]
         self.get_pyvmomi_sdk_provider = MagicMock()
-        self.get_vsphere_sdk_client = MagicMock()
+        self.get_vsphere_sdk_provider = MagicMock()
         self.frozen_vm_scheduler = MagicMock()
 
     with patch.object(VsphereNodeProvider, "__init__", __init__):
@@ -48,102 +45,12 @@ def mock_vsphere_node_provider():
     return copy.deepcopy(node_provider)
 
 
-def test_non_terminated_nodes_returns_no_node():
-    """There is no node in vSphere"""
-    vnp = mock_vsphere_node_provider()
-    vnp.lock = RLock()
-    vnp.get_vsphere_sdk_client().vcenter.VM.list.return_value = []
-
-    nodes = vnp.non_terminated_nodes({})  # assert
-    assert len(nodes) == 0
-
-
-def test_non_terminated_nodes_returns_nodes_in_powered_off_creating_state():
-    vnp = mock_vsphere_node_provider()
-    vnp.lock = RLock()
-    vnp.tag_cache_lock = threading.Lock()
-    vnp.get_vsphere_sdk_client().vcenter.VM.list.return_value = [
-        MagicMock(vm="vm1"),
-        MagicMock(vm="vm2"),
-    ]
-    vnp.get_vsphere_sdk_client().vcenter.vm.Power.get.side_effect = [
-        MagicMock(state="POWERED_ON"),
-        MagicMock(state="POWERED_OFF"),
-    ]
-    # The 2nd vm is powered off but is in creating status
-    vnp.get_matched_tags = MagicMock(
-        return_value=(
-            {"ray-cluster-name": "test"},
-            {
-                "ray-cluster-name": "test",
-                "custom-tag": "custom-value",
-                "vsphere-node-status": "creating",
-            },
-        )
-    )
-    # The tag filter is none
-    nodes = vnp.non_terminated_nodes({})
-    assert len(nodes) == 2
-
-
-def test_non_terminated_nodes_with_custom_tag_filters():
-    """Test nodes with custom tag filters"""
-    vnp = mock_vsphere_node_provider()
-    vnp.lock = RLock()
-    vnp.tag_cache_lock = threading.Lock()
-    vnp.get_vsphere_sdk_client().vcenter.VM.list.return_value = [
-        MagicMock(vm="vm1"),
-        MagicMock(vm="vm2"),
-    ]
-    vnp.get_vsphere_sdk_client().vcenter.vm.Power.get.side_effect = [
-        MagicMock(state="POWERED_ON"),
-        MagicMock(state="POWERED_OFF"),
-    ]
-    vnp.get_matched_tags = MagicMock(
-        return_value=(
-            {"ray-cluster-name": "test", "custom-tag": "custom-value"},
-            {
-                "ray-cluster-name": "test",
-                "custom-tag": "custom-value",
-                "vsphere-node-status": "blabla",
-            },
-        )
-    )
-    # This time we applied a tag filter, but the 2nd vm is not in creating
-    # status so only the first vm will be returned
-    nodes = vnp.non_terminated_nodes({"custom-tag": "custom-value"})  # assert
-    assert len(nodes) == 1
-    assert nodes[0] == "vm1"
-
-
-def test_non_terminated_nodes_with_multiple_filters_not_matching():
-    """Test nodes with tag filters not matching"""
-    vnp = mock_vsphere_node_provider()
-    vnp.lock = RLock()
-    vnp.tag_cache_lock = threading.Lock()
-    vnp.get_vsphere_sdk_client().vcenter.VM.list.return_value = [
-        MagicMock(vm="vm1"),
-        MagicMock(vm="vm2"),
-    ]
-    vnp.get_vsphere_sdk_client().vcenter.vm.Power.get.side_effect = [
-        MagicMock(state="POWERED_ON"),
-        MagicMock(state="POWERED_OFF"),
-    ]
-    vnp.get_matched_tags = MagicMock(
-        return_value=(
-            {"ray-cluster-name": "test"},
-            {"ray-cluster-name": "test", "vsphere-node-status": "blabla"},
-        )
-    )
-    # tag not much so no VM should be returned this time
-    nodes = vnp.non_terminated_nodes({"custom-tag": "another-value"})
-    assert len(nodes) == 0
-
-
 def test_is_terminated():
     """Should return true if a cached node is not in POWERED_ON state"""
     vnp = mock_vsphere_node_provider()
+    vnp.get_vsphere_sdk_provider = MagicMock()
     vnp.get_pyvmomi_sdk_provider().is_vm_power_on.return_value = False
+    vnp.get_vsphere_sdk_provider().is_vm_creating.return_value = False
     is_terminated = vnp.is_terminated("node1")
     assert is_terminated is True
 
@@ -165,28 +72,17 @@ def test_node_tags():
     assert tags == vnp.tag_cache["test_vm_id_1"]
 
 
-@patch("ray.autoscaler._private.vsphere.node_provider.vim.vm.RelocateSpec")
-@patch("ray.autoscaler._private.vsphere.node_provider.vim.vm.InstantCloneSpec")
-@patch("ray.autoscaler._private.vsphere.pyvmomi_sdk_provider.WaitForTask")
-def test_create_instant_clone_node(mock_wait_task, mock_ic_spec, mock_relo_spec):
+def test_create_instant_clone_node():
     vnp = mock_vsphere_node_provider()
-    VM.InstantCloneSpec = MagicMock(return_value="Clone Spec")
-    vnp.get_vsphere_sdk_client().vcenter.VM.instant_clone.return_value = "test_id_1"
-    vnp.get_vsphere_sdk_client().vcenter.vm.Power.stop.return_value = None
+    vnp.get_pyvmomi_sdk_provider().instance_clone_vm = MagicMock(return_value=None)
     vnp.set_node_tags = MagicMock(return_value=None)
-    vnp.get_vsphere_sdk_client().vcenter.VM.list = MagicMock(
-        return_value=[MagicMock(vm="test VM")]
+    vnp.get_vsphere_sdk_provider().get_vsphere_sdk_vm_obj = MagicMock(
+        return_value="test VM"
     )
-    vnp.connect_nics = MagicMock(return_value=None)
-    vnp.get_vsphere_sdk_client().vcenter.vm.hardware.Ethernet.list.return_value = None
-    vnp.get_vsphere_sdk_vm_obj = MagicMock(return_value="test VM")
 
     node_config = {"resource_pool": "rp1", "datastore": "ds1", "resources": {}}
     tags = {"key": "value"}
     gpu_ids_map = None
-
-    mock_ic_spec.return_value = MagicMock()
-    mock_relo_spec.return_value = MagicMock()
     vm = vnp.create_instant_clone_node(
         "test-1",
         "test VM",
@@ -211,97 +107,26 @@ def test__create_node():
     vnp.create_instant_clone_node = MagicMock(
         side_effect=mock_create_instant_clone_node()
     )
-
-    vnp.get_vsphere_sdk_client().vcenter.vm.Power.get.return_value = HardPower.Info(
-        state=HardPower.State.POWERED_OFF
-    )
-    vnp.get_vsphere_sdk_client().vcenter.vm.Power.start.return_value = None
-
-    vnp.get_category = MagicMock(return_value=None)
-    vnp.create_category = MagicMock(return_value="category_id")
-    vnp.get_tag = MagicMock(return_value=None)
-    vnp.create_node_tag = MagicMock(return_value="tag_id")
-    vnp.attach_tag = MagicMock(return_value=None)
-    vnp.delete_vm = MagicMock(return_value=None)
+    vnp.get_vsphere_sdk_provider().set_node_tags = MagicMock(return_value=None)
+    vnp.get_vsphere_sdk_provider().delete_vm_by_name = MagicMock(return_value=None)
     vnp.create_new_or_fetch_existing_frozen_vms = MagicMock(return_value={"vm": "vm-d"})
     vnp.frozen_vm_scheduler().next_frozen_vm = MagicMock(
         return_value=MagicMock(name=MagicMock("frozen-vm"))
     )
-    vnp.lock = RLock()
-
     created_nodes_dict = vnp._create_node(
         node_config, {"ray-node-name": "ray-node-1", "ray-node-type": "head"}, 2
     )
-
     assert len(created_nodes_dict) == 2
-    vnp.delete_vm.assert_not_called()
-    vnp.create_category.assert_called()
-    vnp.attach_tag.assert_called_with("vm-test", "VirtualMachine", tag_id="tag_id")
-    assert vnp.attach_tag.call_count == 2
-
-
-def test_get_tag():
-    vnp = mock_vsphere_node_provider()
-    mock_tag = MagicMock()
-    mock_tag.name = "ray-node-name"
-    vnp.get_vsphere_sdk_client().tagging.Tag.list_tags_for_category.return_value = [
-        "tag_1"
-    ]
-    vnp.get_vsphere_sdk_client().tagging.Tag.get.return_value = mock_tag
-    assert vnp.get_tag("ray-node-name", "test_category_id") == "tag_1"
-
-
-def test_get_tag_return_none():
-    vnp = mock_vsphere_node_provider()
-    mock_tag = MagicMock()
-    mock_tag.name = "ray-node-name"
-    vnp.get_vsphere_sdk_client().tagging.Tag.list_tags_for_category.return_value = [
-        "tag_1"
-    ]
-    vnp.get_vsphere_sdk_client().tagging.Tag.get.return_value = mock_tag
-    assert vnp.get_tag("ray-node-name1", "test_category_id") is None
-
-
-def test_create_node_tag():
-    vnp = mock_vsphere_node_provider()
-    vnp.get_vsphere_sdk_client().tagging.Tag.CreateSpec.return_value = "tag_spec"
-    vnp.get_vsphere_sdk_client().tagging.Tag.create.return_value = "tag_id_1"
-    tag_id = vnp.create_node_tag("ray_node_tag", "test_category_id")
-    assert tag_id == "tag_id_1"
-
-
-def test_get_category():
-    vnp = mock_vsphere_node_provider()
-    vnp.get_vsphere_sdk_client().tagging.Category.list.return_value = ["category_1"]
-
-    mock_category = MagicMock()
-    mock_category.name = "ray"
-    vnp.get_vsphere_sdk_client().tagging.Category.get.return_value = mock_category
-    category = vnp.get_category()
-    assert category == "category_1"
-    mock_category.name = "default"
-    category = vnp.get_category()
-    assert category is None
-
-
-def test_create_category():
-    vnp = mock_vsphere_node_provider()
-
-    vnp.get_vsphere_sdk_client().tagging.Category.CreateSpec.return_value = (
-        "category_spec"
-    )
-    vnp.get_vsphere_sdk_client().tagging.Category.create.return_value = "category_id_1"
-    category_id = vnp.create_category()
-    assert category_id == "category_id_1"
+    assert vnp.get_vsphere_sdk_provider().set_node_tags.call_count == 2
+    vnp.get_vsphere_sdk_provider().delete_vm_by_name.assert_not_called()
 
 
 def test_terminate_node():
     vnp = mock_vsphere_node_provider()
     vnp.tag_cache_lock = threading.Lock()
-    vnp.get_vsphere_sdk_client().vcenter.vm.Power.stop = MagicMock()
     vnp.tag_cache = {"vm1": ["tag1", "tag2"], "vm2": ["tag1", "tag2"]}
+    vnp.get_vsphere_sdk_provider().delete_vm_by_id = MagicMock(return_value=None)
     vnp.terminate_node("vm2")
-    vnp.get_vsphere_sdk_client().vcenter.vm.Power.stop.assert_called_once_with("vm2")
     assert len(vnp.tag_cache) == 1
 
 

--- a/python/ray/tests/vsphere/test_vsphere_sdk_provider.py
+++ b/python/ray/tests/vsphere/test_vsphere_sdk_provider.py
@@ -1,0 +1,216 @@
+import pytest
+
+from unittest.mock import MagicMock, patch
+from ray.autoscaler._private.vsphere.vsphere_sdk_provider import VsphereSdkProvider
+from ray.autoscaler._private.vsphere.utils import Constants
+from com.vmware.vcenter.vm_client import Power as HardPower
+
+
+@pytest.fixture
+def patch_vsphere_sdk_provider(request):
+    patcher = patch(
+        "ray.autoscaler._private.vsphere.vsphere_sdk_provider.\
+VsphereSdkProvider.__wrapped__.get_client",
+        lambda *args, **kwargs: MagicMock(),
+    )
+    mock_function = patcher.start()
+
+    def fin():
+        patcher.stop()
+
+    request.addfinalizer(fin)
+    return mock_function
+
+
+def mock_vsphere_sdk_provider():
+    sdk_provider = VsphereSdkProvider("", "", "", Constants.SessionType.UNVERIFIED)
+    return sdk_provider
+
+
+def test_delete_vm_by_id(patch_vsphere_sdk_provider):
+    vsp = mock_vsphere_sdk_provider()
+
+    vsp.vsphere_sdk_client.vcenter.vm.Power.stop = MagicMock()
+
+    vsp.vsphere_sdk_client.vcenter.vm.Power.get.return_value = HardPower.Info(
+        state=HardPower.State.POWERED_ON
+    )
+    vsp.delete_vm_by_id("vm2")
+    vsp.vsphere_sdk_client.vcenter.vm.Power.stop.assert_called_once_with("vm2")
+    vsp.vsphere_sdk_client.vcenter.VM.delete.assert_called_once_with("vm2")
+
+
+def test_non_terminated_nodes_returns_no_node(patch_vsphere_sdk_provider):
+    """There is no node in vSphere"""
+    cluster_name = "test"
+    vsp = mock_vsphere_sdk_provider()
+    vsp.vsphere_sdk_client.vcenter.VM.list.return_value = []
+    nodes, tag_cache = vsp.non_terminated_nodes(cluster_name, {})  # assert
+    assert len(nodes) == 0
+
+    return
+
+
+def test_non_terminated_nodes_returns_nodes_in_powered_off_creating_state(
+    patch_vsphere_sdk_provider,
+):
+    cluster_name = "test"
+    vsp = mock_vsphere_sdk_provider()
+
+    vsp.vsphere_sdk_client.vcenter.VM.list.return_value = [
+        MagicMock(vm="vm1"),
+        MagicMock(vm="vm2"),
+    ]
+    vsp.vsphere_sdk_client.vcenter.vm.Power.get.side_effect = [
+        MagicMock(state="POWERED_ON"),
+        MagicMock(state="POWERED_OFF"),
+    ]
+    # The 2nd vm is powered off but is in creating status
+    vsp.get_matched_tags = MagicMock(
+        return_value=(
+            {"ray-cluster-name": "test"},
+            {
+                "ray-cluster-name": "test",
+                "custom-tag": "custom-value",
+                "vsphere-node-status": "creating",
+            },
+        )
+    )
+    # The tag filter is none
+    nodes, tag_cache = vsp.non_terminated_nodes(cluster_name, {})
+    assert len(nodes) == 2
+
+
+def test_non_terminated_nodes_with_custom_tag_filters(patch_vsphere_sdk_provider):
+    """Test nodes with custom tag filters"""
+    cluster_name = "test"
+    vsp = mock_vsphere_sdk_provider()
+
+    vsp.vsphere_sdk_client.vcenter.VM.list.return_value = [
+        MagicMock(vm="vm1"),
+        MagicMock(vm="vm2"),
+    ]
+    vsp.vsphere_sdk_client.vcenter.vm.Power.get.side_effect = [
+        MagicMock(state="POWERED_ON"),
+        MagicMock(state="POWERED_OFF"),
+    ]
+    vsp.get_matched_tags = MagicMock(
+        return_value=(
+            {"ray-cluster-name": "test", "custom-tag": "custom-value"},
+            {
+                "ray-cluster-name": "test",
+                "custom-tag": "custom-value",
+                "vsphere-node-status": "blabla",
+            },
+        )
+    )
+    # This time we applied a tag filter, but the 2nd vm is not in creating
+    # status so only the first vm will be returned
+    nodes, tag_cache = vsp.non_terminated_nodes(
+        cluster_name, {"custom-tag": "custom-value"}
+    )  # assert
+    assert len(nodes) == 1
+    assert nodes[0] == "vm1"
+
+
+def test_non_terminated_nodes_with_multiple_filters_not_matching(
+    patch_vsphere_sdk_provider,
+):
+    """Test nodes with tag filters not matching"""
+    cluster_name = "test"
+    vsp = mock_vsphere_sdk_provider()
+
+    vsp.vsphere_sdk_client.vcenter.VM.list.return_value = [
+        MagicMock(vm="vm1"),
+        MagicMock(vm="vm2"),
+    ]
+    vsp.vsphere_sdk_client.vcenter.vm.Power.get.side_effect = [
+        MagicMock(state="POWERED_ON"),
+        MagicMock(state="POWERED_OFF"),
+    ]
+    vsp.get_matched_tags = MagicMock(
+        return_value=(
+            {"ray-cluster-name": "test"},
+            {"ray-cluster-name": "test", "vsphere-node-status": "blabla"},
+        )
+    )
+    # tag not much so no VM should be returned this time
+    nodes, tag_cache = vsp.non_terminated_nodes(
+        cluster_name, {"custom-tag": "another-value"}
+    )
+    assert len(nodes) == 0
+
+
+def test_get_tag_id_by_name(patch_vsphere_sdk_provider):
+    vsp = mock_vsphere_sdk_provider()
+    mock_tag = MagicMock()
+    mock_tag.name = "ray-node-name"
+    vsp.vsphere_sdk_client.tagging.Tag.list_tags_for_category.return_value = ["tag_1"]
+    vsp.vsphere_sdk_client.tagging.Tag.get.return_value = mock_tag
+    assert vsp.get_tag_id_by_name("ray-node-name", "test_category_id") == "tag_1"
+
+
+def test_get_tag_id_by_name_return_none(patch_vsphere_sdk_provider):
+    vsp = mock_vsphere_sdk_provider()
+    mock_tag = MagicMock()
+    mock_tag.name = "ray-node-name"
+    vsp.vsphere_sdk_client.tagging.Tag.list_tags_for_category.return_value = ["tag_1"]
+    vsp.vsphere_sdk_client.tagging.Tag.get.return_value = mock_tag
+    assert vsp.get_tag_id_by_name("ray-node-name1", "test_category_id") is None
+
+
+def test_create_node_tag(patch_vsphere_sdk_provider):
+    vsp = mock_vsphere_sdk_provider()
+    vsp.vsphere_sdk_client.tagging.Tag.CreateSpec.return_value = "tag_spec"
+    vsp.vsphere_sdk_client.tagging.Tag.create.return_value = "tag_id_1"
+    tag_id = vsp.create_node_tag("ray_node_tag", "test_category_id")
+    assert tag_id == "tag_id_1"
+
+
+def test_get_category(patch_vsphere_sdk_provider):
+    vsp = mock_vsphere_sdk_provider()
+    vsp.vsphere_sdk_client.tagging.Category.list.return_value = ["category_1"]
+
+    mock_category = MagicMock()
+    mock_category.name = "ray"
+    vsp.vsphere_sdk_client.tagging.Category.get.return_value = mock_category
+    category = vsp.get_category()
+    assert category == "category_1"
+    mock_category.name = "default"
+    category = vsp.get_category()
+    assert category is None
+
+
+def test_create_category(patch_vsphere_sdk_provider):
+    vsp = mock_vsphere_sdk_provider()
+
+    vsp.vsphere_sdk_client.tagging.Category.CreateSpec.return_value = "category_spec"
+    vsp.vsphere_sdk_client.tagging.Category.create.return_value = "category_id_1"
+    category_id = vsp.create_category()
+    assert category_id == "category_id_1"
+
+
+def test_set_node_tags(patch_vsphere_sdk_provider):
+    vsp = mock_vsphere_sdk_provider()
+    vsp.vsphere_sdk_client.vcenter.vm.Power.get.return_value = HardPower.Info(
+        state=HardPower.State.POWERED_OFF
+    )
+    vsp.vsphere_sdk_client.vcenter.vm.Power.start.return_value = None
+
+    vsp.get_category = MagicMock(return_value=None)
+    vsp.create_category = MagicMock(return_value="category_id")
+    vsp.get_tag_id_by_name = MagicMock(return_value=None)
+    vsp.create_node_tag = MagicMock(return_value="tag_id")
+    vsp.attach_tag = MagicMock(return_value=None)
+    vsp.remove_tag_from_vm = MagicMock(return_value=None)
+
+    k = Constants.VSPHERE_NODE_STATUS
+    v = Constants.VsphereNodeStatus.CREATED.value
+    vsphere_node_created_tag = {k: v}
+    vm_id = "vm-test"
+
+    vsp.set_node_tags(vm_id, vsphere_node_created_tag)
+
+    vsp.create_category.assert_called()
+    vsp.attach_tag.assert_called_with(vm_id, "VirtualMachine", tag_id="tag_id")
+    vsp.attach_tag.assert_called()

--- a/python/ray/tests/vsphere/test_vsphere_sdk_provider.py
+++ b/python/ray/tests/vsphere/test_vsphere_sdk_provider.py
@@ -1,9 +1,11 @@
 import pytest
 
 from unittest.mock import MagicMock, patch
-from ray.autoscaler._private.vsphere.vsphere_sdk_provider import VsphereSdkProvider
-from ray.autoscaler._private.vsphere.utils import Constants
-from com.vmware.vcenter.vm_client import Power as HardPower
+from ray.autoscaler._private.vsphere.vsphere_sdk_provider import (
+    VsphereSdkProvider,
+    Constants,
+    HardPower,
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Similar with our [previous change](https://github.com/ray-project/ray/pull/41656), in this change we continue to wrap the operations we conduct against the vSphere cluster. We seal the operations in vsphere_sdk_provider.py. We only keep the main logic in node_provider.py

Because of this, some UT for node provider need a change, so we split the original UT into 2 files, to cover the code.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

N/A

<!-- For example: "Closes #1234" -->


## Tests

Our CI is being stronger, and all the CI cases passed, we also test the GPU case manually, passed.

This change has changed only the vSphere related code.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
