### PR TITLE
[Core] improve agent health checking mechanism (#41935)

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -223,9 +223,9 @@ class DashboardAgent:
         tasks = [m.run(self.server) for m in modules]
         if sys.platform not in ["win32", "cygwin"]:
 
-            def callback():
+            def callback(msg):
                 logger.info(
-                    f"Terminated Raylet: ip={self.ip}, node_id={self.node_id}. "
+                    f"Terminated Raylet: ip={self.ip}, node_id={self.node_id}. {msg}"
                 )
 
             check_parent_task = create_check_raylet_task(

--- a/dashboard/consts.py
+++ b/dashboard/consts.py
@@ -1,4 +1,4 @@
-from ray._private.ray_constants import env_integer
+from ray._private.ray_constants import env_integer, env_bool
 
 DASHBOARD_LOG_FILENAME = "dashboard.log"
 DASHBOARD_AGENT_PORT_PREFIX = "DASHBOARD_AGENT_PORT_PREFIX:"
@@ -79,3 +79,6 @@ AVAILABLE_COMPONENT_NAMES_FOR_METRICS = {
     "dashboard",
     "gcs",
 }
+PARENT_HEALTH_CHECK_BY_PIPE = env_bool(
+    "RAY_enable_pipe_based_agent_to_parent_health_check", False
+)

--- a/dashboard/tests/test_dashboard.py
+++ b/dashboard/tests/test_dashboard.py
@@ -213,8 +213,16 @@ def test_raylet_and_agent_share_fate(shutdown_only):
     raylet_proc.wait(15)
 
 
-def test_agent_report_unexpected_raylet_death(shutdown_only):
+@pytest.mark.parametrize("parent_health_check_by_pipe", [True, False])
+def test_agent_report_unexpected_raylet_death(
+    monkeypatch, shutdown_only, parent_health_check_by_pipe
+):
     """Test agent reports Raylet death if it is not SIGTERM."""
+
+    monkeypatch.setenv(
+        "RAY_enable_pipe_based_agent_to_parent_health_check",
+        parent_health_check_by_pipe,
+    )
 
     ray.init()
     p = init_error_pubsub()
@@ -247,8 +255,16 @@ def test_agent_report_unexpected_raylet_death(shutdown_only):
     )
 
 
-def test_agent_report_unexpected_raylet_death_large_file(shutdown_only):
+@pytest.mark.parametrize("parent_health_check_by_pipe", [True, False])
+def test_agent_report_unexpected_raylet_death_large_file(
+    monkeypatch, shutdown_only, parent_health_check_by_pipe
+):
     """Test agent reports Raylet death if it is not SIGTERM."""
+
+    monkeypatch.setenv(
+        "RAY_enable_pipe_based_agent_to_parent_health_check",
+        parent_health_check_by_pipe,
+    )
 
     ray.init()
     p = init_error_pubsub()

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -194,11 +194,12 @@ if __name__ == "__main__":
     check_raylet_task = None
     if sys.platform not in ["win32", "cygwin"]:
 
-        def parent_dead_callback():
+        def parent_dead_callback(msg):
             agent._logger.info(
                 "Raylet is dead! Exiting Runtime Env Agent. "
                 f"addr: {args.node_ip_address}, "
-                f"port: {args.runtime_env_agent_port}"
+                f"port: {args.runtime_env_agent_port}\n"
+                f"{msg}"
             )
 
         # No need to await this task.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -578,6 +578,10 @@ RAY_CONFIG(uint32_t, agent_register_timeout_ms, 100 * 1000)
 RAY_CONFIG(uint32_t, agent_register_timeout_ms, 30 * 1000)
 #endif
 
+/// If true, agent checks the health of parent by reading pipe.
+/// If false, it checks the parent pid using psutil.
+RAY_CONFIG(bool, enable_pipe_based_agent_to_parent_health_check, true)
+
 /// If the agent manager fails to communicate with the dashboard agent or the runtime env
 /// agent, we will retry after this interval.
 RAY_CONFIG(uint32_t, agent_manager_retry_interval_ms, 1000)

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -102,7 +102,8 @@ class ProcessFD {
   static ProcessFD spawnvpe(const char *argv[],
                             std::error_code &ec,
                             bool decouple,
-                            const ProcessEnvironment &env) {
+                            const ProcessEnvironment &env,
+                            bool pipe_to_stdin) {
     ec = std::error_code();
     intptr_t fd;
     pid_t pid;
@@ -172,10 +173,23 @@ class ProcessFD {
     // TODO(mehrdadn): Use clone() on Linux or posix_spawnp() on Mac to avoid duplicating
     // file descriptors into the child process, as that can be problematic.
     int pipefds[2];  // Create pipe to get PID & track lifetime
+    int parent_lifetime_pipe[2];
+
+    // Create pipes to health check parent <> child.
+    // pipefds is used for parent to check child's health.
     if (pipe(pipefds) == -1) {
       pipefds[0] = pipefds[1] = -1;
     }
+    // parent_lifetime_pipe is used for child to check parent's health.
+    if (pipe_to_stdin) {
+      if (pipe(parent_lifetime_pipe) == -1) {
+        parent_lifetime_pipe[0] = parent_lifetime_pipe[1] = -1;
+      }
+    }
+
     pid = pipefds[1] != -1 ? fork() : -1;
+
+    // If we don't pipe to stdin close pipes that are not needed.
     if (pid <= 0 && pipefds[0] != -1) {
       close(pipefds[0]);  // not the parent, so close the read end of the pipe
       pipefds[0] = -1;
@@ -184,6 +198,28 @@ class ProcessFD {
       close(pipefds[1]);  // not the child, so close the write end of the pipe
       pipefds[1] = -1;
     }
+
+    // Create a pipe and redirect the read pipe to a child's stdin.
+    // Child can use it to detect the parent's lifetime.
+    // See the below link for details.
+    // https://stackoverflow.com/questions/12193581/detect-death-of-parent-process
+    if (pipe_to_stdin) {
+      if (pid <= 0 && parent_lifetime_pipe[1] != -1) {
+        // Child. Close sthe write end of the pipe from child.
+        close(parent_lifetime_pipe[1]);
+        parent_lifetime_pipe[1] = -1;
+      }
+      if (pid != 0 && parent_lifetime_pipe[0] != -1) {
+        // Parent. Close the read end of the pipe.
+        close(parent_lifetime_pipe[0]);
+        parent_lifetime_pipe[0] = -1;
+      }
+    } else {
+      // parent_lifetime_pipe pipes are not used.
+      parent_lifetime_pipe[0] = -1;
+      parent_lifetime_pipe[1] = -1;
+    }
+
     if (pid == 0) {
       // Child process case. Reset the SIGCHLD handler.
       signal(SIGCHLD, SIG_DFL);
@@ -191,6 +227,13 @@ class ProcessFD {
       if (pid_t pid2 = decouple ? fork() : 0) {
         _exit(pid2 == -1 ? errno : 0);  // Parent of grandchild; must exit
       }
+
+      // Redirect the read pipe to stdin so that child can track the
+      // parent lifetime.
+      if (parent_lifetime_pipe[0] != -1) {
+        dup2(parent_lifetime_pipe[0], STDIN_FILENO);
+      }
+
       // This is the spawned process. Any intermediate parent is now dead.
       pid_t my_pid = getpid();
       if (write(pipefds[1], &my_pid, sizeof(my_pid)) == sizeof(my_pid)) {
@@ -317,10 +360,11 @@ Process::Process(const char *argv[],
                  void *io_service,
                  std::error_code &ec,
                  bool decouple,
-                 const ProcessEnvironment &env) {
+                 const ProcessEnvironment &env,
+                 bool pipe_to_stdin) {
   /// TODO: use io_service with boost asio notify_fork.
   (void)io_service;
-  ProcessFD procfd = ProcessFD::spawnvpe(argv, ec, decouple, env);
+  ProcessFD procfd = ProcessFD::spawnvpe(argv, ec, decouple, env, pipe_to_stdin);
   if (!ec) {
     p_ = std::make_shared<ProcessFD>(std::move(procfd));
   }

--- a/src/ray/util/process.h
+++ b/src/ray/util/process.h
@@ -74,11 +74,15 @@ class Process {
   /// \param[in] decouple True iff the parent will not wait for the child to exit.
   /// \param[in] env Additional environment variables to be set on this process besides
   /// the environment variables of the parent process.
+  /// \param[in] pipe_to_stdin If true, it creates a pipe and redirect to child process'
+  /// stdin. It is used for health checking from a child process.
+  /// Child process can read stdin to detect when the current process dies.
   explicit Process(const char *argv[],
                    void *io_service,
                    std::error_code &ec,
                    bool decouple = false,
-                   const ProcessEnvironment &env = {});
+                   const ProcessEnvironment &env = {},
+                   bool pipe_to_stdin = false);
   /// Convenience function to run the given command line and wait for it to finish.
   static std::error_code Call(const std::vector<std::string> &args,
                               const ProcessEnvironment &env = {});


### PR DESCRIPTION
Right now, we use psutil to get the parent's pid and check if parent pid is changed to figure out if the parent is dead.

This works most of time, but there's a rare edge case (from psutil) where this mechanism doesn't work. psutil has a process identifier based on (pid, creation_time), but if the system clock is synchronized again, the creation time could be changed. See the related issue for more details.

Since agent death == raylet death, this edge case is still critical although it is rare. We fix the issue by using more reliable health checking; parent opens up a pipe and redirect to the child process stdin. Child process reads stdin. If stdin returns 0 bytes, it means the parent is dead (see https://stackoverflow.com/questions/12193581/detect-death-of-parent-process). This is the same mechanism we are using to detect worker failure from raylet (but opposite direction).

Note that the PR is a bit ugly because I made a feature flag for this feature. Since it is the last minute PR merge, we should be careful, and that's why I added the feature flag.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
