### PR TITLE
[ci] move core/serverless window python tests to rayci

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -43,6 +43,23 @@ steps:
         --test-env=TEST_EXTERNAL_REDIS=1
         --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,xcommit,container,manual
 
+  - label: ":ray: core: :windows: python tests"
+    tags: python
+    job_env: WINDOWS
+    instance_type: windows
+    parallelism: 5
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
+        --build-name windowsbuild
+        --operating-system windows
+        --except-tags no_windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 2
+    depends_on: windowsbuild
+
   - label: ":ray: core: memory pressure tests"
     tags:
       - python
@@ -313,12 +330,3 @@ steps:
       - forge
       - raycpubase
       - corebuild
-    
-  - label: ":windows: python tests"
-    tags:
-      - python
-    job_env: WINDOWS
-    instance_type: windows
-    commands:
-      - bash /c/workdir/.buildkite/windows_ci.sh test_python
-    parallelism: 10

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -41,7 +41,23 @@ steps:
     instance_type: windows
     commands:
       - bash ci/ray_ci/windows/install_tools.sh
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
+      - bazel run //ci/ray_ci:test_in_docker -- ///:all //src/... /python/ray/tests/... core
+        --run-flaky-tests
+        --build-name windowsbuild
+        --operating-system windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless
+        --skip-ray-installation
+        --run-flaky-tests
+        --build-name windowsbuild
+        --operating-system windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+      - bazel run //ci/ray_ci:test_in_docker -- /python/ray/serve/... serve
+        --skip-ray-installation
         --run-flaky-tests
         --build-name windowsbuild
         --operating-system windows
@@ -49,3 +65,4 @@ steps:
         --test-env=RAY_CI_POST_WHEEL_TESTS="1"
         --test-env=USERPROFILE
     depends_on: windowsbuild
+    soft_fail: true

--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -19,6 +19,22 @@ steps:
         --parallelism-per-worker 3
         --except-tags manual,kuberay_operator,spark_plugin_tests
 
+  - label: ":serverless: serverless: :windows: tests"
+    tags: python
+    job_env: WINDOWS
+    instance_type: windows
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless
+        --build-name windowsbuild
+        --operating-system windows
+        --except-tags no_windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+        --parallelism-per-worker 3
+    depends_on: windowsbuild
+
   - label: ":serverless: serverless: spark tests"
     tags: python
     instance_type: medium

--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -1,3 +1,11 @@
 flaky_tests:
   - //python/ray/tests:test_autoscaler
   - windows://:metric_exporter_grpc_test
+  - windows://python/ray/tests:test_actor_retry
+  - windows://python/ray/tests:test_object_spilling
+  - windows://python/ray/tests:test_object_spilling_asan
+  - windows://python/ray/tests:test_object_spilling_debug_mode
+  - windows://python/ray/tests:test_placement_group_3
+  - windows://python/ray/tests:test_reference_counting_2 
+  - windows://python/ray/tests:test_runtime_env_working_dir_3
+  - windows://python/ray/tests:test_task_events_2

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -41,7 +41,6 @@ py_test_module_list(
     "test_autoscaling_policy.py",
     "test_actor_cancel.py",
     "test_dashboard_profiler.py",
-    "test_gcs_fault_tolerance.py",
     "test_gcs_utils.py",
     "test_metrics_agent.py",
     "test_metrics_head.py",
@@ -49,19 +48,28 @@ py_test_module_list(
     "test_component_failures_3.py",
     "test_error_ray_not_initialized.py",
     "test_gcs_pubsub.py",
-    "test_global_gc.py",
     "test_grpc_client_credentials.py",
-    "test_job.py",
     "test_get_locations.py",
     "test_global_state.py",
     "test_healthcheck.py",
     "test_kill_raylet_signal_log.py",
-    "test_memstat.py",
     "test_node_label_scheduling_strategy.py",
     "test_protobuf_compatibility.py"
   ],
   size = "medium",
   tags = ["exclusive", "medium_size_python_tests_a_to_j", "team:core"],
+  deps = ["//:ray_lib", ":conftest"],
+)
+
+py_test_module_list(
+  files = [
+    "test_gcs_fault_tolerance.py",
+    "test_global_gc.py",
+    "test_job.py",
+    "test_memstat.py",
+  ],
+  size = "medium",
+  tags = ["exclusive", "medium_size_python_tests_a_to_j", "no_windows", "team:core"],
   deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -87,7 +95,6 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_client_builder.py",
-    "test_client_init.py",
     "test_client_proxy.py",
     "test_client_compat.py",
     "test_client_multi.py",
@@ -97,6 +104,15 @@ py_test_module_list(
   ],
   size = "medium",
   tags = ["exclusive", "client_tests", "team:core"],
+  deps = ["//:ray_lib", ":conftest"],
+)
+
+py_test_module_list(
+  files = [
+    "test_client_init.py",
+  ],
+  size = "medium",
+  tags = ["exclusive", "client_tests", "no_windows", "team:core"],
   deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -152,7 +168,6 @@ py_test_module_list(
     "test_ray_init.py",
     "test_ray_init_2.py",
     "test_ray_shutdown.py",
-    "test_resource_demand_scheduler.py",
     "test_resource_metrics.py",
     "test_runtime_context.py",
     "test_runtime_env_env_vars.py",
@@ -165,14 +180,11 @@ py_test_module_list(
     "test_shuffle.py",
     "test_state_api_log.py",
     "test_state_api_summary.py",
-    "test_stress.py",
-    "test_stress_sharded.py",
     "test_tempfile.py",
     "test_tensorflow.py",
     "test_tls_auth.py",
     "test_ray_debugger.py",
     "test_worker_capping.py",
-    "test_object_manager.py",
     "test_multi_tenancy.py",
     "test_namespace.py",
     "test_scheduling.py",
@@ -189,6 +201,18 @@ py_test_module_list(
   ],
   size = "medium",
   tags = ["exclusive", "medium_size_python_tests_k_to_z", "team:core"],
+  deps = ["//:ray_lib", ":conftest"],
+)
+
+py_test_module_list(
+  files = [
+    "test_object_manager.py",
+    "test_resource_demand_scheduler.py",
+    "test_stress.py",
+    "test_stress_sharded.py",
+  ],
+  size = "medium",
+  tags = ["exclusive", "medium_size_python_tests_k_to_z", "no_windows", "team:core"],
   deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -315,7 +339,6 @@ py_test_module_list(
 
 py_test_module_list(
   files = [
-    "test_autoscaler.py",
     "test_autoscaler_drain_node_api.py",
     "test_autoscaler_util.py",
     "test_autoscaler_gcp.py",
@@ -327,12 +350,18 @@ py_test_module_list(
 
 py_test_module_list(
   files = [
-    "test_batch_node_provider_unit.py",
-    "test_batch_node_provider_integration.py",
+    "test_autoscaler.py",
+  ],
+  size = "small",
+  tags = ["exclusive", "small_size_python_tests", "no_windows", "team:core"],
+  deps = ["//:ray_lib", ":conftest"],
+)
+
+py_test_module_list(
+  files = [
     "test_cli_logger.py",
     "test_client_metadata.py",
     "test_client_terminate.py",
-    "test_command_runner.py",
     "test_coordinator_server.py",
     "test_monitor.py",
     "test_node_provider_availability_tracker.py",
@@ -342,6 +371,17 @@ py_test_module_list(
   ],
   size = "small",
   tags = ["exclusive", "small_size_python_tests", "team:serverless"],
+  deps = ["//:ray_lib", ":conftest"],
+)
+
+py_test_module_list(
+  files = [
+    "test_command_runner.py",
+    "test_batch_node_provider_unit.py",
+    "test_batch_node_provider_integration.py",
+  ],
+  size = "small",
+  tags = ["exclusive", "small_size_python_tests", "no_windows", "team:serverless"],
   deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -379,7 +419,6 @@ py_test_module_list(
     "test_actor_failures.py",
     "test_actor_resources.py",
     "test_failure.py",
-    "test_actor_advanced.py",
     "test_multi_node.py",
     "test_threaded_actor.py",
     "test_generators.py",
@@ -406,12 +445,21 @@ py_test_module_list(
   deps = ["//:ray_lib", ":conftest"],
 )
 
+py_test_module_list(
+  files = [
+    "test_actor_advanced.py",
+  ],
+  size = "large",
+  tags = ["exclusive", "large_size_python_tests_shard_0", "no_windows", "team:core"],
+  deps = ["//:ray_lib", ":conftest"],
+)
+
 py_test(
   name = "test_cli",
   srcs = ["test_cli.py"],
   data = glob(["test_cli_patterns/*.txt", "test_cli_patterns/*.yaml"]),
   size = "large",
-  tags = ["exclusive", "large_size_python_tests_shard_0", "team:core"],
+  tags = ["exclusive", "large_size_python_tests_shard_0", "no_windows", "team:core"],
   deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -428,12 +476,20 @@ py_test_module_list(
     "test_plasma_unlimited.py",
     "test_placement_group_mini_integration.py",
     "test_scheduling_2.py",
-    "test_multi_node_3.py",
     "test_multiprocessing.py",
     "test_reference_counting.py",
   ],
   size = "large",
   tags = ["exclusive", "large_size_python_tests_shard_1", "team:core"],
+  deps = ["//:ray_lib", ":conftest"],
+)
+
+py_test_module_list(
+  files = [
+    "test_multi_node_3.py",
+  ],
+  size = "large",
+  tags = ["exclusive", "large_size_python_tests_shard_1", "no_windows", "team:core"],
   deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -507,7 +563,7 @@ py_test(
     name = "test_autoscaler_aws",
     size = "small",
     srcs = ["aws/test_autoscaler_aws.py"],
-    tags = ["exclusive", "small_size_python_tests", "team:core"],
+    tags = ["exclusive", "small_size_python_tests", "no_windows", "team:core"],
     deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -531,7 +587,7 @@ py_test(
     name = "test_gcp_tpu_command_runner",
     size = "small",
     srcs = ["gcp/test_gcp_tpu_command_runner.py"],
-    tags = ["exclusive", "small_size_python_tests", "team:serverless"],
+    tags = ["exclusive", "small_size_python_tests", "no_windows", "team:serverless"],
     deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -539,7 +595,7 @@ py_test(
     name = "vsphere/test_vsphere_node_provider",
     size = "small",
     srcs = ["vsphere/test_vsphere_node_provider.py"],
-    tags = ["exclusive", "small_size_python_tests", "team:serverless"],
+    tags = ["exclusive", "small_size_python_tests", "no_windows", "team:serverless"],
     deps = ["//:ray_lib", ":conftest"],
 )
 
@@ -559,7 +615,7 @@ py_test(
   name = "test_tracing",
   size = "medium",
   srcs = ["test_tracing.py"],
-  tags = ["exclusive", "medium_size_python_tests_k_to_z", "team:serve"],
+  tags = ["exclusive", "medium_size_python_tests_k_to_z", "no_windows", "team:serve"],
   deps = ["//:ray_lib", ":conftest"]
 )
 
@@ -587,7 +643,7 @@ py_test(
     name = "kuberay/test_autoscaling_e2e",
     size = "large",
     srcs = ["kuberay/test_autoscaling_e2e.py"],
-    tags = ["exclusive", "kuberay_operator", "team:serverless"],
+    tags = ["exclusive", "kuberay_operator", "no_windows", "team:serverless"],
     deps = ["//:ray_lib", ":conftest"],
 )
 


### PR DESCRIPTION
Move core+serverless window python tests to rayci

Test:
- CI