### PR TITLE
fix: doc `model_composition.md` Basic Deployment line number Example

### DIFF
--- a/doc/source/serve/model_composition.md
+++ b/doc/source/serve/model_composition.md
@@ -36,9 +36,9 @@ This example has two deployments:
 :linenos: true
 ```
 
-In line 44, the `LanguageClassifier` deployment takes in the `spanish_responder` and `french_responder` as constructor arguments. At runtime, Ray Serve converts these arguments into `DeploymentHandles`. `LanguageClassifier` can then call the `spanish_responder` and `french_responder`'s deployment methods using this handle.
+In line 42, the `LanguageClassifier` deployment takes in the `spanish_responder` and `french_responder` as constructor arguments. At runtime, Ray Serve converts these arguments into `DeploymentHandles`. `LanguageClassifier` can then call the `spanish_responder` and `french_responder`'s deployment methods using this handle.
 
-For example, the `LanguageClassifier`'s `__call__` method uses the HTTP request's values to decide whether to respond in Spanish or French. It then forwards the request's name to the `spanish_responder` or the `french_responder` on lines 20 and 23 using the `DeploymentHandle`s. The format of the calls is as follows:
+For example, the `LanguageClassifier`'s `__call__` method uses the HTTP request's values to decide whether to respond in Spanish or French. It then forwards the request's name to the `spanish_responder` or the `french_responder` on lines 19 and 21 using the `DeploymentHandle`s. The format of the calls is as follows:
 
 ```python
 response: DeploymentResponse = self.spanish_responder.say_hello.remote(name)
@@ -54,7 +54,7 @@ This call returns a `DeploymentResponse` object, which is a reference to the res
 This pattern allows the call to execute asynchronously.
 To get the actual result, `await` the response.
 `await` blocks until the asynchronous call executes and then returns the result.
-In this example, line 23 calls `await response` and returns the resulting string.
+In this example, line 25 calls `await response` and returns the resulting string.
 
 (serve-model-composition-await-warning)=
 :::{warning}


### PR DESCRIPTION
Update line numbers (some of the line numbers were inaccurate).

## Why are these changes needed?

Fixing an inaccurate line number references in an example found in the docs (specifically, the serve documentation).

This is to increase readability for those interested in the docs. Here is the problematic doc: [Basic Deployment Example](https://docs.ray.io/en/latest/serve/model_composition.html#basic-deploymenthandle-example).

## Related issue number

None known


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
