### PR TITLE
[Doc] Fix port default value description for `dashboard-agent-listen-port`

### DIFF
--- a/doc/source/ray-core/configure.rst
+++ b/doc/source/ray-core/configure.rst
@@ -130,7 +130,7 @@ The node manager and object manager run as separate processes with their own por
 The following options specify the ports used by dashboard agent process.
 
 - ``--dashboard-agent-grpc-port``: The port to listen for grpc on. Default: Random value.
-- ``--dashboard-agent-listen-port``: The port to listen for http on. Default: Random value.
+- ``--dashboard-agent-listen-port``: The port to listen for http on. Default: 52365.
 - ``--metrics-export-port``: The port to use to expose Ray metrics. Default: Random value.
 
 The following options specify the range of ports used by worker processes across machines. All ports in the range should be open.


### PR DESCRIPTION
As the document shows, the default value for `dashboard-agent-listen-port` is a random one.

![image](https://github.com/ray-project/ray/assets/69104485/f291d2d9-b83d-4828-8f51-56c35e4ebb55)

It may be not correct, as the Ray start script shows:

![image](https://github.com/ray-project/ray/assets/69104485/f6ad2eca-c03b-4bcf-8243-95b32ca88b96)

It would be set a default value.

