### PR TITLE
Fix None exception in evaluate.

### DIFF
--- a/rllib/evaluate.py
+++ b/rllib/evaluate.py
@@ -219,7 +219,7 @@ def run(
     # Merge with `evaluation_config` (first try from command line, then from
     # pkl file).
     evaluation_config = copy.deepcopy(
-        config_args.get("evaluation_config", config.get("evaluation_config", {}))
+        config_args.get("evaluation_config") or config.get("evaluation_config") or {}
     )
     config = merge_dicts(config, evaluation_config)
     # Merge with command line `--config` settings (if not already the same anyways).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I encounter the following error when run `rllib evaluate`, 

```
│ /opt/homebrew/lib/python3.11/site-packages/ray/rllib/evaluate.py:230 in run                      │
│                                                                                                  │
│   227 │   evaluation_config = copy.deepcopy(                                                     │
│   228 │   │   config_args.get("evaluation_config", config.get("evaluation_config", {}))          │
│   229 │   )                                                                                      │
│ ❱ 230 │   config = merge_dicts(config, evaluation_config)                                        │
│   231 │   # Merge with command line `--config` settings (if not already the same anyways).       │
│   232 │   config = merge_dicts(config, config_args)                                              │
│   233 │   if not env:                                                                            │
│                                                                                                  │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │              algo = 'PPO'                                                                    │ │
│ │        checkpoint = '/Users/haosdent/ray_results/default_9e9d18f7979748b3979f16fc87e7b490/P… │ │
│ │            config = {                                                                        │ │
│ │                     │   'extra_python_environs_for_driver': {},                              │ │
│ │                     │   'extra_python_environs_for_worker': {},                              │ │
│ │                     │   'num_gpus': 0,                                                       │ │
│ │                     │   'num_cpus_per_worker': 1,                                            │ │
│ │                     │   'num_gpus_per_worker': 0,                                            │ │
│ │                     │   '_fake_gpus': False,                                                 │ │
│ │                     │   'num_learner_workers': 0,                                            │ │
│ │                     │   'num_gpus_per_learner_worker': 0,                                    │ │
│ │                     │   'num_cpus_per_learner_worker': 1,                                    │ │
│ │                     │   'local_gpu_idx': 0,                                                  │ │
│ │                     │   ... +142                                                             │ │
│ │                     }                                                                        │ │
│ │       config_args = {}                                                                       │ │
│ │        config_dir = '/Users/haosdent/ray_results/default_9e9d18f7979748b3979f16fc87e7b490/P… │ │
│ │       config_path = '/Users/haosdent/ray_results/default_9e9d18f7979748b3979f16fc87e7b490/P… │ │
│ │               env = 'K8s-v0'                                                                 │ │
│ │          episodes = 0                                                                        │ │
│ │ evaluation_config = None                                                                     │ │
│ │                 f = <_io.BufferedReader                                                      │ │
│ │                     name='/Users/haosdent/ray_results/default_9e9d18f7979748b3979f16fc87e7b… │ │
│ │        local_mode = False                                                                    │ │
│ │               out = None                                                                     │ │
│ │            render = False                                                                    │ │
│ │         save_info = False                                                                    │ │
│ │             steps = 10000                                                                    │ │
│ │    track_progress = False                                                                    │ │
│ │        use_shelve = False                                                                    │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
│                                                                                                  │
│ /opt/homebrew/lib/python3.11/site-packages/ray/_private/dict.py:22 in merge_dicts                │
│                                                                                                  │
│    19 │   │    dict: A new dict that is d1 and d2 deep merged.                                   │
│    20 │   """                                                                                    │
│    21 │   merged = copy.deepcopy(d1)                                                             │
│ ❱  22 │   deep_update(merged, d2, True, [])                                                      │
│    23 │   return merged                                                                          │
│    24                                                                                            │
│    25                                                                                            │
│                                                                                                  │
│ ╭─────────────────────── locals ───────────────────────╮                                         │
│ │     d1 = {                                           │                                         │
│ │          │   'extra_python_environs_for_driver': {}, │                                         │
│ │          │   'extra_python_environs_for_worker': {}, │                                         │
│ │          │   'num_gpus': 0,                          │                                         │
│ │          │   'num_cpus_per_worker': 1,               │                                         │
│ │          │   'num_gpus_per_worker': 0,               │                                         │
│ │          │   '_fake_gpus': False,                    │                                         │
│ │          │   'num_learner_workers': 0,               │                                         │
│ │          │   'num_gpus_per_learner_worker': 0,       │                                         │
│ │          │   'num_cpus_per_learner_worker': 1,       │                                         │
│ │          │   'local_gpu_idx': 0,                     │                                         │
│ │          │   ... +142                                │                                         │
│ │          }                                           │                                         │
│ │     d2 = None                                        │                                         │
│ │ merged = {                                           │                                         │
│ │          │   'extra_python_environs_for_driver': {}, │                                         │
│ │          │   'extra_python_environs_for_worker': {}, │                                         │
│ │          │   'num_gpus': 0,                          │                                         │
│ │          │   'num_cpus_per_worker': 1,               │                                         │
│ │          │   'num_gpus_per_worker': 0,               │                                         │
│ │          │   '_fake_gpus': False,                    │                                         │
│ │          │   'num_learner_workers': 0,               │                                         │
│ │          │   'num_gpus_per_learner_worker': 0,       │                                         │
│ │          │   'num_cpus_per_learner_worker': 1,       │                                         │
│ │          │   'local_gpu_idx': 0,                     │                                         │
│ │          │   ... +142                                │                                         │
│ │          }                                           │                                         │
│ ╰──────────────────────────────────────────────────────╯                                         │
│                                                                                                  │
│ /opt/homebrew/lib/python3.11/site-packages/ray/_private/dict.py:58 in deep_update                │
│                                                                                                  │
│    55 │   override_all_if_type_changes = override_all_if_type_changes or []                      │
│    56 │   override_all_key_list = override_all_key_list or []                                    │
│    57 │                                                                                          │
│ ❱  58 │   for k, value in new_dict.items():                                                      │
│    59 │   │   if k not in original and not new_keys_allowed:                                     │
│    60 │   │   │   raise Exception("Unknown config parameter `{}` ".format(k))                    │
│    61                                                                                            │
│                                                                                                  │
│ ╭────────────────────────────────── locals ──────────────────────────────────╮                   │
│ │        allow_new_subkey_list = []                                          │                   │
│ │                     new_dict = None                                        │                   │
│ │             new_keys_allowed = True                                        │                   │
│ │                     original = {                                           │                   │
│ │                                │   'extra_python_environs_for_driver': {}, │                   │
│ │                                │   'extra_python_environs_for_worker': {}, │                   │
│ │                                │   'num_gpus': 0,                          │                   │
│ │                                │   'num_cpus_per_worker': 1,               │                   │
│ │                                │   'num_gpus_per_worker': 0,               │                   │
│ │                                │   '_fake_gpus': False,                    │                   │
│ │                                │   'num_learner_workers': 0,               │                   │
│ │                                │   'num_gpus_per_learner_worker': 0,       │                   │
│ │                                │   'num_cpus_per_learner_worker': 1,       │                   │
│ │                                │   'local_gpu_idx': 0,                     │                   │
│ │                                │   ... +142                                │                   │
│ │                                }                                           │                   │
│ │ override_all_if_type_changes = []                                          │                   │
│ │        override_all_key_list = []                                          │                   │
│ ╰────────────────────────────────────────────────────────────────────────────╯                   │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'NoneType' object has no attribute 'items'
```

The `evaluation_config` key appears in the config while the value is None.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
