### PR TITLE
[Data] Support pandas 2.2.0 for pandas tensor extensions

### DIFF
--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -168,9 +168,11 @@ _FORMATTER_ENABLED_ENV_VAR = "TENSOR_COLUMN_EXTENSION_FORMATTER_ENABLED"
 if os.getenv(_FORMATTER_ENABLED_ENV_VAR, "1") == "1":
     if Version(pd.__version__) < Version("2.2.0"):
         from pandas.io.formats.format import ExtensionArrayFormatter
+
         formatter_cls = ExtensionArrayFormatter
     else:
         from pandas.io.formats.format import _ExtensionArrayFormatter
+
         formatter_cls = _ExtensionArrayFormatter
     formatter_cls._format_strings_orig = formatter_cls._format_strings
     if Version("1.1.0") <= Version(pd.__version__) < Version("1.3.0"):

--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -168,21 +168,16 @@ _FORMATTER_ENABLED_ENV_VAR = "TENSOR_COLUMN_EXTENSION_FORMATTER_ENABLED"
 if os.getenv(_FORMATTER_ENABLED_ENV_VAR, "1") == "1":
     if Version(pd.__version__) < Version("2.2.0"):
         from pandas.io.formats.format import ExtensionArrayFormatter
-
-        ExtensionArrayFormatter._format_strings_orig = (
-            ExtensionArrayFormatter._format_strings
-        )
-        if Version("1.1.0") <= Version(pd.__version__) < Version("1.3.0"):
-            ExtensionArrayFormatter._format_strings = _format_strings_patched
-        else:
-            ExtensionArrayFormatter._format_strings = _format_strings_patched_v1_0_0
-        ExtensionArrayFormatter._patched_by_ray_datasets = True
+        formatter_cls = ExtensionArrayFormatter
     else:
-        # pandas 2.2.0+ simplifies ExtensionArrayFormatter to ExtensionArray._formatter.
-        from pandas.io.formats.format import ExtensionArray
-
-        ExtensionArray._formatter = _format_strings_patched_v1_0_0
-        ExtensionArray._patched_by_ray_datasets = True
+        from pandas.io.formats.format import _ExtensionArrayFormatter
+        formatter_cls = _ExtensionArrayFormatter
+    formatter_cls._format_strings_orig = formatter_cls._format_strings
+    if Version("1.1.0") <= Version(pd.__version__) < Version("1.3.0"):
+        formatter_cls._format_strings = _format_strings_patched
+    else:
+        formatter_cls._format_strings = _format_strings_patched_v1_0_0
+    formatter_cls._patched_by_ray_datasets = True
 
 ###########################################
 # End patching of ExtensionArrayFormatter #


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`ExtensionArrayFormatter` is replaced with `_ ExtensionArrayFormatter` in pandas 2.2.0. If Ray Data users have this version of pandas installed, it will result in the error in https://github.com/ray-project/ray/issues/42842.

This PR adds the case to support the change to `ExtensionArrayFormatter`. Tested locally with pandas 2.2.0 and Ray Data usage works without the error. 


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
