### PR TITLE
[data][train] Fix air_benchmark_xgboost_cpu_10

### DIFF
--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -81,6 +81,10 @@ def test_autoshutdown_dangling_executors(ray_start_10_cpus_shared):
     initial = streaming_executor._num_shutdown
     for _ in range(num_runs):
         executor = StreamingExecutor(ExecutionOptions())
+        o = InputDataBuffer([])
+        # Start the executor. Because non-started executors don't
+        # need to be shut down.
+        executor.execute(o)
         del executor
     assert streaming_executor._num_shutdown - initial == num_runs
 

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -81,10 +81,6 @@ def test_autoshutdown_dangling_executors(ray_start_10_cpus_shared):
     initial = streaming_executor._num_shutdown
     for _ in range(num_runs):
         executor = StreamingExecutor(ExecutionOptions())
-        o = InputDataBuffer([])
-        # Start the executor. Because non-started executors don't
-        # need to be shut down.
-        executor.execute(o)
         del executor
     assert streaming_executor._num_shutdown - initial == num_runs
 

--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -125,7 +125,7 @@ def run_xgboost_prediction(model_path: str, data_path: str):
         # Improve prediction throughput for xgboost with larger
         # batch size than default 4096
         batch_size=8192,
-        compute=ray.data.ActorPoolStrategy(min_size=1, max_size=None),
+        concurrency=50,
         fn_constructor_kwargs={"model": model},
         batch_format="pandas",
     )

--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -125,7 +125,7 @@ def run_xgboost_prediction(model_path: str, data_path: str):
         # Improve prediction throughput for xgboost with larger
         # batch size than default 4096
         batch_size=8192,
-        concurrency=50,
+        concurrency=80,
         fn_constructor_kwargs={"model": model},
         batch_format="pandas",
     )

--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -120,12 +120,13 @@ def run_xgboost_prediction(model_path: str, data_path: str):
             dmatrix = xgb.DMatrix(data)
             return {"predictions": self.model.predict(dmatrix)}
 
+    concurrency = ray.cluster_resources()["CPU"] // 2
     result = ds.map_batches(
         XGBoostPredictor,
         # Improve prediction throughput for xgboost with larger
         # batch size than default 4096
         batch_size=8192,
-        concurrency=80,
+        concurrency=concurrency,
         fn_constructor_kwargs={"model": model},
         batch_format="pandas",
     )

--- a/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
+++ b/release/air_tests/air_benchmarks/workloads/xgboost_benchmark.py
@@ -120,7 +120,7 @@ def run_xgboost_prediction(model_path: str, data_path: str):
             dmatrix = xgb.DMatrix(data)
             return {"predictions": self.model.predict(dmatrix)}
 
-    concurrency = ray.cluster_resources()["CPU"] // 2
+    concurrency = int(ray.cluster_resources()["CPU"] // 2)
     result = ds.map_batches(
         XGBoostPredictor,
         # Improve prediction throughput for xgboost with larger


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`air_benchmark_xgboost_cpu_10` is failing because actor pool autoscaling strategy is problematic and it makes data ingestion too slow. Changing to fixed sized actor pool to fix this issue.

The autoscaling issue will be fixed later, as it's not a commonly used feature. https://github.com/ray-project/ray/issues/41956

## Related issue number

Closes https://github.com/ray-project/ray/issues/41859

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
