### PR TITLE
[ci][state-machine] increase continuous passing threshold

### DIFF
--- a/release/ray_release/test_automation/ci_state_machine.py
+++ b/release/ray_release/test_automation/ci_state_machine.py
@@ -7,7 +7,7 @@ from ray_release.test import Test, TestState
 
 
 CONTINUOUS_FAILURE_TO_FLAKY = 10  # Number of continuous failures before flaky
-CONTINUOUS_PASSING_TO_PASSING = 10  # Number of continuous passing before passing
+CONTINUOUS_PASSING_TO_PASSING = 20  # Number of continuous passing before passing
 FLAKY_PERCENTAGE_THRESHOLD = 5  # Percentage threshold to be considered as flaky
 FAILING_TO_FLAKY_MESSAGE = (
     "This test is now considered as flaky because it has been "


### PR DESCRIPTION
I'm seeing quite a lot of flaky tests go between passing and flaky state. Since the threshold for flakiness is 5% in 100 runs, the continuous passing should be at least 5% * 100 which is 20. 10 is too short to know if a flaky test has been good again.

Test:
- CI