### PR TITLE
[core][gcs] Fix task events profile events per task leak

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.cc
@@ -149,6 +149,15 @@ void GcsTaskManager::GcsTaskManagerStorage::UpdateExistingTaskAttempt(
   // Update the task event.
   existing_task.MergeFrom(task_events);
 
+  // Truncate the profile events if needed.
+  auto max_num_profile_events_per_task =
+      RayConfig::instance().task_events_max_num_profile_events_per_task();
+  if (existing_task.profile_events().events_size() > max_num_profile_events_per_task) {
+    existing_task.mutable_profile_events()->mutable_events()->DeleteSubrange(
+        0,
+        existing_task.profile_events().events_size() - max_num_profile_events_per_task);
+  }
+
   // Move the task events around different gc priority list.
   auto target_list_index = gc_policy_->GetTaskListPriority(existing_task);
   auto cur_list_index = loc->GetCurrentListIndex();

--- a/src/ray/gcs/gcs_server/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.h
@@ -543,6 +543,7 @@ class GcsTaskManager : public rpc::TaskInfoHandler {
   FRIEND_TEST(GcsTaskManagerTest, TestTaskDataLossWorker);
   FRIEND_TEST(GcsTaskManagerTest, TestMultipleJobsDataLoss);
   FRIEND_TEST(GcsTaskManagerDroppedTaskAttemptsLimit, TestDroppedTaskAttemptsLimit);
+  FRIEND_TEST(GcsTaskManagerProfileEventsLimitTest, TestProfileEventsNoLeak);
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
@@ -1053,10 +1053,16 @@ TEST_F(GcsTaskManagerProfileEventsLimitTest, TestProfileEventsNoLeak) {
 
   // Assert on the profile events in the buffer.
   {
-    auto reply = SyncGetTaskEvents({task});
+    auto reply = SyncGetTaskEvents({});
     EXPECT_EQ(reply.events_by_task_size(), 1);
     EXPECT_EQ(reply.events_by_task().begin()->profile_events().events().size(),
               RayConfig::instance().task_events_max_num_profile_events_per_task());
+
+    // assert on the profile events dropped counter.
+    EXPECT_EQ(reply.num_profile_task_events_dropped(),
+              100 - RayConfig::instance().task_events_max_num_profile_events_per_task());
+    EXPECT_EQ(task_manager->GetTotalNumProfileTaskEventsDropped(),
+              100 - RayConfig::instance().task_events_max_num_profile_events_per_task());
   }
 }
 

--- a/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
@@ -284,6 +284,18 @@ class GcsTaskManagerMemoryLimitedTest : public GcsTaskManagerTest {
   }
 };
 
+class GcsTaskManagerProfileEventsLimitTest : public GcsTaskManagerTest {
+ public:
+  GcsTaskManagerProfileEventsLimitTest() : GcsTaskManagerTest() {
+    RayConfig::instance().initialize(
+        R"(
+{
+  "task_events_max_num_profile_events_per_task": 10
+}
+  )");
+  }
+};
+
 class GcsTaskManagerDroppedTaskAttemptsLimit : public GcsTaskManagerTest {
  public:
   GcsTaskManagerDroppedTaskAttemptsLimit() : GcsTaskManagerTest() {
@@ -1023,6 +1035,29 @@ TEST_F(GcsTaskManagerDroppedTaskAttemptsLimit, TestDroppedTaskAttemptsLimit) {
   EXPECT_EQ(job_summary.dropped_task_attempts_.size(), 5);
   EXPECT_EQ(job_summary.num_dropped_task_attempts_evicted_, 5);
   EXPECT_EQ(job_summary.NumTaskAttemptsDropped(), 10);
+}
+
+TEST_F(GcsTaskManagerProfileEventsLimitTest, TestProfileEventsNoLeak) {
+  auto task = GenTaskIDs(1)[0];
+
+  // Keep generating profile events and make sure the number of profile events
+  // is bounded.
+  for (int i = 0; i < 100; i++) {
+    auto events = GenTaskEvents({task},
+                                /* attempt_number */ 0,
+                                /* job_id */ 0,
+                                GenProfileEvents("event", 1, 1));
+    auto events_data = Mocker::GenTaskEventsData(events);
+    SyncAddTaskEventData(events_data);
+  }
+
+  // Assert on the profile events in the buffer.
+  {
+    auto reply = SyncGetTaskEvents({task});
+    EXPECT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_EQ(reply.events_by_task().begin()->profile_events().events().size(),
+              RayConfig::instance().task_events_max_num_profile_events_per_task());
+  }
 }
 
 TEST_F(GcsTaskManagerMemoryLimitedTest, TestLimitGcPriorityBased) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When a long running task keeps submitting tasks (e.g. driver task, actor task), it generates many profile events as part of task submission. 

While we already cap the number of profile events in a task at the core worker (where task events are produced and reported), we are not doing that on GCS (the sink), so it's possible when new task events merged to existing ones, it goes unbounded. 

Closes https://github.com/ray-project/ray/issues/42144
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
