### PR TITLE
[ci] revert macos back to python 3.8

### DIFF
--- a/.buildkite/pipeline.macos.yml
+++ b/.buildkite/pipeline.macos.yml
@@ -4,7 +4,7 @@ common: &common
   env:
     BUILDKITE: "true"
     CI: "true"
-    PYTHON: "3.9"
+    PYTHON: "3.8"
     RAY_USE_RANDOM_PORTS: "1"
     RAY_DEFAULT_BUILD: "1"
     LC_ALL: en_US.UTF-8
@@ -92,7 +92,7 @@ steps:
     - export MAC_JARS=1
     - export RAY_INSTALL_JAVA=1
     - export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1
-    - export PYTHON=3.9
+    - export PYTHON=3.8
     - . ./ci/ci.sh init && source ~/.zshenv
     - ./ci/ci.sh build
     # Test wheels

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -3,7 +3,7 @@
 set -ex
 
 export CI="true"
-export PYTHON="3.9"
+export PYTHON="3.8"
 export RAY_USE_RANDOM_PORTS="1"
 export RAY_DEFAULT_BUILD="1"
 export LC_ALL="en_US.UTF-8"


### PR DESCRIPTION
Revert macos back to python 3.8

Test:
- CI