### PR TITLE
[data] deflake test_huggingface

### DIFF
--- a/ci/ray_ci/data.tests.yml
+++ b/ci/ray_ci/data.tests.yml
@@ -1,4 +1,2 @@
 flaky_tests:
   - //python/ray/data:test_streaming_integration
-  - //python/ray/data:test_split
-  - //python/ray/data:test_huggingface

--- a/python/ray/data/tests/test_huggingface.py
+++ b/python/ray/data/tests/test_huggingface.py
@@ -1,4 +1,5 @@
 import datasets
+import pyarrow
 import pytest
 
 import ray
@@ -44,6 +45,10 @@ def test_from_huggingface(ray_start_regular_shared):
 @pytest.mark.skipif(
     datasets.Version(datasets.__version__) < datasets.Version("2.8.0"),
     reason="IterableDataset.iter() added in 2.8.0",
+)
+@pytest.mark.skipif(
+    datasets.Version(pyarrow.__version__) < datasets.Version("8.0.0"),
+    reason="pyarrow.Table.to_reader() added in 8.0.0",
 )
 # Note, pandas is excluded here because IterableDatasets do not support pandas format.
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_huggingface.py
+++ b/python/ray/data/tests/test_huggingface.py
@@ -5,7 +5,7 @@ import ray
 from ray.tests.conftest import *  # noqa
 
 
-def test_huggingface(ray_start_regular_shared):
+def test_from_huggingface(ray_start_regular_shared):
     data = datasets.load_dataset("tweet_eval", "emotion")
 
     # Check that DatasetDict is not directly supported.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
For `datasets>=2.11` package, there is a minimum requirement of `"pyarrow>=8.0.0"` as introduced here: https://github.com/huggingface/datasets/blob/main/setup.py#L116C2-L117

We skip the streaming read test for lower pyarrow versions, since the underlying `pyarrow.Table.to_reader()` method, which is used by the HF iterable dataset path, will not be available.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #42192 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
