### PR TITLE
[Release] Add release logs for 2.9.0 commit 15a558e

### DIFF
--- a/release/release_logs/2.9.0/benchmarks/many_actors.json
+++ b/release/release_logs/2.9.0/benchmarks/many_actors.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 504.758272,
+    "_dashboard_test_success": true,
+    "_peak_memory": 5.7,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.65GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1175\t0.92GiB\tpython distributed/test_many_actors.py\n266\t0.42GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n428\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n994\t0.07GiB\tray::JobSupervisor\n426\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n586\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1324\t0.06GiB\tray::DashboardTester.run\n1235\t0.06GiB\tray::MemoryMonitorActor.run\n367\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/log_m",
+    "actors_per_second": 590.5931553046038,
+    "num_actors": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "actors_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 590.5931553046038
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 23.754
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2569.856
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4473.111
+        }
+    ],
+    "success": "1",
+    "time": 16.932129859924316
+}

--- a/release/release_logs/2.9.0/benchmarks/many_nodes.json
+++ b/release/release_logs/2.9.0/benchmarks/many_nodes.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 195.25632,
+    "_dashboard_test_success": true,
+    "_peak_memory": 12.72,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.51GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n872\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n266\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n1073\t0.08GiB\tray::StateAPIGeneratorActor.start\n425\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n692\t0.07GiB\tray::JobSupervisor\n423\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n578\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n932\t0.06GiB\tray::MemoryMonitorActor.run\n1020\t0.06GiB\tray::DashboardTester.run",
+    "num_tasks": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 328.5366336052011
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4.494
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 79.189
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 173.647
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 328.5366336052011,
+    "time": 303.0438005924225,
+    "used_cpus": 250.0
+}

--- a/release/release_logs/2.9.0/benchmarks/many_tasks.json
+++ b/release/release_logs/2.9.0/benchmarks/many_tasks.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 577.37216,
+    "_dashboard_test_success": true,
+    "_peak_memory": 16.01,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.26GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.86GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n807\t0.72GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1007\t0.08GiB\tray::StateAPIGeneratorActor.start\n428\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n955\t0.07GiB\tray::DashboardTester.run\n627\t0.07GiB\tray::JobSupervisor\n426\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n585\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n867\t0.06GiB\tray::MemoryMonitorActor.run",
+    "num_tasks": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 586.1652936197164
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2500.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 5.978
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 6455.1
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 10057.867
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 586.1652936197164,
+    "time": 317.06003427505493,
+    "used_cpus": 2500.0
+}

--- a/release/release_logs/2.9.0/microbenchmark.json
+++ b/release/release_logs/2.9.0/microbenchmark.json
@@ -1,0 +1,283 @@
+{
+    "1_1_actor_calls_async": [
+        8802.650097299196,
+        60.842258466035204
+    ],
+    "1_1_actor_calls_concurrent": [
+        5354.497412488227,
+        215.75397384758347
+    ],
+    "1_1_actor_calls_sync": [
+        2075.2443816745968,
+        27.48530234379788
+    ],
+    "1_1_async_actor_calls_async": [
+        3320.575179316923,
+        91.55707790698456
+    ],
+    "1_1_async_actor_calls_sync": [
+        1250.487251391533,
+        26.38078059028117
+    ],
+    "1_1_async_actor_calls_with_args_async": [
+        2415.0979141352886,
+        92.3235539900223
+    ],
+    "1_n_actor_calls_async": [
+        8622.116661460657,
+        124.38168455924563
+    ],
+    "1_n_async_actor_calls_async": [
+        7460.962715134404,
+        109.57983472020985
+    ],
+    "client__1_1_actor_calls_async": [
+        1012.4837493368098,
+        12.872775417083595
+    ],
+    "client__1_1_actor_calls_concurrent": [
+        1006.7547148607874,
+        6.920447225648246
+    ],
+    "client__1_1_actor_calls_sync": [
+        530.5597986550025,
+        19.689813807169436
+    ],
+    "client__get_calls": [
+        1120.242286739544,
+        18.524761265491748
+    ],
+    "client__put_calls": [
+        808.3571852957423,
+        9.005278054612543
+    ],
+    "client__put_gigabytes": [
+        0.1168388142260294,
+        0.0024866858121896447
+    ],
+    "client__tasks_and_get_batch": [
+        0.9407620914250454,
+        0.01811244476544575
+    ],
+    "client__tasks_and_put_batch": [
+        11472.04637188305,
+        147.7999130055102
+    ],
+    "multi_client_put_calls_Plasma_Store": [
+        12988.08350923366,
+        84.92740217106494
+    ],
+    "multi_client_put_gigabytes": [
+        30.918984626602807,
+        1.5956800472487598
+    ],
+    "multi_client_tasks_async": [
+        24316.337428119852,
+        2250.184401985024
+    ],
+    "n_n_actor_calls_async": [
+        26694.138600078164,
+        536.633193344434
+    ],
+    "n_n_actor_calls_with_arg_async": [
+        2718.2145554952413,
+        26.576867640657934
+    ],
+    "n_n_async_actor_calls_async": [
+        23089.526825423094,
+        668.8359864104164
+    ],
+    "perf_metrics": [
+        {
+            "perf_metric_name": "single_client_get_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10676.942537676008
+        },
+        {
+            "perf_metric_name": "single_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5567.259268000422
+        },
+        {
+            "perf_metric_name": "multi_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 12988.08350923366
+        },
+        {
+            "perf_metric_name": "single_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 20.6372354079233
+        },
+        {
+            "perf_metric_name": "single_client_tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8.429852592930626
+        },
+        {
+            "perf_metric_name": "multi_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 30.918984626602807
+        },
+        {
+            "perf_metric_name": "single_client_get_object_containing_10k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 13.112230033151658
+        },
+        {
+            "perf_metric_name": "single_client_wait_1k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5.424892169925369
+        },
+        {
+            "perf_metric_name": "single_client_tasks_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1009.4349525282154
+        },
+        {
+            "perf_metric_name": "single_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8443.260998630982
+        },
+        {
+            "perf_metric_name": "multi_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 24316.337428119852
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2075.2443816745968
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8802.650097299196
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5354.497412488227
+        },
+        {
+            "perf_metric_name": "1_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8622.116661460657
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 26694.138600078164
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_with_arg_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2718.2145554952413
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1250.487251391533
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 3320.575179316923
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_with_args_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2415.0979141352886
+        },
+        {
+            "perf_metric_name": "1_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 7460.962715134404
+        },
+        {
+            "perf_metric_name": "n_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 23089.526825423094
+        },
+        {
+            "perf_metric_name": "placement_group_create/removal",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 845.7511547073977
+        },
+        {
+            "perf_metric_name": "client__get_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1120.242286739544
+        },
+        {
+            "perf_metric_name": "client__put_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 808.3571852957423
+        },
+        {
+            "perf_metric_name": "client__put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.1168388142260294
+        },
+        {
+            "perf_metric_name": "client__tasks_and_put_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 11472.04637188305
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 530.5597986550025
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1012.4837493368098
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1006.7547148607874
+        },
+        {
+            "perf_metric_name": "client__tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.9407620914250454
+        }
+    ],
+    "placement_group_create/removal": [
+        845.7511547073977,
+        8.79413426744309
+    ],
+    "single_client_get_calls_Plasma_Store": [
+        10676.942537676008,
+        204.82706706888098
+    ],
+    "single_client_get_object_containing_10k_refs": [
+        13.112230033151658,
+        0.1509373457410296
+    ],
+    "single_client_put_calls_Plasma_Store": [
+        5567.259268000422,
+        80.95082943098477
+    ],
+    "single_client_put_gigabytes": [
+        20.6372354079233,
+        4.832837780263238
+    ],
+    "single_client_tasks_and_get_batch": [
+        8.429852592930626,
+        0.27991828083528164
+    ],
+    "single_client_tasks_async": [
+        8443.260998630982,
+        435.3596758485647
+    ],
+    "single_client_tasks_sync": [
+        1009.4349525282154,
+        13.102940883041759
+    ],
+    "single_client_wait_1k_refs": [
+        5.424892169925369,
+        0.08031908760259526
+    ]
+}

--- a/release/release_logs/2.9.0/scalability/object_store.json
+++ b/release/release_logs/2.9.0/scalability/object_store.json
@@ -1,0 +1,13 @@
+{
+    "broadcast_time": 95.796644017,
+    "num_nodes": 50,
+    "object_size": 1073741824,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 95.796644017
+        }
+    ],
+    "success": "1"
+}

--- a/release/release_logs/2.9.0/scalability/single_node.json
+++ b/release/release_logs/2.9.0/scalability/single_node.json
@@ -1,0 +1,40 @@
+{
+    "args_time": 17.811292093000006,
+    "get_time": 24.51010805099999,
+    "large_object_size": 107374182400,
+    "large_object_time": 30.452989563000017,
+    "num_args": 10000,
+    "num_get_args": 10000,
+    "num_queued": 1000000,
+    "num_returns": 3000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "10000_args_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 17.811292093000006
+        },
+        {
+            "perf_metric_name": "3000_returns_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 6.094248331000003
+        },
+        {
+            "perf_metric_name": "10000_get_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 24.51010805099999
+        },
+        {
+            "perf_metric_name": "1000000_queued_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 192.29910237700003
+        },
+        {
+            "perf_metric_name": "107374182400_large_object_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 30.452989563000017
+        }
+    ],
+    "queued_time": 192.29910237700003,
+    "returns_time": 6.094248331000003,
+    "success": "1"
+}

--- a/release/release_logs/2.9.0/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.9.0/stress_tests/stress_test_dead_actors.json
@@ -1,0 +1,14 @@
+{
+    "avg_iteration_time": 1.4471865177154541,
+    "max_iteration_time": 3.1998844146728516,
+    "min_iteration_time": 0.11375546455383301,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1.4471865177154541
+        }
+    ],
+    "success": 1,
+    "total_time": 144.71888136863708
+}

--- a/release/release_logs/2.9.0/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.9.0/stress_tests/stress_test_many_tasks.json
@@ -1,0 +1,47 @@
+{
+    "perf_metrics": [
+        {
+            "perf_metric_name": "stage_0_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 13.148497581481934
+        },
+        {
+            "perf_metric_name": "stage_1_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 24.360094380378722
+        },
+        {
+            "perf_metric_name": "stage_2_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 57.301159954071046
+        },
+        {
+            "perf_metric_name": "stage_3_creation_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2.475653648376465
+        },
+        {
+            "perf_metric_name": "stage_3_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3242.995056629181
+        },
+        {
+            "perf_metric_name": "stage_4_spread",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.6446957966039432
+        }
+    ],
+    "stage_0_time": 13.148497581481934,
+    "stage_1_avg_iteration_time": 24.360094380378722,
+    "stage_1_max_iteration_time": 26.564361095428467,
+    "stage_1_min_iteration_time": 23.07029676437378,
+    "stage_1_time": 243.60105633735657,
+    "stage_2_avg_iteration_time": 57.301159954071046,
+    "stage_2_max_iteration_time": 59.181641578674316,
+    "stage_2_min_iteration_time": 53.46572279930115,
+    "stage_2_time": 286.50717878341675,
+    "stage_3_creation_time": 2.475653648376465,
+    "stage_3_time": 3242.995056629181,
+    "stage_4_spread": 0.6446957966039432,
+    "success": 1
+}

--- a/release/release_logs/2.9.0/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.9.0/stress_tests/stress_test_placement_group.json
@@ -1,0 +1,17 @@
+{
+    "avg_pg_create_time_ms": 0.9053212447438167,
+    "avg_pg_remove_time_ms": 0.913254288288353,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_pg_create_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.9053212447438167
+        },
+        {
+            "perf_metric_name": "avg_pg_remove_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.913254288288353
+        }
+    ],
+    "success": 1
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Adds performance logs for Ray 2.9.0. Taken from the tests at https://buildkite.com/ray-project/release-tests-branch/builds?branch=releases%2F2.9.0 for commit 15a558e8aeb6e2ee0c5f95a93b2ceaccf2279ffe by running `python fetch_release_logs.py 2.9.0`.

Below I have included the result of running the regression script. From the release instructions: 
> This script will catch regressions in perf_metrics, **you still need to manually check other metrics (e.g. _peak_memory)**

I have not done the "manual check" and will leave that to the reviewers of this PR.
 
```
(base) architkulkarni@archit-Q4WXGF2WQY release_logs % python compare_perf_metrics 2.8.0 2.9.0                        
REGRESSION 21.61%: actors_per_second (THROUGHPUT) regresses from 753.4446893211699 to 590.5931553046038 (21.61%) in 2.9.0/benchmarks/many_actors.json
REGRESSION 14.94%: multi_client_put_gigabytes (THROUGHPUT) regresses from 36.34816401372876 to 30.918984626602807 (14.94%) in 2.9.0/microbenchmark.json
REGRESSION 13.26%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 8601.993472120319 to 7460.962715134404 (13.26%) in 2.9.0/microbenchmark.json
REGRESSION 13.10%: single_client_tasks_sync (THROUGHPUT) regresses from 1161.670131632561 to 1009.4349525282154 (13.10%) in 2.9.0/microbenchmark.json
REGRESSION 11.34%: n_n_actor_calls_async (THROUGHPUT) regresses from 30108.565209428394 to 26694.138600078164 (11.34%) in 2.9.0/microbenchmark.json
REGRESSION 10.64%: multi_client_tasks_async (THROUGHPUT) regresses from 27211.51041454346 to 24316.337428119852 (10.64%) in 2.9.0/microbenchmark.json
REGRESSION 10.02%: 1_n_actor_calls_async (THROUGHPUT) regresses from 9581.728569086026 to 8622.116661460657 (10.02%) in 2.9.0/microbenchmark.json
REGRESSION 9.21%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1377.3257452550822 to 1250.487251391533 (9.21%) in 2.9.0/microbenchmark.json
REGRESSION 8.67%: placement_group_create/removal (THROUGHPUT) regresses from 926.0840791839338 to 845.7511547073977 (8.67%) in 2.9.0/microbenchmark.json
REGRESSION 6.25%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2213.6033025230176 to 2075.2443816745968 (6.25%) in 2.9.0/microbenchmark.json
REGRESSION 6.12%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2895.292478069285 to 2718.2145554952413 (6.12%) in 2.9.0/microbenchmark.json
REGRESSION 5.79%: client__put_gigabytes (THROUGHPUT) regresses from 0.12401864230452364 to 0.1168388142260294 (5.79%) in 2.9.0/microbenchmark.json
REGRESSION 5.62%: client__put_calls (THROUGHPUT) regresses from 856.533614603169 to 808.3571852957423 (5.62%) in 2.9.0/microbenchmark.json
REGRESSION 4.94%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 24290.541801601616 to 23089.526825423094 (4.94%) in 2.9.0/microbenchmark.json
REGRESSION 3.77%: client__get_calls (THROUGHPUT) regresses from 1164.1583807193044 to 1120.242286739544 (3.77%) in 2.9.0/microbenchmark.json
REGRESSION 3.26%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.55352518200595 to 13.112230033151658 (3.26%) in 2.9.0/microbenchmark.json
REGRESSION 3.24%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 8.7124898510668 to 8.429852592930626 (3.24%) in 2.9.0/microbenchmark.json
REGRESSION 3.09%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1038.8711159440322 to 1006.7547148607874 (3.09%) in 2.9.0/microbenchmark.json
REGRESSION 2.32%: single_client_tasks_async (THROUGHPUT) regresses from 8643.833466025399 to 8443.260998630982 (2.32%) in 2.9.0/microbenchmark.json
REGRESSION 2.29%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5697.447666436941 to 5567.259268000422 (2.29%) in 2.9.0/microbenchmark.json
REGRESSION 2.27%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1036.0321459583472 to 1012.4837493368098 (2.27%) in 2.9.0/microbenchmark.json
REGRESSION 0.89%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 535.3383020010909 to 530.5597986550025 (0.89%) in 2.9.0/microbenchmark.json
REGRESSION 65.87%: stage_0_time (LATENCY) regresses from 7.927043914794922 to 13.148497581481934 (65.87%) in 2.9.0/stress_tests/stress_test_many_tasks.json
REGRESSION 44.84%: dashboard_p99_latency_ms (LATENCY) regresses from 3088.301 to 4473.111 (44.84%) in 2.9.0/benchmarks/many_actors.json
REGRESSION 15.81%: avg_pg_remove_time_ms (LATENCY) regresses from 0.7885501576572757 to 0.913254288288353 (15.81%) in 2.9.0/stress_tests/stress_test_placement_group.json
REGRESSION 15.50%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 82.940892212 to 95.796644017 (15.50%) in 2.9.0/scalability/object_store.json
REGRESSION 14.83%: dashboard_p95_latency_ms (LATENCY) regresses from 2237.99 to 2569.856 (14.83%) in 2.9.0/benchmarks/many_actors.json
REGRESSION 10.19%: stage_3_time (LATENCY) regresses from 2943.001654624939 to 3242.995056629181 (10.19%) in 2.9.0/stress_tests/stress_test_many_tasks.json
REGRESSION 9.51%: stage_3_creation_time (LATENCY) regresses from 2.260662794113159 to 2.475653648376465 (9.51%) in 2.9.0/stress_tests/stress_test_many_tasks.json
REGRESSION 3.30%: 3000_returns_time (LATENCY) regresses from 5.899374322999989 to 6.094248331000003 (3.30%) in 2.9.0/scalability/single_node.json
REGRESSION 2.08%: avg_pg_create_time_ms (LATENCY) regresses from 0.8868904699705661 to 0.9053212447438167 (2.08%) in 2.9.0/stress_tests/stress_test_placement_group.json
REGRESSION 0.86%: 10000_args_time (LATENCY) regresses from 17.66019733799999 to 17.811292093000006 (0.86%) in 2.9.0/scalability/single_node.json
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
