### PR TITLE
[Serve] Enable `serve status` when proxies disabled

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -54,7 +54,7 @@ from ray.serve._private.utils import (
     get_all_live_placement_group_names,
     get_head_node_id,
 )
-from ray.serve.config import HTTPOptions, gRPCOptions, ProxyLocation
+from ray.serve.config import HTTPOptions, ProxyLocation, gRPCOptions
 from ray.serve.generated.serve_pb2 import (
     ActorNameList,
     DeploymentArgs,
@@ -930,7 +930,8 @@ class ServeController:
         http_options = HTTPOptionsSchema.parse_obj(http_config.dict(exclude_unset=True))
         grpc_options = gRPCOptionsSchema.parse_obj(grpc_config.dict(exclude_unset=True))
         proxy_location = (
-            None if http_config.location is None
+            None
+            if http_config.location is None
             else ProxyLocation._from_deployment_mode(http_config.location)
         )
         return ServeInstanceDetails(

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -54,7 +54,7 @@ from ray.serve._private.utils import (
     get_all_live_placement_group_names,
     get_head_node_id,
 )
-from ray.serve.config import HTTPOptions, gRPCOptions
+from ray.serve.config import HTTPOptions, gRPCOptions, ProxyLocation
 from ray.serve.generated.serve_pb2 import (
     ActorNameList,
     DeploymentArgs,
@@ -929,10 +929,14 @@ class ServeController:
         # Eventually we want to remove route_prefix from DeploymentSchema.
         http_options = HTTPOptionsSchema.parse_obj(http_config.dict(exclude_unset=True))
         grpc_options = gRPCOptionsSchema.parse_obj(grpc_config.dict(exclude_unset=True))
+        proxy_location = (
+            None if http_config.location is None
+            else ProxyLocation._from_deployment_mode(http_config.location)
+        )
         return ServeInstanceDetails(
             target_capacity=self._target_capacity,
             controller_info=self._actor_details,
-            proxy_location=http_config.location,
+            proxy_location=proxy_location,
             http_options=http_options,
             grpc_options=grpc_options,
             proxies=self.proxy_state_manager.get_proxy_details()

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -929,15 +929,10 @@ class ServeController:
         # Eventually we want to remove route_prefix from DeploymentSchema.
         http_options = HTTPOptionsSchema.parse_obj(http_config.dict(exclude_unset=True))
         grpc_options = gRPCOptionsSchema.parse_obj(grpc_config.dict(exclude_unset=True))
-        proxy_location = (
-            None
-            if http_config.location is None
-            else ProxyLocation._from_deployment_mode(http_config.location)
-        )
         return ServeInstanceDetails(
             target_capacity=self._target_capacity,
             controller_info=self._actor_details,
-            proxy_location=proxy_location,
+            proxy_location=ProxyLocation._from_deployment_mode(http_config.location),
             http_options=http_options,
             grpc_options=grpc_options,
             proxies=self.proxy_state_manager.get_proxy_details()

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -150,17 +150,30 @@ class ProxyLocation(str, Enum):
     EveryNode = "EveryNode"
 
     @classmethod
-    def _to_deployment_mode(cls, v: Union["ProxyLocation", str]) -> DeploymentMode:
-        if not isinstance(v, (cls, str)):
-            raise TypeError(f"Must be a `ProxyLocation` or str, got: {type(v)}.")
-        elif v == ProxyLocation.Disabled:
+    def _to_deployment_mode(cls, proxy_location: Union["ProxyLocation", str]) -> DeploymentMode:
+        if isinstance(proxy_location, str):
+            proxy_location = ProxyLocation(proxy_location)
+        elif not isinstance(proxy_location, ProxyLocation):
+            raise TypeError(f"Must be a `ProxyLocation` or str, got: {type(proxy_location)}.") 
+        
+        if proxy_location == ProxyLocation.Disabled:
             return DeploymentMode.NoServer
-        elif v == ProxyLocation.HeadOnly:
-            return DeploymentMode.HeadOnly
-        elif v == ProxyLocation.EveryNode:
-            return DeploymentMode.EveryNode
         else:
-            raise ValueError(f"Unrecognized `ProxyLocation`: {v}.")
+            return DeploymentMode(proxy_location.value)
+    
+    @classmethod
+    def _from_deployment_mode(cls, deployment_mode: Union[DeploymentMode, str]) -> "ProxyLocation":
+        if isinstance(deployment_mode, str):
+            deployment_mode = DeploymentMode(deployment_mode)
+        elif not isinstance(deployment_mode, DeploymentMode):
+            raise TypeError(
+                f"Must be a `DeploymentMode` or str, got: {type(deployment_mode)}."
+            )
+
+        if deployment_mode == DeploymentMode.NoServer:
+            return ProxyLocation.Disabled
+        else:
+            return ProxyLocation(deployment_mode.value)
 
 
 @PublicAPI(stability="stable")

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -150,19 +150,25 @@ class ProxyLocation(str, Enum):
     EveryNode = "EveryNode"
 
     @classmethod
-    def _to_deployment_mode(cls, proxy_location: Union["ProxyLocation", str]) -> DeploymentMode:
+    def _to_deployment_mode(
+        cls, proxy_location: Union["ProxyLocation", str]
+    ) -> DeploymentMode:
         if isinstance(proxy_location, str):
             proxy_location = ProxyLocation(proxy_location)
         elif not isinstance(proxy_location, ProxyLocation):
-            raise TypeError(f"Must be a `ProxyLocation` or str, got: {type(proxy_location)}.") 
-        
+            raise TypeError(
+                f"Must be a `ProxyLocation` or str, got: {type(proxy_location)}."
+            )
+
         if proxy_location == ProxyLocation.Disabled:
             return DeploymentMode.NoServer
         else:
             return DeploymentMode(proxy_location.value)
-    
+
     @classmethod
-    def _from_deployment_mode(cls, deployment_mode: Union[DeploymentMode, str]) -> "ProxyLocation":
+    def _from_deployment_mode(
+        cls, deployment_mode: Union[DeploymentMode, str]
+    ) -> "ProxyLocation":
         if isinstance(deployment_mode, str):
             deployment_mode = DeploymentMode(deployment_mode)
         elif not isinstance(deployment_mode, DeploymentMode):

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -167,9 +167,17 @@ class ProxyLocation(str, Enum):
 
     @classmethod
     def _from_deployment_mode(
-        cls, deployment_mode: Union[DeploymentMode, str]
-    ) -> "ProxyLocation":
-        if isinstance(deployment_mode, str):
+        cls, deployment_mode: Optional[Union[DeploymentMode, str]]
+    ) -> Optional["ProxyLocation"]:
+        """Converts DeploymentMode enum into ProxyLocation enum.
+
+        DeploymentMode is a deprecated version of ProxyLocation that's still
+        used internally throughout Serve.
+        """
+
+        if deployment_mode is None:
+            return None
+        elif isinstance(deployment_mode, str):
             deployment_mode = DeploymentMode(deployment_mode)
         elif not isinstance(deployment_mode, DeploymentMode):
             raise TypeError(

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -545,6 +545,31 @@ def test_proxy_location_to_deployment_mode():
         ProxyLocation._to_deployment_mode({"some_other_obj"})
 
 
+def test_deployment_mode_to_proxy_location():
+    assert (
+        ProxyLocation._from_deployment_mode(DeploymentMode.NoServer)
+        == ProxyLocation.Disabled
+    )
+    assert (
+        ProxyLocation._from_deployment_mode(DeploymentMode.HeadOnly)
+        == ProxyLocation.HeadOnly
+    )
+    assert (
+        ProxyLocation._from_deployment_mode(DeploymentMode.EveryNode)
+        == ProxyLocation.EveryNode
+    )
+
+    assert ProxyLocation._from_deployment_mode("NoServer") == ProxyLocation.Disabled
+    assert ProxyLocation._from_deployment_mode("HeadOnly") == ProxyLocation.HeadOnly
+    assert ProxyLocation._from_deployment_mode("EveryNode") == ProxyLocation.EveryNode
+
+    with pytest.raises(ValueError):
+        ProxyLocation._from_deployment_mode("Unknown")
+
+    with pytest.raises(TypeError):
+        ProxyLocation._from_deployment_mode({"some_other_obj"})
+
+
 @pytest.mark.parametrize(
     "policy", [None, fake_policy, "ray.serve.tests.unit.test_config:fake_policy"]
 )

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -546,6 +546,8 @@ def test_proxy_location_to_deployment_mode():
 
 
 def test_deployment_mode_to_proxy_location():
+    assert ProxyLocation._from_deployment_mode(None) is None
+
     assert (
         ProxyLocation._from_deployment_mode(DeploymentMode.NoServer)
         == ProxyLocation.Disabled


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Serve proxies can be disabled by setting `serve.start(..., proxy_location=ProxyLocation.Disabled)`. However, `serve status` currently fails when proxies are disabled.

This change fixes the issue and lets `serve status` succeed even when `proxy_location==ProxyLocation.Disabled`.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #41723.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds a unit test to `test_config.py`.
