### PR TITLE
[ci] remove job_env for core out of memory tests

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -111,7 +111,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
         --only-tags=tmpfs --tmp-filesystem=tmpfs
-    job_env: corebuild
 
   - label: ":ray: core: out of disk redis tests"
     tags:
@@ -122,7 +121,6 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
         --test-env=TEST_EXTERNAL_REDIS=1
         --only-tags=tmpfs --tmp-filesystem=tmpfs
-    job_env: corebuild
 
   - label: ":ray: core: workflow tests"
     tags: 


### PR DESCRIPTION
it is not required to run on the corebuild base as the tests run inside the docker container
