### PR TITLE
[ci][mac/3] move ray cpp+java tests to civ2

### DIFF
--- a/.buildkite/macos.rayci.yml
+++ b/.buildkite/macos.rayci.yml
@@ -65,3 +65,15 @@ steps:
     soft_fail: true
     commands:
       - ./ci/ray_ci/macos/macos_ci.sh run_core_dashboard_test
+
+  - label: ":ray: core: :mac: core c++ and java tests"
+    tags:
+      - cpp
+      - java
+      - macos_wheels
+      - oss
+    job_env: MACOS
+    instance_type: macos
+    soft_fail: true
+    commands:
+      - RAY_INSTALL_JAVA=1 ./ci/ray_ci/macos/macos_ci.sh run_ray_cpp_and_java

--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -109,15 +109,3 @@ steps:
     # Upload to latest directory.
     - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
     - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/darwin; fi
-
-- label: ":mac: :apple: Ray C++ and Java"
-  <<: *common
-  conditions: ["RAY_CI_CPP_AFFECTED", "RAY_CI_JAVA_AFFECTED"]
-  commands:
-    - export RAY_INSTALL_JAVA=1
-    - *prelude_commands
-    # clang-format is needed by java/test.sh
-    - pip install clang-format==12.0.1
-    - ./java/test.sh
-    - ./ci/ci.sh test_cpp
-    - *epilogue_commands

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -49,6 +49,13 @@ run_core_dashboard_test() {
     //:all python/ray/dashboard/... -python/ray/serve/... -rllib/... -core_worker_test
 }
 
+run_ray_cpp_and_java() {
+  # clang-format is needed by java/test.sh
+  pip install clang-format==12.0.1
+  ./java/test.sh
+  ./ci/ci.sh test_cpp
+}
+
 _prelude() {
   rm -rf /tmp/bazel_event_logs
   cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT


### PR DESCRIPTION
Move ray cpp+java tests to civ2

Test:
- CI, failed (https://buildkite.com/ray-project/premerge/builds/15840#018cdb75-7e85-4425-86ea-66b4975e1bf1), but in the same way as master (https://buildkite.com/ray-project/oss-ci-build-branch/builds/7422#018cdaff-dc4a-4a59-9386-10c01a17d945/3834-11217)