### PR TITLE
Disable follow_symlinks

### DIFF
--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -47,7 +47,7 @@ def setup_static_dir():
         )
 
     static_dir = os.path.join(build_dir, "static")
-    routes.static("/static", static_dir, follow_symlinks=True)
+    routes.static("/static", static_dir)
     return build_dir
 
 


### PR DESCRIPTION
I'm checking that this parameter wasn't set by mistake.
The parameter allows a symlink to point to somewhere _outside_ of the static directory. Symlinks that point within the directory will work without enabling this parameter (it's badly named). Therefore enabling this option could make it easy to misconfigure an environment and introduce security issues.