### PR TITLE
[ci] no p0 for ci test failure issues

### DIFF
--- a/release/ray_release/test_automation/ci_state_machine.py
+++ b/release/ray_release/test_automation/ci_state_machine.py
@@ -58,7 +58,6 @@ class CITestStateMachine(TestStateMachine):
 
     def _create_github_issue(self) -> None:
         labels = [
-            "P0",
             "bug",
             "ci-test",
             "ray-test-bot",


### PR DESCRIPTION
Probably too overwhelm for teams; will let Sam triage the priority

Test:
- CI