### PR TITLE
[tune] remove tensorboardX upper bound

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -51,7 +51,7 @@ scikit-image
 prometheus_client>=0.7.1
 requests
 pandas
-tensorboardX<=2.6.0,>=1.9  # >=2.6.1 uses protobuf>=4, and conflicts with other packages.
+tensorboardX>=1.9
 aiohttp>=3.7,<3.9
 starlette
 typer

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -92,7 +92,6 @@ importlib-metadata==4.10.0
 
 # Some packages have downstream dependencies that we have to specify here to resolve conflicts.
 # Feel free to add (or remove!) packages here liberally.
-tensorboardX==2.6.0
 starlette==0.27.0
 h11==0.12.0
 markdown-it-py==1.1.0

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -2207,11 +2207,6 @@ tensorboard-data-server==0.6.1
     # via tensorboard
 tensorboard-plugin-wit==1.8.1
     # via tensorboard
-tensorboardx==2.6
-    # via
-    #   -r /ray/ci/../python/requirements.txt
-    #   -r /ray/ci/../python/requirements/test-requirements.txt
-    #   ray
 tensorflow==2.11.0 ; sys_platform != "darwin" or platform_machine != "arm64"
     # via
     #   -r /ray/ci/../python/requirements/ml/dl-cpu-requirements.txt


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Our python 3.11 images require `protobuf>=4`, which has a conflict with the existing version of `tensorboardX`.

This upper bound was originally added in https://github.com/ray-project/ray/pull/36643, when there was a requirement for `protobuf<4`. 

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #42577

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
