### PR TITLE
[ci] fix minbuild setup

### DIFF
--- a/ci/docker/min.build.Dockerfile
+++ b/ci/docker/min.build.Dockerfile
@@ -26,17 +26,21 @@ MINIMAL_INSTALL=1 PYTHON=${PYTHON_VERSION} ci/env/install-dependencies.sh
 rm -rf python/ray/thirdparty_files
 
 # install test requirements
-python -m pip install -U pytest==7.0.1
+python -m pip install -U pytest==7.0.1 pip-tools==7.3.0
 
 # install extra dependencies
 if [[ "${EXTRA_DEPENDENCY}" == "core" ]]; then
   ./ci/env/install-core-prerelease-dependencies.sh
-elif [[ "${EXTRA_DEPENDENCY}" == "ml" ]]; then 
-  python -m pip install -U "ray[tune]"
+elif [[ "${EXTRA_DEPENDENCY}" == "ml" ]]; then
+  pip-compile -o min_requirements.txt python/setup.py --extra ml
 elif [[ "${EXTRA_DEPENDENCY}" == "default" ]]; then
-  python -m pip install -U "ray[default]"
+  pip-compile -o min_requirements.txt python/setup.py --extra default
 elif [[ "${EXTRA_DEPENDENCY}" == "serve" ]]; then
-  python -m pip install -U "ray[serve]"
+  pip-compile -o min_requirements.txt python/setup.py --extra serve
+fi
+
+if [[ -f min_requirements.txt ]]; then
+  pip install -r min_requirements.txt
 fi
 
 EOF

--- a/ci/docker/min.build.wanda.yaml
+++ b/ci/docker/min.build.wanda.yaml
@@ -4,6 +4,9 @@ dockerfile: ci/docker/min.build.Dockerfile
 srcs:
   - ci/env/install-dependencies.sh
   - ci/env/install-core-prerelease-dependencies.sh
+  - python/setup.py
+  - python/ray/_version.py
+  - README.rst
 build_args:
   - PYTHON_VERSION
   - EXTRA_DEPENDENCY


### PR DESCRIPTION
Currently minbuild install dependencies from the release version of ray. This makes sure it install dependencies from the local version of ray

Test:
- CI