### PR TITLE
[Doc] Add back in missing search button to top nav bar

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -287,6 +287,7 @@ html_theme_options = {
     },
     "navbar_start": ["navbar-ray-logo"],
     "navbar_end": [
+        "search-button-field",
         "navbar-icon-links",
         "navbar-anyscale",
     ],


### PR DESCRIPTION
## Why are these changes needed?

A previous PR removed the search field from the primary sidebar - this adds it back into the top nav bar, where it will go in a future redesign.

## Related issue number

None.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
