### PR TITLE
[ci] fix linkcheck

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -86,12 +86,23 @@ steps:
     commands:
       - ./ci/lint/check-documentation-style.sh
 
-  - label: ":lint-roller: lint: linkcheck"
+  # premerge linkcheck run; validate links within the ray repository
+  - label: ":lint-roller: lint: ray linkcheck"
+    if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b"
     instance_type: medium
     commands:
-      - if [[ ${BUILDKITE_BRANCH} == 'master' ]]; then make -C doc/ linkcheck_all; else make -C doc/ linkcheck; fi
+      - make -C doc/ linkcheck
     depends_on: docbuild
     job_env: docbuild
-    soft_fail: true
+
+  # postmerge linkcheck run; validate links within ray and also external links
+  - label: ":lint-roller: lint: all linkcheck"
+    instance_type: medium
+    commands:
+      - make -C doc/ linkcheck_all
+    depends_on: docbuild
+    job_env: docbuild
     tags:
       - oss
+      - skip-on-premerge
+    soft_fail: true

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -310,7 +310,10 @@ if __name__ == "__main__":
             elif any(changed_file.startswith(prefix) for prefix in skip_prefix_list):
                 # nothing is run but linting in these cases
                 pass
-            elif changed_file.startswith("ci/lint"):
+            elif (
+                changed_file.startswith("ci/lint")
+                or changed_file == ".buildkite/lint.rayci.yml"
+            ):
                 # Linter will always be run
                 RAY_CI_TOOLS_AFFECTED = 1
             elif (


### PR DESCRIPTION
Split link check jobs into two, one for premerge and one for postmerge. Postmerge run validates all the links and software. Premerge run validates only links within ray repositories and hard block.

Test:
- CI