### PR TITLE
[core][client] Remove protocol version, instead just compare Ray and Python versions.

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -386,7 +386,10 @@ class Node:
 
         if not cluster_metadata:
             return
-        ray._private.utils.check_version_info(cluster_metadata)
+        node_ip_address = ray._private.services.get_node_ip_address()
+        ray._private.utils.check_version_info(
+            cluster_metadata, f"node {node_ip_address}"
+        )
 
     def _register_shutdown_hooks(self):
         # Register the atexit handler. In this case, we shouldn't call sys.exit

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1516,14 +1516,34 @@ def get_directory_size_bytes(path: Union[str, Path] = ".") -> int:
     return total_size_bytes
 
 
-def check_version_info(cluster_metadata, this_process_address, raise_on_mismatch=True):
+def check_version_info(
+    cluster_metadata,
+    this_process_address,
+    raise_on_mismatch=True,
+    python_version_match_level="patch",
+):
     """Check if the Python and Ray versions stored in GCS matches this process.
     Args:
         cluster_metadata: Ray cluster metadata from GCS.
         this_process_address: Informational only. The address of this process.
             e.g. "node address:port" or "Ray Client".
         raise_on_mismatch: Raise an exception on True, log a warning otherwise.
+        python_version_match_level: "minor" or "patch". To which python version level we
+            try to match. Note if "minor" and the patch is different, we will still log
+            a warning.
 
+    Behavior:
+        - We raise or log a warning, based on raise_on_mismatch, if:
+            - Ray versions do not match; OR
+            - Python (major, minor) versions do not match,
+                if python_version_match_level == 'minor'; OR
+            - Python (major, minor, patch) versions do not match,
+                if python_version_match_level == 'patch'.
+        - We also log a warning if:
+            - Python (major, minor) versions match, AND
+            - Python patch versions do not match, AND
+            - python_version_match_level == 'minor' AND
+            - raise_on_mismatch == False.
     Raises:
         Exception: An exception is raised if there is a version mismatch.
     """
@@ -1531,16 +1551,37 @@ def check_version_info(cluster_metadata, this_process_address, raise_on_mismatch
         cluster_metadata["ray_version"],
         cluster_metadata["python_version"],
     )
-    version_info = compute_version_info()
-    if version_info != cluster_version_info:
-        error_message = (
-            "Version mismatch: The cluster was started with:\n"
-            "    Ray: " + cluster_version_info[0] + "\n"
-            "    Python: " + cluster_version_info[1] + "\n"
-            "This process on " + this_process_address + " was started with:" + "\n"
-            "    Ray: " + version_info[0] + "\n"
-            "    Python: " + version_info[1] + "\n"
+    my_version_info = compute_version_info()
+
+    # Calculate: ray_matches, python_matches, python_full_matches
+    ray_matches = cluster_version_info[0] == my_version_info[0]
+    python_full_matches = cluster_version_info[1] == my_version_info[1]
+    if python_version_match_level == "patch":
+        python_matches = cluster_version_info[1] == my_version_info[1]
+    elif python_version_match_level == "minor":
+        my_python_versions = my_version_info[1].split(".")
+        cluster_python_versions = cluster_version_info[1].split(".")
+        python_matches = my_python_versions[:2] == cluster_python_versions[:2]
+    else:
+        raise ValueError(
+            f"Invalid python_version_match_level: {python_version_match_level}, "
+            "want: 'minor' or 'patch'"
         )
+
+    mismatch_msg = (
+        "The cluster was started with:\n"
+        f"    Ray: {cluster_version_info[0]}\n"
+        f"    Python: {cluster_version_info[1]}\n"
+        f"This process on {this_process_address} was started with:\n"
+        f"    Ray: {my_version_info[0]}\n"
+        f"    Python: {my_version_info[1]}\n"
+    )
+
+    if ray_matches and python_matches:
+        if not python_full_matches:
+            logger.warning(f"Python patch version mismatch: {mismatch_msg}")
+    else:
+        error_message = f"Version mismatch: {mismatch_msg}"
         if raise_on_mismatch:
             raise RuntimeError(error_message)
         else:

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1166,7 +1166,6 @@ class RayContext(BaseContext, Mapping):
     python_version: str
     ray_version: str
     ray_commit: str
-    protocol_version: Optional[str]
 
     def __init__(self, address_info: Dict[str, Optional[str]]):
         super().__init__()
@@ -1174,9 +1173,6 @@ class RayContext(BaseContext, Mapping):
         self.python_version = "{}.{}.{}".format(*sys.version_info[:3])
         self.ray_version = ray.__version__
         self.ray_commit = ray.__commit__
-        # No client protocol version since this driver was intiialized
-        # directly
-        self.protocol_version = None
         self.address_info = address_info
 
     def __getitem__(self, key):

--- a/python/ray/client_builder.py
+++ b/python/ray/client_builder.py
@@ -41,9 +41,9 @@ class ClientContext(BaseContext):
     python_version: str
     ray_version: str
     ray_commit: str
-    protocol_version: Optional[str]
     _num_clients: int
     _context_to_restore: Optional[ray.util.client.RayAPIStub]
+    protocol_version: Optional[str] = None  # Deprecated
 
     def __enter__(self) -> "ClientContext":
         self._swap_context()

--- a/python/ray/client_builder.py
+++ b/python/ray/client_builder.py
@@ -33,6 +33,8 @@ CLIENT_DOCS_URL = (
 class ClientContext(BaseContext):
     """
     Basic context manager for a ClientBuilder connection.
+
+    `protocol_version` is no longer used.
     """
 
     dashboard_url: Optional[str]
@@ -185,7 +187,6 @@ class ClientBuilder:
             python_version=client_info_dict["python_version"],
             ray_version=client_info_dict["ray_version"],
             ray_commit=client_info_dict["ray_commit"],
-            protocol_version=client_info_dict["protocol_version"],
             _num_clients=client_info_dict["num_clients"],
             _context_to_restore=ray.util.client.ray.get_context(),
         )
@@ -308,7 +309,6 @@ class _LocalClientBuilder(ClientBuilder):
             ),
             ray_version=ray.__version__,
             ray_commit=ray.__commit__,
-            protocol_version=None,
             _num_clients=1,
             _context_to_restore=None,
         )

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -114,8 +114,6 @@ def test_connect_to_cluster(ray_start_regular_shared):
         assert client_context.python_version == python_version
         assert client_context.ray_version == ray.__version__
         assert client_context.ray_commit == ray.__commit__
-        protocol_version = ray.util.client.CURRENT_PROTOCOL_VERSION
-        assert client_context.protocol_version == protocol_version
 
     server.stop(0)
     subprocess.check_output("ray stop --force", shell=True)

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import ray.util.client.server.server as ray_client_server
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
 
-from ray.util.client import _ClientContext, CURRENT_PROTOCOL_VERSION
+from ray.util.client import _ClientContext
 from ray.cluster_utils import cluster_not_supported
 
 import ray
@@ -144,7 +144,6 @@ def test_num_clients(init_and_serve_lazy):
     assert isinstance(info3["ray_version"], str), info3
     assert isinstance(info3["ray_commit"], str), info3
     assert isinstance(info3["python_version"], str), info3
-    assert isinstance(info3["protocol_version"], str), info3
     api3.disconnect()
 
 
@@ -164,38 +163,6 @@ def test_python_version(init_and_serve):
             python_version="2.7.12",
             ray_version="",
             ray_commit="",
-            protocol_version=CURRENT_PROTOCOL_VERSION,
-        )
-
-    # inject mock connection function
-    server_handle.data_servicer._build_connection_response = mock_connection_response
-
-    ray = _ClientContext()
-    with pytest.raises(RuntimeError):
-        _ = ray.connect("localhost:50051")
-
-    ray = _ClientContext()
-    info3 = ray.connect("localhost:50051", ignore_version=True)
-    assert info3["num_clients"] == 1, info3
-    ray.disconnect()
-
-
-def test_protocol_version(init_and_serve):
-    server_handle = init_and_serve
-    ray = _ClientContext()
-    info1 = ray.connect("localhost:50051")
-    local_py_version = ".".join([str(x) for x in list(sys.version_info)[:3]])
-    assert info1["protocol_version"] == CURRENT_PROTOCOL_VERSION, info1
-    ray.disconnect()
-    time.sleep(1)
-
-    def mock_connection_response():
-        return ray_client_pb2.ConnectionInfoResponse(
-            num_clients=1,
-            python_version=local_py_version,
-            ray_version="",
-            ray_commit="",
-            protocol_version="2050-01-01",  # from the future
         )
 
     # inject mock connection function

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import threading
-import json
 from typing import Any, Dict, List, Optional, Tuple
 
 import ray._private.ray_constants as ray_constants
@@ -9,7 +8,6 @@ from ray._private.client_mode_hook import (
     _explicitly_disable_client_mode,
     _explicitly_enable_client_mode,
 )
-import ray._private.usage.usage_constants as usage_constant
 from ray._private.ray_logging import setup_logger
 from ray.job_config import JobConfig
 from ray.util.annotations import DeveloperAPI

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -126,8 +126,12 @@ class _ClientContext:
                 namespace=ray_constants.KV_NAMESPACE_CLUSTER,
             ).decode("utf-8")
         )
+        ignore_version = ignore_version or ("RAY_IGNORE_VERSION_MISMATCH" in os.environ)
         check_version_info(
-            cluster_metadata, "Ray Client", raise_on_mismatch=not ignore_version
+            cluster_metadata,
+            "Ray Client",
+            raise_on_mismatch=not ignore_version,
+            python_version_match_level="minor",
         )
 
     def disconnect(self):

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -118,16 +118,10 @@ class _ClientContext:
         ray.util.serialization_addons.apply(ctx)
 
     def _check_versions(self, conn_info: Dict[str, Any], ignore_version: bool) -> None:
-        # blocking get
-        cluster_metadata = json.loads(
-            self._internal_kv_get(
-                usage_constant.CLUSTER_METADATA_KEY,
-                namespace=ray_constants.KV_NAMESPACE_CLUSTER,
-            ).decode("utf-8")
-        )
+        # conn_info has "python_version" and "ray_version" so it can be used to compare.
         ignore_version = ignore_version or ("RAY_IGNORE_VERSION_MISMATCH" in os.environ)
         check_version_info(
-            cluster_metadata,
+            conn_info,
             "Ray Client",
             raise_on_mismatch=not ignore_version,
             python_version_match_level="minor",

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 import threading
 import json
 from typing import Any, Dict, List, Optional, Tuple
@@ -126,8 +125,12 @@ class _ClientContext:
                 namespace=ray_constants.KV_NAMESPACE_CLUSTER,
             ).decode("utf-8")
         )
+        ignore_version = ignore_version or ("RAY_IGNORE_VERSION_MISMATCH" in os.environ)
         check_version_info(
-            cluster_metadata, "Ray Client", raise_on_mismatch=not ignore_version
+            cluster_metadata,
+            "Ray Client",
+            raise_on_mismatch=not ignore_version,
+            python_version_match_level="minor",
         )
 
     def disconnect(self):

--- a/python/ray/util/client/server/dataservicer.py
+++ b/python/ray/util/client/server/dataservicer.py
@@ -17,7 +17,6 @@ from ray.util.client.common import (
     _propagate_error_in_context,
     OrderedResponseCache,
 )
-from ray.util.client import CURRENT_PROTOCOL_VERSION
 from ray.util.debug import log_once
 from ray._private.client_mode_hook import disable_client_hook
 
@@ -412,5 +411,4 @@ class DataServicer(ray_client_pb2_grpc.RayletDataStreamerServicer):
             ),
             ray_version=ray.__version__,
             ray_commit=ray.__commit__,
-            protocol_version=CURRENT_PROTOCOL_VERSION,
         )

--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -388,7 +388,6 @@ class Worker:
             "python_version": data.python_version,
             "ray_version": data.ray_version,
             "ray_commit": data.ray_commit,
-            "protocol_version": data.protocol_version,
         }
 
     def register_callback(

--- a/src/ray/protobuf/ray_client.proto
+++ b/src/ray/protobuf/ray_client.proto
@@ -380,6 +380,7 @@ message ConnectionInfoResponse {
   // The Python version (e.g., "3.7.2").
   string python_version = 4;
   // The protocol version of the server (e.g., "2020-02-01").
+  // DEPRECATED. Not used anywhere. Will remove.
   string protocol_version = 5;
 }
 


### PR DESCRIPTION
In a regular Ray worker init, (python version, ray version) is compared against the cluster. In Ray Client, however, a (python version, *protocol_version*) is compared. This makes it a looser requirement for the client connection than for the workers.

This commit removes that and unifies version check between both sides to (python version, ray version). This helps avoiding any confusion in version mismatch.

Fixes #42356