### PR TITLE
[serve] collect request metrics at handles

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -268,3 +268,9 @@ RAY_SERVE_MAX_QUEUE_LENGTH_RESPONSE_DEADLINE_S = float(
 
 # The default autoscaling policy to use if none is specified.
 DEFAULT_AUTOSCALING_POLICY = "ray.serve.autoscaling_policy:default_autoscaling_policy"
+
+# Feature flag to enable collecting all queued and ongoing request
+# metrics at handles instead of replicas. OFF by default.
+RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE = (
+    os.environ.get("RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE", "0") == "1"
+)

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -260,7 +260,7 @@ class ServeController:
         )
         self.deployment_state_manager.record_autoscaling_metrics(data, send_timestamp)
 
-    def record_handle_metrics(self, data: Dict[str, float], send_timestamp: float):
+    def record_handle_metrics(self, data, send_timestamp: float):
         logger.debug(f"Received handle metrics: {data} at timestamp {send_timestamp}")
         self.deployment_state_manager.record_handle_metrics(data, send_timestamp)
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -33,6 +33,7 @@ from ray.serve._private.constants import (
     DEFAULT_LATENCY_BUCKET_MS,
     GRPC_CONTEXT_ARG_NAME,
     HEALTH_CHECK_METHOD,
+    RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
     RAY_SERVE_GAUGE_METRIC_SET_PERIOD_S,
     RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S,
     RECONFIGURE_METHOD,
@@ -180,7 +181,10 @@ class ReplicaMetricsManager:
 
         self._autoscaling_config = autoscaling_config
 
-        if self._autoscaling_config:
+        if (
+            not RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE
+            and self._autoscaling_config
+        ):
             # Push autoscaling metrics to the controller periodically.
             self._metrics_pusher.register_or_update_task(
                 self.PUSH_METRICS_TO_CONTROLLER_TASK_NAME,

--- a/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
@@ -6,7 +6,17 @@ import random
 import time
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import AsyncGenerator, DefaultDict, Deque, Dict, List, Optional, Set, Union
+from typing import (
+    AsyncGenerator,
+    DefaultDict,
+    Deque,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import ray
 from ray.exceptions import RayActorError
@@ -657,11 +667,11 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
 
     async def assign_replica(
         self, query: Query
-    ) -> Union[ray.ObjectRef, "ray._raylet.ObjectRefGenerator"]:
+    ) -> Tuple[Union[ray.ObjectRef, "ray._raylet.ObjectRefGenerator"], str]:
         """Choose a replica for the request and send it.
 
         This will block indefinitely if no replicas are available to handle the
         request, so it's up to the caller to time out or cancel the request.
         """
         replica = await self.choose_replica_for_query(query)
-        return replica.send_query(query)
+        return replica.send_query(query), replica.replica_id

--- a/python/ray/serve/_private/version.py
+++ b/python/ray/serve/_private/version.py
@@ -176,6 +176,10 @@ class DeploymentVersion:
                 reconfigure_dict[option_name] = getattr(
                     self.deployment_config, option_name
                 )
+                # If autoscaling config was changed, only broadcast to
+                # replicas if metrics_interval_s or look_back_period_s
+                # was changed, because the rest of the fields are only
+                # used in deployment state manager
                 if isinstance(reconfigure_dict[option_name], AutoscalingConfig):
                     reconfigure_dict[option_name] = reconfigure_dict[option_name].dict(
                         include={"metrics_interval_s", "look_back_period_s"}

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -84,6 +84,17 @@ py_test_module_list(
   deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
 )
 
+# Test autoscaling with RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE set to 1
+py_test(
+    name = "test_autoscaling_metrics_on_handle",
+    size = "medium",
+    main = "test_autoscaling_policy.py",
+    srcs = ["test_autoscaling_policy.py"],
+    tags = ["exclusive", "team:serve", "autoscaling"],
+    deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
+    env = {"RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "1"},
+)
+
 py_test_module_list(
   files = [
     "test_gcs_failure.py",

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -22,7 +22,11 @@ from ray.serve._private.common import (
     DeploymentStatusTrigger,
     ReplicaState,
 )
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_NAMESPACE
+from ray.serve._private.constants import (
+    RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
+    SERVE_DEFAULT_APP_NAME,
+    SERVE_NAMESPACE,
+)
 from ray.serve._private.controller import ServeController
 from ray.serve._private.test_utils import (
     check_num_replicas_eq,
@@ -875,6 +879,65 @@ app = g.bind()
     for _ in range(15):
         pids.add(ray.get(send_request.remote()))
     assert existing_pid in pids
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+@pytest.mark.skipif(
+    not RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
+    reason="Only works when collecting request metrics at handle.",
+)
+def test_max_concurrent_queries_set_to_one(serve_instance):
+    assert RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE
+    signal = SignalActor.remote()
+
+    @serve.deployment(
+        max_concurrent_queries=1,
+        autoscaling_config=AutoscalingConfig(
+            min_replicas=1,
+            max_replicas=5,
+            upscale_delay_s=0.5,
+            downscale_delay_s=0.5,
+            metrics_interval_s=0.5,
+            look_back_period_s=2,
+        ),
+        graceful_shutdown_timeout_s=1,
+        ray_actor_options={"num_cpus": 0},
+    )
+    async def f():
+        await signal.wait.remote()
+        return os.getpid()
+
+    h = serve.run(f.bind())
+    check_num_replicas_eq("f", 1)
+
+    # Repeatedly (5 times):
+    # 1. Send a new request.
+    # 2. Wait for the number of waiters on signal to increase by 1.
+    # 3. Assert the number of replicas has increased by 1.
+    refs = []
+    for i in range(5):
+        refs.append(h.remote())
+
+        def check_num_waiters(target: int):
+            assert ray.get(signal.cur_num_waiters.remote()) == target
+            return True
+
+        wait_for_condition(check_num_waiters, target=i + 1)
+        print(time.time(), f"Number of waiters on signal reached {i+1}.")
+        check_num_replicas_eq("f", i + 1)
+        print(time.time(), f"Confirmed number of replicas are at {i+1}.")
+
+    print(time.time(), "Releasing signal.")
+    signal.send.remote()
+
+    # Check that pids returned are unique
+    # This implies that each replica only served one request, so the
+    # number of "running" requests per replica was at most 1 at any time;
+    # meaning the "queued" requests were taken into consideration for
+    # autoscaling.
+    pids = [ref.result() for ref in refs]
+    assert len(pids) == len(set(pids)), f"Pids {pids} are not unique."
+    print("Confirmed each replica only served one request.")
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")


### PR DESCRIPTION
[serve] collect request metrics at handles

Collect request metrics for autoscaling at handles instead of replicas. This will allow queued metrics to be taken into account instead of just ongoing requests.

(3x) DeploymentHandle streaming throughput (ASYNC) (num_replicas=1, tokens_per_request=1000, batch_size=10)
| Collect on handles | Original |
| --- | --- |
| 12140.58 +- 431.94 tokens/s | 12365.42 +- 353.48 tokens/s |
| 12119.03 +- 255.58 tokens/s | 12395.43 +- 642.92 tokens/s |
| 12168.44 +- 653.06 tokens/s | 12365.76 +- 680.51 tokens/s |

(5x) HTTP streaming throughput (num_replicas=1, tokens_per_request=1000, batch_size=10, use_intermediate_deployment=False)
| Collect on handles | Original |
| --- | --- |
| 141118.93 +- 103940.74 tokens/s | 143454.65 +- 103615.47 tokens/s |
| 225063.66 +- 5347.35 tokens/s | 228244.37 +- 6209.89 tokens/s |
| 225684.1 +- 3262.97 tokens/s | 221354.73 +- 2928.82 tokens/s |
| 220755.65 +- 6837.1 tokens/s | 188224.32 +- 78546.09 tokens/s |
| 221404.26 +- 3427.73 tokens/s | 223172.25 +- 4064.79 tokens/s |

(4x) DeploymentHandle throughput (num_replicas=1, batch_size=100)
| Collect on handles | Original |
| --- | --- |
| 1766.19 +- 15.25 requests/s | 1819.54 +- 5.26 requests/s |
| 1760.92 +- 51.87 requests/s | 1762.08 +- 21.04 requests/s |
| 1796.22 +- 10.52 requests/s | 1750.08 +- 31.73 requests/s |
| 1788.1 +- 29.98 requests/s | 1779.63 +- 24.86 requests/s |


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
Streaming HTTP throughput
