### PR TITLE
[Data] Fix `test_huggingface` for arrow nightly

### DIFF
--- a/python/ray/data/tests/test_huggingface.py
+++ b/python/ray/data/tests/test_huggingface.py
@@ -1,6 +1,7 @@
 import datasets
 import pyarrow
 import pytest
+from packaging.version import Version
 
 import ray
 from ray.tests.conftest import *  # noqa
@@ -47,7 +48,7 @@ def test_from_huggingface(ray_start_regular_shared):
     reason="IterableDataset.iter() added in 2.8.0",
 )
 @pytest.mark.skipif(
-    datasets.Version(pyarrow.__version__) < datasets.Version("8.0.0"),
+    Version(pyarrow.__version__) < Version("8.0.0"),
     reason="pyarrow.Table.to_reader() added in 8.0.0",
 )
 # Note, pandas is excluded here because IterableDatasets do not support pandas format.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For Arrow nightly Data CI tests, the Pyarrow version is of the form: `15.0.0.dev404`, which is not able to be handled by the previous `datasets.Version` utility we were using to gate the test. Use generic `Version` class instead, which can handle these version types.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
