### PR TITLE
Fixed error in 'SingleAgentEpisode' when starting without data but non-zero lookback.

### DIFF
--- a/rllib/env/utils.py
+++ b/rllib/env/utils.py
@@ -336,7 +336,8 @@ class BufferWithInfiniteLookback:
         if self._final_len is not None:
             assert self.finalized
             return self._final_len
-        return len(self.data) - self.lookback
+        # Only count the data after the lookback.
+        return max(len(self.data) - self.lookback, 0)
 
     def _get_all_data(self, one_hot_discrete=False):
         data = self[:]


### PR DESCRIPTION
Solution counts now only data after the lookback, which is fine as length is used for comparison only and the lookback can be different between different data anyways, e.g. if a user needs 10 prior observations, but not corresponding infos.

## Why are these changes needed?

Starting a `SingleAgentEpisode` without data, but giving a positive `len_lookback_buffer` resulted in an error, due to the definition of the length of the `BufferWithInfiniteLookback`. This was due to the fact that if the data is less than the lookback, length would become negative which is not allowed in Python. 

The solution uses the `max` to take care of such edge cases. 

## Related issue number

#41730 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
