### PR TITLE
[ci] remove duplicated artifact mount in linux container

### DIFF
--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -55,8 +55,6 @@ class LinuxContainer(Container):
         extra_args = [
             "--env",
             "NVIDIA_DISABLE_REQUIRE=1",
-            "--volume",
-            "/tmp/artifacts:/artifact-mount",
             "--add-host",
             "rayci.localhost:host-gateway",
         ]


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/42205 moved artifact mount to the parent container class so this line is now duplicated for linux

Test:
- CI