### PR TITLE
[ci][test-data/1] move upload_build_info into rayci

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -8,22 +8,25 @@
 # after uploading artifacts to make sure no stale artifacts
 # remain on the node when a Buildkite runner is re-used.
 set -ex
-if [ -d "/tmp/artifacts" ]; then
-    echo "Cleaning up old artifacts before command."
-    echo "Artifact directory contents before cleanup:"
-    find /tmp/artifacts -print || true
 
-    if [ "$(ls -A /tmp/artifacts)" ]; then
-      echo "Directory not empty, cleaning up..."
-      # Need to run in docker to avoid permission issues
-      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
-    else
-      echo "Directory already empty, no need to clean up."
+_cleanup() {
+  for dir in "$@"; do
+    if [ -d $dir ]; then
+      echo "Cleaning up old artifacts before command."
+      echo "Artifact directory contents before cleanup:"
+      find $dir -print || true
+
+      if [ "$(ls -A $dir)" ]; then
+        echo "Directory not empty, cleaning up..."
+        # Need to run in docker to avoid permission issues
+        docker run --rm -v $dir:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
+      else
+        echo "Directory already empty, no need to clean up."
+      fi
+
+      echo "Artifact directory contents after cleanup:"
+      find $dir -print || true
     fi
-
-    echo "Artifact directory contents after cleanup:"
-    find /tmp/artifacts -print || true
-fi
 
 echo "Creating artifact directory..."
 if [[ "${OSTYPE}" == linux* ]]; then
@@ -35,6 +38,8 @@ elif [[ "${OSTYPE}" == msys ]]; then
   mkdir -p /c/tmp/artifacts
 fi
 
+# Clean up the artifacts directory before any command.
+_cleanup /tmp/artifacts /tmp/bazel_event_logs
 
 RAYCI_CHECKOUT_DIR="$(pwd)"
 export RAYCI_CHECKOUT_DIR

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -8,25 +8,22 @@
 # after uploading artifacts to make sure no stale artifacts
 # remain on the node when a Buildkite runner is re-used.
 set -ex
+if [ -d "/tmp/artifacts" ]; then
+    echo "Cleaning up old artifacts before command."
+    echo "Artifact directory contents before cleanup:"
+    find /tmp/artifacts -print || true
 
-_cleanup() {
-  for dir in "$@"; do
-    if [ -d $dir ]; then
-      echo "Cleaning up old artifacts before command."
-      echo "Artifact directory contents before cleanup:"
-      find $dir -print || true
-
-      if [ "$(ls -A $dir)" ]; then
-        echo "Directory not empty, cleaning up..."
-        # Need to run in docker to avoid permission issues
-        docker run --rm -v $dir:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
-      else
-        echo "Directory already empty, no need to clean up."
-      fi
-
-      echo "Artifact directory contents after cleanup:"
-      find $dir -print || true
+    if [ "$(ls -A /tmp/artifacts)" ]; then
+      echo "Directory not empty, cleaning up..."
+      # Need to run in docker to avoid permission issues
+      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
+    else
+      echo "Directory already empty, no need to clean up."
     fi
+
+    echo "Artifact directory contents after cleanup:"
+    find /tmp/artifacts -print || true
+fi
 
 echo "Creating artifact directory..."
 if [[ "${OSTYPE}" == linux* ]]; then
@@ -38,8 +35,6 @@ elif [[ "${OSTYPE}" == msys ]]; then
   mkdir -p /c/tmp/artifacts
 fi
 
-# Clean up the artifacts directory before any command.
-_cleanup /tmp/artifacts /tmp/bazel_event_logs
 
 RAYCI_CHECKOUT_DIR="$(pwd)"
 export RAYCI_CHECKOUT_DIR

--- a/ci/build/upload_build_info.sh
+++ b/ci/build/upload_build_info.sh
@@ -3,6 +3,8 @@
 # Cause the script to exit if a single command fails.
 set -ex
 
+BAZEL_LOG_DIR=${1:-"/tmp/bazel_event_logs"}
+
 readonly PIPELINE_POSTMERGE="0189e759-8c96-4302-b6b5-b4274406bf89"
 readonly PIPELINE_CIV1_BRANCH="0183465b-c6fb-479b-8577-4cfd743b545d"
 if [[
@@ -23,10 +25,10 @@ RAY_DIR=$(cd "${ROOT_DIR}/../../"; pwd)
 
 cd "${RAY_DIR}"
 
-mkdir -p /tmp/bazel_event_logs
+mkdir -p "$BAZEL_LOG_DIR"
 
-./ci/build/get_build_info.py > /tmp/bazel_event_logs/metadata.json
+./ci/build/get_build_info.py > "$BAZEL_LOG_DIR"/metadata.json
 
 # Keep cryptography/openssl in sync with `requirements/test-requirements.txt`
 pip install -q -c "${RAY_DIR}/python/requirements.txt" docker aws_requests_auth boto3 cryptography==38.0.1 PyOpenSSL==23.0.0
-python .buildkite/copy_files.py --destination logs --path /tmp/bazel_event_logs
+python .buildkite/copy_files.py --destination logs --path "$BAZEL_LOG_DIR"

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -70,6 +70,7 @@ class Container(abc.ABC):
         script: List[str],
         network: Optional[str] = None,
         gpu_ids: Optional[List[int]] = None,
+        volumes: Optional[List[str]] = None,
     ) -> List[str]:
         """
         Get docker run command
@@ -89,6 +90,8 @@ class Container(abc.ABC):
             command += ["--env", env]
         if network:
             command += ["--network", network]
+        for volume in volumes or []:
+            command += ["--volume", volume]
         return (
             command
             + self.get_run_command_extra_args(gpu_ids)

--- a/ci/ray_ci/linux_tester_container.py
+++ b/ci/ray_ci/linux_tester_container.py
@@ -30,6 +30,7 @@ class LinuxTesterContainer(TesterContainer, LinuxContainer):
             self,
             shard_count,
             gpus,
+            bazel_log_dir="/tmp/bazel_event_logs",
             network=network,
             test_envs=test_envs,
             shard_ids=shard_ids,

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -1,6 +1,10 @@
+import os
 import platform
+import random
+import shutil
+import string
 import subprocess
-from typing import List, Optional
+from typing import List, Tuple, Optional
 
 from ci.ray_ci.utils import shard_tests, chunk_into_n
 from ci.ray_ci.utils import logger
@@ -16,6 +20,7 @@ class TesterContainer(Container):
         self,
         shard_count: int = 1,
         gpus: int = 0,
+        bazel_log_dir: str = "/tmp",
         network: Optional[str] = None,
         test_envs: Optional[List[str]] = None,
         shard_ids: Optional[List[int]] = None,
@@ -28,6 +33,7 @@ class TesterContainer(Container):
         used to run tests in a distributed fashion.
         :param shard_ids: The list of shard ids to run. If none, run no shards.
         """
+        self.bazel_log_dir = bazel_log_dir
         self.shard_count = shard_count
         self.shard_ids = shard_ids or []
         self.test_envs = test_envs or []
@@ -40,6 +46,21 @@ class TesterContainer(Container):
 
         if not skip_ray_installation:
             self.install_ray(build_type)
+
+    def _create_bazel_log_mount(self, tmp_dir: Optional[str] = None) -> Tuple[str, str]:
+        """
+        Create a temporary directory in the current container to store bazel event logs
+        produced by the test runs. We do this by using the artifact mount directory from
+        the host machine as a shared directory between all containers.
+        """
+        tmp_dir = tmp_dir or "".join(
+            random.choice(string.ascii_lowercase) for _ in range(5)
+        )
+        artifact_host, artifact_container = self.get_artifact_mount()
+        bazel_log_dir_host = os.path.join(artifact_host, tmp_dir)
+        bazel_log_dir_container = os.path.join(artifact_container, tmp_dir)
+        os.mkdir(bazel_log_dir_container)
+        return (bazel_log_dir_host, bazel_log_dir_container)
 
     def run_tests(
         self,
@@ -65,23 +86,47 @@ class TesterContainer(Container):
 
         # divide gpus evenly among chunks
         gpu_ids = chunk_into_n(list(range(self.gpus)), len(chunks))
+        bazel_log_dir_host, bazel_log_dir_container = self._create_bazel_log_mount()
         runs = [
-            self._run_tests_in_docker(chunks[i], gpu_ids[i], self.test_envs, test_arg)
+            self._run_tests_in_docker(
+                chunks[i], gpu_ids[i], bazel_log_dir_host, self.test_envs, test_arg
+            )
             for i in range(len(chunks))
         ]
         exits = [run.wait() for run in runs]
+        self._persist_test_results(bazel_log_dir_container)
+        self._cleanup_bazel_log_mount(bazel_log_dir_container)
+
         return all(exit == 0 for exit in exits)
+
+    def _persist_test_results(self, bazel_log_dir: str) -> None:
+        # TODO(can): implement the logic to persist test results to a database
+        self._upload_build_info(bazel_log_dir)
+
+    def _upload_build_info(self, bazel_log_dir) -> None:
+        logger.info("Uploading bazel test logs")
+        subprocess.check_call(
+            [
+                "bash",
+                "ci/build/upload_build_info.sh",
+                bazel_log_dir,
+            ]
+        )
+
+    def _cleanup_bazel_log_mount(self, bazel_log_dir: str) -> None:
+        shutil.rmtree(bazel_log_dir)
 
     def _run_tests_in_docker(
         self,
         test_targets: List[str],
         gpu_ids: List[int],
+        bazel_log_dir_host: str,
         test_envs: List[str],
         test_arg: Optional[str] = None,
     ) -> subprocess.Popen:
         logger.info("Running tests: %s", test_targets)
         commands = [
-            "cleanup() { ./ci/build/upload_build_info.sh; }",
+            f'cleanup() {{ chmod -R a+r "{self.bazel_log_dir}"; }}',
             "trap cleanup EXIT",
         ]
         if platform.system() == "Windows":
@@ -119,5 +164,6 @@ class TesterContainer(Container):
                 commands,
                 network=self.network,
                 gpu_ids=gpu_ids,
+                volumes=[f"{bazel_log_dir_host}:{self.bazel_log_dir}"],
             )
         )

--- a/ci/ray_ci/windows_tester_container.py
+++ b/ci/ray_ci/windows_tester_container.py
@@ -19,6 +19,7 @@ class WindowsTesterContainer(TesterContainer, WindowsContainer):
             self,
             shard_count,
             gpus=0,  # We don't support GPU tests on Windows yet.
+            bazel_log_dir="C:\\msys64\\tmp\\bazel_event_logs",
             network=network,
             test_envs=test_envs,
             shard_ids=shard_ids,


### PR DESCRIPTION
Move the `upload_build_info` login into rayci itself. We do this by creating a shared mount to share the bazel event logs across containers, then run the upload_build_info on the rayci container (forge).

Test:
- CI
- postmerge: https://buildkite.com/ray-project/postmerge/builds/2406