### PR TITLE
[ci] replace xcommit with mem_pressure

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -41,7 +41,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --test-env=TEST_EXTERNAL_REDIS=1
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,xcommit,container,manual
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,container,manual
 
   - label: ":ray: core: :windows: python tests"
     tags: python
@@ -103,7 +103,7 @@ steps:
         --parallelism-per-worker 3
       # doc examples
       - bazel run //ci/ray_ci:test_in_docker -- //doc/... core
-        --except-tags gpu,post_wheel_build,xcommit,doctest
+        --except-tags gpu,post_wheel_build,mem_pressure,doctest
         --parallelism-per-worker 3
         --skip-ray-installation
 

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -17,10 +17,10 @@ steps:
         --only-tags doctest
         --except-tags gpu
         --parallelism-per-worker 3
-      # doc examples
+      # doc memory pressure example
       - bazel run //ci/ray_ci:test_in_docker -- //doc/... core
         --build-name doctestbuild
-        --only-tags xcommit
+        --only-tags mem_pressure
         --except-tags gpu
         --skip-ray-installation
     depends_on: doctestbuild

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -136,7 +136,7 @@ steps:
         --parallelism-per-worker 3
       # doc examples
       - bazel run //ci/ray_ci:test_in_docker -- //doc/... serve 
-        --except-tags gpu,post_wheel_build,timeseries_libs,doctest,xcommit
+        --except-tags gpu,post_wheel_build,timeseries_libs,doctest
         --parallelism-per-worker 3
         --skip-ray-installation
     depends_on: servebuild

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -100,7 +100,7 @@ py_test(
     size = "medium",
     main = "source/ray-core/doc_code/ray_oom_prevention.py",
     srcs = ["source/ray-core/doc_code/ray_oom_prevention.py"],
-    tags = ["exclusive", "xcommit", "team:core"]
+    tags = ["exclusive", "mem_pressure", "team:core"]
 )
 
 py_test_run_all_subdirectory(


### PR DESCRIPTION
xcommit means the test is testing across more than one commits. it was misused for memory/OOM pressure tests.
