### PR TITLE
[Data] Fix `iter_tensor_batches_benchmark`

### DIFF
--- a/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
+++ b/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
@@ -22,7 +22,7 @@ def run_iter_tensor_batches_benchmark(
         batch["label"] = label
         return batch
 
-    ds = ds.map_batches(add_label, batch_format="pandas").materialize()
+    ds = ds.map_batches(add_label, batch_format="pandas")
 
     # Test iter_torch_batches() with default args.
     benchmark.run_iterate_ds(

--- a/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
+++ b/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
@@ -1,9 +1,7 @@
 import argparse
 import numpy as np
-from typing import Optional, Union, List
 
 import ray
-from ray.data.dataset import Dataset
 
 from benchmark import Benchmark
 

--- a/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
+++ b/release/nightly_tests/dataset/iter_tensor_batches_benchmark.py
@@ -8,57 +8,6 @@ from ray.data.dataset import Dataset
 from benchmark import Benchmark
 
 
-def iter_torch_batches(
-    ds: Dataset,
-    batch_size: Optional[int] = None,
-    local_shuffle_buffer_size: Optional[int] = None,
-    prefetch_batches: int = 0,
-    use_default_params: bool = False,
-) -> Dataset:
-    num_batches = 0
-    if use_default_params:
-        for batch in ds.iter_torch_batches():
-            num_batches += 1
-    else:
-        for batch in ds.iter_torch_batches(
-            batch_size=batch_size,
-            local_shuffle_buffer_size=local_shuffle_buffer_size,
-            prefetch_batches=prefetch_batches,
-        ):
-            num_batches += 1
-    print(
-        "iter_torch_batches done, block_format:",
-        "pyarrow",
-        "num_rows:",
-        ds.count(),
-        "num_blocks:",
-        ds.num_blocks(),
-        "num_batches:",
-        num_batches,
-    )
-    return ds
-
-
-def to_tf(
-    ds: Dataset,
-    feature_columns: Union[str, List[str]],
-    label_columns: Union[str, List[str]],
-    batch_size: Optional[int] = None,
-    local_shuffle_buffer_size: Optional[int] = None,
-    use_default_params: bool = False,
-) -> Dataset:
-    if use_default_params:
-        ds.to_tf(feature_columns=feature_columns, label_columns=label_columns)
-    else:
-        ds.to_tf(
-            feature_columns=feature_columns,
-            label_columns=label_columns,
-            batch_size=batch_size,
-            local_shuffle_buffer_size=local_shuffle_buffer_size,
-        )
-    return ds
-
-
 def run_iter_tensor_batches_benchmark(
     benchmark: Benchmark, data_size_gb: int, block_size_mb: int
 ):
@@ -78,32 +27,23 @@ def run_iter_tensor_batches_benchmark(
     ds = ds.map_batches(add_label, batch_format="pandas").materialize()
 
     # Test iter_torch_batches() with default args.
-    benchmark.run_materialize_ds(
+    benchmark.run_iterate_ds(
         "iter-torch-batches-default",
-        iter_torch_batches,
-        ds=ds,
-        use_default_params=True,
+        ds.iter_torch_batches(),
     )
 
     # Test to_tf() with default args.
-    benchmark.run_materialize_ds(
-        "to-tf-default",
-        to_tf,
-        ds=ds,
-        feature_columns="image",
-        label_columns="label",
-        use_default_params=True,
+    benchmark.run_iterate_ds(
+        "to-tf-default", ds.to_tf(feature_columns="image", label_columns="label")
     )
 
     batch_sizes = [16, 32]
 
     # Test with varying batch sizes for iter_torch_batches() and to_tf().
     for batch_size in batch_sizes:
-        benchmark.run_materialize_ds(
+        benchmark.run_iterate_ds(
             f"iter-torch-batches-{batch_size}-block-size-{block_size_mb}",
-            iter_torch_batches,
-            ds=ds,
-            batch_size=batch_size,
+            ds.iter_torch_batches(batch_size=batch_size),
         )
 
     prefetch_batches = [0, 1, 4]
@@ -111,34 +51,30 @@ def run_iter_tensor_batches_benchmark(
     for prefetch_batch in prefetch_batches:
         for shuffle_buffer_size in [None, 64]:
             test_name = f"iter-torch-batches-bs-{32}-prefetch-{prefetch_batch}-shuffle{shuffle_buffer_size}"  # noqa: E501
-            benchmark.run_materialize_ds(
+            benchmark.run_iterate_ds(
                 test_name,
-                iter_torch_batches,
-                ds=ds,
-                batch_size=32,
-                prefetch_batches=prefetch_batch,
+                ds.iter_torch_batches(batch_size=32, prefetch_batches=prefetch_batch),
             )
 
     # Test with varying batch sizes and shuffle for iter_torch_batches() and to_tf().
     for batch_size in batch_sizes:
         for shuffle_buffer_size in [batch_size, 2 * batch_size]:
             test_name = f"iter-torch-batches-shuffle-{batch_size}-{shuffle_buffer_size}"
-            benchmark.run_materialize_ds(
+            benchmark.run_iterate_ds(
                 test_name,
-                iter_torch_batches,
-                ds=ds,
-                batch_size=batch_size,
-                local_shuffle_buffer_size=shuffle_buffer_size,
+                ds.iter_torch_batches(
+                    batch_size=batch_size, local_shuffle_buffer_size=shuffle_buffer_size
+                ),
             )
             test_name = f"to-tf-shuffle-{batch_size}-{shuffle_buffer_size}"
-            benchmark.run_materialize_ds(
+            benchmark.run_iterate_ds(
                 test_name,
-                to_tf,
-                ds=ds,
-                feature_columns="image",
-                label_columns="label",
-                batch_size=batch_size,
-                local_shuffle_buffer_size=shuffle_buffer_size,
+                ds.to_tf(
+                    feature_columns="image",
+                    label_columns="label",
+                    batch_size=batch_size,
+                    local_shuffle_buffer_size=shuffle_buffer_size,
+                ),
             )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `iter_tensor_batches_benchark` doesn't actually iterate over TensorFlow datasets; it just creates them. This PR fixes the issue, and also simplifies the benchmark by leveraging the `run_iterate_ds` method.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
