### PR TITLE
[ci][auto/4] allow linux flaky test to be with and without os prefixes

### DIFF
--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -142,13 +142,16 @@ def test_get_all_test_query() -> None:
 
 
 def test_get_flaky_test_targets() -> None:
-    _TEST_YAML = "flaky_tests: [windows://t1, //t2]"
+    _TEST_YAML = "flaky_tests: [windows://t1, //t2, linux://t3]"
 
     with TemporaryDirectory() as tmp:
         with open(os.path.join(tmp, "core.tests.yml"), "w") as f:
             f.write(_TEST_YAML)
         assert _get_flaky_test_targets("core", "windows", yaml_dir=tmp) == ["//t1"]
-        assert _get_flaky_test_targets("core", "linux", yaml_dir=tmp) == ["//t2"]
+        assert _get_flaky_test_targets("core", "linux", yaml_dir=tmp) == [
+            "//t2",
+            "//t3",
+        ]
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -353,15 +353,22 @@ def _get_flaky_test_targets(
 
     with open(f"{yaml_dir}/{team}.tests.yml", "rb") as f:
         all_flaky_tests = yaml.safe_load(f)["flaky_tests"]
+        flaky_tests = []
 
-        # linux tests are prefixed with "//"
+        # linux tests can also be prefixed with "//"
         if operating_system == "linux":
-            return [test for test in all_flaky_tests if test.startswith("//")]
+            flaky_tests.extend(
+                [test for test in all_flaky_tests if test.startswith("//")]
+            )
 
-        # and other os tests are prefixed with "os:"
+        # os tests are prefixed with "os:"
         os_prefix = f"{operating_system}:"
-        return [
-            test.lstrip(os_prefix)
-            for test in all_flaky_tests
-            if test.startswith(os_prefix)
-        ]
+        flaky_tests.extend(
+            [
+                test.lstrip(os_prefix)
+                for test in all_flaky_tests
+                if test.startswith(os_prefix)
+            ]
+        )
+
+        return flaky_tests


### PR DESCRIPTION
Allow linux flaky test definition to be with or without the linux prefixes

Test:
- CI