### PR TITLE
[ci] ray test failure logs for windows

### DIFF
--- a/ci/run/bazel_export_options
+++ b/ci/run/bazel_export_options
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
 mkdir -p /tmp/bazel_event_logs
+if [[ "${OSTYPE}" == "msys" ]]; then
+  artifact_mount_path="/c/artifact-mount"
+else
+  artifact_mount_path="/artifact-mount"
+fi
 event_json_flag=--build_event_json_file=$(mktemp /tmp/bazel_event_logs/bazel_log.XXXXX)
-logs_archive_flag=--test_env=RAY_TEST_FAILURE_LOGS_ARCHIVE_DIR=/artifact-mount/.failed_test_logs
-summary_directory_flag=--test_env=RAY_TEST_SUMMARY_DIR=/artifact-mount/test-summaries
+logs_archive_flag=--test_env=RAY_TEST_FAILURE_LOGS_ARCHIVE_DIR="${artifact_mount_path}"/failed_test_logs
+summary_directory_flag=--test_env=RAY_TEST_SUMMARY_DIR="${artifact_mount_path}"/test-summaries
 summary_directory_host_flag=--test_env=RAY_TEST_SUMMARY_DIR_HOST=/tmp/artifacts/test-summaries
 buildkite_env_vars="--test_env=BUILDKITE_COMMIT --test_env=BUILDKITE_LABEL --test_env=BUILDKITE_JOB_ID"
 mujoco_env_var="--test_env=LD_LIBRARY_PATH=/root/.mujoco/mujoco210/bin"

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -1048,7 +1048,7 @@ def append_short_test_summary(rep):
 
     summary_dir = os.environ.get("RAY_TEST_SUMMARY_DIR")
 
-    if platform.system() != "Linux":
+    if platform.system() == "Darwin":
         summary_dir = os.environ.get("RAY_TEST_SUMMARY_DIR_HOST")
 
     if not summary_dir:
@@ -1059,9 +1059,9 @@ def append_short_test_summary(rep):
 
     test_name = rep.nodeid.replace(os.sep, "::")
 
-    if os.name == "nt":
+    if platform.system() == "Windows":
         # ":" is not legal in filenames in windows
-        test_name.replace(":", "$")
+        test_name = test_name.replace(":", "$")
 
     header_file = os.path.join(summary_dir, "000_header.txt")
     summary_file = os.path.join(summary_dir, test_name + ".txt")
@@ -1183,7 +1183,7 @@ def create_ray_logs_for_failed_test(rep):
 
     # We temporarily restrict to Linux until we have artifact dirs
     # for Windows and Mac
-    if platform.system() != "Linux":
+    if platform.system() != "Linux" and platform.system() != "Windows":
         return
 
     # Only archive failed tests after the "call" phase of the test
@@ -1208,6 +1208,9 @@ def create_ray_logs_for_failed_test(rep):
 
     # Write zipped logs to logs archive dir
     test_name = rep.nodeid.replace(os.sep, "::")
+    if platform.system() == "Windows":
+        # ":" is not legal in filenames in windows
+        test_name = test_name.replace(":", "$")
     output_file = os.path.join(archive_dir, f"{test_name}_{time.time():.4f}")
     shutil.make_archive(output_file, "zip", logs_dir)
 


### PR DESCRIPTION
Ray logs for window tests as buildkite artifacts. This feature already exists in Linux. Porting in Windows is simple since we have artifact mount for Windows now.

Test:
- CI, check the log where I intentionally fail a window test: https://buildkite.com/ray-project/premerge/builds/17883#018d5aa8-2bdb-4137-8b8f-dbd0578d541b