### PR TITLE
[serve] Fix workspace template using `port` in `serve.run`

### DIFF
--- a/doc/source/templates/03_serving_stable_diffusion/start.ipynb
+++ b/doc/source/templates/03_serving_stable_diffusion/start.ipynb
@@ -215,11 +215,10 @@
    "outputs": [],
    "source": [
     "entrypoint = APIIngress.bind(StableDiffusionV2.bind())\n",
-    "port = 8000\n",
     "\n",
     "# Shutdown any existing Serve replicas, if they're still around.\n",
     "serve.shutdown()\n",
-    "serve.run(entrypoint, port=port, name=\"serving_stable_diffusion_template\", route_prefix=\"/\")\n",
+    "serve.run(entrypoint, name=\"serving_stable_diffusion_template\")\n",
     "print(\"Done setting up replicas! Now accepting requests...\")\n"
    ]
   },

--- a/doc/source/workflows/doc_code/wait_for_event_http.py
+++ b/doc/source/workflows/doc_code/wait_for_event_http.py
@@ -8,7 +8,7 @@ import requests
 ray.init(storage="/tmp/ray/workflow/data")
 # Start a Ray Serve instance. This will automatically start
 # or connect to an existing Ray cluster.
-serve.start(detached=True)
+serve.start()
 
 # fmt: off
 # __wait_for_event_begin__


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Also another drive-by to remove the `detached=True` in workspace docs.

## Related issue number

Closes https://github.com/ray-project/ray/issues/42650

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
