### PR TITLE
[Serve] fix missing message body for json log formats

### DIFF
--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -81,10 +81,10 @@ class ServeJSONFormatter(logging.Formatter):
                 SERVE_LOG_APPLICATION
             ]
 
-        if SERVE_LOG_MESSAGE in record.__dict__:
-            record_format[SERVE_LOG_MESSAGE] = (
-                SERVE_LOG_RECORD_FORMAT[SERVE_LOG_MESSAGE] % record.__dict__
-            )
+        message_formatter = logging.Formatter(
+            SERVE_LOG_RECORD_FORMAT[SERVE_LOG_MESSAGE]
+        )
+        record_format[SERVE_LOG_MESSAGE] = message_formatter.format(record)
 
         if SERVE_LOG_EXTRA_FIELDS in record.__dict__:
             if not isinstance(record.__dict__[SERVE_LOG_EXTRA_FIELDS], dict):

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -556,6 +556,12 @@ def test_json_log_formatter(is_replica_type_component):
         expected_json["deployment"] = "component"
         expected_json["replica"] = "component_id"
 
+    # Ensure message exists in the output.
+    # Note that there is no "message" key in the record dict until it has been
+    # formatted. This check should go before other fields are set and checked.
+    expected_json["message"] = "my_path:1 - my_message"
+    format_and_verify_json_output(record, expected_json)
+
     # Set request id
     record.request_id = "request_id"
     expected_json["request_id"] = "request_id"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Found quite a lot of logs misses log message body when working on the logs observability (on Workspaces).  
<img width="1691" alt="image" src="https://github.com/ray-project/ray/assets/7553988/f2e45ebc-9535-4319-a006-c182ad9cd19a">

After a bit more digging, it seems like in some occasion, the `message` attribute would not be presented on the `record.__dict__`  so caused the if statement to be skipped and logged a line without the `message` body. Internally in `LogRecord`, the `message` field is "...computed as `msg % args`. This is set when [Formatter.format()](https://docs.python.org/3/library/logging.html#logging.Formatter.format) is invoked." This PR uses `logging.Formatter` to format the message directly instead of relying on Python's string substitution so the message can always be computed. Also did it in the TDD way to ensure there is a test covering it.  

LogRecord Doc: https://docs.python.org/3/library/logging.html#logrecord-objects 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
