### PR TITLE
[ci] add explicity depends_on for wait

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -30,6 +30,8 @@ steps:
       EXTRA_DEPENDENCY: core
 
   - wait: ~
+    depends_on:
+      - corebuild
 
   # tests
   - label: ":ray: core: python tests"
@@ -268,6 +270,8 @@ steps:
         --test-env=RAY_MINIMAL=1
         --only-tags minimal
         --skip-ray-installation
+    depends_on:
+      - minbuild-core
     matrix:
       - "3.8"
       - "3.9"

--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -7,8 +7,8 @@ steps:
 
   - wait: ~
     depends_on:
-    - serverlessbuild
-    - forge
+      - serverlessbuild
+      - forge
 
   # tests
   - label: ":serverless: serverless: python tests"


### PR DESCRIPTION
required for proper dependency tracking when executing only a part of the ci execution graph.
