### PR TITLE
[Doc] Prevent line from wrapping for tag buttons in example gallery

### DIFF
--- a/doc/source/_static/css/examples.css
+++ b/doc/source/_static/css/examples.css
@@ -85,6 +85,11 @@
   line-height: 20px;
 }
 
+.tag > span {
+  white-space: nowrap;
+  min-width: auto;
+}
+
 .tag > svg > path {
   fill: var(--pst-color-text-base);
 }


### PR DESCRIPTION
## Why are these changes needed?

This PR prevents tag buttons with long text from wrapping in the example gallery.

## Related issue number

Closes https://github.com/ray-project/ray/issues/42210.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
