### PR TITLE
[RLlib] Cast types for new configurations in `PB2`.

### DIFF
--- a/python/ray/tune/schedulers/pb2.py
+++ b/python/ray/tune/schedulers/pb2.py
@@ -231,8 +231,9 @@ def _explore(
         for i, col in enumerate(hparams.columns):
             # Use the type from the old config. Like this types
             # should be passed on from the first config downwards.
-            new_config[col] = type(config[col])(new[i])
-            values.append(type(config[col])(new[i]))
+            type_ = type(config[col])
+            new_config[col] = type_(new[i])
+            values.append(type_(new[i]))
 
         new_T = df[df["Trial"] == str(base)].iloc[-1, :]["Time"]
         new_Reward = df[df["Trial"] == str(base)].iloc[-1, :].Reward

--- a/python/ray/tune/schedulers/pb2.py
+++ b/python/ray/tune/schedulers/pb2.py
@@ -227,13 +227,12 @@ def _explore(
 
         new_config = config.copy()
         values = []
+        # Cast types for new hyperparameters.
         for i, col in enumerate(hparams.columns):
-            if isinstance(config[col], int):
-                new_config[col] = int(new[i])
-                values.append(int(new[i]))
-            else:
-                new_config[col] = new[i]
-                values.append(new[i])
+            # Use the type from the old config. Like this types
+            # should be passed on from the first config downwards.
+            new_config[col] = type(config[col])(new[i])
+            values.append(type(config[col])(new[i]))
 
         new_T = df[df["Trial"] == str(base)].iloc[-1, :]["Time"]
         new_Reward = df[df["Trial"] == str(base)].iloc[-1, :].Reward


### PR DESCRIPTION
Fixed a bug in generating a new config in 'PB2'. The type for floats were actually 'numpy.dtype.float64' and resulted so far in error in 'ray.rllib.utils.schedule.Scheduler.validate()' where this type is not allowed for the learning rate,

## Why are these changes needed?

`PB2` as one of Ray major hyperparameter tuning algorithms for ML and specifically RL was erroring out when tuning the learning rate. This was due to the fact that `ray.rllib.utils.schedule.Scheduler.validate` is allowing only specific types for the learning rate. Whenever `PB2` created a new config it assigned the values received from `ray.tune.schedulers.pb2._explore` and that was type `numpy.dtype.float64`. So, basically it was not possible to tune the learning parameter in experiments. 

This PR fixes this shortcoming and casts types from a new config explored via Bayesian Optimization to the ones from the old config. Like this configs will keep types over the course of an experiment and `PB2`does not error out anymore.

## Related issue number

Closes #42180 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
