### PR TITLE
Revert "[ci] temp skip linkcheck on premerge, which is failing"

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -92,8 +92,6 @@ steps:
     instance_type: medium
     commands:
       - make -C doc/ linkcheck
-    tags:
-      - skip-on-premerge
     depends_on: docbuild
     job_env: docbuild
 


### PR DESCRIPTION
Reverts ray-project/ray#42707

issue already fixed on master.