### PR TITLE
Allow setting of kwargs in `init_torch_dist_process_group`

### DIFF
--- a/python/ray/air/util/torch_dist.py
+++ b/python/ray/air/util/torch_dist.py
@@ -47,7 +47,7 @@ def _init_torch_distributed(
     master_addr: str,
     master_port: str,
     gpu_ids: List[int],
-    **kwargs,
+    **init_process_group_kwargs,
 ):
     """Initialize torch distributed backend"""
     if init_method == "env":
@@ -72,7 +72,6 @@ def _init_torch_distributed(
         if "NCCL_SOCKET_IFNAME" not in os.environ:
             os.environ["NCCL_SOCKET_IFNAME"] = DEFAULT_NCCL_SOCKET_IFNAME
 
-    init_process_group_kwargs = kwargs
     init_process_group_kwargs.update(
         dict(
             backend=backend,

--- a/python/ray/air/util/torch_dist.py
+++ b/python/ray/air/util/torch_dist.py
@@ -102,7 +102,7 @@ def init_torch_dist_process_group(
     workers: List[ActorHandle],
     backend: str = "gloo",
     init_method: str = "env",
-    **kwargs,
+    **init_process_group_kwargs,
 ) -> List[int]:
     """Initialize a torch distributed process group.
 

--- a/python/ray/air/util/torch_dist.py
+++ b/python/ray/air/util/torch_dist.py
@@ -47,6 +47,7 @@ def _init_torch_distributed(
     master_addr: str,
     master_port: str,
     gpu_ids: List[int],
+    **kwargs,
 ):
     """Initialize torch distributed backend"""
     if init_method == "env":
@@ -71,13 +72,18 @@ def _init_torch_distributed(
         if "NCCL_SOCKET_IFNAME" not in os.environ:
             os.environ["NCCL_SOCKET_IFNAME"] = DEFAULT_NCCL_SOCKET_IFNAME
 
-    dist.init_process_group(
-        backend=backend,
-        init_method=url,
-        rank=rank,
-        world_size=world_size,
-        timeout=timedelta(seconds=1800),
+    init_process_group_kwargs = kwargs
+    init_process_group_kwargs.update(
+        dict(
+            backend=backend,
+            init_method=url,
+            rank=rank,
+            world_size=world_size,
+        )
     )
+    init_process_group_kwargs.setdefault("timeout", timedelta(seconds=1800))
+
+    dist.init_process_group(**init_process_group_kwargs)
 
     os.environ["RANK"] = str(rank)
     os.environ["LOCAL_RANK"] = str(local_rank)
@@ -96,6 +102,7 @@ def init_torch_dist_process_group(
     workers: List[ActorHandle],
     backend: str = "gloo",
     init_method: str = "env",
+    **kwargs,
 ) -> List[int]:
     """Initialize a torch distributed process group.
 
@@ -108,6 +115,9 @@ def init_torch_dist_process_group(
             possible choices are "gloo" or "nccl".
         init_method: The initialization method to use,
             possible choices are "env" or "tcp".
+        kwargs: Additional kwargs to pass to
+            torch.distributed.init_process_group call
+            on the workers.
 
     Returns:
         Local ranks on their respective nodes for the list of workers.
@@ -156,6 +166,7 @@ def init_torch_dist_process_group(
                 # list(set) will sort the gpu ids, so VISIBLE_CUDA_DEVICES
                 # is always sorted.
                 gpu_ids=list(node_to_gpu_ids[node_id]),
+                **kwargs,
             )
         )
         local_ranks.append(local_rank)

--- a/python/ray/air/util/torch_dist.py
+++ b/python/ray/air/util/torch_dist.py
@@ -115,9 +115,8 @@ def init_torch_dist_process_group(
             possible choices are "gloo" or "nccl".
         init_method: The initialization method to use,
             possible choices are "env" or "tcp".
-        kwargs: Additional kwargs to pass to
-            torch.distributed.init_process_group call
-            on the workers.
+        kwargs: Additional kwargs to pass to the call to
+            :meth:`torch.distributed.init_process_group`.
 
     Returns:
         Local ranks on their respective nodes for the list of workers.

--- a/python/ray/air/util/torch_dist.py
+++ b/python/ray/air/util/torch_dist.py
@@ -115,7 +115,7 @@ def init_torch_dist_process_group(
             possible choices are "gloo" or "nccl".
         init_method: The initialization method to use,
             possible choices are "env" or "tcp".
-        kwargs: Additional kwargs to pass to the call to
+        init_process_group_kwargs: Additional kwargs to pass to the call to
             :meth:`torch.distributed.init_process_group`.
 
     Returns:
@@ -165,7 +165,7 @@ def init_torch_dist_process_group(
                 # list(set) will sort the gpu ids, so VISIBLE_CUDA_DEVICES
                 # is always sorted.
                 gpu_ids=list(node_to_gpu_ids[node_id]),
-                **kwargs,
+                **init_process_group_kwargs,
             )
         )
         local_ranks.append(local_rank)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR allows for more configurability in `init_torch_dist_process_group` function by enabling the passing of user defined kwargs to the `torch.distributed.init_process_group` function. Crucially, this allows for the timeout argument to be specified by the user.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
