### PR TITLE
[serve] Use long poll to broadcast autoscaling config to handles

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1260,6 +1260,7 @@ class DeploymentState:
         self._multiplexed_model_ids_updated = False
 
         self._last_notified_running_replica_infos: List[RunningReplicaInfo] = []
+        self._last_notified_autoscaling_config = None
 
     @property
     def autoscaling_policy_manager(self) -> AutoscalingPolicyManager:
@@ -1402,6 +1403,20 @@ class DeploymentState:
         )
         self._last_notified_running_replica_infos = running_replica_infos
         self._multiplexed_model_ids_updated = False
+
+    def notify_autoscaling_config_changed(self) -> None:
+        current_autoscaling_config = (
+            self._target_state.info.deployment_config.autoscaling_config
+        )
+        if self._last_notified_autoscaling_config == current_autoscaling_config:
+            return
+
+        self._long_poll_host.notify_changed(
+            (LongPollNamespace.AUTOSCALING_CONFIG, self._id),
+            current_autoscaling_config,
+        )
+
+        self._last_notified_autoscaling_config = current_autoscaling_config
 
     def _set_target_state_deleting(self) -> None:
         """Set the target state for the deployment to be deleted."""
@@ -2659,6 +2674,7 @@ class DeploymentStateManager:
 
         for deployment_state in self._deployment_states.values():
             deployment_state.notify_running_replicas_changed()
+            deployment_state.notify_autoscaling_config_changed()
 
         for deployment_id in deleted_ids:
             self._deployment_scheduler.on_deployment_deleted(deployment_id)

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -41,6 +41,7 @@ class LongPollNamespace(Enum):
     RUNNING_REPLICAS = auto()
     ROUTE_TABLE = auto()
     GLOBAL_LOGGING_CONFIG = auto()
+    AUTOSCALING_CONFIG = auto()
 
 
 @dataclass

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -35,10 +35,8 @@ from ray.serve._private.constants import (
     RAY_SERVE_QUEUE_LENGTH_RESPONSE_DEADLINE_S,
     SERVE_LOGGER_NAME,
 )
-from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.long_poll import LongPollClient, LongPollNamespace
 from ray.serve._private.utils import JavaActorHandleProxy, MetricsPusher
-from ray.serve.generated.serve_pb2 import DeploymentRoute
 from ray.serve.generated.serve_pb2 import RequestMetadata as RequestMetadataProto
 from ray.serve.grpc_util import RayServegRPCContext
 from ray.util import metrics
@@ -967,7 +965,6 @@ class Router:
             description="The number of requests processed by the router.",
             tag_keys=("deployment", "route", "application"),
         )
-        # TODO(zcin): use deployment name and application name instead of deployment id
         self.num_router_requests.set_default_tags(
             {"deployment": deployment_id.name, "application": deployment_id.app}
         )
@@ -981,7 +978,6 @@ class Router:
             ),
             tag_keys=("deployment", "application"),
         )
-        # TODO(zcin): use deployment name and application name instead of deployment id
         self.num_queued_queries_gauge.set_default_tags(
             {"deployment": deployment_id.name, "application": deployment_id.app}
         )
@@ -993,21 +989,37 @@ class Router:
                     LongPollNamespace.RUNNING_REPLICAS,
                     deployment_id,
                 ): self._replica_scheduler.update_running_replicas,
+                (
+                    LongPollNamespace.AUTOSCALING_CONFIG,
+                    deployment_id,
+                ): self.update_autoscaling_config,
             },
             call_in_event_loop=event_loop,
         )
 
-        # Start the metrics pusher if autoscaling is enabled.
-        deployment_route = DeploymentRoute.FromString(
-            ray.get(controller_handle.get_deployment_info.remote(*deployment_id))
-        )
-        deployment_info = DeploymentInfo.from_proto(deployment_route.deployment_info)
         self.metrics_pusher = None
-        if deployment_info.deployment_config.autoscaling_config:
+        self.autoscaling_enabled = False
+        self.push_metrics_to_controller = controller_handle.record_handle_metrics.remote
+
+    def update_autoscaling_config(self, autoscaling_config):
+        self.autoscaling_config = autoscaling_config
+
+        # Start the metrics pusher if autoscaling is enabled.
+        if self.autoscaling_config:
             self.autoscaling_enabled = True
-            self.push_metrics_to_controller = (
-                controller_handle.record_handle_metrics.remote
-            )
+
+            # Optimization for autoscaling cold start time. If there are
+            # currently 0 replicas for the deployment, and there is at
+            # least one queued query on this router, then immediately
+            # push handle metric to the controller.
+            if (
+                len(self._replica_scheduler.curr_replicas) == 0
+                and self.num_queued_queries
+            ):
+                self.push_metrics_to_controller(
+                    {self.deployment_id: self.num_queued_queries}, time.time()
+                )
+
             self.metrics_pusher = MetricsPusher()
             self.metrics_pusher.register_task(
                 self._collect_handle_queue_metrics,
@@ -1018,6 +1030,8 @@ class Router:
             self.metrics_pusher.start()
         else:
             self.autoscaling_enabled = False
+            if self.metrics_pusher:
+                self.metrics_pusher.shutdown()
 
     def _collect_handle_queue_metrics(self) -> Dict[str, int]:
         return {self.deployment_id: self.num_queued_queries}
@@ -1037,6 +1051,10 @@ class Router:
         # Optimization: if there are currently zero replicas for a deployment,
         # push handle metric to controller to allow for fast cold start time.
         # Only do it for the first query to arrive on the router.
+        # NOTE(zcin): this is making the assumption that this method DOES
+        # NOT give up the async event loop above this conditional. If
+        # you need to yield the event loop above this conditional, you
+        # will need to remove the check "self.num_queued_queries == 1"
         if (
             self.autoscaling_enabled
             and len(self._replica_scheduler.curr_replicas) == 0

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -917,10 +917,9 @@ def test_status_package_unavailable_in_controller(serve_instance):
 
     def check_for_failed_deployment():
         default_app = serve.status().applications[SERVE_DEFAULT_APP_NAME]
-        return (
-            default_app.status == "DEPLOY_FAILED"
-            and "some_wrong_url" in default_app.deployments["MyDeployment"].message
-        )
+        assert default_app.status == "DEPLOY_FAILED"
+        assert "some_wrong_url" in default_app.deployments["MyDeployment"].message
+        return True
 
     wait_for_condition(check_for_failed_deployment, timeout=15)
 

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -1107,6 +1107,11 @@ def test_queued_queries_disconnected(serve_start_shutdown):
         timeout=15,
         metric="ray_serve_num_scheduling_tasks",
         expected=-1,  # -1 means not expected to be present yet.
+        # TODO(zcin): this tag shouldn't be necessary, there shouldn't be a mix of
+        # metrics from new and old sessions.
+        expected_tags={
+            "SessionName": ray._private.worker.global_worker.node.session_name
+        },
     )
     print("ray_serve_num_scheduling_tasks updated successfully.")
     wait_for_condition(
@@ -1114,6 +1119,11 @@ def test_queued_queries_disconnected(serve_start_shutdown):
         timeout=15,
         metric="serve_num_scheduling_tasks_in_backoff",
         expected=-1,  # -1 means not expected to be present yet.
+        # TODO(zcin): this tag shouldn't be necessary, there shouldn't be a mix of
+        # metrics from new and old sessions.
+        expected_tags={
+            "SessionName": ray._private.worker.global_worker.node.session_name
+        },
     )
     print("serve_num_scheduling_tasks_in_backoff updated successfully.")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Use long poll to broadcast a certain deployment's autoscaling config to deployment handles.
This helps with 2 things:
1. Handles no longer have to make [a blocking call](https://github.com/ray-project/ray/blob/eb19da2add8342a4d34fe3970eb14debbd8f829d/python/ray/serve/_private/router.py#L1001-L1003) to the controller upon initialization.
2. For the [upcoming autoscaling metrics changes](https://github.com/ray-project/ray/pull/42188) (which switches to collecting all autoscaling metrics on handles), handles will need to be updated when the user modifies the autoscaling config for an existing deployment. This should be done through long poll.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
