### PR TITLE
[ci][automation/4] complete state machine bot script

### DIFF
--- a/ci/ray_ci/automation/state_machine_bot.py
+++ b/ci/ray_ci/automation/state_machine_bot.py
@@ -4,6 +4,11 @@ from typing import List
 from ci.ray_ci.utils import logger
 from ray_release.test import Test
 from ray_release.test_automation.ci_state_machine import CITestStateMachine
+from ray_release.configs.global_config import init_global_config
+from ray_release.bazel import bazel_runfile
+
+
+ALL_TEST_PREFIXES = ["linux:", "windows:", "macos:"]
 
 
 @click.command()
@@ -14,12 +19,23 @@ from ray_release.test_automation.ci_state_machine import CITestStateMachine
     default=False,
     help=("Update the state of the test on S3 and perform state transition actions."),
 )
-def main(production: bool) -> None:
+@click.option(
+    "--test-prefix",
+    multiple=True,
+    type=str,
+    help=(
+        "Prefix of tests to run the state machine on. "
+        "If not specified, run on all tests."
+    ),
+)
+def main(production: bool, test_prefix: List[str]) -> None:
     """
     Run state machine on all CI tests.
     """
     logger.info("Starting state machine bot ...")
-    tests = _get_all_ci_tests()
+    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    test_prefix = test_prefix or ALL_TEST_PREFIXES
+    tests = _get_ci_tests(test_prefix)
     for test in tests:
         _move_state(test, production)
 
@@ -42,11 +58,15 @@ def _move_state(test, production: bool) -> None:
     logger.info("\tTest state updated successfully")
 
 
-def _get_all_ci_tests() -> List[Test]:
+def _get_ci_tests(prefixes: List[str]) -> List[Test]:
     """
     Get all CI tests.
     """
-    return []
+    tests = []
+    for prefix in prefixes:
+        tests.extend(Test.gen_from_s3(prefix))
+
+    return tests
 
 
 if __name__ == "__main__":

--- a/release/ray_release/test_automation/ci_state_machine.py
+++ b/release/ray_release/test_automation/ci_state_machine.py
@@ -23,9 +23,9 @@ MAX_REPORT_FAILURE_NO = 5
 
 
 class CITestStateMachine(TestStateMachine):
-    def __init__(self, test: Test) -> None:
+    def __init__(self, test: Test, dry_run: bool = False) -> None:
         # Need long enough test history to detect flaky tests
-        super().__init__(test, history_length=100)
+        super().__init__(test, dry_run=dry_run, history_length=100)
 
     def _move_hook(self, from_state: TestState, to_state: TestState) -> None:
         change = (from_state, to_state)


### PR DESCRIPTION
```
(py38) ubuntu@devbox:~/ray$ bazel run //ci/ray_ci/automation:state_machine_bot -- --test-prefix linux:__python_ray_air:test_api
[INFO 2024-01-12 05:35:02,283] state_machine_bot.py: 35  Starting state machine bot ...
[INFO 2024-01-12 05:35:02,612] state_machine_bot.py: 47  Running state machine on test linux://python/ray/air:test_api ...
[INFO 2024-01-12 05:35:02,735] state_machine_bot.py: 49         Old state: TestState.PASSING
[INFO 2024-01-12 05:35:03,473] state_machine_bot.py: 52         New state: TestState.PASSING
```