### PR TITLE
[ray ci] use hermetic python to run all tests

### DIFF
--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -51,6 +51,7 @@ py_test(
     name = "test_linux_container",
     size = "small",
     srcs = ["test_linux_container.py"],
+    exec_compatible_with = ["//:hermetic_python"],
     tags = [
         "ci_unit",
         "team:ci",
@@ -66,6 +67,7 @@ py_test(
     name = "test_windows_container",
     size = "small",
     srcs = ["test_windows_container.py"],
+    exec_compatible_with = ["//:hermetic_python"],
     tags = [
         "ci_unit",
         "team:ci",
@@ -81,6 +83,7 @@ py_test(
     name = "test_tester",
     size = "small",
     srcs = ["test_tester.py"],
+    exec_compatible_with = ["//:hermetic_python"],
     tags = [
         "ci_unit",
         "team:ci",
@@ -96,6 +99,7 @@ py_test(
     name = "test_utils",
     size = "small",
     srcs = ["test_utils.py"],
+    exec_compatible_with = ["//:hermetic_python"],
     tags = [
         "ci_unit",
         "team:ci",
@@ -111,6 +115,7 @@ py_test(
     name = "test_builder_container",
     size = "small",
     srcs = ["test_builder_container.py"],
+    exec_compatible_with = ["//:hermetic_python"],
     tags = [
         "ci_unit",
         "team:ci",
@@ -126,6 +131,7 @@ py_test(
     name = "test_linux_tester_container",
     size = "small",
     srcs = ["test_linux_tester_container.py"],
+    exec_compatible_with = ["//:hermetic_python"],
     tags = [
         "ci_unit",
         "team:ci",
@@ -141,6 +147,7 @@ py_test(
     name = "test_windows_tester_container",
     size = "small",
     srcs = ["test_windows_tester_container.py"],
+    exec_compatible_with = ["//:hermetic_python"],
     tags = [
         "ci_unit",
         "team:ci",
@@ -156,6 +163,7 @@ py_test(
     name = "test_ray_docker_container",
     size = "small",
     srcs = ["test_ray_docker_container.py"],
+    exec_compatible_with = ["//:hermetic_python"],
     tags = [
         "ci_unit",
         "team:ci",
@@ -171,6 +179,7 @@ py_test(
     name = "test_anyscale_docker_container",
     size = "small",
     srcs = ["test_anyscale_docker_container.py"],
+    exec_compatible_with = ["//:hermetic_python"],
     tags = [
         "ci_unit",
         "team:ci",
@@ -187,6 +196,7 @@ py_test(
     size = "small",
     srcs = ["test_bazel_sharding.py"],
     data = ["mock_BUILD"],
+    exec_compatible_with = ["//:hermetic_python"],
     tags = [
         "ci_unit",
         "team:ci",


### PR DESCRIPTION
so that the python runtime is pinned, and test results are more deterministic.