### PR TITLE
Add download links to the log viewer page

### DIFF
--- a/dashboard/client/src/pages/log/LogViewer.tsx
+++ b/dashboard/client/src/pages/log/LogViewer.tsx
@@ -160,11 +160,7 @@ export const LogViewer = ({
                   variant="contained"
                   component="a"
                   href={downloadUrl}
-                  download={
-                    path.startsWith("/logs/")
-                      ? path.substring("/logs/".length)
-                      : path
-                  }
+                  download={path}
                 >
                   Download log file
                 </Button>

--- a/dashboard/client/src/pages/log/Logs.tsx
+++ b/dashboard/client/src/pages/log/Logs.tsx
@@ -1,5 +1,8 @@
 import {
+  Box,
   Button,
+  createStyles,
+  IconButton,
   Link,
   List,
   ListItem,
@@ -8,6 +11,7 @@ import {
   Typography,
 } from "@material-ui/core";
 import React, { useMemo, useState } from "react";
+import { RiDownload2Line } from "react-icons/ri";
 import { Outlet, Link as RouterLink, useSearchParams } from "react-router-dom";
 import useSWR from "swr";
 import { StateApiLogViewer } from "../../common/MultiTabLogViewer";
@@ -132,6 +136,14 @@ export const StateApiLogsNodesList = () => {
   );
 };
 
+const useStateApiLogsFilesListStyles = makeStyles((theme) =>
+  createStyles({
+    iconButton: {
+      verticalAlign: "baseline",
+    },
+  }),
+);
+
 type StateApiLogsFilesListProps = {
   nodeId: string;
   folder: string | null;
@@ -143,6 +155,8 @@ export const StateApiLogsFilesList = ({
   folder,
   fileName,
 }: StateApiLogsFilesListProps) => {
+  const classes = useStateApiLogsFilesListStyles();
+
   // We want to do a partial search for file name.
   const fileNameGlob = fileName ? `*${fileName}*` : undefined;
   const glob = fileNameGlob
@@ -224,12 +238,17 @@ export const StateApiLogsFilesList = ({
                   {name}
                 </Link>
                 {downloadUrl && (
-                  <React.Fragment>
-                    &nbsp;
-                    <Link href={downloadUrl} download={fileName}>
-                      (download)
-                    </Link>
-                  </React.Fragment>
+                  <Box paddingLeft={0.5}>
+                    <IconButton
+                      component="a"
+                      href={downloadUrl}
+                      download={fileName}
+                      size="small"
+                      className={classes.iconButton}
+                    >
+                      <RiDownload2Line size={16} />
+                    </IconButton>
+                  </Box>
                 )}
               </ListItem>
             );

--- a/dashboard/client/src/pages/log/Logs.tsx
+++ b/dashboard/client/src/pages/log/Logs.tsx
@@ -10,6 +10,7 @@ import {
   Paper,
   Typography,
 } from "@material-ui/core";
+import { grey } from "@material-ui/core/colors";
 import React, { useMemo, useState } from "react";
 import { RiDownload2Line } from "react-icons/ri";
 import { Outlet, Link as RouterLink, useSearchParams } from "react-router-dom";
@@ -140,6 +141,7 @@ const useStateApiLogsFilesListStyles = makeStyles((theme) =>
   createStyles({
     iconButton: {
       verticalAlign: "baseline",
+      color: grey[700],
     },
   }),
 );


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Adding links at the log viewer list page allows logs to be downloaded much quicker.

![Screenshot 2024-01-24 at 2 55 13 PM](https://github.com/ray-project/ray/assets/711935/f1c1e91c-d072-410e-aeea-7239d5689288)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
fixes #42346
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
