### PR TITLE
[ci][test-data/3] persist ci test results

### DIFF
--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -16,6 +16,8 @@ from ci.ray_ci.linux_tester_container import LinuxTesterContainer
 from ci.ray_ci.windows_tester_container import WindowsTesterContainer
 from ci.ray_ci.tester_container import TesterContainer
 from ci.ray_ci.utils import docker_login
+from ray_release.configs.global_config import init_global_config
+from ray_release.bazel import bazel_runfile
 
 CUDA_COPYRIGHT = """
 ==========
@@ -175,6 +177,7 @@ def main(
     if not bazel_workspace_dir:
         raise Exception("Please use `bazelisk run //ci/ray_ci`")
     os.chdir(bazel_workspace_dir)
+    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
     docker_login(_DOCKER_ECR_REPO.split("/")[0])
 
     if build_type == "wheel" or build_type == "wheel-aarch64":

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -393,6 +393,7 @@ py_library(
     data = glob(["ray_release/environments/*.env"]) + [
         "ray_release/buildkite/aws_instance_types.csv",
         "ray_release/schema.json",
+        "ray_release/configs/oss_config.yaml",
     ],
     imports = ["."],
     visibility = ["//visibility:public"],

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -387,13 +387,19 @@ class Test(dict):
 
     def persist_result_to_s3(self, result: Result) -> bool:
         """
+        Persist result object to s3
+        """
+        self.persist_test_result_to_s3(TestResult.from_result(result))
+
+    def persist_test_result_to_s3(self, test_result: TestResult) -> bool:
+        """
         Persist test result object to s3
         """
         boto3.client("s3").put_object(
             Bucket=get_global_config()["state_machine_aws_bucket"],
             Key=f"{AWS_TEST_RESULT_KEY}/"
             f"{self._get_s3_name()}-{int(time.time() * 1000)}.json",
-            Body=json.dumps(TestResult.from_result(result).__dict__),
+            Body=json.dumps(test_result.__dict__),
         )
 
     def persist_to_s3(self) -> bool:


### PR DESCRIPTION
Persist CI test results on every test run:

Test:
- CI
- Run in postmerge, log data just fine: https://buildkite.com/ray-project/postmerge/builds/2501