### PR TITLE
[ci] unbreak linkcheck

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -92,5 +92,6 @@ steps:
       - if [[ ${BUILDKITE_BRANCH} == 'master' ]]; then make -C doc/ linkcheck_all; else make -C doc/ linkcheck; fi
     depends_on: docbuild
     job_env: docbuild
+    soft_fail: true
     tags:
       - oss


### PR DESCRIPTION
Move linkcheck to softfail. It fails too fast too often due to the internet to be a premerge check. We need to move this to a continuous run model.

Test:
- CI