### PR TITLE
[Doc] Add remix icon set

### DIFF
--- a/doc/source/_templates/extrahead.html
+++ b/doc/source/_templates/extrahead.html
@@ -21,6 +21,10 @@ both in the usual template (layout.html) as well as (index.html). -->
   href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
   disabled="disabled"
 />
+<link
+  href="https://cdn.jsdelivr.net/npm/remixicon@4.1.0/fonts/remixicon.css"
+  rel="stylesheet"
+/>
 
 <!-- Used for text embedded in html on the index page  -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>


### PR DESCRIPTION
## Why are these changes needed?

In anticipation of upcoming design changes, this PR adds the [remix icon](https://remixicon.com/) set to the docs.

## Related issue number

Closes https://github.com/ray-project/ray/issues/42626.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
