### PR TITLE
[ci] migrate cpp window tests to rayci

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -240,6 +240,22 @@ steps:
         --except-tags no_tsan
         --parallelism-per-worker 2
 
+  - label: ":ray: core: :windows: cpp tests"
+    tags: core_cpp
+    job_env: WINDOWS
+    instance_type: windows
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
+        --build-name windowsbuild
+        --operating-system windows
+        --except-tags no_windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+        --parallelism-per-worker 2
+    depends_on: windowsbuild
+
   - label: ":ray: core: flaky tests"
     tags:
       - python
@@ -306,11 +322,3 @@ steps:
     commands:
       - bash /c/workdir/.buildkite/windows_ci.sh test_python
     parallelism: 10
-
-  - label: ":windows: core tests"
-    tags:
-      - core_cpp
-    job_env: WINDOWS
-    instance_type: windows
-    commands:
-      - bash /c/workdir/.buildkite/windows_ci.sh test_core

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -34,3 +34,18 @@ steps:
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild /bin/bash -iecuo pipefail 
         "./java/test.sh"
     depends_on: [ "corebuild", "forge" ]
+
+  - label: "flaky :windows: tests"
+    tags: skip-on-premerge
+    job_env: WINDOWS
+    instance_type: windows
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
+        --run-flaky-tests
+        --build-name windowsbuild
+        --operating-system windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+    depends_on: windowsbuild

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -811,7 +811,7 @@ ray_cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
-    tags = ["team:core", "manual"],
+    tags = ["team:core", "no_windows", "manual"],
     deps = [
         ":core_worker_lib",
         ":gcs",
@@ -1564,7 +1564,7 @@ ray_cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
-    tags = ["team:core", "no_tsan"],
+    tags = ["team:core", "no_windows", "no_tsan"],
     deps = [
         ":gcs_server_lib",
         ":gcs_test_util_lib",
@@ -1610,7 +1610,7 @@ ray_cc_test(
     srcs = [
         "src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc",
     ],
-    tags = ["team:core"],
+    tags = ["team:core", "no_windows"],
     deps = [
         ":gcs_server_lib",
         "@com_google_googletest//:gtest_main",
@@ -1977,7 +1977,7 @@ ray_cc_test(
         "//:redis-cli",
         "//:redis-server",
     ],
-    tags = ["team:core"],
+    tags = ["team:core", "no_windows"],
     deps = [
         ":gcs_client_lib",
         ":gcs_server_lib",
@@ -2224,7 +2224,7 @@ ray_cc_test(
         "//:redis-server",
     ],
     env = {"REDIS_CHAOS": "1"},
-    tags = ["team:core"],
+    tags = ["team:core", "no_windows"],
     target_compatible_with = [
         "@platforms//os:linux",
     ],

--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -1,2 +1,3 @@
 flaky_tests:
   - //python/ray/tests:test_autoscaler
+  - windows://:metric_exporter_grpc_test

--- a/src/ray/common/test/BUILD
+++ b/src/ray/common/test/BUILD
@@ -45,6 +45,7 @@ ray_cc_test(
     tags = [
         "no_tsan",
         "no_ubsan",
+        "no_windows",
         "team:core",
     ],
     deps = [
@@ -166,7 +167,7 @@ ray_cc_test(
     srcs = [
         "memory_monitor_test.cc",
     ],
-    tags = ["team:core"],
+    tags = ["team:core", "no_windows"],
     target_compatible_with = [
         "@platforms//os:linux",
     ],

--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -34,6 +34,7 @@ cc_test(
     copts = COPTS,
     tags = [
         "no_tsan",
+        "no_windows",
         "team:core",
     ],
     deps = [


### PR DESCRIPTION
Migrate window cpp tests to rayci
- Mark windows://:metric_exporter_grpc_test as flaky
- Mark tests we don't want to run in windows as no_windows

Test:
- CI