### PR TITLE
[Docs] Theme revamp: primary sidebar

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: prettier
         files: 'doc/'
-        types_or: [javascript, ts, tsx, html]
+        types_or: [javascript, ts, tsx, html, css]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.7.0

--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -4,17 +4,78 @@
 * dark/light theme specific values, which normally take precedence over the PST defaults.
 * */
 html {
-  --anyscale-blue: #0641AC;
-  --ray-blue: #3C8AE9; /* Ray blue color - use this for all ray branding */
+  --anyscale-blue: #0641ac;
+  --ray-blue: #3c8ae9; /* Ray blue color - use this for all ray branding */
   --pst-color-primary: var(--ray-blue) !important;
-  --pst-color-link-hover: var(--ray-blue) !important;
   --pst-color-inline-code-links: var(--ray-blue) !important;
 
   /* Transparent highlight color; default yellow is hard on the eyes */
-  --pst-color-target: #FFFFFF00 !important;
+  --pst-color-target: #ffffff00 !important;
   --color-diff-delete-bg: rgba(212, 118, 22, 0.3);
   --color-diff-insert-bg: rgba(56, 139, 253, 0.3);
   --color-diff-nochange-bg: rgba(0, 0, 0, 0);
+
+  --pst-font-family-base: 'Inter', sans-serif;
+  --stata-dark-background: #232629;
+}
+
+html[data-theme='dark'] {
+  --pst-color-background: #161a1d;
+  --pst-color-text-base: #f1f2f4;
+  --pst-color-text-muted: #b3b9c4;
+  --heading-color: #ffffff;
+  --base-pygments-code-color: #cccccc;
+}
+
+html[data-theme='light'] {
+  --pst-color-background: #ffffff;
+  --pst-color-text-base: #22272b;
+  --pst-color-text-muted: #454f59;
+  --heading-color: #161a1d;
+  --base-pygments-code-color: #cccccc;
+}
+
+nav.bd-links li > a:hover {
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration-thickness: unset;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--heading-color);
+}
+
+/* Gradient ellipse background */
+.bd-sidebar-secondary {
+  background-color: transparent;
+}
+.bd-content:after {
+  background: linear-gradient(
+    60deg,
+    rgba(0, 85, 204, 0.18) 14%,
+    rgba(110, 93, 198, 0.18) 49.2%,
+    rgba(174, 71, 135, 0.18) 81.54%
+  );
+  background-size: 746px 746px;
+  background-repeat: no-repeat;
+  background-position: center;
+  border-radius: 373px;
+  background-origin: 50%;
+  background-attachment: scroll;
+  content: '';
+  transform: translate(50%, 0%);
+  width: 746px;
+  height: 746px;
+  position: absolute;
+  filter: blur(100px);
+  z-index: -1;
 }
 
 /* Pygments diff code cell line colors; match github colorblind theme */
@@ -29,6 +90,14 @@ div.highlight > pre > span.gi {
 div.highlight > pre > span.w {
   background-color: var(--color-diff-nochange-bg);
   color: var(--pst-color-text-base) !important;
+}
+
+/* Make the article content take up all available space */
+.bd-main .bd-content .bd-article-container {
+  max-width: 100%; /* default is 60em */
+}
+.bd-page-width {
+  max-width: 100%; /* default is 88rem */
 }
 
 /* Hide the "Hide Search Matches" button (we aren't highlighting search terms anyway) */
@@ -70,9 +139,6 @@ span.navbar-link-title {
 }
 ul.navbar-toplevel li:hover > div.navbar-dropdown {
   display: block;
-}
-ul.navbar-toplevel > li:hover {
-  border-bottom:
 }
 ul.navbar-toplevel {
   display: flex;
@@ -181,32 +247,58 @@ button#pst-back-to-top {
 }
 
 .bottom-right-promo-banner {
-    position: fixed;
-    bottom: 100px;
-    right: 20px;
-    width: 270px;
+  position: fixed;
+  bottom: 100px;
+  right: 20px;
+  width: 270px;
 }
 
 @media (max-width: 1500px) {
-    .bottom-right-promo-banner {
-        display: none;
-    }
+  .bottom-right-promo-banner {
+    display: none;
+  }
 }
 
 /* Nav sidebar styles */
-/* Sidebar checkboxes are toggled by clicking on the label; hide actual checkboxes */
-.sidebar-checkbox {
-  display: none;
+.bd-sidebar-primary {
+  width: 280px;
+  padding: 2em 2em 0em 2em;
 }
-.sidebar-checkbox[type="checkbox"]:checked ~ dd {
-  display: none;
+/* Make sidebar take up full primary sidebar gutter, but don't wrap content */
+#main-sidebar {
+  width: 100%;
+}
+nav.bd-links li > a {
+  color: var(--pst-color-text-base);
+}
+/* Sidebar checkboxes are toggled by clicking on the label; hide actual checkboxes */
+.toctree-checkbox[type='checkbox']:checked ~ ul > li.current-page:before {
+  background-color: var(--ray-blue);
+  border-radius: 0.5px;
+}
+.toctree-checkbox[type='checkbox']:checked ~ ul > li:before {
+  content: '';
+  width: 1px;
+  height: 100%;
+  position: absolute;
+  background-color: var(--pst-color-border);
+}
+/* Highlight and bold the primary sidebar entry for the current page */
+#main-sidebar li.current-page > a {
+  color: var(--ray-blue) !important;
+  font-weight: 600;
+}
+/* Bold the top level primary sidebar links */
+#main-sidebar > .navbar-nav > .nav.bd-sidenav > li > a {
+  font-weight: 500;
 }
 
 /* Fix some spacing issues associated with competition with PST styles */
 .sidebar-content dl {
   margin-bottom: 0;
 }
-.sidebar-content ol li > p:first-child, ul li > p:first-child {
+.sidebar-content ol li > p:first-child,
+ul li > p:first-child {
   margin-top: 0 !important;
 }
 
@@ -229,4 +321,18 @@ table.autosummary tr > td:first-child > p > a > code > span {
   display: block;
   overflow: clip;
   text-overflow: ellipsis;
+}
+
+/* RTD footer container makes the parent */
+/* #main-sidebar always scrollable if you don't remove negative margin. */
+/* Restrict width to 30% of the window */
+.bd-sidebar-primary div#rtd-footer-container {
+  margin: unset;
+  max-width: 30vw;
+}
+
+/* Fix some pygments styles that inadvertently get overridden by PST */
+.highlight pre {
+  background-color: var(--stata-dark-background);
+  color: var(--base-pygments-code-color);
 }

--- a/doc/source/_static/css/examples.css
+++ b/doc/source/_static/css/examples.css
@@ -124,15 +124,19 @@ div.gallery-item {
 
 /* Override sphinx-design box shadow styles */
 div.gallery-item > div.sd-card {
-  box-shadow: 0 .125rem .25rem var(--pst-color-shadow) !important;
+  box-shadow: 0 0.125rem 0.25rem var(--pst-color-shadow) !important;
   border: none;
 }
 
 /* Example gallery "Tutorial" title */
 div.sd-card-title > span.sd-bg-success.sd-bg-text-success {
-  color: #2F80ED !important;
+  color: #2f80ed !important;
   font-weight: 500;
-  background: linear-gradient(180deg, rgba(25, 177, 226, 0.2) 0%, rgba(0, 109, 255, 0.2) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(25, 177, 226, 0.2) 0%,
+    rgba(0, 109, 255, 0.2) 100%
+  );
   background-color: initial !important;
 }
 
@@ -140,31 +144,47 @@ div.sd-card-title > span.sd-bg-success.sd-bg-text-success {
 div.sd-card-title > span.sd-bg-secondary.sd-bg-text-secondary {
   color: #219653 !important;
   font-weight: 500;
-  background: linear-gradient(180deg, rgba(29, 151, 108, 0.2) 0%, rgba(0, 226, 147, 0.2) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(29, 151, 108, 0.2) 0%,
+    rgba(0, 226, 147, 0.2) 100%
+  );
   background-color: initial !important;
 }
 
 /* Example gallery "Blog" title */
 div.sd-card-title > span.sd-bg-primary.sd-bg-text-primary {
-  color: #F2994A !important;
+  color: #f2994a !important;
   font-weight: 500;
-  background: linear-gradient(180deg, rgba(255, 230, 5, 0.2) 0%, rgba(255, 185, 80, 0.2) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 230, 5, 0.2) 0%,
+    rgba(255, 185, 80, 0.2) 100%
+  );
   background-color: initial !important;
 }
 
 /* Example gallery "Video" title */
 div.sd-card-title > span.sd-bg-warning.sd-bg-text-warning {
-  color: #EB5757 !important;
+  color: #eb5757 !important;
   font-weight: 500;
-  background: linear-gradient(180deg, rgba(150, 7, 7, 0.2) 0%, rgba(255, 115, 115, 0.2) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(150, 7, 7, 0.2) 0%,
+    rgba(255, 115, 115, 0.2) 100%
+  );
   background-color: initial !important;
 }
 
 /* Example gallery "Course" title */
 div.sd-card-title > span.sd-bg-info.sd-bg-text-info {
-  color: #7A64FF !important;
+  color: #7a64ff !important;
   font-weight: 500;
-  background: linear-gradient(180deg, rgba(53, 25, 226, 0.2) 0%, rgba(183, 149, 255, 0.2) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(53, 25, 226, 0.2) 0%,
+    rgba(183, 149, 255, 0.2) 100%
+  );
   background-color: initial !important;
 }
 
@@ -182,6 +202,13 @@ div.sd-card-title > span.sd-bg-info.sd-bg-text-info {
   justify-content: center;
 }
 
-#noMatches.hidden,.gallery-item.hidden {
+#noMatches.hidden,
+.gallery-item.hidden {
   display: none !important;
+}
+
+/* Set a max width to prevent the sidebar */
+/* from growing indefinitely to accommodate the tag buttons flexbox */
+.bd-sidebar-primary {
+  max-width: 30%;
 }

--- a/doc/source/_static/css/splash.css
+++ b/doc/source/_static/css/splash.css
@@ -1,99 +1,98 @@
 .image-header {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    padding-left: 16px;
-    padding-right:16px;
-    gap: 16px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding-left: 16px;
+  padding-right: 16px;
+  gap: 16px;
 }
 
 .info-box {
-    background-color: var(--pst-color-surface);
-    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.05);
-    border-radius: 8px;
-    padding: 20px;
+  background-color: var(--pst-color-surface);
+  box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.05);
+  border-radius: 8px;
+  padding: 20px;
 }
 
-.info-box:hover{
-    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
+.info-box:hover {
+  box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
 }
 
-.no-underline{
-    text-decoration: none;
+.no-underline {
+  text-decoration: none;
 }
-.no-underline:hover{
-    text-decoration: none;
+.no-underline:hover {
+  text-decoration: none;
 }
 
-.icon-hover:hover{
-    height: 30px ;
-    width: 30px;
+.icon-hover:hover {
+  height: 30px;
+  width: 30px;
 }
 
 .info-box-2 {
-    background-color: var(--pst-color-surface);
-    border-radius: 8px;
-    padding-right: 16px;
-    padding-left: 16px;
-    padding-bottom: 24px;
-    padding-top: 4px;
+  background-color: var(--pst-color-surface);
+  border-radius: 8px;
+  padding-right: 16px;
+  padding-left: 16px;
+  padding-bottom: 24px;
+  padding-top: 4px;
 }
 
-
 .bold-link {
-    color: var(--pst-color-link) !important;
-    font-weight: 600;
+  color: var(--pst-color-link) !important;
+  font-weight: 600;
 }
 
 .community-box {
-    border: 1px solid var(--pst-color-border);
-    border-radius: 8px;
-    display: flex;
-    margin-bottom: 16px;
+  border: 1px solid var(--pst-color-border);
+  border-radius: 8px;
+  display: flex;
+  margin-bottom: 16px;
 }
 
 .community-box:hover {
-    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.05);
-    text-decoration: none;
+  box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.05);
+  text-decoration: none;
 }
 
 .community-box p {
-    margin-top: 1rem !important;
+  margin-top: 1rem !important;
 }
 
 .tab-pane pre {
-    margin: 0;
-    padding: 0;
-    max-height: 252px;
-    overflow-y: auto;
-    animation: fadeEffect 1s; /* Fading effect takes 1 second */
+  margin: 0;
+  padding: 0;
+  max-height: 252px;
+  overflow-y: auto;
+  animation: fadeEffect 1s; /* Fading effect takes 1 second */
 }
 
 .grid-container {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-gap: 16px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 16px;
 }
 
 .grid-item {
-padding: 20px;
+  padding: 20px;
 }
 
 .nav-pills {
-    background-color: var(--pst-color-surface);
-    padding: 8px;
-    border-bottom:none;
-    border-radius: 8px;
+  background-color: var(--pst-color-surface);
+  padding: 8px;
+  border-bottom: none;
+  border-radius: 8px;
 }
 
 .nav-pills .nav-link.active {
-    background-color: var(--pst-color-background) !important;
-    box-shadow: 0px 3px 14px 2px var(--pst-color-shadow);
-    border-radius: 8px;
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-    color: var(--pst-color-text-base);
-    font-weight: 500;
+  background-color: var(--pst-color-background) !important;
+  box-shadow: 0px 3px 14px 2px var(--pst-color-shadow);
+  border-radius: 8px;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  color: var(--pst-color-text-base);
+  font-weight: 500;
 }
 
 #v-pills-tab > .nav-link:hover {
@@ -108,9 +107,13 @@ padding: 20px;
   color: var(--pst-color-text-base);
 }
 
+#v-pills-tabContent .row {
+  background-color: var(--pst-color-background);
+}
+
 #v-pills-tabContent {
   box-shadow: 0px 6px 30px 5px var(--pst-color-shadow);
-  border-radius:8px;
+  border-radius: 8px;
 }
 
 #v-pills-data {
@@ -119,8 +122,12 @@ padding: 20px;
 
 /* Go from zero to full opacity */
 @keyframes fadeEffect {
-  from {opacity: 0;}
-  to {opacity: 1;}
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 #ray-intro-video {

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,12 +1,26 @@
-{% extends "!layout.html" %}
+{% extends "pydata_sphinx_theme/layout.html" %} {%- block extrahead %}
 
-{%- block extrahead %}
-
-<link rel="stylesheet" title="light" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" disabled="disabled"/>
-<link rel="stylesheet" title="dark" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" disabled="disabled"/>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;900&family=Roboto:wght@400;500;700&display=swap"
+  rel="stylesheet"
+/>
+<link
+  rel="stylesheet"
+  title="light"
+  href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css"
+  disabled="disabled"
+/>
+<link
+  rel="stylesheet"
+  title="dark"
+  href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+  disabled="disabled"
+/>
 
 <!-- Used for text embedded in html on the index page  -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" ></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 
 <!-- Parser used to call hljs on responses from Ray Assistant -->
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -19,24 +33,38 @@
 <!-- / Fathom -->
 
 <script>
-(function(apiKey){
-    (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=o._q||[];
-    v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
-        o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
-        y=e.createElement(n);y.async=!0;y.src='https://cdn.pendo.io/agent/static/'+apiKey+'/pendo.js';
-        z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
+  (function (apiKey) {
+    (function (p, e, n, d, o) {
+      var v, w, x, y, z;
+      o = p[d] = p[d] || {};
+      o._q = o._q || [];
+      v = ['initialize', 'identify', 'updateOptions', 'pageLoad', 'track'];
+      for (w = 0, x = v.length; w < x; ++w)
+        (function (m) {
+          o[m] =
+            o[m] ||
+            function () {
+              o._q[m === v[0] ? 'unshift' : 'push'](
+                [m].concat([].slice.call(arguments, 0)),
+              );
+            };
+        })(v[w]);
+      y = e.createElement(n);
+      y.async = !0;
+      y.src = 'https://cdn.pendo.io/agent/static/' + apiKey + '/pendo.js';
+      z = e.getElementsByTagName(n)[0];
+      z.parentNode.insertBefore(y, z);
+    })(window, document, 'script', 'pendo');
 
-        pendo.initialize({
-            visitor: {
-                id: 'VISITOR-UNIQUE-ID'
-            },
-            account: {
-                id: 'ACCOUNT-UNIQUE-ID'
-            }
-        });
-})('f89fa48a-6dd7-4d7c-67cf-a8051ed891f2');
+    pendo.initialize({
+      visitor: {
+        id: 'VISITOR-UNIQUE-ID',
+      },
+      account: {
+        id: 'ACCOUNT-UNIQUE-ID',
+      },
+    });
+  })('f89fa48a-6dd7-4d7c-67cf-a8051ed891f2');
 </script>
 
-  {{ super() }}
-
-{% endblock %}
+{{ super() }} {% endblock %}

--- a/doc/source/_templates/release-header.html
+++ b/doc/source/_templates/release-header.html
@@ -1,3 +1,0 @@
-<div class="release-header-div">
-  <h5 id="release-header">Ray {{ release|e }}</h5>
-</div>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -213,9 +213,6 @@ if build_one_lib and build_one_lib in all_toc_libs:
     exclude_patterns += all_toc_libs
 
 
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "lovelace"
-
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
@@ -307,6 +304,8 @@ html_theme_options = {
     ],
     "navigation_depth": 4,
     "analytics": {"google_analytics_id": "UA-110413294-1"},
+    "pygment_light_style": "stata-dark",
+    "pygment_dark_style": "stata-dark",
 }
 
 html_context = {
@@ -317,11 +316,7 @@ html_context = {
 }
 
 html_sidebars = {
-    "**": [
-        "release-header",
-        "search-button-field",
-        "main-sidebar",
-    ],
+    "**": ["main-sidebar"],
     "ray-overview/examples": ["examples-sidebar"],
 }
 

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -320,6 +320,12 @@ def preload_sidebar_nav(
         a["href"] = to_root_prefix + absolute_href
 
         if absolute_href == f"{pagename}.html":
+
+            # Add a current-page class to the parent li element for styling
+            parent_li = a.find_parent("li")
+            parent_li["class"] = parent_li.get("class", []) + ["current-page"]
+
+            # Open the dropdowns of every parent li for the active page
             for parent_li in a.find_parents("li", attrs={"class": "has-children"}):
                 el = parent_li.find("input")
                 if el:


### PR DESCRIPTION
## Why are these changes needed?

This PR implements a number of style changes to the docs to match new designs created by @simran-2797.

### Changes

- Added an `::after` pseudo-element that gives a splash of color to the main content of the page
- Set the `max-width` of the primary sidebar to 30% for the example gallery; otherwise the primary sidebar grows indefinitely to accommodate the flexbox that holds the tag filter buttons
- Set background, text-base, text-muted, and heading CSS color variables for dark and light themes
- Removed the empty space on either side of the main article content, allowing articles to expand to the size of the user's browser. This gives us a HUGE increase in screen real estate!
- Modify styles of primary sidebar dropdown; highlight the current page in the sidebar
- Add the `Inter` font globally
- Added css to the list of filetypes formatted by the `prettier` pre-commit hook. Also now that pre-commit is in the repo, the hooks ran on these files, causing a bit of reformatting.

Docs splash page:

![image](https://github.com/ray-project/ray/assets/14017872/5d777db3-0a6b-45f3-bccc-fd7d21be5309)

## Related issue number

Closes #41618.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
