### PR TITLE
[Core] Only release CPU resources for getting owned objects

### DIFF
--- a/cpp/src/ray/runtime/object/local_mode_object_store.cc
+++ b/cpp/src/ray/runtime/object/local_mode_object_store.cc
@@ -63,7 +63,6 @@ std::vector<std::shared_ptr<msgpack::sbuffer>> LocalModeObjectStore::GetRaw(
                                             (int)ids.size(),
                                             timeout_ms,
                                             local_mode_ray_tuntime_.GetWorkerContext(),
-                                            false,
                                             &results);
   if (!status.ok()) {
     throw RayException("Get object error: " + status.ToString());

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1211,6 +1211,7 @@ Status CoreWorker::PutInLocalPlasmaStore(const RayObject &object,
       RAY_RETURN_NOT_OK(plasma_store_provider_->Release(object_id));
     }
   }
+  RAY_LOG(INFO) << "jjyao PutInLocalPlasmaStore " << object_id;
   RAY_CHECK(memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA), object_id));
   return Status::OK();
 }
@@ -1313,6 +1314,7 @@ Status CoreWorker::CreateOwnedAndIncrementLocalRef(
     } else if (*data == nullptr) {
       // Object already exists in plasma. Store the in-memory value so that the
       // client will check the plasma store.
+      RAY_LOG(INFO) << "jjyao CreateOwnedAndIncrementLocalRef " << *object_id;
       RAY_CHECK(
           memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA), *object_id));
     }
@@ -1393,6 +1395,7 @@ Status CoreWorker::SealExisting(const ObjectID &object_id,
     RAY_RETURN_NOT_OK(plasma_store_provider_->Release(object_id));
     reference_counter_->FreePlasmaObjects({object_id});
   }
+  RAY_LOG(INFO) << "jjyao SealExisting " << object_id;
   RAY_CHECK(memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA), object_id));
   return Status::OK();
 }
@@ -3159,10 +3162,12 @@ Status CoreWorker::GetAndPinArgsForExecutor(const TaskSpecification &task,
       // NOTE: This needs to be done after adding reference to reference counter
       // otherwise, the put is a no-op.
       if (!options_.is_local_mode) {
+        RAY_LOG(INFO) << "jjyao GetAndPinArgsForExecutor " << task.ArgId(i);
         RAY_UNUSED(memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA),
                                       task.ArgId(i)));
       }
     } else {
+      RAY_LOG(INFO) << "jjyao pass-by-value";
       // A pass-by-value argument.
       std::shared_ptr<LocalMemoryBuffer> data = nullptr;
       if (task.ArgDataSize(i)) {
@@ -4135,6 +4140,7 @@ void CoreWorker::HandleAssignObjectOwner(rpc::AssignObjectOwnerRequest request,
       /*add_local_ref=*/false,
       /*pinned_at_raylet_id=*/NodeID::FromBinary(borrower_address.raylet_id()));
   reference_counter_->AddBorrowerAddress(object_id, borrower_address);
+  RAY_LOG(INFO) << "jjyao HandleAssignObjectOwner " << object_id;
   RAY_CHECK(memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA), object_id));
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }

--- a/src/ray/core_worker/future_resolver.cc
+++ b/src/ray/core_worker/future_resolver.cc
@@ -101,6 +101,7 @@ void FutureResolver::ProcessResolvedObject(const ObjectID &object_id,
                                             object_id,
                                             inlined_ref.owner_address());
     }
+    RAY_LOG(INFO) << "Future resolver put " << object_id;
     RAY_UNUSED(in_memory_store_->Put(
         RayObject(data_buffer, metadata_buffer, inlined_refs), object_id));
   }

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -35,7 +35,6 @@ struct MemoryStoreStats {
 };
 
 class GetRequest;
-class CoreWorkerMemoryStore;
 
 /// The class provides implementations for local process memory store.
 /// An example usage for this is to retrieve the returned objects from direct
@@ -44,8 +43,7 @@ class CoreWorkerMemoryStore {
  public:
   /// Create a memory store.
   ///
-  /// \param[in] counter If not null, this enables ref counting for local objects,
-  ///            and the `remove_after_get` flag for Get() will be ignored.
+  /// \param[in] counter If not null, this enables ref counting for local objects.
   /// \param[in] raylet_client If not null, used to notify tasks blocked / unblocked.
   CoreWorkerMemoryStore(
       std::shared_ptr<ReferenceCounter> counter = nullptr,
@@ -71,15 +69,12 @@ class CoreWorkerMemoryStore {
   /// \param[in] num_objects Number of objects that should appear.
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
   /// \param[in] ctx The current worker context.
-  /// \param[in] remove_after_get When to remove the objects from store after `Get`
-  /// finishes. This has no effect if ref counting is enabled.
   /// \param[out] results Result list of objects data.
   /// \return Status.
   Status Get(const std::vector<ObjectID> &object_ids,
              int num_objects,
              int64_t timeout_ms,
              const WorkerContext &ctx,
-             bool remove_after_get,
              std::vector<std::shared_ptr<RayObject>> *results);
 
   /// Convenience wrapper around Get() that stores results in a given result map.
@@ -176,7 +171,6 @@ class CoreWorkerMemoryStore {
                  int num_objects,
                  int64_t timeout_ms,
                  const WorkerContext &ctx,
-                 bool remove_after_get,
                  std::vector<std::shared_ptr<RayObject>> *results,
                  bool abort_if_any_object_is_exception);
 

--- a/src/ray/core_worker/test/memory_store_test.cc
+++ b/src/ray/core_worker/test/memory_store_test.cc
@@ -62,8 +62,8 @@ TEST(TestMemoryStore, TestReportUnhandledErrors) {
   // Check delete after get.
   RAY_CHECK(provider->Put(obj1, id1));
   RAY_CHECK(provider->Put(obj1, id2));
-  RAY_UNUSED(provider->Get({id1}, 1, 100, context, false, &results));
-  RAY_UNUSED(provider->Get({id2}, 1, 100, context, false, &results));
+  RAY_UNUSED(provider->Get({id1}, 1, 100, context, &results));
+  RAY_UNUSED(provider->Get({id2}, 1, 100, context, &results));
   provider->Delete({id1, id2});
   ASSERT_EQ(unhandled_count, 0);
 

--- a/src/ray/core_worker/test/reference_count_test.cc
+++ b/src/ray/core_worker/test/reference_count_test.cc
@@ -834,7 +834,7 @@ TEST(MemoryStoreIntegrationTest, TestSimple) {
   RAY_CHECK(store.Put(buffer, id2));
   ASSERT_EQ(store.Size(), 0);
 
-  // Tests ref counting overrides remove after get option.
+  // Tests object is not removed after get.
   rc->AddLocalReference(id1, "");
   RAY_CHECK(store.Put(buffer, id1));
   ASSERT_EQ(store.Size(), 1);
@@ -844,7 +844,6 @@ TEST(MemoryStoreIntegrationTest, TestSimple) {
                          /*num_objects*/ 1,
                          /*timeout_ms*/ -1,
                          ctx,
-                         /*remove_after_get*/ true,
                          &results));
   ASSERT_EQ(results.size(), 1);
   ASSERT_EQ(store.Size(), 1);

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -223,7 +223,7 @@ TEST_F(TaskManagerTest, TestTaskSuccess) {
   ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   std::vector<std::shared_ptr<RayObject>> results;
-  RAY_CHECK_OK(store_->Get({return_id}, 1, -1, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get({return_id}, 1, -1, ctx, &results));
   ASSERT_EQ(results.size(), 1);
   ASSERT_FALSE(results[0]->IsException());
   ASSERT_EQ(std::memcmp(results[0]->GetData()->Data(),
@@ -260,7 +260,7 @@ TEST_F(TaskManagerTest, TestTaskFailure) {
   ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   std::vector<std::shared_ptr<RayObject>> results;
-  RAY_CHECK_OK(store_->Get({return_id}, 1, -1, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get({return_id}, 1, -1, ctx, &results));
   ASSERT_EQ(results.size(), 1);
   rpc::ErrorType stored_error;
   ASSERT_TRUE(results[0]->IsException(&stored_error));
@@ -302,7 +302,7 @@ TEST_F(TaskManagerTest, TestPlasmaConcurrentFailure) {
   std::vector<std::shared_ptr<RayObject>> results;
   // Caller of FlushObjectsToRecover is responsible for deleting the object
   // from the in-memory store and recovering the object.
-  ASSERT_TRUE(store_->Get({return_id}, 1, 0, ctx, false, &results).ok());
+  ASSERT_TRUE(store_->Get({return_id}, 1, 0, ctx, &results).ok());
   auto objects_to_recover = reference_counter_->FlushObjectsToRecover();
   ASSERT_EQ(objects_to_recover.size(), 1);
   ASSERT_EQ(objects_to_recover[0], return_id);
@@ -330,7 +330,7 @@ TEST_F(TaskManagerTest, TestFailPendingTask) {
   ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   std::vector<std::shared_ptr<RayObject>> results;
-  RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, &results));
   ASSERT_EQ(results.size(), 1);
   rpc::ErrorType stored_error;
   ASSERT_TRUE(results[0]->IsException(&stored_error));
@@ -365,7 +365,7 @@ TEST_F(TaskManagerTest, TestTaskReconstruction) {
     ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
     ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 3);
     std::vector<std::shared_ptr<RayObject>> results;
-    ASSERT_FALSE(store_->Get({return_id}, 1, 0, ctx, false, &results).ok());
+    ASSERT_FALSE(store_->Get({return_id}, 1, 0, ctx, &results).ok());
     ASSERT_EQ(num_retries_, i + 1);
     ASSERT_EQ(last_delay_ms_, RayConfig::instance().task_retry_delay_ms());
     ASSERT_EQ(last_object_recovery_, false);
@@ -378,7 +378,7 @@ TEST_F(TaskManagerTest, TestTaskReconstruction) {
   ASSERT_FALSE(reference_counter_->IsObjectPendingCreation(return_id));
 
   std::vector<std::shared_ptr<RayObject>> results;
-  RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, &results));
   ASSERT_EQ(results.size(), 1);
   rpc::ErrorType stored_error;
   ASSERT_TRUE(results[0]->IsException(&stored_error));
@@ -407,7 +407,7 @@ TEST_F(TaskManagerTest, TestTaskKill) {
   manager_.FailOrRetryPendingTask(spec.TaskId(), error);
   ASSERT_FALSE(manager_.IsTaskPending(spec.TaskId()));
   std::vector<std::shared_ptr<RayObject>> results;
-  RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, &results));
   ASSERT_EQ(results.size(), 1);
   rpc::ErrorType stored_error;
   ASSERT_TRUE(results[0]->IsException(&stored_error));
@@ -430,7 +430,7 @@ TEST_F(TaskManagerTest, TestTaskOomKillNoOomRetryFailsImmediately) {
 
     std::vector<std::shared_ptr<RayObject>> results;
     WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-    RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, false, &results));
+    RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, &results));
     ASSERT_EQ(results.size(), 1);
     rpc::ErrorType stored_error;
     ASSERT_TRUE(results[0]->IsException(&stored_error));
@@ -450,7 +450,7 @@ TEST_F(TaskManagerTest, TestTaskOomKillNoOomRetryFailsImmediately) {
 
     std::vector<std::shared_ptr<RayObject>> results;
     WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-    RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, false, &results));
+    RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, &results));
     ASSERT_EQ(results.size(), 1);
     rpc::ErrorType stored_error;
     ASSERT_TRUE(results[0]->IsException(&stored_error));
@@ -488,7 +488,7 @@ TEST_F(TaskManagerTest, TestTaskOomAndNonOomKillReturnsLastError) {
 
   std::vector<std::shared_ptr<RayObject>> results;
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-  RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, &results));
   ASSERT_EQ(results.size(), 1);
   rpc::ErrorType stored_error;
   ASSERT_TRUE(results[0]->IsException(&stored_error));
@@ -530,7 +530,7 @@ TEST_F(TaskManagerTest, TestTaskNotRetriableOomFailsImmediatelyEvenWithOomRetryC
 
   std::vector<std::shared_ptr<RayObject>> results;
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-  RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, &results));
   ASSERT_EQ(results.size(), 1);
   rpc::ErrorType stored_error;
   ASSERT_TRUE(results[0]->IsException(&stored_error));
@@ -557,7 +557,7 @@ TEST_F(TaskManagerTest, TestFailsImmediatelyOverridesRetry) {
 
     std::vector<std::shared_ptr<RayObject>> results;
     WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-    RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, false, &results));
+    RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, &results));
     ASSERT_EQ(results.size(), 1);
     rpc::ErrorType stored_error;
     ASSERT_TRUE(results[0]->IsException(&stored_error));
@@ -581,7 +581,7 @@ TEST_F(TaskManagerTest, TestFailsImmediatelyOverridesRetry) {
 
     std::vector<std::shared_ptr<RayObject>> results;
     WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-    RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, false, &results));
+    RAY_CHECK_OK(store_->Get({return_id}, 1, 0, ctx, &results));
     ASSERT_EQ(results.size(), 1);
     rpc::ErrorType stored_error;
     ASSERT_TRUE(results[0]->IsException(&stored_error));
@@ -1113,7 +1113,7 @@ TEST_F(TaskManagerLineageTest, TestDynamicReturnsTask) {
 
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
   std::vector<std::shared_ptr<RayObject>> results;
-  RAY_CHECK_OK(store_->Get(dynamic_return_ids, 3, -1, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get(dynamic_return_ids, 3, -1, ctx, &results));
   ASSERT_EQ(results.size(), 3);
   for (int i = 0; i < 3; i++) {
     ASSERT_TRUE(results[i]->IsInPlasmaError());
@@ -1192,10 +1192,10 @@ TEST_F(TaskManagerLineageTest, TestResubmittedDynamicReturnsTaskFails) {
   // No error stored for the generator ID, which should have gone out of scope.
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
   std::vector<std::shared_ptr<RayObject>> results;
-  ASSERT_FALSE(store_->Get({generator_id}, 1, 0, ctx, false, &results).ok());
+  ASSERT_FALSE(store_->Get({generator_id}, 1, 0, ctx, &results).ok());
 
   // The internal ObjectRefs have the right error.
-  RAY_CHECK_OK(store_->Get(dynamic_return_ids, 3, -1, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get(dynamic_return_ids, 3, -1, ctx, &results));
   ASSERT_EQ(results.size(), 3);
   for (int i = 0; i < 3; i++) {
     rpc::ErrorType stored_error;
@@ -1565,7 +1565,7 @@ TEST_F(TaskManagerTest, TestObjectRefStreamEndtoEnd) {
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 2);
   std::vector<std::shared_ptr<RayObject>> results;
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-  RAY_CHECK_OK(store_->Get({dynamic_return_id}, 1, 1, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get({dynamic_return_id}, 1, 1, ctx, &results));
   ASSERT_EQ(results.size(), 1);
 
   // Make sure you can read.
@@ -1594,7 +1594,7 @@ TEST_F(TaskManagerTest, TestObjectRefStreamEndtoEnd) {
 
   // NumObjectIDsInScope == Generator + 2 intermediate result.
   results.clear();
-  RAY_CHECK_OK(store_->Get({dynamic_return_id2}, 1, 1, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get({dynamic_return_id2}, 1, 1, ctx, &results));
   ASSERT_EQ(results.size(), 1);
 
   // Make sure you can read.
@@ -1657,10 +1657,10 @@ TEST_F(TaskManagerTest, TestObjectRefStreamDelCleanReferences) {
   ASSERT_EQ(store_->Size(), 2);
   std::vector<std::shared_ptr<RayObject>> results;
   WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-  RAY_CHECK_OK(store_->Get({dynamic_return_id}, 1, 1, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get({dynamic_return_id}, 1, 1, ctx, &results));
   ASSERT_EQ(results.size(), 1);
   results.clear();
-  RAY_CHECK_OK(store_->Get({dynamic_return_id2}, 1, 1, ctx, false, &results));
+  RAY_CHECK_OK(store_->Get({dynamic_return_id2}, 1, 1, ctx, &results));
   ASSERT_EQ(results.size(), 1);
   results.clear();
 
@@ -1669,9 +1669,9 @@ TEST_F(TaskManagerTest, TestObjectRefStreamDelCleanReferences) {
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
   // All the in memory objects should be cleaned up.
   ASSERT_EQ(store_->Size(), 0);
-  ASSERT_TRUE(store_->Get({dynamic_return_id}, 1, 1, ctx, false, &results).IsTimedOut());
+  ASSERT_TRUE(store_->Get({dynamic_return_id}, 1, 1, ctx, &results).IsTimedOut());
   results.clear();
-  ASSERT_TRUE(store_->Get({dynamic_return_id2}, 1, 1, ctx, false, &results).IsTimedOut());
+  ASSERT_TRUE(store_->Get({dynamic_return_id2}, 1, 1, ctx, &results).IsTimedOut());
   results.clear();
 
   // NOTE: We panic if READ is called after DELETE. The
@@ -1693,7 +1693,7 @@ TEST_F(TaskManagerTest, TestObjectRefStreamDelCleanReferences) {
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
   // All the in memory objects should be cleaned up.
   ASSERT_EQ(store_->Size(), 0);
-  ASSERT_TRUE(store_->Get({dynamic_return_id3}, 1, 1, ctx, false, &results).IsTimedOut());
+  ASSERT_TRUE(store_->Get({dynamic_return_id3}, 1, 1, ctx, &results).IsTimedOut());
   results.clear();
 
   CompletePendingStreamingTask(spec, caller_address, 2);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2020,6 +2020,7 @@ void NodeManager::HandleDirectCallTaskBlocked(
       !release_resources) {
     return;  // The worker may have died or is no longer processing the task.
   }
+  RAY_LOG(INFO) << "jjyao release CPU resource";
   local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker);
   cluster_task_manager_->ScheduleAndDispatchTasks();
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
