### PR TITLE
[Data] Auto increasing block size for read_json

### DIFF
--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -75,7 +75,7 @@ class JSONDatasource(FileBasedDatasource):
                 if "straddling object straddles two block boundaries" in str(e):
                     if self.read_options.block_size < max_block_size:
                         # Increase the block size in case it was too small.
-                        logger.get_logger(log_to_stdout=True).info(
+                        logger.get_logger(log_to_stdout=False).info(
                             f"JSONDatasource read failed with "
                             f"block_size={self.read_options.block_size}. Retrying with "
                             f"block_size={self.read_options.block_size * 2}."

--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -53,6 +53,7 @@ class JSONDatasource(FileBasedDatasource):
                 yield json.read_json(
                     f, read_options=local_read_options, **self.arrow_json_args
                 )
+                break
             except ArrowInvalid as e:
                 # TODO: Figure out what MAX_BLOCK_SIZE would be / if necessary.
                 if (

--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -1,6 +1,7 @@
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from ray.data.context import DataContext
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 from ray.util.annotations import PublicAPI
 
@@ -45,6 +46,8 @@ class JSONDatasource(FileBasedDatasource):
             use_threads=self.read_options.use_threads,
             block_size=self.read_options.block_size,
         )
+        ctx = DataContext.get_current()
+        max_block_size = ctx.target_max_block_size
         while True:
             try:
                 yield json.read_json(
@@ -55,7 +58,7 @@ class JSONDatasource(FileBasedDatasource):
                 if (
                     isinstance(e, ArrowInvalid)
                     and "straddling" not in str(e)
-                    or local_read_options.block_size > MAX_BLOCK_SIZE
+                    or local_read_options.block_size > max_block_size
                 ):
                     raise e
                 else:

--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -1,6 +1,6 @@
-import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from ray.data._internal.dataset_logger import DatasetLogger
 from ray.data.context import DataContext
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 from ray.util.annotations import PublicAPI
@@ -8,7 +8,7 @@ from ray.util.annotations import PublicAPI
 if TYPE_CHECKING:
     import pyarrow
 
-logger = logging.getLogger(__name__)
+logger = DatasetLogger(__name__)
 
 
 @PublicAPI
@@ -42,32 +42,50 @@ class JSONDatasource(FileBasedDatasource):
 
         from pyarrow import ArrowInvalid, json
 
+        # When reading large files, the default block size configured in PyArrow can be
+        # too small, resulting in the following error: `pyarrow.lib.ArrowInvalid:
+        # straddling object straddles two block boundaries (try to increase block
+        # size?)`. The read will be retried with geometrically increasing block size
+        # until the size reaches `DataContext.get_current().target_max_block_size`.
+        # The initial block size will start at the PyArrow default block size or it can
+        # be manually set through the `read_options` parameter as follows.
+        #
+        # >>> import pyarrow.json as pajson
+        # >>> block_size = 10 << 20 # Set block size to 10MB
+        # >>> ray.data.read_json(  # doctest: +SKIP
+        # ...     "s3://anonymous@ray-example-data/log.json",
+        # ...     read_options=pajson.ReadOptions(block_size=block_size)
+        # ... )
+
         buffer = f.read_buffer()
-        block_size = self.read_options.block_size
-        use_threads = self.read_options.use_threads
+        init_block_size = self.read_options.block_size
         max_block_size = DataContext.get_current().target_max_block_size
         while True:
             try:
                 yield json.read_json(
                     BytesIO(buffer),
-                    read_options=json.ReadOptions(
-                        use_threads=use_threads, block_size=block_size
-                    ),
+                    read_options=self.read_options,
                     **self.arrow_json_args,
                 )
+                self.read_options.block_size = init_block_size
                 break
             except ArrowInvalid as e:
-                if (
-                    isinstance(e, ArrowInvalid)
-                    and "straddling" not in str(e)
-                    or block_size > max_block_size
-                ):
-                    raise e
+                if isinstance(e, ArrowInvalid) and "straddling" in str(e):
+                    if self.read_options.block_size < max_block_size:
+                        # Increase the block size in case it was too small.
+                        logger.get_logger(log_to_stdout=False).info(
+                            f"JSONDatasource read failed with "
+                            f"block_size={self.read_options.block_size}. Retrying with "
+                            f"block_size={self.read_options.block_size * 2}."
+                        )
+                        self.read_options.block_size *= 2
+                    else:
+                        raise ArrowInvalid(
+                            f"{e} - Auto-increasing block size to "
+                            f"{self.read_options.block_size}B failed. "
+                            f"More information on this issue can be found here: "
+                            f"https://github.com/apache/arrow/issues/25674"
+                        )
                 else:
-                    # Increase the block size in case it was too small.
-                    logger.info(
-                        f"JSONDatasource read failed with "
-                        f"block_size={block_size}. Retrying with "
-                        f"block_size={block_size * 2}."
-                    )
-                    block_size *= 2
+                    # unrelated error, simply reraise
+                    raise e

--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -36,48 +36,38 @@ class JSONDatasource(FileBasedDatasource):
         )
         self.arrow_json_args = arrow_json_args
 
-    def _open_input_source(
-        self,
-        filesystem: "pyarrow.fs.FileSystem",
-        path: str,
-        **open_args,
-    ) -> "pyarrow.NativeFile":
-        # JSON requires `open_input_file` for seekable file access
-        return filesystem.open_input_file(path, **open_args)
-
-
     # TODO(ekl) The PyArrow JSON reader doesn't support streaming reads.
     def _read_stream(self, f: "pyarrow.NativeFile", path: str):
+        from io import BytesIO
+
         from pyarrow import ArrowInvalid, json
 
-        # Create local copy of read_options so block_size increases are not persisted
-        # between _read_stream calls.
-        local_read_options = json.ReadOptions(
-            use_threads=self.read_options.use_threads,
-            block_size=self.read_options.block_size,
-        )
-        init_file_pos = f.tell()
+        buffer = f.read_buffer()
+        block_size = self.read_options.block_size
+        use_threads = self.read_options.use_threads
         max_block_size = DataContext.get_current().target_max_block_size
         while True:
             try:
                 yield json.read_json(
-                    f, read_options=local_read_options, **self.arrow_json_args
+                    BytesIO(buffer),
+                    read_options=json.ReadOptions(
+                        use_threads=use_threads, block_size=block_size
+                    ),
+                    **self.arrow_json_args,
                 )
                 break
             except ArrowInvalid as e:
                 if (
                     isinstance(e, ArrowInvalid)
                     and "straddling" not in str(e)
-                    or local_read_options.block_size > max_block_size
+                    or block_size > max_block_size
                 ):
                     raise e
                 else:
                     # Increase the block size in case it was too small.
                     logger.info(
                         f"JSONDatasource read failed with "
-                        f"block_size={local_read_options.block_size}. Retrying with "
-                        f"block_size={local_read_options.block_size * 2}."
+                        f"block_size={block_size}. Retrying with "
+                        f"block_size={block_size * 2}."
                     )
-                    local_read_options.block_size *= 2
-                    # Reset file position to re-attempt read.
-                    f.seek(init_file_pos)
+                    block_size *= 2

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1045,9 +1045,10 @@ def read_json(
         When reading large files, the default block size configured in PyArrow can be too small,
         resulting in the following error:
         ``pyarrow.lib.ArrowInvalid: straddling object straddles two block boundaries
-        (try to increase block size?)``.
-
-        To resolve this, use the ``read_options`` parameter to set a larger block size:
+        (try to increase block size?)``. The read will be retried with geometrically
+        increasing block size until the size reaches `DataContext.get_current().target_max_block_size`.
+        The initial block size will start at the PyArrow default block size or it can be
+        manually set through the ``read_options`` parameter as follows:
 
         >>> import pyarrow.json as pajson
         >>> block_size = 10 << 20 # Set block size to 10MB

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1042,21 +1042,6 @@ def read_json(
         >>> ds.take(1)
         [{'order_number': 10107, 'quantity': 30, 'year': '2022', 'month': '09'}]
 
-        When reading large files, the default block size configured in PyArrow can be too small,
-        resulting in the following error:
-        ``pyarrow.lib.ArrowInvalid: straddling object straddles two block boundaries
-        (try to increase block size?)``. The read will be retried with geometrically
-        increasing block size until the size reaches `DataContext.get_current().target_max_block_size`.
-        The initial block size will start at the PyArrow default block size or it can be
-        manually set through the ``read_options`` parameter as follows:
-
-        >>> import pyarrow.json as pajson
-        >>> block_size = 10 << 20 # Set block size to 10MB
-        >>> ray.data.read_json(  # doctest: +SKIP
-        ...     "s3://anonymous@ray-example-data/log.json",
-        ...     read_options=pajson.ReadOptions(block_size=block_size)
-        ... )
-
     Args:
         paths: A single file or directory, or a list of file or directory paths.
             A list of paths can contain both files and directories.

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -7,7 +7,6 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.json as pajson
 import pytest
-import smart_open
 from pytest_lazyfixture import lazy_fixture
 
 import ray
@@ -653,13 +652,8 @@ def test_json_read_across_blocks(ray_start_regular_shared, fs, data_path, endpoi
             "two": ["b" * num_chars for _ in range(num_rows)],
         }
     )
-    tmp2 = os.path.join(data_path, "tmp2.json")
     path2 = os.path.join(data_path, "test2.json")
-    df2.to_json(tmp2, orient="records", lines=True, storage_options=storage_options)
-    # force long line to break line size
-    with smart_open.open(path2, "w") as w_file:
-        with smart_open.open(tmp2, "r") as r_file:
-            w_file.write(r_file.read().replace("\n", ""))
+    df2.to_json(path2, orient="records", lines=True, storage_options=storage_options)
     ds = ray.data.read_json(path2, filesystem=fs)
     dsdf = ds.to_pandas()
     assert df2.equals(dsdf)

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -633,7 +633,9 @@ def test_json_read_across_blocks(ray_start_regular_shared, fs, data_path, endpoi
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
     path1 = os.path.join(data_path, "test1.json")
     df1.to_json(path1, orient="records", lines=True, storage_options=storage_options)
-    ds = ray.data.read_json(path1, filesystem=fs, read_options=pajson.ReadOptions(block_size=1))
+    ds = ray.data.read_json(
+        path1, filesystem=fs, read_options=pajson.ReadOptions(block_size=1)
+    )
     dsdf = ds.to_pandas()
     assert df1.equals(dsdf)
     # Test metadata ops.
@@ -644,7 +646,12 @@ def test_json_read_across_blocks(ray_start_regular_shared, fs, data_path, endpoi
     # Single large file, default block_size
     num_chars = 2500000
     num_rows = 3
-    df2 = pd.DataFrame({"one": ["a" * num_chars for _ in range(num_rows)], "two": ["b" * num_chars for _ in range(num_rows)]})
+    df2 = pd.DataFrame(
+        {
+            "one": ["a" * num_chars for _ in range(num_rows)],
+            "two": ["b" * num_chars for _ in range(num_rows)],
+        }
+    )
     tmp2 = os.path.join(data_path, "tmp2.json")
     path2 = os.path.join(data_path, "test2.json")
     df2.to_json(tmp2, orient="records", lines=True, storage_options=storage_options)
@@ -666,13 +673,17 @@ def test_json_read_across_blocks(ray_start_regular_shared, fs, data_path, endpoi
     df3.to_json(path3, orient="records", lines=True, storage_options=storage_options)
     try:
         # Negative Buffer Size
-        ds = ray.data.read_json(path3, filesystem=fs, read_options=pajson.ReadOptions(block_size=-1))
+        ds = ray.data.read_json(
+            path3, filesystem=fs, read_options=pajson.ReadOptions(block_size=-1)
+        )
         dsdf = ds.to_pandas()
     except pa.ArrowInvalid as e:
         assert "Negative buffer resize" in str(e.cause)
     try:
         # Zero Buffer Size
-        ds = ray.data.read_json(path3, filesystem=fs, read_options=pajson.ReadOptions(block_size=0))
+        ds = ray.data.read_json(
+            path3, filesystem=fs, read_options=pajson.ReadOptions(block_size=0)
+        )
         dsdf = ds.to_pandas()
     except pa.ArrowInvalid as e:
         assert "Empty JSON file" in str(e.cause)

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -615,6 +615,69 @@ def test_json_write_block_path_provider(
     assert df.equals(ds_df)
 
 
+@pytest.mark.parametrize(
+    "fs,data_path,endpoint_url",
+    [
+        (None, lazy_fixture("local_path"), None),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path"), None),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path"), lazy_fixture("s3_server")),
+    ],
+)
+def test_json_read_across_blocks(ray_start_regular_shared, fs, data_path, endpoint_url):
+    if endpoint_url is None:
+        storage_options = {}
+    else:
+        storage_options = dict(client_kwargs=dict(endpoint_url=endpoint_url))
+
+    # Single small file, unit block_size
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    path1 = os.path.join(data_path, "test1.json")
+    df1.to_json(path1, orient="records", lines=True, storage_options=storage_options)
+    ds = ray.data.read_json(path1, filesystem=fs, read_options=pajson.ReadOptions(block_size=1))
+    dsdf = ds.to_pandas()
+    assert df1.equals(dsdf)
+    # Test metadata ops.
+    assert ds.count() == 3
+    assert ds.input_files() == [_unwrap_protocol(path1)]
+    assert "{one: int64, two: string}" in str(ds), ds
+
+    # Single large file, default block_size
+    num_chars = 2500000
+    num_rows = 3
+    df2 = pd.DataFrame({"one": ["a" * num_chars for _ in range(num_rows)], "two": ["b" * num_chars for _ in range(num_rows)]})
+    tmp2 = os.path.join(data_path, "tmp2.json")
+    path2 = os.path.join(data_path, "test2.json")
+    df2.to_json(tmp2, orient="records", lines=True, storage_options=storage_options)
+    # force long line to break line size
+    with open(path2, "w") as w_file:
+        with open(tmp2, "r") as r_file:
+            w_file.write(r_file.read().replace("\n", ""))
+    ds = ray.data.read_json(path2, filesystem=fs)
+    dsdf = ds.to_pandas()
+    assert df2.equals(dsdf)
+    # Test metadata ops.
+    assert ds.count() == num_rows
+    assert ds.input_files() == [_unwrap_protocol(path2)]
+    assert "{one: string, two: string}" in str(ds), ds
+
+    # Single file, negative and zero block_size (expect failure)
+    df3 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    path3 = os.path.join(data_path, "test3.json")
+    df3.to_json(path3, orient="records", lines=True, storage_options=storage_options)
+    try:
+        # Negative Buffer Size
+        ds = ray.data.read_json(path3, filesystem=fs, read_options=pajson.ReadOptions(block_size=-1))
+        dsdf = ds.to_pandas()
+    except pa.ArrowInvalid as e:
+        assert "Negative buffer resize" in str(e.cause)
+    try:
+        # Zero Buffer Size
+        ds = ray.data.read_json(path3, filesystem=fs, read_options=pajson.ReadOptions(block_size=0))
+        dsdf = ds.to_pandas()
+    except pa.ArrowInvalid as e:
+        assert "Empty JSON file" in str(e.cause)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -7,8 +7,8 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.json as pajson
 import pytest
-from pytest_lazyfixture import lazy_fixture
 import smart_open
+from pytest_lazyfixture import lazy_fixture
 
 import ray
 from ray.data.block import BlockAccessor
@@ -657,8 +657,8 @@ def test_json_read_across_blocks(ray_start_regular_shared, fs, data_path, endpoi
     path2 = os.path.join(data_path, "test2.json")
     df2.to_json(tmp2, orient="records", lines=True, storage_options=storage_options)
     # force long line to break line size
-    with smart_open(path2, "w") as w_file:
-        with smart_open(tmp2, "r") as r_file:
+    with smart_open.open(path2, "w") as w_file:
+        with smart_open.open(tmp2, "r") as r_file:
             w_file.write(r_file.read().replace("\n", ""))
     ds = ray.data.read_json(path2, filesystem=fs)
     dsdf = ds.to_pandas()

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 import pyarrow.json as pajson
 import pytest
 from pytest_lazyfixture import lazy_fixture
+import smart_open
 
 import ray
 from ray.data.block import BlockAccessor
@@ -656,8 +657,8 @@ def test_json_read_across_blocks(ray_start_regular_shared, fs, data_path, endpoi
     path2 = os.path.join(data_path, "test2.json")
     df2.to_json(tmp2, orient="records", lines=True, storage_options=storage_options)
     # force long line to break line size
-    with open(path2, "w") as w_file:
-        with open(tmp2, "r") as r_file:
+    with smart_open(path2, "w") as w_file:
+        with smart_open(tmp2, "r") as r_file:
             w_file.write(r_file.read().replace("\n", ""))
     ds = ray.data.read_json(path2, filesystem=fs)
     dsdf = ds.to_pandas()


### PR DESCRIPTION
## Why are these changes needed?
This PR adds logic to dynamically increase `block_size` used in Arrow's JSON loader, if the initial `block_size` resulting in a more graceful handling of these cases.

## Related issue number
Closes #41196 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
