### PR TITLE
[ci] remove bazel logs only on mac

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -67,7 +67,7 @@ steps:
       - skip-on-premerge
     instance_type: medium
     commands:
-      - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+      - cleanup() { ./ci/build/upload_build_info.sh; }; trap cleanup EXIT
       - (cd dashboard/client && npm ci && npm run build)
       - pip install -e python[client]
       - bazel test --config=ci --jobs=1 $(./ci/run/bazel_export_options)

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -10,7 +10,8 @@
 # tests to make it easy for users to see which tests are failing.
 # Because we upload them to Buildkite, we don't need to
 # upload them as artifacts and delete them afterwards.
-set -e
+set -ex
+
 if [ -d "/tmp/artifacts/test-summaries" ] && [ "$(ls -A /tmp/artifacts/test-summaries)" ]; then
     # Only upload annotations if there are at least 2 files in the directory:
     # 1 header and 1 failed test.
@@ -23,3 +24,8 @@ if [ -d "/tmp/artifacts/test-summaries" ] && [ "$(ls -A /tmp/artifacts/test-summ
     echo "--- Cleaning up"
     docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/test-summaries' || true
 fi
+
+# clean up bazel logs if any, this only has effect when the bazel test runs in the same 
+# environment as the buildkite job commands, and has no effect when the tests run 
+# inside another test container
+rm -rf /tmp/bazel_event_logs

--- a/.buildkite/windows_ci.sh
+++ b/.buildkite/windows_ci.sh
@@ -26,9 +26,7 @@ powershell ci/pipeline/fix-windows-bazel.ps1
 readonly PIPELINE_POSTMERGE="0189e759-8c96-4302-b6b5-b4274406bf89"
 
 cleanup() {
-    if [[ "${BUILDKITE_PIPELINE_ID:-}" == "${PIPELINE_POSTMERGE}" ]]; then
-        bash ./ci/build/upload_build_info.sh
-    fi
+    bash ./ci/build/upload_build_info.sh
 }
 trap cleanup EXIT
 

--- a/ci/build/test-worker-in-container.sh
+++ b/ci/build/test-worker-in-container.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+cleanup() { ./ci/build/upload_build_info.sh; }; trap cleanup EXIT
 
 set -exo pipefail
 

--- a/ci/build/upload_build_info.sh
+++ b/ci/build/upload_build_info.sh
@@ -18,12 +18,6 @@ RAY_DIR=$(cd "${ROOT_DIR}/../../"; pwd)
 
 cd "${RAY_DIR}"
 
-cleanup() {
-  # Cleanup the directory because macOS file system is shared between builds.
-  rm -rf /tmp/bazel_event_logs
-}
-trap cleanup EXIT
-
 mkdir -p /tmp/bazel_event_logs
 
 ./ci/build/get_build_info.py > /tmp/bazel_event_logs/metadata.json

--- a/ci/build/upload_build_info.sh
+++ b/ci/build/upload_build_info.sh
@@ -7,9 +7,10 @@ readonly PIPELINE_POSTMERGE="0189e759-8c96-4302-b6b5-b4274406bf89"
 readonly PIPELINE_CIV1_BRANCH="0183465b-c6fb-479b-8577-4cfd743b545d"
 if [[
   "${BUILDKITE_PIPELINE_ID:-}" != "${PIPELINE_POSTMERGE}" && 
-  "${BUILDKITE_PIPELINE_ID:-}" != "${PIPELINE_CIV1_BRANCH}"
+  "${BUILDKITE_PIPELINE_ID:-}" != "${PIPELINE_CIV1_BRANCH}" &&
+  "${BUILDKITE_BRANCH:-}" != "master"
 ]]; then
-  echo "Skip build info uploading on non-postmerge pipeline."
+  echo "Skip build info uploading on master branch."
   exit 0
 fi
 

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -1,4 +1,3 @@
-import os
 import platform
 import subprocess
 from typing import List, Optional
@@ -81,14 +80,10 @@ class TesterContainer(Container):
         test_arg: Optional[str] = None,
     ) -> subprocess.Popen:
         logger.info("Running tests: %s", test_targets)
-        commands = []
-        if os.environ.get("BUILDKITE_BRANCH", "") == "master":
-            commands.extend(
-                [
-                    "cleanup() { ./ci/build/upload_build_info.sh; }",
-                    "trap cleanup EXIT",
-                ]
-            )
+        commands = [
+            "cleanup() { ./ci/build/upload_build_info.sh; }",
+            "trap cleanup EXIT",
+        ]
         if platform.system() == "Windows":
             # allow window tests to access aws services
             commands.append(


### PR DESCRIPTION
As per comment on the code; remove bazel logs only on mac. Other platform runs in docker so it doesn't matter if the log is removed.

Test:
- CI