### PR TITLE
[Data] Fix local paths for file-based APIs

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -155,6 +155,15 @@ class FileBasedDatasource(Datasource):
         file_extensions: Optional[List[str]] = None,
     ):
         _check_pyarrow_version()
+
+        self._supports_distributed_reads = not _is_local_scheme(paths)
+        if not self._supports_distributed_reads and ray.util.client.ray.is_connected():
+            raise ValueError(
+                "Because you're using Ray Client, read tasks scheduled on the Ray "
+                "cluster can't access your local files. To fix this issue, store "
+                "files in cloud storage or a distributed filesystem like NFS."
+            )
+
         self._schema = schema
         self._open_stream_args = open_stream_args
         self._meta_provider = meta_provider
@@ -179,14 +188,6 @@ class FileBasedDatasource(Datasource):
             raise ValueError(
                 "None of the provided paths exist. "
                 "The 'ignore_missing_paths' field is set to True."
-            )
-
-        self._supports_distributed_reads = not _is_local_scheme(paths)
-        if not self._supports_distributed_reads and ray.util.client.ray.is_connected():
-            raise ValueError(
-                "Because you're using Ray Client, read tasks scheduled on the Ray "
-                "cluster can't access your local files. To fix this issue, store "
-                "files in cloud storage or a distributed filesystem like NFS."
             )
 
         if self._partition_filter is not None:

--- a/python/ray/data/tests/test_file_based_datasource.py
+++ b/python/ray/data/tests/test_file_based_datasource.py
@@ -35,6 +35,20 @@ def test_local_paths(ray_start_regular_shared, tmp_path):
     assert not datasource.supports_distributed_reads
 
 
+def test_local_paths_with_client_raises_error(ray_start_cluster_enabled, tmp_path):
+    ray_start_cluster_enabled.add_node(num_cpus=1)
+    ray_start_cluster_enabled.head_node._ray_params.ray_client_server_port = "10004"
+    ray_start_cluster_enabled.head_node.start_ray_client_server()
+    ray.init("ray://localhost:10004")
+
+    path = os.path.join(tmp_path, "test.txt")
+    with open(path, "w"):
+        pass
+
+    with pytest.raises(ValueError):
+        MockFileBasedDatasource(f"local://{path}")
+
+
 def test_include_paths(ray_start_regular_shared, tmp_path):
     path = os.path.join(tmp_path, "test.txt")
     with open(path, "w"):

--- a/python/ray/data/tests/test_file_based_datasource.py
+++ b/python/ray/data/tests/test_file_based_datasource.py
@@ -23,6 +23,18 @@ class MockFileBasedDatasource(FileBasedDatasource):
         yield builder.build()
 
 
+def test_local_paths(ray_start_regular_shared, tmp_path):
+    path = os.path.join(tmp_path, "test.txt")
+    with open(path, "w"):
+        pass
+
+    datasource = MockFileBasedDatasource(path)
+    assert datasource.supports_distributed_reads
+
+    datasource = MockFileBasedDatasource(f"local://{path}")
+    assert not datasource.supports_distributed_reads
+
+
 def test_include_paths(ray_start_regular_shared, tmp_path):
     path = os.path.join(tmp_path, "test.txt")
     with open(path, "w"):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you specify a path with the `local://` scheme (for example, `local:///tmp/image.png`), Ray Data should read files from the driver's node only. But, this isn't happening because of a bug in the `FileBasedDatasource` implementation. For information about the bug, see https://github.com/ray-project/ray/issues/42261.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/42261

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
