### PR TITLE
[Serve] Improve handling the websocket server disconnect scenario

### DIFF
--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1037,6 +1037,8 @@ class HTTPProxy(GenericProxy):
             )
 
         finally:
+            # For websocket connection, queue receive task is done when receiving
+            # disconnect message from client.
             receive_client_disconnect_msg = False
             if not proxy_asgi_receive_task.done():
                 proxy_asgi_receive_task.cancel()
@@ -1061,10 +1063,11 @@ class HTTPProxy(GenericProxy):
                         code="1000",  # [Sihan] is there a better code for this?
                         is_error=True,
                     )
+                    pass
 
             del self.asgi_receive_queues[request_id]
 
-        # Final message should always be the status code.
+        # The status code should always be set.
         assert status is not None
         yield status
 

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1045,7 +1045,7 @@ class HTTPProxy(GenericProxy):
             # If client disconnects, the disconnect code comes from
             # a client message via the receive interface, but is is not guaranteed.
             if status is None and proxy_request.request_type == "websocket":
-                if not proxy_asgi_receive_task.cancelled:
+                if not proxy_asgi_receive_task.cancelled():
                     # The disconnect message is sent from the client.
                     status = ResponseStatus(
                         code=str(proxy_asgi_receive_task.result()),

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1063,7 +1063,6 @@ class HTTPProxy(GenericProxy):
                         code="1000",  # [Sihan] is there a better code for this?
                         is_error=True,
                     )
-                    pass
 
             del self.asgi_receive_queues[request_id]
 

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1064,6 +1064,7 @@ class HTTPProxy(GenericProxy):
 
             del self.asgi_receive_queues[request_id]
 
+        # Final message should always be the status code.
         assert status is not None
         yield status
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Server disconnect message is not guaranteed to be sent. So we need to handle it when finish the websocket connection. 

## Related issue number

Closes: https://github.com/ray-project/ray/issues/42124

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
