### PR TITLE
[Core] Fix naming of ReleaseCpuResourcesFromUnblockedWorker and ReturnCpuResourcesToBlockedWorker

### DIFF
--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -970,7 +970,7 @@ void LocalTaskManager::ReleaseWorkerResources(std::shared_ptr<WorkerInterface> w
   }
 }
 
-bool LocalTaskManager::ReleaseCpuResourcesFromUnblockedWorker(
+bool LocalTaskManager::ReleaseCpuResourcesFromBlockedWorker(
     std::shared_ptr<WorkerInterface> worker) {
   if (!worker || worker->IsBlocked()) {
     return false;
@@ -989,7 +989,7 @@ bool LocalTaskManager::ReleaseCpuResourcesFromUnblockedWorker(
   return false;
 }
 
-bool LocalTaskManager::ReturnCpuResourcesToBlockedWorker(
+bool LocalTaskManager::ReturnCpuResourcesToUnblockedWorker(
     std::shared_ptr<WorkerInterface> worker) {
   if (!worker || !worker->IsBlocked()) {
     return false;

--- a/src/ray/raylet/local_task_manager.h
+++ b/src/ray/raylet/local_task_manager.h
@@ -147,7 +147,7 @@ class LocalTaskManager : public ILocalTaskManager {
   /// \param worker: The worker who will give up the CPU resources.
   /// \return true if the cpu resources of the specified worker are released successfully,
   /// else false.
-  bool ReleaseCpuResourcesFromUnblockedWorker(std::shared_ptr<WorkerInterface> worker);
+  bool ReleaseCpuResourcesFromBlockedWorker(std::shared_ptr<WorkerInterface> worker);
 
   /// When a task is no longer blocked in a ray.get or ray.wait, the CPU resources that
   /// the worker gave up should be returned to it.
@@ -155,7 +155,7 @@ class LocalTaskManager : public ILocalTaskManager {
   /// \param worker The blocked worker.
   /// \return true if the cpu resources are returned back to the specified worker, else
   /// false.
-  bool ReturnCpuResourcesToBlockedWorker(std::shared_ptr<WorkerInterface> worker);
+  bool ReturnCpuResourcesToUnblockedWorker(std::shared_ptr<WorkerInterface> worker);
 
   /// TODO(Chong-Li): Removing this and maintaining normal task resources by local
   /// resource manager.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2020,7 +2020,7 @@ void NodeManager::HandleDirectCallTaskBlocked(
       !release_resources) {
     return;  // The worker may have died or is no longer processing the task.
   }
-  local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker);
+  local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker);
   cluster_task_manager_->ScheduleAndDispatchTasks();
 }
 
@@ -2035,7 +2035,7 @@ void NodeManager::HandleDirectCallTaskUnblocked(
   dependency_manager_.CancelGetRequest(worker->WorkerId());
 
   if (worker->IsBlocked()) {
-    local_task_manager_->ReturnCpuResourcesToBlockedWorker(worker);
+    local_task_manager_->ReturnCpuResourcesToUnblockedWorker(worker);
     cluster_task_manager_->ScheduleAndDispatchTasks();
   }
 }

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -448,8 +448,8 @@ TEST_F(ClusterTaskManagerTest, IdempotencyTest) {
   /*
     A few task manager methods are meant to be idempotent.
     * `TaskFinished`
-    * `ReleaseCpuResourcesFromUnblockedWorker`
-    * `ReturnCpuResourcesToBlockedWorker`
+    * `ReleaseCpuResourcesFromBlockedWorker`
+    * `ReturnCpuResourcesToUnblockedWorker`
    */
   RayTask task = CreateTask({{ray::kCPU_ResourceLabel, 4}});
   rpc::RequestWorkerLeaseReply reply;
@@ -478,13 +478,13 @@ TEST_F(ClusterTaskManagerTest, IdempotencyTest) {
 
   ASSERT_EQ(scheduler_->GetLocalResourceManager().GetLocalAvailableCpus(), 4.0);
 
-  local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker);
-  local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker);
+  local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker);
+  local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker);
 
   ASSERT_EQ(scheduler_->GetLocalResourceManager().GetLocalAvailableCpus(), 8.0);
 
-  local_task_manager_->ReturnCpuResourcesToBlockedWorker(worker);
-  local_task_manager_->ReturnCpuResourcesToBlockedWorker(worker);
+  local_task_manager_->ReturnCpuResourcesToUnblockedWorker(worker);
+  local_task_manager_->ReturnCpuResourcesToUnblockedWorker(worker);
 
   ASSERT_EQ(scheduler_->GetLocalResourceManager().GetLocalAvailableCpus(), 4.0);
 
@@ -599,7 +599,7 @@ TEST_F(ClusterTaskManagerTest, BlockedWorkerDiesTest) {
   ASSERT_EQ(node_info_calls_, 0);
 
   // Block the worker. Which releases only the CPU resource.
-  local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker);
+  local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker);
 
   RayTask finished_task;
   // If a resource was double-freed, we will crash in this call.
@@ -649,7 +649,7 @@ TEST_F(ClusterTaskManagerTest, BlockedWorkerDies2Test) {
             task.GetTaskSpecification().TaskId());
 
   // Block the worker. Which releases only the CPU resource.
-  local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker);
+  local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker);
 
   AssertNoLeaks();
 }
@@ -1775,7 +1775,7 @@ TEST_F(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources) 
   auto worker = std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
 
   // Check failed as the worker has no allocated resource instances.
-  ASSERT_FALSE(local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker));
+  ASSERT_FALSE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker));
 
   auto node_resource_instances =
       scheduler_->GetLocalResourceManager().GetLocalResources();
@@ -1793,7 +1793,7 @@ TEST_F(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources) 
   ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
 
   // Check that the cpu resources are released successfully.
-  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker));
+  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker));
 
   // Check that only cpu resources are released.
   ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
@@ -1802,13 +1802,13 @@ TEST_F(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources) 
   // Mark worker as blocked.
   worker->MarkBlocked();
   // Check failed as the worker is blocked.
-  ASSERT_FALSE(local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker));
+  ASSERT_FALSE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker));
   // Check nothing will be changed.
   ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
   ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
 
   // Check that the cpu resources are returned back to worker successfully.
-  ASSERT_TRUE(local_task_manager_->ReturnCpuResourcesToBlockedWorker(worker));
+  ASSERT_TRUE(local_task_manager_->ReturnCpuResourcesToUnblockedWorker(worker));
 
   // Check that only cpu resources are returned back to the worker.
   ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
@@ -1816,7 +1816,7 @@ TEST_F(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources) 
 
   // Mark worker as unblocked.
   worker->MarkUnblocked();
-  ASSERT_FALSE(local_task_manager_->ReturnCpuResourcesToBlockedWorker(worker));
+  ASSERT_FALSE(local_task_manager_->ReturnCpuResourcesToUnblockedWorker(worker));
   // Check nothing will be changed.
   ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
   ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
@@ -2122,8 +2122,8 @@ TEST_F(ClusterTaskManagerTest, CapRunningOnDispatchQueue) {
 
   ASSERT_EQ(num_callbacks, 2);
 
-  local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(workers[0]);
-  local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(workers[1]);
+  local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(workers[0]);
+  local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(workers[1]);
 
   task_manager_.ScheduleAndDispatchTasks();
 
@@ -2296,7 +2296,7 @@ TEST_F(ClusterTaskManagerTest, SchedulingClassCapIncrease) {
 
   current_time_ms_ += UNIT;
   ASSERT_FALSE(workers.back()->IsBlocked());
-  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(
+  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(
       get_unblocked_worker(workers)));
   task_manager_.ScheduleAndDispatchTasks();
   pool_.TriggerCallbacks();
@@ -2305,7 +2305,7 @@ TEST_F(ClusterTaskManagerTest, SchedulingClassCapIncrease) {
 
   // Since we're increasing exponentially, increasing by a unit show no longer be enough.
   current_time_ms_ += UNIT;
-  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(
+  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(
       get_unblocked_worker(workers)));
   task_manager_.ScheduleAndDispatchTasks();
   pool_.TriggerCallbacks();
@@ -2388,7 +2388,7 @@ TEST_F(ClusterTaskManagerTest, SchedulingClassCapResetTest) {
   pool_.TriggerCallbacks();
   task_manager_.ScheduleAndDispatchTasks();
 
-  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker1));
+  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker1));
   current_time_ms_ += UNIT;
 
   std::shared_ptr<MockWorker> worker2 =
@@ -2419,7 +2419,7 @@ TEST_F(ClusterTaskManagerTest, SchedulingClassCapResetTest) {
   task_manager_.ScheduleAndDispatchTasks();
   ASSERT_EQ(num_callbacks, 3);
 
-  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker3));
+  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker3));
   current_time_ms_ += UNIT;
 
   std::shared_ptr<MockWorker> worker4 =
@@ -2489,7 +2489,7 @@ TEST_F(ClusterTaskManagerTest, DispatchTimerAfterRequestTest) {
   ASSERT_EQ(num_callbacks, 1);
   for (auto &worker : workers) {
     if (worker->GetAllocatedInstances() && !worker->IsBlocked()) {
-      local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker);
+      local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker);
     }
   }
 
@@ -2500,7 +2500,7 @@ TEST_F(ClusterTaskManagerTest, DispatchTimerAfterRequestTest) {
   ASSERT_EQ(num_callbacks, 2);
   for (auto &worker : workers) {
     if (worker->GetAllocatedInstances() && !worker->IsBlocked()) {
-      local_task_manager_->ReleaseCpuResourcesFromUnblockedWorker(worker);
+      local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker);
     }
   }
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`ReleaseCpuResourcesFromUnblockedWorker` -> `ReleaseCpuResourcesFromBlockedWorker`
`ReturnCpuResourcesToBlockedWorker` -> `ReturnCpuResourcesToUnblockedWorker`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
