### PR TITLE
Storage context local

### DIFF
--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -478,15 +478,18 @@ class StorageContext:
         Invariant: (`storage_filesystem`, `storage_path`) is the location where
         *all* results can be accessed.
 
-        If given storage_path is a local path, then set storage_local_path = storage_path.
+        If given storage_path is a local path,
+        then set storage_local_path = storage_path.
 
         Args:
-            storage_path (str): storage path or URI.
-            storage_filesystem (pyarrow.fs.FileSystem): custom filesystem to use.
-            ray_storage_uri (Optional[str], optional): Ray Storage URI. Defaults to None.
+            storage_path: A storage path or URI.
+            storage_filesystem: custom filesystem to use.
+            ray_storage_uri: Ray Storage URI.
+                Defaults to None.
 
         Returns:
-            Tuple[pyarrow.fs.FileSystem, str, str]: Tuple of (storage_filesystem, storage_fs_path, storage_local_path)
+            Tuple[pyarrow.fs.FileSystem, str, str]: Tuple of
+                (storage_filesystem, storage_fs_path, storage_local_path)
 
         """
         storage_path = storage_path or ray_storage_uri or _get_defaults_results_dir()

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -28,7 +28,6 @@ from ray.tune import Experiment, TuneError, ExperimentAnalysis
 from ray.tune.execution.experiment_state import _ResumeConfig
 from ray.tune.tune import _Config
 from ray.tune.registry import is_function_trainable
-from ray.tune.result import _get_defaults_results_dir
 from ray.tune.result_grid import ResultGrid
 from ray.tune.trainable import Trainable
 from ray.tune.tune import run

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -442,7 +442,9 @@ class TunerInternal:
         experiment_dir_name = run_config.name or StorageContext.get_experiment_dir_name(
             trainable
         )
-        storage_local_path = _get_defaults_results_dir()
+        _, _, storage_local_path = StorageContext.get_storage_context(
+            run_config.storage_path, run_config.storage_filesystem
+        )
         experiment_path = (
             Path(storage_local_path).joinpath(experiment_dir_name).as_posix()
         )


### PR DESCRIPTION
## Why are these changes needed?

Despite specifying a local storage path using the `storage_path` attribute within the `RunConfig` when using the `tune.Tuner`, logs are consistently being saved to the default `~/ray_result` directory. Furthermore, it's observed that even after manually deleting files from the custom `storage_path`, duplicate logs are regenerated and synchronized from 
the `~/ray_result` directory.

Currently, the only workaround for this issue is to set the RAY_AIR_LOCAL_CACHE_DIR environment variable to the same value as `storage_path`

I think original behavior that described in [docs](https://docs.ray.io/en/latest/train/user-guides/persistent-storage.html#using-local-storage-for-a-single-node-cluster) is not working now. It happened after updating ray 2.8.0.

To address this behavior, consider setting the provided `storage_path` as the default storage location when it's a local file system path, rather than falling back to `~/ray_result`.

## Related issue number

None

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Unit test
I tested `ray/tune/tests/test_tuner.py` and `ray/air/tests/test_air_usage.py`