### PR TITLE
[Dashboard][Test] Fix osx tests failures on memory profiling

### DIFF
--- a/dashboard/modules/reporter/tests/test_profile_manager.py
+++ b/dashboard/modules/reporter/tests/test_profile_manager.py
@@ -40,6 +40,10 @@ def setup_memory_profiler():
     reason="This test is not supposed to work for minimal installation.",
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="No memray on Windows.")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Fails on OSX, requires memray & lldb installed in osx image",
+)
 class TestMemoryProfiling:
     async def test_basic_attach_profiler(self, setup_memory_profiler, shutdown_only):
         # test basic attach profiler to running process

--- a/dashboard/modules/reporter/tests/test_reporter.py
+++ b/dashboard/modules/reporter/tests/test_reporter.py
@@ -809,6 +809,10 @@ def test_get_task_traceback_running_task(shutdown_only):
     reason="This test is not supposed to work for minimal installation.",
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="No memray on Windows.")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Fails on OSX, requires memray & lldb installed in osx image",
+)
 def test_get_memory_profile_running_task(shutdown_only):
     """
     Verify that we can get the memory profile for a running task.
@@ -944,6 +948,10 @@ def test_get_cpu_profile_non_running_task(shutdown_only):
     reason="This test is not supposed to work for minimal installation.",
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="No py-spy on Windows.")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Fails on OSX, requires memray & lldb installed in osx image",
+)
 def test_task_get_memory_profile_missing_params(shutdown_only):
     """
     Verify that we throw an error for a non-running task.

--- a/python/ray/tests/test_dashboard_profiler.py
+++ b/python/ray/tests/test_dashboard_profiler.py
@@ -97,6 +97,10 @@ def test_profiler_endpoints(ray_start_with_dashboard, native):
     reason="This test is not supposed to work for minimal installation.",
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="No memray on Windows.")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Fails on OSX, requires memray & lldb installed in osx image",
+)
 @pytest.mark.parametrize("leaks", ["0", "1"])
 def test_memory_profiler_endpoint(ray_start_with_dashboard, leaks):
     # Sanity check memray are installed.
@@ -172,6 +176,10 @@ def test_memory_profiler_endpoint(ray_start_with_dashboard, leaks):
     reason="This test is not supposed to work for minimal installation.",
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="No py-spy on Windows.")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="Fails on OSX, requires memray & lldb installed in osx image",
+)
 def test_profiler_failure_message(ray_start_with_dashboard):
     # Sanity check py-spy and memray is installed.
     subprocess.check_call(["py-spy", "--version"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes need
Fix memory profiling osx test since memray is not installed in osx image.
<img width="590" alt="Screen Shot 2023-12-21 at 21 59 19" src="https://github.com/ray-project/ray/assets/63906312/35d4b635-198e-422c-b686-0253bb5a5dbd">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
