### PR TITLE
Add A100-40G and A100-80G to the accelerator type enum

### DIFF
--- a/python/ray/util/accelerators/__init__.py
+++ b/python/ray/util/accelerators/__init__.py
@@ -27,6 +27,8 @@ __all__ = [
     "NVIDIA_TESLA_K80",
     "NVIDIA_TESLA_A10G",
     "NVIDIA_A100",
+    "NVIDIA_A100_40G",
+    "NVIDIA_A100_80G",
     "INTEL_MAX_1550",
     "INTEL_MAX_1100",
     "INTEL_GAUDI",

--- a/python/ray/util/accelerators/accelerators.py
+++ b/python/ray/util/accelerators/accelerators.py
@@ -13,5 +13,6 @@ GOOGLE_TPU_V2 = "TPU-V2"
 GOOGLE_TPU_V3 = "TPU-V3"
 GOOGLE_TPU_V4 = "TPU-V4"
 
-# Deprecated as A100 is not part of the "TESLA" suite.
-NVIDIA_TESLA_A100 = "A100"
+# Use these instead of NVIDIA_A100 if you need a specific accelerator size.
+NVIDIA_A100_40G = "A100-40G"
+NVIDIA_A100_80G = "A100-80G"

--- a/python/ray/util/accelerators/accelerators.py
+++ b/python/ray/util/accelerators/accelerators.py
@@ -13,6 +13,8 @@ GOOGLE_TPU_V2 = "TPU-V2"
 GOOGLE_TPU_V3 = "TPU-V3"
 GOOGLE_TPU_V4 = "TPU-V4"
 
-# Use these instead of NVIDIA_A100 if you need a specific accelerator size.
+# Use these instead of NVIDIA_A100 if you need a specific accelerator size. Note that
+# these labels are not auto-added to nodes, you'll have to add them manually in
+# addition to the default A100 label if needed.
 NVIDIA_A100_40G = "A100-40G"
 NVIDIA_A100_80G = "A100-80G"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add a standard entry to distinguish between these two accelerator types, which is a common use case for LLM use cases.