### PR TITLE
[RLlib] Fix issue 41518 `action_masking_tf2` error.

### DIFF
--- a/rllib/core/learner/tf/tf_learner.py
+++ b/rllib/core/learner/tf/tf_learner.py
@@ -423,8 +423,8 @@ class TfLearner(Learner):
             #  constraint on forward_train and compute_loss APIs. This seems to be
             #  in-efficient. However, for tf>=2.12, it works also w/o this conversion
             #  so remove this after we upgrade officially to tf==2.12.
-            _batch = NestedDict(_batch)
-            with tf.GradientTape(persistent=True) as tape:
+            _batch = NestedDict(_batch.copy())
+            with tf.GradientTape(persistent=False) as tape:
                 fwd_out = self._module.forward_train(_batch)
                 loss_per_module = self.compute_loss(fwd_out=fwd_out, batch=_batch)
             gradients = self.compute_gradients(loss_per_module, gradient_tape=tape)

--- a/rllib/core/learner/tf/tf_learner.py
+++ b/rllib/core/learner/tf/tf_learner.py
@@ -424,7 +424,7 @@ class TfLearner(Learner):
             #  in-efficient. However, for tf>=2.12, it works also w/o this conversion
             #  so remove this after we upgrade officially to tf==2.12.
             _batch = NestedDict(_batch.copy())
-            with tf.GradientTape(persistent=False) as tape:
+            with tf.GradientTape(persistent=True) as tape:
                 fwd_out = self._module.forward_train(_batch)
                 loss_per_module = self.compute_loss(fwd_out=fwd_out, batch=_batch)
             gradients = self.compute_gradients(loss_per_module, gradient_tape=tape)

--- a/rllib/examples/action_masking.py
+++ b/rllib/examples/action_masking.py
@@ -80,10 +80,8 @@ def get_cli_args():
 if __name__ == "__main__":
     args = get_cli_args()
 
-    args.local_model = True
     ray.init(num_cpus=args.num_cpus or None, local_mode=args.local_mode)
 
-    args.framework = "tf2"
     if args.framework == "torch":
         rlm_class = TorchActionMaskRLM
     elif args.framework == "tf2":

--- a/rllib/examples/action_masking.py
+++ b/rllib/examples/action_masking.py
@@ -80,8 +80,10 @@ def get_cli_args():
 if __name__ == "__main__":
     args = get_cli_args()
 
+    args.local_model = True
     ray.init(num_cpus=args.num_cpus or None, local_mode=args.local_mode)
 
+    args.framework = "tf2"
     if args.framework == "torch":
         rlm_class = TorchActionMaskRLM
     elif args.framework == "tf2":


### PR DESCRIPTION
## Why are these changes needed?

The example file `action_masking.py` was showing an error in the CI tests. However, it was unclear what the exact root of the error was in the CI test. Running on Linux Fedora 37 with TensorFlow v2.13. I got an error with TF2: 

```
ValueError: TfLearner._untraced_update(batch: ray.rllib.utils.nested_dict.NestedDict, _ray_trace_ctx=None) should not modify its Python input arguments. Modifying a copy is allowed. The following parameter(s) were modified: batch
```

This was due to the fact that inside of `tf.function`-decorated function we used `NestedDict(batch)` which builds a `NestedDict` referring to the attributes of `batch`. The simple solution here is to just use a copy of the batch. 

If this error was indeed the error in the flaky test is not clear. 

## Related issue number

Closes #41518 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
