### PR TITLE
[Docs] Fix spelling in garbage collection docs for generators

### DIFF
--- a/doc/source/ray-core/ray-generator.rst
+++ b/doc/source/ray-core/ray-generator.rst
@@ -125,17 +125,17 @@ use ``__anext__`` or ``async for`` loops.
     :start-after: __streaming_generator_asyncio_start__
     :end-before: __streaming_generator_asyncio_end__
 
-Garbage collection of object referneces
+Garbage collection of object references
 ---------------------------------------
-The returned ref from ``next(generator)`` is just a regular Ray object reference and is distribute ref counted in the same way.
-If references are not consumed from a generator by the ``next`` API, referencesare garbage collected (GC’ed) when the generator is GC’ed
+The returned ref from ``next(generator)`` is just a regular Ray object reference and is distributed ref counted in the same way.
+If references are not consumed from a generator by the ``next`` API, references are garbage collected (GC’ed) when the generator is GC’ed.
 
 .. literalinclude:: doc_code/streaming_generator.py
     :language: python
     :start-after: __streaming_generator_gc_start__
     :end-before: __streaming_generator_gc_end__
 
-In the following example, Ray counts ``ref1`` a normal Ray object reference after Ray returns it. Other references
+In the following example, Ray counts ``ref1`` as a normal Ray object reference after Ray returns it. Other references
 that aren't consumed with ``next(gen)`` are removed when the generator is GC'ed. In this example, garbage collection happens when you call ``del gen``.
 
 Fault tolerance


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change fixes some spelling mistakes in the docs for generators.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change only affects docs.