### PR TITLE
[ci] Convert Core & Serve Windows test to continuous runs

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -71,6 +71,7 @@ steps:
         --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual
 
   - label: ":ray: core: :windows: python tests"
+    if: build.env("RAYCI_CONTINUOUS_BUILD") == "1" || build.pull_request.labels includes "continuous-build"
     tags: python
     job_env: WINDOWS
     mount_windows_artifacts: true
@@ -307,6 +308,7 @@ steps:
         --parallelism-per-worker 2
 
   - label: ":ray: core: :windows: cpp tests"
+    if: build.env("RAYCI_CONTINUOUS_BUILD") == "1" || build.pull_request.labels includes "continuous-build"
     tags: core_cpp
     job_env: WINDOWS
     mount_windows_artifacts: true

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -77,6 +77,7 @@ steps:
         worker_id: ["0", "1"]
 
   - label: ":ray-serve: serve: :windows: tests"
+    if: build.env("RAYCI_CONTINUOUS_BUILD") == "1" || build.pull_request.labels includes "continuous-build"
     tags: serve
     job_env: WINDOWS
     mount_windows_artifacts: true


### PR DESCRIPTION
## Why are these changes needed?
- Convert these Windows tests on Core/Serve test suite to be continuous runs in `postmerge` Buildkite pipeline schedule.

## Checks
- Custom builds on `postmerge` confirmed that these changed tests only show up on builds with flag on.