### PR TITLE
[serve] Remove name defaulting logic from `serve publish`

### DIFF
--- a/python/ray/serve/_private/publish_provider.py
+++ b/python/ray/serve/_private/publish_provider.py
@@ -18,7 +18,7 @@ class PublishProvider(ABC):
     def publish(
         config: Dict,
         *,
-        name: str,
+        name: Optional[str],
         ray_version: str,
         base_image: Optional[str] = None,
     ):
@@ -49,14 +49,15 @@ class AnyscalePublishProvider(PublishProvider):
     def publish(
         config: Dict,
         *,
-        name: str,
+        name: Optional[str],
         ray_version: str,
         base_image: Optional[str] = None,
     ):
         service_config = {
-            "name": name,
             "ray_serve_config": config,
         }
+        if name is not None:
+            service_config["name"] = name
         if base_image is not None:
             service_config["cluster_env"] = base_image
 

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -769,11 +769,8 @@ def _generate_config_from_file_or_import_path(
     *,
     arguments: Dict[str, str],
     runtime_env: Optional[Dict[str, Any]],
-) -> Tuple[ServeDeploySchema, str]:
-    """Generates a deployable config schema and name for the passed applications(s).
-
-    NOTE: the returned name must not contain any "." or ":" characters.
-    """
+) -> ServeDeploySchema:
+    """Generates a deployable config schema for the passed applications(s)."""
     if pathlib.Path(config_or_import_path).is_file():
         config_path = config_or_import_path
         cli_logger.print(f"Publishing from config file: '{config_path}'.")
@@ -783,7 +780,6 @@ def _generate_config_from_file_or_import_path(
             )
 
         # TODO(edoakes): runtime_env is silently ignored -- should we enable overriding?
-        name = os.path.basename(config_path).split(".")[0]
         with open(config_path, "r") as config_file:
             config_dict = yaml.safe_load(config_file)
             config = ServeDeploySchema.parse_obj(config_dict)
@@ -797,7 +793,6 @@ def _generate_config_from_file_or_import_path(
                 "Import path must be of the form 'module.submodule:app_or_builder', "
                 f"got: '{import_path}'."
             )
-        name = import_path.split(":")[1]
         app = ServeApplicationSchema(
             import_path=import_path,
             runtime_env=runtime_env,
@@ -806,8 +801,7 @@ def _generate_config_from_file_or_import_path(
         config = ServeDeploySchema(applications=[app])
 
     assert isinstance(config, ServeDeploySchema)
-    assert isinstance(name, str) and name
-    return config, name
+    return config
 
 
 @cli.command(
@@ -883,14 +877,11 @@ def publish(
 
     # Skip validating runtime_env URIs so publishers can enable local URI usage.
     with _skip_validating_runtime_env_uris():
-        config, default_name = _generate_config_from_file_or_import_path(
+        config = _generate_config_from_file_or_import_path(
             config_or_import_path,
             arguments=args_dict,
             runtime_env=final_runtime_env,
         )
-
-    if name is None:
-        name = default_name
 
     publish_provider = get_publish_provider(provider)
     publish_provider.publish(

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -770,7 +770,7 @@ def _generate_config_from_file_or_import_path(
     arguments: Dict[str, str],
     runtime_env: Optional[Dict[str, Any]],
 ) -> ServeDeploySchema:
-    """Generates a deployable config schema for the passed applications(s)."""
+    """Generates a deployable config schema for the passed application(s)."""
     if pathlib.Path(config_or_import_path).is_file():
         config_path = config_or_import_path
         cli_logger.print(f"Publishing from config file: '{config_path}'.")

--- a/python/ray/serve/tests/unit/publish_provider.py
+++ b/python/ray/serve/tests/unit/publish_provider.py
@@ -19,7 +19,7 @@ class TestPublishProvider(PublishProvider):
         self,
         config: Dict,
         *,
-        name: str,
+        name: Optional[str],
         ray_version: str,
         base_image: Optional[str] = None,
     ):

--- a/python/ray/serve/tests/unit/test_cli.py
+++ b/python/ray/serve/tests/unit/test_cli.py
@@ -29,7 +29,7 @@ class TestPublish:
                 "runtime_env": {},
             }
         ]
-        assert publish_provider.published_name == "my_app"
+        assert publish_provider.published_name is None
         assert publish_provider.published_ray_version == ray.__version__
         assert publish_provider.published_base_image is None
 
@@ -70,7 +70,7 @@ class TestPublish:
                 "runtime_env": {},
             }
         ]
-        assert publish_provider.published_name == "my_app"
+        assert publish_provider.published_name is None
         assert publish_provider.published_ray_version == ray.__version__
         assert publish_provider.published_base_image == "test-image"
 
@@ -90,7 +90,7 @@ class TestPublish:
                 "runtime_env": {},
             }
         ]
-        assert publish_provider.published_name == "my_app"
+        assert publish_provider.published_name is None
         assert publish_provider.published_ray_version == ray.__version__
         assert publish_provider.published_base_image is None
 
@@ -139,7 +139,7 @@ class TestPublish:
                 "runtime_env": runtime_env,
             }
         ]
-        assert publish_provider.published_name == "my_app"
+        assert publish_provider.published_name is None
         assert publish_provider.published_ray_version == ray.__version__
         assert publish_provider.published_base_image is None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Allows publishers to define their own name-defaulting logic.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
