### PR TITLE
[data] Remove TestStreamOutputBackpressurePolicy.test_e2e_backpressure

### DIFF
--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -360,24 +360,6 @@ class TestStreamOutputBackpressurePolicy(unittest.TestCase):
             [row["consumer_timestamp"] for row in res],
         )
 
-    def test_e2e_backpressure(self):
-        producer_timestamps, consumer_timestamps = self._run_dataset(
-            producer_num_cpus=1, consumer_num_cpus=2
-        )
-        # We can buffer at most 2 blocks.
-        # Thus the producer should be backpressured after producing 2 blocks.
-        # Note, although block 2 is backpressured, producer_timestamps[2] has
-        # been generated before the backpressure.
-        # Thus producer_timestamps[2] < consumer_timestamps[0].
-        # For block 3, it should be generated after the first consumer task
-        # is scheduled. But there is a delay between the consumer task is scheduled
-        # and the consumer task starts to run. Thus the order of
-        # producer_timestamps[3] and consumer_timestamps[0] is not deterministic.
-        # To avoid flakiness, we check consumer_timestamps[0] < producer_timestamps[4].
-        assert (
-            producer_timestamps[2] < consumer_timestamps[0] < producer_timestamps[4]
-        ), (producer_timestamps, consumer_timestamps)
-
     def test_no_deadlock(self):
         # The producer needs all 5 CPUs, and the consumer has no CPU to run.
         # In this case, we shouldn't backpressure the producer and let it run


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This test is flaky. The purpose of this test is to check that the producer will pause stop producing blocks after block 2 is generated and before block 0 is taken by the consumer. However it's hard to collect the timestamps for some events that happen in Data and Core internal. E.g., the time when an object is taken at the streaming generator level. We used the consumer task timestamp as an approximation. But the test is still flaky on some slow machines where the task can take long time to get started after being scheduled. 

Remove this flaky test as we already have another e2e backpressure test `test_large_e2e_backpressure`, which will check the amount of spilling data. 


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
