### PR TITLE
[data] Deflake TestStreamOutputBackpressurePolicy.test_e2e_backpressure

### DIFF
--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -342,10 +342,10 @@ class TestStreamOutputBackpressurePolicy(unittest.TestCase):
 
         def consumer(batch):
             assert len(batch["id"]) == 1
-            time.sleep(0.1)
             print("Consuming block", batch["id"][0])
-            del batch["data"]
             batch["consumer_timestamp"] = [time.time()]
+            time.sleep(0.1)
+            del batch["data"]
             return batch
 
         ds = ray.data.range(1, parallelism=1).materialize()
@@ -365,11 +365,16 @@ class TestStreamOutputBackpressurePolicy(unittest.TestCase):
         )
         # We can buffer at most 2 blocks.
         # Thus the producer should be backpressured after producing 2 blocks.
-        # Note, although block 2 is backpressured, but producer_timestamps[2] has
-        # been generated before the backpressure. Thus we assert
-        # producer_timestamps[2] < consumer_timestamps[0] < producer_timestamps[3].
+        # Note, although block 2 is backpressured, producer_timestamps[2] has
+        # been generated before the backpressure.
+        # Thus producer_timestamps[2] < consumer_timestamps[0].
+        # For block 3, it should be generated after the first consumer task
+        # is scheduled. But there is a delay between the consumer task is scheduled
+        # and the consumer task starts to run. Thus the order of
+        # producer_timestamps[3] and consumer_timestamps[0] is not deterministic.
+        # To avoid flakiness, we check consumer_timestamps[0] < producer_timestamps[4].
         assert (
-            producer_timestamps[2] < consumer_timestamps[0] < producer_timestamps[3]
+            producer_timestamps[2] < consumer_timestamps[0] < producer_timestamps[4]
         ), (producer_timestamps, consumer_timestamps)
 
     def test_no_deadlock(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test is flakey on slow machines. See comments for details. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
