### PR TITLE
[Serve] Log Serve config when controller receives it

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -781,6 +781,8 @@ class ServeController:
         ServeUsageTag.API_VERSION.record("v2")
         if not deployment_time:
             deployment_time = time.time()
+        
+        logger.info(f"Received config: {config}")
 
         new_config_checkpoint = {}
 

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -781,7 +781,7 @@ class ServeController:
         ServeUsageTag.API_VERSION.record("v2")
         if not deployment_time:
             deployment_time = time.time()
-        
+
         logger.info(f"Received config: {config}")
 
         new_config_checkpoint = {}

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -782,7 +782,11 @@ class ServeController:
         if not deployment_time:
             deployment_time = time.time()
 
-        logger.info(f"Received config: {config}")
+        config_str = config.json(exclude_unset=True, indent=4, encoder=str)
+        logger.info(
+            f"Received config:\n{config_str}",
+            extra={"log_to_stderr": False},
+        )
 
         new_config_checkpoint = {}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

With this change, the controller logs the Serve config when it receives it.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
