### PR TITLE
[ci] fix windows tests

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -603,7 +603,7 @@ py_test(
     name = "vsphere/test_vsphere_sdk_provider",
     size = "small",
     srcs = ["vsphere/test_vsphere_sdk_provider.py"],
-    tags = ["exclusive", "small_size_python_tests", "team:serverless"],
+    tags = ["exclusive", "small_size_python_tests", "no_windows", "team:serverless"],
     deps = ["//:ray_lib", ":conftest"],
 )
 


### PR DESCRIPTION
Move another test to no_windows. Race with https://buildkite.com/ray-project/postmerge/builds/2222 and is now failing pre/postmerge.

Error: https://buildkite.com/ray-project/postmerge/builds/2222#018c7f73-aec5-4dff-a03b-06e8454a5134/6086-6117

Test:
- CI