### PR TITLE
Revert "[Doc] Fix lint errors in docs"

### DIFF
--- a/doc/source/_templates/csat.html
+++ b/doc/source/_templates/csat.html
@@ -8,13 +8,13 @@
       <svg id="csat-yes-icon" class="csat-hidden csat-icon" width="18" height="13" viewBox="0 0 18 13" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M7.00023 10.172L16.1922 0.979004L17.6072 2.393L7.00023 13L0.63623 6.636L2.05023 5.222L7.00023 10.172Z" />
       </svg>
-      <span>Yes</span>
+      <span>Yes<span>
     </div>
     <div id="csat-no" class="csat-button">
       <svg id="csat-no-icon" class="csat-hidden csat-icon" width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M7.00023 5.58599L11.9502 0.635986L13.3642 2.04999L8.41423 6.99999L13.3642 11.95L11.9502 13.364L7.00023 8.41399L2.05023 13.364L0.63623 11.95L5.58623 6.99999L0.63623 2.04999L2.05023 0.635986L7.00023 5.58599Z" />
       </svg>
-      <span>No</span>
+      <span>No<span>
     </div>
   </div>
   <div id="csat-textarea-group" class="csat-hidden">

--- a/doc/source/ray-core/actors.rst
+++ b/doc/source/ray-core/actors.rst
@@ -104,7 +104,7 @@ Use `ray list actors` from :ref:`State API <state-api-overview-ref>` to see acto
   Stats:
   ------------------------------
   Total: 1
-
+  
   Table:
   ------------------------------
       ACTOR_ID                          CLASS_NAME    STATE      JOB_ID  NAME    NODE_ID                                                     PID  RAY_NAMESPACE
@@ -403,8 +403,8 @@ Cancel Actor Tasks by calling :func:`ray.cancel() <ray.cancel>` on the returned 
 In Ray, Task cancellation behavior is contingent on the Task's current state:
 
 **Unscheduled Tasks**:
-If the Actor Task hasn't been scheduled yet, Ray attempts to cancel the scheduling.
-When successfully cancelled at this stage, invoking ``ray.get(actor_task_ref)``
+If the Actor Task hasn't been scheduled yet, Ray attempts to cancel the scheduling. 
+When successfully cancelled at this stage, invoking ``ray.get(actor_task_ref)`` 
 produce a :class:`TaskCancelledError <ray.exceptions.TaskCancelledError>`.
 
 **Running Actor Tasks (Regular Actor, Threaded Actor)**:
@@ -412,8 +412,8 @@ For tasks classified as a single-threaded Actor or a multi-threaded Actor,
 Ray offers no mechanism for interruption.
 
 **Running Async Actor Tasks**:
-For Tasks classified as `async Actors <_async-actors>`, Ray seeks to cancel the associated `asyncio.Task`.
-This cancellation approach aligns with the standards presented in
+For Tasks classified as `async Actors <_async-actors>`, Ray seeks to cancel the associated `asyncio.Task`. 
+This cancellation approach aligns with the standards presented in 
 `asyncio task cancellation <https://docs.python.org/3/library/asyncio-task.html#task-cancellation>`__.
 Note that `asyncio.Task` won't be interrupted in the middle of execution if you don't `await` within the async function.
 
@@ -424,7 +424,7 @@ the Task might not be cancelled.
 You can check if a Task was successfully cancelled using ``ray.get(actor_task_ref)``.
 
 **Recursive Cancellation**:
-Ray tracks all child and Actor Tasks. When the ``recursive=True`` argument is given,
+Ray tracks all child and Actor Tasks. When the``recursive=True`` argument is given,
 it cancels all child and Actor Tasks.
 
 Scheduling

--- a/doc/source/rllib/rllib-advanced-api.rst
+++ b/doc/source/rllib/rllib-advanced-api.rst
@@ -322,7 +322,7 @@ indicating every how many ``Algorithm.train()`` calls an "evaluation step" is ru
     }
 
 
-An evaluation step runs - using its own ``RolloutWorker`` instances - for ``evaluation_duration``
+An evaluation step runs - using its own ``RolloutWorker``s - for ``evaluation_duration``
 episodes or time-steps, depending on the ``evaluation_duration_unit`` setting, which can
 take values of either ``"episodes"`` (default) or ``"timesteps"``.
 

--- a/doc/source/splash.html
+++ b/doc/source/splash.html
@@ -33,7 +33,7 @@
   </div>
 </div>
 
-<div class="container remove-mobile" style="margin-bottom:30px; margin-top:80px; padding:0px;"></div>
+<div class="container remove-mobile" style="margin-bottom:30px; margin-top:80px; padding:0px;">
 
 <h2 style="font-weight:600;">Scaling with Ray</h2>
 


### PR DESCRIPTION
The PR seems to have broken the landing page https://docs.ray.io/en/master/

Reverts ray-project/ray#41809