### PR TITLE
[serve] Fix autoscaling test

### DIFF
--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -451,8 +451,6 @@ def test_e2e_intermediate_downscaling(serve_instance):
 def test_downscaling_with_fractional_smoothing_factor(
     serve_instance, initial_replicas: int
 ):
-    controller = serve_instance._controller
-
     signal = SignalActor.options(name="signal123").remote()
     signal.send.remote(clear=True)
 
@@ -479,7 +477,7 @@ def test_downscaling_with_fractional_smoothing_factor(
     # Deploy with initial replicas = 2+, smoothing factor = 0.5
     serve_instance.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
     wait_for_condition(
-        lambda: get_deployment_status(controller, "A") == DeploymentStatus.HEALTHY
+        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
     )
 
     # Send a blocked request to one of two replicas.
@@ -487,7 +485,7 @@ def test_downscaling_with_fractional_smoothing_factor(
     # downscale delay = 5
     h = serve.get_app_handle(SERVE_DEFAULT_APP_NAME)
     h.remote()
-    check_autoscale_num_replicas_eq(controller, "A", initial_replicas)
+    check_num_replicas_eq("A", initial_replicas)
 
     # There is 1 ongoing (blocked) request and 2+ replicas. The
     # deployment should autoscale down to 1 replica despite the
@@ -495,10 +493,7 @@ def test_downscaling_with_fractional_smoothing_factor(
     current_num_replicas = initial_replicas
     while current_num_replicas > 1:
         wait_for_condition(
-            check_autoscale_num_replicas_eq,
-            controller=controller,
-            name="A",
-            target=current_num_replicas - 1,
+            check_num_replicas_eq, name="A", target=current_num_replicas - 1
         )
         current_num_replicas -= 1
         print(f"Deployment has downscaled to {current_num_replicas} replicas.")


### PR DESCRIPTION
[serve] Fix autoscaling test

An autoscaling test is broken because https://github.com/ray-project/ray/pull/42661 and https://github.com/ray-project/ray/pull/42394 were merged in around the same time, resulting in an uncaught conflict.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
