### PR TITLE
[Core] Replace ray._private.worker.global_worker.node.unique_id with ray.get_runtime_context().get_node_id()

### DIFF
--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -80,7 +80,7 @@ def test_actor_load_balancing(ray_start_cluster):
             pass
 
         def get_location(self):
-            return ray._private.worker.global_worker.node.unique_id
+            return ray.get_runtime_context().get_node_id()
 
     # Create a bunch of actors.
     num_actors = 30
@@ -181,7 +181,7 @@ def test_exception_raised_when_actor_node_dies(ray_start_cluster_head):
             self.x = 0
 
         def node_id(self):
-            return ray._private.worker.global_worker.node.unique_id
+            return ray.get_runtime_context().get_node_id()
 
         def inc(self):
             self.x += 1

--- a/python/ray/tests/test_actor_resources.py
+++ b/python/ray/tests/test_actor_resources.py
@@ -98,7 +98,7 @@ def test_actor_gpus(ray_start_cluster):
         def get_location_and_ids(self):
             assert ray.get_gpu_ids() == self.gpu_ids
             return (
-                ray._private.worker.global_worker.node.unique_id,
+                ray.get_runtime_context().get_node_id(),
                 tuple(self.gpu_ids),
             )
 
@@ -141,7 +141,7 @@ def test_actor_multiple_gpus(ray_start_cluster):
         def get_location_and_ids(self):
             assert ray.get_gpu_ids() == self.gpu_ids
             return (
-                ray._private.worker.global_worker.node.unique_id,
+                ray.get_runtime_context().get_node_id(),
                 tuple(self.gpu_ids),
             )
 
@@ -175,7 +175,7 @@ def test_actor_multiple_gpus(ray_start_cluster):
 
         def get_location_and_ids(self):
             return (
-                ray._private.worker.global_worker.node.unique_id,
+                ray.get_runtime_context().get_node_id(),
                 tuple(self.gpu_ids),
             )
 
@@ -217,7 +217,7 @@ def test_actor_different_numbers_of_gpus(ray_start_cluster):
 
         def get_location_and_ids(self):
             return (
-                ray._private.worker.global_worker.node.unique_id,
+                ray.get_runtime_context().get_node_id(),
                 tuple(self.gpu_ids),
             )
 
@@ -264,7 +264,7 @@ def test_actor_multiple_gpus_from_multiple_tasks(ray_start_cluster):
 
             def get_location_and_ids(self):
                 return (
-                    (ray._private.worker.global_worker.node.unique_id),
+                    (ray.get_runtime_context().get_node_id()),
                     tuple(self.gpu_ids),
                 )
 
@@ -310,7 +310,7 @@ def test_actor_multiple_gpus_from_multiple_tasks(ray_start_cluster):
 
         def get_location_and_ids(self):
             return (
-                ray._private.worker.global_worker.node.unique_id,
+                ray.get_runtime_context().get_node_id(),
                 tuple(self.gpu_ids),
             )
 
@@ -356,7 +356,7 @@ def test_actors_and_tasks_with_gpus(ray_start_cluster):
         assert len(gpu_ids) == 1
         assert gpu_ids[0] in range(num_gpus_per_raylet)
         return (
-            ray._private.worker.global_worker.node.unique_id,
+            ray.get_runtime_context().get_node_id(),
             tuple(gpu_ids),
             [t1, t2],
         )
@@ -371,7 +371,7 @@ def test_actors_and_tasks_with_gpus(ray_start_cluster):
         assert gpu_ids[0] in range(num_gpus_per_raylet)
         assert gpu_ids[1] in range(num_gpus_per_raylet)
         return (
-            ray._private.worker.global_worker.node.unique_id,
+            ray.get_runtime_context().get_node_id(),
             tuple(gpu_ids),
             [t1, t2],
         )
@@ -386,7 +386,7 @@ def test_actors_and_tasks_with_gpus(ray_start_cluster):
         def get_location_and_ids(self):
             assert ray.get_gpu_ids() == self.gpu_ids
             return (
-                ray._private.worker.global_worker.node.unique_id,
+                ray.get_runtime_context().get_node_id(),
                 tuple(self.gpu_ids),
             )
 
@@ -598,12 +598,12 @@ def test_custom_label_placement(ray_start_cluster):
     @ray.remote(resources={"CustomResource1": 1})
     class ResourceActor1:
         def get_location(self):
-            return ray._private.worker.global_worker.node.unique_id
+            return ray.get_runtime_context().get_node_id()
 
     @ray.remote(resources={"CustomResource2": 1})
     class ResourceActor2:
         def get_location(self):
-            return ray._private.worker.global_worker.node.unique_id
+            return ray.get_runtime_context().get_node_id()
 
     # Create some actors.
     actors1 = [ResourceActor1.remote() for _ in range(2)]

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -141,7 +141,7 @@ def test_zero_cpus_actor(ray_start_cluster):
     @ray.remote
     class Foo:
         def method(self):
-            return ray._private.worker.global_worker.node.unique_id
+            return ray.get_runtime_context().get_node_id()
 
     # Make sure tasks and actors run on the remote raylet.
     a = Foo.remote()
@@ -358,16 +358,16 @@ def test_custom_resources(ray_start_cluster):
 
     @ray.remote
     def f():
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     @ray.remote(resources={"CustomResource": 1})
     def g():
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     @ray.remote(resources={"CustomResource": 1})
     def h():
         ray.get([f.remote() for _ in range(5)])
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     # The g tasks should be scheduled only on the second raylet.
     raylet_ids = set(ray.get([g.remote() for _ in range(50)]))
@@ -412,7 +412,7 @@ def test_two_custom_resources(ray_start_cluster):
         # Sleep a while to emulate a slow operation. This is needed to make
         # sure tasks are scheduled to different nodes.
         time.sleep(0.1)
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     # Make sure each node has at least one idle worker.
     wait_for_condition(lambda: len(set(ray.get([foo.remote() for _ in range(6)]))) == 2)
@@ -423,27 +423,27 @@ def test_two_custom_resources(ray_start_cluster):
     @ray.remote(resources={"CustomResource1": 1})
     def f():
         time.sleep(0.001)
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     @ray.remote(resources={"CustomResource2": 1})
     def g():
         time.sleep(0.001)
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     @ray.remote(resources={"CustomResource1": 1, "CustomResource2": 3})
     def h():
         time.sleep(0.001)
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     @ray.remote(resources={"CustomResource1": 4})
     def j():
         time.sleep(0.001)
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     @ray.remote(resources={"CustomResource3": 1})
     def k():
         time.sleep(0.001)
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     # The f and g tasks should be scheduled on both raylets.
     assert len(set(ray.get([f.remote() for _ in range(500)]))) == 2

--- a/python/ray/tests/test_advanced_5.py
+++ b/python/ray/tests/test_advanced_5.py
@@ -163,7 +163,7 @@ def test_actor_distribution_balance(ray_start_cluster_enabled, args):
     @ray.remote(memory=100 * 1024**2, num_cpus=0.01, scheduling_strategy="SPREAD")
     class Foo:
         def method(self):
-            return ray._private.worker.global_worker.node.unique_id
+            return ray.get_runtime_context().get_node_id()
 
     actor_distribution = {}
     actor_list = [Foo.remote() for _ in range(actor_count)]
@@ -213,7 +213,7 @@ def test_worker_lease_reply_with_resources(ray_start_cluster_enabled):
     @ray.remote(memory=800 * 1024**2, num_cpus=0.01)
     class Foo:
         def method(self):
-            return ray._private.worker.global_worker.node.unique_id
+            return ray.get_runtime_context().get_node_id()
 
     foo1 = Foo.remote()
     o1 = foo1.method.remote()

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -634,7 +634,7 @@ def test_locality_aware_scheduling_for_dead_nodes(shutdown_only):
     # This function requires obj1 and obj2.
     @ray.remote
     def func(obj1, obj2):
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     # This function should be scheduled to node2. As node2 has both objects.
     assert ray.get(func.remote(obj1, obj2)) == node2.unique_id

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -57,9 +57,9 @@ def test_load_balancing_under_constrained_memory(
 
     @ray.remote
     def f(i, x):
-        print(i, ray._private.worker.global_worker.node.unique_id)
+        print(i, ray.get_runtime_context().get_node_id())
         time.sleep(0.1)
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     deps = [create_object.remote() for _ in range(num_tasks)]
     for i, dep in enumerate(deps):
@@ -91,7 +91,7 @@ def test_critical_object_store_mem_resource_utilization(ray_start_cluster):
 
     @ray.remote
     def f():
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     # Wait for resource availabilities to propagate.
     time.sleep(1)

--- a/python/ray/tests/test_scheduling_performance.py
+++ b/python/ray/tests/test_scheduling_performance.py
@@ -34,7 +34,8 @@ def test_actor_scheduling_latency(ray_start_cluster, args):
             if i == 0
             else {},
         )
-    ray.init(address=cluster.address)
+        if i == 0:
+            ray.init(address=cluster.address)
     cluster.wait_for_nodes()
 
     # Driver will create all UpperActors, and then each UpperActor will
@@ -45,7 +46,7 @@ def test_actor_scheduling_latency(ray_start_cluster, args):
             self.start = time.time()
 
         def info(self):
-            return [ray._private.worker.global_worker.node.unique_id, self.start]
+            return [ray.get_runtime_context().get_node_id(), self.start]
 
         def create(self, num):
             ret_list = []
@@ -60,7 +61,7 @@ def test_actor_scheduling_latency(ray_start_cluster, args):
             self.start = time.time()
 
         def info(self):
-            return [ray._private.worker.global_worker.node.unique_id, self.start]
+            return [ray.get_runtime_context().get_node_id(), self.start]
 
     actor_distribution = {}
     actor_list = []

--- a/python/ray/util/dask/tests/test_dask_scheduler.py
+++ b/python/ray/util/dask/tests/test_dask_scheduler.py
@@ -80,7 +80,7 @@ def test_ray_dask_resources(ray_start_cluster, ray_enable_dask_on_ray):
     ray.init(address=cluster.address)
 
     def get_node_id():
-        return ray._private.worker.global_worker.node.unique_id
+        return ray.get_runtime_context().get_node_id()
 
     # Test annotations on collection.
     with dask.annotate(ray_remote_args=dict(num_cpus=1, resources={"pin": 0.01})):

--- a/release/nightly_tests/stress_tests/test_many_tasks.py
+++ b/release/nightly_tests/stress_tests/test_many_tasks.py
@@ -143,7 +143,7 @@ def stage4():
         start = time.perf_counter()
         time.sleep(1)
         end = time.perf_counter()
-        return start, end, ray._private.worker.global_worker.node.unique_id
+        return start, end, ray.get_runtime_context().get_node_id()
 
     results = ray.get([func.remote(i) for i in range(num_tasks)])
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We should use public API instead of private API.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
