### PR TITLE
Fix a bug where start_time could be None leading to a crash in TuneTerminalReporter

### DIFF
--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -626,7 +626,11 @@ class ProgressReporter(Callback):
         start_time: Optional[float] = None,
         **kwargs,
     ):
-        self._start_time = start_time
+        # setup may be called to update time by the AirProgressReporter, but is
+        # also called with arguments derived from the spec which won't set
+        # start_time, in which case we don't wish to update it
+        if start_time is not None:
+            self._start_time = start_time
 
     def _start_block(self, indicator: Any):
         if self._in_block != indicator:


### PR DESCRIPTION
## Why are these changes needed?

```
Traceback (most recent call last):
  File ".venv/lib/python3.11/site-packages/ray/tune/execution/tune_controller.py", line 1474, in stop_trial
    self._callbacks.on_trial_complete(
  File ".venv/lib/python3.11/site-packages/ray/tune/callback.py", line 416, in on_trial_complete
    callback.on_trial_complete(**info)
  File ".venv/lib/python3.11/site-packages/ray/tune/experimental/output.py", line 728, in on_trial_complete
    curr_time_str, running_time_str = _get_time_str(self._start_time, time.time())
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/ray/tune/experimental/output.py", line 165, in _get_time_str
    start_time_dt = datetime.datetime.fromtimestamp(start_time)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object cannot be interpreted as an integer
```

We can trace this back to https://github.com/ray-project/ray/blob/c0b069c60986a42ba8c79c02055fc219e8d296e8/python/ray/tune/execution/tune_controller.py#L301

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(