### PR TITLE
[data] add file extensions to error output

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -206,7 +206,8 @@ class FileBasedDatasource(Datasource):
             file_sizes = [path_to_size[p] for p in paths]
             if len(paths) == 0:
                 raise ValueError(
-                    "No input files found to read. Please double check that "
+                    "No input files found to read with the following file extensions: "
+                    f"{file_extensions}. Please double check that "
                     "'file_extensions' field is set properly."
                 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`file_extension` can get set internally by `Datasource`. This can be confusing for the user if they use the wrong read api. This adds the file extensions to the error output.

For example, if someone is trying to read parquet files with `read_images`, we now get
```
ValueError: No input files found to read with the following file extensions: ['png', 'jpg', 'jpeg', 'tif', 'tiff', 'bmp', 'gif']. Please double check that 'file_extensions' field is set properly.
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #41455

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
