### PR TITLE
[release/1] add release build to postmerge

### DIFF
--- a/.buildkite/release.rayci.yml
+++ b/.buildkite/release.rayci.yml
@@ -1,0 +1,16 @@
+group: release
+depends_on:
+  - anyscalebuild
+  - anyscalemlbuild
+steps:
+  - label: "microbenchmark.aws"
+    tags: 
+      - skip-on-premerge
+      - oss
+    commands:
+      - ./release/run_release_test.sh microbenchmark.aws --report
+    instance_type: release
+    job_env: oss-ci-base_build
+    depends_on:
+      - forge
+      - oss-ci-base_build

--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -1,6 +1,9 @@
-group: build
+group: release build
 steps:
   - label: ":tapioca: build: anyscale py{{matrix.python}}-{{matrix.platform}} docker"
+    tags: skip-on-premerge
+    key: anyscalebuild
+    instance_type: release
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- anyscale 
         --python-version {{matrix.python}} --platform {{matrix.platform}} 
@@ -22,6 +25,9 @@ steps:
           - cpu
 
   - label: ":tapioca: build: anyscale-ml py{{matrix}}-cu11.8.0 docker"
+    tags: skip-on-premerge
+    key: anyscalemlbuild
+    instance_type: release
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- anyscale --python-version {{matrix}}
         --platform cu11.8.0 --image-type ray-ml --upload

--- a/.buildkite/release/config.yml
+++ b/.buildkite/release/config.yml
@@ -6,7 +6,7 @@ forge_prefix: cr.ray.io/rayproject/
 builder_queues:
   builder: builder_queue_branch
 runner_queues:
-  default: release_queue_small
+  release: release_queue_small
 buildkite_dirs:
   - .buildkite/release
 env:

--- a/.buildkite/releasebuild.rayci.yml
+++ b/.buildkite/releasebuild.rayci.yml
@@ -1,0 +1,1 @@
+release/build.rayci.yml


### PR DESCRIPTION
Add release builds to postmerge. This is part of the work to run postmerge + release tests together in one commit.

Test:
- CI
- https://buildkite.com/ray-project/postmerge/builds/2673