### PR TITLE
[Serve] Support draining with start & stop

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -266,3 +266,8 @@ RAY_SERVE_MAX_QUEUE_LENGTH_RESPONSE_DEADLINE_S = float(
 
 # The default autoscaling policy to use if none is specified.
 DEFAULT_AUTOSCALING_POLICY = "ray.serve.autoscaling_policy:default_autoscaling_policy"
+
+# The behavior of draining replicas when scaling down.
+RAY_SERVE_DRAINING_START_REPLICA_BEFORE_STOP = (
+    os.environ.get("RAY_SERVE_DRAINING_START_REPLICA_BEFORE_STOP", "0") == "1"
+)

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2239,7 +2239,10 @@ class DeploymentState:
         )
         num_extra_replicas_needed = 0
         for replica in self._replicas.pop(states=[ReplicaState.RUNNING]):
-            if replica.actor_node_id in draining_nodes and num_extra_running_replicas > 0:
+            if (
+                replica.actor_node_id in draining_nodes
+                and num_extra_running_replicas > 0
+            ):
                 # Only terminate replica when there is a extra replica which
                 # is already running.
                 logger.info(
@@ -2251,7 +2254,7 @@ class DeploymentState:
                 self._stop_replica(replica, graceful_stop=True)
             else:
                 if replica.actor_node_id in draining_nodes:
-                    # If there is no extra replica running, count it as a extra 
+                    # If there is no extra replica running, count it as a extra
                     # replica needed.
                     num_extra_replicas_needed += 1
                 self._replicas.add(replica.actor_details.state, replica)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This is to support safe draining process:
1. Start the extra replicas when node is drained.
2. Only terminate the replicas on the draining node when there is spare replica.
3. The behavior is turned off by default, we can turn it on by using environment variable.
4. In current implementation, it is processing all draining nodes at the same time, which means potentially serve will spawn up num extra replicas == total_num_replicas_on_all_draining_nodes.


Tested with local: (3 nodes)

```
INFO 2024-01-21 18:23:17,818 controller 56521 deployment_state.py:1550 - Deploying new version of deployment Echo in application 'default'. Setting initial target number of replicas to 5.
INFO 2024-01-21 18:23:17,921 controller 56521 deployment_state.py:1838 - Adding 5 replicas to deployment Echo in application 'default'.
INFO 2024-01-21 18:23:17,921 controller 56521 deployment_state.py:387 - Starting replica default#Echo#scqjgihu for deployment Echo in application 'default'.
INFO 2024-01-21 18:23:17,925 controller 56521 deployment_state.py:387 - Starting replica default#Echo#bc6v3b9h for deployment Echo in application 'default'.
INFO 2024-01-21 18:23:17,925 controller 56521 deployment_state.py:387 - Starting replica default#Echo#hr4pwfrq for deployment Echo in application 'default'.
INFO 2024-01-21 18:23:17,925 controller 56521 deployment_state.py:387 - Starting replica default#Echo#9ldr4kef for deployment Echo in application 'default'.
INFO 2024-01-21 18:23:17,925 controller 56521 deployment_state.py:387 - Starting replica default#Echo#0z7j7ztz for deployment Echo in application 'default'.
INFO 2024-01-21 18:23:18,554 controller 56521 deployment_state.py:1983 - Replica default#Echo#scqjgihu started successfully on node 10862217b31485b0404dc02ee7e130f38436b8481810b874da05828c.
INFO 2024-01-21 18:23:18,554 controller 56521 deployment_state.py:1983 - Replica default#Echo#bc6v3b9h started successfully on node a7b3196c162ab7d6ac37beacdc1609ce3f4b991b276ee3c5b66d9629.
INFO 2024-01-21 18:23:18,555 controller 56521 deployment_state.py:1983 - Replica default#Echo#9ldr4kef started successfully on node 10862217b31485b0404dc02ee7e130f38436b8481810b874da05828c.
INFO 2024-01-21 18:23:18,555 controller 56521 deployment_state.py:1983 - Replica default#Echo#0z7j7ztz started successfully on node a7b3196c162ab7d6ac37beacdc1609ce3f4b991b276ee3c5b66d9629.
INFO 2024-01-21 18:23:18,556 controller 56521 proxy_state.py:151 - Starting proxy with name 'SERVE_PROXY_ACTOR-a7b3196c162ab7d6ac37beacdc1609ce3f4b991b276ee3c5b66d9629' on node 'a7b3196c162ab7d6ac37beacdc1609ce3f4b991b276ee3c5b66d9629' listening on '127.0.0.1:8000'
INFO 2024-01-21 18:23:18,660 controller 56521 deployment_state.py:1983 - Replica default#Echo#hr4pwfrq started successfully on node c7eb424dc5940d6ca8b8cb3b1cfcd02b11d8f03016e9896165fb90ae.
INFO 2024-01-21 18:23:18,661 controller 56521 proxy_state.py:151 - Starting proxy with name 'SERVE_PROXY_ACTOR-c7eb424dc5940d6ca8b8cb3b1cfcd02b11d8f03016e9896165fb90ae' on node 'c7eb424dc5940d6ca8b8cb3b1cfcd02b11d8f03016e9896165fb90ae' listening on '127.0.0.1:8000'
INFO 2024-01-21 18:23:50,945 controller 56521 deployment_state.py:1838 - Adding 2 replicas to deployment Echo in application 'default'.
**INFO 2024-01-21 18:23:50,945 controller 56521 deployment_state.py:387 - Starting replica default#Echo#2917czks for deployment Echo in application 'default'.
INFO 2024-01-21 18:23:50,946 controller 56521 deployment_state.py:387 - Starting replica default#Echo#zvybw24x for deployment Echo in application 'default'.**
INFO 2024-01-21 18:23:50,949 controller 56521 proxy_state.py:553 - Start to drain the proxy actor on node a7b3196c162ab7d6ac37beacdc1609ce3f4b991b276ee3c5b66d9629
INFO 2024-01-21 18:23:51,564 controller 56521 deployment_state.py:1983 - Replica default#Echo#2917czks started successfully on node c7eb424dc5940d6ca8b8cb3b1cfcd02b11d8f03016e9896165fb90ae.
INFO 2024-01-21 18:23:51,564 controller 56521 deployment_state.py:1983 - Replica default#Echo#zvybw24x started successfully on node 10862217b31485b0404dc02ee7e130f38436b8481810b874da05828c.
**INFO 2024-01-21 18:23:51,564 controller 56521 deployment_state.py:2250 - Stopping replica default#Echo#bc6v3b9h of deployment 'Echo' in application 'default' on draining node*a7b3196c162ab7d6ac37beacdc1609ce3f4b991b276ee3c5b66d9629.**
INFO 2024-01-21 18:23:51,564 controller 56521 deployment_state.py:1009 - Stopping replica default#Echo#bc6v3b9h for deployment 'Echo' in application 'default'.
**INFO 2024-01-21 18:23:51,565 controller 56521 deployment_state.py:2250 - Stopping replica default#Echo#0z7j7ztz of deployment 'Echo' in application 'default' on draining node a7b3196c162ab7d6ac37beacdc1609ce3f4b991b276ee3c5b66d9629.**
INFO 2024-01-21 18:23:51,566 controller 56521 deployment_state.py:1009 - Stopping replica default#Echo#0z7j7ztz for deployment 'Echo' in application 'default'.
INFO 2024-01-21 18:23:53,760 controller 56521 deployment_state.py:2176 - Replica default#Echo#bc6v3b9h is stopped.
INFO 2024-01-21 18:23:53,760 controller 56521 deployment_state.py:2176 - Replica default#Echo#0z7j7ztz is stopped.
```




## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
