### PR TITLE
[ci] clean up test summaries on mac properly

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -29,3 +29,4 @@ fi
 # environment as the buildkite job commands, and has no effect when the tests run 
 # inside another test container
 rm -rf /tmp/bazel_event_logs
+rm -rf /tmp/artifacts/test-summaries


### PR DESCRIPTION
The clean up code currently using a docker command that works only on linux

Test:
- CI