### PR TITLE
[Data] Allow to specify application-level error to retry for actor task

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -83,7 +83,7 @@ class ActorPoolMapOperator(MapOperator):
         self._ray_remote_args = self._apply_default_remote_args(self._ray_remote_args)
         self._ray_actor_task_remote_args = {}
         actor_task_errors = DataContext.get_current().actor_task_retry_on_errors
-        if len(actor_task_errors) > 0:
+        if actor_task_errors:
             self._ray_actor_task_remote_args["retry_exceptions"] = actor_task_errors
         self._min_rows_per_bundle = min_rows_per_bundle
 

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -80,11 +80,11 @@ class ActorPoolMapOperator(MapOperator):
             min_rows_per_bundle,
             ray_remote_args,
         )
-        # Extract the remote argument for actor task.
-        self._ray_actor_task_remote_args = self._ray_remote_args.pop(
-            "ray_actor_task_remote_args", {}
-        )
         self._ray_remote_args = self._apply_default_remote_args(self._ray_remote_args)
+        self._ray_actor_task_remote_args = {}
+        actor_task_errors = DataContext.get_current().actor_task_retry_on_errors
+        if len(actor_task_errors) > 0:
+            self._ray_actor_task_remote_args["retry_exceptions"] = actor_task_errors
         self._min_rows_per_bundle = min_rows_per_bundle
 
         # Create autoscaling policy from compute strategy.

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -80,6 +80,10 @@ class ActorPoolMapOperator(MapOperator):
             min_rows_per_bundle,
             ray_remote_args,
         )
+        # Extract the remote argument for actor task.
+        self._ray_actor_task_remote_args = self._ray_remote_args.pop(
+            "ray_actor_task_remote_args", {}
+        )
         self._ray_remote_args = self._apply_default_remote_args(self._ray_remote_args)
         self._min_rows_per_bundle = min_rows_per_bundle
 
@@ -194,9 +198,11 @@ class ActorPoolMapOperator(MapOperator):
                 task_idx=self._next_data_task_idx,
                 target_max_block_size=self.actual_target_max_block_size,
             )
-            gen = actor.submit.options(num_returns="streaming", name=self.name).remote(
-                DataContext.get_current(), ctx, *input_blocks
-            )
+            gen = actor.submit.options(
+                num_returns="streaming",
+                name=self.name,
+                **self._ray_actor_task_remote_args,
+            ).remote(DataContext.get_current(), ctx, *input_blocks)
 
             def _task_done_callback(actor_to_return):
                 # Return the actor that was running the task to the pool.

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -159,6 +159,10 @@ DEFAULT_WRITE_FILE_RETRY_ON_ERRORS = [
     "AWS Error SLOW_DOWN",
 ]
 
+# The application-level errors that actor task would retry.
+# Default to empty list to not retry on any errors.
+DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS = []
+
 
 @DeveloperAPI
 class DataContext:
@@ -201,6 +205,7 @@ class DataContext:
         enable_get_object_locations_for_metrics: bool,
         use_runtime_metrics_scheduling: bool,
         write_file_retry_on_errors: List[str],
+        actor_task_retry_on_errors: List[str],
     ):
         """Private constructor (use get_current() instead)."""
         self.target_max_block_size = target_max_block_size
@@ -239,6 +244,7 @@ class DataContext:
         )
         self.use_runtime_metrics_scheduling = use_runtime_metrics_scheduling
         self.write_file_retry_on_errors = write_file_retry_on_errors
+        self.actor_task_retry_on_errors = actor_task_retry_on_errors
         # The additonal ray remote args that should be added to
         # the task-pool-based data tasks.
         self._task_pool_data_task_remote_args: Dict[str, Any] = {}
@@ -309,6 +315,7 @@ class DataContext:
                     enable_get_object_locations_for_metrics=DEFAULT_ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS,  # noqa E501
                     use_runtime_metrics_scheduling=DEFAULT_USE_RUNTIME_METRICS_SCHEDULING,  # noqa: E501
                     write_file_retry_on_errors=DEFAULT_WRITE_FILE_RETRY_ON_ERRORS,
+                    actor_task_retry_on_errors=DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS,
                 )
 
             return _default_context

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -1,6 +1,6 @@
 import os
 import threading
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import ray
 from ray._private.ray_constants import env_integer
@@ -160,8 +160,10 @@ DEFAULT_WRITE_FILE_RETRY_ON_ERRORS = [
 ]
 
 # The application-level errors that actor task would retry.
-# Default to empty list to not retry on any errors.
-DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS = []
+# Default to `False` to not retry on any errors.
+# Set to `True` to retry all errors, or set to a list of errors to retry.
+# This follows same format as `retry_exceptions` in Ray Core.
+DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS = False
 
 
 @DeveloperAPI
@@ -205,7 +207,7 @@ class DataContext:
         enable_get_object_locations_for_metrics: bool,
         use_runtime_metrics_scheduling: bool,
         write_file_retry_on_errors: List[str],
-        actor_task_retry_on_errors: List[str],
+        actor_task_retry_on_errors: Union[bool, List[BaseException]],
     ):
         """Private constructor (use get_current() instead)."""
         self.target_max_block_size = target_max_block_size

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -339,7 +339,7 @@ class Dataset:
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
-                ray for each map worker.
+                Ray for each map worker.
 
         .. seealso::
 
@@ -1029,7 +1029,7 @@ class Dataset:
                 For an autoscaling worker pool from ``m`` to ``n`` workers, specify
                 ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
-                ray for each map worker.
+                ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """
         compute = get_compute_strategy(
             fn,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -339,10 +339,7 @@ class Dataset:
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
-                ray for each map worker. This applies to Ray tasks and actors.
-                To request resource requirements for tasks launched by Ray actor,
-                specify ``ray_actor_task_remote_args={...}`` inside
-                ``ray_remote_args``.
+                ray for each map worker.
 
         .. seealso::
 
@@ -566,10 +563,7 @@ class Dataset:
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
-                ray for each map worker. This applies to Ray tasks and actors.
-                To request resource requirements for tasks launched by Ray actor,
-                specify ``ray_actor_task_remote_args={...}`` inside
-                ``ray_remote_args``.
+                ray for each map worker.
 
         .. note::
 
@@ -941,10 +935,7 @@ class Dataset:
                 For an autoscaling worker pool from ``m`` to ``n`` workers, specify
                 ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
-                ray for each map worker. This applies to Ray tasks and actors.
-                To request resource requirements for tasks launched by Ray actor,
-                specify ``ray_actor_task_remote_args={...}`` inside
-                ``ray_remote_args``.
+                ray for each map worker.
 
         .. seealso::
 
@@ -1038,10 +1029,7 @@ class Dataset:
                 For an autoscaling worker pool from ``m`` to ``n`` workers, specify
                 ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
-                ray for each map worker. This applies to Ray tasks and actors.
-                To request resource requirements for tasks launched by Ray actor,
-                specify ``ray_actor_task_remote_args={...}`` inside
-                ``ray_remote_args``.
+                ray for each map worker.
         """
         compute = get_compute_strategy(
             fn,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -339,7 +339,10 @@ class Dataset:
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
-                Ray for each map worker.
+                ray for each map worker. This applies to Ray tasks and actors.
+                To request resource requirements for tasks launched by Ray actor,
+                specify ``ray_actor_task_remote_args={...}`` inside
+                ``ray_remote_args``.
 
         .. seealso::
 
@@ -563,7 +566,10 @@ class Dataset:
                 worker pool of size ``n``, specify ``concurrency=n``. For an autoscaling
                 worker pool from ``m`` to ``n`` workers, specify ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
-                ray for each map worker.
+                ray for each map worker. This applies to Ray tasks and actors.
+                To request resource requirements for tasks launched by Ray actor,
+                specify ``ray_actor_task_remote_args={...}`` inside
+                ``ray_remote_args``.
 
         .. note::
 
@@ -935,7 +941,10 @@ class Dataset:
                 For an autoscaling worker pool from ``m`` to ``n`` workers, specify
                 ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
-                ray for each map worker.
+                ray for each map worker. This applies to Ray tasks and actors.
+                To request resource requirements for tasks launched by Ray actor,
+                specify ``ray_actor_task_remote_args={...}`` inside
+                ``ray_remote_args``.
 
         .. seealso::
 
@@ -1029,7 +1038,10 @@ class Dataset:
                 For an autoscaling worker pool from ``m`` to ``n`` workers, specify
                 ``concurrency=(m, n)``.
             ray_remote_args: Additional resource requirements to request from
-                ray (e.g., num_gpus=1 to request GPUs for the map tasks).
+                ray for each map worker. This applies to Ray tasks and actors.
+                To request resource requirements for tasks launched by Ray actor,
+                specify ``ray_actor_task_remote_args={...}`` inside
+                ``ray_remote_args``.
         """
         compute = get_compute_strategy(
             fn,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
User reported issue that they cannot specify application-level exception retry for actor task (`retry_exceptions`). This is due to our actor pool operator does not allow specify ray remote arguments for actor task. This PR adds a config as `DataContext.actor_task_retry_on_errors`, so users can control application-level exceptions retry. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
