### PR TITLE
[ci][automation/1] add dry-run mode for state machine

### DIFF
--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -28,9 +28,10 @@ class TestStateMachine(abc.ABC):
     ray_repo = None
     ray_buildkite = None
 
-    def __init__(self, test: Test) -> None:
+    def __init__(self, test: Test, dry_run: bool = False) -> None:
         self.test = test
         self.test_results = test.get_test_results()
+        self.dry_run = dry_run
         TestStateMachine._init_ray_repo()
         TestStateMachine._init_ray_buildkite()
 
@@ -59,6 +60,9 @@ class TestStateMachine(abc.ABC):
         from_state = self.test.get_state()
         to_state = self._next_state(from_state)
         self.test.set_state(to_state)
+        if self.dry_run:
+            # Don't perform any action if dry run
+            return
         self._move_hook(from_state, to_state)
         self._state_hook(to_state)
 


### PR DESCRIPTION
Add a dry-run mode for state machine. In dry run mode, we change state of the test object in memory, but do not perform any state transition actions.

Test:
- CI