### PR TITLE
[RLlib] Issue 40910: Gymnasium docs.

### DIFF
--- a/python/ray/tune/logger/json.py
+++ b/python/ray/tune/logger/json.py
@@ -60,7 +60,7 @@ class JsonLogger(Logger):
         self.local_out.close()
 
     def update_config(self, config: Dict):
-        self.config = config
+        self.config = config if isinstance(config, dict) else config.to_dict()
         config_out = os.path.join(self.logdir, EXPR_PARAM_FILE)
         with open(config_out, "w") as f:
             json.dump(self.config, f, indent=2, sort_keys=True, cls=SafeFallbackEncoder)
@@ -115,7 +115,7 @@ class JsonLoggerCallback(LoggerCallback):
         del self._trial_files[trial]
 
     def update_config(self, trial: "Trial", config: Dict):
-        self._trial_configs[trial] = config
+        self._trial_configs[trial] = config if isinstance(config, dict) else config.to_dict()
 
         config_out = os.path.join(trial.local_path, EXPR_PARAM_FILE)
         with open(config_out, "w") as f:

--- a/python/ray/tune/logger/json.py
+++ b/python/ray/tune/logger/json.py
@@ -115,7 +115,9 @@ class JsonLoggerCallback(LoggerCallback):
         del self._trial_files[trial]
 
     def update_config(self, trial: "Trial", config: Dict):
-        self._trial_configs[trial] = config if isinstance(config, dict) else config.to_dict()
+        self._trial_configs[trial] = (
+            config if isinstance(config, dict) else config.to_dict()
+        )
 
         config_out = os.path.join(trial.local_path, EXPR_PARAM_FILE)
         with open(config_out, "w") as f:

--- a/rllib/README.rst
+++ b/rllib/README.rst
@@ -39,7 +39,7 @@ Install RLlib and run your first experiment on your laptop in seconds:
 
     $ conda create -n rllib python=3.8
     $ conda activate rllib
-    $ pip install "ray[rllib]" tensorflow "gym[atari]" "gym[accept-rom-license]" atari_py
+    $ pip install "ray[rllib]" tensorflow "gymnasium[atari]" "gymnasium[accept-rom-license]" atari_py
     $ # Run a test job:
     $ rllib train --run APPO --env CartPole-v0
 
@@ -50,7 +50,7 @@ Install RLlib and run your first experiment on your laptop in seconds:
 
     $ conda create -n rllib python=3.8
     $ conda activate rllib
-    $ pip install "ray[rllib]" torch "gym[atari]" "gym[accept-rom-license]" atari_py
+    $ pip install "ray[rllib]" torch "gymnasium[atari]" "gymnasium[accept-rom-license]" atari_py
     $ # Run a test job:
     $ rllib train --run APPO --env CartPole-v0 --torch
 


### PR DESCRIPTION
## Why are these changes needed?

Some code blocks in the main documentation of `RLlib` did not yet implement the new Farama `gymnasium` and used instead the OpenAI `gym`. As we support fully the latter and follow therewith the trend in the RL community, we should change this.

## Related issue number

Closes #40910 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
