### PR TITLE
[Train] Add Intel HPU Support and Training Scripts for BERT and ResNet in Ray Train

### DIFF
--- a/doc/source/train/examples.rst
+++ b/doc/source/train/examples.rst
@@ -66,3 +66,18 @@ Advanced
     - :ref:`Fine-tune vicuna-13b with PyTorch Lightning and DeepSpeed <vicuna_lightning_deepspeed_finetuning>`
   * - Lightning
     - :ref:`Fine-tune dolly-v2-7b with PyTorch Lightning and FSDP <dolly_lightning_fsdp_finetuning>`
+
+
+Community Examples
+------------------
+
+.. list-table::
+  :widths: 1 5
+  :header-rows: 1
+
+  * - Topic
+    - Example
+  * - HPU
+    - `BERT Model Training with HPU <hpu_bert_training>`
+  * - HPU
+    - `ResNet Model Training with HPU <hpu_resnet_training>`

--- a/doc/source/train/examples/hpu/bert.ipynb
+++ b/doc/source/train/examples/hpu/bert.ipynb
@@ -4,6 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "(hpu_bert_training)=\n",
     "# BERT Model Training with HPU\n",
     "\n",
     "In this notebook, we will train a BERT model for sequence classification using the Yelp review full dataset. We will use the `transformers` and `datasets` libraries from Hugging Face, along with `ray.train` for distributed training."

--- a/doc/source/train/examples/hpu/bert.ipynb
+++ b/doc/source/train/examples/hpu/bert.ipynb
@@ -1,0 +1,242 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BERT Model Training with HPU\n",
+    "\n",
+    "In this notebook, we will train a BERT model for sequence classification using the Yelp review full dataset. We will use the `transformers` and `datasets` libraries from Hugging Face, along with `ray.train` for distributed training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import necessary libraries\n",
+    "\n",
+    "import os\n",
+    "from typing import Dict\n",
+    "\n",
+    "import torch\n",
+    "from torch import nn\n",
+    "from torch.utils.data import DataLoader\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "import numpy as np\n",
+    "import evaluate\n",
+    "from datasets import load_dataset\n",
+    "import transformers\n",
+    "from transformers import (\n",
+    "    Trainer,\n",
+    "    TrainingArguments,\n",
+    "    AutoTokenizer,\n",
+    "    AutoModelForSequenceClassification,\n",
+    ")\n",
+    "\n",
+    "import ray.train\n",
+    "from ray.train import ScalingConfig\n",
+    "from ray.train.torch import TorchTrainer\n",
+    "from ray.train.torch import TorchConfig\n",
+    "from ray.runtime_env import RuntimeEnv\n",
+    "\n",
+    "import habana_frameworks.torch.core as htcore"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Metrics Setup\n",
+    "\n",
+    "We will use accuracy as our evaluation metric. The `compute_metrics` function will calculate the accuracy of our model's predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Metrics\n",
+    "metric = evaluate.load(\"accuracy\")\n",
+    "\n",
+    "def compute_metrics(eval_pred):\n",
+    "    logits, labels = eval_pred\n",
+    "    predictions = np.argmax(logits, axis=-1)\n",
+    "    return metric.compute(predictions=predictions, references=labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training Function\n",
+    "\n",
+    "This function will be executed by each worker during training. It handles data loading, tokenization, model initialization, and the training loop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_func_per_worker(config: Dict):\n",
+    "    \n",
+    "    # Datasets\n",
+    "    dataset = load_dataset(\"yelp_review_full\")\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(\"bert-base-cased\")\n",
+    "    \n",
+    "    def tokenize_function(examples):\n",
+    "        return tokenizer(examples[\"text\"], padding=\"max_length\", truncation=True)\n",
+    "\n",
+    "    lr = config[\"lr\"]\n",
+    "    epochs = config[\"epochs\"]\n",
+    "    batch_size = config[\"batch_size_per_worker\"]\n",
+    "\n",
+    "    train_dataset = dataset[\"train\"].select(range(1000)).map(tokenize_function, batched=True)\n",
+    "    eval_dataset = dataset[\"test\"].select(range(1000)).map(tokenize_function, batched=True)\n",
+    "\n",
+    "    # Prepare dataloader for each worker\n",
+    "    dataloaders = {}\n",
+    "    dataloaders[\"train\"] = torch.utils.data.DataLoader(\n",
+    "        train_dataset, \n",
+    "        shuffle=True, \n",
+    "        collate_fn=transformers.default_data_collator, \n",
+    "        batch_size=batch_size\n",
+    "    )\n",
+    "    dataloaders[\"test\"] = torch.utils.data.DataLoader(\n",
+    "        eval_dataset, \n",
+    "        shuffle=True, \n",
+    "        collate_fn=transformers.default_data_collator, \n",
+    "        batch_size=batch_size\n",
+    "    )\n",
+    "\n",
+    "    # Model\n",
+    "    model = AutoModelForSequenceClassification.from_pretrained(\n",
+    "        \"bert-base-cased\", num_labels=5\n",
+    "    )\n",
+    "\n",
+    "    device = ray.train.torch.get_device()\n",
+    "    model = model.to(device)\n",
+    "    \n",
+    "    # \n",
+    "    optimizer = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9)\n",
+    "\n",
+    "    # Start training loops\n",
+    "    for epoch in range(epochs):\n",
+    "        # Each epoch has a training and validation phase\n",
+    "        for phase in [\"train\", \"test\"]:\n",
+    "            if phase == \"train\":\n",
+    "                model.train()  # Set model to training mode\n",
+    "            else:\n",
+    "                model.eval()  # Set model to evaluate mode\n",
+    "\n",
+    "            # breakpoint()\n",
+    "            for batch  in dataloaders[phase]:\n",
+    "                batch = {k: v.to(device) for k, v in batch.items()}\n",
+    "\n",
+    "                # zero the parameter gradients\n",
+    "                optimizer.zero_grad()\n",
+    "\n",
+    "                # forward\n",
+    "                with torch.set_grad_enabled(phase == \"train\"):\n",
+    "                    # Get model outputs and calculate loss\n",
+    "                    \n",
+    "                    outputs = model(**batch)\n",
+    "                    loss = outputs.loss\n",
+    "\n",
+    "                    # backward + optimize only if in training phase\n",
+    "                    if phase == \"train\":\n",
+    "                        loss.backward()\n",
+    "                        optimizer.step()\n",
+    "                        print(f\"train epoch:[{epoch}]\\tloss:{loss:.6f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Main Training Function\n",
+    "\n",
+    "The `train_bert` function sets up the distributed training environment using Ray and starts the training process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_bert(num_workers=2, use_gpu=False):\n",
+    "    global_batch_size = 8\n",
+    "\n",
+    "    train_config = {\n",
+    "        \"lr\": 1e-3,\n",
+    "        \"epochs\": 10,\n",
+    "        \"batch_size_per_worker\": global_batch_size // num_workers,\n",
+    "    }\n",
+    "\n",
+    "    # Configure computation resources\n",
+    "    scaling_config = ScalingConfig(num_workers=num_workers, resources_per_worker={\"CPU\": 1, \"HPU\": 1})\n",
+    "    torch_config = TorchConfig(backend = \"hccl\")\n",
+    "    \n",
+    "    # start your ray cluster\n",
+    "    ray.init()\n",
+    "    \n",
+    "    # Initialize a Ray TorchTrainer\n",
+    "    trainer = TorchTrainer(\n",
+    "        train_loop_per_worker=train_func_per_worker,\n",
+    "        train_loop_config=train_config,\n",
+    "        torch_config=torch_config,\n",
+    "        scaling_config=scaling_config,\n",
+    "    )\n",
+    "\n",
+    "    result = trainer.fit()\n",
+    "    print(f\"Training result: {result}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Start Training\n",
+    "\n",
+    "Finally, we call the `train_bert` function to start the training process. You can adjust the number of workers and whether to use a GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_bert(num_workers=2)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/doc/source/train/examples/hpu/resnet.ipynb
+++ b/doc/source/train/examples/hpu/resnet.ipynb
@@ -4,6 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "(hpu_resnet_training)=\n",
     "# ResNet Model Training with HPU\n",
     "\n",
     "In this Jupyter notebook, we will train a ResNet-50 model to classify images of ants and bees. We will use PyTorch for model training and Ray for distributed training. The dataset will be downloaded and processed using torchvision's datasets and transforms."

--- a/doc/source/train/examples/hpu/resnet.ipynb
+++ b/doc/source/train/examples/hpu/resnet.ipynb
@@ -1,0 +1,358 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ResNet Model Training with HPU\n",
+    "\n",
+    "In this Jupyter notebook, we will train a ResNet-50 model to classify images of ants and bees. We will use PyTorch for model training and Ray for distributed training. The dataset will be downloaded and processed using torchvision's datasets and transforms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from typing import Dict\n",
+    "from tempfile import TemporaryDirectory\n",
+    "\n",
+    "import torch\n",
+    "from filelock import FileLock\n",
+    "from torch import nn\n",
+    "import torch.optim as optim\n",
+    "from torch.utils.data import DataLoader\n",
+    "from torchvision import datasets, transforms, models\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "import ray\n",
+    "import ray.train as train\n",
+    "from ray.train import ScalingConfig, Checkpoint\n",
+    "from ray.train.torch import TorchTrainer\n",
+    "from ray.train.torch import TorchConfig\n",
+    "from ray.runtime_env import RuntimeEnv\n",
+    "\n",
+    "import habana_frameworks.torch.core as htcore"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define Data Transforms\n",
+    "\n",
+    "We will set up the data transforms for preprocessing images for training and validation. This includes random cropping, flipping, and normalization for the training set, and resizing and normalization for the validation set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Data augmentation and normalization for training\n",
+    "# Just normalization for validation\n",
+    "data_transforms = {\n",
+    "    \"train\": transforms.Compose([\n",
+    "        transforms.RandomResizedCrop(224),\n",
+    "        transforms.RandomHorizontalFlip(),\n",
+    "        transforms.ToTensor(),\n",
+    "        transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),\n",
+    "    ]),\n",
+    "    \"val\": transforms.Compose([\n",
+    "        transforms.Resize(256),\n",
+    "        transforms.CenterCrop(224),\n",
+    "        transforms.ToTensor(),\n",
+    "        transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),\n",
+    "    ]),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dataset Download Function\n",
+    "\n",
+    "We will define a function to download the Hymenoptera dataset. This dataset contains images of ants and bees for a binary classification problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_datasets():\n",
+    "    os.system(\"wget https://download.pytorch.org/tutorial/hymenoptera_data.zip >/dev/null 2>&1\")\n",
+    "    os.system(\"unzip hymenoptera_data.zip >/dev/null 2>&1\")\n",
+    "download_datasets()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dataset Preparation Function\n",
+    "\n",
+    "After downloading the dataset, we need to build PyTorch datasets for training and validation. The `build_datasets` function will apply the previously defined transforms and create the datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_datasets():\n",
+    "    torch_datasets = {}\n",
+    "    for split in [\"train\", \"val\"]:\n",
+    "        torch_datasets[split] = datasets.ImageFolder(\n",
+    "            os.path.join(\"./hymenoptera_data\", split), data_transforms[split]\n",
+    "        )\n",
+    "    return torch_datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model Initialization Functions\n",
+    "\n",
+    "We will define two functions to initialize our model. The `initialize_model` function will load a pre-trained ResNet-50 model and replace the final classification layer for our binary classification task. The `initialize_model_from_checkpoint` function will load a model from a saved checkpoint if available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def initialize_model():\n",
+    "    # Load pretrained model params\n",
+    "    model = models.resnet50(pretrained=True)\n",
+    "\n",
+    "    # Replace the original classifier with a new Linear layer\n",
+    "    num_features = model.fc.in_features\n",
+    "    model.fc = nn.Linear(num_features, 2)\n",
+    "\n",
+    "    # Ensure all params get updated during finetuning\n",
+    "    for param in model.parameters():\n",
+    "        param.requires_grad = True\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluation Function\n",
+    "\n",
+    "To assess the performance of our model during training, we define an `evaluate` function. This function computes the number of correct predictions by comparing the predicted labels with the true labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def evaluate(logits, labels):\n",
+    "    _, preds = torch.max(logits, 1)\n",
+    "    corrects = torch.sum(preds == labels).item()\n",
+    "    return corrects"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training Loop Function\n",
+    "\n",
+    "This function defines the training loop that will be executed by each worker. It includes downloading the dataset, preparing data loaders, initializing the model, and running the training and validation phases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_loop_per_worker(configs):\n",
+    "    import warnings\n",
+    "\n",
+    "    warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "    # Calculate the batch size for a single worker\n",
+    "    worker_batch_size = configs[\"batch_size\"] // train.get_context().get_world_size()\n",
+    "\n",
+    "    # Download dataset once on local rank 0 worker\n",
+    "    if train.get_context().get_local_rank() == 0:\n",
+    "        download_datasets()\n",
+    "    torch.distributed.barrier()\n",
+    "\n",
+    "    # Build datasets on each worker\n",
+    "    torch_datasets = build_datasets()\n",
+    "\n",
+    "    # Prepare dataloader for each worker\n",
+    "    dataloaders = dict()\n",
+    "    dataloaders[\"train\"] = DataLoader(\n",
+    "        torch_datasets[\"train\"], batch_size=worker_batch_size, shuffle=True\n",
+    "    )\n",
+    "    dataloaders[\"val\"] = DataLoader(\n",
+    "        torch_datasets[\"val\"], batch_size=worker_batch_size, shuffle=False\n",
+    "    )\n",
+    "\n",
+    "    # Distribute\n",
+    "    dataloaders[\"train\"] = train.torch.prepare_data_loader(dataloaders[\"train\"])\n",
+    "    dataloaders[\"val\"] = train.torch.prepare_data_loader(dataloaders[\"val\"])\n",
+    "\n",
+    "    device = train.torch.get_device()\n",
+    "\n",
+    "    # Prepare DDP Model, optimizer, and loss function\n",
+    "    model = initialize_model()\n",
+    "    model = model.to(device)\n",
+    "\n",
+    "    optimizer = optim.SGD(\n",
+    "        model.parameters(), lr=configs[\"lr\"], momentum=configs[\"momentum\"]\n",
+    "    )\n",
+    "    criterion = nn.CrossEntropyLoss()\n",
+    "\n",
+    "    # Start training loops\n",
+    "    for epoch in range(configs[\"num_epochs\"]):\n",
+    "        # Each epoch has a training and validation phase\n",
+    "        for phase in [\"train\", \"val\"]:\n",
+    "            if phase == \"train\":\n",
+    "                model.train()  # Set model to training mode\n",
+    "            else:\n",
+    "                model.eval()  # Set model to evaluate mode\n",
+    "\n",
+    "            running_loss = 0.0\n",
+    "            running_corrects = 0\n",
+    "\n",
+    "            for inputs, labels in dataloaders[phase]:\n",
+    "                inputs = inputs.to(device)\n",
+    "                labels = labels.to(device)\n",
+    "\n",
+    "                # zero the parameter gradients\n",
+    "                optimizer.zero_grad()\n",
+    "\n",
+    "                # forward\n",
+    "                with torch.set_grad_enabled(phase == \"train\"):\n",
+    "                    # Get model outputs and calculate loss\n",
+    "                    outputs = model(inputs)\n",
+    "                    loss = criterion(outputs, labels)\n",
+    "\n",
+    "                    # backward + optimize only if in training phase\n",
+    "                    if phase == \"train\":\n",
+    "                        loss.backward()\n",
+    "                        optimizer.step()\n",
+    "\n",
+    "                # calculate statistics\n",
+    "                running_loss += loss.item() * inputs.size(0)\n",
+    "                running_corrects += evaluate(outputs, labels)\n",
+    "\n",
+    "            size = len(torch_datasets[phase]) // train.get_context().get_world_size()\n",
+    "            epoch_loss = running_loss / size\n",
+    "            epoch_acc = running_corrects / size\n",
+    "\n",
+    "            if train.get_context().get_world_rank() == 0:\n",
+    "                print(\n",
+    "                    \"Epoch {}-{} Loss: {:.4f} Acc: {:.4f}\".format(\n",
+    "                        epoch, phase, epoch_loss, epoch_acc\n",
+    "                    )\n",
+    "                )\n",
+    "\n",
+    "            # Report metrics and checkpoint every epoch\n",
+    "            if phase == \"val\":\n",
+    "                train.report(\n",
+    "                    metrics={\"loss\": epoch_loss, \"acc\": epoch_acc},\n",
+    "                )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Main Training Function\n",
+    "\n",
+    "The `train_resnet` function sets up the distributed training environment using Ray and starts the training process. It specifies the batch size, number of epochs, learning rate, and momentum for the SGD optimizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_resnet(num_workers=2, use_gpu=False):\n",
+    "    global_batch_size = 16\n",
+    "\n",
+    "    train_loop_config = {\n",
+    "        \"input_size\": 224,  # Input image size (224 x 224)\n",
+    "        \"batch_size\": 32,  # Batch size for training\n",
+    "        \"num_epochs\": 10,  # Number of epochs to train for\n",
+    "        \"lr\": 0.001,  # Learning Rate\n",
+    "        \"momentum\": 0.9,  # SGD optimizer momentum\n",
+    "    }\n",
+    "    # Configure computation resources\n",
+    "    scaling_config = ScalingConfig(num_workers=num_workers, resources_per_worker={\"CPU\": 1, \"HPU\": 1})\n",
+    "    torch_config = TorchConfig(backend = \"hccl\")\n",
+    "    \n",
+    "    ray.init()\n",
+    "    \n",
+    "    # Initialize a Ray TorchTrainer\n",
+    "    trainer = TorchTrainer(\n",
+    "        train_loop_per_worker=train_loop_per_worker,\n",
+    "        train_loop_config=train_loop_config,\n",
+    "        torch_config=torch_config,\n",
+    "        scaling_config=scaling_config,\n",
+    "    )\n",
+    "\n",
+    "    result = trainer.fit()\n",
+    "    print(f\"Training result: {result}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Start Training\n",
+    "\n",
+    "Finally, we call the `train_resnet` function to start the training process. You can adjust the number of workers and whether to use a GPU. Before running this cell, ensure that Ray is properly set up in your environment to handle distributed training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_resnet(num_workers=2) "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -10,8 +10,10 @@ import ray
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
 
 from ray._private.accelerators.hpu import HPU_PACKAGE_AVAILABLE
+
 if HPU_PACKAGE_AVAILABLE:
     import habana_frameworks.torch.hpu as torch_hpu
+
 
 def get_device() -> Union[torch.device, List[torch.device]]:
     """Gets the correct torch device configured for this process.

--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -9,6 +9,9 @@ import torch
 import ray
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
 
+from ray._private.accelerators.hpu import HPU_PACKAGE_AVAILABLE
+if HPU_PACKAGE_AVAILABLE:
+    import habana_frameworks.torch.hpu as torch_hpu
 
 def get_device() -> Union[torch.device, List[torch.device]]:
     """Gets the correct torch device configured for this process.
@@ -56,6 +59,8 @@ def get_device() -> Union[torch.device, List[torch.device]]:
 
         devices = [torch.device(f"cuda:{device_id}") for device_id in device_ids]
         device = devices[0] if len(devices) == 1 else devices
+    elif HPU_PACKAGE_AVAILABLE and torch_hpu.is_available():
+        device = torch.device("hpu")
     else:
         device = torch.device("cpu")
 

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -8,16 +8,16 @@ import torch
 import torch.distributed as dist
 
 import ray
+from ray._private.accelerators.hpu import HPU_PACKAGE_AVAILABLE
 from ray.train._internal.utils import get_address_and_port
 from ray.train._internal.worker_group import WorkerGroup
 from ray.train.backend import Backend, BackendConfig
 from ray.train.constants import DEFAULT_NCCL_SOCKET_IFNAME
 from ray.util import PublicAPI
 
-from ray._private.accelerators.hpu import HPU_PACKAGE_AVAILABLE
 if HPU_PACKAGE_AVAILABLE:
-    import habana_frameworks.torch.core as htcore
-    import habana_frameworks.torch.distributed.hccl as hpu_dist
+    import habana_frameworks.torch.core as htcore  # noqa: F401
+    import habana_frameworks.torch.distributed.hccl as hpu_dist  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -14,6 +14,11 @@ from ray.train.backend import Backend, BackendConfig
 from ray.train.constants import DEFAULT_NCCL_SOCKET_IFNAME
 from ray.util import PublicAPI
 
+from ray._private.accelerators.hpu import HPU_PACKAGE_AVAILABLE
+if HPU_PACKAGE_AVAILABLE:
+    import habana_frameworks.torch.core as htcore
+    import habana_frameworks.torch.distributed.hccl as hpu_dist
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To leverage the potential of Intel's Habana Processing Units (HPUs), we extend Ray Train's capabilities by adding support for Intel HPU hardware. This update also includes training scripts for BERT and ResNet models, which are widely used in NLP and computer vision tasks, respectively.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
