### PR TITLE
[train][release-test] Fix gptj finetuning example to be less sensitive to data ordering

### DIFF
--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -17,7 +17,7 @@
     "Read [Ray Train Key Concepts](train-key-concepts) and [Ray Data Integration User Guides](data-ingest-torch) before starting this example.\n",
     "\n",
     "```{note}\n",
-    "To run this example, make sure your Ray cluster has access to at least one GPU with 16 or more GBs of memory. The required amount of memory depends on the model. This notebook is tested with 16 g4dn.4xlarge instances (including the head node). To use a CPU head node, turn on [cloud checkpointing](tune-cloud-checkpointing) to avoid OOM errors that may happen due to the default behavior of syncing the checkpoint files to the head node.\n",
+    "To run this example, make sure your Ray cluster has access to at least one GPU with 16 or more GBs of memory. The required amount of memory depends on the model. This notebook is tested with 16 g4dn.4xlarge instances (including the head node).\n",
     "```\n",
     "\n",
     "This notebook has the following steps:\n",

--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Uncomment and run the following line in order to install all the necessary dependencies (this notebook is being tested with `transformers==4.26.0`):"
+    "Uncomment and run the following line in order to install all the necessary dependencies (this notebook was tested with `accelerate=0.18.0`, `transformers==4.26.0`, `deepspeed==0.12.3`):"
    ]
   },
   {
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install \"datasets\" \"evaluate\" \"accelerate==0.18.0\" \"transformers>=4.26.0\" \"torch>=1.12.0\" \"deepspeed==0.12.3\""
+    "! pip install \"datasets\" \"evaluate\" \"accelerate==0.18.0\" \"transformers==4.26.0\" \"torch>=1.12.0\" \"deepspeed==0.12.3\""
    ]
   },
   {
@@ -105,11 +105,11 @@
     "        \"pip\": [\n",
     "            \"datasets\",\n",
     "            \"evaluate\",\n",
-    "            # Latest combination of accelerate==0.19.0 and transformers==4.29.0\n",
-    "            # seems to have issues with DeepSpeed process group initialization,\n",
+    "            # The latest combination accelerate==0.25.0, transformers==4.36.0, deepspeed==0.12.4\n",
+    "            # has issues with DeepSpeed process group initialization,\n",
     "            # and will result in a batch_size validation problem.\n",
-    "            # TODO(jungong) : get rid of the pins once the issue is fixed.\n",
-    "            \"accelerate==0.16.0\",\n",
+    "            # TODO(ml-team): get rid of the pins once the issue is fixed.\n",
+    "            \"accelerate==0.18.0\",\n",
     "            \"transformers==4.26.0\",\n",
     "            \"torch>=1.12.0\",\n",
     "            \"deepspeed==0.12.3\",\n",
@@ -245,7 +245,7 @@
     "\n",
     "ray_datasets = {\n",
     "    \"train\": ray.data.from_huggingface(current_dataset[\"train\"]),\n",
-    "    \"validation\": ray.data.from_huggingface(current_dataset[\"validation\"])\n",
+    "    \"validation\": ray.data.from_huggingface(current_dataset[\"validation\"]),\n",
     "}\n",
     "\n",
     "ray_datasets"
@@ -302,6 +302,7 @@
    "source": [
     "from transformers import AutoTokenizer\n",
     "\n",
+    "\n",
     "def split_text(batch: pd.DataFrame) -> pd.DataFrame:\n",
     "    text = list(batch[\"text\"])\n",
     "    flat_text = \"\".join(text)\n",
@@ -326,8 +327,12 @@
     "    ret[\"labels\"] = ret[\"input_ids\"].copy()\n",
     "    return dict(ret)\n",
     "\n",
+    "\n",
     "processed_datasets = {\n",
-    "    key: ds.map_batches(split_text, batch_format=\"pandas\").map_batches(tokenize, batch_format=\"pandas\").random_shuffle(seed=42)\n",
+    "    key: (\n",
+    "        ds.map_batches(split_text, batch_format=\"pandas\")\n",
+    "        .map_batches(tokenize, batch_format=\"pandas\")\n",
+    "    )\n",
     "    for key, ds in ray_datasets.items()\n",
     "}\n",
     "processed_datasets"
@@ -388,10 +393,7 @@
     "from transformers.utils.logging import disable_progress_bar, enable_progress_bar\n",
     "\n",
     "from ray import train\n",
-    "from ray.train.huggingface.transformers import (\n",
-    "    prepare_trainer,\n",
-    "    RayTrainReportCallback\n",
-    ")\n",
+    "from ray.train.huggingface.transformers import prepare_trainer, RayTrainReportCallback\n",
     "\n",
     "\n",
     "def train_func(config):\n",
@@ -413,6 +415,8 @@
     "        \"fp16\": {\n",
     "            \"enabled\": \"auto\",\n",
     "            \"initial_scale_power\": 8,\n",
+    "            \"hysteresis\": 4,\n",
+    "            \"consecutive_hysteresis\": True,\n",
     "        },\n",
     "        \"bf16\": {\"enabled\": \"auto\"},\n",
     "        \"optimizer\": {\n",
@@ -426,10 +430,6 @@
     "        \"zero_optimization\": {\n",
     "            \"stage\": 3,\n",
     "            \"offload_optimizer\": {\n",
-    "                \"device\": \"cpu\",\n",
-    "                \"pin_memory\": True,\n",
-    "            },\n",
-    "            \"offload_param\": {\n",
     "                \"device\": \"cpu\",\n",
     "                \"pin_memory\": True,\n",
     "            },\n",
@@ -456,6 +456,8 @@
     "        save_strategy=\"steps\",\n",
     "        save_steps=steps_per_epoch,\n",
     "        max_steps=steps_per_epoch * epochs,\n",
+    "        per_device_train_batch_size=batch_size,\n",
+    "        gradient_accumulation_steps=1,\n",
     "        learning_rate=learning_rate,\n",
     "        weight_decay=weight_decay,\n",
     "        warmup_steps=warmup_steps,\n",
@@ -486,7 +488,10 @@
     "    train_ds = train.get_dataset_shard(\"train\")\n",
     "    eval_ds = train.get_dataset_shard(\"validation\")\n",
     "\n",
-    "    train_ds_iterable = train_ds.iter_torch_batches(batch_size=batch_size)\n",
+    "    train_ds_iterable = train_ds.iter_torch_batches(\n",
+    "        batch_size=batch_size,\n",
+    "        local_shuffle_buffer_size=train.get_context().get_world_size() * batch_size,\n",
+    "    )\n",
     "    eval_ds_iterable = eval_ds.iter_torch_batches(batch_size=batch_size)\n",
     "\n",
     "    def compute_metrics(eval_pred):\n",
@@ -531,7 +536,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "storage_path=\"s3://your-bucket-here\"  # TODO: Set up cloud storage\n",
+    "storage_path = \"s3://your-bucket-here\"  # TODO: Set up cloud storage\n",
     "# storage_path=\"/mnt/path/to/nfs\"     # TODO: Alternatively, set up NFS"
    ]
   },
@@ -546,9 +551,37 @@
    "outputs": [],
    "source": [
     "import os, re\n",
+    "\n",
     "artifact_storage = os.environ.get(\"ANYSCALE_ARTIFACT_STORAGE\", \"artifact_storage\")\n",
     "user_name = re.sub(r\"\\s+\", \"__\", os.environ.get(\"ANYSCALE_USERNAME\", \"user\"))\n",
-    "storage_path = (f\"{artifact_storage}/{user_name}/gptj-deepspeed-finetune\")"
+    "storage_path = f\"{artifact_storage}/{user_name}/gptj-deepspeed-finetune\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_size = 16\n",
+    "train_ds_size = processed_datasets[\"train\"].count()\n",
+    "steps_per_epoch = train_ds_size // (batch_size * num_workers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# SMOKE TEST SETTINGS FOR CI\n",
+    "steps_per_epoch = 10\n",
+    "num_workers = 8\n",
+    "batch_size = 1"
    ]
   },
   {
@@ -562,16 +595,12 @@
     "from ray.train.torch import TorchTrainer\n",
     "from ray.train import RunConfig, ScalingConfig\n",
     "\n",
-    "batch_size = 16\n",
-    "train_ds_size = processed_datasets[\"train\"].count()\n",
-    "steps_per_epoch = train_ds_size // (batch_size * num_workers)\n",
-    "\n",
     "trainer = TorchTrainer(\n",
     "    train_loop_per_worker=train_func,\n",
     "    train_loop_config={\n",
     "        \"epochs\": 1,\n",
     "        \"batch_size\": batch_size,  # per device\n",
-    "        \"steps_per_epoch\": steps_per_epoch\n",
+    "        \"steps_per_epoch\": steps_per_epoch,\n",
     "    },\n",
     "    scaling_config=ScalingConfig(\n",
     "        num_workers=num_workers,\n",
@@ -1446,7 +1475,9 @@
    ],
    "source": [
     "# Generate from prompts!\n",
-    "for sentence in pipe([\"Romeo and Juliet\", \"Romeo\", \"Juliet\"], do_sample=True, min_length=20):\n",
+    "for sentence in pipe(\n",
+    "    [\"Romeo and Juliet\", \"Romeo\", \"Juliet\"], do_sample=True, min_length=20\n",
+    "):\n",
     "    print(sentence)"
    ]
   }
@@ -1467,7 +1498,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.9.18"
   },
   "orphan": true,
   "vscode": {

--- a/release/air_examples/gptj_deepspeed_finetuning/gptj_deepspeed_compute_aws.yaml
+++ b/release/air_examples/gptj_deepspeed_finetuning/gptj_deepspeed_compute_aws.yaml
@@ -8,8 +8,8 @@ head_node_type:
 worker_node_types:
     - name: worker_node
       instance_type: g4dn.4xlarge
-      min_workers: 15
-      max_workers: 15
+      min_workers: 7
+      max_workers: 7
       use_spot: false
 
 aws:

--- a/release/air_examples/gptj_deepspeed_finetuning/gptj_deepspeed_compute_gce.yaml
+++ b/release/air_examples/gptj_deepspeed_finetuning/gptj_deepspeed_compute_gce.yaml
@@ -10,8 +10,8 @@ head_node_type:
 worker_node_types:
     - name: worker_node
       instance_type: n1-standard-16-nvidia-tesla-t4-1
-      min_workers: 15
-      max_workers: 15
+      min_workers: 7
+      max_workers: 7
       use_spot: false
 
 #aws:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR fixes the `air_example_gptj_deepspeed_fine_tuning` release test to be less sensitive to data ordering. This test has failed in the past for a similar reason: Ray Data changes some implementation details, most likely causing the data ordering to change a little bit. Since this example uses fp16 weights to fit the GPTJ 6B model into a T4 16GB GPU, the learning dynamics are pretty brittle, and the gradients can blow up to NaN/inf pretty easily, just with a slightly different data ordering.

The previous fix (https://github.com/ray-project/ray/pull/40648) was to add a seeded `random_shuffle` to the dataset preprocessing pipeline that caused the fp16 training to run stably for an epoch. Since then, the test has started facing training instability again (and erroring out in the middle), so this PR introduces a longer term solution, which is to increase the tolerance of skipping batches when NaN/inf gradients appear. This is controlled by the `hysteresis` and `consecutive_hysteresis` deepspeed fp16 parameters:
* `hysteresis=4`: You must have 4 batches in a row give NaN/inf gradients before reducing the loss scale factor by 2
* `consecutive_hysteresis=True`: Any non-NaN/inf gradient batch will reset the counter back to 4.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/41391

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
