### PR TITLE
[serve] Improve stack traces for request failures

### DIFF
--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -762,9 +762,7 @@ class gRPCProxy(GenericProxy):
             if isinstance(e, (RayActorError, RayTaskError)):
                 logger.warning(f"Request failed: {e}", extra={"log_to_stderr": False})
             else:
-                logger.exception(
-                    f"Request failed due to unexpected error."
-                )
+                logger.exception("Request failed due to unexpected error.")
             yield ResponseStatus(
                 code=grpc.StatusCode.INTERNAL,
                 is_error=True,
@@ -1022,9 +1020,7 @@ class HTTPProxy(GenericProxy):
                 code=TIMEOUT_ERROR_CODE,
                 is_error=True,
             )
-            logger.warning(
-                f"Request timed out after {self.request_timeout_s}s."
-            )
+            logger.warning(f"Request timed out after {self.request_timeout_s}s.")
             # We should only send timeout response if we have not sent
             # any messages to the client yet. Header (including status code)
             # messages can only be sent once.
@@ -1043,9 +1039,7 @@ class HTTPProxy(GenericProxy):
             if isinstance(e, (RayActorError, RayTaskError)):
                 logger.warning(f"Request failed: {e}", extra={"log_to_stderr": False})
             else:
-                logger.exception(
-                    f"Request failed due to unexpected error."
-                )
+                logger.exception("Request failed due to unexpected error.")
             status = ResponseStatus(
                 code="500",
                 is_error=True,

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -749,7 +749,7 @@ class RayServeReplica:
             yield
         except Exception as e:
             user_exception = e
-            logger.exception(f"Request failed due to {type(e).__name__}:")
+            logger.error(f"Request failed:\n{e}")
             if ray.util.pdb._is_ray_debugger_enabled():
                 ray.util.pdb._post_mortem()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Removes redundancy between replica and proxy logs when a request fails by logging the traceback only to the file in the proxy.
- Cleans up the traceback so we don't have a long list of internal stack frames.
- Removes redundant `request_id` in the proxy logs.

Before:
```
2023-12-19 11:06:32,463 SUCC scripts.py:496 -- Deployed Serve app successfully.
(ProxyActor pid=34105) ERROR 2023-12-19 11:06:33,104 proxy 127.0.0.1 ddfee632-f31a-47b8-9d44-d425635e15b3 / proxy.py:1037 - ray::ServeReplica:default:A.handle_request_streaming() (pid=34107, ip=127.0.0.1, actor_id=2ccd8118651d5d8e4f635b7e01000000, repr=<ray.serve._private.replica.ServeReplica:default:A object at 0x10fe57b50>)
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/replica.py", line 379, in handle_request_streaming
(ProxyActor pid=34105)     async for result in generator:
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/replica.py", line 334, in _handle_http_request_generator
(ProxyActor pid=34105)     raise e from None
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/replica.py", line 910, in call_user_method
(ProxyActor pid=34105)     raise e from None
(ProxyActor pid=34105) ray.exceptions.RayTaskError: ray::ServeReplica:default:A.handle_request_streaming() (pid=34107, ip=127.0.0.1)
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/utils.py", line 165, in wrap_to_ray_error
(ProxyActor pid=34105)     raise exception
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/replica.py", line 891, in call_user_method
(ProxyActor pid=34105)     result = await method_to_call(*request_args, **request_kwargs)
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/./t.py", line 9, in __call__
(ProxyActor pid=34105)     raise Exception("hi")
(ProxyActor pid=34105) Exception: hi
(ProxyActor pid=34105) Traceback (most recent call last):
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/proxy.py", line 971, in send_request_to_replica
(ProxyActor pid=34105)     async for asgi_message_batch in response_generator:
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/proxy_response_generator.py", line 111, in __anext__
(ProxyActor pid=34105)     raise e from None
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/proxy_response_generator.py", line 91, in __anext__
(ProxyActor pid=34105)     result = await self._get_next_streaming_result()
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/proxy_response_generator.py", line 134, in _get_next_streaming_result
(ProxyActor pid=34105)     return next_result_task.result()
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/proxy_response_generator.py", line 116, in _await_response_anext
(ProxyActor pid=34105)     return await self._response.__anext__()
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/handle.py", line 781, in __anext__
(ProxyActor pid=34105)     return await next_obj_ref
(ProxyActor pid=34105) ray.exceptions.RayTaskError: ray::ServeReplica:default:A.handle_request_streaming() (pid=34107, ip=127.0.0.1, actor_id=2ccd8118651d5d8e4f635b7e01000000, repr=<ray.serve._private.replica.ServeReplica:default:A object at 0x10fe57b50>)
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/replica.py", line 379, in handle_request_streaming
(ProxyActor pid=34105)     async for result in generator:
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/replica.py", line 334, in _handle_http_request_generator
(ProxyActor pid=34105)     raise e from None
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/replica.py", line 910, in call_user_method
(ProxyActor pid=34105)     raise e from None
(ProxyActor pid=34105) ray.exceptions.RayTaskError: ray::ServeReplica:default:A.handle_request_streaming() (pid=34107, ip=127.0.0.1)
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/utils.py", line 165, in wrap_to_ray_error
(ProxyActor pid=34105)     raise exception
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/python/ray/serve/_private/replica.py", line 891, in call_user_method
(ProxyActor pid=34105)     result = await method_to_call(*request_args, **request_kwargs)
(ProxyActor pid=34105)   File "/Users/eoakes/code/ray/./t.py", line 9, in __call__
(ProxyActor pid=34105)     raise Exception("hi")
(ProxyActor pid=34105) Exception: hi
(ServeReplica:default:A pid=34107) ERROR 2023-12-19 11:06:33,102 default_A 6pl59g0b ddfee632-f31a-47b8-9d44-d425635e15b3 / replica.py:752 - Request failed due to RayTaskError:
(ServeReplica:default:A pid=34107)   File "/Users/eoakes/code/ray/python/ray/serve/_private/replica.py", line 749, in wrap_user_method_call
(ServeReplica:default:A pid=34107)     yield
(ServeReplica:default:A pid=34107) INFO 2023-12-19 11:06:33,102 default_A 6pl59g0b ddfee632-f31a-47b8-9d44-d425635e15b3 / replica.py:768 - __CALL__ ERROR 1.1ms
```

After:
```
2023-12-19 11:06:00,085 SUCC scripts.py:496 -- Deployed Serve app successfully.
(ServeReplica:default:A pid=33977) ERROR 2023-12-19 11:06:10,715 default_A v0qgmu2m af03e4f3-305a-41e5-9c9c-b6943d7dcc39 / replica.py:752 - Request failed:
(ServeReplica:default:A pid=33977) ray::ServeReplica:default:A.handle_request_streaming() (pid=33977, ip=127.0.0.1)
(ServeReplica:default:A pid=33977)   File "/Users/eoakes/code/ray/python/ray/serve/_private/utils.py", line 165, in wrap_to_ray_error
(ServeReplica:default:A pid=33977)     raise exception
(ServeReplica:default:A pid=33977)   File "/Users/eoakes/code/ray/python/ray/serve/_private/replica.py", line 891, in call_user_method
(ServeReplica:default:A pid=33977)     result = await method_to_call(*request_args, **request_kwargs)
(ServeReplica:default:A pid=33977)   File "/Users/eoakes/code/ray/./t.py", line 9, in __call__
(ServeReplica:default:A pid=33977)     raise Exception("hi")
(ServeReplica:default:A pid=33977) Exception: hi
(ServeReplica:default:A pid=33977) INFO 2023-12-19 11:06:10,715 default_A v0qgmu2m af03e4f3-305a-41e5-9c9c-b6943d7dcc39 / replica.py:768 - __CALL__ ERROR 1.0ms
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
