### PR TITLE
[ci] disable finetuning  release tests

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1024,7 +1024,7 @@
   group: Workspace templates
   working_dir: workspace_templates/04_finetuning_llms_with_deepspeed
   python: "3.9"
-  frequency: nightly-3x
+  frequency: manual
   team: ml
   cluster:
     byod:
@@ -1049,7 +1049,7 @@
   group: Workspace templates
   working_dir: workspace_templates/04_finetuning_llms_with_deepspeed
   python: "3.9"
-  frequency: nightly-3x
+  frequency: manual
   team: ml
   cluster:
     byod:


### PR DESCRIPTION
The finetuning release tests are failing to build due to dependency conflicts: https://buildkite.com/ray-project/release/builds/4480#018c7bd5-5e8a-4085-9dc1-1b7361dc6c87/6-415. I moved it to manual run temporarily since it blocks all other tests from running

Test:
- CI