### PR TITLE
[Core] Make sure redis sync context and async context connect to the same redis instance

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -490,7 +490,7 @@ Status RedisContext::Connect(const std::string &address,
   // Connect to async context
   std::unique_ptr<redisAsyncContext, RedisContextDeleter> async_context;
   {
-    auto resp = ConnectWithRetries<redisAsyncContext>(address, port, redisAsyncConnect);
+    auto resp = ConnectWithRetries<redisAsyncContext>(ip_addresses[0], port, redisAsyncConnect);
     RAY_CHECK_OK(resp.first);
     async_context = std::move(resp.second);
   }

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -490,7 +490,8 @@ Status RedisContext::Connect(const std::string &address,
   // Connect to async context
   std::unique_ptr<redisAsyncContext, RedisContextDeleter> async_context;
   {
-    auto resp = ConnectWithRetries<redisAsyncContext>(ip_addresses[0], port, redisAsyncConnect);
+    auto resp =
+        ConnectWithRetries<redisAsyncContext>(ip_addresses[0], port, redisAsyncConnect);
     RAY_CHECK_OK(resp.first);
     async_context = std::move(resp.second);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We are using ip for redis sync context connection but domain name for redis async context so there is a chance redis async context doesn't connect to the master.

I think what can happen is that during `RedisContext::Connect()`, the domain name is resolved to two ips (ip[0] is master, ip[1] is replica). sync context is connected to ip[0] so it's fine while async context is connected using domain name so it might be connected to ip[1] which is a replica. Later on we have check to make sure we are connected to the master but we only do the check for sync context so we don't realize that the async context is connected to the replica. Then when we use async context to send `HGET` request, replica will return MOVED (https://redis.io/commands/readonly/) to redirect us to the master and since we don't handle MOVED at that time, it failed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
