### PR TITLE
[Release] Add 2.9.1 release logs for commit b2d50b

### DIFF
--- a/release/release_logs/2.9.1/benchmarks/many_actors.json
+++ b/release/release_logs/2.9.1/benchmarks/many_actors.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 453.431296,
+    "_dashboard_test_success": true,
+    "_peak_memory": 5.73,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.64GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1166\t0.89GiB\tpython distributed/test_many_actors.py\n266\t0.44GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n428\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n1316\t0.07GiB\tray::DashboardTester.run\n986\t0.07GiB\tray::JobSupervisor\n426\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n585\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1226\t0.06GiB\tray::MemoryMonitorActor.run\n367\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/log_m",
+    "actors_per_second": 637.164609708907,
+    "num_actors": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "actors_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 637.164609708907
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 16.532
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3827.804
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4462.651
+        }
+    ],
+    "success": "1",
+    "time": 15.694531440734863
+}

--- a/release/release_logs/2.9.1/benchmarks/many_nodes.json
+++ b/release/release_logs/2.9.1/benchmarks/many_nodes.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 188.1088,
+    "_dashboard_test_success": true,
+    "_peak_memory": 13.42,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.51GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n965\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n266\t0.16GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n1165\t0.08GiB\tray::StateAPIGeneratorActor.start\n425\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n785\t0.07GiB\tray::JobSupervisor\n423\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n578\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1025\t0.06GiB\tray::MemoryMonitorActor.run\n1113\t0.06GiB\tray::DashboardTester.run",
+    "num_tasks": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 329.0778352327688
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4.357
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 63.529
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 170.095
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 329.0778352327688,
+    "time": 303.03879475593567,
+    "used_cpus": 250.0
+}

--- a/release/release_logs/2.9.1/benchmarks/many_tasks.json
+++ b/release/release_logs/2.9.1/benchmarks/many_tasks.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 583.258112,
+    "_dashboard_test_success": true,
+    "_peak_memory": 15.26,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.18GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n803\t0.72GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n266\t0.71GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n1066\t0.08GiB\tray::StateAPIGeneratorActor.start\n428\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n998\t0.07GiB\tray::DashboardTester.run\n622\t0.07GiB\tray::JobSupervisor\n426\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n585\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n926\t0.06GiB\tray::MemoryMonitorActor.run",
+    "num_tasks": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 602.1326065772118
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2500.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 6.57
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 7081.234
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 12026.394
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 602.1326065772118,
+    "time": 316.6076374053955,
+    "used_cpus": 2500.0
+}

--- a/release/release_logs/2.9.1/microbenchmark.json
+++ b/release/release_logs/2.9.1/microbenchmark.json
@@ -1,0 +1,283 @@
+{
+    "1_1_actor_calls_async": [
+        8893.774429553452,
+        188.24082201492956
+    ],
+    "1_1_actor_calls_concurrent": [
+        5341.269962232736,
+        213.32205245023562
+    ],
+    "1_1_actor_calls_sync": [
+        2027.2170609355023,
+        32.822857269204626
+    ],
+    "1_1_async_actor_calls_async": [
+        3271.440337578971,
+        56.78964676999986
+    ],
+    "1_1_async_actor_calls_sync": [
+        1347.4950703661839,
+        10.381062549245799
+    ],
+    "1_1_async_actor_calls_with_args_async": [
+        2462.0238109378256,
+        96.25594168501775
+    ],
+    "1_n_actor_calls_async": [
+        8678.70171915089,
+        100.59530061738451
+    ],
+    "1_n_async_actor_calls_async": [
+        7721.014844123292,
+        159.4019993885159
+    ],
+    "client__1_1_actor_calls_async": [
+        1025.1288696984304,
+        12.183779934662013
+    ],
+    "client__1_1_actor_calls_concurrent": [
+        1012.596725233742,
+        8.988958508703112
+    ],
+    "client__1_1_actor_calls_sync": [
+        528.8310578685707,
+        11.453549170022413
+    ],
+    "client__get_calls": [
+        1106.302302475376,
+        57.77599797101417
+    ],
+    "client__put_calls": [
+        820.9753277731347,
+        16.962334647585465
+    ],
+    "client__put_gigabytes": [
+        0.12685006511870062,
+        0.002781706222337644
+    ],
+    "client__tasks_and_get_batch": [
+        0.8962128050676432,
+        0.052919365385292745
+    ],
+    "client__tasks_and_put_batch": [
+        11437.82677765297,
+        115.0629133496417
+    ],
+    "multi_client_put_calls_Plasma_Store": [
+        12540.397229728096,
+        122.14917381452236
+    ],
+    "multi_client_put_gigabytes": [
+        31.61822342467306,
+        1.9468683851353286
+    ],
+    "multi_client_tasks_async": [
+        23719.66327537073,
+        717.1769113833857
+    ],
+    "n_n_actor_calls_async": [
+        26673.745813547583,
+        640.7840849664005
+    ],
+    "n_n_actor_calls_with_arg_async": [
+        2789.469231454511,
+        29.07309055052719
+    ],
+    "n_n_async_actor_calls_async": [
+        22548.690692568587,
+        727.382398453557
+    ],
+    "perf_metrics": [
+        {
+            "perf_metric_name": "single_client_get_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8759.005330034825
+        },
+        {
+            "perf_metric_name": "single_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5553.826073156352
+        },
+        {
+            "perf_metric_name": "multi_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 12540.397229728096
+        },
+        {
+            "perf_metric_name": "single_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 18.524555152850073
+        },
+        {
+            "perf_metric_name": "single_client_tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8.309152473588654
+        },
+        {
+            "perf_metric_name": "multi_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 31.61822342467306
+        },
+        {
+            "perf_metric_name": "single_client_get_object_containing_10k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 12.750227454563198
+        },
+        {
+            "perf_metric_name": "single_client_wait_1k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5.428138252129144
+        },
+        {
+            "perf_metric_name": "single_client_tasks_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1026.643476301354
+        },
+        {
+            "perf_metric_name": "single_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8506.380971293862
+        },
+        {
+            "perf_metric_name": "multi_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 23719.66327537073
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2027.2170609355023
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8893.774429553452
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5341.269962232736
+        },
+        {
+            "perf_metric_name": "1_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8678.70171915089
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 26673.745813547583
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_with_arg_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2789.469231454511
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1347.4950703661839
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 3271.440337578971
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_with_args_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2462.0238109378256
+        },
+        {
+            "perf_metric_name": "1_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 7721.014844123292
+        },
+        {
+            "perf_metric_name": "n_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 22548.690692568587
+        },
+        {
+            "perf_metric_name": "placement_group_create/removal",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 842.9977659421876
+        },
+        {
+            "perf_metric_name": "client__get_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1106.302302475376
+        },
+        {
+            "perf_metric_name": "client__put_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 820.9753277731347
+        },
+        {
+            "perf_metric_name": "client__put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.12685006511870062
+        },
+        {
+            "perf_metric_name": "client__tasks_and_put_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 11437.82677765297
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 528.8310578685707
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1025.1288696984304
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1012.596725233742
+        },
+        {
+            "perf_metric_name": "client__tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.8962128050676432
+        }
+    ],
+    "placement_group_create/removal": [
+        842.9977659421876,
+        3.143082288661882
+    ],
+    "single_client_get_calls_Plasma_Store": [
+        8759.005330034825,
+        1221.975306787145
+    ],
+    "single_client_get_object_containing_10k_refs": [
+        12.750227454563198,
+        0.07109473871398135
+    ],
+    "single_client_put_calls_Plasma_Store": [
+        5553.826073156352,
+        24.565617400276945
+    ],
+    "single_client_put_gigabytes": [
+        18.524555152850073,
+        5.2470892495065105
+    ],
+    "single_client_tasks_and_get_batch": [
+        8.309152473588654,
+        0.47378924576560916
+    ],
+    "single_client_tasks_async": [
+        8506.380971293862,
+        323.22786958392606
+    ],
+    "single_client_tasks_sync": [
+        1026.643476301354,
+        17.56103940975842
+    ],
+    "single_client_wait_1k_refs": [
+        5.428138252129144,
+        0.11066358617971674
+    ]
+}

--- a/release/release_logs/2.9.1/scalability/object_store.json
+++ b/release/release_logs/2.9.1/scalability/object_store.json
@@ -1,0 +1,13 @@
+{
+    "broadcast_time": 82.62057669799992,
+    "num_nodes": 50,
+    "object_size": 1073741824,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 82.62057669799992
+        }
+    ],
+    "success": "1"
+}

--- a/release/release_logs/2.9.1/scalability/single_node.json
+++ b/release/release_logs/2.9.1/scalability/single_node.json
@@ -1,0 +1,40 @@
+{
+    "args_time": 17.335877245000006,
+    "get_time": 24.582241897000003,
+    "large_object_size": 107374182400,
+    "large_object_time": 29.51348918299999,
+    "num_args": 10000,
+    "num_get_args": 10000,
+    "num_queued": 1000000,
+    "num_returns": 3000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "10000_args_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 17.335877245000006
+        },
+        {
+            "perf_metric_name": "3000_returns_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 5.986532734999997
+        },
+        {
+            "perf_metric_name": "10000_get_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 24.582241897000003
+        },
+        {
+            "perf_metric_name": "1000000_queued_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 186.033770544
+        },
+        {
+            "perf_metric_name": "107374182400_large_object_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 29.51348918299999
+        }
+    ],
+    "queued_time": 186.033770544,
+    "returns_time": 5.986532734999997,
+    "success": "1"
+}

--- a/release/release_logs/2.9.1/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.9.1/stress_tests/stress_test_dead_actors.json
@@ -1,0 +1,14 @@
+{
+    "avg_iteration_time": 1.5158571934700011,
+    "max_iteration_time": 4.122779369354248,
+    "min_iteration_time": 0.7777400016784668,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1.5158571934700011
+        }
+    ],
+    "success": 1,
+    "total_time": 151.58593797683716
+}

--- a/release/release_logs/2.9.1/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.9.1/stress_tests/stress_test_many_tasks.json
@@ -1,0 +1,47 @@
+{
+    "perf_metrics": [
+        {
+            "perf_metric_name": "stage_0_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 12.316547632217407
+        },
+        {
+            "perf_metric_name": "stage_1_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 23.82839834690094
+        },
+        {
+            "perf_metric_name": "stage_2_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 71.04048314094544
+        },
+        {
+            "perf_metric_name": "stage_3_creation_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2.1129021644592285
+        },
+        {
+            "perf_metric_name": "stage_3_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3254.6724829673767
+        },
+        {
+            "perf_metric_name": "stage_4_spread",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.653275216465358
+        }
+    ],
+    "stage_0_time": 12.316547632217407,
+    "stage_1_avg_iteration_time": 23.82839834690094,
+    "stage_1_max_iteration_time": 27.290878772735596,
+    "stage_1_min_iteration_time": 22.4323091506958,
+    "stage_1_time": 238.2840645313263,
+    "stage_2_avg_iteration_time": 71.04048314094544,
+    "stage_2_max_iteration_time": 125.15896534919739,
+    "stage_2_min_iteration_time": 54.33980369567871,
+    "stage_2_time": 355.2037703990936,
+    "stage_3_creation_time": 2.1129021644592285,
+    "stage_3_time": 3254.6724829673767,
+    "stage_4_spread": 0.653275216465358,
+    "success": 1
+}

--- a/release/release_logs/2.9.1/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.9.1/stress_tests/stress_test_placement_group.json
@@ -1,0 +1,17 @@
+{
+    "avg_pg_create_time_ms": 0.8915424159152262,
+    "avg_pg_remove_time_ms": 0.8945640930936268,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_pg_create_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.8915424159152262
+        },
+        {
+            "perf_metric_name": "avg_pg_remove_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.8945640930936268
+        }
+    ],
+    "success": 1
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Adds release logs from commit b2d50b87a5fb9f1db157e9bc33329d769fda13d2.


Output of `compare_perf_metrics 2.9.0 2.9.1`:

```
REGRESSION 17.96%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10676.942537676008 to 8759.005330034825 (17.96%) in 2.9.1/microbenchmark.json
REGRESSION 10.24%: single_client_put_gigabytes (THROUGHPUT) regresses from 20.6372354079233 to 18.524555152850073 (10.24%) in 2.9.1/microbenchmark.json
REGRESSION 4.74%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9407620914250454 to 0.8962128050676432 (4.74%) in 2.9.1/microbenchmark.json
REGRESSION 3.45%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12988.08350923366 to 12540.397229728096 (3.45%) in 2.9.1/microbenchmark.json
REGRESSION 2.76%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.112230033151658 to 12.750227454563198 (2.76%) in 2.9.1/microbenchmark.json
REGRESSION 2.45%: multi_client_tasks_async (THROUGHPUT) regresses from 24316.337428119852 to 23719.66327537073 (2.45%) in 2.9.1/microbenchmark.json
REGRESSION 2.34%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23089.526825423094 to 22548.690692568587 (2.34%) in 2.9.1/microbenchmark.json
REGRESSION 2.31%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2075.2443816745968 to 2027.2170609355023 (2.31%) in 2.9.1/microbenchmark.json
REGRESSION 1.48%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 3320.575179316923 to 3271.440337578971 (1.48%) in 2.9.1/microbenchmark.json
REGRESSION 1.43%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 8.429852592930626 to 8.309152473588654 (1.43%) in 2.9.1/microbenchmark.json
REGRESSION 1.24%: client__get_calls (THROUGHPUT) regresses from 1120.242286739544 to 1106.302302475376 (1.24%) in 2.9.1/microbenchmark.json
REGRESSION 0.33%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 530.5597986550025 to 528.8310578685707 (0.33%) in 2.9.1/microbenchmark.json
REGRESSION 0.33%: placement_group_create/removal (THROUGHPUT) regresses from 845.7511547073977 to 842.9977659421876 (0.33%) in 2.9.1/microbenchmark.json
REGRESSION 0.30%: client__tasks_and_put_batch (THROUGHPUT) regresses from 11472.04637188305 to 11437.82677765297 (0.30%) in 2.9.1/microbenchmark.json
REGRESSION 0.25%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5354.497412488227 to 5341.269962232736 (0.25%) in 2.9.1/microbenchmark.json
REGRESSION 0.24%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5567.259268000422 to 5553.826073156352 (0.24%) in 2.9.1/microbenchmark.json
REGRESSION 0.08%: n_n_actor_calls_async (THROUGHPUT) regresses from 26694.138600078164 to 26673.745813547583 (0.08%) in 2.9.1/microbenchmark.json
REGRESSION 48.95%: dashboard_p95_latency_ms (LATENCY) regresses from 2569.856 to 3827.804 (48.95%) in 2.9.1/benchmarks/many_actors.json
REGRESSION 23.98%: stage_2_avg_iteration_time (LATENCY) regresses from 57.301159954071046 to 71.04048314094544 (23.98%) in 2.9.1/stress_tests/stress_test_many_tasks.json
REGRESSION 19.57%: dashboard_p99_latency_ms (LATENCY) regresses from 10057.867 to 12026.394 (19.57%) in 2.9.1/benchmarks/many_tasks.json
REGRESSION 9.90%: dashboard_p50_latency_ms (LATENCY) regresses from 5.978 to 6.57 (9.90%) in 2.9.1/benchmarks/many_tasks.json
REGRESSION 9.70%: dashboard_p95_latency_ms (LATENCY) regresses from 6455.1 to 7081.234 (9.70%) in 2.9.1/benchmarks/many_tasks.json
REGRESSION 4.75%: avg_iteration_time (LATENCY) regresses from 1.4471865177154541 to 1.5158571934700011 (4.75%) in 2.9.1/stress_tests/stress_test_dead_actors.json
REGRESSION 1.33%: stage_4_spread (LATENCY) regresses from 0.6446957966039432 to 0.653275216465358 (1.33%) in 2.9.1/stress_tests/stress_test_many_tasks.json
REGRESSION 0.36%: stage_3_time (LATENCY) regresses from 3242.995056629181 to 3254.6724829673767 (0.36%) in 2.9.1/stress_tests/stress_test_many_tasks.json
REGRESSION 0.29%: 10000_get_time (LATENCY) regresses from 24.51010805099999 to 24.582241897000003 (0.29%) in 2.9.1/scalability/single_node.json
```

According to the release instructions:

> This script will catch regressions in perf_metrics, you still need to manually check other metrics (e.g. _peak_memory)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
