### PR TITLE
[Core] Fix check failure when sync and async tasks are mixed up #41724

### DIFF
--- a/python/ray/tests/test_streaming_generator_4.py
+++ b/python/ray/tests/test_streaming_generator_4.py
@@ -4,6 +4,9 @@ import sys
 import time
 import gc
 import random
+import asyncio
+from typing import Optional
+from pydantic import BaseModel
 
 import ray
 
@@ -132,6 +135,60 @@ def test_local_gc_not_hang(shutdown_only, monkeypatch):
         # It should not hang.
         for ref in gen:
             ray.get(gen)
+
+
+def test_sync_async_mix_regression_test(shutdown_only):
+    """Verify when sync and async tasks are mixed up
+    it doesn't raise a segfault
+
+    https://github.com/ray-project/ray/issues/41346
+    """
+
+    class PayloadPydantic(BaseModel):
+        class Error(BaseModel):
+            msg: str
+            code: int
+            type: str
+
+        text: Optional[str] = None
+        ts: Optional[float] = None
+        reason: Optional[str] = None
+        error: Optional[Error] = None
+
+    ray.init()
+
+    @ray.remote
+    class B:
+        def __init__(self, a):
+            self.a = a
+
+        async def stream(self):
+            async for ref in self.a.stream.remote(1):
+                print("stream")
+                await ref
+
+        async def start(self):
+            await asyncio.gather(*[self.stream() for _ in range(2)])
+
+    @ray.remote
+    class A:
+        def stream(self, i):
+            payload = PayloadPydantic(
+                text="Test output",
+                ts=time.time(),
+                reason="Success!",
+            )
+
+            for _ in range(10):
+                yield payload
+
+        async def aio_stream(self):
+            for _ in range(10):
+                yield 1
+
+    a = A.remote()
+    b = B.remote(a)
+    ray.get(b.start.remote())
 
 
 if __name__ == "__main__":

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2991,10 +2991,11 @@ Status CoreWorker::ReportGeneratorItemReturns(
           const Status &status, const rpc::ReportGeneratorItemReturnsReply &reply) {
         RAY_LOG(DEBUG) << "ReportGeneratorItemReturns replied. " << generator_id
                        << "index: " << item_index
-                       << ". Total object consumed: " << waiter->TotalObjectConsumed()
-                       << ". Total object generated: " << waiter->TotalObjectGenerated()
                        << ". total_consumed_reported: "
                        << reply.total_num_object_consumed();
+        RAY_CHECK(waiter != nullptr);
+        RAY_LOG(DEBUG) << "Total object consumed: " << waiter->TotalObjectConsumed()
+                       << ". Total object generated: " << waiter->TotalObjectGenerated();
         if (status.ok()) {
           /// Since unary gRPC requests are not ordered, it is possible the stale
           /// total value can be replied. Since total object consumed only can


### PR DESCRIPTION
When sync and async tasks are mixed up, there are sometimes where TaskID is not correctly set, which causes the check failure. This is the case where check failure correctly found a bug.

I fixed the issue by passing TaskID correctly. Also improved get_current_task_id API to always return the correct task ID when used within raylet.pyx

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
