### PR TITLE
[data] Reduce default min parallelism to 32

### DIFF
--- a/doc/source/data/performance-tips.rst
+++ b/doc/source/data/performance-tips.rst
@@ -30,7 +30,7 @@ Usually, if the read is followed by a :func:`~ray.data.Dataset.map` or :func:`~r
 
 Ray Data decides the default value for ``parallelism`` based on the following heuristics, applied in order:
 
-1. Start with the default parallelism of 200. You can overwrite this by setting :class:`DataContext.min_parallelism <ray.data.context.DataContext>`.
+1. Start with the default parallelism of 32. You can overwrite this by setting :class:`DataContext.min_parallelism <ray.data.context.DataContext>`.
 2. Min block size (default=1 MiB). If the parallelism would make blocks smaller than this threshold, reduce parallelism to avoid the overhead of tiny blocks. You can override by setting :class:`DataContext.target_min_block_size <ray.data.context.DataContext>` (bytes).
 3. Max block size (default=128 MiB). If the parallelism would make blocks larger than this threshold, increase parallelism to avoid out-of-memory errors during processing. You can override by setting :class:`DataContext.target_max_block_size <ray.data.context.DataContext>` (bytes).
 4. Available CPUs. Increase parallelism to utilize all of the available CPUs in the cluster. Ray Data chooses the number of read tasks to be at least 2x the number of available CPUs.
@@ -155,7 +155,7 @@ For example, the following code executes :func:`~ray.data.read_csv` with only on
     ...
     Stage 1 ReadCSV->SplitBlocks(4): 4/4 blocks executed in 0.01s
     ...
-    
+
     Stage 2 Map(<lambda>): 4/4 blocks executed in 0.03s
     ...
 

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -65,7 +65,7 @@ DEFAULT_OPTIMIZE_FUSE_SHUFFLE_STAGES = True
 
 # Minimum amount of parallelism to auto-detect for a dataset. Note that the min
 # block size config takes precedence over this.
-DEFAULT_MIN_PARALLELISM = 200
+DEFAULT_MIN_PARALLELISM = 32
 
 # Wether to use actor based block prefetcher.
 DEFAULT_ACTOR_PREFETCHER_ENABLED = False
@@ -186,7 +186,7 @@ class DataContext:
         use_streaming_executor: bool,
         eager_free: bool,
         decoding_size_estimation: bool,
-        min_parallelism: bool,
+        min_parallelism: int,
         enable_tensor_extension_casting: bool,
         enable_auto_log_stats: bool,
         trace_allocations: bool,

--- a/python/ray/data/tests/test_auto_parallelism.py
+++ b/python/ray/data/tests/test_auto_parallelism.py
@@ -42,20 +42,14 @@ TEST_CASES = [
     TestCase(
         avail_cpus=4,
         target_max_block_size=DataContext.get_current().target_max_block_size,
-        data_size=100 * MiB,
-        expected_parallelism=100,  # MIN_BLOCK_SIZE has precedence
-    ),
-    TestCase(
-        avail_cpus=4,
-        target_max_block_size=DataContext.get_current().target_max_block_size,
         data_size=1 * GiB,
-        expected_parallelism=200,  # MIN_PARALLELISM has precedence
+        expected_parallelism=32,  # MIN_PARALLELISM has precedence
     ),
     TestCase(
         avail_cpus=4,
         target_max_block_size=DataContext.get_current().target_max_block_size,
-        data_size=10 * GiB,
-        expected_parallelism=200,  # MIN_PARALLELISM has precedence
+        data_size=4 * GiB,
+        expected_parallelism=32,  # MIN_PARALLELISM has precedence
     ),
     TestCase(
         avail_cpus=150,

--- a/python/ray/data/tests/test_mongo.py
+++ b/python/ray/data/tests/test_mongo.py
@@ -134,7 +134,7 @@ def test_read_write_mongo(ray_start_regular_shared, start_mongo):
     )
     assert str(ds) == (
         "Dataset(\n"
-        "   num_blocks=200,\n"
+        "   num_blocks=35,\n"
         "   num_rows=5,\n"
         "   schema={_id: fixed_size_binary[12], float_field: double, "
         "int_field: int32}\n"
@@ -247,7 +247,7 @@ def test_mongo_datasource(ray_start_regular_shared, start_mongo):
     ).materialize()
     assert str(ds) == (
         "MaterializedDataset(\n"
-        "   num_blocks=200,\n"
+        "   num_blocks=35,\n"
         "   num_rows=5,\n"
         "   schema={_id: fixed_size_binary[12], float_field: double, "
         "int_field: int32}\n"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

the 200 default min_parallelism is too large for small jobs. It will result in too many small blocks and bad perf. Reducing the default to mitigate this issue.
 
## Related issue number

https://github.com/ray-project/ray/issues/41496

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
