### PR TITLE
[ci] the extra dependency for ml is called tune

### DIFF
--- a/ci/docker/min.build.Dockerfile
+++ b/ci/docker/min.build.Dockerfile
@@ -32,7 +32,7 @@ python -m pip install -U pytest==7.0.1 pip-tools==7.3.0
 if [[ "${EXTRA_DEPENDENCY}" == "core" ]]; then
   ./ci/env/install-core-prerelease-dependencies.sh
 elif [[ "${EXTRA_DEPENDENCY}" == "ml" ]]; then
-  pip-compile -o min_requirements.txt python/setup.py --extra ml
+  pip-compile -o min_requirements.txt python/setup.py --extra tune
 elif [[ "${EXTRA_DEPENDENCY}" == "default" ]]; then
   pip-compile -o min_requirements.txt python/setup.py --extra default
 elif [[ "${EXTRA_DEPENDENCY}" == "serve" ]]; then

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -192,6 +192,8 @@ if __name__ == "__main__":
                 or changed_file == ".buildkite/pipeline.gpu_large.yml"
                 or changed_file == "ci/docker/ml.build.wanda.yaml"
                 or changed_file == "ci/ray_ci/ml.tests.yml"
+                or changed_file == "ci/docker/min.build.Dockerfile"
+                or changed_file == "ci/docker/min.build.wanda.yaml"
             ):
                 RAY_CI_ML_AFFECTED = 1
                 RAY_CI_TRAIN_AFFECTED = 1


### PR DESCRIPTION
Fix forward which breaks ml-minimal test. The extra dependency for ml is called `tune` and not ml:

Test:
- all test run: https://buildkite.com/ray-project/postmerge/builds/2726