### PR TITLE
[ci][7up/2] remove python 3.8

### DIFF
--- a/.buildkite/_forge.aarch64.rayci.yml
+++ b/.buildkite/_forge.aarch64.rayci.yml
@@ -18,7 +18,6 @@ steps:
     matrix:
       setup:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -41,7 +40,6 @@ steps:
       - core_cpp
     wanda: ci/docker/ray.cpu.base.aarch64.wanda.yaml
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"

--- a/.buildkite/_forge.rayci.yml
+++ b/.buildkite/_forge.rayci.yml
@@ -15,7 +15,6 @@ steps:
     matrix:
       setup:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -39,7 +38,6 @@ steps:
       - serve
     wanda: ci/docker/ray.cpu.base.wanda.yaml
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -56,7 +54,6 @@ steps:
     matrix:
       setup:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
         cuda:
@@ -73,7 +70,6 @@ steps:
     wanda: ci/docker/ray-ml.cpu.base.wanda.yaml
     depends_on: raycpubase
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
     env:

--- a/.buildkite/base.rayci.yml
+++ b/.buildkite/base.rayci.yml
@@ -7,7 +7,7 @@ steps:
     label: "wanda: oss-ci-base_test-py{{matrix}}"
     wanda: ci/docker/base.test.wanda.yaml
     matrix:
-      - "3.8"
+      - "3.9"
       - "3.10"
       - "3.11"
     env:
@@ -21,7 +21,7 @@ steps:
     label: "wanda: oss-ci-base_build-py{{matrix}}"
     wanda: ci/docker/base.build.wanda.yaml
     matrix:
-      - "3.8"
+      - "3.9"
       - "3.10"
       - "3.11"
     env:
@@ -45,7 +45,7 @@ steps:
     label: "wanda: oss-ci-base_ml-py{{matrix}}"
     wanda: ci/docker/base.ml.wanda.yaml
     matrix:
-      - "3.8"
+      - "3.9"
       - "3.10"
     env:
       PYTHON: "{{matrix}}"
@@ -58,7 +58,7 @@ steps:
     label: "wanda: oss-ci-base_gpu-py{{matrix}}"
     wanda: ci/docker/base.gpu.wanda.yaml
     matrix:
-      - "3.8"
+      - "3.9"
       - "3.10"
     env:
       PYTHON: "{{matrix}}"

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -8,7 +8,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- wheel --python-version {{matrix}} --architecture x86_64 --upload
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -24,7 +23,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- wheel --python-version {{matrix}} --architecture aarch64 --upload
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -81,7 +79,6 @@ steps:
       - raycudabase
       - raycpubase
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -107,7 +104,6 @@ steps:
       - raycpubase-aarch64
     job_env: forge-aarch64
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -128,6 +124,5 @@ steps:
       - ray-mlcudabase
       - ray-mlcpubase
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -11,7 +11,6 @@ steps:
     label: "wanda: corebuild-py{{matrix}}"
     wanda: ci/docker/core.build.wanda.yaml
     matrix:
-      - "3.8"
       - "3.10"
     env:
       PYTHON: "{{matrix}}"
@@ -21,7 +20,6 @@ steps:
     label: "wanda: minbuild-core-py{{matrix}}"
     wanda: ci/docker/min.build.wanda.yaml
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -59,7 +57,7 @@ steps:
     depends_on: corebuild-multipy
     matrix:
       setup:
-        python: ["3.8"]
+        python: ["3.9"]
         worker_id: ["0", "1", "2", "3"]
 
   - label: ":ray: core: redis tests"
@@ -256,7 +254,6 @@ steps:
     depends_on:
       - minbuild-core
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -13,10 +13,10 @@ steps:
   - name: databuild-multipy
     label: "wanda: databuild-py{{matrix}}"
     wanda: ci/docker/data.build.wanda.yaml
-    matrix: ["3.8", "3.10"]
+    matrix: ["3.9", "3.10"]
     env:
       PYTHON: "{{matrix}}"
-    depends_on: oss-ci-base_build-multipy
+    depends_on: oss-ci-base_ml-multipy
 
   - name: datanbuild
     wanda: ci/docker/datan.build.wanda.yaml
@@ -70,7 +70,7 @@ steps:
     depends_on: databuild-multipy
     matrix:
       setup:
-        python: ["3.8"]
+        python: ["3.9"]
         worker_id: ["0", "1"]
 
   - label: ":database: data: arrow nightly tests"

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -25,7 +25,7 @@ steps:
       IMAGE_TO: mlbuild-py{{matrix}}
       RAYCI_IS_GPU_BUILD: "false"
     matrix:
-      - "3.8"
+      - "3.9"
 
   - name: mllightning2gpubuild
     wanda: ci/docker/mllightning2gpu.build.wanda.yaml
@@ -47,7 +47,7 @@ steps:
       IMAGE_TO: mlgpubuild-py{{matrix}}
       RAYCI_IS_GPU_BUILD: "true"
     matrix:
-      - "3.8"
+      - "3.9"
 
   # tests
   - label: ":train: ml: train tests"
@@ -72,7 +72,7 @@ steps:
     depends_on: [ "mlbuild-multipy", "forge" ]
     matrix:
       setup:
-        python: ["3.8"]
+        python: ["3.9"]
         worker_id: ["0", "1"]
 
   - label: ":train: ml: train gpu tests"
@@ -103,7 +103,7 @@ steps:
     depends_on: [ "mlgpubuild-multipy", "forge" ]
     matrix:
       setup:
-        python: ["3.8"]
+        python: ["3.9"]
         worker_id: ["0", "1"]
 
   - label: ":train: ml: train authentication tests"
@@ -141,7 +141,7 @@ steps:
         --except-tags soft_imports,gpu_only,rllib,multinode
         --python-version {{matrix}}
     depends_on: [ "mlbuild-multipy", "forge" ]
-    matrix: ["3.8"]
+    matrix: ["3.9"]
 
   - label: ":train: ml: tune new output tests"
     tags: tune
@@ -190,7 +190,7 @@ steps:
         --python-version {{matrix}}
         --skip-ray-installation
     depends_on: [ "mlbuild-multipy", "forge" ]
-    matrix: ["3.8"]
+    matrix: ["3.9"]
 
   - label: ":train: ml: train+tune tests"
     tags: train

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -11,7 +11,7 @@ steps:
     label: "wanda: servebuild-py{{matrix}}"
     wanda: ci/docker/serve.build.wanda.yaml
     matrix:
-      - "3.8"
+      - "3.9"
       - "3.11"
     env:
       PYTHON: "{{matrix}}"
@@ -73,7 +73,7 @@ steps:
     depends_on: servebuild-multipy
     matrix:
       setup:
-        python: ["3.8", "3.11"]
+        python: ["3.9", "3.11"]
         worker_id: ["0", "1"]
 
   - label: ":ray-serve: serve: release tests"

--- a/ci/build/build-docker-images.py
+++ b/ci/build/build-docker-images.py
@@ -38,7 +38,6 @@ DOCKER_HUB_DESCRIPTION = {
 }
 
 PY_MATRIX = {
-    "py38": "3.8",
     "py39": "3.9",
     "py310": "3.10",
     "py311": "3.11",

--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -48,8 +48,8 @@ function retry {
 
 if [[ "$platform" == "linux" ]]; then
   # Install miniconda.
-  PY_WHEEL_VERSIONS=("38" "39")
-  PY_MMS=("3.8.10" "3.9.5")
+  PY_WHEEL_VERSIONS=("39")
+  PY_MMS=("3.9.5")
   wget --quiet "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda3.sh
   "${ROOT_DIR}"/../suppress_output bash miniconda3.sh -b -p "$HOME/miniconda3"
   export PATH="$HOME/miniconda3/bin:$PATH"
@@ -93,8 +93,8 @@ if [[ "$platform" == "linux" ]]; then
 elif [[ "$platform" == "macosx" ]]; then
   MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
 
-  PY_WHEEL_VERSIONS=("38" "39" "310")
-  PY_MMS=("3.8" "3.9" "3.10")
+  PY_WHEEL_VERSIONS=("39" "310")
+  PY_MMS=("3.9" "3.10")
 
   for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     PY_MM="${PY_MMS[i]}"

--- a/ci/env/install-minimal.sh
+++ b/ci/env/install-minimal.sh
@@ -2,13 +2,11 @@
 
 set -xe
 
-# Python version can be specified as 3.8, 3.9, etc..
+# Python version can be specified as 3.9, etc..
 if [ -z "$1" ]; then
-    PYTHON_VERSION=${PYTHON-3.8}
+    PYTHON_VERSION=${PYTHON-3.9}
 else
-    if [ "$1" = "3.8" ]; then
-        PYTHON_VERSION="3.8"
-    elif [ "$1" = "3.9" ]; then
+    if [ "$1" = "3.9" ]; then
         PYTHON_VERSION="3.9"
     elif [ "$1" = "3.10" ]; then
         PYTHON_VERSION="3.10"

--- a/ci/ray_ci/builder_container.py
+++ b/ci/ray_ci/builder_container.py
@@ -17,7 +17,6 @@ ARCHITECTURE = [
     "aarch64",
 ]
 PYTHON_VERSIONS = {
-    "3.8": PythonVersionInfo(bin_path="cp38-cp38"),
     "3.9": PythonVersionInfo(bin_path="cp39-cp39"),
     "3.10": PythonVersionInfo(bin_path="cp310-cp310"),
     "3.11": PythonVersionInfo(bin_path="cp311-cp311"),

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -3,7 +3,7 @@
 set -ex
 
 export CI="true"
-export PYTHON="3.8"
+export PYTHON="3.9"
 export RAY_USE_RANDOM_PORTS="1"
 export RAY_DEFAULT_BUILD="1"
 export LC_ALL="en_US.UTF-8"

--- a/ci/ray_ci/macos/macos_ci_build.sh
+++ b/ci/ray_ci/macos/macos_ci_build.sh
@@ -3,7 +3,7 @@
 set -ex
 
 export CI="true"
-export PYTHON="3.8"
+export PYTHON="3.9"
 export RAY_USE_RANDOM_PORTS="1"
 export RAY_DEFAULT_BUILD="1"
 export LC_ALL="en_US.UTF-8"


### PR DESCRIPTION
Remove CI/CD for ray python 3.8. Python 3.8 end-of-life is approaching and it's standing on our way of providing python 3.11/3.12 support. Removing it for ray 2.11+.

Test:
- CI