### PR TITLE
[Dashboard] Make GPU name tooltip appear when hovering over entire GPU entry

### DIFF
--- a/dashboard/client/src/pages/node/GPUColumn.tsx
+++ b/dashboard/client/src/pages/node/GPUColumn.tsx
@@ -41,7 +41,6 @@ export const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({ gpu, slot }) => {
   );
 };
 
-
 export const NodeGPUView = ({ node }: { node: NodeDetail }) => {
   const classes = useStyles();
   return (

--- a/dashboard/client/src/pages/node/GPUColumn.tsx
+++ b/dashboard/client/src/pages/node/GPUColumn.tsx
@@ -23,23 +23,24 @@ export type NodeGPUEntryProps = {
 export const NodeGPUEntry: React.FC<NodeGPUEntryProps> = ({ gpu, slot }) => {
   const classes = useStyles();
   return (
-    <Box className={classes.box}>
-      <Tooltip title={gpu.name}>
+    <Tooltip title={gpu.name}>
+      <Box className={classes.box}>
         <RightPaddedTypography variant="body1">[{slot}]:</RightPaddedTypography>
-      </Tooltip>
-      {gpu.utilizationGpu !== undefined ? (
-        <UsageBar
-          percent={gpu.utilizationGpu}
-          text={`${gpu.utilizationGpu.toFixed(1)}%`}
-        />
-      ) : (
-        <Typography color="textSecondary" component="span" variant="inherit">
-          N/A
-        </Typography>
-      )}
-    </Box>
+        {gpu.utilizationGpu !== undefined ? (
+          <UsageBar
+            percent={gpu.utilizationGpu}
+            text={`${gpu.utilizationGpu.toFixed(1)}%`}
+          />
+        ) : (
+          <Typography color="textSecondary" component="span" variant="inherit">
+            N/A
+          </Typography>
+        )}
+      </Box>
+    </Tooltip>
   );
 };
+
 
 export const NodeGPUView = ({ node }: { node: NodeDetail }) => {
   const classes = useStyles();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously the GPU name would only appear when hovering over the slot name (the part that says [0]).

This PR makes it appear also when hovering over the rest of the entry (the utilization bar).  This is consistent with how the GRAM entry is currently displayed.



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #42208 

Context copied from the linked issue:
> Actually, for the GPU column, the tooltip currently appears, but only if you hover over the "[0]" part, not over the utilization bar.
> 
> <img alt="Screenshot 2024-01-09 at 3 23 46 PM" width="188" src="https://private-user-images.githubusercontent.com/5459654/295367825-9ae26b55-0b63-405f-9760-131f438529ee.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDQ4NDQwMzYsIm5iZiI6MTcwNDg0MzczNiwicGF0aCI6Ii81NDU5NjU0LzI5NTM2NzgyNS05YWUyNmI1NS0wYjYzLTQwNWYtOTc2MC0xMzFmNDM4NTI5ZWUucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDEwOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDAxMDlUMjM0MjE2WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MTY3ODk5YWRhMThiMGM3OWFiZTc5MmU3YjYwYjY5YTVlMTlmNWI4NTRjZjNhYzcxMDk2MzIwNmZjMmI0Y2I0YiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.OYS249F0YnHebfOUiHhkUFwEsyWEi9OZMqJdOpLy7JI">
>
> For the GRAM column, the tooltip appears if you hover over the "[0]" part or the utilization bar. 
> <img alt="Screenshot 2024-01-09 at 3 24 26 PM" width="197" src="https://private-user-images.githubusercontent.com/5459654/295367907-0c21a27f-aabc-4355-a5a1-3b31d36051ef.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDQ4NDQwMzYsIm5iZiI6MTcwNDg0MzczNiwicGF0aCI6Ii81NDU5NjU0LzI5NTM2NzkwNy0wYzIxYTI3Zi1hYWJjLTQzNTUtYTVhMS0zYjMxZDM2MDUxZWYucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDEwOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDAxMDlUMjM0MjE2WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9M2Q0NzA3ZGY0MDcyNzhhYmQ1NmIxZWRkZWQwYzVmMzc5NTY0ZWIyOTJiMDdkZmVjMDU5ZjNjZTRjOGE5NzljMyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.-MapjzgSxLGDpgeOSjXRtIoLN0LrLdfn8erOxm3IdBs">
> 
> So I think we just need to make sure that the tooltip appears when hovering over the utilization bar in the GPU column.


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
