### PR TITLE
[tune+rllib] Enforce input type for `Experiment(config)` to handle rllib `AlgorithmConfig`s

### DIFF
--- a/python/ray/tune/experiment/experiment.py
+++ b/python/ray/tune/experiment/experiment.py
@@ -172,6 +172,11 @@ class Experiment:
         logger.debug(f"StorageContext on the DRIVER:\n{self.storage}")
 
         config = config or {}
+        if not isinstance(config, dict):
+            raise ValueError(
+                f"`Experiment(config)` must be a dict, got: {type(config)}. "
+                "Please convert your search space to a dict before passing it in."
+            )
 
         self._stopper = None
         stopping_criteria = {}

--- a/python/ray/tune/logger/json.py
+++ b/python/ray/tune/logger/json.py
@@ -60,9 +60,7 @@ class JsonLogger(Logger):
         self.local_out.close()
 
     def update_config(self, config: Dict):
-        from ray.tune.tune import _Config
-
-        self.config = config.to_dict() if isinstance(config, _Config) else config
+        self.config = config
         config_out = os.path.join(self.logdir, EXPR_PARAM_FILE)
         with open(config_out, "w") as f:
             json.dump(self.config, f, indent=2, sort_keys=True, cls=SafeFallbackEncoder)
@@ -117,11 +115,7 @@ class JsonLoggerCallback(LoggerCallback):
         del self._trial_files[trial]
 
     def update_config(self, trial: "Trial", config: Dict):
-        from ray.tune.tune import _Config
-
-        self._trial_configs[trial] = (
-            config.to_dict() if isinstance(config, _Config) else config
-        )
+        self._trial_configs[trial] = config
 
         config_out = os.path.join(trial.local_path, EXPR_PARAM_FILE)
         with open(config_out, "w") as f:

--- a/python/ray/tune/tests/test_experiment.py
+++ b/python/ray/tune/tests/test_experiment.py
@@ -76,10 +76,22 @@ class ExperimentTest(unittest.TestCase):
                 checkpoint_config=CheckpointConfig(checkpoint_at_end=True),
             )
 
+    def testInvalidExperimentConfig(self):
+        with self.assertRaises(ValueError):
+            Experiment(name="foo", run="f1", config="invalid")
+
+        class InvalidClass:
+            def to_dict(self):
+                return {"valid": 1}
+
+        with self.assertRaises(ValueError):
+            Experiment(name="foo", run="f1", config=InvalidClass())
+
+        Experiment(name="foo", run="f1", config=InvalidClass().to_dict())
+
 
 class ValidateUtilTest(unittest.TestCase):
     def testDiagnoseSerialization(self):
-
         # this is not serializable
         e = threading.Event()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
https://github.com/ray-project/ray/pull/42116 resulted in `params.json` saving the wrong data due to dumping an `AlgorithmConfig` object rather than a dict, which is the expected type for `Experiment.config`.

The fix should be to force the user to call `AlgorithmConfig.to_dict` to satisfy the Ray Tune API, rather than adding more rllib specific instance checks in Ray Tune, as is done in [this other PR](https://github.com/ray-project/ray/pull/42116). The `_Config` class is a hack that is used in one place, but we should not add more of this class throughout the codebase when possible.

The fix to the user post linked below:

```python
experiment_spec = tune.Experiment(..., config=ppo_config.to_dict())`
tune.run_experiments(...)
```

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/41370

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
