### PR TITLE
[ci][7up/2.3] refactor runtime_env_container tests

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -2117,3 +2117,11 @@ def skip_flaky_core_test_premerge(reason: str):
         )(func)
 
     return wrapper
+
+
+def get_ray_default_worker_file_path():
+    py_version = f"{sys.version_info[0]}.{sys.version_info[1]}"
+    return (
+        f"/home/ray/anaconda3/lib/python{py_version}/"
+        "site-packages/ray/_private/workers/default_worker.py"
+    )

--- a/python/ray/tests/runtime_env_container/test_log_file_exists.py
+++ b/python/ray/tests/runtime_env_container/test_log_file_exists.py
@@ -2,14 +2,14 @@ import ray
 from pathlib import Path
 import re
 from ray.util.state import list_tasks
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import wait_for_condition, get_ray_default_worker_file_path
 import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--image", type=str, help="The docker image to use for Ray worker")
 args = parser.parse_args()
 
-worker_pth = "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/workers/default_worker.py"  # noqa
+worker_pth = get_ray_default_worker_file_path()
 
 ray.init(num_cpus=1)
 

--- a/python/ray/tests/runtime_env_container/test_put_get.py
+++ b/python/ray/tests/runtime_env_container/test_put_get.py
@@ -1,12 +1,13 @@
 import ray
 import numpy as np
 import argparse
+from ray._private.test_utils import get_ray_default_worker_file_path
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--image", type=str, help="The docker image to use for Ray worker")
 args = parser.parse_args()
 
-worker_pth = "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/workers/default_worker.py"  # noqa
+worker_pth = get_ray_default_worker_file_path()
 
 
 @ray.remote(runtime_env={"container": {"image": args.image, "worker_path": worker_pth}})

--- a/python/ray/tests/runtime_env_container/test_ray_env_vars.py
+++ b/python/ray/tests/runtime_env_container/test_ray_env_vars.py
@@ -2,12 +2,13 @@ import argparse
 import os
 
 import ray
+from ray._private.test_utils import get_ray_default_worker_file_path
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--image", type=str, help="The docker image to use for Ray worker")
 args = parser.parse_args()
 
-worker_pth = "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/workers/default_worker.py"  # noqa
+worker_pth = get_ray_default_worker_file_path()
 
 
 @ray.remote(runtime_env={"container": {"image": args.image, "worker_path": worker_pth}})

--- a/python/ray/tests/runtime_env_container/test_serve_basic.py
+++ b/python/ray/tests/runtime_env_container/test_serve_basic.py
@@ -1,13 +1,13 @@
 import argparse
 from ray import serve
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import wait_for_condition, get_ray_default_worker_file_path
 from ray.serve.handle import DeploymentHandle
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--image", type=str, help="The docker image to use for Ray worker")
 args = parser.parse_args()
 
-WORKER_PATH = "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/workers/default_worker.py"  # noqa
+WORKER_PATH = get_ray_default_worker_file_path()
 
 
 @serve.deployment(

--- a/python/ray/tests/runtime_env_container/test_serve_telemetry.py
+++ b/python/ray/tests/runtime_env_container/test_serve_telemetry.py
@@ -4,7 +4,7 @@ import subprocess
 
 import ray
 from ray import serve
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import wait_for_condition, get_ray_default_worker_file_path
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve.context import _get_global_client
 from ray.serve.schema import ServeDeploySchema
@@ -18,7 +18,7 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument("--image", type=str, help="The docker image to use for Ray worker")
 args = parser.parse_args()
-worker_pth = "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/workers/default_worker.py"  # noqa
+worker_pth = get_ray_default_worker_file_path()
 
 os.environ["RAY_USAGE_STATS_ENABLED"] = "1"
 os.environ["RAY_USAGE_STATS_REPORT_URL"] = "http://127.0.0.1:8000/telemetry"

--- a/python/ray/tests/runtime_env_container/test_shared_memory.py
+++ b/python/ray/tests/runtime_env_container/test_shared_memory.py
@@ -3,11 +3,13 @@ import numpy as np
 import sys
 import argparse
 
+from ray._private.test_utils import get_ray_default_worker_file_path
+
 parser = argparse.ArgumentParser()
 parser.add_argument("--image", type=str, help="The docker image to use for Ray worker")
 args = parser.parse_args()
 
-worker_pth = "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/workers/default_worker.py"  # noqa
+worker_pth = get_ray_default_worker_file_path()
 
 
 @ray.remote(runtime_env={"container": {"image": args.image, "worker_path": worker_pth}})

--- a/python/ray/tests/runtime_env_container/test_worker_exit_intended_system_exit_and_user_error.py
+++ b/python/ray/tests/runtime_env_container/test_worker_exit_intended_system_exit_and_user_error.py
@@ -5,13 +5,13 @@ import argparse
 import ray
 from ray._private.state_api_test_utils import verify_failed_task
 from ray.util.state import list_workers
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import wait_for_condition, get_ray_default_worker_file_path
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--image", type=str, help="The docker image to use for Ray worker")
 args = parser.parse_args()
-worker_pth = "/home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/workers/default_worker.py"  # noqa
+worker_pth = get_ray_default_worker_file_path()
 
 
 ray.init(num_cpus=1)


### PR DESCRIPTION
Make runtime_env_container more agnostic to the host python version. Also move the command path to test_utils. This is to make python upgrades a bit easier.

Test:
- CI