### PR TITLE
[ci] fix macos test prefixes on state machine bot

### DIFF
--- a/ci/ray_ci/automation/state_machine_bot.py
+++ b/ci/ray_ci/automation/state_machine_bot.py
@@ -8,7 +8,7 @@ from ray_release.configs.global_config import init_global_config
 from ray_release.bazel import bazel_runfile
 
 
-ALL_TEST_PREFIXES = ["linux:", "windows:", "macos:"]
+ALL_TEST_PREFIXES = ["linux:", "windows:", "darwin:"]
 
 
 @click.command()


### PR DESCRIPTION
Fix macos test prefixes on state machine bot. The prefix is the return value of `sys.platform`, which is darwin for macos

Test:
- CI