### PR TITLE
[ci] refactor state machine into a base class

### DIFF
--- a/release/ray_release/reporter/ray_test_db.py
+++ b/release/ray_release/reporter/ray_test_db.py
@@ -3,7 +3,7 @@ import json
 from ray_release.reporter.reporter import Reporter
 from ray_release.result import Result, ResultStatus
 from ray_release.test import Test
-from ray_release.test_automation.state_machine import TestStateMachine
+from ray_release.test_automation.release_state_machine import ReleaseTestStateMachine
 from ray_release.logger import logger
 
 
@@ -37,7 +37,7 @@ class RayTestDBReporter(Reporter):
         )
 
         # Compute and update the next test state
-        TestStateMachine(test).move()
+        ReleaseTestStateMachine(test).move()
 
         # Persist the updated test object to S3
         test.persist_to_s3()

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -17,7 +17,7 @@ from ray_release.byod.build import (
 from ray_release.config import read_and_validate_release_test_collection
 from ray_release.configs.global_config import init_global_config
 from ray_release.test import Test
-from ray_release.test_automation.state_machine import TestStateMachine
+from ray_release.test_automation.release_state_machine import ReleaseTestStateMachine
 
 
 @click.command()
@@ -261,7 +261,7 @@ def _update_test_state(test: Test, blamed_commit: str) -> None:
     test[Test.KEY_BISECT_BLAMED_COMMIT] = blamed_commit
 
     # Compute and update the next test state, then comment blamed commit on github issue
-    sm = TestStateMachine(test)
+    sm = ReleaseTestStateMachine(test)
     sm.move()
     sm.comment_blamed_commit_on_github_issue()
 

--- a/release/ray_release/test_automation/release_state_machine.py
+++ b/release/ray_release/test_automation/release_state_machine.py
@@ -1,0 +1,139 @@
+from datetime import datetime, timedelta
+
+from ray_release.test_automation.state_machine import TestStateMachine
+from ray_release.test import Test, TestState
+from ray_release.logger import logger
+
+
+MAX_BISECT_PER_DAY = 10  # Max number of bisects to run per day for all tests
+BUILDKITE_ORGANIZATION = "ray-project"
+BUILDKITE_BISECT_PIPELINE = "release-tests-bisect"
+CONTINUOUS_FAILURE_TO_JAIL = 3  # Number of continuous failures before jailing
+
+
+class ReleaseTestStateMachine(TestStateMachine):
+    """
+    State transition logic
+    """
+
+    def _move_hook(self, from_state: TestState, to_state: TestState) -> None:
+        change = (from_state, to_state)
+        if change == (TestState.PASSING, TestState.CONSITENTLY_FAILING):
+            self._create_github_issue()
+        elif change == (TestState.FAILING, TestState.CONSITENTLY_FAILING):
+            self._create_github_issue()
+        elif change == (TestState.CONSITENTLY_FAILING, TestState.PASSING):
+            self._close_github_issue()
+        elif change == (TestState.PASSING, TestState.FAILING):
+            self._trigger_bisect()
+        elif change == (TestState.CONSITENTLY_FAILING, TestState.JAILED):
+            self._jail_test()
+        elif change == (TestState.JAILED, TestState.PASSING):
+            self._close_github_issue()
+
+    def _state_hook(self, state: TestState) -> None:
+        if state == TestState.JAILED:
+            self._keep_github_issue_open()
+        if state == TestState.PASSING:
+            self.test.pop(Test.KEY_BISECT_BUILD_NUMBER, None)
+            self.test.pop(Test.KEY_BISECT_BLAMED_COMMIT, None)
+
+    def _consistently_failing_to_jailed(self) -> bool:
+        return len(self.test_results) >= CONTINUOUS_FAILURE_TO_JAIL and all(
+            result.is_failing()
+            for result in self.test_results[:CONTINUOUS_FAILURE_TO_JAIL]
+        )
+
+    """
+    Action hooks performed during state transitions
+    """
+
+    def _create_github_issue(self) -> None:
+        labels = [
+            "P0",
+            "bug",
+            "release-test",
+            "ray-test-bot",
+            "triage",
+            self.test.get_oncall(),
+        ]
+        if not self.test.is_stable():
+            labels.append("unstable-release-test")
+        issue_number = self.ray_repo.create_issue(
+            title=f"Release test {self.test.get_name()} failed",
+            body=(
+                f"Release test **{self.test.get_name()}** failed. "
+                f"See {self.test_results[0].url} for more details.\n\n"
+                f"Managed by OSS Test Policy"
+            ),
+            labels=labels,
+            assignee="can-anyscale",
+        ).number
+        self.test[Test.KEY_GITHUB_ISSUE_NUMBER] = issue_number
+
+    def _bisect_rate_limit_exceeded(self) -> bool:
+        """
+        Check if we have exceeded the rate limit of bisects per day.
+        """
+        builds = self.ray_buildkite.builds().list_all_for_pipeline(
+            BUILDKITE_ORGANIZATION,
+            BUILDKITE_BISECT_PIPELINE,
+            created_from=datetime.now() - timedelta(days=1),
+            branch="master",
+        )
+        return len(builds) >= MAX_BISECT_PER_DAY
+
+    def _trigger_bisect(self) -> None:
+        if self._bisect_rate_limit_exceeded():
+            logger.info(f"Skip bisect {self.test.get_name()} due to rate limit")
+            return
+        build = self.ray_buildkite.builds().create_build(
+            BUILDKITE_ORGANIZATION,
+            BUILDKITE_BISECT_PIPELINE,
+            "HEAD",
+            "master",
+            message=f"[ray-test-bot] {self.test.get_name()} failing",
+            env={
+                "UPDATE_TEST_STATE_MACHINE": "1",
+            },
+        )
+        failing_commit = self.test_results[0].commit
+        passing_commits = [r.commit for r in self.test_results if r.is_passing()]
+        if not passing_commits:
+            logger.info(f"Skip bisect {self.test.get_name()} due to no passing commit")
+            return
+        passing_commit = passing_commits[0]
+        self.ray_buildkite.jobs().unblock_job(
+            BUILDKITE_ORGANIZATION,
+            BUILDKITE_BISECT_PIPELINE,
+            build["number"],
+            build["jobs"][0]["id"],  # first job is the blocked job
+            fields={
+                "test-name": self.test.get_name(),
+                "passing-commit": passing_commit,
+                "failing-commit": failing_commit,
+                "concurrency": "3",
+                "run-per-commit": "1",
+            },
+        )
+        self.test[Test.KEY_BISECT_BUILD_NUMBER] = build["number"]
+
+    def comment_blamed_commit_on_github_issue(self) -> None:
+        """
+        Comment the blamed commit on the github issue.
+        """
+        blamed_commit = self.test.get(Test.KEY_BISECT_BLAMED_COMMIT)
+        issue_number = self.test.get(Test.KEY_GITHUB_ISSUE_NUMBER)
+        bisect_build_number = self.test.get(Test.KEY_BISECT_BUILD_NUMBER)
+        if not issue_number or not bisect_build_number or not blamed_commit:
+            logger.info(
+                "Skip commenting blamed commit on github issue "
+                f"for {self.test.get_name()}"
+            )
+            return
+        issue = self.ray_repo.get_issue(issue_number)
+        issue.create_comment(
+            f"Blamed commit: {blamed_commit} "
+            f"found by bisect job https://buildkite.com/{BUILDKITE_ORGANIZATION}/"
+            f"{BUILDKITE_BISECT_PIPELINE}/builds/{bisect_build_number}"
+        )

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+import abc
 
 from github import Github
 from pybuildkite.buildkite import Buildkite
@@ -7,19 +7,14 @@ from ray_release.test import (
     Test,
     TestState,
 )
-from ray_release.logger import logger
 from ray_release.aws import get_secret_token
 
 RAY_REPO = "ray-project/ray"
 AWS_SECRET_GITHUB = "ray_ci_github_token"
 AWS_SECRET_BUILDKITE = "ray_ci_buildkite_token"
-MAX_BISECT_PER_DAY = 10  # Max number of bisects to run per day for all tests
-CONTINUOUS_FAILURE_TO_JAIL = 3  # Number of continuous failures before jailing
-BUILDKITE_ORGANIZATION = "ray-project"
-BUILDKITE_BISECT_PIPELINE = "release-tests-bisect"
 
 
-class TestStateMachine:
+class TestStateMachine(abc.ABC):
     """
     State machine that computes the next state of a test based on the current state and
     perform actions accordingly during the state transition. For example:
@@ -94,161 +89,6 @@ class TestStateMachine:
 
         return current_state
 
-    def _move_hook(self, from_state: TestState, to_state: TestState) -> None:
-        """
-        Action performed when test transitions to a different state. This is where we do
-        things like creating and closing github issues, trigger bisects, etc.
-        """
-        change = (from_state, to_state)
-        if change == (TestState.PASSING, TestState.CONSITENTLY_FAILING):
-            self._create_github_issue()
-        elif change == (TestState.FAILING, TestState.CONSITENTLY_FAILING):
-            self._create_github_issue()
-        elif change == (TestState.CONSITENTLY_FAILING, TestState.PASSING):
-            self._close_github_issue()
-        elif change == (TestState.PASSING, TestState.FAILING):
-            self._trigger_bisect()
-        elif change == (TestState.CONSITENTLY_FAILING, TestState.JAILED):
-            self._jail_test()
-        elif change == (TestState.JAILED, TestState.PASSING):
-            self._close_github_issue()
-
-    def _state_hook(self, state: TestState) -> None:
-        """
-        Action performed when test is in a particular state. This is where we do things
-        to keep an invariant for a state. For example, we can keep the github issue open
-        if the test is failing.
-        """
-        if state == TestState.JAILED:
-            self._keep_github_issue_open()
-        if state == TestState.PASSING:
-            self.test.pop(Test.KEY_BISECT_BUILD_NUMBER, None)
-            self.test.pop(Test.KEY_BISECT_BLAMED_COMMIT, None)
-
-    def _jail_test(self) -> None:
-        """
-        Notify github issue owner that the test is jailed
-        """
-        github_issue_number = self.test.get(Test.KEY_GITHUB_ISSUE_NUMBER)
-        if not github_issue_number:
-            return
-        issue = self.ray_repo.get_issue(github_issue_number)
-        issue.create_comment("Test has been failing for far too long. Jailing.")
-        labels = ["jailed-test"] + [label.name for label in issue.get_labels()]
-        issue.edit(labels=labels)
-
-    def _bisect_rate_limit_exceeded(self) -> bool:
-        """
-        Check if we have exceeded the rate limit of bisects per day.
-        """
-        builds = self.ray_buildkite.builds().list_all_for_pipeline(
-            BUILDKITE_ORGANIZATION,
-            BUILDKITE_BISECT_PIPELINE,
-            created_from=datetime.now() - timedelta(days=1),
-            branch="master",
-        )
-        return len(builds) >= MAX_BISECT_PER_DAY
-
-    def _trigger_bisect(self) -> None:
-        if self._bisect_rate_limit_exceeded():
-            logger.info(f"Skip bisect {self.test.get_name()} due to rate limit")
-            return
-        build = self.ray_buildkite.builds().create_build(
-            BUILDKITE_ORGANIZATION,
-            BUILDKITE_BISECT_PIPELINE,
-            "HEAD",
-            "master",
-            message=f"[ray-test-bot] {self.test.get_name()} failing",
-            env={
-                "UPDATE_TEST_STATE_MACHINE": "1",
-            },
-        )
-        failing_commit = self.test_results[0].commit
-        passing_commits = [r.commit for r in self.test_results if r.is_passing()]
-        if not passing_commits:
-            logger.info(f"Skip bisect {self.test.get_name()} due to no passing commit")
-            return
-        passing_commit = passing_commits[0]
-        self.ray_buildkite.jobs().unblock_job(
-            BUILDKITE_ORGANIZATION,
-            BUILDKITE_BISECT_PIPELINE,
-            build["number"],
-            build["jobs"][0]["id"],  # first job is the blocked job
-            fields={
-                "test-name": self.test.get_name(),
-                "passing-commit": passing_commit,
-                "failing-commit": failing_commit,
-                "concurrency": "3",
-                "run-per-commit": "1",
-            },
-        )
-        self.test[Test.KEY_BISECT_BUILD_NUMBER] = build["number"]
-
-    def comment_blamed_commit_on_github_issue(self) -> None:
-        """
-        Comment the blamed commit on the github issue.
-        """
-        blamed_commit = self.test.get(Test.KEY_BISECT_BLAMED_COMMIT)
-        issue_number = self.test.get(Test.KEY_GITHUB_ISSUE_NUMBER)
-        bisect_build_number = self.test.get(Test.KEY_BISECT_BUILD_NUMBER)
-        if not issue_number or not bisect_build_number or not blamed_commit:
-            logger.info(
-                "Skip commenting blamed commit on github issue "
-                f"for {self.test.get_name()}"
-            )
-            return
-        issue = self.ray_repo.get_issue(issue_number)
-        issue.create_comment(
-            f"Blamed commit: {blamed_commit} "
-            f"found by bisect job https://buildkite.com/{BUILDKITE_ORGANIZATION}/"
-            f"{BUILDKITE_BISECT_PIPELINE}/builds/{bisect_build_number}"
-        )
-
-    def _create_github_issue(self) -> None:
-        labels = [
-            "P0",
-            "bug",
-            "release-test",
-            "ray-test-bot",
-            "triage",
-            self.test.get_oncall(),
-        ]
-        if not self.test.is_stable():
-            labels.append("unstable-release-test")
-        issue_number = self.ray_repo.create_issue(
-            title=f"Release test {self.test.get_name()} failed",
-            body=(
-                f"Release test **{self.test.get_name()}** failed. "
-                f"See {self.test_results[0].url} for more details.\n\n"
-                f"Managed by OSS Test Policy"
-            ),
-            labels=labels,
-            assignee="can-anyscale",
-        ).number
-        self.test[Test.KEY_GITHUB_ISSUE_NUMBER] = issue_number
-
-    def _close_github_issue(self) -> None:
-        github_issue_number = self.test.get(Test.KEY_GITHUB_ISSUE_NUMBER)
-        if not github_issue_number:
-            return
-        issue = self.ray_repo.get_issue(github_issue_number)
-        issue.create_comment(f"Test passed on latest run: {self.test_results[0].url}")
-        issue.edit(state="closed")
-        self.test.pop(Test.KEY_GITHUB_ISSUE_NUMBER, None)
-
-    def _keep_github_issue_open(self) -> None:
-        github_issue_number = self.test.get(Test.KEY_GITHUB_ISSUE_NUMBER)
-        if not github_issue_number:
-            return
-        issue = self.ray_repo.get_issue(github_issue_number)
-        if issue.state == "open":
-            return
-        issue.edit(state="open")
-        issue.create_comment(
-            "Re-opening issue as test is still failing. "
-            f"Latest run: {self.test_results[0].url}"
-        )
-
     def _jailed_to_passing(self) -> bool:
         return len(self.test_results) > 0 and self.test_results[0].is_passing()
 
@@ -277,8 +117,69 @@ class TestStateMachine:
     def _consistently_failing_to_passing(self) -> bool:
         return self._failing_to_passing()
 
+    """
+    Abstract methods
+    """
+
+    @abc.abstractmethod
+    def _move_hook(self, from_state: TestState, to_state: TestState) -> None:
+        """
+        Action performed when test transitions to a different state. This is where we do
+        things like creating and closing github issues, trigger bisects, etc.
+        """
+        pass
+
+    @abc.abstractmethod
+    def _state_hook(self, state: TestState) -> None:
+        """
+        Action performed when test is in a particular state. This is where we do things
+        to keep an invariant for a state. For example, we can keep the github issue open
+        if the test is failing.
+        """
+        pass
+
+    @abc.abstractmethod
     def _consistently_failing_to_jailed(self) -> bool:
-        return len(self.test_results) >= CONTINUOUS_FAILURE_TO_JAIL and all(
-            result.is_failing()
-            for result in self.test_results[:CONTINUOUS_FAILURE_TO_JAIL]
+        """
+        Condition to jail a test. This is an abstract method since different state
+        machine implements this logic differently.
+        """
+        pass
+
+    """
+    Common helper methods
+    """
+
+    def _jail_test(self) -> None:
+        """
+        Notify github issue owner that the test is jailed
+        """
+        github_issue_number = self.test.get(Test.KEY_GITHUB_ISSUE_NUMBER)
+        if not github_issue_number:
+            return
+        issue = self.ray_repo.get_issue(github_issue_number)
+        issue.create_comment("Test has been failing for far too long. Jailing.")
+        labels = ["jailed-test"] + [label.name for label in issue.get_labels()]
+        issue.edit(labels=labels)
+
+    def _close_github_issue(self) -> None:
+        github_issue_number = self.test.get(Test.KEY_GITHUB_ISSUE_NUMBER)
+        if not github_issue_number:
+            return
+        issue = self.ray_repo.get_issue(github_issue_number)
+        issue.create_comment(f"Test passed on latest run: {self.test_results[0].url}")
+        issue.edit(state="closed")
+        self.test.pop(Test.KEY_GITHUB_ISSUE_NUMBER, None)
+
+    def _keep_github_issue_open(self) -> None:
+        github_issue_number = self.test.get(Test.KEY_GITHUB_ISSUE_NUMBER)
+        if not github_issue_number:
+            return
+        issue = self.ray_repo.get_issue(github_issue_number)
+        if issue.state == "open":
+            return
+        issue.edit(state="open")
+        issue.create_comment(
+            "Re-opening issue as test is still failing. "
+            f"Latest run: {self.test_results[0].url}"
         )

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -12,6 +12,7 @@ from ray_release.result import (
     Result,
     ResultStatus,
 )
+from ray_release.test_automation.release_state_machine import ReleaseTestStateMachine
 from ray_release.test_automation.state_machine import TestStateMachine
 
 
@@ -100,7 +101,7 @@ def test_move_from_passing_to_failing():
         0,
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
     )
-    sm = TestStateMachine(test)
+    sm = ReleaseTestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.FAILING
     assert test[Test.KEY_BISECT_BUILD_NUMBER] == 1
@@ -110,7 +111,7 @@ def test_move_from_passing_to_failing():
         0,
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
     )
-    sm = TestStateMachine(test)
+    sm = ReleaseTestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.CONSITENTLY_FAILING
     assert test[Test.KEY_GITHUB_ISSUE_NUMBER] == MockIssueDB.issue_id - 1
@@ -122,11 +123,11 @@ def test_move_from_failing_to_consisently_failing():
     test.test_results = [
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
     ]
-    sm = TestStateMachine(test)
+    sm = ReleaseTestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.FAILING
     test[Test.KEY_BISECT_BLAMED_COMMIT] = "1234567890"
-    sm = TestStateMachine(test)
+    sm = ReleaseTestStateMachine(test)
     sm.move()
     sm.comment_blamed_commit_on_github_issue()
     issue = MockIssueDB.issue_db[test.get(Test.KEY_GITHUB_ISSUE_NUMBER)]
@@ -143,7 +144,7 @@ def test_move_from_failing_to_passing():
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
     ]
-    sm = TestStateMachine(test)
+    sm = ReleaseTestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.CONSITENTLY_FAILING
     assert test[Test.KEY_GITHUB_ISSUE_NUMBER] == MockIssueDB.issue_id - 1
@@ -151,7 +152,7 @@ def test_move_from_failing_to_passing():
         0,
         TestResult.from_result(Result(status=ResultStatus.SUCCESS.value)),
     )
-    sm = TestStateMachine(test)
+    sm = ReleaseTestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.PASSING
     assert test.get(Test.KEY_GITHUB_ISSUE_NUMBER) is None
@@ -167,14 +168,14 @@ def test_move_from_failing_to_jailed():
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
     ]
-    sm = TestStateMachine(test)
+    sm = ReleaseTestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.CONSITENTLY_FAILING
     test.test_results.insert(
         0,
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
     )
-    sm = TestStateMachine(test)
+    sm = ReleaseTestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.JAILED
 
@@ -185,7 +186,7 @@ def test_move_from_failing_to_jailed():
         0,
         TestResult.from_result(Result(status=ResultStatus.ERROR.value)),
     )
-    sm = TestStateMachine(test)
+    sm = ReleaseTestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.JAILED
     assert issue.state == "open"
@@ -195,7 +196,7 @@ def test_move_from_failing_to_jailed():
         0,
         TestResult.from_result(Result(status=ResultStatus.SUCCESS.value)),
     )
-    sm = TestStateMachine(test)
+    sm = ReleaseTestStateMachine(test)
     sm.move()
     assert test.get_state() == TestState.PASSING
     assert test.get(Test.KEY_GITHUB_ISSUE_NUMBER) is None


### PR DESCRIPTION
Refactor state machine into a base class, and separate out logic that is specific to release test. Do this so I can add a state machine for CI where the rules are a bit different.

Purely code moving, no additional logic.

Test:
- CI