### PR TITLE
shorten bazel output directories even more on windows

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -560,13 +560,22 @@ def build(build_python, build_java, build_cpp):
             FutureWarning,
         )
 
-    if not is_automated_build:
-        bazel_precmd_flags = []
     if is_automated_build:
-        root_dir = os.path.join(
-            os.path.abspath(os.environ["SRC_DIR"]), "..", "bazel-root"
-        )
-        out_dir = os.path.join(os.path.abspath(os.environ["SRC_DIR"]), "..", "b-o")
+        if is_native_windows_or_msys():
+            root_dir = os.path.join(
+                os.path.splitdrive(os.environ["SRC_DIR"])[0], "bazel-root"
+            )
+            out_dir = os.path.join(
+                os.path.splitdrive(os.environ["SRC_DIR"])[0], "b-o"
+            )
+            bazel_flags.append("--enable_runfiles=false")
+        else:
+            root_dir = os.path.join(
+                os.path.abspath(os.environ["SRC_DIR"]), "..", "bazel-root"
+            )
+            out_dir = os.path.join(
+                os.path.abspath(os.environ["SRC_DIR"]), "..", "b-o"
+            )
 
         for d in (root_dir, out_dir):
             if not os.path.exists(d):
@@ -576,9 +585,8 @@ def build(build_python, build_java, build_cpp):
             "--output_user_root=" + root_dir,
             "--output_base=" + out_dir,
         ]
-
-        if is_native_windows_or_msys():
-            bazel_flags.append("--enable_runfiles=false")
+    else:
+        bazel_precmd_flags = []
 
     bazel_targets = []
     bazel_targets += ["//:ray_pkg"] if build_python else []

--- a/python/setup.py
+++ b/python/setup.py
@@ -565,17 +565,13 @@ def build(build_python, build_java, build_cpp):
             root_dir = os.path.join(
                 os.path.splitdrive(os.environ["SRC_DIR"])[0], "bazel-root"
             )
-            out_dir = os.path.join(
-                os.path.splitdrive(os.environ["SRC_DIR"])[0], "b-o"
-            )
+            out_dir = os.path.join(os.path.splitdrive(os.environ["SRC_DIR"])[0], "b-o")
             bazel_flags.append("--enable_runfiles=false")
         else:
             root_dir = os.path.join(
                 os.path.abspath(os.environ["SRC_DIR"]), "..", "bazel-root"
             )
-            out_dir = os.path.join(
-                os.path.abspath(os.environ["SRC_DIR"]), "..", "b-o"
-            )
+            out_dir = os.path.join(os.path.abspath(os.environ["SRC_DIR"]), "..", "b-o")
 
         for d in (root_dir, out_dir):
             if not os.path.exists(d):

--- a/python/setup.py
+++ b/python/setup.py
@@ -49,7 +49,7 @@ CLEANABLE_SUBDIRS = [
 
 # In automated builds, we do a few adjustments before building. For instance,
 # the bazel environment is set up slightly differently, and symlinks are
-# replaced with junctions in Windows. This variable is set e.g. in our conda
+# replaced with junctions in Windows. This variable is set e.g. in our conda-forge
 # feedstock.
 is_automated_build = bool(int(os.environ.get("IS_AUTOMATED_BUILD", "0")))
 
@@ -561,17 +561,16 @@ def build(build_python, build_java, build_cpp):
         )
 
     if is_automated_build:
+        src_dir = os.environ.get("SRC_DIR", False) or os.getcwd()
+        src_dir = os.path.abspath(src_dir)
         if is_native_windows_or_msys():
-            root_dir = os.path.join(
-                os.path.splitdrive(os.environ["SRC_DIR"])[0], "bazel-root"
-            )
-            out_dir = os.path.join(os.path.splitdrive(os.environ["SRC_DIR"])[0], "b-o")
+            drive = os.path.splitdrive(src_dir)[0] + "\\"
+            root_dir = os.path.join(drive, "bazel-root")
+            out_dir = os.path.join(drive, "b-o")
             bazel_flags.append("--enable_runfiles=false")
         else:
-            root_dir = os.path.join(
-                os.path.abspath(os.environ["SRC_DIR"]), "..", "bazel-root"
-            )
-            out_dir = os.path.join(os.path.abspath(os.environ["SRC_DIR"]), "..", "b-o")
+            root_dir = os.path.join(src_dir, "..", "bazel-root")
+            out_dir = os.path.join(src_dir, "..", "b-o")
 
         for d in (root_dir, out_dir):
             if not os.path.exists(d):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The AUTOMATED_BUILD environment variable is set on the conda-forge builds to solve various build problems when building there. One problem that came up in the 2.9.0 update is that the windows path is too long, which resulted in hard-to-debug build problems. This effectively does the fix for #42098 (setting up `.bazelrc` with `startup --output_user_root=d:/tmp`) programatically without involving `.bazelrc`.

The code path will not be hit in the buildkite CI tests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Related to #42098 and https://github.com/conda-forge/ray-packages-feedstock/pull/137

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
