### PR TITLE
[runtime-env] automatically infer worker path when starting worker in container

### DIFF
--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -72,7 +72,6 @@ class RuntimeEnvContext:
         # However, the path to default_worker.py inside the container
         # can be different. We need the user to specify the path to
         # default_worker.py inside the container.
-        # default_worker_path = self.container.get("worker_path")
         if self.override_worker_entrypoint:
             logger.debug(
                 f"Changing the worker entrypoint from {passthrough_args[0]} to "

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -4,20 +4,40 @@ from typing import List, Optional
 
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray._private.runtime_env.utils import check_output_cmd
 
 default_logger = logging.getLogger(__name__)
 
 
+async def _create_impl(image_uri: str, logger: logging.Logger):
+    # Pull image if it doesn't exist
+    # Also get path to `default_worker.py` inside the image.
+    pull_image_cmd = [
+        "podman",
+        "run",
+        "--rm",
+        image_uri,
+        "python",
+        "-c",
+        (
+            "import ray._private.workers.default_worker as default_worker; "
+            "print(default_worker.__file__)"
+        ),
+    ]
+    logger.info("Pulling image %s", image_uri)
+    worker_path = await check_output_cmd(pull_image_cmd, logger=logger)
+    return worker_path.strip()
+
+
 def _modify_context_impl(
     image_uri: str,
+    worker_path: str,
     run_options: Optional[List[str]],
-    worker_path: Optional[str],
     context: RuntimeEnvContext,
     logger: logging.Logger,
     ray_tmp_dir: str,
 ):
-    if worker_path:
-        context.override_worker_entrypoint = worker_path
+    context.override_worker_entrypoint = worker_path
 
     container_driver = "podman"
     container_command = [
@@ -81,6 +101,18 @@ class ImageURIPlugin(RuntimeEnvPlugin):
     def __init__(self, ray_tmp_dir: str):
         self._ray_tmp_dir = ray_tmp_dir
 
+    async def create(
+        self,
+        uri: Optional[str],
+        runtime_env: "RuntimeEnv",  # noqa: F821
+        context: RuntimeEnvContext,
+        logger: logging.Logger,
+    ) -> float:
+        if not runtime_env.image_uri():
+            return
+
+        self.worker_path = await _create_impl(runtime_env.image_uri(), logger)
+
     def modify_context(
         self,
         uris: List[str],
@@ -92,7 +124,12 @@ class ImageURIPlugin(RuntimeEnvPlugin):
             return
 
         _modify_context_impl(
-            runtime_env.image_uri(), [], None, context, logger, self._ray_tmp_dir
+            runtime_env.image_uri(),
+            self.worker_path,
+            [],
+            context,
+            logger,
+            self._ray_tmp_dir,
         )
 
 
@@ -104,6 +141,18 @@ class ContainerPlugin(RuntimeEnvPlugin):
     def __init__(self, ray_tmp_dir: str):
         self._ray_tmp_dir = ray_tmp_dir
 
+    async def create(
+        self,
+        uri: Optional[str],
+        runtime_env: "RuntimeEnv",  # noqa: F821
+        context: RuntimeEnvContext,
+        logger: logging.Logger,
+    ) -> float:
+        if not runtime_env.has_py_container() or not runtime_env.py_container_image():
+            return
+
+        self.worker_path = await _create_impl(runtime_env.py_container_image(), logger)
+
     def modify_context(
         self,
         uris: List[str],
@@ -114,10 +163,18 @@ class ContainerPlugin(RuntimeEnvPlugin):
         if not runtime_env.has_py_container() or not runtime_env.py_container_image():
             return
 
+        if runtime_env.py_container_worker_path():
+            logger.warning(
+                "You are using `container.worker_path`, but the path to "
+                "`default_worker.py` is now automatically detected from the image. "
+                "`container.worker_path` is deprecated and will be removed in future "
+                "versions."
+            )
+
         _modify_context_impl(
             runtime_env.py_container_image(),
+            runtime_env.py_container_worker_path() or self.worker_path,
             runtime_env.py_container_run_options(),
-            runtime_env.py_container_worker_path(),
             context,
             logger,
             self._ray_tmp_dir,

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -2184,14 +2184,6 @@ def skip_flaky_core_test_premerge(reason: str):
     return wrapper
 
 
-def get_ray_default_worker_file_path():
-    py_version = f"{sys.version_info[0]}.{sys.version_info[1]}"
-    return (
-        f"/home/ray/anaconda3/lib/python{py_version}/"
-        "site-packages/ray/_private/workers/default_worker.py"
-    )
-
-
 def close_common_connections(pid):
     """
     Closes ipv4 connections between the current process and another process specified by

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -211,7 +211,6 @@ class RuntimeEnv(dict):
         # Example for using container
         RuntimeEnv(
             container={"image": "anyscale/ray-ml:nightly-py38-cpu",
-            "worker_path": "/root/python/ray/_private/workers/default_worker.py",
             "run_options": ["--cap-drop SYS_ADMIN","--log-level=debug"]})
 
         # Example for set env_vars
@@ -250,7 +249,6 @@ class RuntimeEnv(dict):
             https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually
         container: Require a given (Docker) container image,
             The Ray worker process will run in a container with this image.
-            The `worker_path` is the default_worker.py path.
             The `run_options` list spec is here:
             https://docs.docker.com/engine/reference/run/
         env_vars: Environment variables to set.

--- a/python/ray/tests/runtime_env_container/test_log_file_exists.py
+++ b/python/ray/tests/runtime_env_container/test_log_file_exists.py
@@ -2,7 +2,7 @@ import ray
 from pathlib import Path
 import re
 from ray.util.state import list_tasks
-from ray._private.test_utils import wait_for_condition, get_ray_default_worker_file_path
+from ray._private.test_utils import wait_for_condition
 import argparse
 
 parser = argparse.ArgumentParser()
@@ -13,8 +13,6 @@ parser.add_argument(
     help="Whether to use the new `image_uri` API instead of the old `container` API.",
 )
 args = parser.parse_args()
-
-worker_pth = get_ray_default_worker_file_path()
 
 ray.init(num_cpus=1)
 
@@ -35,7 +33,7 @@ def task_finished():
 if args.use_image_uri_api:
     runtime_env = {"image_uri": args.image}
 else:
-    runtime_env = {"container": {"image": args.image, "worker_path": worker_pth}}
+    runtime_env = {"container": {"image": args.image}}
 
 
 # Run a basic workload.

--- a/python/ray/tests/runtime_env_container/test_put_get.py
+++ b/python/ray/tests/runtime_env_container/test_put_get.py
@@ -1,7 +1,6 @@
 import ray
 import numpy as np
 import argparse
-from ray._private.test_utils import get_ray_default_worker_file_path
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--image", type=str, help="The docker image to use for Ray worker")
@@ -12,13 +11,11 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-worker_pth = get_ray_default_worker_file_path()
-
 
 if args.use_image_uri_api:
     runtime_env = {"image_uri": args.image}
 else:
-    runtime_env = {"container": {"image": args.image, "worker_path": worker_pth}}
+    runtime_env = {"container": {"image": args.image}}
 
 
 @ray.remote(runtime_env=runtime_env)

--- a/python/ray/tests/runtime_env_container/test_ray_env_vars.py
+++ b/python/ray/tests/runtime_env_container/test_ray_env_vars.py
@@ -2,7 +2,6 @@ import argparse
 import os
 
 import ray
-from ray._private.test_utils import get_ray_default_worker_file_path
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--image", type=str, help="The docker image to use for Ray worker")
@@ -13,13 +12,11 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-worker_pth = get_ray_default_worker_file_path()
-
 
 if args.use_image_uri_api:
     runtime_env = {"image_uri": args.image}
 else:
-    runtime_env = {"container": {"image": args.image, "worker_path": worker_pth}}
+    runtime_env = {"container": {"image": args.image}}
 
 
 @ray.remote(runtime_env=runtime_env)

--- a/python/ray/tests/runtime_env_container/test_serve_basic.py
+++ b/python/ray/tests/runtime_env_container/test_serve_basic.py
@@ -1,6 +1,6 @@
 import argparse
 from ray import serve
-from ray._private.test_utils import wait_for_condition, get_ray_default_worker_file_path
+from ray._private.test_utils import wait_for_condition
 from ray.serve.handle import DeploymentHandle
 
 parser = argparse.ArgumentParser()
@@ -12,12 +12,10 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-WORKER_PATH = get_ray_default_worker_file_path()
-
 if args.use_image_uri_api:
     runtime_env = {"image_uri": args.image}
 else:
-    runtime_env = {"container": {"image": args.image, "worker_path": WORKER_PATH}}
+    runtime_env = {"container": {"image": args.image}}
 
 
 @serve.deployment(ray_actor_options={"runtime_env": runtime_env})

--- a/python/ray/tests/runtime_env_container/test_serve_telemetry.py
+++ b/python/ray/tests/runtime_env_container/test_serve_telemetry.py
@@ -4,7 +4,7 @@ import subprocess
 
 import ray
 from ray import serve
-from ray._private.test_utils import wait_for_condition, get_ray_default_worker_file_path
+from ray._private.test_utils import wait_for_condition
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve.context import _get_global_client
 from ray.serve.schema import ServeDeploySchema
@@ -23,7 +23,6 @@ parser.add_argument(
 )
 parser.add_argument("--image", type=str, help="The docker image to use for Ray worker")
 args = parser.parse_args()
-worker_pth = get_ray_default_worker_file_path()
 
 os.environ["RAY_USAGE_STATS_ENABLED"] = "1"
 os.environ["RAY_USAGE_STATS_REPORT_URL"] = "http://127.0.0.1:8000/telemetry"
@@ -33,7 +32,7 @@ os.environ["RAY_USAGE_STATS_REPORT_INTERVAL_S"] = "1"
 if args.use_image_uri_api:
     runtime_env = {"image_uri": args.image}
 else:
-    runtime_env = {"container": {"image": args.image, "worker_path": worker_pth}}
+    runtime_env = {"container": {"image": args.image}}
 
 
 def check_app(app_name: str, expected: str):

--- a/python/ray/tests/runtime_env_container/test_shared_memory.py
+++ b/python/ray/tests/runtime_env_container/test_shared_memory.py
@@ -3,7 +3,6 @@ import numpy as np
 import sys
 import argparse
 
-from ray._private.test_utils import get_ray_default_worker_file_path
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--image", type=str, help="The docker image to use for Ray worker")
@@ -14,12 +13,10 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-worker_pth = get_ray_default_worker_file_path()
-
 if args.use_image_uri_api:
     runtime_env = {"image_uri": args.image}
 else:
-    runtime_env = {"container": {"image": args.image, "worker_path": worker_pth}}
+    runtime_env = {"container": {"image": args.image}}
 
 
 @ray.remote(runtime_env=runtime_env)

--- a/python/ray/tests/runtime_env_container/test_worker_exit_intended_system_exit_and_user_error.py
+++ b/python/ray/tests/runtime_env_container/test_worker_exit_intended_system_exit_and_user_error.py
@@ -5,7 +5,7 @@ import argparse
 import ray
 from ray._private.state_api_test_utils import verify_failed_task
 from ray.util.state import list_workers
-from ray._private.test_utils import wait_for_condition, get_ray_default_worker_file_path
+from ray._private.test_utils import wait_for_condition
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 parser = argparse.ArgumentParser()
@@ -17,12 +17,11 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-worker_pth = get_ray_default_worker_file_path()
 
 if args.use_image_uri_api:
     runtime_env = {"image_uri": args.image}
 else:
-    runtime_env = {"container": {"image": args.image, "worker_path": worker_pth}}
+    runtime_env = {"container": {"image": args.image}}
 
 ray.init(num_cpus=1)
 

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -940,7 +940,6 @@ def test_runtime_env_interface():
     # Test the interface related to container
     container_init = {
         "image": "anyscale/ray-ml:nightly-py38-cpu",
-        "worker_path": "/root/python/ray/_private/workers/default_worker.py",
         "run_options": ["--cap-drop SYS_ADMIN", "--log-level=debug"],
     }
     update_container = {"image": "test_modify"}
@@ -948,7 +947,6 @@ def test_runtime_env_interface():
     runtime_env_dict = runtime_env.to_dict()
     assert runtime_env.has_py_container()
     assert runtime_env.py_container_image() == container_init["image"]
-    assert runtime_env.py_container_worker_path() == container_init["worker_path"]
     assert runtime_env.py_container_run_options() == container_init["run_options"]
     runtime_env["container"].update(update_container)
     runtime_env_dict["container"].update(update_container)
@@ -957,7 +955,6 @@ def test_runtime_env_interface():
     assert runtime_env_dict == runtime_env.to_dict()
     assert runtime_env.has_py_container()
     assert runtime_env.py_container_image() == container_copy["image"]
-    assert runtime_env.py_container_worker_path() == container_copy["worker_path"]
     assert runtime_env.py_container_run_options() == container_copy["run_options"]
 
     runtime_env.pop("container")


### PR DESCRIPTION
[runtime-env] automatically infer worker path when starting worker in container

Instead of requiring user provide the path to `default_worker.py` in the container, which is bad UX, we should be able to automatically detect where it is. During runtime environment setup, pull the image ahead of time and run a python command to import `ray._private.workers.default_worker` and get its file path.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
