### PR TITLE
[ci] move macos x86_64 build to civ2

### DIFF
--- a/.buildkite/macos.rayci.yml
+++ b/.buildkite/macos.rayci.yml
@@ -4,6 +4,15 @@ steps:
   - block: "run macos tests"
     if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b"
 
+  - label: ":tapioca: build: :mac: wheels and jars (x86_64)"
+    tags:
+      - macos_wheels
+      - python_dependencies
+    job_env: MACOS
+    instance_type: macos
+    commands:
+      - ./ci/ray_ci/macos/macos_ci_build.sh build_x86_64
+
   - label: ":ray: core: :mac: small & client tests"
     tags: 
       - core_cpp

--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -31,44 +31,6 @@ epilogue_commands: &epilogue_commands |-
   bazel clean
 
 steps:
-- label: ":mac: :apple: Wheels and Jars (intel)"
-  <<: *common
-  conditions: ["RAY_CI_MACOS_WHEELS_AFFECTED", "RAY_CI_PYTHON_DEPENDENCIES_AFFECTED"]
-  commands:
-    # Cleanup environments
-    - rm -rf /tmp/bazel_event_logs
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - (which bazel && bazel clean) || true
-    # TODO(simon): make sure to change both PR and wheel builds
-    # Special setup for jar builds (will be installed to the machine instead)
-    # - brew remove --force java & brew uninstall --force java & rm -rf /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask
-    # - brew install --cask adoptopenjdk/openjdk/adoptopenjdk8
-    - diskutil list external physical
-    - export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
-    - java -version
-    # Build wheels
-    - export UPLOAD_WHEELS_AS_ARTIFACTS=1
-    - export MAC_WHEELS=1
-    - export MAC_JARS=1
-    - export RAY_INSTALL_JAVA=1
-    - export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1
-    - . ./ci/ci.sh init && source ~/.zshenv
-    - ./ci/ci.sh build
-    # Test wheels
-    - ./ci/ci.sh test_wheels
-    # Build jars
-    - bash ./java/build-jar-multiplatform.sh darwin
-    # Upload the wheels and jars
-    # We don't want to push on PRs, in fact, the copy_files will fail because unauthenticated.
-    - if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then exit 0; fi
-    - pip install -q docker aws_requests_auth boto3
-    # Upload to branch directory.
-    - python .buildkite/copy_files.py --destination branch_wheels --path ./.whl
-    - python .buildkite/copy_files.py --destination branch_jars --path ./.jar/darwin
-    # Upload to latest directory.
-    - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
-    - if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/darwin; fi
-
 - label: ":mac: :mechanical_arm: Wheels and Jars (arm64)"
   <<: *common
   conditions: ["RAY_CI_MACOS_WHEELS_AFFECTED", "RAY_CI_PYTHON_DEPENDENCIES_AFFECTED"]

--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -139,7 +139,7 @@ elif [[ "$platform" == "macosx" ]]; then
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp aiosignal frozenlist 'pytest==7.0.1' requests proxy.py
+    "$PIP_CMD" install -q aiohttp aiosignal numpy frozenlist 'pytest==7.0.1' requests proxy.py
 
     # Run a simple test script to make sure that the wheel works.
     # We set the python path to prefer the directory of the wheel content: https://github.com/ray-project/ray/pull/30090

--- a/ci/ray_ci/macos/macos_ci_build.sh
+++ b/ci/ray_ci/macos/macos_ci_build.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -ex
+
+export CI="true"
+export PYTHON="3.8"
+export RAY_USE_RANDOM_PORTS="1"
+export RAY_DEFAULT_BUILD="1"
+export LC_ALL="en_US.UTF-8"
+export LANG="en_US.UTF-8"
+export BUILD="1"
+export DL="1"
+
+
+build_x86_64() {
+  # Cleanup environments
+  rm -rf /tmp/bazel_event_logs
+  cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
+  (which bazel && bazel clean) || true
+  # TODO(simon): make sure to change both PR and wheel builds
+  # Special setup for jar builds (will be installed to the machine instead)
+  # - brew remove --force java & brew uninstall --force java & rm -rf /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask
+  # - brew install --cask adoptopenjdk/openjdk/adoptopenjdk8
+  diskutil list external physical
+  export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
+  java -version
+  # Build wheels
+  export UPLOAD_WHEELS_AS_ARTIFACTS=1
+  export MAC_WHEELS=1
+  export MAC_JARS=1
+  export RAY_INSTALL_JAVA=1
+  export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1
+  . ./ci/ci.sh init && source ~/.zshenv
+  source ~/.zshrc
+  ./ci/ci.sh build
+  # Test wheels
+  ./ci/ci.sh test_wheels
+  # Build jars
+  bash ./java/build-jar-multiplatform.sh darwin
+  # Upload the wheels and jars
+  # We don't want to push on PRs, in fact, the copy_files will fail because unauthenticated.
+  if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then exit 0; fi
+  pip install -q docker aws_requests_auth boto3
+  # Upload to branch directory.
+  python .buildkite/copy_files.py --destination branch_wheels --path ./.whl
+  python .buildkite/copy_files.py --destination branch_jars --path ./.jar/darwin
+  # Upload to latest directory.
+  if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
+  if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/darwin; fi
+}
+
+"$@"


### PR DESCRIPTION
Move macos x86_64  build to civ2. Remove macos from civ1. Just copy the code as it is. Also fix test wheels logic.

![](https://media2.giphy.com/media/ToMjGpqWojvqz7ts2li/giphy.gif?cid=5a38a5a2uhgl5mv37pg4vpdtpqpehhp7im7um1msz2t8t1jf&ep=v1_gifs_search&rid=giphy.gif&ct=g)

Test:
- CI