### PR TITLE
[Release] Add 2.9.2 release logs and fix release log script

### DIFF
--- a/release/release_logs/2.9.2/benchmarks/many_actors.json
+++ b/release/release_logs/2.9.2/benchmarks/many_actors.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 549.94944,
+    "_dashboard_test_success": true,
+    "_peak_memory": 5.62,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.61GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1190\t0.88GiB\tpython distributed/test_many_actors.py\n266\t0.42GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n428\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n1387\t0.07GiB\tray::DashboardTester.run\n1010\t0.07GiB\tray::JobSupervisor\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n584\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1313\t0.06GiB\tray::MemoryMonitorActor.run\n367\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/log_m",
+    "actors_per_second": 651.1270434383275,
+    "num_actors": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "actors_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 651.1270434383275
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 44.354
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2635.463
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3562.385
+        }
+    ],
+    "success": "1",
+    "time": 15.357985973358154
+}

--- a/release/release_logs/2.9.2/benchmarks/many_nodes.json
+++ b/release/release_logs/2.9.2/benchmarks/many_nodes.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 195.387392,
+    "_dashboard_test_success": true,
+    "_peak_memory": 3.48,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.51GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.18GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n1110\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1310\t0.08GiB\tray::StateAPIGeneratorActor.start\n425\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n423\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n928\t0.07GiB\tray::JobSupervisor\n577\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1170\t0.06GiB\tray::MemoryMonitorActor.run\n1258\t0.06GiB\tray::DashboardTester.run",
+    "num_tasks": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 321.31153016474485
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4.37
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 30.418
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 133.785
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 321.31153016474485,
+    "time": 303.1122443675995,
+    "used_cpus": 250.0
+}

--- a/release/release_logs/2.9.2/benchmarks/many_tasks.json
+++ b/release/release_logs/2.9.2/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 645.48864,
+    "_dashboard_memory_usage_mb": 713.076736,
     "_dashboard_test_success": true,
-    "_peak_memory": 14.74,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.2GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.74GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n883\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1146\t0.08GiB\tray::StateAPIGeneratorActor.start\n428\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n1077\t0.07GiB\tray::DashboardTester.run\n702\t0.07GiB\tray::JobSupervisor\n426\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n587\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1006\t0.06GiB\tray::MemoryMonitorActor.run",
+    "_peak_memory": 15.84,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.22GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.77GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n883\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1083\t0.08GiB\tray::StateAPIGeneratorActor.start\n1031\t0.08GiB\tray::DashboardTester.run\n425\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n703\t0.07GiB\tray::JobSupervisor\n423\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n562\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n943\t0.06GiB\tray::MemoryMonitorActor.run",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 593.1561081925439
+            "perf_metric_value": 602.534829993774
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.034
+            "perf_metric_value": 7.805
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7720.86
+            "perf_metric_value": 8331.543
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 13826.952
+            "perf_metric_value": 14095.515
         }
     ],
     "success": "1",
-    "tasks_per_second": 593.1561081925439,
-    "time": 316.85896825790405,
+    "tasks_per_second": 602.534829993774,
+    "time": 316.5965509414673,
     "used_cpus": 2500.0
 }

--- a/release/release_logs/2.9.2/benchmarks/many_tasks.json
+++ b/release/release_logs/2.9.2/benchmarks/many_tasks.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 645.48864,
+    "_dashboard_test_success": true,
+    "_peak_memory": 14.74,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.2GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.74GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n883\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1146\t0.08GiB\tray::StateAPIGeneratorActor.start\n428\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n1077\t0.07GiB\tray::DashboardTester.run\n702\t0.07GiB\tray::JobSupervisor\n426\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n587\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1006\t0.06GiB\tray::MemoryMonitorActor.run",
+    "num_tasks": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 593.1561081925439
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2500.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 8.034
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 7720.86
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 13826.952
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 593.1561081925439,
+    "time": 316.85896825790405,
+    "used_cpus": 2500.0
+}

--- a/release/release_logs/2.9.2/microbenchmark.json
+++ b/release/release_logs/2.9.2/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        9042.710869690089,
-        63.62085730466312
+        9183.17944721335,
+        78.38648186021622
     ],
     "1_1_actor_calls_concurrent": [
-        5538.885186515366,
-        266.8781556995926
+        5534.73056654751,
+        124.43650664492625
     ],
     "1_1_actor_calls_sync": [
-        2069.668256767318,
-        24.04434086505614
+        2138.2053853346897,
+        40.78171916767457
     ],
     "1_1_async_actor_calls_async": [
-        3198.2452064501954,
-        207.90653414767863
+        3443.4109493516467,
+        128.39188347423953
     ],
     "1_1_async_actor_calls_sync": [
-        1346.9273686110646,
-        53.72802518864216
+        1376.5443058239355,
+        16.74446599146489
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2404.0655646196824,
-        86.99541432527154
+        2445.3917020087183,
+        33.423799115190285
     ],
     "1_n_actor_calls_async": [
-        7686.2005077877675,
-        270.66402414641783
+        9023.20183457132,
+        250.12461112169518
     ],
     "1_n_async_actor_calls_async": [
-        7769.178329165985,
-        187.42812654040966
+        7819.413819348124,
+        91.98665807865511
     ],
     "client__1_1_actor_calls_async": [
-        1048.0638150235914,
-        4.887001560877178
+        1036.1143314918054,
+        7.250087421019438
     ],
     "client__1_1_actor_calls_concurrent": [
-        1032.1273072581214,
-        6.71540782331122
+        1037.112715415745,
+        6.346362849374269
     ],
     "client__1_1_actor_calls_sync": [
-        548.9025253096465,
-        5.049064695362747
+        544.5787447668264,
+        7.300924067025734
     ],
     "client__get_calls": [
-        1140.4589686415818,
-        58.29801140418089
+        1050.0307192769721,
+        8.974013465547582
     ],
     "client__put_calls": [
-        850.0130225802546,
-        43.90873408067339
+        868.8457104788757,
+        4.843071345592962
     ],
     "client__put_gigabytes": [
-        0.12571780234292362,
-        0.0009634752625132644
+        0.1188387933899692,
+        0.0011089752759238724
     ],
     "client__tasks_and_get_batch": [
-        0.963514714801502,
-        0.02111448699134845
+        0.9437038816702141,
+        0.023903611351821986
     ],
     "client__tasks_and_put_batch": [
-        11448.200956281493,
-        124.63430966694564
+        12030.005606095068,
+        179.23053492898228
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12691.66387624551,
-        93.46702510776397
+        12681.58168167148,
+        253.2245649044316
     ],
     "multi_client_put_gigabytes": [
-        32.16603791675267,
-        1.9822375813807749
+        33.605927354752815,
+        3.0430100233936006
     ],
     "multi_client_tasks_async": [
-        23674.761911259015,
-        979.4320107702001
+        26696.641001299315,
+        3853.925090106036
     ],
     "n_n_actor_calls_async": [
-        26537.555565896397,
-        857.3781397158533
+        28921.500058081027,
+        528.6255203493145
     ],
     "n_n_actor_calls_with_arg_async": [
-        3005.0093040937622,
-        52.94469167391438
+        2858.2486735378648,
+        28.770585428693433
     ],
     "n_n_async_actor_calls_async": [
-        23168.617762817485,
-        649.0718850914941
+        23691.103253812682,
+        392.51682165592905
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10110.669836472582
+            "perf_metric_value": 10738.562473287413
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5561.796272720696
+            "perf_metric_value": 5626.784525019393
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12691.66387624551
+            "perf_metric_value": 12681.58168167148
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.570552345060236
+            "perf_metric_value": 19.45047172438498
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8.868906341564493
+            "perf_metric_value": 9.162108196113913
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 32.16603791675267
+            "perf_metric_value": 33.605927354752815
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.720260733349566
+            "perf_metric_value": 12.889352554386498
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.570617513099608
+            "perf_metric_value": 5.24437824055842
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1018.79213518621
+            "perf_metric_value": 1045.9572930683776
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8956.257620701814
+            "perf_metric_value": 8158.711929873504
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23674.761911259015
+            "perf_metric_value": 26696.641001299315
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2069.668256767318
+            "perf_metric_value": 2138.2053853346897
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9042.710869690089
+            "perf_metric_value": 9183.17944721335
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5538.885186515366
+            "perf_metric_value": 5534.73056654751
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7686.2005077877675
+            "perf_metric_value": 9023.20183457132
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26537.555565896397
+            "perf_metric_value": 28921.500058081027
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3005.0093040937622
+            "perf_metric_value": 2858.2486735378648
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1346.9273686110646
+            "perf_metric_value": 1376.5443058239355
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3198.2452064501954
+            "perf_metric_value": 3443.4109493516467
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2404.0655646196824
+            "perf_metric_value": 2445.3917020087183
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7769.178329165985
+            "perf_metric_value": 7819.413819348124
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23168.617762817485
+            "perf_metric_value": 23691.103253812682
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 853.2971271119943
+            "perf_metric_value": 899.1009604416595
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1140.4589686415818
+            "perf_metric_value": 1050.0307192769721
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 850.0130225802546
+            "perf_metric_value": 868.8457104788757
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.12571780234292362
+            "perf_metric_value": 0.1188387933899692
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11448.200956281493
+            "perf_metric_value": 12030.005606095068
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 548.9025253096465
+            "perf_metric_value": 544.5787447668264
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1048.0638150235914
+            "perf_metric_value": 1036.1143314918054
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1032.1273072581214
+            "perf_metric_value": 1037.112715415745
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.963514714801502
+            "perf_metric_value": 0.9437038816702141
         }
     ],
     "placement_group_create/removal": [
-        853.2971271119943,
-        3.603842904070138
+        899.1009604416595,
+        5.867369951008003
     ],
     "single_client_get_calls_Plasma_Store": [
-        10110.669836472582,
-        395.9374390419555
+        10738.562473287413,
+        62.492164854915536
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.720260733349566,
-        0.13088888736560989
+        12.889352554386498,
+        0.26733589691743903
     ],
     "single_client_put_calls_Plasma_Store": [
-        5561.796272720696,
-        49.28007881875913
+        5626.784525019393,
+        91.61522124981595
     ],
     "single_client_put_gigabytes": [
-        20.570552345060236,
-        4.885645804613
+        19.45047172438498,
+        5.268472181194665
     ],
     "single_client_tasks_and_get_batch": [
-        8.868906341564493,
-        0.41416617720091714
+        9.162108196113913,
+        0.5995755661972636
     ],
     "single_client_tasks_async": [
-        8956.257620701814,
-        600.4053080787356
+        8158.711929873504,
+        298.3496995336287
     ],
     "single_client_tasks_sync": [
-        1018.79213518621,
-        21.468878872767664
+        1045.9572930683776,
+        11.756601544227808
     ],
     "single_client_wait_1k_refs": [
-        5.570617513099608,
-        0.18296936599561525
+        5.24437824055842,
+        0.09892176076482266
     ]
 }

--- a/release/release_logs/2.9.2/microbenchmark.json
+++ b/release/release_logs/2.9.2/microbenchmark.json
@@ -1,0 +1,283 @@
+{
+    "1_1_actor_calls_async": [
+        9042.710869690089,
+        63.62085730466312
+    ],
+    "1_1_actor_calls_concurrent": [
+        5538.885186515366,
+        266.8781556995926
+    ],
+    "1_1_actor_calls_sync": [
+        2069.668256767318,
+        24.04434086505614
+    ],
+    "1_1_async_actor_calls_async": [
+        3198.2452064501954,
+        207.90653414767863
+    ],
+    "1_1_async_actor_calls_sync": [
+        1346.9273686110646,
+        53.72802518864216
+    ],
+    "1_1_async_actor_calls_with_args_async": [
+        2404.0655646196824,
+        86.99541432527154
+    ],
+    "1_n_actor_calls_async": [
+        7686.2005077877675,
+        270.66402414641783
+    ],
+    "1_n_async_actor_calls_async": [
+        7769.178329165985,
+        187.42812654040966
+    ],
+    "client__1_1_actor_calls_async": [
+        1048.0638150235914,
+        4.887001560877178
+    ],
+    "client__1_1_actor_calls_concurrent": [
+        1032.1273072581214,
+        6.71540782331122
+    ],
+    "client__1_1_actor_calls_sync": [
+        548.9025253096465,
+        5.049064695362747
+    ],
+    "client__get_calls": [
+        1140.4589686415818,
+        58.29801140418089
+    ],
+    "client__put_calls": [
+        850.0130225802546,
+        43.90873408067339
+    ],
+    "client__put_gigabytes": [
+        0.12571780234292362,
+        0.0009634752625132644
+    ],
+    "client__tasks_and_get_batch": [
+        0.963514714801502,
+        0.02111448699134845
+    ],
+    "client__tasks_and_put_batch": [
+        11448.200956281493,
+        124.63430966694564
+    ],
+    "multi_client_put_calls_Plasma_Store": [
+        12691.66387624551,
+        93.46702510776397
+    ],
+    "multi_client_put_gigabytes": [
+        32.16603791675267,
+        1.9822375813807749
+    ],
+    "multi_client_tasks_async": [
+        23674.761911259015,
+        979.4320107702001
+    ],
+    "n_n_actor_calls_async": [
+        26537.555565896397,
+        857.3781397158533
+    ],
+    "n_n_actor_calls_with_arg_async": [
+        3005.0093040937622,
+        52.94469167391438
+    ],
+    "n_n_async_actor_calls_async": [
+        23168.617762817485,
+        649.0718850914941
+    ],
+    "perf_metrics": [
+        {
+            "perf_metric_name": "single_client_get_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10110.669836472582
+        },
+        {
+            "perf_metric_name": "single_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5561.796272720696
+        },
+        {
+            "perf_metric_name": "multi_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 12691.66387624551
+        },
+        {
+            "perf_metric_name": "single_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 20.570552345060236
+        },
+        {
+            "perf_metric_name": "single_client_tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8.868906341564493
+        },
+        {
+            "perf_metric_name": "multi_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 32.16603791675267
+        },
+        {
+            "perf_metric_name": "single_client_get_object_containing_10k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 13.720260733349566
+        },
+        {
+            "perf_metric_name": "single_client_wait_1k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5.570617513099608
+        },
+        {
+            "perf_metric_name": "single_client_tasks_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1018.79213518621
+        },
+        {
+            "perf_metric_name": "single_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8956.257620701814
+        },
+        {
+            "perf_metric_name": "multi_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 23674.761911259015
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2069.668256767318
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 9042.710869690089
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5538.885186515366
+        },
+        {
+            "perf_metric_name": "1_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 7686.2005077877675
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 26537.555565896397
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_with_arg_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 3005.0093040937622
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1346.9273686110646
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 3198.2452064501954
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_with_args_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2404.0655646196824
+        },
+        {
+            "perf_metric_name": "1_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 7769.178329165985
+        },
+        {
+            "perf_metric_name": "n_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 23168.617762817485
+        },
+        {
+            "perf_metric_name": "placement_group_create/removal",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 853.2971271119943
+        },
+        {
+            "perf_metric_name": "client__get_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1140.4589686415818
+        },
+        {
+            "perf_metric_name": "client__put_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 850.0130225802546
+        },
+        {
+            "perf_metric_name": "client__put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.12571780234292362
+        },
+        {
+            "perf_metric_name": "client__tasks_and_put_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 11448.200956281493
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 548.9025253096465
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1048.0638150235914
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1032.1273072581214
+        },
+        {
+            "perf_metric_name": "client__tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.963514714801502
+        }
+    ],
+    "placement_group_create/removal": [
+        853.2971271119943,
+        3.603842904070138
+    ],
+    "single_client_get_calls_Plasma_Store": [
+        10110.669836472582,
+        395.9374390419555
+    ],
+    "single_client_get_object_containing_10k_refs": [
+        13.720260733349566,
+        0.13088888736560989
+    ],
+    "single_client_put_calls_Plasma_Store": [
+        5561.796272720696,
+        49.28007881875913
+    ],
+    "single_client_put_gigabytes": [
+        20.570552345060236,
+        4.885645804613
+    ],
+    "single_client_tasks_and_get_batch": [
+        8.868906341564493,
+        0.41416617720091714
+    ],
+    "single_client_tasks_async": [
+        8956.257620701814,
+        600.4053080787356
+    ],
+    "single_client_tasks_sync": [
+        1018.79213518621,
+        21.468878872767664
+    ],
+    "single_client_wait_1k_refs": [
+        5.570617513099608,
+        0.18296936599561525
+    ]
+}

--- a/release/release_logs/2.9.2/scalability/object_store.json
+++ b/release/release_logs/2.9.2/scalability/object_store.json
@@ -1,0 +1,13 @@
+{
+    "broadcast_time": 82.13346181200001,
+    "num_nodes": 50,
+    "object_size": 1073741824,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 82.13346181200001
+        }
+    ],
+    "success": "1"
+}

--- a/release/release_logs/2.9.2/scalability/object_store.json
+++ b/release/release_logs/2.9.2/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 82.13346181200001,
+    "broadcast_time": 74.646136904,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 82.13346181200001
+            "perf_metric_value": 74.646136904
         }
     ],
     "success": "1"

--- a/release/release_logs/2.9.2/scalability/single_node.json
+++ b/release/release_logs/2.9.2/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 18.237642927999985,
-    "get_time": 26.10482553,
+    "args_time": 17.403529387000006,
+    "get_time": 25.059263131999984,
     "large_object_size": 107374182400,
-    "large_object_time": 31.070047604000024,
+    "large_object_time": 29.50047878800001,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.237642927999985
+            "perf_metric_value": 17.403529387000006
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.901565304000002
+            "perf_metric_value": 6.779333391999998
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 26.10482553
+            "perf_metric_value": 25.059263131999984
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 202.29460393899998
+            "perf_metric_value": 193.28140517800003
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 31.070047604000024
+            "perf_metric_value": 29.50047878800001
         }
     ],
-    "queued_time": 202.29460393899998,
-    "returns_time": 5.901565304000002,
+    "queued_time": 193.28140517800003,
+    "returns_time": 6.779333391999998,
     "success": "1"
 }

--- a/release/release_logs/2.9.2/scalability/single_node.json
+++ b/release/release_logs/2.9.2/scalability/single_node.json
@@ -1,0 +1,40 @@
+{
+    "args_time": 18.237642927999985,
+    "get_time": 26.10482553,
+    "large_object_size": 107374182400,
+    "large_object_time": 31.070047604000024,
+    "num_args": 10000,
+    "num_get_args": 10000,
+    "num_queued": 1000000,
+    "num_returns": 3000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "10000_args_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 18.237642927999985
+        },
+        {
+            "perf_metric_name": "3000_returns_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 5.901565304000002
+        },
+        {
+            "perf_metric_name": "10000_get_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 26.10482553
+        },
+        {
+            "perf_metric_name": "1000000_queued_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 202.29460393899998
+        },
+        {
+            "perf_metric_name": "107374182400_large_object_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 31.070047604000024
+        }
+    ],
+    "queued_time": 202.29460393899998,
+    "returns_time": 5.901565304000002,
+    "success": "1"
+}

--- a/release/release_logs/2.9.2/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.9.2/stress_tests/stress_test_dead_actors.json
@@ -1,0 +1,14 @@
+{
+    "avg_iteration_time": 1.4987098264694214,
+    "max_iteration_time": 3.973320245742798,
+    "min_iteration_time": 0.270723819732666,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1.4987098264694214
+        }
+    ],
+    "success": 1,
+    "total_time": 149.8711953163147
+}

--- a/release/release_logs/2.9.2/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.9.2/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.4987098264694214,
-    "max_iteration_time": 3.973320245742798,
-    "min_iteration_time": 0.270723819732666,
+    "avg_iteration_time": 1.5535523080825806,
+    "max_iteration_time": 4.397601842880249,
+    "min_iteration_time": 0.17409896850585938,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4987098264694214
+            "perf_metric_value": 1.5535523080825806
         }
     ],
     "success": 1,
-    "total_time": 149.8711953163147
+    "total_time": 155.3554835319519
 }

--- a/release/release_logs/2.9.2/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.9.2/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.95952582359314
+            "perf_metric_value": 10.46918272972107
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.16728506088257
+            "perf_metric_value": 22.608211970329286
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 58.58917393684387
+            "perf_metric_value": 54.63260869979858
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.4432339668273926
+            "perf_metric_value": 2.076388359069824
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3202.4680984020233
+            "perf_metric_value": 3057.80943608284
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.6165194769207957
+            "perf_metric_value": 0.64618222013863
         }
     ],
-    "stage_0_time": 12.95952582359314,
-    "stage_1_avg_iteration_time": 25.16728506088257,
-    "stage_1_max_iteration_time": 25.976984977722168,
-    "stage_1_min_iteration_time": 24.2444486618042,
-    "stage_1_time": 251.6729428768158,
-    "stage_2_avg_iteration_time": 58.58917393684387,
-    "stage_2_max_iteration_time": 59.801358461380005,
-    "stage_2_min_iteration_time": 56.11144685745239,
-    "stage_2_time": 292.9467442035675,
-    "stage_3_creation_time": 2.4432339668273926,
-    "stage_3_time": 3202.4680984020233,
-    "stage_4_spread": 0.6165194769207957,
+    "stage_0_time": 10.46918272972107,
+    "stage_1_avg_iteration_time": 22.608211970329286,
+    "stage_1_max_iteration_time": 23.692232370376587,
+    "stage_1_min_iteration_time": 21.36727476119995,
+    "stage_1_time": 226.08220982551575,
+    "stage_2_avg_iteration_time": 54.63260869979858,
+    "stage_2_max_iteration_time": 55.34358763694763,
+    "stage_2_min_iteration_time": 53.89388942718506,
+    "stage_2_time": 273.1641137599945,
+    "stage_3_creation_time": 2.076388359069824,
+    "stage_3_time": 3057.80943608284,
+    "stage_4_spread": 0.64618222013863,
     "success": 1
 }

--- a/release/release_logs/2.9.2/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.9.2/stress_tests/stress_test_many_tasks.json
@@ -1,0 +1,47 @@
+{
+    "perf_metrics": [
+        {
+            "perf_metric_name": "stage_0_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 12.95952582359314
+        },
+        {
+            "perf_metric_name": "stage_1_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 25.16728506088257
+        },
+        {
+            "perf_metric_name": "stage_2_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 58.58917393684387
+        },
+        {
+            "perf_metric_name": "stage_3_creation_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2.4432339668273926
+        },
+        {
+            "perf_metric_name": "stage_3_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3202.4680984020233
+        },
+        {
+            "perf_metric_name": "stage_4_spread",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.6165194769207957
+        }
+    ],
+    "stage_0_time": 12.95952582359314,
+    "stage_1_avg_iteration_time": 25.16728506088257,
+    "stage_1_max_iteration_time": 25.976984977722168,
+    "stage_1_min_iteration_time": 24.2444486618042,
+    "stage_1_time": 251.6729428768158,
+    "stage_2_avg_iteration_time": 58.58917393684387,
+    "stage_2_max_iteration_time": 59.801358461380005,
+    "stage_2_min_iteration_time": 56.11144685745239,
+    "stage_2_time": 292.9467442035675,
+    "stage_3_creation_time": 2.4432339668273926,
+    "stage_3_time": 3202.4680984020233,
+    "stage_4_spread": 0.6165194769207957,
+    "success": 1
+}

--- a/release/release_logs/2.9.2/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.9.2/stress_tests/stress_test_placement_group.json
@@ -1,0 +1,17 @@
+{
+    "avg_pg_create_time_ms": 0.9140677417423678,
+    "avg_pg_remove_time_ms": 0.8934716381374143,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_pg_create_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.9140677417423678
+        },
+        {
+            "perf_metric_name": "avg_pg_remove_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.8934716381374143
+        }
+    ],
+    "success": 1
+}

--- a/release/release_logs/2.9.2/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.9.2/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9140677417423678,
-    "avg_pg_remove_time_ms": 0.8934716381374143,
+    "avg_pg_create_time_ms": 0.884080222223619,
+    "avg_pg_remove_time_ms": 0.863579004504134,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9140677417423678
+            "perf_metric_value": 0.884080222223619
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.8934716381374143
+            "perf_metric_value": 0.863579004504134
         }
     ],
     "success": 1

--- a/release/release_logs/fetch_release_logs.py
+++ b/release/release_logs/fetch_release_logs.py
@@ -38,7 +38,7 @@ import click
 from pybuildkite.buildkite import Buildkite
 
 BUILDKITE_ORGANIZATION = "ray-project"
-BUILDKITE_PIPELINE = "release-tests-branch"
+BUILDKITE_PIPELINE = "release"
 
 # Format: job name regex --> filename to save results to
 RESULTS_TO_FETCH = {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds performance logs for [fce7a36180](https://github.com/ray-project/ray/commit/fce7a361807580953364e2da964f9498f3123bf9)

```
(ray) gene@geneanycale2023 release_logs % python compare_perf_metrics 2.9.1 2.9.2
REGRESSION 8.15%: client__put_gigabytes (THROUGHPUT) regresses from 0.12938700124608027 to 0.1188387933899692 (8.15%) in 2.9.2/microbenchmark.json
REGRESSION 6.75%: client__get_calls (THROUGHPUT) regresses from 1125.9811184876232 to 1050.0307192769721 (6.75%) in 2.9.2/microbenchmark.json
REGRESSION 5.05%: single_client_tasks_async (THROUGHPUT) regresses from 8592.305437413408 to 8158.711929873504 (5.05%) in 2.9.2/microbenchmark.json
REGRESSION 4.70%: multi_client_put_gigabytes (THROUGHPUT) regresses from 35.263877895454804 to 33.605927354752815 (4.70%) in 2.9.2/microbenchmark.json
REGRESSION 1.76%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9605952574022111 to 0.9437038816702141 (1.76%) in 2.9.2/microbenchmark.json
REGRESSION 1.66%: tasks_per_second (THROUGHPUT) regresses from 326.73502105628876 to 321.31153016474485 (1.66%) in 2.9.2/benchmarks/many_nodes.json
REGRESSION 0.11%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2861.4449722009826 to 2858.2486735378648 (0.11%) in 2.9.2/microbenchmark.json
REGRESSION 237.49%: dashboard_p95_latency_ms (LATENCY) regresses from 9.013 to 30.418 (237.49%) in 2.9.2/benchmarks/many_nodes.json
REGRESSION 76.92%: dashboard_p50_latency_ms (LATENCY) regresses from 25.07 to 44.354 (76.92%) in 2.9.2/benchmarks/many_actors.json
REGRESSION 39.79%: dashboard_p99_latency_ms (LATENCY) regresses from 10083.034 to 14095.515 (39.79%) in 2.9.2/benchmarks/many_tasks.json
REGRESSION 32.51%: dashboard_p95_latency_ms (LATENCY) regresses from 6287.46 to 8331.543 (32.51%) in 2.9.2/benchmarks/many_tasks.json
REGRESSION 4.98%: 3000_returns_time (LATENCY) regresses from 6.457862126000009 to 6.779333391999998 (4.98%) in 2.9.2/scalability/single_node.json
REGRESSION 4.00%: 10000_get_time (LATENCY) regresses from 24.095646799999997 to 25.059263131999984 (4.00%) in 2.9.2/scalability/single_node.json
REGRESSION 2.82%: avg_iteration_time (LATENCY) regresses from 1.5108911991119385 to 1.5535523080825806 (2.82%) in 2.9.2/stress_tests/stress_test_dead_actors.json
REGRESSION 2.43%: 1000000_queued_time (LATENCY) regresses from 188.693754931 to 193.28140517800003 (2.43%) in 2.9.2/scalability/single_node.json
REGRESSION 1.29%: stage_4_spread (LATENCY) regresses from 0.637963224514887 to 0.64618222013863 (1.29%) in 2.9.2/stress_tests/stress_test_many_tasks.json
REGRESSION 0.25%: dashboard_p50_latency_ms (LATENCY) regresses from 4.359 to 4.37 (0.25%) in 2.9.2/benchmarks/many_nodes.json
REGRESSION 0.23%: 107374182400_large_object_time (LATENCY) regresses from 29.431489800999998 to 29.50047878800001 (0.23%) in 2.9.2/scalability/single_node.json
REGRESSION 0.21%: avg_pg_remove_time_ms (LATENCY) regresses from 0.8617512267259182 to 0.863579004504134 (0.21%) in 2.9.2/stress_tests/stress_test_placement_group.json
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
