### PR TITLE
[ci] unblock premerge

### DIFF
--- a/ci/ray_ci/serve.tests.yml
+++ b/ci/ray_ci/serve.tests.yml
@@ -1,2 +1,4 @@
 flaky_tests:
   - //python/ray/serve/tests:test_util
+  - //python/ray/serve/tests:test_model_composition
+  - //python/ray/serve/tests:test_api


### PR DESCRIPTION
Move to flaky 2 serve tests that are failing on postmerge that cannot be blamed to a PR

<img width="1433" alt="Screenshot 2024-01-16 at 8 01 44 AM" src="https://github.com/ray-project/ray/assets/128072568/bebfc931-403d-4415-b71b-608d2c2e0cbc">


Test:
- CI