### PR TITLE
[serve] Turn on locality routing by default

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -198,9 +198,9 @@ RAY_SERVE_ENABLE_NEW_HANDLE_API = (
     os.environ.get("RAY_SERVE_ENABLE_NEW_HANDLE_API", "1") == "1"
 )
 
-# Feature flag to turn on node locality routing for proxies. Off by default.
+# Feature flag to turn on node locality routing for proxies. On by default.
 RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING = (
-    os.environ.get("RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING", "0") == "1"
+    os.environ.get("RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING", "1") == "1"
 )
 
 # Feature flag to turn on AZ locality routing for proxies. On by default.

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -350,8 +350,8 @@ def test_proxy_prefers_replicas_on_same_node(ray_cluster: Cluster, set_flag):
     should route to all replicas equally.
     """
 
-    if set_flag:
-        os.environ["RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING"] = "1"
+    if not set_flag:
+        os.environ["RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING"] = "0"
 
     cluster = ray_cluster
     cluster.add_node(num_cpus=1)


### PR DESCRIPTION
[serve] Turn on locality routing by default

Turn on local node routing by default for proxies.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
