### PR TITLE
WIP [data] A streaming compatible implementation of repartition-by-column

### DIFF
--- a/python/ray/data/_internal/planner/exchange/repartition_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/repartition_task_scheduler.py
@@ -1,0 +1,129 @@
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple, TypeVar
+
+import ray
+from ray.data._internal.execution.interfaces import RefBundle, TaskContext
+from ray.data._internal.planner.exchange.interfaces import ExchangeTaskScheduler
+from ray.data._internal.planner.exchange.repartition_task_spec import (
+    RepartitionByColumnTaskSpec,
+)
+from ray.data._internal.repartition_by_column import repartition_runner
+from ray.data._internal.stats import StatsDict
+from ray.data.block import BlockMetadata
+
+logger = logging.getLogger(__name__)
+
+
+KeyType = TypeVar("KeyType")
+
+
+class RepartitionByColumnTaskScheduler(ExchangeTaskScheduler):
+    """Split-by-column experiment"""
+
+    def execute(
+        self,
+        refs: List[RefBundle],
+        output_num_blocks: int,
+        ctx: TaskContext,
+        map_ray_remote_args: Optional[Dict[str, Any]] = None,
+        reduce_ray_remote_args: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[List[RefBundle], StatsDict]:
+        """
+        Args:
+            output_num_blocks: not used as it's determined by the actual split
+        """
+        time_start = time.perf_counter()
+
+        input_owned_by_consumer = all(rb.owns_blocks for rb in refs)
+
+        logger.info(f"number of RefBundles = {len(refs)}")
+
+        if map_ray_remote_args is None:
+            map_ray_remote_args = {}
+        if reduce_ray_remote_args is None:
+            reduce_ray_remote_args = {}
+        if "scheduling_strategy" not in reduce_ray_remote_args:
+            reduce_ray_remote_args = reduce_ray_remote_args.copy()
+            reduce_ray_remote_args["scheduling_strategy"] = "SPREAD"
+
+        # TODO: currently, 'concurrency' only means number of actors.
+        num_actors = self._exchange_spec._map_args[1]
+
+        ref_id = 0
+        # drop the metadata
+        all_blocks = [b for ref_bundle in refs for b, _ in ref_bundle.blocks]
+
+        total_number_of_rows_input = sum(
+            [m.num_rows for ref_bundle in refs for _, m in ref_bundle.blocks]
+        )
+        logger.info(f"total number of rows input = {total_number_of_rows_input}")
+
+        tstart = time.perf_counter()
+        result_refs = list(
+            repartition_runner(
+                ref_id,
+                all_blocks,
+                self._exchange_spec._map_args,
+            )
+        )
+        tend = time.perf_counter()
+        logger.info(
+            f"Finished repartitioning {len(result_refs)=}, ({(tend-tstart):.2f}s)"
+        )
+
+        # all_keys = []
+        # for _ in range(num_actors):
+        #     all_keys.append(result_refs.pop())
+        all_keys, result_refs = result_refs[-num_actors:], result_refs[:-num_actors]
+        all_metadata, result_refs = result_refs[-num_actors:], result_refs[:-num_actors]
+        # all_metadata = []
+        # for _ in range(num_actors):
+        #     all_metadata.append(result_refs.pop())
+
+        sub_progress_bar_dict = ctx.sub_progress_bar_dict
+        bar_name = RepartitionByColumnTaskSpec.SPLIT_SUB_PROGRESS_BAR_NAME
+        assert bar_name in sub_progress_bar_dict, sub_progress_bar_dict
+        # map_bar = sub_progress_bar_dict[bar_name]
+
+        # all_metadata = map_bar.fetch_until_complete(all_metadata)
+        all_metadata = ray.get(all_metadata)
+        all_metadata: List[BlockMetadata] = [
+            m for metadata in all_metadata for m in metadata
+        ]
+        time_mid = time.perf_counter()
+        logger.info(
+            f"repartition time (up to all_metadata)= {(time_mid - time_start):.4}s"
+        )
+
+        # all_keys = ray.get(all_keys)
+        # all_keys = [m for keys in all_keys for m in keys]
+
+        all_blocks = [
+            RefBundle([(block, meta)], input_owned_by_consumer)
+            for block, meta in zip(result_refs, all_metadata)
+        ]
+
+        assert (
+            len(all_blocks)
+            == len(all_metadata)
+            #     len(all_blocks) == len(all_metadata) == len(all_keys)
+        ), f"{len(all_blocks)=}, {len(all_metadata)=}, {len(all_keys)=}"
+
+        logger.info(f"number of output blocks = {len(all_blocks)}")
+        # # logger.info(f"number of keys = {len(all_keys)}")
+        # total_number_of_rows = sum(
+        #     [stat.num_rows for stat in all_metadata if stat.num_rows is not None]
+        # )
+        # logger.info(f"total number of rows = {total_number_of_rows}")
+
+        # TODO: add progress bar
+        # TODO: use reduce_bar.fetch_until_complete etc
+        # TODO: handle block metadata better
+
+        stats = {"repartition": all_metadata}
+
+        time_end = time.perf_counter()
+        logger.info(f"repartition time = {(time_end - time_start):.4}s")
+
+        return (all_blocks, stats)

--- a/python/ray/data/_internal/planner/exchange/repartition_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/repartition_task_spec.py
@@ -1,0 +1,40 @@
+from typing import List, Optional, Tuple, TypeVar, Union
+
+from ray.data._internal.planner.exchange.interfaces import ExchangeTaskSpec
+from ray.data.block import Block, BlockMetadata
+
+T = TypeVar("T")
+
+
+class RepartitionByColumnTaskSpec(ExchangeTaskSpec):
+    """Example ExchangeTaskSpec"""
+
+    SPLIT_SUB_PROGRESS_BAR_NAME = "Split blocks by column"
+    MERGE_SUB_PROGRESS_BAR_NAME = "Merge blocks by column"
+
+    def __init__(
+        self,
+        keys: Union[str, List[str]],
+        concurrency: Optional[int],
+    ):
+        super().__init__(
+            map_args=[keys, concurrency],
+            reduce_args=[keys],
+        )
+
+    @staticmethod
+    def map(
+        idx: int,
+        block: Block,
+        output_num_blocks: int,
+        keys: Union[str, List[str]],
+    ) -> List[Union[BlockMetadata, Block]]:
+        pass
+
+    @staticmethod
+    def reduce(
+        keys: Union[str, List[str]],
+        *mapper_outputs: List[Block],
+        partial_reduce: bool = False,
+    ) -> Tuple[Block, BlockMetadata]:
+        pass

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -10,12 +10,16 @@ from ray.data._internal.logical.operators.all_to_all_operator import (
     RandomizeBlocks,
     RandomShuffle,
     Repartition,
+    RepartitionByColumn,
     Sort,
 )
 from ray.data._internal.planner.aggregate import generate_aggregate_fn
 from ray.data._internal.planner.random_shuffle import generate_random_shuffle_fn
 from ray.data._internal.planner.randomize_blocks import generate_randomize_blocks_fn
 from ray.data._internal.planner.repartition import generate_repartition_fn
+from ray.data._internal.planner.repartition_by_column import (
+    generate_repartition_by_column_fn,
+)
 from ray.data._internal.planner.sort import generate_sort_fn
 from ray.data.context import DataContext
 
@@ -61,6 +65,13 @@ def plan_all_to_all_op(
             op._shuffle,
             debug_limit_shuffle_execution_to_num_blocks,
         )
+    elif isinstance(op, RepartitionByColumn):
+        fn = generate_repartition_by_column_fn(
+            op._keys,
+            op._concurrency,
+            op._ray_remote_args,
+        )
+        target_max_block_size = None
     elif isinstance(op, Sort):
         debug_limit_shuffle_execution_to_num_blocks = data_context.get_config(
             "debug_limit_shuffle_execution_to_num_blocks", None

--- a/python/ray/data/_internal/planner/repartition_by_column.py
+++ b/python/ray/data/_internal/planner/repartition_by_column.py
@@ -1,0 +1,54 @@
+import logging
+from functools import partial
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from ray.data._internal.execution.interfaces import (
+    AllToAllTransformFn,
+    RefBundle,
+    TaskContext,
+)
+from ray.data._internal.planner.exchange.repartition_task_scheduler import (
+    RepartitionByColumnTaskScheduler,
+)
+from ray.data._internal.planner.exchange.repartition_task_spec import (
+    RepartitionByColumnTaskSpec,
+)
+from ray.data._internal.stats import StatsDict
+
+logger = logging.getLogger(__name__)
+
+
+def generate_repartition_by_column_fn(
+    keys: Union[str, List[str]],
+    concurrency: Optional[int],
+    ray_remote_args: Optional[Dict[str, Any]],
+) -> AllToAllTransformFn:
+    """Generate function to split blocks by the specified key column"""
+
+    def fn(
+        refs: List[RefBundle],
+        ctx: TaskContext,
+        keys: Union[str, List[str]],
+        concurrency: Optional[int],
+        ray_remote_args: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[List[RefBundle], StatsDict]:
+        repartition_task_spec = RepartitionByColumnTaskSpec(
+            keys=keys,
+            concurrency=concurrency,
+        )
+        scheduler = RepartitionByColumnTaskScheduler(repartition_task_spec)
+
+        return scheduler.execute(
+            refs=refs,
+            output_num_blocks=-1,
+            ctx=ctx,
+            map_ray_remote_args=ray_remote_args,
+            reduce_ray_remote_args=ray_remote_args,
+        )
+
+    return partial(
+        fn,
+        keys=keys,
+        concurrency=concurrency,
+        ray_remote_args=ray_remote_args,
+    )

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -72,7 +72,9 @@ class ProgressBar:
         if not enabled:
             self._bar = None
         elif tqdm:
-            ctx = ray.data.context.DataContext.get_current()
+            from ray.data import DataContext
+
+            ctx = DataContext.get_current()
             if ctx.use_ray_tqdm:
                 self._bar = tqdm_ray.tqdm(total=total, unit=unit, position=position)
             else:

--- a/python/ray/data/_internal/repartition_by_column.py
+++ b/python/ray/data/_internal/repartition_by_column.py
@@ -1,0 +1,320 @@
+import asyncio
+import itertools
+import logging
+import time
+from collections import deque
+from math import ceil
+from typing import Any, Deque, Iterator, List, Tuple, TypeVar, Union
+
+import ray
+from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
+from ray.data.block import Block, BlockAccessor, BlockExecStats
+
+logger = logging.getLogger(__name__)
+
+KeyType = TypeVar("KeyType")
+
+
+def batched(blocks: List[Any], batch_size: int) -> Iterator[List[Any]]:
+    """Iterates over the blocks and yields batches of objects.
+
+    Note:
+        This function can be replaced by itertools.batched when Python 3.12.
+    """
+    for i in range(0, len(blocks), batch_size):
+        yield blocks[i : i + batch_size]
+
+
+def split_single_block(
+    block: Block, keys: Union[List[str], str]
+) -> Iterator[Tuple[Union[str, int], Block]]:
+    """Split a single block into multiple blocks based on the key column(s).
+
+    Args:
+        block: pyarrow table or pandas DataFrame
+        keys: The key column(s) to split on.
+
+    Yields:
+        Tuples of key and block. If multiple key columns are specified, the
+        key is a tuple of values.
+    """
+    import numpy as np
+
+    if isinstance(keys, list) and len(keys) == 1:
+        keys = keys[0]
+
+    accessor = BlockAccessor.for_block(block)
+
+    if accessor.num_rows() == 0:
+        return []
+
+    arr = accessor.to_numpy(keys)
+
+    if isinstance(arr, np.ndarray):
+        indices = np.hstack([[0], np.where(arr[1:] != arr[:-1])[0] + 1, [len(arr)]])
+        arr_ = arr
+    else:
+        arr_ = np.rec.fromarrays(arr.values())
+        indices = np.hstack([[0], np.where(arr_[1:] != arr_[:-1])[0] + 1, [len(arr_)]])
+
+    for start, end in zip(indices[:-1], indices[1:]):
+        key = arr_[start]
+        key = tuple(key) if isinstance(key, np.record) else key
+        yield key, accessor.slice(start, end, copy=True)
+
+
+def merge_tables(keys_and_blocks: List[Tuple]):
+    """Merge pyarrow tables
+
+    Neighboring tables with the same group key are concatenated. Similar to
+    `itertools.groupby`, this operation is local and does not give the same
+    result as a `groupby` which collects same key globally.
+
+    Yields:
+        This function yields a list of merged tables. The last element of
+        the output is a list of metadata for each block.
+    """
+    if len(keys_and_blocks) == 0:
+        return [], [], []
+
+    all_blocks, all_metadata, all_keys = [], [], []
+    for key, block_iterator in itertools.groupby(keys_and_blocks, lambda x: x[0]):
+        all_keys.append(key)
+
+        stats = BlockExecStats.builder()
+        block_builder = DelegatingBlockBuilder()
+
+        for _, b in block_iterator:
+            block_builder.add_block(b)
+
+        block = block_builder.build()
+
+        meta = BlockAccessor.for_block(block).get_metadata(
+            input_files=None,
+            exec_stats=stats.build(),
+        )
+        all_blocks.append(block)
+        all_metadata.append(meta)
+        all_keys.append(key)
+
+    return all_blocks, all_metadata, all_keys
+
+
+@ray.remote
+class Actor:
+    def __init__(self, idx: int, world_size: int, keys: str):
+        self.idx = idx
+        self.world_size = world_size
+        self.keys = keys
+        self.name = f"Actor-({self.idx})"
+
+        self.split_queue: Deque[Tuple[int, ray.ObjectRef]] = deque()
+
+        # For exchange boundary
+        self.is_left_most = self.idx == 0
+        self.is_right_most = self.idx == self.world_size - 1
+        self.left_bucket = None if self.is_left_most else asyncio.Queue(1)
+        self.right_bucket = (
+            None if self.is_right_most else asyncio.Queue(1)
+        )  # local only
+
+        self.right_actor = None
+        self.right_actor_ready = asyncio.Event() if not self.is_right_most else None
+
+        # Indicate it's ready to consume
+        self.consume_ready = asyncio.Event()
+
+        # For output
+        self._num_output_blocks = 0
+        self.output_queue = asyncio.Queue()
+
+        # For logging
+        self._input_num_rows = 0
+        self._split_num_rows = 0
+        self._merge_num_rows = 0
+
+    def __repr__(self):
+        return self.name
+
+    def set_right_actor(self, right_actor):
+        self.right_actor = right_actor
+        self.right_actor_ready.set()
+
+    async def process(self, blocks: List[ray.ObjectRef]):
+        """Process the blocks"""
+
+        # split blocks and handle boundary
+        await self.split_blocks(blocks)
+
+        # merge blocks
+        await self.merge_blocks()
+
+    async def split_blocks(
+        self, block_refs: List[ray.ObjectRef]
+    ) -> List[ray.ObjectRef]:
+        """Split a list of blocks based on the group key.
+
+        This is the map task that generates multiple sub-blocks for each input block,
+        depending on the group key.
+        """
+        blocks = await asyncio.gather(*block_refs)
+
+        for block in blocks:
+            self._input_num_rows += len(block)
+            for key, blk in split_single_block(block, self.keys):
+                self._split_num_rows += len(blk)
+                self.split_queue.append((key, blk))
+
+        # handle left boundary: take the first sub-block
+        # if it's not the left-most actor
+        if not self.is_left_most:
+            key, blk = self.split_queue.popleft()
+            self.left_bucket.put_nowait((key, blk))
+
+        # handle right boundary: take the last sub-block
+        if not self.is_right_most:
+            key, blk = self.split_queue.pop()
+            self.right_bucket.put_nowait((key, blk))
+
+        # TODO: this flag may be removed when it is converted into
+        # a fully streaming operation
+        self.consume_ready.set()
+
+    async def merge_blocks(self):
+        await self.consume_ready.wait()
+
+        all_blocks, all_metadata, all_keys = merge_tables(self.split_queue)
+
+        for block, meta, key in zip(all_blocks, all_metadata, all_keys):
+            self.output_queue.put_nowait((block, meta, key))
+        self._num_output_blocks = self.output_queue.qsize()
+
+        if not self.is_right_most:
+            await self.merge_right_blocks()
+
+        self.output_queue.put_nowait("done")
+        # tend = time.perf_counter()
+        # logger.info(f"{self.name}-merge-blocks: time = {(tend-tstart):0.3f}s")
+
+    async def send_to_left(self):
+        """Send the left item to the left actor."""
+        return await self.left_bucket.get()
+
+    async def merge_right_blocks(self):
+        await self.right_actor_ready.wait()
+        logger.info(f"{self.name}-merge_right_blocks: Get value from right actor")
+
+        # current actor's right is left of the right actor's left
+        right_key, right_blk = await self.right_actor.send_to_left.remote()
+        left_key, left_block = await self.right_bucket.get()
+
+        all_blocks, all_metadata, all_keys = merge_tables(
+            [(left_key, left_block), (right_key, right_blk)]
+        )
+
+        for blk, meta, key in zip(all_blocks, all_metadata, all_keys):
+            self.output_queue.put_nowait((blk, meta, key))
+
+        # update
+        self._num_output_blocks = self.output_queue.qsize()
+
+    async def consume(self):
+        """Consume the output queue
+
+        It returns N+2 items, where N is the number of output blocks.
+        """
+        all_blocks, all_metadata, all_keys = [], [], []
+        while True:
+            item = await self.output_queue.get()
+            if item == "done":
+                print(f"{len(all_blocks)=}")
+                return *all_blocks, all_metadata, all_keys
+            block, meta, key = item
+            all_blocks.append(block)
+            all_metadata.append(meta)
+            all_keys.append(key)
+
+    def get_num_output_blocks(self):
+        return self._num_output_blocks
+
+    def get_input_num_rows(self):
+        return self._input_num_rows
+
+    def get_split_num_rows(self):
+        return self._split_num_rows
+
+
+def retreive_results(actors):
+    """Retreive the results from the actors.
+
+    Since we do not know the number of blocks in advance, we need
+    to call `get_num_output_blocks` to get the number of blocks.
+    The rest of the function is simply rearranging the output
+    without materializing the object references.
+    """
+    num_ouput_blocks = ray.get(
+        [actor.get_num_output_blocks.remote() for actor in actors]
+    )
+
+    refs = [
+        actor.consume.options(num_returns=num_blocks + 2).remote()
+        for num_blocks, actor in zip(num_ouput_blocks, actors)
+    ]
+
+    output_blocks, output_metadata, output_keys = [], [], []
+    for refs_per_actor in refs:
+        output_keys.append(refs_per_actor.pop())
+        output_metadata.append(refs_per_actor.pop())
+        output_blocks.extend(refs_per_actor)
+
+    # yield each blocks
+    yield from output_blocks
+    # yield 2*K lists of metadata and keys
+    yield from output_metadata
+    yield from output_keys
+
+
+def repartition_runner(
+    ref_id,
+    blocks,
+    map_args,
+) -> Iterator[ray.ObjectRef]:
+    """
+    Yields:
+        Assuming K actors, this function first yields each block's object reference
+        individually. Then it yields K refs from each actor for the metadata, i.e.,
+        K lists of metadata. Finally, it yields K refs from each actor for the keys,
+        i.e., K lists of keys.
+    """
+
+    # TODO: currently, 'concurrency' only means number of actors.
+    keys, num_actors = map_args
+
+    if len(blocks) <= num_actors:
+        num_actors = 1
+
+    num_blocks_per_actor = ceil(len(blocks) / num_actors)
+    logger.info(f"{ref_id}: {len(blocks)=}, {num_actors=}, {num_blocks_per_actor=}")
+
+    actors = [Actor.remote(i, num_actors, keys) for i in range(num_actors)]
+
+    add_right = [
+        left.set_right_actor.remote(right)
+        for left, right in zip(actors[:-1], actors[1:])
+    ]
+
+    process_tasks = [
+        actors[i].process.remote(batch_per_actor)
+        for i, batch_per_actor in enumerate(batched(blocks, num_blocks_per_actor))
+    ]
+
+    ray.get(add_right + process_tasks)
+
+    time_consume_start = time.perf_counter()
+    yield from retreive_results(actors)
+    time_consume_end = time.perf_counter()
+
+    logger.info(
+        "retreive results from actors: taken "
+        f"{(time_consume_end - time_consume_start):.3f}s"
+    )

--- a/python/ray/data/tests/test_repartition_by_column.py
+++ b/python/ray/data/tests/test_repartition_by_column.py
@@ -1,0 +1,145 @@
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from ray.data._internal.planner.repartition_by_column import split_single_block
+
+"""Unit tests for the repartition_by_column module.
+
+The actual test to the dataset API is tested elsewhere.
+"""
+
+
+@pytest.fixture
+def empty_block():
+    return pa.Table.from_pydict({})
+
+
+@pytest.fixture
+def non_varied_block():
+    return pa.Table.from_pydict(
+        {
+            "x": np.array([1, 1, 1]),
+            "y": np.array([2, 2, 2]),
+        }
+    )
+
+
+@pytest.fixture
+def non_numeric_block():
+    return pa.Table.from_pydict(
+        {
+            "x": np.array(["a", "b", "b"]),
+            "y": np.array(["c", "d", "d"]),
+        }
+    )
+
+
+@pytest.fixture
+def missing_values_block():
+    return pa.Table.from_pydict(
+        {
+            "x": np.array([1, np.nan, 2]),
+            "y": np.array([2, 3, np.nan]),
+        }
+    )
+
+
+@pytest.fixture
+def single_row_block():
+    return pa.Table.from_pydict(
+        {
+            "x": np.array([1]),
+            "y": np.array([2]),
+        }
+    )
+
+
+@pytest.fixture
+def pyarrow_block_0():
+    return pa.Table.from_pydict(
+        {
+            "x": np.array([1, 1, 1]),
+            "y": np.array([2, 4, 6]),
+        }
+    )
+
+
+@pytest.fixture
+def pyarrow_block_1():
+    return pa.Table.from_pydict(
+        {
+            "x": np.array([1, 1, 1, 2, 2, 2]),
+            "y": np.array([2, 2, 3, 4, 4, 5]),
+        }
+    )
+
+
+def test_split_single_block_single_block(pyarrow_block_0):
+    keys_and_blocks = list(split_single_block(pyarrow_block_0, "x"))
+
+    assert len(keys_and_blocks) == 1
+    assert keys_and_blocks[0][0] == 1
+
+    keys_and_blocks = list(split_single_block(pyarrow_block_0, ["x"]))
+
+    assert len(keys_and_blocks) == 1
+
+
+def test_split_single_block_2_blocks(pyarrow_block_1):
+    keys_and_blocks = list(split_single_block(pyarrow_block_1, "x"))
+
+    assert len(keys_and_blocks) == 2
+    assert [k for k, _ in keys_and_blocks] == [1, 2]
+
+    keys_and_blocks = list(split_single_block(pyarrow_block_1, ["x"]))
+
+    assert len(keys_and_blocks) == 2
+    assert [k for k, _ in keys_and_blocks] == [1, 2]
+
+
+def test_split_single_block_2_blocks_2_keys(pyarrow_block_1):
+    keys_and_blocks = list(split_single_block(pyarrow_block_1, ["x", "y"]))
+
+    assert len(keys_and_blocks) == 4
+    assert [k for k, _ in keys_and_blocks] == [(1, 2), (1, 3), (2, 4), (2, 5)]
+
+
+def test_split_single_block_empty_block(empty_block):
+    keys_and_blocks = list(split_single_block(empty_block, "x"))
+    assert len(keys_and_blocks) == 0
+
+
+def test_split_single_block_non_varied_block(non_varied_block):
+    keys_and_blocks = list(split_single_block(non_varied_block, "x"))
+    assert len(keys_and_blocks) == 1
+    assert keys_and_blocks[0][0] == 1
+
+
+def test_split_single_block_non_numeric_block(non_numeric_block):
+    keys_and_blocks = list(split_single_block(non_numeric_block, "x"))
+    assert len(keys_and_blocks) == 2
+    assert [k for k, _ in keys_and_blocks] == ["a", "b"]
+
+
+def test_split_single_block_missing_values_block(missing_values_block):
+    keys_and_blocks = list(split_single_block(missing_values_block, "x"))
+    assert (
+        len(keys_and_blocks) == 3
+    )  # Assuming the function handles NaN as a separate group
+    # Assuming that the NaN group comes last, the keys should be 1, 2, and then NaN
+    assert keys_and_blocks[0][0] == 1
+    assert np.isnan(keys_and_blocks[1][0])
+    assert keys_and_blocks[2][0] == 2
+
+
+def test_split_single_block_single_row_block(single_row_block):
+    keys_and_blocks = list(split_single_block(single_row_block, "x"))
+    assert len(keys_and_blocks) == 1
+    assert keys_and_blocks[0][0] == 1
+
+
+def test_split_single_block_multiple_keys(non_numeric_block):
+    keys_and_blocks = list(split_single_block(non_numeric_block, ["x", "y"]))
+    assert len(keys_and_blocks) == 2
+    assert [k for k, _ in keys_and_blocks] == [("a", "c"), ("b", "d")]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

WIP

tl;dr: For large partitioned dataset with continuous group, we can avoid `groupby.map_groups` (and sort within) by using repartition-by-column. See #42288 

TODO:

- [ ] finalize the public API
- [ ] handle `concurrency`
- [ ] add unit tests

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #42288 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
