### PR TITLE
[spark] Kill hanging spark jobs when databricks notebook is detached

### DIFF
--- a/python/ray/util/spark/databricks_hook.py
+++ b/python/ray/util/spark/databricks_hook.py
@@ -145,3 +145,7 @@ class DefaultDatabricksRayOnSparkStartHook(RayOnSparkStartHook):
                 time.sleep(DATABRICKS_AUTO_SHUTDOWN_POLL_INTERVAL_SECONDS)
 
         threading.Thread(target=auto_shutdown_watcher, daemon=True).start()
+
+    def on_spark_job_created(self, job_group_id):
+        db_api_entry = get_db_entry_point()
+        db_api_entry.registerBackgroundSparkJobGroup("job_group_id")

--- a/python/ray/util/spark/start_hook_base.py
+++ b/python/ray/util/spark/start_hook_base.py
@@ -10,3 +10,7 @@ class RayOnSparkStartHook:
 
     def on_cluster_created(self, ray_cluster_handler):
         pass
+
+    def on_spark_job_created(self, job_group_id):
+        pass
+

--- a/python/ray/util/spark/start_hook_base.py
+++ b/python/ray/util/spark/start_hook_base.py
@@ -13,4 +13,3 @@ class RayOnSparkStartHook:
 
     def on_spark_job_created(self, job_group_id):
         pass
-


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

On databricks runtime, when user starts a Ray on spark cluster in a notebook, when notebook is detached, the Ray head node is killed, but we observe the Ray worker nodes are still running in some cases, so it causes the background spark job hanging and can't release resources.

So this PR is for addressing this issue. When databricks notebook is detached, we enforce all spark jobs created in this notebook REPL are killed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
