### PR TITLE
[Serve] [Docs] Add `return` statement in batching docs

### DIFF
--- a/doc/source/serve/tutorials/batch.md
+++ b/doc/source/serve/tutorials/batch.md
@@ -38,7 +38,7 @@ These calls will be batched and executed together, but return an individual resu
 they were a normal function call:
 
 ```python
-class MyBackend:
+class BatchingDeployment:
     @serve.batch
     async def my_batch_handler(self, requests: List):
         results = []
@@ -47,7 +47,7 @@ class MyBackend:
         return results
 
     async def __call__(self, request):
-        await self.my_batch_handler(request)
+        return await self.my_batch_handler(request)
 ```
 
 :::{note}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change adds a missing `return` statement to the Serve batching docs.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
