### PR TITLE
[WIP][Serve] Revisited cancellation handling in Proxy to make sure response generator is properly cancelled

### DIFF
--- a/python/ray/serve/_private/proxy_response_generator.py
+++ b/python/ray/serve/_private/proxy_response_generator.py
@@ -82,6 +82,11 @@ class ProxyResponseGenerator(_ProxyResponseGeneratorBase):
     def cancelled(self) -> bool:
         return self._response.cancelled()
 
+    def cancel(self):
+        if not self._response.cancelled():
+            self._response.cancel()
+            self._done = True
+
     async def __anext__(self):
         if self._done:
             raise StopAsyncIteration
@@ -95,17 +100,6 @@ class ProxyResponseGenerator(_ProxyResponseGeneratorBase):
 
             if self._result_callback is not None:
                 result = self._result_callback(result)
-        except asyncio.CancelledError as e:
-            # This is specifically for gRPC. The cancellation can happen from client
-            # dropped connection before the request is completed. If self._response is
-            # not already cancelled, we want to explicitly cancel the task, so it
-            # doesn't waste cluster resource in this case and can be terminated
-            # gracefully.
-            if not self._response.cancelled():
-                self._response.cancel()
-                self._done = True
-
-            raise e from None
         except Exception as e:
             self._done = True
             raise e from None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, in some scenarios, we might miss to cancel the ResponseGenerator, for ex, if Cancellation occurs when the Proxy loop executes and not the PG itself.

This change addresses:

  - Properly cancel RG under all conditions during parent task cancellation
  - Avoid swallowing `CancelledError`, instead propagating it up to make sure all tasks in a chain get properly interrupted

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
