### PR TITLE
Fix num blocks local, remote, and unknown location are all 0

### DIFF
--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -22,19 +22,20 @@ logger = logging.getLogger(__name__)
 def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
     """Given a list of object references, returns how many are already on the local
     node, how many require fetching from another node, and how many have unknown
-    locations."""
+    locations. If enable_get_object_locations_for_metrics is False, this will
+    return 0, 0, 0 as getting object locations is disabled."""
     current_node_id = ray.get_runtime_context().get_node_id()
 
     ctx = ray.data.context.DataContext.get_current()
     if ctx.enable_get_object_locations_for_metrics:
         locs = ray.experimental.get_object_locations(refs)
+        nodes: List[List[str]] = [loc["node_ids"] for loc in locs.values()]
+        hits = sum(current_node_id in node_ids for node_ids in nodes)
+        unknowns = sum(1 for node_ids in nodes if not node_ids)
+        misses = len(nodes) - hits - unknowns
+        return hits, misses, unknowns
     else:
-        locs = {}
-    nodes: List[List[str]] = [loc["node_ids"] for loc in locs.values()]
-    hits = sum(current_node_id in node_ids for node_ids in nodes)
-    unknowns = sum(1 for node_ids in nodes if not node_ids)
-    misses = len(nodes) - hits - unknowns
-    return hits, misses, unknowns
+        return 0, 0, 0
 
 
 def resolve_block_refs(

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
     """Given a list of object references, returns how many are already on the local
     node, how many require fetching from another node, and how many have unknown
-    locations. If `DataContext.get_current().enable_get_object_locations_for_metrics`
-    is False, this will return `(0, 0, 0)` as getting object locations is disabled."""
+    locations. If `DataContext.get_current().enable_get_object_locations_for_metrics` is
+    False, this will return `(-1, -1, -1)` as getting object locations is disabled."""
     current_node_id = ray.get_runtime_context().get_node_id()
 
     ctx = ray.data.context.DataContext.get_current()
@@ -35,7 +35,7 @@ def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
         misses = len(nodes) - hits - unknowns
         return hits, misses, unknowns
 
-    return 0, 0, 0
+    return -1, -1, -1
 
 
 def resolve_block_refs(

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
     """Given a list of object references, returns how many are already on the local
     node, how many require fetching from another node, and how many have unknown
-    locations. If enable_get_object_locations_for_metrics is False, this will
-    return 0, 0, 0 as getting object locations is disabled."""
+    locations. If `DataContext.get_current().enable_get_object_locations_for_metrics`
+    is False, this will return `(0, 0, 0)` as getting object locations is disabled."""
     current_node_id = ray.get_runtime_context().get_node_id()
 
     ctx = ray.data.context.DataContext.get_current()

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -34,7 +34,7 @@ def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
         unknowns = sum(1 for node_ids in nodes if not node_ids)
         misses = len(nodes) - hits - unknowns
         return hits, misses, unknowns
-    else:
+return 0, 0, 0
         return 0, 0, 0
 
 

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -34,8 +34,8 @@ def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
         unknowns = sum(1 for node_ids in nodes if not node_ids)
         misses = len(nodes) - hits - unknowns
         return hits, misses, unknowns
-return 0, 0, 0
-        return 0, 0, 0
+
+    return 0, 0, 0
 
 
 def resolve_block_refs(

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -760,7 +760,7 @@ class DatasetStatsSummary:
                 else:
                     already_printed.add(operator_uuid)
                     out += str(operators_stats_summary)
-        if self.extra_metrics:
+        if DataContext.get_current().verbose_stats_logs and self.extra_metrics:
             indent = (
                 "\t"
                 if operators_stats_summary and operators_stats_summary.is_sub_operator

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1182,11 +1182,12 @@ class IterStatsSummary:
                 )
             if self.total_time.get():
                 out += "* Total time overall: {}\n".format(fmt(self.total_time.get()))
-            out += "* Num blocks local: {}\n".format(self.iter_blocks_local)
-            out += "* Num blocks remote: {}\n".format(self.iter_blocks_remote)
-            out += "* Num blocks unknown location: {}\n".format(
-                self.iter_unknown_location
-            )
+            if DataContext.get_current().enable_get_object_locations_for_metrics:
+                out += "* Num blocks local: {}\n".format(self.iter_blocks_local)
+                out += "* Num blocks remote: {}\n".format(self.iter_blocks_remote)
+                out += "* Num blocks unknown location: {}\n".format(
+                    self.iter_unknown_location
+                )
             out += (
                 "* Batch iteration time breakdown (summed across prefetch threads):\n"
             )

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -102,7 +102,8 @@ DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = True
 # If disabled, users can still manually print stats with Dataset.stats().
 DEFAULT_AUTO_LOG_STATS = False
 
-# Whether stats logs should be verbose.
+# Whether stats logs should be verbose. This will include fields such
+# as `extra_metrics` in the stats output, which are excluded by default.
 DEFAULT_VERBOSE_STATS_LOG = False
 
 # Set this env var to enable distributed tqdm (experimental).

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -102,6 +102,9 @@ DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = True
 # If disabled, users can still manually print stats with Dataset.stats().
 DEFAULT_AUTO_LOG_STATS = False
 
+# Whether stats logs should be verbose.
+DEFAULT_VERBOSE_STATS_LOG = False
+
 # Set this env var to enable distributed tqdm (experimental).
 DEFAULT_USE_RAY_TQDM = bool(int(os.environ.get("RAY_TQDM", "1")))
 
@@ -170,6 +173,7 @@ class DataContext:
         min_parallelism: bool,
         enable_tensor_extension_casting: bool,
         enable_auto_log_stats: bool,
+        verbose_stats_log: bool,
         trace_allocations: bool,
         execution_options: "ExecutionOptions",
         use_ray_tqdm: bool,
@@ -200,6 +204,7 @@ class DataContext:
         self.min_parallelism = min_parallelism
         self.enable_tensor_extension_casting = enable_tensor_extension_casting
         self.enable_auto_log_stats = enable_auto_log_stats
+        self.verbose_stats_logs = verbose_stats_log
         self.trace_allocations = trace_allocations
         # TODO: expose execution options in Dataset public APIs.
         self.execution_options = execution_options
@@ -271,6 +276,7 @@ class DataContext:
                         DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING
                     ),
                     enable_auto_log_stats=DEFAULT_AUTO_LOG_STATS,
+                    verbose_stats_log=DEFAULT_VERBOSE_STATS_LOG,
                     trace_allocations=DEFAULT_TRACE_ALLOCATIONS,
                     execution_options=ray.data.ExecutionOptions(),
                     use_ray_tqdm=DEFAULT_USE_RAY_TQDM,

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -208,7 +208,9 @@ Dataset iterator time breakdown:
 
 
 @pytest.mark.parametrize("verbose_stats_logs", [True, False])
-def test_large_args_scheduling_strategy(ray_start_regular_shared, verbose_stats_logs):
+def test_large_args_scheduling_strategy(
+    ray_start_regular_shared, verbose_stats_logs, restore_data_context
+):
     context = DataContext.get_current()
     context.verbose_stats_logs = verbose_stats_logs
     ds = ray.data.range_tensor(100, shape=(100000,), parallelism=1)
@@ -239,7 +241,10 @@ def test_large_args_scheduling_strategy(ray_start_regular_shared, verbose_stats_
 
 @pytest.mark.parametrize("verbose_stats_logs", [True, False])
 def test_dataset_stats_basic(
-    ray_start_regular_shared, enable_auto_log_stats, verbose_stats_logs
+    ray_start_regular_shared,
+    enable_auto_log_stats,
+    verbose_stats_logs,
+    restore_data_context,
 ):
     context = DataContext.get_current()
     context.verbose_stats_logs = verbose_stats_logs
@@ -943,7 +948,7 @@ def test_stats_actor_cap_num_stats(ray_start_cluster):
 
 
 @pytest.mark.parametrize("verbose_stats_logs", [True, False])
-def test_spilled_stats(shutdown_only, verbose_stats_logs):
+def test_spilled_stats(shutdown_only, verbose_stats_logs, restore_data_context):
     context = DataContext.get_current()
     context.verbose_stats_logs = verbose_stats_logs
     context.enable_get_object_locations_for_metrics = True

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -20,9 +20,9 @@ from ray.data._internal.stats import (
 )
 from ray.data._internal.util import create_dataset_tag
 from ray.data.block import BlockMetadata
+from ray.data.context import DataContext
 from ray.data.tests.util import column_udf
 from ray.tests.conftest import *  # noqa
-from ray.data.context import DataContext
 
 
 def gen_expected_metrics(
@@ -290,8 +290,8 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
             logger_args, logger_kwargs = mock_logger.call_args
 
             assert (
-                    canonicalize(logger_args[0])
-                    == f"""Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}
+                canonicalize(logger_args[0])
+                == f"""Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean
@@ -307,8 +307,8 @@ def test_dataset_stats_basic(ray_start_regular_shared, enable_auto_log_stats):
             logger_args, logger_kwargs = mock_logger.call_args
 
             assert (
-                    canonicalize(logger_args[0])
-                    == f"""Operator N Map(dummy_map_batches): {EXECUTION_STRING}
+                canonicalize(logger_args[0])
+                == f"""Operator N Map(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * Peak heap memory usage (MiB): N min, N max, N mean

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -191,10 +191,10 @@ def test_streaming_split_stats(ray_start_regular_shared, restore_data_context):
 * Extra metrics: {STANDARD_EXTRA_METRICS}
 
 Operator N split(N, equal=False): \n"""
-            # Workaround to preserve trailing whitespace in the above line without
-            # causing linter failures.
-            f"""* Extra metrics: {extra_metrics}\n"""
-            """
+        # Workaround to preserve trailing whitespace in the above line without
+        # causing linter failures.
+        f"""* Extra metrics: {extra_metrics}\n"""
+        """
 Dataset iterator time breakdown:
 * Total time user code is blocked: T
 * Total time in user code: T
@@ -204,7 +204,7 @@ Dataset iterator time breakdown:
     * In batch creation: T min, T max, T avg, T total
     * In batch formatting: T min, T max, T avg, T total
 """
-        )
+    )
 
 
 @pytest.mark.parametrize("verbose_stats_logs", [True, False])
@@ -317,58 +317,6 @@ def test_dataset_stats_basic(
         f"    * In batch creation: T min, T max, T avg, T total\n"
         f"    * In batch formatting: T min, T max, T avg, T total\n"
     )
-
-
-def test_dataset_verbose_log(ray_start_regular_shared, enable_auto_log_stats):
-    try:
-        context = DataContext.get_current()
-        context.optimize_fuse_stages = True
-        context.verbose_stats_logs = True
-
-        logger = DatasetLogger(
-            "ray.data._internal.execution.streaming_executor"
-        ).get_logger(
-            log_to_stdout=enable_auto_log_stats,
-        )
-        with patch.object(logger, "info") as mock_logger:
-            ds = ray.data.range(1000, parallelism=10)
-            ds = ds.map_batches(dummy_map_batches).materialize()
-
-            if enable_auto_log_stats:
-                logger_args, logger_kwargs = mock_logger.call_args
-
-                assert (
-                    canonicalize(logger_args[0])
-                    == f"""Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}
-* Remote wall time: T min, T max, T mean, T total
-* Remote cpu time: T min, T max, T mean, T total
-* Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows per block: N min, N max, N mean, N total
-* Output size bytes per block: N min, N max, N mean, N total
-* Output rows per task: N min, N max, N mean, N tasks used
-* Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {STANDARD_EXTRA_METRICS}
-"""
-                )
-
-            ds = ds.map(dummy_map_batches).materialize()
-            if enable_auto_log_stats:
-                logger_args, logger_kwargs = mock_logger.call_args
-                assert (
-                    canonicalize(logger_args[0])
-                    == f"""Operator N Map(dummy_map_batches): {EXECUTION_STRING}
-* Remote wall time: T min, T max, T mean, T total
-* Remote cpu time: T min, T max, T mean, T total
-* Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows per block: N min, N max, N mean, N total
-* Output size bytes per block: N min, N max, N mean, N total
-* Output rows per task: N min, N max, N mean, N tasks used
-* Tasks per node: N min, N max, N mean; N nodes used
-* Extra metrics: {STANDARD_EXTRA_METRICS}
-"""
-                )
-    finally:
-        context.verbose_stats_logs = False
 
 
 def test_block_location_nums(ray_start_regular_shared, restore_data_context):
@@ -995,7 +943,6 @@ def test_stats_actor_cap_num_stats(ray_start_cluster):
     assert ray.get(actor.get.remote(0))[0] == {}
     # The start_time has 3 entries because we just added it above with record_start().
     assert ray.get(actor._get_stats_dict_size.remote()) == (3, 2, 2)
-
 
 
 @pytest.mark.parametrize("verbose_stats_logs", [True, False])

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -337,29 +337,28 @@ def test_block_location_nums(ray_start_regular_shared, restore_data_context):
     stats = canonicalize(ds.materialize().stats())
 
     assert stats == (
-        f"""Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}
-* Remote wall time: T min, T max, T mean, T total
-* Remote cpu time: T min, T max, T mean, T total
-* Peak heap memory usage (MiB): N min, N max, N mean
-* Output num rows per block: N min, N max, N mean, N total
-* Output size bytes per block: N min, N max, N mean, N total
-* Output rows per task: N min, N max, N mean, N tasks used
-* Tasks per node: N min, N max, N mean; N nodes used
-
-Dataset iterator time breakdown:
-* Total time overall: T
-    * Total time in Ray Data iterator initialization code: T
-    * Total time user thread is blocked by Ray Data iter_batches: T
-    * Total execution time for user thread: T
-* Batch iteration time breakdown (summed across prefetch threads):
-    * In ray.get(): T min, T max, T avg, T total
-    * In batch creation: T min, T max, T avg, T total
-    * In batch formatting: T min, T max, T avg, T total
-Block locations:
-    * Num blocks local: Z
-    * Num blocks remote: Z
-    * Num blocks unknown location: N
-"""
+        f"Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}\n"
+        f"* Remote wall time: T min, T max, T mean, T total\n"
+        f"* Remote cpu time: T min, T max, T mean, T total\n"
+        f"* Peak heap memory usage (MiB): N min, N max, N mean\n"
+        f"* Output num rows per block: N min, N max, N mean, N total\n"
+        f"* Output size bytes per block: N min, N max, N mean, N total\n"
+        f"* Output rows per task: N min, N max, N mean, N tasks used\n"
+        f"* Tasks per node: N min, N max, N mean; N nodes used\n"
+        f"\n"
+        f"Dataset iterator time breakdown:\n"
+        f"* Total time overall: T\n"
+        f"    * Total time in Ray Data iterator initialization code: T\n"
+        f"    * Total time user thread is blocked by Ray Data iter_batches: T\n"
+        f"    * Total execution time for user thread: T\n"
+        f"* Batch iteration time breakdown (summed across prefetch threads):\n"
+        f"    * In ray.get(): T min, T max, T avg, T total\n"
+        f"    * In batch creation: T min, T max, T avg, T total\n"
+        f"    * In batch formatting: T min, T max, T avg, T total\n"
+        f"Block locations:\n"
+        f"    * Num blocks local: Z\n"
+        f"    * Num blocks remote: Z\n"
+        f"    * Num blocks unknown location: N\n"
     )
 
 

--- a/python/ray/experimental/locations.py
+++ b/python/ray/experimental/locations.py
@@ -24,7 +24,8 @@ def get_object_locations(
         The location is stored as a dict with following attributes:
 
         - node_ids (List[str]): The hex IDs of the nodes that have a
-          copy of this object.
+          copy of this object. Objects less than 100KB will be in memory
+          store not plasma store and therefore will have nodes_id = [].
 
         - object_size (int): The size of data + metadata in bytes.
 


### PR DESCRIPTION
## Why are these changes needed?
When printing the stats for a dataset, the counts of blocks that are local, remote or unknown are sometimes all 0. E.g.:
```
Dataset iterator time breakdown:
* Total time user code is blocked: 768.47ms
* Total time in user code: 5.01s
* Total time overall: 6.92s
* Num blocks local: 0
* Num blocks remote: 0
* Num blocks unknown location: 0
* Batch iteration time breakdown (summed across prefetch threads):
	* In ray.get(): 708.48us min, 3.24ms max, 1.54ms avg, 15.4ms total
	* In batch creation: 4.4us min, 14.31us max, 8.33us avg, 83.28us total
	* In batch formatting: 385.99us min, 1.52ms max, 812.77us avg, 8.13ms total
```

This occurs when `ctx.enable_get_object_locations_for_metrics` is false on this [line](https://github.com/ray-project/ray/blob/8c72439793720552c086cdec0380ff6ac252cc26/python/ray/data/_internal/block_batching/util.py#L29) (which is the default behavior). This PR hides these stats if `ctx.enable_get_object_locations_for_metrics` is false as they will all be 0. It also refactors the `_calculate_ref_hits` method to make it more clear that if set to false the return will be all zero counts.

## Related issue number
Closes #42796, closes #31144

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
