### PR TITLE
[misc] Exclude madewithml link from linkcheck

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -238,6 +238,7 @@ if os.environ.get("LINKCHECK_ALL"):
         r"http://localhost[:/].*",  # Ignore localhost links
         r"^http:/$",  # Ignore incomplete links
         # 403 Client Error: Forbidden for url.
+        "https://madewithml.com/#course",
         # They ratelimit bots.
         "https://www.datanami.com/2018/02/01/rays-new-library-targets-high-speed-reinforcement-learning/",
         # 403 Client Error: Forbidden for url.


### PR DESCRIPTION
## Why are these changes needed?
Outdated links are causing Lint test to fail on postmerge CI pipeline.

The host server for `madewithml.com` seems to not allow Sphinx user agent for some reason. I manually verified the link still works and add it to the ignore list so Lint skips this domain. 