### PR TITLE
[green][metric/2] compute number of blockers by team

### DIFF
--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -87,3 +87,10 @@ steps:
     instance_type: small
     commands:
       - bazel run //ci/ray_ci/automation:state_machine_bot -- --production
+
+  - label: ":robot_face: CI weekly green metric"
+    tags: skip-on-premerge
+    if: build.branch == "master" && build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    instance_type: small
+    commands:
+      - bazel run //ci/ray_ci/automation:weekly_green_metric -- --production

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -1,11 +1,28 @@
+import json
+import time
+
+import boto3
 import click
 
 from ci.ray_ci.utils import logger
 from ray_release.test_automation.state_machine import TestStateMachine
+from ray_release.configs.global_config import init_global_config, get_global_config
+from ray_release.bazel import bazel_runfile
+
+
+AWS_WEEKLY_GREEN_METRIC = "ray_weekly_green_metric"
 
 
 @click.command()
-def main() -> None:
+@click.option(
+    "--production",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help=("Persist the weekly green metric to S3."),
+)
+def main(production: bool) -> None:
+    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
     blockers = TestStateMachine.get_release_blockers()
     logger.info(f"Found {blockers.totalCount} release blockers")
 
@@ -13,6 +30,14 @@ def main() -> None:
     num_blocker_by_team = {team: blocker_teams.count(team) for team in blocker_teams}
     for team, num_blocker in num_blocker_by_team.items():
         logger.info(f"\t- Team {team} has {num_blocker} release blockers")
+
+    if production:
+        boto3.client("s3").put_object(
+            Bucket=get_global_config()["state_machine_aws_bucket"],
+            Key=f"{AWS_WEEKLY_GREEN_METRIC}/blocker_{int(time.time() * 1000)}.json",
+            Body=json.dumps(num_blocker_by_team),
+        )
+        logger.info("Weekly green metric updated successfully")
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -1,7 +1,4 @@
-from typing import List
-
 import click
-import github
 
 from ci.ray_ci.utils import logger
 from ray_release.test_automation.state_machine import TestStateMachine
@@ -11,6 +8,11 @@ from ray_release.test_automation.state_machine import TestStateMachine
 def main() -> None:
     blockers = TestStateMachine.get_release_blockers()
     logger.info(f"Found {blockers.totalCount} release blockers")
+
+    blocker_teams = [TestStateMachine.get_issue_owner(blocker) for blocker in blockers]
+    num_blocker_by_team = {team: blocker_teams.count(team) for team in blocker_teams}
+    for team, num_blocker in num_blocker_by_team.items():
+        logger.info(f"\t- Team {team} has {num_blocker} release blockers")
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -1,4 +1,7 @@
+from typing import List
+
 import click
+import github
 
 from ci.ray_ci.utils import logger
 from ray_release.test_automation.state_machine import TestStateMachine

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -16,6 +16,16 @@ AWS_SECRET_GITHUB = "ray_ci_github_token"
 AWS_SECRET_BUILDKITE = "ray_ci_buildkite_token"
 DEFAULT_ISSUE_OWNER = "can-anyscale"
 WEEKLY_RELEASE_BLOCKER_TAG = "weekly-release-blocker"
+NO_TEAM = "none"
+TEAM = [
+    "core",
+    "data",
+    "kuberay",
+    "ml",
+    "rllib",
+    "serve",
+    "serverless",
+]
 
 
 class TestStateMachine(abc.ABC):
@@ -74,6 +84,15 @@ class TestStateMachine(abc.ABC):
         blocker_label = cls.get_ray_repo().get_label(WEEKLY_RELEASE_BLOCKER_TAG)
 
         return user.get_issues(state="open", labels=[blocker_label])
+
+    @classmethod
+    def get_issue_owner(cls, issue: github.Issue.Issue) -> str:
+        labels = issue.get_labels()
+        for label in labels:
+            if label.name in TEAM:
+                return label.name
+
+        return NO_TEAM
 
     def move(self) -> None:
         """

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -24,6 +24,7 @@ from ray_release.test_automation.ci_state_machine import (
 from ray_release.test_automation.state_machine import (
     TestStateMachine,
     WEEKLY_RELEASE_BLOCKER_TAG,
+    NO_TEAM,
 )
 
 
@@ -321,6 +322,13 @@ def test_get_release_blockers() -> None:
     issues = TestStateMachine.get_release_blockers()
     assert len(issues) == 1
     assert issues[0].title == "blocker"
+
+
+def test_get_issue_owner() -> None:
+    issue = TestStateMachine.ray_repo.create_issue(labels=["core"], title="hi")
+    assert TestStateMachine.get_issue_owner(issue) == "core"
+    issue = TestStateMachine.ray_repo.create_issue(labels=["w00t"], title="bye")
+    assert TestStateMachine.get_issue_owner(issue) == NO_TEAM
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Compute number of blockers by team.

Test:

```
bazel run //ci/ray_ci/automation:weekly_green_metric
[INFO 2024-01-22 22:27:06,659] credentials.py: 1124  Found credentials in environment variables.
[INFO 2024-01-22 22:27:07,663] weekly_green_metric.py: 38  Found 17 release blockers
[INFO 2024-01-22 22:27:12,573] weekly_green_metric.py: 43        - core: 10
[INFO 2024-01-22 22:27:12,575] weekly_green_metric.py: 43        - rllib: 6
[INFO 2024-01-22 22:27:12,575] weekly_green_metric.py: 43        - ml: 1
```