### PR TITLE
Fix `IS_PYDANTIC_2` logic for `pydantic<1.9.0`

### DIFF
--- a/python/ray/_private/pydantic_compat.py
+++ b/python/ray/_private/pydantic_compat.py
@@ -28,7 +28,7 @@ if not PYDANTIC_INSTALLED:
 # In pydantic <1.9.0, __version__ attribute is missing, issue ref:
 # https://github.com/pydantic/pydantic/issues/2572, so we need to check
 # the existence prior to comparison.
-elif hasattr(pydantic, "__version__") and packaging.version.parse(
+elif not hasattr(pydantic, "__version__") or packaging.version.parse(
     pydantic.__version__
 ) < packaging.version.parse("2.0"):
     IS_PYDANTIC_2 = False

--- a/python/ray/tests/test_minimal_install.py
+++ b/python/ray/tests/test_minimal_install.py
@@ -3,9 +3,14 @@
 Tests that are specific to minimal installations.
 """
 
-import pytest
+import unittest.mock as mock
+import itertools
+import packaging
 import os
 import sys
+from typing import Dict
+
+import pytest
 
 
 @pytest.mark.skipif(
@@ -29,14 +34,45 @@ def test_correct_python_version():
     )
 
 
+class MockBaseModel:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __init_subclass__(self, *args, **kwargs):
+        pass
+
+
+def _make_mock_pydantic_modules(pydantic_version: str) -> Dict:
+    """Make a mock for the `pydantic` module.
+
+    This module requires special handling to:
+        - Make `BaseModel` a class object so type hints work.
+        - Set the `__version__` attribute appropriately.
+        - Also mock `pydantic.v1` for `pydantic >= 2.0`.
+        - Also mock `pydantic.dataclasses`.
+
+    Returns a dict of mocked modules.
+    """
+    mock_modules = {
+        "pydantic": mock.MagicMock(),
+        "pydantic.dataclasses": mock.MagicMock(),
+    }
+    mock_modules["pydantic"].BaseModel = MockBaseModel
+    if packaging.version.parse(pydantic_version) >= packaging.version.parse("1.9.0"):
+        mock_modules["pydantic"].__version__ = pydantic_version
+
+    if packaging.version.parse(pydantic_version) >= packaging.version.parse("2.0.0"):
+        mock_modules["pydantic.v1"] = mock_modules["pydantic"]
+
+    return mock_modules
+
+
+@pytest.mark.parametrize("pydantic_version", ["1.8.0", "1.9.0", "2.0.0"])
 @pytest.mark.skipif(
     os.environ.get("RAY_MINIMAL", "0") != "1",
     reason="Skip unless running in a minimal install.",
 )
-def test_module_import_with_various_non_minimal_deps():
-    import unittest.mock as mock
-    import itertools
-
+def test_module_import_with_various_non_minimal_deps(pydantic_version: str):
     optional_modules = [
         "opencensus",
         "prometheus_client",
@@ -48,9 +84,14 @@ def test_module_import_with_various_non_minimal_deps():
     for i in range(len(optional_modules)):
         for install_modules in itertools.combinations(optional_modules, i):
             print(install_modules)
-            with mock.patch.dict(
-                "sys.modules", {mod: mock.Mock() for mod in install_modules}
-            ):
+            mock_modules = {}
+            for mod in install_modules:
+                if mod == "pydantic":
+                    mock_modules.update(**_make_mock_pydantic_modules(pydantic_version))
+                else:
+                    mock_modules[mod] = mock.MagicMock()
+
+            with mock.patch.dict("sys.modules", mock_modules):
                 from ray.dashboard.utils import get_all_modules
                 from ray.dashboard.utils import DashboardHeadModule
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `__version__` attribute didn't exist prior to 1.9.0 and our check does not work properly.

Tested manually with `pip install -U pydantic==1.8.0`.

## Related issue number

Closes https://github.com/ray-project/ray/issues/42413

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
