### PR TITLE
Bump Jackson to 2.16.1

### DIFF
--- a/java/dependencies.bzl
+++ b/java/dependencies.bzl
@@ -4,7 +4,7 @@ load("@rules_jvm_external//:specs.bzl", "maven")
 def gen_java_deps():
     maven_install(
         artifacts = [
-            "com.fasterxml.jackson.core:jackson-databind:2.15.2",
+            "com.fasterxml.jackson.core:jackson-databind:2.16.1",
             "com.github.java-json-tools:json-schema-validator:2.2.14",
             "com.google.code.gson:gson:2.9.1",
             "com.google.guava:guava:32.0.1-jre",


### PR DESCRIPTION
## Why are these changes needed?

CVE scanners are triggering on [CVE-2023-35116](https://nvd.nist.gov/vuln/detail/CVE-2023-35116). Doesn't seem to be a real CVE so just cleaning up noise from scanners.

## Related issue number

n/a

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
