### PR TITLE
[ci] add weekly_release_blocker tag for test failure issues

### DIFF
--- a/release/ray_release/test_automation/ci_state_machine.py
+++ b/release/ray_release/test_automation/ci_state_machine.py
@@ -1,6 +1,7 @@
 from ray_release.test_automation.state_machine import (
     TestStateMachine,
     DEFAULT_ISSUE_OWNER,
+    WEEKLY_RELEASE_BLOCKER_TAG,
 )
 
 from ray_release.test import Test, TestState
@@ -64,6 +65,7 @@ class CITestStateMachine(TestStateMachine):
             "flaky-tracker",
             "triage",
             self.test.get_oncall(),
+            WEEKLY_RELEASE_BLOCKER_TAG,
         ]
         recent_failures = [
             result for result in self.test_results if result.is_failing()

--- a/release/ray_release/test_automation/release_state_machine.py
+++ b/release/ray_release/test_automation/release_state_machine.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from ray_release.test_automation.state_machine import (
     TestStateMachine,
     DEFAULT_ISSUE_OWNER,
+    WEEKLY_RELEASE_BLOCKER_TAG,
 )
 from ray_release.test import Test, TestState
 from ray_release.logger import logger
@@ -12,6 +13,7 @@ MAX_BISECT_PER_DAY = 10  # Max number of bisects to run per day for all tests
 BUILDKITE_ORGANIZATION = "ray-project"
 BUILDKITE_BISECT_PIPELINE = "release-tests-bisect"
 CONTINUOUS_FAILURE_TO_JAIL = 3  # Number of continuous failures before jailing
+UNSTABLE_RELEASE_TEST_TAG = "unstable-release-test"
 
 
 class ReleaseTestStateMachine(TestStateMachine):
@@ -73,7 +75,9 @@ class ReleaseTestStateMachine(TestStateMachine):
             self.test.get_oncall(),
         ]
         if not self.test.is_stable():
-            labels.append("unstable-release-test")
+            labels.append(UNSTABLE_RELEASE_TEST_TAG)
+        else:
+            labels.append(WEEKLY_RELEASE_BLOCKER_TAG)
         issue_number = self.ray_repo.create_issue(
             title=f"Release test {self.test.get_name()} failed",
             body=(

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -13,6 +13,7 @@ RAY_REPO = "ray-project/ray"
 AWS_SECRET_GITHUB = "ray_ci_github_token"
 AWS_SECRET_BUILDKITE = "ray_ci_buildkite_token"
 DEFAULT_ISSUE_OWNER = "can-anyscale"
+WEEKLY_RELEASE_BLOCKER_TAG = "weekly-release-blocker"
 
 
 class TestStateMachine(abc.ABC):


### PR DESCRIPTION
Add weekly_release_blocker tag for test failure issues. We'll use this tag to build metrics around how often ray is good enough for weekly release.

Test:
- CI