### PR TITLE
[Doc] Update default value for dashboard agent port from random to 52365

### DIFF
--- a/doc/source/ray-core/configure.rst
+++ b/doc/source/ray-core/configure.rst
@@ -130,7 +130,7 @@ The node manager and object manager run as separate processes with their own por
 The following options specify the ports used by dashboard agent process.
 
 - ``--dashboard-agent-grpc-port``: The port to listen for grpc on. Default: Random value.
-- ``--dashboard-agent-listen-port``: The port to listen for http on. Default: Random value.
+- ``--dashboard-agent-listen-port``: The port to listen for http on. Default: 52365.
 - ``--metrics-export-port``: The port to use to expose Ray metrics. Default: Random value.
 
 The following options specify the range of ports used by worker processes across machines. All ports in the range should be open.


### PR DESCRIPTION
The documented default value of the dashboard agent port was Random. This is incorrect, the default value is 52635.  This PR updates the doc to reflect this.

Source:
https://github.com/ray-project/ray/blob/8ec469403e805287716d058638243114e33c6f61/python/ray/scripts/scripts.py#L423
https://github.com/ray-project/ray/blob/20c7607b8926316a003867fa46564f9fb2978f81/python/ray/_private/ray_constants.py#L116
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
