### PR TITLE
[Data] Add retry for `_sample_fragment` during `ParquetDatasource._estimate_files_encoding_ratio()`

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -179,50 +179,6 @@ def _deserialize_fragments_with_retry(
     raise final_exception
 
 
-# def _fragment_subset_with_retry(
-#     fragment: "pyarrow._dataset.ParquetFileFragment",
-#     **subset_kwargs,
-# ) -> "pyarrow._dataset.ParquetFileFragment":
-#     min_interval = 0
-#     final_exception = None
-#     for i in range(FILE_READING_RETRY):
-#         try:
-#             return fragment.subset(**subset_kwargs)
-#         except Exception as e:
-#             import random
-#             import time
-
-#             retry_timing = (
-#                 ""
-#                 if i == FILE_READING_RETRY - 1
-#                 else (f"Retry after {min_interval} sec. ")
-#             )
-#             log_only_show_in_1st_retry = (
-#                 ""
-#                 if i
-#                 else (
-#                     f"If earlier read attempt threw certain Exception"
-#                     f", it may or may not be an issue depends on these retries "
-#                     f"succeed or not. fragment:{fragment}"
-#                 )
-#             )
-#             logger.exception(
-#                 f"{i + 1}th attempt to get subset of ParquetFileFragment failed. "
-#                 f"{retry_timing}"
-#                 f"{log_only_show_in_1st_retry}"
-#             )
-#             if not min_interval:
-#                 # to make retries of different process hit hdfs server
-#                 # at slightly different time
-#                 min_interval = 1 + random.random()
-#             # exponential backoff at
-#             # 1, 2, 4, 8, 16, 32, 64
-#             time.sleep(min_interval)
-#             min_interval = min_interval * 2
-#             final_exception = e
-#     raise final_exception
-
-
 @PublicAPI
 class ParquetDatasource(Datasource):
     """Parquet datasource, for reading and writing Parquet files.
@@ -625,15 +581,9 @@ def _sample_fragment(
     schema,
     file_fragment: _SerializedFragment,
 ) -> float:
-    # # Sample the first rows batch from file fragment `serialized_fragment`.
-    # # Return the encoding ratio calculated from the sampled rows.
-    # fragment = _deserialize_fragments_with_retry([file_fragment])[0]
-
-    # # Only sample the first row group.
-    # fragment = fragment.subset(row_group_ids=[0])
-
     # Sample the first rows batch from file fragment `serialized_fragment`.
     # Return the encoding ratio calculated from the sampled rows.
+
     # Only sample the first row group.
     fragment = _deserialize_fragments_with_retry(
         [file_fragment], sample_first_row_group=True


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Sometimes, there can be transient errors during the fragment sampling phase of `read_parquet()`, when Ray Data estimates the file encoding ratio prior to execution. We include this fragment sampling phase into a retry loop so that we automatically retry upon failure. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
