### PR TITLE
[Doc] Fix broken splash.html

### DIFF
--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,2 +1,3 @@
 singleQuote = true
 bracketSpacing = false
+htmlWhitespaceSensitivity = 'ignore'

--- a/doc/source/splash.html
+++ b/doc/source/splash.html
@@ -4,20 +4,38 @@
   <div class="container remove-mobile">
     <div class="row">
       <div class="col-6">
-        <h1 style="font-weight:600;">Welcome to Ray!</h1>
-        <p>Ray is an open-source unified framework for scaling AI and Python applications.
-        It provides the compute layer for parallel processing so that
-        you don’t need to be a distributed systems expert.
+        <h1 style="font-weight: 600">Welcome to Ray!</h1>
+        <p>
+          Ray is an open-source unified framework for scaling AI and Python
+          applications. It provides the compute layer for parallel processing so
+          that you don’t need to be a distributed systems expert.
         </p>
-        <div class="image-header" style="padding:0px;">
+        <div class="image-header" style="padding: 0px">
           <a href="https://github.com/ray-project/ray">
-              <img class="icon-hover" src="_static/img/github-fill.png" width="25px" height="25px" />
+            <img
+              class="icon-hover"
+              src="_static/img/github-fill.png"
+              width="25px"
+              height="25px"
+            />
           </a>
-          <a href="https://docs.google.com/forms/d/e/1FAIpQLSfAcoiLCHOguOm8e7Jnn-JJdZaCxPGjgVCvFijHB5PLaQLeig/viewform">
-              <img class="icon-hover" src="_static/img/slack-fill.png" width="25px" height="25px" />
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLSfAcoiLCHOguOm8e7Jnn-JJdZaCxPGjgVCvFijHB5PLaQLeig/viewform"
+          >
+            <img
+              class="icon-hover"
+              src="_static/img/slack-fill.png"
+              width="25px"
+              height="25px"
+            />
           </a>
           <a href="https://twitter.com/raydistributed">
-              <img class="icon-hover" src="_static/img/twitter-fill.png" width="25px" height="25px" />
+            <img
+              class="icon-hover"
+              src="_static/img/twitter-fill.png"
+              width="25px"
+              height="25px"
+            />
           </a>
         </div>
       </div>
@@ -27,39 +45,84 @@
           src="https://www.youtube.com/embed/Iu_F_EzQb5o?modestbranding=1"
           title="YouTube Preview"
           frameborder="0"
-          allowfullscreen></iframe>
+          allowfullscreen
+        ></iframe>
       </div>
     </div>
   </div>
 </div>
 
-<div class="container remove-mobile" style="margin-bottom:30px; margin-top:80px; padding:0px;">
-
-<h2 style="font-weight:600;">Scaling with Ray</h2>
+<h2 style="font-weight: 600">Scaling with Ray</h2>
 
 <div class="row">
   <div class="col-4">
-    <div class="nav flex-column nav-pills" id="v-pills-tab" aria-orientation="vertical">
-      <a class="nav-link active" id="v-pills-batch-tab" data-toggle="pill" role="tab" aria-controls="v-pills-data" aria-selected="true">
+    <div
+      class="nav flex-column nav-pills"
+      id="v-pills-tab"
+      aria-orientation="vertical"
+    >
+      <a
+        class="nav-link active"
+        id="v-pills-batch-tab"
+        data-toggle="pill"
+        role="tab"
+        aria-controls="v-pills-data"
+        aria-selected="true"
+      >
         Batch Inference
       </a>
-      <a class="nav-link" id="v-pills-training-tab" data-toggle="pill" role="tab" aria-controls="v-pills-training" aria-selected="false">
+      <a
+        class="nav-link"
+        id="v-pills-training-tab"
+        data-toggle="pill"
+        role="tab"
+        aria-controls="v-pills-training"
+        aria-selected="false"
+      >
         Model Training
       </a>
-      <a class="nav-link" id="v-pills-tuning-tab" data-toggle="pill" role="tab" aria-controls="v-pills-tuning" aria-selected="false">
+      <a
+        class="nav-link"
+        id="v-pills-tuning-tab"
+        data-toggle="pill"
+        role="tab"
+        aria-controls="v-pills-tuning"
+        aria-selected="false"
+      >
         Hyperparameter Tuning
-      <a class="nav-link" id="v-pills-serving-tab" data-toggle="pill" role="tab" aria-controls="v-pills-serving" aria-selected="false">
+      </a>
+      <a
+        class="nav-link"
+        id="v-pills-serving-tab"
+        data-toggle="pill"
+        role="tab"
+        aria-controls="v-pills-serving"
+        aria-selected="false"
+      >
         Model Serving
       </a>
-      <a class="nav-link" id="v-pills-rl-tab" data-toggle="pill" role="tab" aria-controls="v-pills-rl" aria-selected="false">
+      <a
+        class="nav-link"
+        id="v-pills-rl-tab"
+        data-toggle="pill"
+        role="tab"
+        aria-controls="v-pills-rl"
+        aria-selected="false"
+      >
         Reinforcement Learning
       </a>
     </div>
   </div>
   <div class="col-8">
     <div class="tab-content" id="v-pills-tabContent">
-      <div class="tab-pane fade show active" id="v-pills-data" role="tabpanel" aria-labelledby="v-pills-data-tab">
-        <pre style="margin:0;"><code class="language-python not-selectable">
+      <div
+        class="tab-pane fade show active"
+        id="v-pills-data"
+        role="tabpanel"
+        aria-labelledby="v-pills-data-tab"
+      >
+        <pre style="margin: 0">
+          <code class="language-python not-selectable">
 from typing import Dict
 import numpy as np
 
@@ -94,21 +157,34 @@ scale = ray.data.ActorPoolStrategy(size=2)
 predictions = ds.map_batches(HuggingFacePredictor, compute=scale)
 # Step 4: Show one prediction output.
 predictions.show(limit=1)
-
-            </code></pre>
-              <div class="row" style="padding:16px;">
-                <div class="col-6">
-                  <a href="./data/data.html" target="_blank">Learn more </a> | <a href="./data/api/api.html" target="_blank"> API references</a>
-                </div>
-                <div class="col-6" style="display: flex; justify-content: flex-end;">
-                    <a href="https://github.com/ray-project/ray/blob/master/doc/source/data/examples/huggingface_vit_batch_prediction.ipynb" target="_blank">
-                        <img src="_static/img/github-fill.png" height="25px" /> Open in Github
-                    </a>
-                </div>
-              </div>
+            </code>
+        </pre>
+        <div class="row" style="padding: 16px">
+          <div class="col-6">
+            <a href="./data/data.html" target="_blank">Learn more</a>
+            |
+            <a href="./data/api/api.html" target="_blank">API references</a>
           </div>
-          <div class="tab-pane fade" id="v-pills-training" role="tabpanel" aria-labelledby="v-pills-training-tab" style="user-select:none;">
-            <pre style="margin:0;"><code class="language-python not-selectable">
+          <div class="col-6" style="display: flex; justify-content: flex-end">
+            <a
+              href="https://github.com/ray-project/ray/blob/master/doc/source/data/examples/huggingface_vit_batch_prediction.ipynb"
+              target="_blank"
+            >
+              <img src="_static/img/github-fill.png" height="25px" />
+              Open in Github
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="tab-pane fade"
+        id="v-pills-training"
+        role="tabpanel"
+        aria-labelledby="v-pills-training-tab"
+        style="user-select: none"
+      >
+        <pre style="margin: 0">
+          <code class="language-python not-selectable">
 from ray.train import ScalingConfig
 from ray.train.torch import TorchTrainer
 
@@ -128,20 +204,35 @@ trainer = TorchTrainer(
 
 # Step 3: run distributed model training on 32 GPUs
 result = trainer.fit()
-            </code></pre>
-              <div class="row" style="padding:16px;">
-                <div class="col-6">
-                  <a href="./train/train.html" target="_blank">Learn more </a> | <a href="./train/api/api.html" target="_blank"> API references</a>
-                </div>
-                <div class="col-6" style="display: flex; justify-content: flex-end;">
-                    <a href="https://colab.research.google.com/github/ray-project/ray-educational-materials/blob/main/Computer_vision_workloads/Semantic_segmentation/Scaling_model_training_colab.ipynb" target="_blank">
-                        <img src="_static/img/colab.png" height="25px" /> Open in colab
-                    </a>
-                </div>
-              </div>
+          </code>
+        </pre>
+        <div class="row" style="padding: 16px">
+          <div class="col-6">
+            <a href="./train/train.html" target="_blank">Learn more</a>
+            |
+            <a href="./train/api/api.html" target="_blank">API references</a>
           </div>
-          <div class="tab-pane fade" id="v-pills-tuning" role="tabpanel" aria-labelledby="v-pills-tuning-tab" style="user-select:none;" style="user-select:none;">
-            <pre style="margin:0;"><code class="language-python not-selectable">
+          <div class="col-6" style="display: flex; justify-content: flex-end">
+            <a
+              href="https://colab.research.google.com/github/ray-project/ray-educational-materials/blob/main/Computer_vision_workloads/Semantic_segmentation/Scaling_model_training_colab.ipynb"
+              target="_blank"
+            >
+              <img src="_static/img/colab.png" height="25px" />
+              Open in colab
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="tab-pane fade"
+        id="v-pills-tuning"
+        role="tabpanel"
+        aria-labelledby="v-pills-tuning-tab"
+        style="user-select: none"
+        style="user-select: none"
+      >
+        <pre style="margin: 0">
+          <code class="language-python not-selectable">
 from ray import tune
 from ray.train import ScalingConfig
 from ray.train.lightgbm import LightGBMTrainer
@@ -165,20 +256,35 @@ tuner = tune.Tuner(
 # Step 3: run distributed HPO with 1000 trials; each trial runs on 64 CPUs
 result_grid = tuner.fit()
 
-            </code></pre>
-              <div class="row" style="padding:16px;">
-                <div class="col-6">
-                  <a href="./tune/index.html" target="_blank">Learn more </a> | <a href="./tune/api/api.html" target="_blank"> API references</a>
-                </div>
-                <div class="col-6" style="display: flex; justify-content: flex-end;">
-                    <a href="https://github.com/ray-project/ray/blob/master/doc/source/tune/examples/lightgbm_example.ipynb" target="_blank">
-                        <img src="_static/img/github-fill.png" height="25px" /> Open in Github
-                    </a>
-                </div>
-              </div>
+          </code>
+        </pre>
+        <div class="row" style="padding: 16px">
+          <div class="col-6">
+            <a href="./tune/index.html" target="_blank">Learn more</a>
+            |
+            <a href="./tune/api/api.html" target="_blank">API references</a>
           </div>
-          <div class="tab-pane fade" id="v-pills-serving" role="tabpanel" aria-labelledby="v-pills-serving-tab" style="user-select:none;" style="user-select:none;">
-            <pre style="margin:0;"><code class="language-python">
+          <div class="col-6" style="display: flex; justify-content: flex-end">
+            <a
+              href="https://github.com/ray-project/ray/blob/master/doc/source/tune/examples/lightgbm_example.ipynb"
+              target="_blank"
+            >
+              <img src="_static/img/github-fill.png" height="25px" />
+              Open in Github
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="tab-pane fade"
+        id="v-pills-serving"
+        role="tabpanel"
+        aria-labelledby="v-pills-serving-tab"
+        style="user-select: none"
+        style="user-select: none"
+      >
+        <pre style="margin: 0">
+          <code class="language-python">
 import pandas as pd
 
 from ray import serve
@@ -213,22 +319,34 @@ class PredictDeployment:
     async def __call__(self, http_request: Request) -> str:
         prompts: list[str] = await http_request.json()["prompts"]
         return self.generate(prompts)
-
-
-            </code></pre>
-              <div class="row" style="padding:16px;">
-                <div class="col-6">
-                   <a href="./serve/index.html" target="_blank">Learn more </a> | <a href="./serve/api/index.html" target="_blank"> API references</a>
-                </div>
-                <div class="col-6" style="display: flex; justify-content: flex-end;">
-                    <a href="https://github.com/ray-project/ray/blob/master/doc/source/ray-air/examples/gptj_serving.ipynb" target="_blank">
-                        <img src="_static/img/github-fill.png" height="25px" /> Open in Github
-                    </a>
-                </div>
-              </div>
+          </code>
+        </pre>
+        <div class="row" style="padding: 16px">
+          <div class="col-6">
+            <a href="./serve/index.html" target="_blank">Learn more</a>
+            |
+            <a href="./serve/api/index.html" target="_blank">API references</a>
           </div>
-          <div class="tab-pane fade" id="v-pills-rl" role="tabpanel" aria-labelledby="v-pills-rl-tab" style="user-select:none;">
-            <pre style="margin:0;"><code class="language-python not-selectable">
+          <div class="col-6" style="display: flex; justify-content: flex-end">
+            <a
+              href="https://github.com/ray-project/ray/blob/master/doc/source/ray-air/examples/gptj_serving.ipynb"
+              target="_blank"
+            >
+              <img src="_static/img/github-fill.png" height="25px" />
+              Open in Github
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="tab-pane fade"
+        id="v-pills-rl"
+        role="tabpanel"
+        aria-labelledby="v-pills-rl-tab"
+        style="user-select: none"
+      >
+        <pre style="margin: 0">
+          <code class="language-python not-selectable">
 from ray.rllib.algorithms.ppo import PPOConfig
 
 # Step 1: configure PPO to run 64 parallel workers to collect samples from the env.
@@ -249,149 +367,262 @@ for _ in range(5):
 
 ppo_algo.evaluate()
             </code></pre>
-              <div class="row" style="padding:16px;">
-                <div class="col-6">
-                  <a href="./rllib/index.html" target="_blank">Learn more </a> | <a href="./rllib/package_ref/index.html" target="_blank"> API references</a>
-                </div>
-                <div class="col-6" style="display: flex; justify-content: flex-end;">
-                    <a href="https://github.com/anyscale/ray-summit-2022-training/blob/main/ray-rllib/ex_01_intro_gym_and_rllib.ipynb" target="_blank">
-                        <img src="_static/img/github-fill.png" height="25px" /> Open in Github
-                    </a>
-                </div>
-              </div>
+        <div class="row" style="padding: 16px">
+          <div class="col-6">
+            <a href="./rllib/index.html" target="_blank">Learn more</a>
+            |
+            <a href="./rllib/package_ref/index.html" target="_blank">
+              API references
+            </a>
           </div>
-
-
+          <div class="col-6" style="display: flex; justify-content: flex-end">
+            <a
+              href="https://github.com/anyscale/ray-summit-2022-training/blob/main/ray-rllib/ex_01_intro_gym_and_rllib.ipynb"
+              target="_blank"
+            >
+              <img src="_static/img/github-fill.png" height="25px" />
+              Open in Github
+            </a>
+          </div>
         </div>
+      </div>
     </div>
+  </div>
 </div>
+<div
+  class="container"
+  style="margin-bottom: 30px; margin-top: 80px; padding: 0px"
+>
+  <h2 style="font-weight: 600">Getting Started</h2>
 
-</div>
-
-
-
-<div class="container" style="margin-bottom:30px; margin-top:80px; padding:0px;">
-    <h2 style="font-weight:600;">Getting Started</h2>
-
-<div class="grid-container">
-  <a class="no-underline" href="./ray-overview/index.html" target="_blank"> <div class="info-box" style="height:100%;">
-        <div class="image-header" style="padding:0px;">
-            <img src="_static/img/ray_logo.png" width="44px" height="44px" />
-            <h3 style="font-size:20px;">Learn basics</h3>
+  <div class="grid-container">
+    <a class="no-underline" href="./ray-overview/index.html" target="_blank">
+      <div class="info-box" style="height: 100%">
+        <div class="image-header" style="padding: 0px">
+          <img src="_static/img/ray_logo.png" width="44px" height="44px" />
+          <h3 style="font-size: 20px">Learn basics</h3>
         </div>
         <p>Understand how the Ray framework scales your ML workflows.</p>
-        <p style="font-weight:600;">Learn more > </p>
-  </div> </a>
-   <a class="no-underline" href="./ray-overview/installation.html" target="_blank"> <div class="info-box" style="height:100%;">
-        <div class="image-header" style="padding:0px;">
-            <img src="_static/img/download.png" width="44px" height="44px" />
-            <h3 style="font-size:20px;">Install Ray</h3>
+        <p style="font-weight: 600">Learn more ></p>
+      </div>
+    </a>
+    <a
+      class="no-underline"
+      href="./ray-overview/installation.html"
+      target="_blank"
+    >
+      <div class="info-box" style="height: 100%">
+        <div class="image-header" style="padding: 0px">
+          <img src="_static/img/download.png" width="44px" height="44px" />
+          <h3 style="font-size: 20px">Install Ray</h3>
         </div>
-        <p style="font-weight:600; margin-bottom: 0px;">Installation guide ></p>
-  </div></a>
-  <a class="no-underline" href="https://colab.research.google.com/github/ray-project/ray-educational-materials/blob/main/Introductory_modules/Quickstart_with_Ray_AIR_Colab.ipynb"  target="_blank"
-        ><div class="info-box" style="height:100%;">
-        <div class="image-header" style="padding:0px;">
-            <img src="_static/img/code.png" width="44px" height="44px" />
-            <h3 style="font-size:20px;">Try it out</h3>
+        <p style="font-weight: 600; margin-bottom: 0px">Installation guide ></p>
+      </div>
+    </a>
+    <a
+      class="no-underline"
+      href="https://colab.research.google.com/github/ray-project/ray-educational-materials/blob/main/Introductory_modules/Quickstart_with_Ray_AIR_Colab.ipynb"
+      target="_blank"
+    >
+      <div class="info-box" style="height: 100%">
+        <div class="image-header" style="padding: 0px">
+          <img src="_static/img/code.png" width="44px" height="44px" />
+          <h3 style="font-size: 20px">Try it out</h3>
         </div>
         <p>Experiment with Ray with an introductory notebook.</p>
-        <p style="font-weight:600;">Open the notebook></p>
-  </div></a>
-</div>
-
-
-<div class="container" style="margin-bottom:30px; margin-top:80px; padding:0px;">
-    <h2 style="font-weight:600;">Beyond the basics</h2>
-</div>
-
-<div class = "grid-container">
-  <div class="info-box-2">
-        <div class="image-header" style="padding:0px;">
-            <img src="_static/img/AIR.png" width="32px" height="32px" />
-            <h3 style="font-size:20px; font-weight:600;">Ray Libraries</h3>
-        </div>
-        <p>Scale the entire ML pipeline from data ingest to model serving with high-level Python APIs that integrate with popular ecosystem frameworks.</p>
-        <a class="bold-link" style="letter-spacing:0.05em; text-transform:uppercase; font-weight:500;" href="./ray-overview/getting-started.html#ray-ai-runtime-libraries-quickstart" target="_blank">Learn more about Ray Libraries></a>
+        <p style="font-weight: 600">Open the notebook></p>
+      </div>
+    </a>
   </div>
-  <div class="info-box-2">
-        <div class="image-header" style="padding:0px;">
-            <img src="_static/img/Core.png" width="32px" height="32px" />
-            <h3 style="font-size:20px; font-weight:600;">Ray Core</h3>
-        </div>
-        <p>Scale generic Python code with simple, foundational primitives that enable a high degree of control for building distributed applications or custom platforms.</p>
-        <a class="bold-link" style="letter-spacing:0.05em; text-transform:uppercase; font-weight:500;" href="./ray-core/walkthrough.html" target="_blank">Learn more about Core ></a>
-  </div>
-  <div class="info-box-2">
-        <div class="image-header" style="padding:0px;">
-            <img src="_static/img/rayclusters.png" width="32px" height="32px" />
-            <h3 style="font-size:20px; font-weight:600;">Ray Clusters</h3>
-        </div>
-        <p>Deploy a Ray cluster on AWS, GCP, Azure or kubernetes from a laptop to a large cluster to seamlessly scale workloads for production</p>
-        <a class="bold-link" style="letter-spacing:0.05em; text-transform:uppercase; font-weight:500;" href="./cluster/getting-started.html" target="_blank">Learn more about clusters ></a>
-  </div>
-</div>
 
+  <div
+    class="container"
+    style="margin-bottom: 30px; margin-top: 80px; padding: 0px"
+  >
+    <h2 style="font-weight: 600">Beyond the basics</h2>
+  </div>
 
-<div class="container" style="margin-bottom:5px; margin-top:80px; padding:0px;">
-  <h2 style="font-weight:600;">Getting involved</h2>
-</div>
+  <div class="grid-container">
+    <div class="info-box-2">
+      <div class="image-header" style="padding: 0px">
+        <img src="_static/img/AIR.png" width="32px" height="32px" />
+        <h3 style="font-size: 20px; font-weight: 600">Ray Libraries</h3>
+      </div>
+      <p>
+        Scale the entire ML pipeline from data ingest to model serving with
+        high-level Python APIs that integrate with popular ecosystem frameworks.
+      </p>
+      <a
+        class="bold-link"
+        style="
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          font-weight: 500;
+        "
+        href="./ray-overview/getting-started.html#ray-ai-runtime-libraries-quickstart"
+        target="_blank"
+      >
+        Learn more about Ray Libraries>
+      </a>
+    </div>
+    <div class="info-box-2">
+      <div class="image-header" style="padding: 0px">
+        <img src="_static/img/Core.png" width="32px" height="32px" />
+        <h3 style="font-size: 20px; font-weight: 600">Ray Core</h3>
+      </div>
+      <p>
+        Scale generic Python code with simple, foundational primitives that
+        enable a high degree of control for building distributed applications or
+        custom platforms.
+      </p>
+      <a
+        class="bold-link"
+        style="
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          font-weight: 500;
+        "
+        href="./ray-core/walkthrough.html"
+        target="_blank"
+      >
+        Learn more about Core >
+      </a>
+    </div>
+    <div class="info-box-2">
+      <div class="image-header" style="padding: 0px">
+        <img src="_static/img/rayclusters.png" width="32px" height="32px" />
+        <h3 style="font-size: 20px; font-weight: 600">Ray Clusters</h3>
+      </div>
+      <p>
+        Deploy a Ray cluster on AWS, GCP, Azure or kubernetes from a laptop to a
+        large cluster to seamlessly scale workloads for production
+      </p>
+      <a
+        class="bold-link"
+        style="
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          font-weight: 500;
+        "
+        href="./cluster/getting-started.html"
+        target="_blank"
+      >
+        Learn more about clusters >
+      </a>
+    </div>
+  </div>
+
+  <div
+    class="container"
+    style="margin-bottom: 5px; margin-top: 80px; padding: 0px"
+  >
+    <h2 style="font-weight: 600">Getting involved</h2>
+  </div>
   <div class="grid-container">
     <div>
-    <h4> Join the community </h4>
-    <a class="no-underline" href="https://www.meetup.com/Bay-Area-Ray-Meetup/" target="_blank"> <div class="community-box">
-        <div class="image-header">
+      <h4>Join the community</h4>
+      <a
+        class="no-underline"
+        href="https://www.meetup.com/Bay-Area-Ray-Meetup/"
+        target="_blank"
+      >
+        <div class="community-box">
+          <div class="image-header">
             <img src="_static/img/meetup.png" width="24px" height="24px" />
             <p>Attend community events</p>
+          </div>
         </div>
-    </div></a>
-    <a class="no-underline" href="https://share.hsforms.com/1Ee3Gh8c9TY69ZQib-yZJvgc7w85" target="_blank"> <div class="community-box">
-        <div class="image-header">
+      </a>
+      <a
+        class="no-underline"
+        href="https://share.hsforms.com/1Ee3Gh8c9TY69ZQib-yZJvgc7w85"
+        target="_blank"
+      >
+        <div class="community-box">
+          <div class="image-header">
             <img src="_static/img/mail.png" width="24px" height="24px" />
             <p>Subscribe to the newsletter</p>
+          </div>
         </div>
-    </div></a>
-    <a class="no-underline" href="https://twitter.com/raydistributed" target="_blank"> <div class="community-box">
-        <div class="image-header">
-            <img src="_static/img/twitter-fill.png" width="24px" height="24px" />
+      </a>
+      <a
+        class="no-underline"
+        href="https://twitter.com/raydistributed"
+        target="_blank"
+      >
+        <div class="community-box">
+          <div class="image-header">
+            <img
+              src="_static/img/twitter-fill.png"
+              width="24px"
+              height="24px"
+            />
             <p>Follow us on Twitter</p>
+          </div>
         </div>
-    </div></a>
-  </div>
-<div>
-    <h4> Get Support </h4>
-     <a class="no-underline" href="https://docs.google.com/forms/d/e/1FAIpQLSfAcoiLCHOguOm8e7Jnn-JJdZaCxPGjgVCvFijHB5PLaQLeig/viewform" target="_blank"> <div class="community-box">
-        <div class="image-header">
+      </a>
+    </div>
+    <div>
+      <h4>Get Support</h4>
+      <a
+        class="no-underline"
+        href="https://docs.google.com/forms/d/e/1FAIpQLSfAcoiLCHOguOm8e7Jnn-JJdZaCxPGjgVCvFijHB5PLaQLeig/viewform"
+        target="_blank"
+      >
+        <div class="community-box">
+          <div class="image-header">
             <img src="_static/img/slack-fill.png" width="24px" height="24px" />
             <p>Find community on Slack</p>
+          </div>
         </div>
-    </div></a>
-    <a class="no-underline" href="https://discuss.ray.io/" target="_blank"> <div class="community-box">
-        <div class="image-header">
+      </a>
+      <a class="no-underline" href="https://discuss.ray.io/" target="_blank">
+        <div class="community-box">
+          <div class="image-header">
             <img src="_static/img/chat.png" width="24px" height="24px" />
             <p>Ask questions to the forum</p>
+          </div>
         </div>
-    </div></a>
-    <a class="no-underline" href="https://github.com/ray-project/ray/issues/new/choose" target="_blank"> <div class="community-box">
-        <div class="image-header">
+      </a>
+      <a
+        class="no-underline"
+        href="https://github.com/ray-project/ray/issues/new/choose"
+        target="_blank"
+      >
+        <div class="community-box">
+          <div class="image-header">
             <img src="_static/img/github-fill.png" width="24px" height="24px" />
             <p>Open an issue</p>
+          </div>
         </div>
-    </div></a>
-  </div>
-  <div>
-    <h4> Contribute to Ray </h4>
-    <a class="no-underline" href="./ray-contribute/getting-involved.html" target="_blank"> <div class="community-box">
-        <div class="image-header">
+      </a>
+    </div>
+    <div>
+      <h4>Contribute to Ray</h4>
+      <a
+        class="no-underline"
+        href="./ray-contribute/getting-involved.html"
+        target="_blank"
+      >
+        <div class="community-box">
+          <div class="image-header">
             <img src="_static/img/mail.png" width="24px" height="24px" />
             <p>Contributor's guide</p>
+          </div>
         </div>
-    </div></a>
-    <a class="no-underline" href="https://github.com/ray-project/ray/pulls" target="_blank"> <div class="community-box">
-        <div class="image-header">
+      </a>
+      <a
+        class="no-underline"
+        href="https://github.com/ray-project/ray/pulls"
+        target="_blank"
+      >
+        <div class="community-box">
+          <div class="image-header">
             <img src="_static/img/github-fill.png" width="24px" height="24px" />
             <p>Create a pull request</p>
+          </div>
         </div>
-    </div></a>
+      </a>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes broken HTML in `splash.html`:

- A missing `</a>` caused the page to break; this has been added.
- Part of the issue was that the formatting of the HTML was extremely hard to read; as part of the pre-commit hooks recently introduced, we now can run `prettier` on the code. This helped isolate the issue, and also formatted the file.
- Updated formatting rules to prevent prettier from splitting closing tags across lines

## Related issue number

Re-applies changes introduced in https://github.com/ray-project/ray/pull/41809.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
