### PR TITLE
[ci] script to persist test results

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -5,3 +5,9 @@ py_binary(
     srcs = ["state_machine_bot.py"],
     deps = ["//ci/ray_ci:ray_ci_lib"],
 )
+
+py_binary(
+    name = "test_db_bot",
+    srcs = ["test_db_bot.py"],
+    deps = ["//ci/ray_ci:ray_ci_lib"],
+)

--- a/ci/ray_ci/automation/test_db_bot.py
+++ b/ci/ray_ci/automation/test_db_bot.py
@@ -1,0 +1,28 @@
+import os
+
+import click
+from ci.ray_ci.utils import logger
+from ci.ray_ci.tester_container import TesterContainer, PIPELINE_POSTMERGE
+from ray_release.configs.global_config import init_global_config
+from ray_release.bazel import bazel_runfile
+
+
+@click.command()
+@click.argument("team", required=True, type=str)
+@click.argument("bazel_log_dir", required=True, type=str)
+def main(team: str, bazel_log_dir: str) -> None:
+    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+
+    if os.environ.get("BUILDKITE_BRANCH") != "master":
+        logger.info("Skip upload test results. We only upload on master branch.")
+        return
+
+    if os.environ.get("BUILDKITE_PIPELINE_ID") != PIPELINE_POSTMERGE:
+        logger.info("Skip upload test results. We only upload on postmerge pipeline.")
+        return
+
+    TesterContainer.upload_test_results(team, bazel_log_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -58,7 +58,6 @@ run_ray_cpp_and_java() {
 
 _prelude() {
   rm -rf /tmp/bazel_event_logs
-  cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
   (which bazel && bazel clean) || true;
   . ./ci/ci.sh init && source ~/.zshenv
   source ~/.zshrc
@@ -67,6 +66,10 @@ _prelude() {
 }
 
 _epilogue() {
+  # Upload test results
+  ./ci/build/upload_build_info.sh
+  # Assign all macos tests to core for now
+  bazel run //ci/ray_ci/automation:test_db_bot -- core /tmp/bazel_event_logs
   # Persist ray logs
   mkdir -p /tmp/artifacts/.ray/
   tar -czf /tmp/artifacts/.ray/logs.tgz /tmp/ray

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -206,8 +206,7 @@ def test_get_test_results() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         with open(os.path.join(tmp, "bazel_log"), "w") as f:
             f.write("\n".join(_BAZEL_LOGS))
-        container = LinuxTesterContainer("docker_tag", skip_ray_installation=True)
-        results = container._get_test_and_results("manu", tmp)
+        results = LinuxTesterContainer.get_test_and_results("manu", tmp)
         results.sort(key=lambda x: x[0].get_name())
 
         test, result = results[0]

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -115,7 +115,7 @@ class TesterContainer(Container):
             )
             return
         self._upload_build_info(bazel_log_dir)
-        self._upload_test_results(team, bazel_log_dir)
+        TesterContainer.upload_test_results(team, bazel_log_dir)
 
     def _upload_build_info(self, bazel_log_dir) -> None:
         logger.info("Uploading bazel test logs")
@@ -127,15 +127,17 @@ class TesterContainer(Container):
             ]
         )
 
-    def _upload_test_results(self, team: str, bazel_log_dir: str) -> None:
-        for test, result in self._get_test_and_results(team, bazel_log_dir):
+    @classmethod
+    def upload_test_results(cls, team: str, bazel_log_dir: str) -> None:
+        for test, result in cls.get_test_and_results(team, bazel_log_dir):
             logger.info(f"Test {test.get_name()} run status is {result.status}")
             test.update_from_s3()
             test.persist_to_s3()
             test.persist_test_result_to_s3(result)
 
-    def _get_test_and_results(
-        self, team, bazel_log_dir: str
+    @classmethod
+    def get_test_and_results(
+        cls, team, bazel_log_dir: str
     ) -> List[Tuple[Test, TestResult]]:
         bazel_logs = []
         # Find all bazel logs


### PR DESCRIPTION
Add a script to persist test results and use it for mac jobs

Test:
- CI
- postmerge, upload data just fine: https://buildkite.com/ray-project/postmerge/builds/2565#018d1a43-30ac-4fff-976a-103c6b2c4e27/1379-3372