### PR TITLE
[core][performance] Changed some memcpy calls to use constexpr sizes

### DIFF
--- a/src/ray/common/id.cc
+++ b/src/ray/common/id.cc
@@ -74,7 +74,7 @@ WorkerID ComputeDriverIdFromJob(const JobID &job_id) {
   std::memcpy(data.data(), job_id.Data(), JobID::Size());
   std::fill_n(data.data() + JobID::Size(), WorkerID::Size() - JobID::Size(), 0xFF);
   return WorkerID::FromBinary(
-      std::string(reinterpret_cast<const char *>(data.data()), data.size()));
+      std::string(reinterpret_cast<const char *>(data.data()), WorkerID::Size()));
 }
 
 // This code is from https://sites.google.com/site/murmurhash/
@@ -296,7 +296,7 @@ JobID JobID::FromInt(uint32_t value) {
   std::vector<uint8_t> data(JobID::Size(), 0);
   std::memcpy(data.data(), &value, JobID::Size());
   return JobID::FromBinary(
-      std::string(reinterpret_cast<const char *>(data.data()), data.size()));
+      std::string(reinterpret_cast<const char *>(data.data()), JobID::Size()));
 }
 
 uint32_t JobID::ToInt() {

--- a/src/ray/common/id.cc
+++ b/src/ray/common/id.cc
@@ -70,11 +70,10 @@ void FillNil(T *data) {
 }
 
 WorkerID ComputeDriverIdFromJob(const JobID &job_id) {
-  std::vector<uint8_t> data(WorkerID::Size(), 0);
+  std::string data(WorkerID::Size(), '\0');
   std::memcpy(data.data(), job_id.Data(), JobID::Size());
-  std::fill_n(data.data() + JobID::Size(), WorkerID::Size() - JobID::Size(), 0xFF);
-  return WorkerID::FromBinary(
-      std::string(reinterpret_cast<const char *>(data.data()), WorkerID::Size()));
+  std::fill_n(data.data() + JobID::Size(), WorkerID::Size() - JobID::Size(), (char)0xFF);
+  return WorkerID::FromBinary(data);
 }
 
 // This code is from https://sites.google.com/site/murmurhash/
@@ -255,11 +254,9 @@ ObjectID ObjectID::FromIndex(const TaskID &task_id, ObjectIDIndexType index) {
 }
 
 ObjectID ObjectID::FromRandom() {
-  std::vector<uint8_t> task_id_bytes(TaskID::kLength, 0x0);
+  std::string task_id_bytes(TaskID::kLength, (char)0xFF);
   FillRandom(&task_id_bytes);
-
-  return GenerateObjectId(std::string(
-      reinterpret_cast<const char *>(task_id_bytes.data()), task_id_bytes.size()));
+  return GenerateObjectId(task_id_bytes);
 }
 
 ObjectID ObjectID::ForActorHandle(const ActorID &actor_id) {
@@ -293,10 +290,9 @@ ObjectID ObjectID::GenerateObjectId(const std::string &task_id_binary,
 }
 
 JobID JobID::FromInt(uint32_t value) {
-  std::vector<uint8_t> data(JobID::Size(), 0);
+  std::string data(JobID::Size(), '\0');
   std::memcpy(data.data(), &value, JobID::Size());
-  return JobID::FromBinary(
-      std::string(reinterpret_cast<const char *>(data.data()), JobID::Size()));
+  return JobID::FromBinary(data);
 }
 
 uint32_t JobID::ToInt() {

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -75,10 +75,10 @@ class BaseID {
 
  protected:
   BaseID(const std::string &binary) {
-    RAY_CHECK(binary.size() == Size() || binary.size() == 0)
-        << "expected size is " << Size() << ", but got data " << binary << " of size "
-        << binary.size();
     if (!binary.empty()) {
+      RAY_CHECK(binary.size() == Size())
+          << "expected size is " << Size() << ", but got data " << binary << " of size "
+          << binary.size();
       std::memcpy(const_cast<uint8_t *>(this->Data()), binary.data(), Size());
     }
   }
@@ -403,11 +403,11 @@ std::ostream &operator<<(std::ostream &os, const PlacementGroupID &id);
                                                                                          \
    private:                                                                              \
     explicit type(const std::string &binary) {                                           \
-      RAY_CHECK(binary.size() == Size() || binary.size() == 0)                           \
-          << "expected size is " << Size() << ", but got data " << binary << " of size " \
-          << binary.size();                                                              \
       if (!binary.empty()) {                                                             \
-        std::memcpy(&id_, binary.data(), kUniqueIDSize);                                 \
+        RAY_CHECK(binary.size() == Size())                                               \
+            << "expected size is " << Size() << ", but got data " << binary              \
+            << " of size " << binary.size();                                             \
+        std::memcpy(&id_, binary.data(), Size());                                        \
       }                                                                                  \
     }                                                                                    \
   };
@@ -435,12 +435,14 @@ T BaseID<T>::FromRandom() {
 
 template <typename T>
 T BaseID<T>::FromBinary(const std::string &binary) {
-  RAY_CHECK(binary.size() == T::Size() || binary.size() == 0)
-      << "expected size is " << T::Size() << ", but got data size is " << binary.size();
   T t;
-  if (!binary.empty()) {
-    std::memcpy(t.MutableData(), binary.data(), T::Size());
+  if (binary.empty()) {
+    return t;  // nil
   }
+  RAY_CHECK(binary.size() == T::Size())
+      << "expected size is " << T::Size() << ", but got data size is " << binary.size();
+
+  std::memcpy(t.MutableData(), binary.data(), T::Size());
   return t;
 }
 

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -78,7 +78,9 @@ class BaseID {
     RAY_CHECK(binary.size() == Size() || binary.size() == 0)
         << "expected size is " << Size() << ", but got data " << binary << " of size "
         << binary.size();
-    std::memcpy(const_cast<uint8_t *>(this->Data()), binary.data(), binary.size());
+    if (!binary.empty()) {
+      std::memcpy(const_cast<uint8_t *>(this->Data()), binary.data(), Size());
+    }
   }
   // All IDs are immutable for hash evaluations. MutableData is only allow to use
   // in construction time, so this function is protected.
@@ -404,7 +406,9 @@ std::ostream &operator<<(std::ostream &os, const PlacementGroupID &id);
       RAY_CHECK(binary.size() == Size() || binary.size() == 0)                           \
           << "expected size is " << Size() << ", but got data " << binary << " of size " \
           << binary.size();                                                              \
-      std::memcpy(&id_, binary.data(), binary.size());                                   \
+      if (!binary.empty()) {                                                             \
+        std::memcpy(&id_, binary.data(), kUniqueIDSize);                                 \
+      }                                                                                  \
     }                                                                                    \
   };
 
@@ -434,7 +438,9 @@ T BaseID<T>::FromBinary(const std::string &binary) {
   RAY_CHECK(binary.size() == T::Size() || binary.size() == 0)
       << "expected size is " << T::Size() << ", but got data size is " << binary.size();
   T t;
-  std::memcpy(t.MutableData(), binary.data(), binary.size());
+  if (!binary.empty()) {
+    std::memcpy(t.MutableData(), binary.data(), T::Size());
+  }
   return t;
 }
 
@@ -485,8 +491,7 @@ const T &BaseID<T>::Nil() {
 
 template <typename T>
 bool BaseID<T>::IsNil() const {
-  static T nil_id = T::Nil();
-  return *this == nil_id;
+  return *this == T::Nil();
 }
 
 template <typename T>


### PR DESCRIPTION
In Ray IDs there are some `memcpy`s. Ideally we should always use immediate values for the values call,  because we know it statically. In reality we sometimes used a dynamic one. This PR fixes it.

The perf gain should be minor though.