### PR TITLE
[bisect] fix bisect outcome parsing

### DIFF
--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -208,16 +208,20 @@ def _obtain_test_result(
             if commit in outcomes and len(outcomes[commit]) == run_per_commit:
                 continue
             for run in range(run_per_commit):
-                outcome = subprocess.check_output(
-                    [
-                        "buildkite-agent",
-                        "step",
-                        "get",
-                        "outcome",
-                        "--step",
-                        f"{commit}-{run}",
-                    ]
-                ).decode("utf-8")
+                outcome = (
+                    subprocess.check_output(
+                        [
+                            "buildkite-agent",
+                            "step",
+                            "get",
+                            "outcome",
+                            "--step",
+                            f"{commit}-{run}",
+                        ]
+                    )
+                    .decode("utf-8")
+                    .strip()
+                )
                 if not outcome:
                     continue
                 if commit not in outcomes:


### PR DESCRIPTION
Fix bisect outcome parsing. Since the buildkite stack ugprade, the buildkite-agent now returns a `\n` instead of empty string when the step is still running.

Test:
- CI
- Test: https://buildkite.com/ray-project/release-tests-bisect/builds/812#_