### PR TITLE
[ci] store test name as it is

### DIFF
--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import sys
 import pytest
 import tempfile
@@ -192,7 +193,7 @@ def test_get_test_results() -> None:
         container = LinuxTesterContainer("docker_tag", skip_ray_installation=True)
         results = container._get_test_and_results("manu", tmp)
         test, result = results[0]
-        assert test.get_name() == "ray_ci_test.linux"
+        assert test.get_name() == f"{platform.system().lower()}://ray/ci:test"
         assert test.get_oncall() == "manu"
         assert result.is_passing()
 

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -110,12 +110,11 @@ class Test(dict):
 
     @classmethod
     def from_bazel_event(cls, event: dict, team: str):
-        bazel_rule = event["id"]["testResult"]["label"]
-        prefix = bazel_rule.replace("//", "").replace("/", "_").replace(":", "_")
-        suffix = platform.system().lower()
+        name = event["id"]["testResult"]["label"]
+        system = platform.system().lower()
         return cls(
             {
-                "name": f"{prefix}.{suffix}",
+                "name": f"{system}:{name}",
                 "team": team,
             }
         )
@@ -192,6 +191,13 @@ class Test(dict):
         """
         return self["name"]
 
+    def _get_s3_name(self) -> str:
+        """
+        Returns the name of the test for s3. Since '/' is not allowed in s3 key,
+        replace it with '_'.
+        """
+        return self["name"].replace("/", "_")
+
     def get_oncall(self) -> str:
         """
         Returns the oncall for the test.
@@ -207,7 +213,7 @@ class Test(dict):
                 boto3.client("s3")
                 .get_object(
                     Bucket=get_global_config()["state_machine_aws_bucket"],
-                    Key=f"{AWS_TEST_KEY}/{self.get_name()}.json",
+                    Key=f"{AWS_TEST_KEY}/{self._get_s3_name()}.json",
                 )
                 .get("Body")
                 .read()
@@ -358,7 +364,7 @@ class Test(dict):
         files = sorted(
             s3_client.list_objects_v2(
                 Bucket=get_global_config()["state_machine_aws_bucket"],
-                Prefix=f"{AWS_TEST_RESULT_KEY}/{self.get_name()}-",
+                Prefix=f"{AWS_TEST_RESULT_KEY}/{self._get_s3_name()}-",
             ).get("Contents", []),
             key=lambda file: int(file["LastModified"].strftime("%s")),
             reverse=True,
@@ -386,7 +392,7 @@ class Test(dict):
         boto3.client("s3").put_object(
             Bucket=get_global_config()["state_machine_aws_bucket"],
             Key=f"{AWS_TEST_RESULT_KEY}/"
-            f"{self.get_name()}-{int(time.time() * 1000)}.json",
+            f"{self._get_s3_name()}-{int(time.time() * 1000)}.json",
             Body=json.dumps(TestResult.from_result(result).__dict__),
         )
 
@@ -396,7 +402,7 @@ class Test(dict):
         """
         boto3.client("s3").put_object(
             Bucket=get_global_config()["state_machine_aws_bucket"],
-            Key=f"{AWS_TEST_KEY}/{self.get_name()}.json",
+            Key=f"{AWS_TEST_KEY}/{self._get_s3_name()}.json",
             Body=json.dumps(self),
         )
 

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import os
+import platform
 from unittest import mock
 
 import boto3
@@ -181,7 +182,7 @@ def test_from_bazel_event() -> None:
         },
         "ci",
     )
-    assert test.get_name() == "ray_ci_test.linux"
+    assert test.get_name() == f"{platform.system().lower()}://ray/ci:test"
     assert test.get_oncall() == "ci"
 
 


### PR DESCRIPTION
Store test name without normalization. Instead, create a `_get_s3_name` function to use as a name for s3 file.

Test:
- CI