### PR TITLE
[serve] prepare to collect autoscaling metrics on handles

### DIFF
--- a/python/ray/serve/_private/autoscaling_policy.py
+++ b/python/ray/serve/_private/autoscaling_policy.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from ray.serve._private.common import TargetCapacityDirection
 from ray.serve._private.constants import SERVE_LOGGER_NAME
@@ -30,8 +30,8 @@ class AutoscalingPolicyManager:
     def get_decision_num_replicas(
         self,
         curr_target_num_replicas: int,
-        current_num_ongoing_requests: List[float],
-        current_handle_queued_queries: float,
+        total_num_requests: int,
+        num_running_replicas: int,
         target_capacity: Optional[float] = None,
         target_capacity_direction: Optional[TargetCapacityDirection] = None,
         _skip_bound_check: bool = False,
@@ -52,8 +52,8 @@ class AutoscalingPolicyManager:
         )
         decision_num_replicas = self.policy(
             curr_target_num_replicas=curr_target_num_replicas,
-            current_num_ongoing_requests=current_num_ongoing_requests,
-            current_handle_queued_queries=current_handle_queued_queries,
+            total_num_requests=total_num_requests,
+            num_running_replicas=num_running_replicas,
             config=self.config,
             capacity_adjusted_min_replicas=capacity_adjusted_min_replicas,
             capacity_adjusted_max_replicas=capacity_adjusted_max_replicas,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -17,7 +17,6 @@ from ray.actor import ActorHandle
 from ray.exceptions import RayActorError, RayError, RayTaskError, RuntimeEnvSetupError
 from ray.serve import metrics
 from ray.serve._private import default_impl
-from ray.serve._private.autoscaling_metrics import InMemoryMetricsStore
 from ray.serve._private.autoscaling_policy import AutoscalingPolicyManager
 from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
 from ray.serve._private.common import (
@@ -1246,6 +1245,10 @@ class DeploymentState:
 
         self.replica_average_ongoing_requests: Dict[str, float] = dict()
 
+        # Map from handle ID to (# requests recorded at handle, recording timestamp)
+        self.handle_requests: Dict[str, Tuple(float, float)] = dict()
+        self.replica_average_ongoing_requests: Dict[str, float] = dict()
+
         self.health_check_gauge = metrics.Gauge(
             "serve_deployment_replica_healthy",
             description=(
@@ -1583,40 +1586,38 @@ class DeploymentState:
         self._backoff_time_s = 1
         return True
 
-    def get_replica_current_ongoing_requests(self) -> List[float]:
-        """Return list of replica average ongoing requests.
+    def get_total_num_requests(self) -> int:
+        """Return total number of ongoing requests in Serve.
 
-        The length of list indicate the number of replicas.
+        If there are 0 running replicas, then returns the total number
+        of requests queued at handles.
         """
 
+        total_requests = 0
         running_replicas = self._replicas.get([ReplicaState.RUNNING])
-
-        current_num_ongoing_requests = []
         for replica in running_replicas:
             replica_tag = replica.replica_tag
             if replica_tag in self.replica_average_ongoing_requests:
-                current_num_ongoing_requests.append(
-                    self.replica_average_ongoing_requests[replica_tag]
-                )
-        return current_num_ongoing_requests
+                total_requests += self.replica_average_ongoing_requests[replica_tag][1]
 
-    def autoscale(self, current_handle_queued_queries: int) -> int:
-        """Autoscale the deployment based on metrics.
+        if len(running_replicas) == 0:
+            for handle_metrics in self.handle_requests.values():
+                total_requests += handle_metrics[1]
 
-        Args:
-            current_handle_queued_queries: The number of handle queued queries,
-                if there are multiple handles, the max number of queries at
-                a single handle should be passed in
-        """
+        return total_requests
+
+    def autoscale(self) -> int:
+        """Autoscale the deployment based on metrics."""
+
         if self._target_state.deleting:
             return
 
-        current_num_ongoing_requests = self.get_replica_current_ongoing_requests()
+        total_num_requests = self.get_total_num_requests()
         autoscaling_policy_manager = self.autoscaling_policy_manager
         decision_num_replicas = autoscaling_policy_manager.get_decision_num_replicas(
             curr_target_num_replicas=self._target_state.target_num_replicas,
-            current_num_ongoing_requests=current_num_ongoing_requests,
-            current_handle_queued_queries=current_handle_queued_queries,
+            total_num_requests=total_num_requests,
+            num_running_replicas=len(self.get_running_replica_infos()),
             target_capacity=self._target_state.info.target_capacity,
             target_capacity_direction=self._target_state.info.target_capacity_direction,
         )
@@ -1628,10 +1629,9 @@ class DeploymentState:
             return
 
         logger.info(
-            f"Autoscaling replicas for deployment {self.deployment_name} in "
-            f"application {self.app_name} to {decision_num_replicas}. "
-            f"current_num_ongoing_requests: {current_num_ongoing_requests}, "
-            f"current handle queued queries: {current_handle_queued_queries}."
+            f"Autoscaling replicas for deployment '{self.deployment_name}' in "
+            f"application '{self.app_name}' to {decision_num_replicas}. "
+            f"Current number of requests: {total_num_requests}."
         )
 
         new_info = copy(self._target_state.info)
@@ -2264,10 +2264,30 @@ class DeploymentState:
             downscale=downscale,
         )
 
-    def record_autoscaling_metrics(self, replica_tag: str, window_avg: float) -> None:
+    def record_autoscaling_metrics(
+        self, replica_tag: str, window_avg: float, send_timestamp: float
+    ) -> None:
         """Records average ongoing requests at replicas."""
 
-        self.replica_average_ongoing_requests[replica_tag] = window_avg
+        if (
+            replica_tag not in self.replica_average_ongoing_requests
+            or send_timestamp > self.replica_average_ongoing_requests[replica_tag][0]
+        ):
+            self.replica_average_ongoing_requests[replica_tag] = (
+                send_timestamp,
+                window_avg,
+            )
+
+    def record_request_metrics_for_handle(
+        self, handle_id: str, num_requests: float, send_timestamp: float
+    ) -> None:
+        """Update request metric for a specific handle."""
+
+        if (
+            handle_id not in self.handle_requests
+            or send_timestamp > self.handle_requests[handle_id][0]
+        ):
+            self.handle_requests[handle_id] = (send_timestamp, num_requests)
 
     def record_multiplexed_model_ids(
         self, replica_name: str, multiplexed_model_ids: List[str]
@@ -2326,9 +2346,6 @@ class DeploymentStateManager:
             all_current_actor_names, all_current_placement_group_names
         )
 
-        # TODO(simon): move autoscaling related stuff into a manager.
-        self.handle_metrics_store = InMemoryMetricsStore()
-
     def _create_deployment_state(self, deployment_id):
         self._deployment_scheduler.on_deployment_created(
             deployment_id, SpreadDeploymentSchedulingPolicy()
@@ -2348,17 +2365,26 @@ class DeploymentStateManager:
             replica_name = ReplicaName.from_replica_tag(replica_tag)
             self._deployment_states[
                 replica_name.deployment_id
-            ].record_autoscaling_metrics(replica_tag, window_avg)
+            ].record_autoscaling_metrics(replica_tag, window_avg, send_timestamp)
 
     def record_handle_metrics(self, data: Dict[str, float], send_timestamp: float):
-        self.handle_metrics_store.add_metrics_point(data, send_timestamp)
+        id, num_requests = data
+        if num_requests is not None:
+            deployment_id, handle_id = id
+            # There can be handles to deleted deployments still sending
+            # metrics to the controller
+            if deployment_id in self._deployment_states:
+                self._deployment_states[
+                    deployment_id
+                ].record_request_metrics_for_handle(
+                    handle_id, num_requests, send_timestamp
+                )
 
     def get_autoscaling_metrics(self):
-        """
-        Return autoscaling metrics (used for dumping from controller)
-        """
+        """Return autoscaling metrics (used for dumping from controller)"""
+
         return {
-            deployment: deployment_state.replica_average_ongoing_requests
+            deployment: deployment_state.get_total_num_requests()
             for deployment, deployment_state in self._deployment_states.items()
         }
 
@@ -2616,27 +2642,6 @@ class DeploymentStateManager:
         if id in self._deployment_states:
             self._deployment_states[id].delete()
 
-    def get_handle_queueing_metrics(
-        self, deployment_id: DeploymentID, look_back_period_s
-    ) -> int:
-        """
-        Return handle queue length metrics
-        Args:
-            deployment_id: deployment identifier
-            look_back_period_s: the look back time period to collect the requests
-                metrics
-        Returns:
-            if multiple handles queue length, return the max number of queue length.
-        """
-        current_handle_queued_queries = self.handle_metrics_store.max(
-            deployment_id,
-            time.time() - look_back_period_s,
-        )
-
-        if current_handle_queued_queries is None:
-            current_handle_queued_queries = 0
-        return current_handle_queued_queries
-
     def update(self) -> bool:
         """Updates the state of all deployments to match their goal state.
 
@@ -2650,11 +2655,7 @@ class DeploymentStateManager:
 
         for deployment_id, deployment_state in self._deployment_states.items():
             if deployment_state.should_autoscale():
-                current_handle_queued_queries = self.get_handle_queueing_metrics(
-                    deployment_id,
-                    deployment_state.get_autoscale_metric_lookback_period(),
-                )
-                deployment_state.autoscale(current_handle_queued_queries)
+                deployment_state.autoscale()
 
             deployment_state_update_result = deployment_state.update()
             if deployment_state_update_result.upscale:

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from ray.serve._private.constants import CONTROL_LOOP_PERIOD_S, SERVE_LOGGER_NAME
 from ray.serve.config import AutoscalingConfig
@@ -11,7 +11,8 @@ logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 def _calculate_desired_num_replicas(
     autoscaling_config: AutoscalingConfig,
-    current_num_ongoing_requests: List[float],
+    total_num_requests: int,
+    num_running_replicas: int,
     override_min_replicas: Optional[float] = None,
     override_max_replicas: Optional[float] = None,
 ) -> int:
@@ -33,21 +34,16 @@ def _calculate_desired_num_replicas(
             on the input metrics and the current number of replicas.
 
     """
-    current_num_replicas = len(current_num_ongoing_requests)
-    if current_num_replicas == 0:
+    if num_running_replicas == 0:
         raise ValueError("Number of replicas cannot be zero")
-
-    # The number of ongoing requests per replica, averaged over all replicas.
-    num_ongoing_requests_per_replica: float = sum(current_num_ongoing_requests) / len(
-        current_num_ongoing_requests
-    )
 
     # Example: if error_ratio == 2.0, we have two times too many ongoing
     # requests per replica, so we desire twice as many replicas.
-    error_ratio: float = (
-        num_ongoing_requests_per_replica
-        / autoscaling_config.target_num_ongoing_requests_per_replica
+    target_num_requests = (
+        autoscaling_config.target_num_ongoing_requests_per_replica
+        * num_running_replicas
     )
+    error_ratio: float = total_num_requests / target_num_requests
 
     # If error ratio >= 1, then the number of ongoing requests per
     # replica exceeds the target and we will make an upscale decision,
@@ -62,7 +58,7 @@ def _calculate_desired_num_replicas(
 
     # Multiply the distance to 1 by the smoothing ("gain") factor (default=1).
     smoothed_error_ratio = 1 + ((error_ratio - 1) * smoothing_factor)
-    desired_num_replicas = math.ceil(current_num_replicas * smoothed_error_ratio)
+    desired_num_replicas = math.ceil(num_running_replicas * smoothed_error_ratio)
 
     # If error_ratio = 0, meaning there is no more traffic, and desired
     # num replicas is stuck at a positive number due to the math.ceil
@@ -70,7 +66,7 @@ def _calculate_desired_num_replicas(
     # can eventually scale to 0.
     if (
         error_ratio == 0
-        and desired_num_replicas == current_num_replicas
+        and desired_num_replicas == num_running_replicas
         and desired_num_replicas >= 1
     ):
         desired_num_replicas -= 1
@@ -91,8 +87,8 @@ def _calculate_desired_num_replicas(
 @PublicAPI(stability="alpha")
 def replica_queue_length_autoscaling_policy(
     curr_target_num_replicas: int,
-    current_num_ongoing_requests: List[float],
-    current_handle_queued_queries: float,
+    total_num_requests: int,
+    num_running_replicas: int,
     config: Optional[AutoscalingConfig],
     capacity_adjusted_min_replicas: int,
     capacity_adjusted_max_replicas: int,
@@ -108,9 +104,9 @@ def replica_queue_length_autoscaling_policy(
     seconds.
     """
     decision_counter = policy_state.get("decision_counter", 0)
-    if len(current_num_ongoing_requests) == 0:
+    if num_running_replicas == 0:
         # When 0 replicas and queries are queued, scale up the replicas
-        if current_handle_queued_queries > 0:
+        if total_num_requests > 0:
             return max(
                 math.ceil(1 * config.get_upscale_smoothing_factor()),
                 curr_target_num_replicas,
@@ -121,7 +117,8 @@ def replica_queue_length_autoscaling_policy(
 
     desired_num_replicas = _calculate_desired_num_replicas(
         config,
-        current_num_ongoing_requests,
+        total_num_requests,
+        num_running_replicas=num_running_replicas,
         override_min_replicas=capacity_adjusted_min_replicas,
         override_max_replicas=capacity_adjusted_max_replicas,
     )

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -108,8 +108,9 @@ class _DeploymentHandleBase:
         self._recorded_telemetry = _recorded_telemetry
         self._sync = sync
 
+        self.handle_id = get_random_string()
         self.request_counter = _request_counter or self._create_request_counter(
-            app_name, deployment_name
+            app_name, deployment_name, self.handle_id
         )
 
         self._router: Optional[Router] = _router
@@ -150,6 +151,7 @@ class _DeploymentHandleBase:
             self._router = Router(
                 serve.context._get_global_client()._controller,
                 self.deployment_id,
+                self.handle_id,
                 node_id,
                 get_current_actor_id(),
                 availability_zone,
@@ -168,7 +170,9 @@ class _DeploymentHandleBase:
             return f"{deployment_name}#{handle_id}"
 
     @classmethod
-    def _create_request_counter(cls, app_name, deployment_name):
+    def _create_request_counter(
+        cls, app_name: str, deployment_name: str, handle_id: str
+    ):
         return metrics.Counter(
             "serve_handle_request_counter",
             description=(
@@ -177,10 +181,9 @@ class _DeploymentHandleBase:
             ),
             tag_keys=("handle", "deployment", "route", "application"),
         ).set_default_tags(
-            # TODO(zcin): Separate deployment_id into deployment and application tags
             {
                 "handle": cls._gen_handle_tag(
-                    app_name, deployment_name, handle_id=get_random_string()
+                    app_name, deployment_name, handle_id=handle_id
                 ),
                 "deployment": deployment_name,
                 "application": app_name,

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1,6 +1,5 @@
 import sys
 
-import numpy as np
 import pytest
 
 from ray.serve._private.autoscaling_policy import AutoscalingPolicyManager
@@ -21,19 +20,24 @@ class TestCalculateDesiredNumReplicas:
         )
 
         desired_num_replicas = _calculate_desired_num_replicas(
-            autoscaling_config=config, current_num_ongoing_requests=[150] * num_replicas
+            autoscaling_config=config,
+            total_num_requests=150 * num_replicas,
+            num_running_replicas=num_replicas,
         )
         assert desired_num_replicas == max_replicas
 
         desired_num_replicas = _calculate_desired_num_replicas(
-            autoscaling_config=config, current_num_ongoing_requests=[50] * num_replicas
+            autoscaling_config=config,
+            total_num_requests=50 * num_replicas,
+            num_running_replicas=num_replicas,
         )
         assert desired_num_replicas == min_replicas
 
         for i in range(50, 150):
             desired_num_replicas = _calculate_desired_num_replicas(
                 autoscaling_config=config,
-                current_num_ongoing_requests=[i] * num_replicas,
+                total_num_requests=i * num_replicas,
+                num_running_replicas=num_replicas,
             )
             assert min_replicas <= desired_num_replicas <= max_replicas
 
@@ -45,9 +49,11 @@ class TestCalculateDesiredNumReplicas:
             target_num_ongoing_requests_per_replica=target_requests,
         )
         num_replicas = 10
-        num_ongoing_requests = [2 * target_requests] * num_replicas
+        num_ongoing_requests = 2 * target_requests * num_replicas
         desired_num_replicas = _calculate_desired_num_replicas(
-            autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
+            autoscaling_config=config,
+            total_num_requests=num_ongoing_requests,
+            num_running_replicas=num_replicas,
         )
         assert 19 <= desired_num_replicas <= 21  # 10 * 2 = 20
 
@@ -59,9 +65,11 @@ class TestCalculateDesiredNumReplicas:
             target_num_ongoing_requests_per_replica=target_requests,
         )
         num_replicas = 10
-        num_ongoing_requests = [0.5 * target_requests] * num_replicas
+        num_ongoing_requests = 0.5 * target_requests * num_replicas
         desired_num_replicas = _calculate_desired_num_replicas(
-            autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
+            autoscaling_config=config,
+            total_num_requests=num_ongoing_requests,
+            num_running_replicas=num_replicas,
         )
         assert 4 <= desired_num_replicas <= 6  # 10 * 0.5 = 5
 
@@ -74,15 +82,19 @@ class TestCalculateDesiredNumReplicas:
         )
         num_replicas = 10
 
-        num_ongoing_requests = [4.0] * num_replicas
+        num_ongoing_requests = 4.0 * num_replicas
         desired_num_replicas = _calculate_desired_num_replicas(
-            autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
+            autoscaling_config=config,
+            total_num_requests=num_ongoing_requests,
+            num_running_replicas=num_replicas,
         )
         assert 24 <= desired_num_replicas <= 26  # 10 + 0.5 * (40 - 10) = 25
 
-        num_ongoing_requests = [0.25] * num_replicas
+        num_ongoing_requests = 0.25 * num_replicas
         desired_num_replicas = _calculate_desired_num_replicas(
-            autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
+            autoscaling_config=config,
+            total_num_requests=num_ongoing_requests,
+            num_running_replicas=num_replicas,
         )
         assert 5 <= desired_num_replicas <= 8  # 10 + 0.5 * (2.5 - 10) = 6.25
 
@@ -96,16 +108,20 @@ class TestCalculateDesiredNumReplicas:
         num_replicas = 10
 
         # Should use upscale smoothing factor of 0.5
-        num_ongoing_requests = [4.0] * num_replicas
+        num_ongoing_requests = 4.0 * num_replicas
         desired_num_replicas = _calculate_desired_num_replicas(
-            autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
+            autoscaling_config=config,
+            total_num_requests=num_ongoing_requests,
+            num_running_replicas=num_replicas,
         )
         assert 24 <= desired_num_replicas <= 26  # 10 + 0.5 * (40 - 10) = 25
 
         # Should use downscale smoothing factor of 1 (default)
-        num_ongoing_requests = [0.25] * num_replicas
+        num_ongoing_requests = 0.25 * num_replicas
         desired_num_replicas = _calculate_desired_num_replicas(
-            autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
+            autoscaling_config=config,
+            total_num_requests=num_ongoing_requests,
+            num_running_replicas=num_replicas,
         )
         assert 1 <= desired_num_replicas <= 4  # 10 + (2.5 - 10) = 2.5
 
@@ -119,16 +135,20 @@ class TestCalculateDesiredNumReplicas:
         num_replicas = 10
 
         # Should use upscale smoothing factor of 1 (default)
-        num_ongoing_requests = [4.0] * num_replicas
+        num_ongoing_requests = 4.0 * num_replicas
         desired_num_replicas = _calculate_desired_num_replicas(
-            autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
+            autoscaling_config=config,
+            total_num_requests=num_ongoing_requests,
+            num_running_replicas=num_replicas,
         )
         assert 39 <= desired_num_replicas <= 41  # 10 + (40 - 10) = 40
 
         # Should use downscale smoothing factor of 0.5
-        num_ongoing_requests = [0.25] * num_replicas
+        num_ongoing_requests = 0.25 * num_replicas
         desired_num_replicas = _calculate_desired_num_replicas(
-            autoscaling_config=config, current_num_ongoing_requests=num_ongoing_requests
+            autoscaling_config=config,
+            total_num_requests=num_ongoing_requests,
+            num_running_replicas=num_replicas,
         )
         assert 5 <= desired_num_replicas <= 8  # 10 + 0.5 * (2.5 - 10) = 6.25
 
@@ -146,9 +166,9 @@ class TestGetDecisionNumReplicas:
         )
         policy_manager = AutoscalingPolicyManager(config)
         new_num_replicas = policy_manager.get_decision_num_replicas(
-            current_num_ongoing_requests=[],
+            total_num_requests=1,
+            num_running_replicas=0,
             curr_target_num_replicas=0,
-            current_handle_queued_queries=1,
             _skip_bound_check=True,
         )
 
@@ -158,9 +178,9 @@ class TestGetDecisionNumReplicas:
         config.smoothing_factor = 0.5
         policy_manager = AutoscalingPolicyManager(config)
         new_num_replicas = policy_manager.get_decision_num_replicas(
-            current_num_ongoing_requests=[],
+            total_num_requests=1,
+            num_running_replicas=0,
             curr_target_num_replicas=0,
-            current_handle_queued_queries=1,
             _skip_bound_check=True,
         )
 
@@ -181,9 +201,9 @@ class TestGetDecisionNumReplicas:
         )
         policy_manager = AutoscalingPolicyManager(config)
         new_num_replicas = policy_manager.get_decision_num_replicas(
-            current_num_ongoing_requests=[0, 0, 0, 0, 0],
+            total_num_requests=0,
+            num_running_replicas=5,
             curr_target_num_replicas=5,
-            current_handle_queued_queries=0,
         )
 
         assert new_num_replicas == 0
@@ -196,9 +216,9 @@ class TestGetDecisionNumReplicas:
         num_replicas = 5
         for _ in range(5):
             num_replicas = policy_manager.get_decision_num_replicas(
-                current_num_ongoing_requests=[0] * num_replicas,
+                total_num_requests=0,
+                num_running_replicas=num_replicas,
                 curr_target_num_replicas=num_replicas,
-                current_handle_queued_queries=0,
             )
 
         assert num_replicas == 0
@@ -222,113 +242,113 @@ class TestGetDecisionNumReplicas:
         upscale_wait_periods = int(upscale_delay_s / CONTROL_LOOP_PERIOD_S)
         downscale_wait_periods = int(downscale_delay_s / CONTROL_LOOP_PERIOD_S)
 
-        overload_requests = [100]
+        overload_requests = 100
 
         # Scale up when there are 0 replicas and current_handle_queued_queries > 0
         new_num_replicas = policy_manager.get_decision_num_replicas(
-            current_num_ongoing_requests=[],
+            total_num_requests=1,
+            num_running_replicas=0,
             curr_target_num_replicas=0,
-            current_handle_queued_queries=1,
         )
         assert new_num_replicas == 1
 
         # We should scale up only after enough consecutive scale-up decisions.
         for i in range(upscale_wait_periods):
             new_num_replicas = policy_manager.get_decision_num_replicas(
-                current_num_ongoing_requests=overload_requests,
+                total_num_requests=overload_requests,
+                num_running_replicas=1,
                 curr_target_num_replicas=1,
-                current_handle_queued_queries=0,
             )
             assert new_num_replicas == 1, i
 
         new_num_replicas = policy_manager.get_decision_num_replicas(
-            current_num_ongoing_requests=overload_requests,
+            total_num_requests=overload_requests,
+            num_running_replicas=1,
             curr_target_num_replicas=1,
-            current_handle_queued_queries=0,
         )
         assert new_num_replicas == 2
 
-        no_requests = [0, 0]
+        no_requests = 0
 
         # We should scale down only after enough consecutive scale-down decisions.
         for i in range(downscale_wait_periods):
             new_num_replicas = policy_manager.get_decision_num_replicas(
-                current_num_ongoing_requests=no_requests,
+                total_num_requests=no_requests,
+                num_running_replicas=2,
                 curr_target_num_replicas=2,
-                current_handle_queued_queries=0,
             )
             assert new_num_replicas == 2, i
 
         new_num_replicas = policy_manager.get_decision_num_replicas(
-            current_num_ongoing_requests=no_requests,
+            total_num_requests=no_requests,
+            num_running_replicas=2,
             curr_target_num_replicas=2,
-            current_handle_queued_queries=0,
         )
         assert new_num_replicas == 0
 
         # Get some scale-up decisions, but not enough to trigger a scale up.
         for i in range(int(upscale_wait_periods / 2)):
             new_num_replicas = policy_manager.get_decision_num_replicas(
-                current_num_ongoing_requests=overload_requests,
+                total_num_requests=overload_requests,
+                num_running_replicas=1,
                 curr_target_num_replicas=1,
-                current_handle_queued_queries=0,
             )
             assert new_num_replicas == 1, i
 
         # Interrupt with a scale-down decision.
         policy_manager.get_decision_num_replicas(
-            current_num_ongoing_requests=[0],
+            total_num_requests=0,
+            num_running_replicas=1,
             curr_target_num_replicas=1,
-            current_handle_queued_queries=0,
         )
 
         # The counter should be reset, so it should require `upscale_wait_periods`
         # more periods before we actually scale up.
         for i in range(upscale_wait_periods):
             new_num_replicas = policy_manager.get_decision_num_replicas(
-                current_num_ongoing_requests=overload_requests,
+                total_num_requests=overload_requests,
+                num_running_replicas=1,
                 curr_target_num_replicas=1,
-                current_handle_queued_queries=0,
             )
             assert new_num_replicas == 1, i
 
         new_num_replicas = policy_manager.get_decision_num_replicas(
-            current_num_ongoing_requests=overload_requests,
+            total_num_requests=overload_requests,
+            num_running_replicas=1,
             curr_target_num_replicas=1,
-            current_handle_queued_queries=0,
         )
         assert new_num_replicas == 2
 
         # Get some scale-down decisions, but not enough to trigger a scale down.
         for i in range(int(downscale_wait_periods / 2)):
             new_num_replicas = policy_manager.get_decision_num_replicas(
-                current_num_ongoing_requests=no_requests,
+                total_num_requests=no_requests,
+                num_running_replicas=2,
                 curr_target_num_replicas=2,
-                current_handle_queued_queries=0,
             )
             assert new_num_replicas == 2, i
 
         # Interrupt with a scale-up decision.
         policy_manager.get_decision_num_replicas(
-            current_num_ongoing_requests=[100, 100],
+            total_num_requests=200,
+            num_running_replicas=2,
             curr_target_num_replicas=2,
-            current_handle_queued_queries=0,
         )
 
         # The counter should be reset so it should require `downscale_wait_periods`
         # more periods before we actually scale down.
         for i in range(downscale_wait_periods):
             new_num_replicas = policy_manager.get_decision_num_replicas(
-                current_num_ongoing_requests=no_requests,
+                total_num_requests=no_requests,
+                num_running_replicas=2,
                 curr_target_num_replicas=2,
-                current_handle_queued_queries=0,
             )
             assert new_num_replicas == 2, i
 
         new_num_replicas = policy_manager.get_decision_num_replicas(
-            current_num_ongoing_requests=no_requests,
+            total_num_requests=no_requests,
+            num_running_replicas=2,
             curr_target_num_replicas=2,
-            current_handle_queued_queries=0,
         )
         assert new_num_replicas == 0
 
@@ -344,24 +364,24 @@ class TestGetDecisionNumReplicas:
 
         policy_manager = AutoscalingPolicyManager(config)
 
-        new_num_replicas = policy_manager.get_decision_num_replicas(1, [100], 0)
+        new_num_replicas = policy_manager.get_decision_num_replicas(1, 100, 1)
         assert new_num_replicas == 100
 
         # New target is 100, but no new replicas finished spinning up during this
         # timestep.
-        new_num_replicas = policy_manager.get_decision_num_replicas(100, [100], 0)
+        new_num_replicas = policy_manager.get_decision_num_replicas(100, 100, 1)
         assert new_num_replicas == 100
 
         # Two new replicas spun up during this timestep.
         new_num_replicas = policy_manager.get_decision_num_replicas(
-            100, [100, 20, 3], 0
+            100, 100 + 20 + 3, 3
         )
         assert new_num_replicas == 123
 
         # A lot of queries got drained and a lot of replicas started up, but
         # new_num_replicas should not decrease, because of the downscale delay.
         new_num_replicas = policy_manager.get_decision_num_replicas(
-            123, [6, 2, 1, 1], 0
+            123, 6 + 2 + 1 + 1, 4
         )
         assert new_num_replicas == 123
 
@@ -386,16 +406,16 @@ class TestGetDecisionNumReplicas:
             wait_periods = int(delay_s / CONTROL_LOOP_PERIOD_S)
             assert wait_periods > 1
 
-        underload_requests, overload_requests = [20, 20], [100]
+        underload_requests, overload_requests = 2 * 20, 100
         trials = 1000
 
         new_num_replicas = None
         for trial in range(trials):
             if trial % 2 == 0:
                 new_num_replicas = policy_manager.get_decision_num_replicas(
-                    current_num_ongoing_requests=overload_requests,
+                    total_num_requests=overload_requests,
+                    num_running_replicas=1,
                     curr_target_num_replicas=1,
-                    current_handle_queued_queries=0,
                 )
                 if delay_s > 0:
                     assert new_num_replicas == 1, trial
@@ -403,73 +423,16 @@ class TestGetDecisionNumReplicas:
                     assert new_num_replicas == 2, trial
             else:
                 new_num_replicas = policy_manager.get_decision_num_replicas(
-                    current_num_ongoing_requests=underload_requests,
+                    total_num_requests=underload_requests,
+                    num_running_replicas=2,
                     curr_target_num_replicas=2,
-                    current_handle_queued_queries=0,
                 )
                 if delay_s > 0:
                     assert new_num_replicas == 2, trial
                 else:
                     assert new_num_replicas == 1, trial
 
-    @pytest.mark.parametrize(
-        "ongoing_requests", [[7, 1, 8, 4], [8, 1, 8, 4], [6, 1, 8, 4], [0, 1, 8, 4]]
-    )
-    def test_imbalanced_replicas(self, ongoing_requests):
-        config = AutoscalingConfig(
-            min_replicas=1,
-            max_replicas=10,
-            target_num_ongoing_requests_per_replica=5,
-            upscale_delay_s=0.0,
-            downscale_delay_s=0.0,
-        )
-
-        policy_manager = AutoscalingPolicyManager(config)
-
-        # Check that as long as the average number of ongoing requests equals
-        # the target_num_ongoing_requests_per_replica, the number of replicas
-        # stays the same
-        if np.mean(ongoing_requests) == config.target_num_ongoing_requests_per_replica:
-            new_num_replicas = policy_manager.get_decision_num_replicas(
-                current_num_ongoing_requests=ongoing_requests,
-                curr_target_num_replicas=4,
-                current_handle_queued_queries=0,
-            )
-            assert new_num_replicas == 4
-
-        # Check downscaling behavior when average number of requests
-        # is lower than target_num_ongoing_requests_per_replica
-        elif np.mean(ongoing_requests) < config.target_num_ongoing_requests_per_replica:
-            new_num_replicas = policy_manager.get_decision_num_replicas(
-                current_num_ongoing_requests=ongoing_requests,
-                curr_target_num_replicas=4,
-                current_handle_queued_queries=0,
-            )
-
-            if (
-                config.target_num_ongoing_requests_per_replica
-                - np.mean(ongoing_requests)
-                <= 1
-            ):
-                # Autoscaling uses a ceiling operator, which means a slightly low
-                # current_num_ongoing_requests value is insufficient to downscale
-                assert new_num_replicas == 4
-            else:
-                assert new_num_replicas == 3
-
-        # Check upscaling behavior when average number of requests
-        # is higher than target_num_ongoing_requests_per_replica
-        else:
-            new_num_replicas = policy_manager.get_decision_num_replicas(
-                current_num_ongoing_requests=ongoing_requests,
-                curr_target_num_replicas=4,
-                current_handle_queued_queries=0,
-            )
-            assert new_num_replicas == 5
-
-    @pytest.mark.parametrize(
-        "ongoing_requests", [[20, 0, 0, 0], [100, 0, 0, 0], [10, 0, 0, 0]]
-    )
+    @pytest.mark.parametrize("ongoing_requests", [20, 100, 10])
     def test_single_replica_receives_all_requests(self, ongoing_requests):
         target_requests = 5
 
@@ -484,11 +447,11 @@ class TestGetDecisionNumReplicas:
         policy_manager = AutoscalingPolicyManager(config)
 
         new_num_replicas = policy_manager.get_decision_num_replicas(
-            current_num_ongoing_requests=ongoing_requests,
+            total_num_requests=ongoing_requests,
+            num_running_replicas=4,
             curr_target_num_replicas=4,
-            current_handle_queued_queries=0,
         )
-        assert new_num_replicas == sum(ongoing_requests) / target_requests
+        assert new_num_replicas == ongoing_requests / target_requests
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Prepares for the actual changes to autoscaling metrics collection.
* Get rid of the in memory metrics store for handle metrics, and replace with a map of (handle_id -> number of metrics at handle). The in memory metrics store wasn't being used correctly, and is also overkill since the handle metrics are only used for starting up a replica for a scaled-to-0 deployment. The new map will be used in the next PR to collect all autoscaling metrics from handles.
* Minor autoscaling policy changes. Instead of taking a list of integers (each item corresponding to a distinct replica), just take in `total_num_requests` and `num_running_replicas`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
