### PR TITLE
[ci] move upload build info skipping logic into the script

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -67,7 +67,7 @@ steps:
       - skip-on-premerge
     instance_type: medium
     commands:
-      - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+      - cleanup() { ./ci/build/upload_build_info.sh; }; trap cleanup EXIT
       - (cd dashboard/client && npm ci && npm run build)
       - pip install -e python[client]
       - bazel test --config=ci --jobs=1 $(./ci/run/bazel_export_options)

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -8,33 +8,26 @@
 # after uploading artifacts to make sure no stale artifacts
 # remain on the node when a Buildkite runner is re-used.
 set -ex
+if [ -d "/tmp/artifacts" ]; then
+    echo "Cleaning up old artifacts before command."
+    echo "Artifact directory contents before cleanup:"
+    find /tmp/artifacts -print || true
 
-_cleanup() {
-  for dir in "$@"; do
-    if [ -d $dir ]; then
-      echo "Cleaning up old artifacts before command."
-      echo "Artifact directory contents before cleanup:"
-      find $dir -print || true
-
-      if [ "$(ls -A $dir)" ]; then
-        echo "Directory not empty, cleaning up..."
-        # Need to run in docker to avoid permission issues
-        docker run --rm -v $dir:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
-      else
-        echo "Directory already empty, no need to clean up."
-      fi
-
-      echo "Artifact directory contents after cleanup:"
-      find $dir -print || true
+    if [ "$(ls -A /tmp/artifacts)" ]; then
+      echo "Directory not empty, cleaning up..."
+      # Need to run in docker to avoid permission issues
+      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
+    else
+      echo "Directory already empty, no need to clean up."
     fi
 
-    echo "Creating $dir directory..."
-    docker run --rm -v $dir:/artifact-mount alpine:latest /bin/sh -c 'chown -R 2000 /artifact-mount/' || true
-  done
-}
+    echo "Artifact directory contents after cleanup:"
+    find /tmp/artifacts -print || true
+fi
 
-# Clean up the artifacts directory before any command.
-_cleanup /tmp/artifacts /tmp/bazel_event_logs
+echo "Creating var/ artifact directory..."
+docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'chown -R 2000 /artifact-mount/' || true
+
 
 RAYCI_CHECKOUT_DIR="$(pwd)"
 export RAYCI_CHECKOUT_DIR

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -8,26 +8,33 @@
 # after uploading artifacts to make sure no stale artifacts
 # remain on the node when a Buildkite runner is re-used.
 set -ex
-if [ -d "/tmp/artifacts" ]; then
-    echo "Cleaning up old artifacts before command."
-    echo "Artifact directory contents before cleanup:"
-    find /tmp/artifacts -print || true
 
-    if [ "$(ls -A /tmp/artifacts)" ]; then
-      echo "Directory not empty, cleaning up..."
-      # Need to run in docker to avoid permission issues
-      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
-    else
-      echo "Directory already empty, no need to clean up."
+_cleanup() {
+  for dir in "$@"; do
+    if [ -d $dir ]; then
+      echo "Cleaning up old artifacts before command."
+      echo "Artifact directory contents before cleanup:"
+      find $dir -print || true
+
+      if [ "$(ls -A $dir)" ]; then
+        echo "Directory not empty, cleaning up..."
+        # Need to run in docker to avoid permission issues
+        docker run --rm -v $dir:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
+      else
+        echo "Directory already empty, no need to clean up."
+      fi
+
+      echo "Artifact directory contents after cleanup:"
+      find $dir -print || true
     fi
 
-    echo "Artifact directory contents after cleanup:"
-    find /tmp/artifacts -print || true
-fi
+    echo "Creating $dir directory..."
+    docker run --rm -v $dir:/artifact-mount alpine:latest /bin/sh -c 'chown -R 2000 /artifact-mount/' || true
+  done
+}
 
-echo "Creating var/ artifact directory..."
-docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'chown -R 2000 /artifact-mount/' || true
-
+# Clean up the artifacts directory before any command.
+_cleanup /tmp/artifacts /tmp/bazel_event_logs
 
 RAYCI_CHECKOUT_DIR="$(pwd)"
 export RAYCI_CHECKOUT_DIR

--- a/.buildkite/windows_ci.sh
+++ b/.buildkite/windows_ci.sh
@@ -26,9 +26,7 @@ powershell ci/pipeline/fix-windows-bazel.ps1
 readonly PIPELINE_POSTMERGE="0189e759-8c96-4302-b6b5-b4274406bf89"
 
 cleanup() {
-    if [[ "${BUILDKITE_PIPELINE_ID:-}" == "${PIPELINE_POSTMERGE}" ]]; then
-        bash ./ci/build/upload_build_info.sh
-    fi
+    bash ./ci/build/upload_build_info.sh
 }
 trap cleanup EXIT
 

--- a/ci/build/test-worker-in-container.sh
+++ b/ci/build/test-worker-in-container.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+cleanup() { ./ci/build/upload_build_info.sh; }; trap cleanup EXIT
 
 set -exo pipefail
 

--- a/ci/build/upload_build_info.sh
+++ b/ci/build/upload_build_info.sh
@@ -7,9 +7,10 @@ readonly PIPELINE_POSTMERGE="0189e759-8c96-4302-b6b5-b4274406bf89"
 readonly PIPELINE_CIV1_BRANCH="0183465b-c6fb-479b-8577-4cfd743b545d"
 if [[
   "${BUILDKITE_PIPELINE_ID:-}" != "${PIPELINE_POSTMERGE}" && 
-  "${BUILDKITE_PIPELINE_ID:-}" != "${PIPELINE_CIV1_BRANCH}"
+  "${BUILDKITE_PIPELINE_ID:-}" != "${PIPELINE_CIV1_BRANCH}" &&
+  "${BUILDKITE_BRANCH:-}" != "master"
 ]]; then
-  echo "Skip build info uploading on non-postmerge pipeline."
+  echo "Skip build info uploading on master branch."
   exit 0
 fi
 

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -1,4 +1,3 @@
-import os
 import platform
 import subprocess
 from typing import List, Optional
@@ -81,14 +80,10 @@ class TesterContainer(Container):
         test_arg: Optional[str] = None,
     ) -> subprocess.Popen:
         logger.info("Running tests: %s", test_targets)
-        commands = []
-        if os.environ.get("BUILDKITE_BRANCH", "") == "master":
-            commands.extend(
-                [
-                    "cleanup() { ./ci/build/upload_build_info.sh; }",
-                    "trap cleanup EXIT",
-                ]
-            )
+        commands = [
+            "cleanup() { ./ci/build/upload_build_info.sh; }",
+            "trap cleanup EXIT",
+        ]
         if platform.system() == "Windows":
             # allow window tests to access aws services
             commands.append(


### PR DESCRIPTION
Move all upload build info skipping logic into the script itself, and remove all the check from the caller. Also bring consistency  on the skipping logic across various places (master branch only)

Test:
- CI