### PR TITLE
[spark] Fix Gloo detecting incorrect Interfaces on DBR

### DIFF
--- a/python/ray/autoscaler/_private/spark/spark_job_server.py
+++ b/python/ray/autoscaler/_private/spark/spark_job_server.py
@@ -5,13 +5,9 @@ from functools import partial
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
-# from pyspark.util import inheritable_thread_target
+from pyspark.util import inheritable_thread_target
 
-# from ray.util.spark.cluster_init import _start_ray_worker_nodes
-
-def _start_ray_worker_nodes(*args, **kwargs):
-    print("args:", args)
-    print("kwargs:", kwargs)
+from ray.util.spark.cluster_init import _start_ray_worker_nodes
 
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.WARN)

--- a/python/ray/autoscaler/_private/spark/spark_job_server.py
+++ b/python/ray/autoscaler/_private/spark/spark_job_server.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import threading
-from functools import partial
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
@@ -14,13 +13,6 @@ _logger.setLevel(logging.WARN)
 
 
 class SparkJobServerRequestHandler(BaseHTTPRequestHandler):
-    def __init__(self, *args, extra_env_vars=None, **kwargs):
-        if extra_env_vars is None:
-            extra_env_vars = dict()
-
-        self.extra_env_vars = extra_env_vars
-        super().__init__(*args, **kwargs)
-
     def setup(self) -> None:
         super().setup()
         self._handler_lock = threading.RLock()
@@ -68,7 +60,6 @@ class SparkJobServerRequestHandler(BaseHTTPRequestHandler):
                         collect_log_to_path=collect_log_to_path,
                         autoscale_mode=True,
                         spark_job_server_port=self.server.server_address[1],
-                        extra_env_vars=self.extra_env_vars,
                     )
                 except Exception:
                     if spark_job_group_id in self.server.task_status_dict:
@@ -170,8 +161,8 @@ class SparkJobServer(ThreadingHTTPServer):
     handler must be running in current process.
     """
 
-    def __init__(self, server_address, spark, extra_env_vars=None):
-        super().__init__(server_address, partial(SparkJobServerRequestHandler, extra_env_vars=extra_env_vars))
+    def __init__(self, server_address, spark):
+        super().__init__(server_address, SparkJobServerRequestHandler)
         self.spark = spark
 
         # For ray on spark autoscaling mode,

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -772,7 +772,6 @@ def _setup_ray_cluster(
                     collect_log_to_path=collect_log_to_path,
                     autoscale_mode=False,
                     spark_job_server_port=spark_job_server_port,
-                    extra_env_vars=start_hook.custom_environment_variables(),
                 )
             except Exception as e:
                 # NB:
@@ -1461,7 +1460,6 @@ def _start_ray_worker_nodes(
     collect_log_to_path,
     autoscale_mode,
     spark_job_server_port,
-    extra_env_vars,
 ):
     # NB:
     # In order to start ray worker nodes on spark cluster worker machines,
@@ -1515,11 +1513,13 @@ def _start_ray_worker_nodes(
         if ray_temp_dir is not None:
             ray_worker_node_cmd.append(f"--temp-dir={ray_temp_dir}")
 
+        hook_entry = _create_hook_entry(is_global=(ray_temp_dir is None))
+
         ray_worker_node_extra_envs = {
             RAY_ON_SPARK_COLLECT_LOG_TO_PATH: collect_log_to_path or "",
             RAY_ON_SPARK_START_RAY_PARENT_PID: str(os.getpid()),
             "RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER": "1",
-            **extra_env_vars,
+            **hook_entry.custom_environment_variables(),
         }
 
         if num_gpus_per_node > 0:

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -657,7 +657,6 @@ def _setup_ray_cluster(
             },
             upscaling_speed=autoscale_upscaling_speed,
             idle_timeout_minutes=autoscale_idle_timeout_minutes,
-            extra_env_vars=start_hook.custom_environment_variables(),
         )
         ray_head_proc, tail_output_deque = autoscaling_cluster.start(
             ray_head_ip,
@@ -1655,7 +1654,6 @@ class AutoscalingCluster:
         extra_provider_config: dict,
         upscaling_speed: float,
         idle_timeout_minutes: float,
-        extra_env_vars: dict,
     ):
         """Create the cluster.
 
@@ -1672,7 +1670,6 @@ class AutoscalingCluster:
             upscaling_speed,
             idle_timeout_minutes,
         )
-        self.extra_env_vars = extra_env_vars
 
     def _generate_config(
         self,
@@ -1787,11 +1784,13 @@ class AutoscalingCluster:
         )
         ray_head_node_cmd.extend(_convert_ray_node_options(head_node_options))
 
+        hook_entry = _create_hook_entry(is_global=(ray_temp_dir is None))
+
         extra_env = {
             "AUTOSCALER_UPDATE_INTERVAL_S": "1",
             RAY_ON_SPARK_COLLECT_LOG_TO_PATH: collect_log_to_path or "",
             RAY_ON_SPARK_START_RAY_PARENT_PID: str(os.getpid()),
-            **self.extra_env_vars,
+            **hook_entry.custom_environment_variables(),
         }
 
         self.ray_head_node_cmd = ray_head_node_cmd

--- a/python/ray/util/spark/databricks_hook.py
+++ b/python/ray/util/spark/databricks_hook.py
@@ -167,3 +167,13 @@ class DefaultDatabricksRayOnSparkStartHook(RayOnSparkStartHook):
     def on_spark_job_created(self, job_group_id):
         db_api_entry = get_db_entry_point()
         db_api_entry.registerBackgroundSparkJobGroup("job_group_id")
+
+    def custom_environment_variables(self):
+        """Hardcode `GLOO_SOCKET_IFNAME` to `eth0` for Databricks runtime.
+
+        Torch on DBR does not reliably detect the correct interface to use,
+        and ends up selecting the loopback interface, breaking cross-node
+        commnication."""
+        return {
+            "GLOO_SOCKET_IFNAME": "eth0",
+        }

--- a/python/ray/util/spark/start_hook_base.py
+++ b/python/ray/util/spark/start_hook_base.py
@@ -13,3 +13,6 @@ class RayOnSparkStartHook:
 
     def on_spark_job_created(self, job_group_id):
         pass
+
+    def custom_environment_variables(self):
+        return {}


### PR DESCRIPTION
## Why are these changes needed?
When running distributed Pytorch without GPUs, Pytorch selects a **localhost** interface for gloo (i.e. `127.0.0.1:XXX`), breaking distributed training. This method in [Pytorch](https://github.com/pytorch/pytorch/blob/9b88354b80e2b2cce401bd59c7f0b45e13657a0b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp#L653) can yield the incorrect interface when a) the the hostname resolves locally to the loopback address or b) when hostname lookups fail.

This is scoped to DBR specifically because `eth0` is guaranteed to exist there. Pytorch+Gloo **does not support** deny-listing like NCCL (as we do in https://github.com/ray-project/ray/pull/31824) because Pytorch directly uses the environment variable `GLOO_SOCKET_IFNAME` as the interface to use https://github.com/pytorch/pytorch/blob/7956ca16e649d86cbf11b6e122090fa05678fac3/torch/csrc/distributed/c10d/init.cpp#L2243. 



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
