### PR TITLE
[Data] Rename `min_rows_per_block` to `min_rows_per_bundled_input`

### DIFF
--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -72,7 +72,8 @@ class AbstractUDFMap(AbstractMap):
                 `fn` is a callable class.
             fn_constructor_kwargs: Keyword Arguments to provide to the initializor of
                 `fn` if `fn` is a callable class.
-            min_rows_per_bundled_input: The target size for blocks outputted by this operator.
+            min_rows_per_bundled_input: The target number of rows to pass to
+                ``MapOperator._add_bundled_input()``.
             compute: The compute strategy, either ``"tasks"`` (default) to use Ray
                 tasks, or ``"actors"`` to use an autoscaling actor pool.
             ray_remote_args: Args to provide to ray.remote.

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -23,7 +23,7 @@ class AbstractMap(AbstractOneToOne):
         input_op: Optional[LogicalOperator] = None,
         num_outputs: Optional[int] = None,
         *,
-        min_rows_per_block: Optional[int] = None,
+        min_rows_per_bundled_input: Optional[int] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
         """
@@ -32,11 +32,12 @@ class AbstractMap(AbstractOneToOne):
                 inspecting the logical plan of a Dataset.
             input_op: The operator preceding this operator in the plan DAG. The outputs
                 of `input_op` will be the inputs to this operator.
-            min_rows_per_block: The target size for blocks outputted by this operator.
+            min_rows_per_bundled_input: The target number of rows to pass to
+                ``MapOperator._add_bundled_input()``.
             ray_remote_args: Args to provide to ray.remote.
         """
         super().__init__(name, input_op, num_outputs)
-        self._min_rows_per_block = min_rows_per_block
+        self._min_rows_per_bundled_input = min_rows_per_bundled_input
         self._ray_remote_args = ray_remote_args or {}
 
 
@@ -54,7 +55,7 @@ class AbstractUDFMap(AbstractMap):
         fn_kwargs: Optional[Dict[str, Any]] = None,
         fn_constructor_args: Optional[Iterable[Any]] = None,
         fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        min_rows_per_block: Optional[int] = None,
+        min_rows_per_bundled_input: Optional[int] = None,
         compute: Optional[Union[str, ComputeStrategy]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
@@ -71,7 +72,7 @@ class AbstractUDFMap(AbstractMap):
                 `fn` is a callable class.
             fn_constructor_kwargs: Keyword Arguments to provide to the initializor of
                 `fn` if `fn` is a callable class.
-            min_rows_per_block: The target size for blocks outputted by this operator.
+            min_rows_per_bundled_input: The target size for blocks outputted by this operator.
             compute: The compute strategy, either ``"tasks"`` (default) to use Ray
                 tasks, or ``"actors"`` to use an autoscaling actor pool.
             ray_remote_args: Args to provide to ray.remote.
@@ -80,7 +81,7 @@ class AbstractUDFMap(AbstractMap):
         super().__init__(
             name,
             input_op,
-            min_rows_per_block=min_rows_per_block,
+            min_rows_per_bundled_input=min_rows_per_bundled_input,
             ray_remote_args=ray_remote_args,
         )
         self._fn = fn
@@ -131,7 +132,7 @@ class MapBatches(AbstractUDFMap):
         fn_kwargs: Optional[Dict[str, Any]] = None,
         fn_constructor_args: Optional[Iterable[Any]] = None,
         fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        min_rows_per_block: Optional[int] = None,
+        min_rows_per_bundled_input: Optional[int] = None,
         compute: Optional[Union[str, ComputeStrategy]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
@@ -143,7 +144,7 @@ class MapBatches(AbstractUDFMap):
             fn_kwargs=fn_kwargs,
             fn_constructor_args=fn_constructor_args,
             fn_constructor_kwargs=fn_constructor_kwargs,
-            min_rows_per_block=min_rows_per_block,
+            min_rows_per_bundled_input=min_rows_per_bundled_input,
             compute=compute,
             ray_remote_args=ray_remote_args,
         )

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -18,14 +18,16 @@ class Write(AbstractMap):
         **write_args,
     ):
         if isinstance(datasink_or_legacy_datasource, Datasink):
-            min_rows_per_block = datasink_or_legacy_datasource.num_rows_per_write
+            min_rows_per_bundled_input = (
+                datasink_or_legacy_datasource.num_rows_per_write
+            )
         else:
-            min_rows_per_block = None
+            min_rows_per_bundled_input = None
 
         super().__init__(
             "Write",
             input_op,
-            min_rows_per_block=min_rows_per_block,
+            min_rows_per_bundled_input=min_rows_per_bundled_input,
             ray_remote_args=ray_remote_args,
         )
         self._datasink_or_legacy_datasource = datasink_or_legacy_datasource

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -264,22 +264,27 @@ class OperatorFusionRule(Rule):
         up_logical_op = self._op_map.pop(up_op)
 
         # Merge minimum block sizes.
-        down_min_rows_per_block = (
-            down_logical_op._min_rows_per_block
+        down_min_rows_per_bundled_input = (
+            down_logical_op._min_rows_per_bundled_input
             if isinstance(down_logical_op, AbstractMap)
             else None
         )
-        up_min_rows_per_block = (
-            up_logical_op._min_rows_per_block
+        up_min_rows_per_bundled_input = (
+            up_logical_op._min_rows_per_bundled_input
             if isinstance(up_logical_op, AbstractMap)
             else None
         )
-        if down_min_rows_per_block is not None and up_min_rows_per_block is not None:
-            min_rows_per_block = max(down_min_rows_per_block, up_min_rows_per_block)
-        elif up_min_rows_per_block is not None:
-            min_rows_per_block = up_min_rows_per_block
+        if (
+            down_min_rows_per_bundled_input is not None
+            and up_min_rows_per_bundled_input is not None
+        ):
+            min_rows_per_bundled_input = max(
+                down_min_rows_per_bundled_input, up_min_rows_per_bundled_input
+            )
+        elif up_min_rows_per_bundled_input is not None:
+            min_rows_per_bundled_input = up_min_rows_per_bundled_input
         else:
-            min_rows_per_block = down_min_rows_per_block
+            min_rows_per_bundled_input = down_min_rows_per_bundled_input
 
         target_max_block_size = self._get_merged_target_max_block_size(
             up_op.target_max_block_size, down_op.target_max_block_size
@@ -303,7 +308,7 @@ class OperatorFusionRule(Rule):
             target_max_block_size=target_max_block_size,
             name=name,
             compute_strategy=compute,
-            min_rows_per_bundle=min_rows_per_block,
+            min_rows_per_bundle=min_rows_per_bundled_input,
             ray_remote_args=ray_remote_args,
         )
 
@@ -324,7 +329,7 @@ class OperatorFusionRule(Rule):
                 down_logical_op._fn_kwargs,
                 down_logical_op._fn_constructor_args,
                 down_logical_op._fn_constructor_kwargs,
-                min_rows_per_block,
+                min_rows_per_bundled_input,
                 compute,
                 ray_remote_args,
             )
@@ -335,7 +340,7 @@ class OperatorFusionRule(Rule):
             logical_op = AbstractMap(
                 name,
                 input_op,
-                min_rows_per_block=min_rows_per_block,
+                min_rows_per_bundled_input=min_rows_per_bundled_input,
                 ray_remote_args=ray_remote_args,
             )
         self._op_map[op] = logical_op

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -82,7 +82,7 @@ def plan_udf_map_op(
         name=op.name,
         target_max_block_size=None,
         compute_strategy=compute,
-        min_rows_per_bundle=op._min_rows_per_block,
+        min_rows_per_bundle=op._min_rows_per_bundled_input,
         ray_remote_args=op._ray_remote_args,
     )
 

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -50,5 +50,5 @@ def plan_write_op(op: Write, input_physical_dag: PhysicalOperator) -> PhysicalOp
         name="Write",
         target_max_block_size=None,
         ray_remote_args=op._ray_remote_args,
-        min_rows_per_bundle=op._min_rows_per_block,
+        min_rows_per_bundle=op._min_rows_per_bundled_input,
     )

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -566,12 +566,12 @@ class Dataset:
         if batch_format == "native":
             logger.warning("The 'native' batch format has been renamed 'default'.")
 
-        min_rows_per_block = None
+        min_rows_per_bundled_input = None
         if batch_size is not None and batch_size != "default":
             if batch_size < 1:
                 raise ValueError("Batch size cannot be negative or 0")
             # Enable blocks bundling when batch_size is specified by caller.
-            min_rows_per_block = batch_size
+            min_rows_per_bundled_input = batch_size
 
         batch_size = _apply_strict_mode_batch_size(
             batch_size, use_gpu="num_gpus" in ray_remote_args
@@ -590,7 +590,7 @@ class Dataset:
             batch_size=batch_size,
             batch_format=batch_format,
             zero_copy_batch=zero_copy_batch,
-            min_rows_per_block=min_rows_per_block,
+            min_rows_per_bundled_input=min_rows_per_bundled_input,
             fn_args=fn_args,
             fn_kwargs=fn_kwargs,
             fn_constructor_args=fn_constructor_args,

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -739,14 +739,16 @@ def test_read_map_batches_operator_fusion_incompatible_compute(
     assert upstream_physical_op.name == "ReadParquet->MapBatches(<lambda>)"
 
 
-def test_read_map_batches_operator_fusion_min_rows_per_block(ray_start_regular_shared):
+def test_read_map_batches_operator_fusion_min_rows_per_bundled_input(
+    ray_start_regular_shared,
+):
     # Test that fusion of map operators merges their block sizes in the expected way
     # (taking the max).
     planner = Planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
-    op = MapBatches(read_op, lambda x: x, min_rows_per_block=2)
-    op = MapBatches(op, lambda x: x, min_rows_per_block=5)
-    op = MapBatches(op, lambda x: x, min_rows_per_block=3)
+    op = MapBatches(read_op, lambda x: x, min_rows_per_bundled_input=2)
+    op = MapBatches(op, lambda x: x, min_rows_per_bundled_input=5)
+    op = MapBatches(op, lambda x: x, min_rows_per_bundled_input=3)
     logical_plan = LogicalPlan(op)
     physical_plan = planner.plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The logical map operator has a `min_rows_per_block` parameter with the description "The target size for blocks outputted by this operator."  The parameter name and description aren't accurate; it actually represents the target number of rows to pass to the physical map operator's `_add_bundled_input` method. 

## Related issue number

<!-- For example: "Closes #1234" -->

See https://github.com/ray-project/ray/pull/42694#discussion_r1470194147

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
