### PR TITLE
[ci] add the concept of continuous run

### DIFF
--- a/ci/ci_tags_from_change.sh
+++ b/ci/ci_tags_from_change.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [[ "${RAYCI_RUN_ALL_TESTS:-}" == "1" || "${BUILDKITE_BRANCH:-}" == "master" || "${BUILDKITE_BRANCH:-}" =~ ^releases/.* ]]; then
+if [[ "${RAYCI_RUN_ALL_TESTS:-}" == "1" || "${BUILDKITE_BRANCH:-}" =~ ^releases/.* ]]; then
     echo '*'
     exit 0
 fi


### PR DESCRIPTION
Add continuous run on postmerge/master branch to run things like state machine bot, python 3.8 jobs, mac jobs, etc.

Test:
- CI