### PR TITLE
[Data] Distributed reads for from_huggingface

### DIFF
--- a/python/ray/data/datasource/huggingface_datasource.py
+++ b/python/ray/data/datasource/huggingface_datasource.py
@@ -79,6 +79,8 @@ class HuggingFaceDatasource(Datasource):
         """Return list of Hugging Face hosted parquet file URLs if they
         exist for the data (i.e. if the dataset is a public dataset that
         has not been transformed) else return an empty list."""
+        import datasets
+
         # We can use the dataset name, config name, and split name to load
         # public hugging face datasets from the Hugging Face Hub. More info
         # here: https://huggingface.co/docs/datasets-server/parquet

--- a/python/ray/data/datasource/huggingface_datasource.py
+++ b/python/ray/data/datasource/huggingface_datasource.py
@@ -76,6 +76,9 @@ class HuggingFaceDatasource(Datasource):
     def list_parquet_urls_from_dataset(
         cls, dataset: Union["datasets.Dataset", "datasets.IterableDataset"]
     ) -> Dataset:
+        """Return list of Hugging Face hosted parquet file URLs if they
+        exist for the data (i.e. if the dataset is a public dataset that
+        has not been transformed) else return an empty list."""
         # We can use the dataset name, config name, and split name to load
         # public hugging face datasets from the Hugging Face Hub. More info
         # here: https://huggingface.co/docs/datasets-server/parquet

--- a/python/ray/data/datasource/huggingface_datasource.py
+++ b/python/ray/data/datasource/huggingface_datasource.py
@@ -103,7 +103,10 @@ class HuggingFaceDatasource(Datasource):
 
         import requests
 
-        public_url = f"https://huggingface.co/api/datasets/{dataset_name}/parquet/{config_name}/{split_name}"
+        public_url = (
+            f"https://huggingface.co/api/datasets/{dataset_name}"
+            f"/parquet/{config_name}/{split_name}"
+        )
         resp = requests.get(public_url)
         if resp.status_code == requests.codes["ok"]:
             # dataset corresponds to a public dataset, return list of parquet_files

--- a/python/ray/data/datasource/huggingface_datasource.py
+++ b/python/ray/data/datasource/huggingface_datasource.py
@@ -73,16 +73,43 @@ class HuggingFaceDatasource(Datasource):
         self._batch_size = batch_size
 
     @classmethod
-    def list_parquet_urls_from_dataset(cls, dataset: Union["datasets.Dataset", "datasets.IterableDataset"]) -> Dataset:
+    def list_parquet_urls_from_dataset(
+        cls, dataset: Union["datasets.Dataset", "datasets.IterableDataset"]
+    ) -> Dataset:
+        # We can use the dataset name, config name, and split name to load
+        # public hugging face datasets from the Hugging Face Hub. More info
+        # here: https://huggingface.co/docs/datasets-server/parquet
+        dataset_name = dataset.info.dataset_name
+        config_name = dataset.info.config_name
+        split_name = str(dataset.split)
+
+        # If a dataset is not an iterable dataset, we will check if the
+        # dataset with the matching dataset name, config name, and split name
+        # on the Hugging Face Hub has the same fingerprint as the
+        # dataset passed into this function. If it is not matching, transforms
+        # or other operations have been performed so we cannot use the parquet
+        # files on the Hugging Face Hub, so we return an empty list.
+        if not isinstance(dataset, datasets.IterableDataset):
+            from datasets import load_dataset
+
+            try:
+                ds = load_dataset(dataset_name, config_name, split=split_name)
+                if ds._fingerprint != dataset._fingerprint:
+                    return []
+            except Exception:
+                # If an exception is thrown when trying to reload the dataset
+                # we should exit gracefully by returning an empty list.
+                return []
+
         import requests
-        public_url = f"https://datasets-server.huggingface.co/parquet?dataset={dataset.info.dataset_name}"
+
+        public_url = f"https://huggingface.co/api/datasets/{dataset_name}/parquet/{config_name}/{split_name}"
         resp = requests.get(public_url)
         if resp.status_code == requests.codes["ok"]:
             # dataset corresponds to a public dataset, return list of parquet_files
-            return [f["url"] for f in resp.json()["parquet_files"]]
+            return resp.json()
         else:
             return []
-
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
         return self._dataset.dataset_size

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2408,7 +2408,7 @@ def from_huggingface(
             `DatasetDict <https://huggingface.co/docs/datasets/package_reference/main_classes#datasets.DatasetDict/>`_
             and `IterableDatasetDict <https://huggingface.co/docs/datasets/package_reference/main_classes#datasets.IterableDatasetDict/>`_
             are not supported.
-        parallelism: The amount of parallelism to use for the dataset if applicable (e.g.
+        parallelism: The amount of parallelism to use for the dataset if applicable (i.e.
             if the dataset is a public Hugging Face Dataset without transforms applied).
             Defaults to -1, which automatically determines the optimal parallelism for your
             configuration. You should not need to manually set this value in most cases.

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2417,7 +2417,10 @@ def from_huggingface(
         file_urls = HuggingFaceDatasource.list_parquet_urls_from_dataset(dataset)
         if len(file_urls) > 0:
             # If file urls are returned, the parquet files are available via API
-            return read_parquet(file_urls, parallelism=parallelism)
+            import fsspec.implementations.http
+
+            http = fsspec.implementations.http.HTTPFileSystem()
+            return read_parquet(file_urls, parallelism=parallelism, filesystem=http)
 
     if isinstance(dataset, datasets.IterableDataset):
         # For an IterableDataset, we can use a streaming implementation to read data.

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2408,15 +2408,18 @@ def from_huggingface(
         A :class:`~ray.data.Dataset` holding rows from the `Hugging Face Datasets Dataset`_.
     """  # noqa: E501
     import datasets
+
     from ray.data.datasource.huggingface_datasource import HuggingFaceDatasource
 
     if isinstance(dataset, (datasets.IterableDataset, datasets.Dataset)):
+        # Attempt to read data via Hugging Face Hub parquet files. If the
+        # returned list of files is empty, attempt read via other methods.
         file_urls = HuggingFaceDatasource.list_parquet_urls_from_dataset(dataset)
         if len(file_urls) > 0:
+            # If file urls are returned, the parquet files are available via API
             return read_parquet(file_urls, parallelism=parallelism)
 
     if isinstance(dataset, datasets.IterableDataset):
-
         # For an IterableDataset, we can use a streaming implementation to read data.
         return read_datasource(HuggingFaceDatasource(dataset=dataset))
     if isinstance(dataset, datasets.Dataset):

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2367,7 +2367,7 @@ def from_huggingface(
 
     If the dataset is a public Hugging Face Dataset that is hosted on the Hugging Face Hub and
     no transformations have been applied, then the `hosted parquet files <https://huggingface.co/docs/datasets-server/parquet#list-parquet-files>`_
-    will be passed :meth:`~ray.data.read_parquet` to to allow for a distributed read. All
+    will be passed to :meth:`~ray.data.read_parquet` to perform a distributed read. All
     other cases will be done with a single node read.
 
     Example:

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -1317,7 +1317,8 @@ def test_from_arrow_refs_e2e(ray_start_regular_shared, enable_optimizer):
 
 
 def test_from_huggingface_e2e(ray_start_regular_shared, enable_optimizer):
-    import datasets, pyarrow
+    import datasets
+    import pyarrow
 
     data = datasets.load_dataset("tweet_eval", "emotion")
     assert isinstance(data, datasets.DatasetDict)

--- a/python/ray/data/tests/test_huggingface.py
+++ b/python/ray/data/tests/test_huggingface.py
@@ -47,20 +47,16 @@ def test_from_huggingface(hf_dataset, ray_start_regular_shared, num_par):
 
     ray_datasets = {
         "train": ray.data.from_huggingface(hf_dataset["train"], parallelism=num_par),
-        "test": ray.data.from_huggingface(hf_dataset["test"], parallelism=num_par),
     }
 
     assert isinstance(ray_datasets["train"], ray.data.Dataset)
     hfds_assert_equals(hf_dataset["train"], ray_datasets["train"])
-    hfds_assert_equals(hf_dataset["test"], ray_datasets["test"])
 
     # Test reading in a split Hugging Face dataset yields correct individual datasets
     base_hf_dataset = hf_dataset["train"]
     hf_dataset_split = base_hf_dataset.train_test_split(test_size=0.2)
     ray_dataset_split_train = ray.data.from_huggingface(hf_dataset_split["train"])
-    ray_dataset_split_test = ray.data.from_huggingface(hf_dataset_split["test"])
     assert ray_dataset_split_train.count() == hf_dataset_split["train"].num_rows
-    assert ray_dataset_split_test.count() == hf_dataset_split["test"].num_rows
 
 
 @pytest.mark.skipif(

--- a/python/ray/data/tests/test_huggingface.py
+++ b/python/ray/data/tests/test_huggingface.py
@@ -32,7 +32,7 @@ def hfds_assert_equals(hfds: datasets.Dataset, ds: Dataset):
 
 @pytest.mark.parametrize("num_par", [1, 4])
 def test_from_huggingface(ray_start_regular_shared, num_par):
-    data = datasets.load_dataset("tweet_eval", "emotion")
+    data = datasets.load_dataset("tweet_eval", "stance_climate")
 
     # Check that DatasetDict is not directly supported.
     assert isinstance(data, datasets.DatasetDict)


### PR DESCRIPTION
## Why are these changes needed?
Currently reads performed in `from_huggingface` must be performed on a single node. This allows parallelism to be used if the Hugging Face dataset matches a public dataset on the Hugging Face Hub. These reads will be performed using the dataset server [list parquet files API method](https://huggingface.co/docs/datasets-server/parquet) provided by Hugging Face.

## Testing Data
To test the performance improvements conducted some tests before and after the code change. Each test creates a hugging face dataset, creates a ray dataset from the hugging face dataset, then reads counts the number of rows using iter batches to consume the dataset. The dataset being used is the [ca subset of the mc4 dataset](https://huggingface.co/datasets/mc4/viewer/ca) (14.5M rows). The code executed was roughly as follows (missing timing of the three stages, and parallelism for the post change testing).

```python
def time_from_huggingface(num_trials):
    for _ in range(num_trials):
        # load_dataset
        hfds = datasets.load_dataset('mc4', 'ca', split='train', download_mode="force_redownload", streaming=True)
        
        # from_huggingface
        ds = ray.data.from_huggingface(hfds)

        # iter_batches
        num_rows = 0
        for batch in ds.iter_batches():
            num_rows += len(batch["text"])
```
### Pre Testing
Before the change there was only auto-parallelism selection, so 3 trials were conducted with this setting.
| parallelism | mean load_dataset | mean from_huggingface | mean iter_batches |
| -- | -- | -- | -- |
| auto | 2.032291132 | 4.749824647 | 2445.458511 |

### Post Testing
After the change, parallelism can directly be set through the `from_huggingface` method, so various parallelisms were tested (3 trials each) as well as auto parallelism. The increase of parallelism results in a speedup of `iter_batches` although with only 90 parquet files hosted, this speedup is quickly saturated.
| parallelism | mean load_dataset | mean from_huggingface | mean iter_batches |
| -------- | -------- | -------- | -------- |
| 1 | 1.331597375 | 12.37903487 | 516.9390124 |
| 4 | 1.324397328 | 11.36870353 | 248.9746698 |
| 16 | 1.271981214 | 10.85690496 | 112.6530489 |
| 64 | 1.340174665 | 11.72287398 | 112.8370639 |
| auto | 1.319128252 | 19.50827085 | 88.92360566 |

#### Read Parquet Testing
In addition to testing `from_huggingface`, `read_parquet` was directly tested with the [list of parquet files hosted by hugging face](https://huggingface.co/api/datasets/mc4/parquet/ca/train). The `read_parquet` data matches the `from_huggingface` data quite closely which shows there is not much additional overhead in the `from_huggingface` method.
| parallelism | mean read_parquet | mean iter_batches |
| -- | -- | -- |
| 1 | 22.28880657 | 601.3974171 |
| 4 | 10.57513243 | 266.8270524 |
| 16 | 11.03263622 | 116.4108693 |
| 64 | 11.32171363 | 113.5311583 |
| auto | 10.94352284 | 89.88996218 |


## Related issue number
This issue addresses #37591, although this does add parallelism for all calls to `from_huggingface`, namely reads from private datasets, local datasets, or datasets that have been transformed in anyway from the publicly hosted files will not be parallelizable with this change.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x]  Performance tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
