### PR TITLE
[Serve] Refactor `ReplicaQueueLengthAutoscalingPolicy` into `AutoscalingPolicyManager` and policy function

### DIFF
--- a/python/ray/serve/_private/autoscaling_policy.py
+++ b/python/ray/serve/_private/autoscaling_policy.py
@@ -15,7 +15,7 @@ class AutoscalingPolicyManager:
     def __init__(self, config: Optional[AutoscalingConfig]):
         self.config = config
         self.policy = None
-        self.policy_states = {}
+        self.policy_state = {}
         self._create_policy()
 
     def _create_policy(self):
@@ -57,7 +57,7 @@ class AutoscalingPolicyManager:
             config=self.config,
             capacity_adjusted_min_replicas=capacity_adjusted_min_replicas,
             capacity_adjusted_max_replicas=capacity_adjusted_max_replicas,
-            policy_states=self.policy_states,
+            policy_state=self.policy_state,
         )
 
         if _skip_bound_check:

--- a/python/ray/serve/_private/autoscaling_policy.py
+++ b/python/ray/serve/_private/autoscaling_policy.py
@@ -1,0 +1,135 @@
+import logging
+import time
+from typing import Callable, List, Optional
+
+from ray.serve._private.common import TargetCapacityDirection
+from ray.serve._private.constants import SERVE_LOGGER_NAME
+from ray.serve._private.utils import get_capacity_adjusted_num_replicas
+from ray.serve.autoscaling_policy import AutoscalingContext
+from ray.serve.config import AutoscalingConfig
+
+logger = logging.getLogger(SERVE_LOGGER_NAME)
+
+
+class AutoscalingPolicyManager:
+    """Managing autoscaling policies and the lifecycle of the scaling function calls."""
+
+    def __init__(self, config: Optional[AutoscalingConfig]):
+        self.config = config
+        self.context = AutoscalingContext(config=config)
+        self.policy = None
+        self._create_policy()
+
+    def _create_policy(self):
+        """Creates an autoscaling policy based on the given config."""
+        if self.config:
+            self.policy = self.config.get_policy()
+
+    def should_autoscale(self) -> bool:
+        """Returns whether autoscaling should be performed."""
+        return self.policy is not None
+
+    def get_decision_num_replicas(
+        self,
+        curr_target_num_replicas: int,
+        current_num_ongoing_requests: List[float],
+        current_handle_queued_queries: float,
+        target_capacity: Optional[float] = None,
+        target_capacity_direction: Optional[TargetCapacityDirection] = None,
+        app_name: Optional[str] = None,
+        deployment_name: Optional[str] = None,
+    ) -> Optional[int]:
+        """Interface with the autoscaling policy to get a decision to scale replicas.
+        If the autoscaling policy is not ready or returning the same number as the
+        current replica number, return None to not execute autoscaling.
+        """
+        capacity_adjusted_min_replicas = self.get_current_lower_bound(
+            target_capacity,
+            target_capacity_direction,
+        )
+        capacity_adjusted_max_replicas = get_capacity_adjusted_num_replicas(
+            self.config.max_replicas,
+            target_capacity,
+        )
+        self.context.update(
+            curr_target_num_replicas=curr_target_num_replicas,
+            current_num_ongoing_requests=current_num_ongoing_requests,
+            current_handle_queued_queries=current_handle_queued_queries,
+            capacity_adjusted_min_replicas=capacity_adjusted_min_replicas,
+            capacity_adjusted_max_replicas=capacity_adjusted_max_replicas,
+            app_name=app_name,
+            deployment_name=deployment_name,
+        )
+        # Note: The thread manager will continuously return None until a decision is
+        # made. We do not currently force kill and restart the scaling call due to
+        # complexities. We will add docs to warn users not to make long-running calls
+        # here, and they can set timeout in their policies if needed.
+        decision_num_replicas = self.thread_manager.get_decision_num_replicas(
+            context=self.context,
+        )
+
+        return self.apply_bounds(
+            curr_target_num_replicas=decision_num_replicas,
+            target_capacity=target_capacity,
+            target_capacity_direction=target_capacity_direction,
+        )
+
+    def get_current_lower_bound(
+        self,
+        target_capacity: Optional[float] = None,
+        target_capacity_direction: Optional[TargetCapacityDirection] = None,
+    ) -> int:
+        """Get the autoscaling lower bound, including target_capacity changes.
+
+        The autoscaler uses initial_replicas scaled by target_capacity only
+        if the target capacity direction is UP.
+        """
+
+        if self.config.initial_replicas is not None and (
+            target_capacity_direction == TargetCapacityDirection.UP
+        ):
+            return get_capacity_adjusted_num_replicas(
+                self.config.initial_replicas,
+                target_capacity,
+            )
+        else:
+            return get_capacity_adjusted_num_replicas(
+                self.config.min_replicas,
+                target_capacity,
+            )
+
+    def apply_bounds(
+        self,
+        curr_target_num_replicas: int,
+        target_capacity: Optional[float] = None,
+        target_capacity_direction: Optional[TargetCapacityDirection] = None,
+    ) -> int:
+        """Clips curr_target_num_replicas using the current bounds."""
+
+        upper_bound = get_capacity_adjusted_num_replicas(
+            self.config.max_replicas,
+            target_capacity,
+        )
+        lower_bound = self.get_current_lower_bound(
+            target_capacity, target_capacity_direction
+        )
+        return max(lower_bound, min(upper_bound, curr_target_num_replicas))
+
+    def is_within_bounds(
+        self,
+        num_replicas_running_at_target_version: int,
+        target_capacity: float,
+        target_capacity_direction: TargetCapacityDirection,
+    ) -> bool:
+        assert self.config is not None
+
+        lower_bound = self.get_current_lower_bound(
+            target_capacity,
+            target_capacity_direction,
+        )
+        upper_bound = get_capacity_adjusted_num_replicas(
+            self.config.max_replicas,
+            target_capacity,
+        )
+
+        return lower_bound <= num_replicas_running_at_target_version <= upper_bound

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -269,4 +269,4 @@ RAY_SERVE_MAX_QUEUE_LENGTH_RESPONSE_DEADLINE_S = float(
 )
 
 # The default autoscaling policy to use if none is specified.
-DEFAULT_AUTOSCALING_POLICY = "ray.serve.autoscaling_policy:DefaultAutoscalingPolicy"
+DEFAULT_AUTOSCALING_POLICY = "ray.serve.autoscaling_policy:default_autoscaling_policy"

--- a/python/ray/serve/_private/deployment_info.py
+++ b/python/ray/serve/_private/deployment_info.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, Optional
 
 import ray
+from ray.serve._private.autoscaling_policy import AutoscalingPolicyManager
 from ray.serve._private.common import TargetCapacityDirection
 from ray.serve._private.config import DeploymentConfig, ReplicaConfig
 from ray.serve._private.constants import REPLICA_CONTROL_PLANE_CONCURRENCY_GROUP
-from ray.serve.autoscaling_policy import DefaultAutoscalingPolicy
 from ray.serve.generated.serve_pb2 import DeploymentInfo as DeploymentInfoProto
 from ray.serve.generated.serve_pb2 import (
     TargetCapacityDirection as TargetCapacityDirectionProto,
@@ -53,12 +53,9 @@ class DeploymentInfo:
         self.target_capacity = target_capacity
         self.target_capacity_direction = target_capacity_direction
 
-        if deployment_config.autoscaling_config is not None:
-            self.autoscaling_policy = DefaultAutoscalingPolicy(
-                deployment_config.autoscaling_config
-            )
-        else:
-            self.autoscaling_policy = None
+        self.autoscaling_policy_manager = AutoscalingPolicyManager(
+            config=deployment_config.autoscaling_config
+        )
 
     def __getstate__(self) -> Dict[Any, Any]:
         clean_dict = self.__dict__.copy()

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -18,6 +18,7 @@ from ray.exceptions import RayActorError, RayError, RayTaskError, RuntimeEnvSetu
 from ray.serve import metrics
 from ray.serve._private import default_impl
 from ray.serve._private.autoscaling_metrics import InMemoryMetricsStore
+from ray.serve._private.autoscaling_policy import AutoscalingPolicyManager
 from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
 from ray.serve._private.common import (
     DeploymentID,
@@ -1260,17 +1261,21 @@ class DeploymentState:
 
         self._last_notified_running_replica_infos: List[RunningReplicaInfo] = []
 
+    @property
+    def autoscaling_policy_manager(self) -> AutoscalingPolicyManager:
+        return self._target_state.info.autoscaling_policy_manager
+
     def should_autoscale(self) -> bool:
         """
         Check if the deployment is under autoscaling
         """
-        return self._target_state.info.autoscaling_policy is not None
+        return self.autoscaling_policy_manager.should_autoscale()
 
     def get_autoscale_metric_lookback_period(self) -> float:
         """
         Return the autoscaling metrics look back period
         """
-        return self._target_state.info.autoscaling_policy.config.look_back_period_s
+        return self.autoscaling_policy_manager.config.look_back_period_s
 
     def get_checkpoint_data(self) -> DeploymentTargetState:
         """
@@ -1497,18 +1502,16 @@ class DeploymentState:
             return False
 
         # Decide new target num_replicas.
-        autoscaling_policy = deployment_info.autoscaling_policy
-        if autoscaling_policy is not None:
-            if (
-                deployment_settings_changed
-                and autoscaling_policy.config.initial_replicas is not None
-            ):
+        autoscaling_policy_manager = deployment_info.autoscaling_policy_manager
+        if autoscaling_policy_manager.should_autoscale():
+            initial_replicas = autoscaling_policy_manager.config.initial_replicas
+            if deployment_settings_changed and initial_replicas is not None:
                 target_num_replicas = get_capacity_adjusted_num_replicas(
-                    autoscaling_policy.config.initial_replicas,
+                    initial_replicas,
                     deployment_info.target_capacity,
                 )
             else:
-                target_num_replicas = autoscaling_policy.apply_bounds(
+                target_num_replicas = autoscaling_policy_manager.apply_bounds(
                     self._target_state.target_num_replicas,
                     deployment_info.target_capacity,
                     deployment_info.target_capacity_direction,
@@ -1581,16 +1584,21 @@ class DeploymentState:
             return
 
         current_num_ongoing_requests = self.get_replica_current_ongoing_requests()
-        autoscaling_policy = self._target_state.info.autoscaling_policy
-        decision_num_replicas = autoscaling_policy.get_decision_num_replicas(
+        autoscaling_policy_manager = self.autoscaling_policy_manager
+        decision_num_replicas = autoscaling_policy_manager.get_decision_num_replicas(
             curr_target_num_replicas=self._target_state.target_num_replicas,
             current_num_ongoing_requests=current_num_ongoing_requests,
             current_handle_queued_queries=current_handle_queued_queries,
             target_capacity=self._target_state.info.target_capacity,
             target_capacity_direction=self._target_state.info.target_capacity_direction,
+            app_name=self.app_name,
+            deployment_name=self.deployment_name,
         )
 
-        if decision_num_replicas == self._target_state.target_num_replicas:
+        if (
+            decision_num_replicas is None
+            or decision_num_replicas == self._target_state.target_num_replicas
+        ):
             return
 
         logger.info(
@@ -1639,19 +1647,13 @@ class DeploymentState:
             states=[ReplicaState.RUNNING], version=target_version
         )
 
-        autoscaling_policy = self._target_state.info.autoscaling_policy
-        assert autoscaling_policy is not None
+        assert self.autoscaling_policy_manager is not None
 
-        lower_bound = autoscaling_policy.get_current_lower_bound(
+        return self.autoscaling_policy_manager.is_within_bounds(
+            num_replicas_running_at_target_version,
             self._target_state.info.target_capacity,
             self._target_state.info.target_capacity_direction,
         )
-        upper_bound = get_capacity_adjusted_num_replicas(
-            autoscaling_policy.config.max_replicas,
-            self._target_state.info.target_capacity,
-        )
-
-        return lower_bound <= num_replicas_running_at_target_version <= upper_bound
 
     def delete(self) -> None:
         if not self._target_state.deleting:

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1591,8 +1591,6 @@ class DeploymentState:
             current_handle_queued_queries=current_handle_queued_queries,
             target_capacity=self._target_state.info.target_capacity,
             target_capacity_direction=self._target_state.info.target_capacity_direction,
-            app_name=self.app_name,
-            deployment_name=self.deployment_name,
         )
 
         if (

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1647,10 +1647,13 @@ class DeploymentState:
 
         assert self.autoscaling_policy_manager is not None
 
-        return self.autoscaling_policy_manager.is_within_bounds(
-            num_replicas_running_at_target_version,
-            self._target_state.info.target_capacity,
-            self._target_state.info.target_capacity_direction,
+        return (
+            self.autoscaling_policy_manager.apply_bounds(
+                num_replicas_running_at_target_version,
+                self._target_state.info.target_capacity,
+                self._target_state.info.target_capacity_direction,
+            )
+            == num_replicas_running_at_target_version
         )
 
     def delete(self) -> None:

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -96,7 +96,7 @@ def replica_queue_length_autoscaling_policy(
     config: Optional[AutoscalingConfig],
     capacity_adjusted_min_replicas: int,
     capacity_adjusted_max_replicas: int,
-    policy_states: Dict[str, Any],
+    policy_state: Dict[str, Any],
 ) -> int:
     """The default autoscaling policy based on basic thresholds for scaling.
     There is a minimum threshold for the average queue length in the cluster
@@ -107,7 +107,7 @@ def replica_queue_length_autoscaling_policy(
     `get_decision_num_replicas` is called once every CONTROL_LOOP_PERIOD_S
     seconds.
     """
-    decision_counter = policy_states.get("decision_counter", 0)
+    decision_counter = policy_state.get("decision_counter", 0)
     if len(current_num_ongoing_requests) == 0:
         # When 0 replicas and queries are queued, scale up the replicas
         if current_handle_queued_queries > 0:
@@ -158,7 +158,7 @@ def replica_queue_length_autoscaling_policy(
     else:
         decision_counter = 0
 
-    policy_states["decision_counter"] = decision_counter
+    policy_state["decision_counter"] = decision_counter
     return decision_num_replicas
 
 

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -96,7 +96,7 @@ def replica_queue_length_autoscaling_policy(
     config: Optional[AutoscalingConfig],
     capacity_adjusted_min_replicas: int,
     capacity_adjusted_max_replicas: int,
-    policy_state: Dict[str, Any],
+    policy_states: Dict[str, Any],
 ) -> int:
     """The default autoscaling policy based on basic thresholds for scaling.
     There is a minimum threshold for the average queue length in the cluster
@@ -107,7 +107,7 @@ def replica_queue_length_autoscaling_policy(
     `get_decision_num_replicas` is called once every CONTROL_LOOP_PERIOD_S
     seconds.
     """
-    decision_counter = policy_state.get("decision_counter", 0)
+    decision_counter = policy_states.get("decision_counter", 0)
     if len(current_num_ongoing_requests) == 0:
         # When 0 replicas and queries are queued, scale up the replicas
         if current_handle_queued_queries > 0:
@@ -158,7 +158,7 @@ def replica_queue_length_autoscaling_policy(
     else:
         decision_counter = 0
 
-    policy_state["decision_counter"] = decision_counter
+    policy_states["decision_counter"] = decision_counter
     return decision_num_replicas
 
 

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -1,11 +1,8 @@
 import logging
 import math
-from abc import ABCMeta, abstractmethod
 from typing import List, Optional
 
-from ray.serve._private.common import TargetCapacityDirection
 from ray.serve._private.constants import CONTROL_LOOP_PERIOD_S, SERVE_LOGGER_NAME
-from ray.serve._private.utils import get_capacity_adjusted_num_replicas
 from ray.serve.config import AutoscalingConfig
 from ray.util.annotations import PublicAPI
 
@@ -92,47 +89,65 @@ def _calculate_desired_num_replicas(
 
 
 @PublicAPI(stability="alpha")
-class AutoscalingPolicy:
-    """Defines the interface for an autoscaling policy.
+class AutoscalingContext:
+    """Contains the context for an autoscaling policy.
 
-    To add a new autoscaling policy, a class should be defined that provides
-    this interface. The class may be stateful, in which case it may also want
-    to provide a non-default constructor. However, this state will be lost when
-    the controller recovers from a failure.
+    This context includes the current number of replicas, the current number
+    of ongoing requests, and the current number of queued queries.
     """
 
-    __metaclass__ = ABCMeta
-
-    def __init__(self, config: AutoscalingConfig):
-        """Initialize the policy using the specified config dictionary."""
+    def __init__(
+        self,
+        config: AutoscalingConfig,
+    ):
         self.config = config
+        self.curr_target_num_replicas = 0
+        self.current_num_ongoing_requests = []
+        self.current_handle_queued_queries = 0.0
+        self.capacity_adjusted_min_replicas = None
+        self.capacity_adjusted_max_replicas = None
+        self.decision_counter = 0
+        self.last_scale_time = None
+        self.app_name = None
+        self.deployment_name = None
 
-    @abstractmethod
-    def get_decision_num_replicas(
+    def update(
         self,
         curr_target_num_replicas: int,
         current_num_ongoing_requests: List[float],
         current_handle_queued_queries: float,
-    ) -> int:
-        """Make a decision to scale replicas.
-
+        capacity_adjusted_min_replicas: int,
+        capacity_adjusted_max_replicas: int,
+        app_name: Optional[str] = None,
+        deployment_name: Optional[str] = None,
+    ):
+        """
         Arguments:
-            current_num_ongoing_requests: List[float]: List of number of
-                ongoing requests for each replica.
             curr_target_num_replicas: The number of replicas that the
                 deployment is currently trying to scale to.
-            current_handle_queued_queries : The number of handle queued queries,
+            current_num_ongoing_requests: List of number of
+                ongoing requests for each replica.
+            current_handle_queued_queries: The number of handle queued queries,
                 if there are multiple handles, the max number of queries at
                 a single handle should be passed in
-
-        Returns:
-            int: The new number of replicas to scale to.
+            capacity_adjusted_min_replicas: The `min_replica` of the deployment adjusted
+                by the target capacity.
+            capacity_adjusted_max_replicas: The `max_replica` of the deployment adjusted
+                by the target capacity.
+            app_name: The name of the application.
+            deployment_name: The name of the deployment.
         """
-        return curr_target_num_replicas
+        self.curr_target_num_replicas = curr_target_num_replicas
+        self.current_num_ongoing_requests = current_num_ongoing_requests
+        self.current_handle_queued_queries = current_handle_queued_queries
+        self.capacity_adjusted_min_replicas = capacity_adjusted_min_replicas
+        self.capacity_adjusted_max_replicas = capacity_adjusted_max_replicas
+        self.app_name = app_name
+        self.deployment_name = deployment_name
 
 
 @PublicAPI(stability="alpha")
-class ReplicaQueueLengthAutoscalingPolicy(AutoscalingPolicy):
+def replica_queue_length_autoscaling_policy(context: AutoscalingContext) -> int:
     """The default autoscaling policy based on basic thresholds for scaling.
     There is a minimum threshold for the average queue length in the cluster
     to scale up and a maximum threshold to scale down. Each period, a 'scale
@@ -143,135 +158,61 @@ class ReplicaQueueLengthAutoscalingPolicy(AutoscalingPolicy):
     seconds.
     """
 
-    def __init__(self, config: AutoscalingConfig):
-        self.config = config
-        # TODO(architkulkarni): Make configurable via AutoscalingConfig
-        self.loop_period_s = CONTROL_LOOP_PERIOD_S
-        self.scale_up_consecutive_periods = int(
-            config.upscale_delay_s / self.loop_period_s
-        )
-        self.scale_down_consecutive_periods = int(
-            config.downscale_delay_s / self.loop_period_s
-        )
+    if len(context.current_num_ongoing_requests) == 0:
+        # When 0 replicas and queries are queued, scale up the replicas
+        if context.current_handle_queued_queries > 0:
+            return max(
+                math.ceil(1 * context.config.get_upscale_smoothing_factor()),
+                context.curr_target_num_replicas,
+            )
+        return context.curr_target_num_replicas
 
-        # Keeps track of previous decisions. Each time the load is above
-        # 'scale_up_threshold', the counter is incremented and each time it is
-        # below 'scale_down_threshold', the counter is decremented. When the
-        # load is between the thresholds or a scaling decision is made, the
-        # counter is reset to 0.
-        # TODO(architkulkarni): It may be too noisy to reset the counter each
-        # time the direction changes, especially if we calculate frequently
-        # (like every 0.1s).  A potentially less noisy option is to not reset
-        # the counter, and instead only increment/decrement until we reach
-        # scale_up_periods or scale_down_periods.
-        self.decision_counter = 0
+    decision_num_replicas = context.curr_target_num_replicas
 
-    def get_decision_num_replicas(
-        self,
-        curr_target_num_replicas: int,
-        current_num_ongoing_requests: List[float],
-        current_handle_queued_queries: float,
-        target_capacity: Optional[float] = None,
-        target_capacity_direction: Optional[TargetCapacityDirection] = None,
-    ) -> int:
-        if len(current_num_ongoing_requests) == 0:
-            # When 0 replicas and queries are queued, scale up the replicas
-            if current_handle_queued_queries > 0:
-                return max(
-                    math.ceil(1 * self.config.get_upscale_smoothing_factor()),
-                    curr_target_num_replicas,
-                )
-            return curr_target_num_replicas
+    desired_num_replicas = _calculate_desired_num_replicas(
+        context.config,
+        context.current_num_ongoing_requests,
+        override_min_replicas=context.capacity_adjusted_min_replicas,
+        override_max_replicas=context.capacity_adjusted_max_replicas,
+    )
+    # Scale up.
+    if desired_num_replicas > context.curr_target_num_replicas:
+        # If the previous decision was to scale down (the counter was
+        # negative), we reset it and then increment it (set to 1).
+        # Otherwise, just increment.
+        if context.decision_counter < 0:
+            context.decision_counter = 0
+        context.decision_counter += 1
 
-        decision_num_replicas = curr_target_num_replicas
-
-        desired_num_replicas = _calculate_desired_num_replicas(
-            self.config,
-            current_num_ongoing_requests,
-            override_min_replicas=self.get_current_lower_bound(
-                target_capacity,
-                target_capacity_direction,
-            ),
-            override_max_replicas=get_capacity_adjusted_num_replicas(
-                self.config.max_replicas,
-                target_capacity,
-            ),
-        )
-        # Scale up.
-        if desired_num_replicas > curr_target_num_replicas:
-            # If the previous decision was to scale down (the counter was
-            # negative), we reset it and then increment it (set to 1).
-            # Otherwise, just increment.
-            if self.decision_counter < 0:
-                self.decision_counter = 0
-            self.decision_counter += 1
-
-            # Only actually scale the replicas if we've made this decision for
-            # 'scale_up_consecutive_periods' in a row.
-            if self.decision_counter > self.scale_up_consecutive_periods:
-                self.decision_counter = 0
-                decision_num_replicas = desired_num_replicas
-
-        # Scale down.
-        elif desired_num_replicas < curr_target_num_replicas:
-            # If the previous decision was to scale up (the counter was
-            # positive), reset it to zero before decrementing.
-            if self.decision_counter > 0:
-                self.decision_counter = 0
-            self.decision_counter -= 1
-
-            # Only actually scale the replicas if we've made this decision for
-            # 'scale_down_consecutive_periods' in a row.
-            if self.decision_counter < -self.scale_down_consecutive_periods:
-                self.decision_counter = 0
-                decision_num_replicas = desired_num_replicas
-
-        # Do nothing.
-        else:
-            self.decision_counter = 0
-
-        return decision_num_replicas
-
-    def apply_bounds(
-        self,
-        curr_target_num_replicas: int,
-        target_capacity: Optional[float] = None,
-        target_capacity_direction: Optional[TargetCapacityDirection] = None,
-    ) -> int:
-        """Clips curr_target_num_replicas using the current bounds."""
-
-        upper_bound = get_capacity_adjusted_num_replicas(
-            self.config.max_replicas,
-            target_capacity,
-        )
-        lower_bound = self.get_current_lower_bound(
-            target_capacity, target_capacity_direction
-        )
-        return max(lower_bound, min(upper_bound, curr_target_num_replicas))
-
-    def get_current_lower_bound(
-        self,
-        target_capacity: Optional[float] = None,
-        target_capacity_direction: Optional[TargetCapacityDirection] = None,
-    ) -> int:
-        """Get the autoscaling lower bound, including target_capacity changes.
-
-        The autoscaler uses initial_replicas scaled by target_capacity only
-        if the target capacity direction is UP.
-        """
-
-        if self.config.initial_replicas is not None and (
-            target_capacity_direction == TargetCapacityDirection.UP
+        # Only actually scale the replicas if we've made this decision for
+        # 'scale_up_consecutive_periods' in a row.
+        if context.decision_counter > int(
+            context.config.upscale_delay_s / CONTROL_LOOP_PERIOD_S
         ):
-            return get_capacity_adjusted_num_replicas(
-                self.config.initial_replicas,
-                target_capacity,
-            )
-        else:
-            return get_capacity_adjusted_num_replicas(
-                self.config.min_replicas,
-                target_capacity,
-            )
+            context.decision_counter = 0
+            decision_num_replicas = desired_num_replicas
+
+    # Scale down.
+    elif desired_num_replicas < context.curr_target_num_replicas:
+        # If the previous decision was to scale up (the counter was
+        # positive), reset it to zero before decrementing.
+        if context.decision_counter > 0:
+            context.decision_counter = 0
+        context.decision_counter -= 1
+
+        # Only actually scale the replicas if we've made this decision for
+        # 'scale_down_consecutive_periods' in a row.
+        if context.decision_counter < -int(
+            context.config.downscale_delay_s / CONTROL_LOOP_PERIOD_S
+        ):
+            context.decision_counter = 0
+            decision_num_replicas = desired_num_replicas
+
+    # Do nothing.
+    else:
+        context.decision_counter = 0
+
+    return decision_num_replicas
 
 
-DefaultAutoscalingPolicy = ReplicaQueueLengthAutoscalingPolicy
+default_autoscaling_policy = replica_queue_length_autoscaling_policy

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from ray.serve._private.constants import CONTROL_LOOP_PERIOD_S, SERVE_LOGGER_NAME
 from ray.serve.config import AutoscalingConfig
@@ -89,65 +89,15 @@ def _calculate_desired_num_replicas(
 
 
 @PublicAPI(stability="alpha")
-class AutoscalingContext:
-    """Contains the context for an autoscaling policy.
-
-    This context includes the current number of replicas, the current number
-    of ongoing requests, and the current number of queued queries.
-    """
-
-    def __init__(
-        self,
-        config: AutoscalingConfig,
-    ):
-        self.config = config
-        self.curr_target_num_replicas = 0
-        self.current_num_ongoing_requests = []
-        self.current_handle_queued_queries = 0.0
-        self.capacity_adjusted_min_replicas = None
-        self.capacity_adjusted_max_replicas = None
-        self.decision_counter = 0
-        self.last_scale_time = None
-        self.app_name = None
-        self.deployment_name = None
-
-    def update(
-        self,
-        curr_target_num_replicas: int,
-        current_num_ongoing_requests: List[float],
-        current_handle_queued_queries: float,
-        capacity_adjusted_min_replicas: int,
-        capacity_adjusted_max_replicas: int,
-        app_name: Optional[str] = None,
-        deployment_name: Optional[str] = None,
-    ):
-        """
-        Arguments:
-            curr_target_num_replicas: The number of replicas that the
-                deployment is currently trying to scale to.
-            current_num_ongoing_requests: List of number of
-                ongoing requests for each replica.
-            current_handle_queued_queries: The number of handle queued queries,
-                if there are multiple handles, the max number of queries at
-                a single handle should be passed in
-            capacity_adjusted_min_replicas: The `min_replica` of the deployment adjusted
-                by the target capacity.
-            capacity_adjusted_max_replicas: The `max_replica` of the deployment adjusted
-                by the target capacity.
-            app_name: The name of the application.
-            deployment_name: The name of the deployment.
-        """
-        self.curr_target_num_replicas = curr_target_num_replicas
-        self.current_num_ongoing_requests = current_num_ongoing_requests
-        self.current_handle_queued_queries = current_handle_queued_queries
-        self.capacity_adjusted_min_replicas = capacity_adjusted_min_replicas
-        self.capacity_adjusted_max_replicas = capacity_adjusted_max_replicas
-        self.app_name = app_name
-        self.deployment_name = deployment_name
-
-
-@PublicAPI(stability="alpha")
-def replica_queue_length_autoscaling_policy(context: AutoscalingContext) -> int:
+def replica_queue_length_autoscaling_policy(
+    curr_target_num_replicas: int,
+    current_num_ongoing_requests: List[float],
+    current_handle_queued_queries: float,
+    config: Optional[AutoscalingConfig],
+    capacity_adjusted_min_replicas: int,
+    capacity_adjusted_max_replicas: int,
+    policy_state: Dict[str, Any],
+) -> int:
     """The default autoscaling policy based on basic thresholds for scaling.
     There is a minimum threshold for the average queue length in the cluster
     to scale up and a maximum threshold to scale down. Each period, a 'scale
@@ -157,61 +107,58 @@ def replica_queue_length_autoscaling_policy(context: AutoscalingContext) -> int:
     `get_decision_num_replicas` is called once every CONTROL_LOOP_PERIOD_S
     seconds.
     """
-
-    if len(context.current_num_ongoing_requests) == 0:
+    decision_counter = policy_state.get("decision_counter", 0)
+    if len(current_num_ongoing_requests) == 0:
         # When 0 replicas and queries are queued, scale up the replicas
-        if context.current_handle_queued_queries > 0:
+        if current_handle_queued_queries > 0:
             return max(
-                math.ceil(1 * context.config.get_upscale_smoothing_factor()),
-                context.curr_target_num_replicas,
+                math.ceil(1 * config.get_upscale_smoothing_factor()),
+                curr_target_num_replicas,
             )
-        return context.curr_target_num_replicas
+        return curr_target_num_replicas
 
-    decision_num_replicas = context.curr_target_num_replicas
+    decision_num_replicas = curr_target_num_replicas
 
     desired_num_replicas = _calculate_desired_num_replicas(
-        context.config,
-        context.current_num_ongoing_requests,
-        override_min_replicas=context.capacity_adjusted_min_replicas,
-        override_max_replicas=context.capacity_adjusted_max_replicas,
+        config,
+        current_num_ongoing_requests,
+        override_min_replicas=capacity_adjusted_min_replicas,
+        override_max_replicas=capacity_adjusted_max_replicas,
     )
     # Scale up.
-    if desired_num_replicas > context.curr_target_num_replicas:
+    if desired_num_replicas > curr_target_num_replicas:
         # If the previous decision was to scale down (the counter was
         # negative), we reset it and then increment it (set to 1).
         # Otherwise, just increment.
-        if context.decision_counter < 0:
-            context.decision_counter = 0
-        context.decision_counter += 1
+        if decision_counter < 0:
+            decision_counter = 0
+        decision_counter += 1
 
         # Only actually scale the replicas if we've made this decision for
         # 'scale_up_consecutive_periods' in a row.
-        if context.decision_counter > int(
-            context.config.upscale_delay_s / CONTROL_LOOP_PERIOD_S
-        ):
-            context.decision_counter = 0
+        if decision_counter > int(config.upscale_delay_s / CONTROL_LOOP_PERIOD_S):
+            decision_counter = 0
             decision_num_replicas = desired_num_replicas
 
     # Scale down.
-    elif desired_num_replicas < context.curr_target_num_replicas:
+    elif desired_num_replicas < curr_target_num_replicas:
         # If the previous decision was to scale up (the counter was
         # positive), reset it to zero before decrementing.
-        if context.decision_counter > 0:
-            context.decision_counter = 0
-        context.decision_counter -= 1
+        if decision_counter > 0:
+            decision_counter = 0
+        decision_counter -= 1
 
         # Only actually scale the replicas if we've made this decision for
         # 'scale_down_consecutive_periods' in a row.
-        if context.decision_counter < -int(
-            context.config.downscale_delay_s / CONTROL_LOOP_PERIOD_S
-        ):
-            context.decision_counter = 0
+        if decision_counter < -int(config.downscale_delay_s / CONTROL_LOOP_PERIOD_S):
+            decision_counter = 0
             decision_num_replicas = desired_num_replicas
 
     # Do nothing.
     else:
-        context.decision_counter = 0
+        decision_counter = 0
 
+    policy_state["decision_counter"] = decision_counter
     return decision_num_replicas
 
 

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -16,6 +16,7 @@ import ray
 import ray.util.state as state_api
 from ray import serve
 from ray._private.test_utils import SignalActor, wait_for_condition
+from ray.serve._private.autoscaling_policy import AutoscalingPolicyManager
 from ray.serve._private.common import (
     ApplicationStatus,
     DeploymentID,
@@ -30,10 +31,7 @@ from ray.serve._private.constants import (
     SERVE_NAMESPACE,
 )
 from ray.serve._private.controller import ServeController
-from ray.serve.autoscaling_policy import (
-    DefaultAutoscalingPolicy,
-    _calculate_desired_num_replicas,
-)
+from ray.serve.autoscaling_policy import _calculate_desired_num_replicas
 from ray.serve.config import AutoscalingConfig
 from ray.serve.generated.serve_pb2 import (
     DeploymentStatusInfo as DeploymentStatusInfoProto,
@@ -173,11 +171,11 @@ class TestGetDecisionNumReplicas:
 
         config = AutoscalingConfig(
             min_replicas=0,
-            max_replicas=2,
+            max_replicas=10,
             smoothing_factor=10,
         )
-        policy = DefaultAutoscalingPolicy(config)
-        new_num_replicas = policy.get_decision_num_replicas(
+        policy_manager = AutoscalingPolicyManager(config)
+        new_num_replicas = policy_manager.get_decision_num_replicas(
             current_num_ongoing_requests=[],
             curr_target_num_replicas=0,
             current_handle_queued_queries=1,
@@ -187,8 +185,8 @@ class TestGetDecisionNumReplicas:
         assert new_num_replicas == 10
 
         config.smoothing_factor = 0.5
-        policy = DefaultAutoscalingPolicy(config)
-        new_num_replicas = policy.get_decision_num_replicas(
+        policy_manager = AutoscalingPolicyManager(config)
+        new_num_replicas = policy_manager.get_decision_num_replicas(
             current_num_ongoing_requests=[],
             curr_target_num_replicas=0,
             current_handle_queued_queries=1,
@@ -209,8 +207,8 @@ class TestGetDecisionNumReplicas:
             upscale_delay_s=0,
             downscale_delay_s=0,
         )
-        policy = DefaultAutoscalingPolicy(config)
-        new_num_replicas = policy.get_decision_num_replicas(
+        policy_manager = AutoscalingPolicyManager(config)
+        new_num_replicas = policy_manager.get_decision_num_replicas(
             current_num_ongoing_requests=[0, 0, 0, 0, 0],
             curr_target_num_replicas=5,
             current_handle_queued_queries=0,
@@ -222,10 +220,10 @@ class TestGetDecisionNumReplicas:
         # get stuck at a positive number, and instead should eventually drop
         # to zero
         config.smoothing_factor = 0.2
-        policy = DefaultAutoscalingPolicy(config)
+        policy_manager = AutoscalingPolicyManager(config)
         num_replicas = 5
         for _ in range(5):
-            num_replicas = policy.get_decision_num_replicas(
+            num_replicas = policy_manager.get_decision_num_replicas(
                 current_num_ongoing_requests=[0] * num_replicas,
                 curr_target_num_replicas=num_replicas,
                 current_handle_queued_queries=0,
@@ -247,7 +245,7 @@ class TestGetDecisionNumReplicas:
             downscale_delay_s=600.0,
         )
 
-        policy = DefaultAutoscalingPolicy(config)
+        policy_manager = AutoscalingPolicyManager(config)
 
         upscale_wait_periods = int(upscale_delay_s / CONTROL_LOOP_PERIOD_S)
         downscale_wait_periods = int(downscale_delay_s / CONTROL_LOOP_PERIOD_S)
@@ -255,7 +253,7 @@ class TestGetDecisionNumReplicas:
         overload_requests = [100]
 
         # Scale up when there are 0 replicas and current_handle_queued_queries > 0
-        new_num_replicas = policy.get_decision_num_replicas(
+        new_num_replicas = policy_manager.get_decision_num_replicas(
             current_num_ongoing_requests=[],
             curr_target_num_replicas=0,
             current_handle_queued_queries=1,
@@ -264,14 +262,14 @@ class TestGetDecisionNumReplicas:
 
         # We should scale up only after enough consecutive scale-up decisions.
         for i in range(upscale_wait_periods):
-            new_num_replicas = policy.get_decision_num_replicas(
+            new_num_replicas = policy_manager.get_decision_num_replicas(
                 current_num_ongoing_requests=overload_requests,
                 curr_target_num_replicas=1,
                 current_handle_queued_queries=0,
             )
             assert new_num_replicas == 1, i
 
-        new_num_replicas = policy.get_decision_num_replicas(
+        new_num_replicas = policy_manager.get_decision_num_replicas(
             current_num_ongoing_requests=overload_requests,
             curr_target_num_replicas=1,
             current_handle_queued_queries=0,
@@ -282,14 +280,14 @@ class TestGetDecisionNumReplicas:
 
         # We should scale down only after enough consecutive scale-down decisions.
         for i in range(downscale_wait_periods):
-            new_num_replicas = policy.get_decision_num_replicas(
+            new_num_replicas = policy_manager.get_decision_num_replicas(
                 current_num_ongoing_requests=no_requests,
                 curr_target_num_replicas=2,
                 current_handle_queued_queries=0,
             )
             assert new_num_replicas == 2, i
 
-        new_num_replicas = policy.get_decision_num_replicas(
+        new_num_replicas = policy_manager.get_decision_num_replicas(
             current_num_ongoing_requests=no_requests,
             curr_target_num_replicas=2,
             current_handle_queued_queries=0,
@@ -298,7 +296,7 @@ class TestGetDecisionNumReplicas:
 
         # Get some scale-up decisions, but not enough to trigger a scale up.
         for i in range(int(upscale_wait_periods / 2)):
-            new_num_replicas = policy.get_decision_num_replicas(
+            new_num_replicas = policy_manager.get_decision_num_replicas(
                 current_num_ongoing_requests=overload_requests,
                 curr_target_num_replicas=1,
                 current_handle_queued_queries=0,
@@ -306,7 +304,7 @@ class TestGetDecisionNumReplicas:
             assert new_num_replicas == 1, i
 
         # Interrupt with a scale-down decision.
-        policy.get_decision_num_replicas(
+        policy_manager.get_decision_num_replicas(
             current_num_ongoing_requests=[0],
             curr_target_num_replicas=1,
             current_handle_queued_queries=0,
@@ -315,14 +313,14 @@ class TestGetDecisionNumReplicas:
         # The counter should be reset, so it should require `upscale_wait_periods`
         # more periods before we actually scale up.
         for i in range(upscale_wait_periods):
-            new_num_replicas = policy.get_decision_num_replicas(
+            new_num_replicas = policy_manager.get_decision_num_replicas(
                 current_num_ongoing_requests=overload_requests,
                 curr_target_num_replicas=1,
                 current_handle_queued_queries=0,
             )
             assert new_num_replicas == 1, i
 
-        new_num_replicas = policy.get_decision_num_replicas(
+        new_num_replicas = policy_manager.get_decision_num_replicas(
             current_num_ongoing_requests=overload_requests,
             curr_target_num_replicas=1,
             current_handle_queued_queries=0,
@@ -331,7 +329,7 @@ class TestGetDecisionNumReplicas:
 
         # Get some scale-down decisions, but not enough to trigger a scale down.
         for i in range(int(downscale_wait_periods / 2)):
-            new_num_replicas = policy.get_decision_num_replicas(
+            new_num_replicas = policy_manager.get_decision_num_replicas(
                 current_num_ongoing_requests=no_requests,
                 curr_target_num_replicas=2,
                 current_handle_queued_queries=0,
@@ -339,7 +337,7 @@ class TestGetDecisionNumReplicas:
             assert new_num_replicas == 2, i
 
         # Interrupt with a scale-up decision.
-        policy.get_decision_num_replicas(
+        policy_manager.get_decision_num_replicas(
             current_num_ongoing_requests=[100, 100],
             curr_target_num_replicas=2,
             current_handle_queued_queries=0,
@@ -348,14 +346,14 @@ class TestGetDecisionNumReplicas:
         # The counter should be reset so it should require `downscale_wait_periods`
         # more periods before we actually scale down.
         for i in range(downscale_wait_periods):
-            new_num_replicas = policy.get_decision_num_replicas(
+            new_num_replicas = policy_manager.get_decision_num_replicas(
                 current_num_ongoing_requests=no_requests,
                 curr_target_num_replicas=2,
                 current_handle_queued_queries=0,
             )
             assert new_num_replicas == 2, i
 
-        new_num_replicas = policy.get_decision_num_replicas(
+        new_num_replicas = policy_manager.get_decision_num_replicas(
             current_num_ongoing_requests=no_requests,
             curr_target_num_replicas=2,
             current_handle_queued_queries=0,
@@ -372,23 +370,27 @@ class TestGetDecisionNumReplicas:
             downscale_delay_s=100000,
         )
 
-        policy = DefaultAutoscalingPolicy(config)
+        policy_manager = AutoscalingPolicyManager(config)
 
-        new_num_replicas = policy.get_decision_num_replicas(1, [100], 0)
+        new_num_replicas = policy_manager.get_decision_num_replicas(1, [100], 0)
         assert new_num_replicas == 100
 
         # New target is 100, but no new replicas finished spinning up during this
         # timestep.
-        new_num_replicas = policy.get_decision_num_replicas(100, [100], 0)
+        new_num_replicas = policy_manager.get_decision_num_replicas(100, [100], 0)
         assert new_num_replicas == 100
 
         # Two new replicas spun up during this timestep.
-        new_num_replicas = policy.get_decision_num_replicas(100, [100, 20, 3], 0)
+        new_num_replicas = policy_manager.get_decision_num_replicas(
+            100, [100, 20, 3], 0
+        )
         assert new_num_replicas == 123
 
         # A lot of queries got drained and a lot of replicas started up, but
         # new_num_replicas should not decrease, because of the downscale delay.
-        new_num_replicas = policy.get_decision_num_replicas(123, [6, 2, 1, 1], 0)
+        new_num_replicas = policy_manager.get_decision_num_replicas(
+            123, [6, 2, 1, 1], 0
+        )
         assert new_num_replicas == 123
 
     @pytest.mark.parametrize("delay_s", [30.0, 0.0])
@@ -406,7 +408,7 @@ class TestGetDecisionNumReplicas:
             downscale_delay_s=delay_s,
         )
 
-        policy = DefaultAutoscalingPolicy(config)
+        policy_manager = AutoscalingPolicyManager(config)
 
         if delay_s > 0:
             wait_periods = int(delay_s / CONTROL_LOOP_PERIOD_S)
@@ -418,7 +420,7 @@ class TestGetDecisionNumReplicas:
         new_num_replicas = None
         for trial in range(trials):
             if trial % 2 == 0:
-                new_num_replicas = policy.get_decision_num_replicas(
+                new_num_replicas = policy_manager.get_decision_num_replicas(
                     current_num_ongoing_requests=overload_requests,
                     curr_target_num_replicas=1,
                     current_handle_queued_queries=0,
@@ -428,7 +430,7 @@ class TestGetDecisionNumReplicas:
                 else:
                     assert new_num_replicas == 2, trial
             else:
-                new_num_replicas = policy.get_decision_num_replicas(
+                new_num_replicas = policy_manager.get_decision_num_replicas(
                     current_num_ongoing_requests=underload_requests,
                     curr_target_num_replicas=2,
                     current_handle_queued_queries=0,
@@ -450,13 +452,13 @@ class TestGetDecisionNumReplicas:
             downscale_delay_s=0.0,
         )
 
-        policy = DefaultAutoscalingPolicy(config)
+        policy_manager = AutoscalingPolicyManager(config)
 
         # Check that as long as the average number of ongoing requests equals
         # the target_num_ongoing_requests_per_replica, the number of replicas
         # stays the same
         if np.mean(ongoing_requests) == config.target_num_ongoing_requests_per_replica:
-            new_num_replicas = policy.get_decision_num_replicas(
+            new_num_replicas = policy_manager.get_decision_num_replicas(
                 current_num_ongoing_requests=ongoing_requests,
                 curr_target_num_replicas=4,
                 current_handle_queued_queries=0,
@@ -466,7 +468,7 @@ class TestGetDecisionNumReplicas:
         # Check downscaling behavior when average number of requests
         # is lower than target_num_ongoing_requests_per_replica
         elif np.mean(ongoing_requests) < config.target_num_ongoing_requests_per_replica:
-            new_num_replicas = policy.get_decision_num_replicas(
+            new_num_replicas = policy_manager.get_decision_num_replicas(
                 current_num_ongoing_requests=ongoing_requests,
                 curr_target_num_replicas=4,
                 current_handle_queued_queries=0,
@@ -486,7 +488,7 @@ class TestGetDecisionNumReplicas:
         # Check upscaling behavior when average number of requests
         # is higher than target_num_ongoing_requests_per_replica
         else:
-            new_num_replicas = policy.get_decision_num_replicas(
+            new_num_replicas = policy_manager.get_decision_num_replicas(
                 current_num_ongoing_requests=ongoing_requests,
                 curr_target_num_replicas=4,
                 current_handle_queued_queries=0,
@@ -507,9 +509,9 @@ class TestGetDecisionNumReplicas:
             downscale_delay_s=0.0,
         )
 
-        policy = DefaultAutoscalingPolicy(config)
+        policy_manager = AutoscalingPolicyManager(config)
 
-        new_num_replicas = policy.get_decision_num_replicas(
+        new_num_replicas = policy_manager.get_decision_num_replicas(
             current_num_ongoing_requests=ongoing_requests,
             curr_target_num_replicas=4,
             current_handle_queued_queries=0,

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -171,7 +171,7 @@ class TestGetDecisionNumReplicas:
 
         config = AutoscalingConfig(
             min_replicas=0,
-            max_replicas=10,
+            max_replicas=2,
             smoothing_factor=10,
         )
         policy_manager = AutoscalingPolicyManager(config)
@@ -179,6 +179,7 @@ class TestGetDecisionNumReplicas:
             current_num_ongoing_requests=[],
             curr_target_num_replicas=0,
             current_handle_queued_queries=1,
+            _skip_bound_check=True,
         )
 
         # 1 * 10
@@ -190,6 +191,7 @@ class TestGetDecisionNumReplicas:
             current_num_ongoing_requests=[],
             curr_target_num_replicas=0,
             current_handle_queued_queries=1,
+            _skip_bound_check=True,
         )
 
         # math.ceil(1 * 0.5)

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -916,9 +916,9 @@ class TestOverrideDeploymentInfo:
         updated_info = updated_infos["A"]
         assert updated_info.route_prefix == "/"
         assert updated_info.version == "123"
-        assert updated_info.autoscaling_policy.config.min_replicas == 1
-        assert updated_info.autoscaling_policy.config.initial_replicas == 12
-        assert updated_info.autoscaling_policy.config.max_replicas == 79
+        assert updated_info.autoscaling_policy_manager.config.min_replicas == 1
+        assert updated_info.autoscaling_policy_manager.config.initial_replicas == 12
+        assert updated_info.autoscaling_policy_manager.config.max_replicas == 79
 
     def test_override_route_prefix_1(self, info):
         config = ServeApplicationSchema(

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -6,7 +6,7 @@ from ray._private.utils import import_attr
 from ray.serve._private.config import DeploymentConfig, ReplicaConfig, _proto_to_dict
 from ray.serve._private.constants import DEFAULT_AUTOSCALING_POLICY, DEFAULT_GRPC_PORT
 from ray.serve._private.utils import DEFAULT
-from ray.serve.autoscaling_policy import DefaultAutoscalingPolicy
+from ray.serve.autoscaling_policy import default_autoscaling_policy
 from ray.serve.config import (
     AutoscalingConfig,
     DeploymentMode,
@@ -564,7 +564,7 @@ def test_autoscaling_policy_serializations(policy):
     ).autoscaling_config.get_policy()
 
     if policy is None:
-        assert deserialized_autoscaling_policy == DefaultAutoscalingPolicy
+        assert deserialized_autoscaling_policy == default_autoscaling_policy
     else:
         assert deserialized_autoscaling_policy() == fake_policy_return_value
 
@@ -584,7 +584,7 @@ def test_default_autoscaling_policy_import_path():
     """Test that default autoscaling policy can be imported."""
     policy = import_attr(DEFAULT_AUTOSCALING_POLICY)
 
-    assert policy == DefaultAutoscalingPolicy
+    assert policy == default_autoscaling_policy
 
 
 class TestProtoToDict:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Refactor the existing `ReplicaQueueLengthAutoscalingPolicy` into `AutoscalingPolicyManager` to managing the lifecycle of policy call and applies bounds. `AutoscalingPolicyManager` also served as interface layer between the policy and the `DeploymentState`. Refactored the rest of core policy logics into `replica_queue_length_autoscaling_policy` policy function for use by `AutoscalingPolicyManager`. 


## Related issue number

Second PR for https://github.com/ray-project/ray/issues/41135

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
