### PR TITLE
[serve] Unify the `handle_request` unary path for http and grpc in `UserCallableWrapper`

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -299,13 +299,9 @@ class ReplicaActor:
         **request_kwargs,
     ) -> Tuple[bytes, Any]:
         request_metadata = pickle.loads(pickled_request_metadata)
-        result = await self._user_callable_wrapper.call_user_method(
+        return await self._user_callable_wrapper.call_user_method(
             request_metadata, request_args, request_kwargs
         )
-        if request_metadata.is_grpc_request:
-            result = (request_metadata.grpc_context, result.SerializeToString())
-
-        return result
 
     async def _handle_http_request_generator(
         self,
@@ -931,6 +927,8 @@ class UserCallableWrapper:
                 # ASGI interface, but for the vanilla deployment codepath we need to
                 # send it.
                 await self.send_user_result_over_asgi(result, scope, receive, send)
+            elif request_metadata.is_grpc_request:
+                result = (request_metadata.grpc_context, result.SerializeToString())
 
             return result
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -872,7 +872,7 @@ class UserCallableWrapper:
                 assert len(request_args) == 1 and isinstance(
                     request_args[0], gRPCRequest
                 )
-                request_args = (pickle.loads(request.grpc_user_request),)
+                request_args = (pickle.loads(request_args[0].grpc_user_request),)
 
             runner_method = None
             try:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -299,16 +299,11 @@ class ReplicaActor:
         **request_kwargs,
     ) -> Tuple[bytes, Any]:
         request_metadata = pickle.loads(pickled_request_metadata)
+        result = await self._user_callable_wrapper.call_user_method(
+            request_metadata, request_args, request_kwargs
+        )
         if request_metadata.is_grpc_request:
-            # Ensure the request args are a single gRPCRequest object.
-            assert len(request_args) == 1 and isinstance(request_args[0], gRPCRequest)
-            result = await self._user_callable_wrapper.call_user_method_grpc_unary(
-                request_metadata=request_metadata, request=request_args[0]
-            )
-        else:
-            result = await self._user_callable_wrapper.call_user_method(
-                request_metadata, request_args, request_kwargs
-            )
+            result = (request_metadata.grpc_context, result.SerializeToString())
 
         return result
 
@@ -855,38 +850,6 @@ class UserCallableWrapper:
                     f"function, but '{user_method.__name__}' is not."
                 )
 
-    async def call_user_method_grpc_unary(
-        self, request_metadata: RequestMetadata, request: gRPCRequest
-    ) -> Tuple[RayServegRPCContext, bytes]:
-        """Call a user method that is *not* expected to be a generator.
-
-        Deserializes gRPC request into protobuf object and pass into replica's runner
-        method. Returns a serialized protobuf bytes from the replica.
-        """
-        async with self.wrap_user_method_call(request_metadata):
-            user_request = pickle.loads(request.grpc_user_request)
-
-            runner_method = self.get_runner_method(request_metadata)
-            if inspect.isgeneratorfunction(runner_method) or inspect.isasyncgenfunction(
-                runner_method
-            ):
-                raise TypeError(
-                    f"Method '{runner_method.__name__}' is a generator function. "
-                    "You must use `handle.options(stream=True)` to call "
-                    "generators on a deployment."
-                )
-
-            method_to_call = sync_to_async(runner_method)
-
-            if GRPC_CONTEXT_ARG_NAME in inspect.signature(runner_method).parameters:
-                result = await method_to_call(
-                    user_request,
-                    grpc_context=request_metadata.grpc_context,
-                )
-            else:
-                result = await method_to_call(user_request)
-            return request_metadata.grpc_context, result.SerializeToString()
-
     async def call_user_method(
         self,
         request_metadata: RequestMetadata,
@@ -908,6 +871,11 @@ class UserCallableWrapper:
                     request_args = (scope, receive, send)
                 else:
                     request_args = (Request(scope, receive, send),)
+            elif request_metadata.is_grpc_request:
+                # Ensure the request args are a single gRPCRequest object.
+                assert len(request_args) == 1 and isinstance(
+                    request_args[0], gRPCRequest
+                )
 
             runner_method = None
             try:
@@ -925,11 +893,15 @@ class UserCallableWrapper:
 
                 # Edge case to support empty HTTP handlers: don't pass the Request
                 # argument if the callable has no parameters.
-                if (
-                    request_metadata.is_http_request
-                    and len(inspect.signature(runner_method).parameters) == 0
-                ):
+                params = inspect.signature(runner_method).parameters
+                if request_metadata.is_http_request and len(params) == 0:
                     request_args, request_kwargs = tuple(), {}
+                elif (
+                    request_metadata.is_grpc_request and GRPC_CONTEXT_ARG_NAME in params
+                ):
+                    request_kwargs = {
+                        GRPC_CONTEXT_ARG_NAME: request_metadata.grpc_context
+                    }
 
                 result = await method_to_call(*request_args, **request_kwargs)
                 if inspect.isgenerator(result) or inspect.isasyncgen(result):

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -872,6 +872,7 @@ class UserCallableWrapper:
                 assert len(request_args) == 1 and isinstance(
                     request_args[0], gRPCRequest
                 )
+                request_args = (pickle.loads(request.grpc_user_request),)
 
             runner_method = None
             try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We had two separate methods, refactored to share one following the same style as the HTTP path.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
