### PR TITLE
[ci][mac/1] move macos small test to civ2

### DIFF
--- a/.buildkite/macos.rayci.yml
+++ b/.buildkite/macos.rayci.yml
@@ -1,0 +1,15 @@
+group: macos tests
+steps:
+  # block on premerge
+  - block: "run macos tests"
+    if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b"
+
+  - label: ":ray: core: :mac: small & client tests"
+    tags: 
+      - core_cpp
+      - python
+      - oss
+    job_env: MACOS
+    instance_type: macos
+    commands:
+      - ./ci/ray_ci/macos/macos_ci.sh run_small_test

--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -136,19 +136,6 @@ steps:
     - ./ci/ci.sh test_cpp
     - *epilogue_commands
 
-
-- label: ":mac: :apple: Small & Client"
-  <<: *common
-  conditions: ["RAY_CI_CORE_CPP_AFFECTED", "RAY_CI_PYTHON_AFFECTED"]
-  commands:
-    - *prelude_commands
-    - bazel test $(./ci/run/bazel_export_options) --config=ci
-      --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX
-      --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --test_env=CI
-      --test_tag_filters=client_tests,small_size_python_tests
-      -- python/ray/tests/...
-    - *epilogue_commands
-
 - label: ":mac: :apple: Large"
   <<: *common
   parallelism: 3

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -508,6 +508,10 @@ install_pip_packages() {
 }
 
 install_thirdparty_packages() {
+  if [[ "${OSTYPE}" = darwin* ]]; then
+    # Currently do not work on macOS
+    return
+  fi
   mkdir -p "${WORKSPACE_DIR}/python/ray/thirdparty_files"
   RAY_THIRDPARTY_FILES="$(realpath "${WORKSPACE_DIR}/python/ray/thirdparty_files")"
   CC=gcc python -m pip install psutil setproctitle==1.2.2 colorama --target="${RAY_THIRDPARTY_FILES}"

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -ex
+
+export CI="true"
+export PYTHON="3.8"
+export RAY_USE_RANDOM_PORTS="1"
+export RAY_DEFAULT_BUILD="1"
+export LC_ALL="en_US.UTF-8"
+export LANG="en_US.UTF-8"
+export BUILD="1"
+export DL="1"
+
+run_small_test() {
+  # shellcheck disable=SC2046
+  bazel test $(./ci/run/bazel_export_options) --config=ci \
+    --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX \
+    --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --test_env=CI \
+    --test_tag_filters=client_tests,small_size_python_tests \
+    -- python/ray/tests/...
+}
+
+_prelude() {
+  rm -rf /tmp/bazel_event_logs
+  cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+  (which bazel && bazel clean) || true;
+  . ./ci/ci.sh init && source ~/.zshenv
+  source ~/.zshrc
+  ./ci/ci.sh build
+  ./ci/env/env_info.sh
+}
+
+_epilogue() {
+  # Persist ray logs
+  mkdir -p /tmp/artifacts/.ray/
+  tar -czf /tmp/artifacts/.ray/logs.tgz /tmp/ray
+  # Cleanup runtime environment to save storage
+  rm -rf /tmp/ray
+  # Cleanup local caches - this should not clean up global disk cache
+  bazel clean
+}
+trap _epilogue EXIT
+
+_prelude
+"$@"


### PR DESCRIPTION
Move as it is. Note that the test `//python/ray/tests:test_actor_client_mode` is failing on this PR and is also failing on master

Test:
- CI