### PR TITLE
Revert "[release] Fix golden_notebook_torch_tune_serve_test missing argument"

### DIFF
--- a/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
+++ b/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
@@ -96,7 +96,7 @@ def training_loop(config):
     criterion = nn.CrossEntropyLoss()
 
     for epoch_idx in range(2):
-        train_epoch(epoch_idx, train_loader, model, criterion, optimizer)
+        train_epoch(train_loader, model, criterion, optimizer)
         validation_loss = validate_epoch(validation_loader, model, criterion)
 
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This reverts commit a90417dcf90de0ed26da19ece0c0ba7b8d8fc4fa.

There were 2 similarly named PRs merged into master -- one of which broke the serve release test. The PR that didn't break the serve test was merged into the release branch, and I accidentally picked in the fix PR that was not actually needed on this branch.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
