### PR TITLE
[ci] unify os naming schema of go/flaky and testdb

### DIFF
--- a/ci/build/get_build_info.py
+++ b/ci/build/get_build_info.py
@@ -11,7 +11,7 @@ $ python get_build_info.py
 """
 
 import os
-import sys
+import platform
 import json
 
 
@@ -50,11 +50,7 @@ def get_build_env():
             "TRAVIS_JOB_WEB_URL": (
                 os.environ["BUILDKITE_BUILD_URL"] + "#" + os.environ["BUILDKITE_JOB_ID"]
             ),
-            "TRAVIS_OS_NAME": {  # The map is used to stay consistent with Travis
-                "linux": "linux",
-                "darwin": "osx",
-                "win32": "windows",
-            }[sys.platform],
+            "TRAVIS_OS_NAME": platform.system().lower(),
         }
 
     keys = [


### PR DESCRIPTION
Unify the os naming schema (test name prefixes such as linux, windows, osx, darwin, etc.) for test name in go/flaky and testdb. Let's use the standard name in python and drop the naming schema from travis.

https://github.com/ray-project/travis-tracker-v2/pull/47 makes sure this change doesn't not interupt the UI

Test:
- CI