### PR TITLE
[Doc] Fix code block diff colors

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -81,15 +81,17 @@ h6 {
 /* Pygments diff code cell line colors; match github colorblind theme */
 div.highlight > pre > span.gd {
   background-color: var(--color-diff-delete-bg);
-  color: var(--pst-color-text-base) !important;
 }
 div.highlight > pre > span.gi {
   background-color: var(--color-diff-insert-bg);
-  color: var(--pst-color-text-base) !important;
 }
 div.highlight > pre > span.w {
   background-color: var(--color-diff-nochange-bg);
-  color: var(--pst-color-text-base) !important;
+}
+/* Fix some pygments styles that inadvertently get overridden by PST */
+.highlight pre {
+  background-color: var(--stata-dark-background);
+  color: var(--base-pygments-code-color);
 }
 
 /* Make the article content take up all available space */
@@ -329,10 +331,4 @@ table.autosummary tr > td:first-child > p > a > code > span {
 .bd-sidebar-primary div#rtd-footer-container {
   margin: unset;
   max-width: 30vw;
-}
-
-/* Fix some pygments styles that inadvertently get overridden by PST */
-.highlight pre {
-  background-color: var(--stata-dark-background);
-  color: var(--base-pygments-code-color);
 }


### PR DESCRIPTION
This PR fixes the colors of the diff block found on some pages of the docs.

## Why are these changes needed?

Currently we are inadvertently setting the color of the text that has highlighted backgrounds for diff blocks to `--pst-color-text-base`. Since we're using a dark background for code blocks irrespective of the current site theme, the text looks fine in dark mode and is near impossible to read in light mode.

This PR changes the color of the text in the highlighted diff blocks to the same value as in _unhighlighted_ code blocks: `--base-pygments-code-color`. This offers good contrast with the `stata-dark` code theme we're using, and does not change when the user toggles the site theme.

Current `master`:
![image](https://github.com/ray-project/ray/assets/14017872/1ae4757c-2435-4522-b67c-8c912841aafa)
![image](https://github.com/ray-project/ray/assets/14017872/8fac98db-8d03-480f-a2fd-1d3c00af1fcf)

This PR:
![image](https://github.com/ray-project/ray/assets/14017872/d9854b70-f0d6-4d43-b0d8-5a40f387905e)
![image](https://github.com/ray-project/ray/assets/14017872/dc5883c5-b68e-47ae-8b81-758666e251fe)

## Related issue number

Closes https://github.com/ray-project/ray/issues/42270.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
