### PR TITLE
[serve] Avoid spamming error logs when deployments are unhealthy

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -735,10 +735,15 @@ class ApplicationState:
         return {k: v for k, v in details.items() if v is not None}
 
     def _update_status(self, status: ApplicationStatus, status_msg: str = "") -> None:
-        if status_msg and status in [
-            ApplicationStatus.DEPLOY_FAILED,
-            ApplicationStatus.UNHEALTHY,
-        ]:
+        if (
+            status_msg
+            and status
+            in [
+                ApplicationStatus.DEPLOY_FAILED,
+                ApplicationStatus.UNHEALTHY,
+            ]
+            and status_msg != self._status_msg
+        ):
             logger.warning(status_msg)
 
         self._status = status


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Application state manager currently prints the error/status msg every control loop iteration if the application is unhealthy/deploy_failed. This PR fixes the spammy error logs.

I.e. avoid:
```
(ServeController pid=5124) WARNING 2023-12-15 04:22:40,569 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
(ServeController pid=5124) WARNING 2023-12-15 04:22:40,673 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
(ServeController pid=5124) WARNING 2023-12-15 04:22:40,780 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
(ServeController pid=5124) WARNING 2023-12-15 04:22:40,884 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
(ServeController pid=5124) WARNING 2023-12-15 04:22:40,986 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
(ServeController pid=5124) WARNING 2023-12-15 04:22:41,089 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
(ServeController pid=5124) WARNING 2023-12-15 04:22:41,193 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
(ServeController pid=5124) WARNING 2023-12-15 04:22:41,299 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
(ServeController pid=5124) WARNING 2023-12-15 04:22:41,403 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
(ServeController pid=5124) WARNING 2023-12-15 04:22:41,506 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
(ServeController pid=5124) WARNING 2023-12-15 04:22:41,611 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
(ServeController pid=5124) WARNING 2023-12-15 04:22:41,714 controller 5124 application_state.py:747 - The deployments ['Model'] are UNHEALTHY.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
