### PR TITLE
allow victoria metrics response message

### DIFF
--- a/dashboard/modules/metrics/metrics_head.py
+++ b/dashboard/modules/metrics/metrics_head.py
@@ -166,7 +166,7 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
                 text = await resp.text()
                 # Basic sanity check of prometheus health check schema
                 # Different flavors of Prometheus may use different health check strings
-                if "Prometheus" not in text:
+                if "Prometheus" not in text or "VictoriaMetrics" not in text:
                     return dashboard_optional_utils.rest_response(
                         success=False,
                         message="prometheus healthcheck failed.",

--- a/dashboard/modules/metrics/metrics_head.py
+++ b/dashboard/modules/metrics/metrics_head.py
@@ -44,6 +44,12 @@ PROMETHEUS_CONFIG_INPUT_PATH = os.path.join(
     METRICS_INPUT_ROOT, "prometheus", "prometheus.yml"
 )
 PROMETHEUS_HEALTHCHECK_PATH = "-/healthy"
+# Allows for different flavors of Prometheus as metrics backend
+PROMETHEUS_HEALTHCHECK_RESPONSES = (
+    "Prometheus",
+    "VictoriaMetrics",
+    "OK",  # Thanos
+)
 
 DEFAULT_GRAFANA_HOST = "http://localhost:3000"
 GRAFANA_HOST_ENV_VAR = "RAY_GRAFANA_HOST"
@@ -166,7 +172,7 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
                 text = await resp.text()
                 # Basic sanity check of prometheus health check schema
                 # Different flavors of Prometheus may use different health check strings
-                if "Prometheus" not in text or "VictoriaMetrics" not in text:
+                if all(check not in text for check in PROMETHEUS_HEALTHCHECK_RESPONSES):
                     return dashboard_optional_utils.rest_response(
                         success=False,
                         message="prometheus healthcheck failed.",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change allows [VictoriaMetrics](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#prometheus-querying-api-usage) as the metrics backend for the Ray dashboard

## Related issue number

Closes https://github.com/ray-project/ray/issues/42619

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
