### PR TITLE
[ci] fix test update_from_s3 logic

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -199,7 +199,7 @@ class Test(dict):
 
     def update_from_s3(self) -> None:
         """
-        Update test object with data field from s3
+        Update test object with data fields that exist only on s3
         """
         try:
             data = (
@@ -215,7 +215,9 @@ class Test(dict):
         except ClientError as e:
             logger.warning(f"Failed to update data for {self.get_name()} from s3:  {e}")
             return
-        self.update(json.loads(data))
+        for key, value in json.loads(data).items():
+            if key not in self:
+                self[key] = value
 
     def get_state(self) -> TestState:
         """


### PR DESCRIPTION
Currently update_from_s3 will override all fields in the test object. When I write this function, I wanted it to update on field that the test object doesn't currently have yet (e.g. state, github_issue, etc.). Correct its logic to what I intended to do.

Test:
- CI