### PR TITLE
[ci][automation/3] script to run state machine

### DIFF
--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -11,7 +11,7 @@ py_library(
             "build_in_docker.py",
         ],
     ),
-    visibility = ["//visibility:private"],
+    visibility = ["//ci/ray_ci:__subpackages__"],
     deps = [
         ci_require("boto3"),
         ci_require("pyyaml"),

--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+
+py_binary(
+    name = "state_machine_bot",
+    srcs = ["state_machine_bot.py"],
+    deps = ["//ci/ray_ci:ray_ci_lib"],
+)

--- a/ci/ray_ci/automation/state_machine_bot.py
+++ b/ci/ray_ci/automation/state_machine_bot.py
@@ -1,0 +1,53 @@
+import click
+from typing import List
+
+from ci.ray_ci.utils import logger
+from ray_release.test import Test
+from ray_release.test_automation.ci_state_machine import CITestStateMachine
+
+
+@click.command()
+@click.option(
+    "--production",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help=("Update the state of the test on S3 and perform state transition actions."),
+)
+def main(production: bool) -> None:
+    """
+    Run state machine on all CI tests.
+    """
+    logger.info("Starting state machine bot ...")
+    tests = _get_all_ci_tests()
+    for test in tests:
+        _move_state(test, production)
+
+
+def _move_state(test, production: bool) -> None:
+    """
+    Run state machine on all CI tests.
+    """
+    logger.info(f"Running state machine on test {test.get_name()} ...")
+    test.update_from_s3()
+    logger.info(f"\tOld state: {test.get_state()}")
+
+    CITestStateMachine(test, dry_run=not production).move()
+    logger.info(f"\tNew state: {test.get_state()}")
+
+    if not production:
+        return
+
+    test.persist_to_s3()
+    logger.info("\tTest state updated successfully")
+
+
+def _get_all_ci_tests() -> List[Test]:
+    """
+    Get all CI tests.
+    """
+    return []
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A script to run CI state machine. Later on I'll create a buildkite job to run this nightly.

Test:
- CI

```
bazel run //ci/ray_ci/automation:state_machine_bot
[INFO 2024-01-11 23:55:46,018] state_machine_bot.py: 21  Starting state machine bot ...
```