### PR TITLE
[Workspace template] Fix version conflict with torch

### DIFF
--- a/doc/source/templates/testing/cluster_envs/04_finetuning_llms_with_deepspeed.yaml
+++ b/doc/source/templates/testing/cluster_envs/04_finetuning_llms_with_deepspeed.yaml
@@ -7,9 +7,7 @@ debian_packages:
 
 python:
   pip_packages: [
-    torchvision==0.15.1,
     peft==0.7.0,
-    torchaudio==2.0.1,
     deepspeed,
     fairscale,
     transformers>=4.31.0,

--- a/release/ray_release/byod/byod_finetune_llvms.sh
+++ b/release/ray_release/byod/byod_finetune_llvms.sh
@@ -6,8 +6,6 @@ set -exo pipefail
 
 pip3 install -U \
     torch==2.1.1 \
-    torchvision==0.15.1 \
-    torchaudio==2.0.1 \
     deepspeed==0.12.3 \
     fairscale==0.4.13 \
     datasets==2.14.4 \

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1024,7 +1024,7 @@
   group: Workspace templates
   working_dir: workspace_templates/04_finetuning_llms_with_deepspeed
   python: "3.9"
-  frequency: manual
+  frequency: nightly-3x
   team: ml
   cluster:
     byod:
@@ -1049,7 +1049,7 @@
   group: Workspace templates
   working_dir: workspace_templates/04_finetuning_llms_with_deepspeed
   python: "3.9"
-  frequency: manual
+  frequency: nightly-3x
   team: ml
   cluster:
     byod:


### PR DESCRIPTION
## Why are these changes needed?

Release tests for the LLM fine-tuning template have been failing.
https://buildkite.com/ray-project/release/builds/4480#018c7bd5-5e8a-4085-9dc1-1b7361dc6c87/6-415

The tests were therefore disabled before: https://github.com/ray-project/ray/pull/42038

That is because of torchvision and torchaudio version requirements that we don't have in the template Docker, but cluster env we use for testing, which makes no sense.

These changes fix that.