### PR TITLE
[green][metric/1] collect metric of weekly green

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -11,3 +11,9 @@ py_binary(
     srcs = ["test_db_bot.py"],
     deps = ["//ci/ray_ci:ray_ci_lib"],
 )
+
+py_binary(
+    name = "weekly_green_metric",
+    srcs = ["weekly_green_metric.py"],
+    deps = ["//ci/ray_ci:ray_ci_lib"],
+)

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -1,19 +1,14 @@
 import click
 
 from ci.ray_ci.utils import logger
-from ci.ray_ci.tester_container import TesterContainer, PIPELINE_POSTMERGE
-from ray_release.configs.global_config import init_global_config
 from ray_release.test_automation.state_machine import TestStateMachine
 
 
 @click.command()
-@click.option(
-    "--production",
-    is_flag=True,
-    show_default=True,
-    default=False,
-    help=("Persist weekly green metric to S3"),
-)
-def main(production: bool) -> None:
-    ray_repo = TestStateMachine.get_ray_repo()
+def main() -> None:
+    blockers = TestStateMachine.get_release_blockers()
+    logger.info(f"Found {blockers.totalCount} release blockers")
 
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -1,0 +1,19 @@
+import click
+
+from ci.ray_ci.utils import logger
+from ci.ray_ci.tester_container import TesterContainer, PIPELINE_POSTMERGE
+from ray_release.configs.global_config import init_global_config
+from ray_release.test_automation.state_machine import TestStateMachine
+
+
+@click.command()
+@click.option(
+    "--production",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help=("Persist weekly green metric to S3"),
+)
+def main(production: bool) -> None:
+    ray_repo = TestStateMachine.get_ray_repo()
+

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -1,5 +1,7 @@
 import abc
+from typing import List
 
+import github
 from github import Github
 from pybuildkite.buildkite import Buildkite
 
@@ -26,6 +28,7 @@ class TestStateMachine(abc.ABC):
     ...
     """
 
+    ray_user = None
     ray_repo = None
     ray_buildkite = None
 
@@ -41,8 +44,17 @@ class TestStateMachine(abc.ABC):
     @classmethod
     def _init_ray_repo(cls):
         if not cls.ray_repo:
-            github_token = get_secret_token(AWS_SECRET_GITHUB)
-            cls.ray_repo = Github(github_token).get_repo(RAY_REPO)
+            cls.ray_repo = cls.get_github().get_repo(RAY_REPO)
+
+    @classmethod
+    def get_github(cls):
+        return Github(get_secret_token(AWS_SECRET_GITHUB))
+
+    @classmethod
+    def get_ray_user(cls):
+        if not cls.ray_user:
+            cls.ray_user = cls.get_github().get_user()
+        return cls.ray_user
 
     @classmethod
     def get_ray_repo(cls):
@@ -55,6 +67,13 @@ class TestStateMachine(abc.ABC):
             buildkite_token = get_secret_token(AWS_SECRET_BUILDKITE)
             cls.ray_buildkite = Buildkite()
             cls.ray_buildkite.set_access_token(buildkite_token)
+
+    @classmethod
+    def get_release_blockers(cls) -> List[github.Issue.Issue]:
+        user = cls.get_ray_user()
+        blocker_label = cls.get_ray_repo().get_label(WEEKLY_RELEASE_BLOCKER_TAG)
+
+        return user.get_issues(state="open", labels=[blocker_label])
 
     def move(self) -> None:
         """

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -21,7 +21,10 @@ from ray_release.test_automation.ci_state_machine import (
     JAILED_TAG,
     JAILED_MESSAGE,
 )
-from ray_release.test_automation.state_machine import TestStateMachine
+from ray_release.test_automation.state_machine import (
+    TestStateMachine,
+    WEEKLY_RELEASE_BLOCKER_TAG,
+)
 
 
 class MockLabel:
@@ -61,6 +64,19 @@ class MockIssueDB:
     issue_db = {}
 
 
+class MockUser:
+    def get_issues(self, state: str, labels: List[MockLabel]) -> List[MockIssue]:
+        issues = []
+        for issue in MockIssueDB.issue_db.values():
+            if issue.state != state:
+                continue
+            issue_labels = [label.name for label in issue.labels]
+            if all(label.name in issue_labels for label in labels):
+                issues.append(issue)
+
+        return issues
+
+
 class MockRepo:
     def create_issue(self, labels: List[str], title: str, *args, **kwargs):
         label_objs = [MockLabel(label) for label in labels]
@@ -71,6 +87,9 @@ class MockRepo:
 
     def get_issue(self, number: int):
         return MockIssueDB.issue_db[number]
+
+    def get_label(self, name: str):
+        return MockLabel(name)
 
 
 class MockBuildkiteBuild:
@@ -97,6 +116,7 @@ class MockBuildkite:
         return MockBuildkiteJob()
 
 
+TestStateMachine.ray_user = MockUser()
 TestStateMachine.ray_repo = MockRepo()
 TestStateMachine.ray_buildkite = MockBuildkite()
 
@@ -289,6 +309,18 @@ def test_release_move_from_failing_to_jailed():
     assert test.get_state() == TestState.PASSING
     assert test.get(Test.KEY_GITHUB_ISSUE_NUMBER) is None
     assert issue.state == "closed"
+
+
+def test_get_release_blockers() -> None:
+    MockIssueDB.issue_id = 1
+    MockIssueDB.issue_db = {}
+    TestStateMachine.ray_repo.create_issue(labels=["non-blocker"], title="non-blocker")
+    TestStateMachine.ray_repo.create_issue(
+        labels=[WEEKLY_RELEASE_BLOCKER_TAG], title="blocker"
+    )
+    issues = TestStateMachine.get_release_blockers()
+    assert len(issues) == 1
+    assert issues[0].title == "blocker"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Create a script to continuously query the number of weekly-release-blocker tag. This will be used as a main source to measure the readiness of weekly green.

Test:
- CI

```
bazel run //ci/ray_ci/automation:weekly_green_metric
[INFO 2024-01-22 21:59:36,085] credentials.py: 1124  Found credentials in environment variables.
[INFO 2024-01-22 21:59:37,098] weekly_green_metric.py: 29  Found 18 release blockers
```