### PR TITLE
[data] propogate error from `tensorize`

### DIFF
--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -145,11 +145,11 @@ def convert_pandas_to_torch_tensor(
             col_vals = batch[col].values
             try:
                 t = tensorize(col_vals, dtype=dtype)
-            except Exception:
+            except Exception as e:
                 raise ValueError(
                     f"Failed to convert column {col} to a Torch Tensor of dtype "
                     f"{dtype}. See above exception chain for the exact failure."
-                )
+                ) from e
             if unsqueeze:
                 t = t.unsqueeze(1)
             feature_tensors.append(t)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->

Small fix to make sure error message gets propagated. When called from a remote task (?) the original error does not get output as expected.

Note that this code path is only called within `Dataset.to_torch` -> `convert_pandas_to_torch_tensor`, which can potentially be unified in the future with `Dataset.iter_torch_batches` -> `convert_ndarray_batch_to_torch_tensor_batch` instead.


**Repro:**
```python
import ray.data
import pandas as pd
from ray.train import ScalingConfig
from ray.train.torch import TorchTrainer


df = pd.DataFrame({"text": ["banana", "apple", "orange"]})
ds = ray.data.from_pandas(df)


def train_func():
    ds = ray.train.get_dataset_shard("train")
    dl = ds.to_torch()
    for batch in dl:
        pass


trainer = TorchTrainer(
    train_func, scaling_config=ScalingConfig(num_workers=1), datasets={"train": ds}
)
trainer.fit()
```


**Before:**
```

ray.exceptions.RayTaskError(ValueError): ray::_Inner.train() (pid=15474, ip=127.0.0.1, actor_id=61c34b91491ba68dbfa297b201000000, repr=TorchTrainer)
  File "/Users/matt/miniconda3/envs/ray/lib/python3.8/site-packages/ray/tune/trainable/trainable.py", line 342, in train
    raise skipped from exception_cause(skipped)
  File "/Users/matt/miniconda3/envs/ray/lib/python3.8/site-packages/ray/train/_internal/utils.py", line 43, in check_for_failure
    ray.get(object_ref)
ray.exceptions.RayTaskError(ValueError): ray::_RayTrainWorker__execute.get_next() (pid=15479, ip=127.0.0.1, actor_id=cadfed6d660506b438cef97901000000, repr=<ray.train._internal.worker_group.RayTrainWorker object at 0x11b8c0df0>)
  File "/Users/matt/miniconda3/envs/ray/lib/python3.8/site-packages/ray/train/_internal/worker_group.py", line 33, in __execute
    raise skipped from exception_cause(skipped)
  File "/Users/matt/miniconda3/envs/ray/lib/python3.8/site-packages/ray/train/_internal/utils.py", line 118, in discard_return_wrapper
    train_func(*args, **kwargs)
  File "text_to_tensor.py", line 15, in train_func
    for batch in dl:
  File "/Users/matt/miniconda3/envs/ray/lib/python3.8/site-packages/ray/data/_internal/torch_iterable_dataset.py", line 10, in __iter__
    yield from it
  File "/Users/matt/miniconda3/envs/ray/lib/python3.8/site-packages/ray/data/iterator.py", line 648, in make_generator
    features_tensor = convert_pandas_to_torch_tensor(
  File "/Users/matt/miniconda3/envs/ray/lib/python3.8/site-packages/ray/air/_internal/torch_utils.py", line 171, in convert_pandas_to_torch_tensor
    return get_tensor_for_columns(columns=columns, dtype=column_dtypes)
  File "/Users/matt/miniconda3/envs/ray/lib/python3.8/site-packages/ray/air/_internal/torch_utils.py", line 149, in get_tensor_for_columns
    raise ValueError(
ValueError: Failed to convert column text to a Torch Tensor of dtype None. See above exception chain for the exact failure.
```

**After:**
```
ray.exceptions.RayTaskError(ValueError): ray::_Inner.train() (pid=44055, ip=127.0.0.1, actor_id=7ba19ff842f779e3fc6b0df901000000, repr=TorchTrainer)
  File "/Users/matt/workspace/ray/python/ray/tune/trainable/trainable.py", line 342, in train
    raise skipped from exception_cause(skipped)
  File "/Users/matt/workspace/ray/python/ray/train/_internal/utils.py", line 43, in check_for_failure
    ray.get(object_ref)
ray.exceptions.RayTaskError(ValueError): ray::_RayTrainWorker__execute.get_next() (pid=44060, ip=127.0.0.1, actor_id=532ef496b9c71a4039a7028501000000, repr=<ray.train._internal.worker_group.RayTrainWorker object at 0x11684f610>)
  File "/Users/matt/workspace/ray/python/ray/air/_internal/torch_utils.py", line 125, in tensorize
    tensors = [tensorize(x, dtype) for x in vals]
  File "/Users/matt/workspace/ray/python/ray/air/_internal/torch_utils.py", line 125, in <listcomp>
    tensors = [tensorize(x, dtype) for x in vals]
  File "/Users/matt/workspace/ray/python/ray/air/_internal/torch_utils.py", line 122, in tensorize
    if vals.dtype.type is np.object_:
AttributeError: 'str' object has no attribute 'dtype'

The above exception was the direct cause of the following exception:

ray::_RayTrainWorker__execute.get_next() (pid=44060, ip=127.0.0.1, actor_id=532ef496b9c71a4039a7028501000000, repr=<ray.train._internal.worker_group.RayTrainWorker object at 0x11684f610>)
  File "/Users/matt/workspace/ray/python/ray/train/_internal/worker_group.py", line 33, in __execute
    raise skipped from exception_cause(skipped)
  File "/Users/matt/workspace/ray/python/ray/train/_internal/utils.py", line 118, in discard_return_wrapper
    train_func(*args, **kwargs)
  File "text_to_tensor.py", line 15, in train_func
    for batch in dl:
  File "/Users/matt/workspace/ray/python/ray/data/_internal/torch_iterable_dataset.py", line 10, in __iter__
    yield from it
  File "/Users/matt/workspace/ray/python/ray/data/iterator.py", line 654, in make_generator
    features_tensor = convert_pandas_to_torch_tensor(
  File "/Users/matt/workspace/ray/python/ray/air/_internal/torch_utils.py", line 171, in convert_pandas_to_torch_tensor
    return get_tensor_for_columns(columns=columns, dtype=column_dtypes)
  File "/Users/matt/workspace/ray/python/ray/air/_internal/torch_utils.py", line 149, in get_tensor_for_columns
    raise ValueError(
ValueError: Failed to convert column text to a Torch Tensor of dtype None. See above exception chain for the exact failure.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
