### PR TITLE
[ci][multipy/1] add multipy version of corebuild images

### DIFF
--- a/.buildkite/base.rayci.yml
+++ b/.buildkite/base.rayci.yml
@@ -1,11 +1,30 @@
 group: base
 steps:
   - name: oss-ci-base_test
+    wanda: ci/docker/base.test.py39.wanda.yaml
+
+  - name: oss-ci-base_test-multipy
+    label: "wanda: oss-ci-base_test-py{{matrix}}"
     wanda: ci/docker/base.test.wanda.yaml
+    matrix:
+      - "3.8"
+      - "3.10"
+    env:
+      PYTHON: "{{matrix}}"
   
   - name: oss-ci-base_build
-    wanda: ci/docker/base.build.wanda.yaml
+    wanda: ci/docker/base.build.py39.wanda.yaml
     depends_on: oss-ci-base_test
+
+  - name: oss-ci-base_build-multipy
+    label: "wanda: oss-ci-base_build-py{{matrix}}"
+    wanda: ci/docker/base.build.wanda.yaml
+    matrix:
+      - "3.8"
+      - "3.10"
+    env:
+      PYTHON: "{{matrix}}"
+    depends_on: oss-ci-base_test-multipy
 
   - name: oss-ci-base_test-aarch64
     wanda: ci/docker/base.test.aarch64.wanda.yaml

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -5,7 +5,17 @@ depends_on:
 steps:
   # builds
   - name: corebuild
+    wanda: ci/docker/core.build.py39.wanda.yaml
+
+  - name: corebuild-multipy
+    label: "wanda: corebuild-py{{matrix}}"
     wanda: ci/docker/core.build.wanda.yaml
+    matrix:
+      - "3.8"
+      - "3.10"
+    env:
+      PYTHON: "{{matrix}}"
+    depends_on: oss-ci-base_build-multipy
 
   - name: minbuild-core
     label: "wanda: minbuild-core-py{{matrix}}"

--- a/ci/ci_tags_from_change.sh
+++ b/ci/ci_tags_from_change.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [[ "${RAYCI_RUN_ALL_TESTS:-}" == "1" || "${BUILDKITE_BRANCH:-}" =~ ^releases/.* ]]; then
+if [[ "${RAYCI_RUN_ALL_TESTS:-}" == "1" || "${BUILDKITE_BRANCH:-}" == "master" || "${BUILDKITE_BRANCH:-}" =~ ^releases/.* ]]; then
     echo '*'
     exit 0
 fi

--- a/ci/ci_tags_from_change.sh
+++ b/ci/ci_tags_from_change.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if [[ "${RAYCI_RUN_ALL_TESTS:-}" == "1" || "${BUILDKITE_BRANCH:-}" == "master" || "${BUILDKITE_BRANCH:-}" =~ ^releases/.* ]]; then
+if [[ "${RAYCI_RUN_ALL_TESTS:-}" == "1" || "${BUILDKITE_BRANCH:-}" =~ ^releases/.* ]]; then
     echo '*'
     exit 0
 fi

--- a/ci/docker/base.build.py39.wanda.yaml
+++ b/ci/docker/base.build.py39.wanda.yaml
@@ -1,5 +1,5 @@
-name: "oss-ci-base_build-py$PYTHON"
-froms: ["cr.ray.io/rayproject/oss-ci-base_test-py$PYTHON"]
+name: "oss-ci-base_build"
+froms: ["cr.ray.io/rayproject/oss-ci-base_test"]
 dockerfile: ci/docker/base.build.Dockerfile
 srcs:
   - .bazelrc
@@ -11,7 +11,5 @@ srcs:
   - python/requirements.txt
   - python/requirements_compiled.txt
   - python/requirements/test-requirements.txt
-build_args:
-  - DOCKER_IMAGE_BASE_TEST=cr.ray.io/rayproject/oss-ci-base_test-py$PYTHON
 tags:
-  - cr.ray.io/rayproject/oss-ci-base_build-py$PYTHON
+  - cr.ray.io/rayproject/oss-ci-base_build

--- a/ci/docker/base.test.py39.wanda.yaml
+++ b/ci/docker/base.test.py39.wanda.yaml
@@ -1,4 +1,4 @@
-name: "oss-ci-base_test-py$PYTHON"
+name: "oss-ci-base_test"
 froms: ["ubuntu:focal"]
 dockerfile: ci/docker/base.test.Dockerfile
 srcs:
@@ -6,6 +6,5 @@ srcs:
   - .bazeliskrc
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
-  - PYTHON
 tags:
-  - cr.ray.io/rayproject/oss-ci-base_test-py$PYTHON
+  - cr.ray.io/rayproject/oss-ci-base_test

--- a/ci/docker/core.build.py39.wanda.yaml
+++ b/ci/docker/core.build.py39.wanda.yaml
@@ -1,0 +1,10 @@
+name: "corebuild"
+froms: ["cr.ray.io/rayproject/oss-ci-base_build"]
+dockerfile: ci/docker/core.build.Dockerfile
+srcs:
+  - python/requirements.txt
+  - python/requirements_compiled.txt
+  - python/requirements/test-requirements.txt
+  - python/requirements/ml/dl-cpu-requirements.txt
+tags:
+  - cr.ray.io/rayproject/corebuild

--- a/ci/docker/core.build.wanda.yaml
+++ b/ci/docker/core.build.wanda.yaml
@@ -1,10 +1,12 @@
-name: "corebuild"
-froms: ["cr.ray.io/rayproject/oss-ci-base_build"]
+name: "corebuild-py$PYTHON"
+froms: ["cr.ray.io/rayproject/oss-ci-base_build-py$PYTHON"]
 dockerfile: ci/docker/core.build.Dockerfile
 srcs:
   - python/requirements.txt
   - python/requirements_compiled.txt
   - python/requirements/test-requirements.txt
   - python/requirements/ml/dl-cpu-requirements.txt
+build_args:
+  - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build-py$PYTHON
 tags:
-  - cr.ray.io/rayproject/corebuild
+  - cr.ray.io/rayproject/corebuild-py$PYTHON

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -11,9 +11,6 @@ from pprint import pformat
 import traceback
 
 
-PIPELINE_POSTMERGE = "0189e759-8c96-4302-b6b5-b4274406bf89"
-
-
 # NOTE(simon): do not add type hint here because it's ran using python2 in CI.
 def list_changed_files(commit_range):
     """Returns a list of names of files changed in the given commit range.
@@ -51,14 +48,6 @@ def is_pull_request():
         event_type = "pull_request"
 
     return event_type == "pull_request"
-
-
-def is_continuous_run():
-    # Periodically continuous run only on master branch
-    return (
-        os.environ.get("RAYCI_CONTINUOUS_RUN")
-        and os.environ.get("BUILDKITE_PIPELINE_ID") == PIPELINE_POSTMERGE
-    )
 
 
 def get_commit_range():
@@ -119,12 +108,8 @@ if __name__ == "__main__":
     RAY_CI_WORKFLOW_AFFECTED = 0
     RAY_CI_RELEASE_TESTS_AFFECTED = 0
     RAY_CI_COMPILED_PYTHON_AFFECTED = 0
-    RAY_CI_CONTINUOUS_RUN_AFFECTED = 0
 
-    if is_continuous_run():
-        # Run only continuous jobs on continuous run
-        RAY_CI_CONTINUOUS_RUN_AFFECTED = 1
-    elif is_pull_request():
+    if is_pull_request():
         commit_range = get_commit_range()
         files = list_changed_files(commit_range)
         print(pformat(commit_range), file=sys.stderr)
@@ -434,7 +419,6 @@ if __name__ == "__main__":
         RAY_CI_DATA_AFFECTED = 1
         RAY_CI_RELEASE_TESTS_AFFECTED = 1
         RAY_CI_COMPILED_PYTHON_AFFECTED = 1
-        RAY_CI_CONTINUOUS_RUN_AFFECTED = 1
 
     # Log the modified environment variables visible in console.
     output_string = " ".join(
@@ -466,7 +450,6 @@ if __name__ == "__main__":
             "RAY_CI_COMPILED_PYTHON_AFFECTED={}".format(
                 RAY_CI_COMPILED_PYTHON_AFFECTED
             ),
-            "RAY_CI_CONTINUOUS_RUN_AFFECTED={}".format(RAY_CI_CONTINUOUS_RUN_AFFECTED),
         ]
     )
 


### PR DESCRIPTION
Add multipy version for corebuild images. I copy the existing wanda file into another multipy version. Will deprecate the old wanda file when the system is completely migrated into multipy.

Test:
- CI