### PR TITLE
[serve] Move `replace_known_types` logic out of `Query`

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -85,64 +85,6 @@ class Query:
     kwargs: Dict[Any, Any]
     metadata: RequestMetadata
 
-    async def replace_known_types_in_args(self):
-        """Uses the `_PyObjScanner` to find and replace known types.
-
-        1) Replaces `asyncio.Task` objects with their results. This is used for the old
-           serve handle API and should be removed once that API is deprecated & removed.
-        2) Replaces `DeploymentResponse` objects with their resolved object refs. This
-           enables composition without explicitly calling `_to_object_ref`.
-        """
-        from ray.serve.handle import (
-            DeploymentResponse,
-            DeploymentResponseGenerator,
-            _DeploymentResponseBase,
-        )
-
-        scanner = _PyObjScanner(source_type=(asyncio.Task, _DeploymentResponseBase))
-
-        try:
-            tasks = []
-            responses = []
-            replacement_table = {}
-            objs = scanner.find_nodes((self.args, self.kwargs))
-            for obj in objs:
-                if isinstance(obj, asyncio.Task):
-                    tasks.append(obj)
-                elif isinstance(obj, DeploymentResponseGenerator):
-                    raise RuntimeError(
-                        "Streaming deployment handle results cannot be passed to "
-                        "downstream handle calls. If you have a use case requiring "
-                        "this feature, please file a feature request on GitHub."
-                    )
-                elif isinstance(obj, DeploymentResponse):
-                    responses.append(obj)
-
-            for task in tasks:
-                # NOTE(edoakes): this is a hack to enable the legacy behavior of passing
-                # `asyncio.Task` objects directly to downstream handle calls without
-                # `await`. Because the router now runs on a separate loop, the
-                # `asyncio.Task` can't directly be awaited here. So we use the
-                # thread-safe `concurrent.futures.Future` instead.
-                # This can be removed when `RayServeHandle` is fully deprecated.
-                if hasattr(task, "_ray_serve_object_ref_future"):
-                    future = task._ray_serve_object_ref_future
-                    replacement_table[task] = await asyncio.wrap_future(future)
-                else:
-                    replacement_table[task] = task
-
-            # Gather `DeploymentResponse` object refs concurrently.
-            if len(responses) > 0:
-                obj_refs = await asyncio.gather(
-                    *[r._to_object_ref() for r in responses]
-                )
-                replacement_table.update((zip(responses, obj_refs)))
-
-            self.args, self.kwargs = scanner.replace_nodes(replacement_table)
-        finally:
-            # Make the scanner GC-able to avoid memory leaks.
-            scanner.clear()
-
 
 class ReplicaWrapper(ABC):
     """Defines the interface for a scheduler to talk to a replica.
@@ -1037,6 +979,66 @@ class Router:
     def _collect_handle_queue_metrics(self) -> Dict[str, int]:
         return (self.deployment_id, self.handle_id), self.num_queued_queries
 
+    async def _replace_known_types_in_args(
+        self, request_args: Tuple[Any], request_kwargs: Dict[str, Any]
+    ) -> Tuple[Tuple[Any], Dict[str, Any]]:
+        """Uses the `_PyObjScanner` to find and replace known types.
+
+        1) Replaces `asyncio.Task` objects with their results. This is used for the old
+           serve handle API and should be removed once that API is deprecated & removed.
+        2) Replaces `DeploymentResponse` objects with their resolved object refs. This
+           enables composition without explicitly calling `_to_object_ref`.
+        """
+        from ray.serve.handle import (
+            DeploymentResponse,
+            DeploymentResponseGenerator,
+            _DeploymentResponseBase,
+        )
+
+        scanner = _PyObjScanner(source_type=(asyncio.Task, _DeploymentResponseBase))
+
+        try:
+            tasks = []
+            responses = []
+            replacement_table = {}
+            objs = scanner.find_nodes((request_args, request_kwargs))
+            for obj in objs:
+                if isinstance(obj, asyncio.Task):
+                    tasks.append(obj)
+                elif isinstance(obj, DeploymentResponseGenerator):
+                    raise RuntimeError(
+                        "Streaming deployment handle results cannot be passed to "
+                        "downstream handle calls. If you have a use case requiring "
+                        "this feature, please file a feature request on GitHub."
+                    )
+                elif isinstance(obj, DeploymentResponse):
+                    responses.append(obj)
+
+            for task in tasks:
+                # NOTE(edoakes): this is a hack to enable the legacy behavior of passing
+                # `asyncio.Task` objects directly to downstream handle calls without
+                # `await`. Because the router now runs on a separate loop, the
+                # `asyncio.Task` can't directly be awaited here. So we use the
+                # thread-safe `concurrent.futures.Future` instead.
+                # This can be removed when `RayServeHandle` is fully deprecated.
+                if hasattr(task, "_ray_serve_object_ref_future"):
+                    future = task._ray_serve_object_ref_future
+                    replacement_table[task] = await asyncio.wrap_future(future)
+                else:
+                    replacement_table[task] = task
+
+            # Gather `DeploymentResponse` object refs concurrently.
+            if len(responses) > 0:
+                obj_refs = await asyncio.gather(
+                    *[r._to_object_ref() for r in responses]
+                )
+                replacement_table.update((zip(responses, obj_refs)))
+
+            return scanner.replace_nodes(replacement_table)
+        finally:
+            # Make the scanner GC-able to avoid memory leaks.
+            scanner.clear()
+
     async def assign_request(
         self,
         request_meta: RequestMetadata,
@@ -1066,12 +1068,14 @@ class Router:
             )
 
         try:
+            request_args, request_kwargs = await self._replace_known_types_in_args(
+                request_args, request_kwargs
+            )
             query = Query(
                 args=list(request_args),
                 kwargs=request_kwargs,
                 metadata=request_meta,
             )
-            await query.replace_known_types_in_args()
             return await self._replica_scheduler.assign_replica(query)
         finally:
             # If the query is disconnected before assignment, this coroutine


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Helps with breaking apart `router.py`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
