### PR TITLE
[ci] fix build upload info for windows

### DIFF
--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -14,6 +14,7 @@ _DOCKER_GCP_REGISTRY = os.environ.get(
     "us-west1-docker.pkg.dev/anyscale-oss-ci",
 )
 _DOCKER_ENV = [
+    "BUILDKITE",
     "BUILDKITE_BUILD_URL",
     "BUILDKITE_BRANCH",
     "BUILDKITE_COMMIT",

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -51,7 +51,7 @@ def test_run_tests_in_docker() -> None:
             "team", build_type="debug", test_envs=["ENV_01", "ENV_02"]
         )._run_tests_in_docker(["t1", "t2"], [0, 1], ["v=k"], "flag")
         input_str = inputs[-1]
-        assert "--env ENV_01 --env ENV_02 --env BUILDKITE_BUILD_URL" in input_str
+        assert "--env ENV_01 --env ENV_02 --env BUILDKITE" in input_str
         assert '--gpus "device=0,1"' in input_str
         assert (
             "bazel test --jobs=1 --config=ci $(./ci/run/bazel_export_options) "

--- a/ci/ray_ci/test_windows_container.py
+++ b/ci/ray_ci/test_windows_container.py
@@ -4,6 +4,7 @@ from unittest import mock
 from typing import List
 
 from ci.ray_ci.windows_container import WindowsContainer
+from ci.ray_ci.container import _DOCKER_ENV
 
 
 def test_install_ray() -> None:
@@ -36,23 +37,16 @@ def test_install_ray() -> None:
 
 def test_get_run_command() -> None:
     container = WindowsContainer("test")
+    envs = []
+    for env in _DOCKER_ENV:
+        envs.extend(["--env", env])
+
     assert container.get_run_command(["hi", "hello"]) == [
         "docker",
         "run",
         "-i",
         "--rm",
-        "--env",
-        "BUILDKITE_BUILD_URL",
-        "--env",
-        "BUILDKITE_BRANCH",
-        "--env",
-        "BUILDKITE_COMMIT",
-        "--env",
-        "BUILDKITE_JOB_ID",
-        "--env",
-        "BUILDKITE_LABEL",
-        "--env",
-        "BUILDKITE_PIPELINE_ID",
+    ] + envs + [
         "029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp:unknown-test",
         "bash",
         "-c",

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import subprocess
 from typing import List, Optional
 
@@ -85,6 +86,11 @@ class TesterContainer(Container):
                     "cleanup() { ./ci/build/upload_build_info.sh; }",
                     "trap cleanup EXIT",
                 ]
+            )
+        if platform.system() == "Windows":
+            # allow window tests to access aws services
+            commands.append(
+                "powershell ci/pipeline/fix-windows-container-networking.ps1"
             )
         if self.build_type == "ubsan":
             # clang currently runs into problems with ubsan builds, this will revert to


### PR DESCRIPTION
Need another en variable for go/flaky upload to work in windows. Currently failing with https://buildkite.com/ray-project/postmerge/builds/2191#018c6eb6-d391-4b82-a804-a9b60aa19e05/5929-5945

Validating with https://buildkite.com/ray-project/postmerge/builds/2199

Test:
- CI