### PR TITLE
[Doc] Reenable disabled toctrees

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -368,7 +368,7 @@ build_sphinx_docs() {
     if [ "${OSTYPE}" = msys ]; then
       echo "WARNING: Documentation not built on Windows due to currently-unresolved issues"
     else
-      FAST=True make html
+      make html
       pip install datasets==2.0.0
     fi
   )
@@ -380,7 +380,7 @@ check_sphinx_links() {
     if [ "${OSTYPE}" = msys ]; then
       echo "WARNING: Documentation not built on Windows due to currently-unresolved issues"
     else
-      FAST=True make linkcheck
+      make linkcheck
     fi
   )
 }

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -66,7 +66,8 @@ html:
 	$(SPHINXBUILD) -W --keep-going -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
-
+	@echo "View the documentation by opening a browser and going to $(BUILDDIR)/html/index.html."
+	
 develop: html
 
 dirhtml:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -67,11 +67,7 @@ html:
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-develop:
-	FAST=True $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
-	@echo "View the documentation by opening a browser and going to $(BUILDDIR)/html/index.html."
+develop: html
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/doc/README.md
+++ b/doc/README.md
@@ -19,12 +19,6 @@ To compile the documentation and open it locally, run the following command from
 make develop && open _build/html/index.html
 ```
 
-> **_NOTE:_**  The above command is for development. To reproduce build failures from the
-> CI, you should use `make html` which is the same as `make develop` but treats warnings as errors.
-> Additionally, note that `make develop` uses the `FAST` environment variable to skip some
-> expensive parts of the build process. In particular, it will aggressively prune the
-> left-hand side navigation, but leave the documents itself intact.
-
 ## Building just one subproject
 
 Often your changes in documentation just concern one subproject, such as Tune or Train.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -78,26 +78,6 @@ remove_from_toctrees = [
     "rllib/package_ref/utils/*",
 ]
 
-# Prune deep toc-trees on demand for smaller html and faster builds.
-# This only effects the navigation bar, not the content.
-if os.getenv("FAST", False):
-    remove_from_toctrees += [
-        "ray-observability/api/state/doc/*",
-        "workflows/api/doc/*",
-        "serve/production-guide/*",
-        "serve/tutorials/deployment-graph-patterns/*",
-        "workflows/api/*",
-        "cluster/kubernetes/user-guides/*",
-        "cluster/kubernetes/examples/*",
-        "cluster/vms/user-guides/*",
-        "cluster/running-applications/job-submission/*",
-        "ray-core/actors/*",
-        "ray-core/objects/*",
-        "ray-core/scheduling/*",
-        "ray-core/tasks/*",
-        "ray-core/patterns/*",
-    ]
-
 myst_enable_extensions = [
     "dollarmath",
     "amsmath",


### PR DESCRIPTION
## Why are these changes needed?

The sphinx configuration uses a plugin called `sphinx_remove_toctrees` to trim toctrees from the docs that are built. This is really useful for removing unwanted individual pages (such as the huge number of toctree entries generated by autodoc for certain APIs) and for keeping build time down. But currently `make develop`, the command most users use when building docs, sets an environment variable which removes some other documents from toctrees as well. This can lead to counterintuitive behavior when a user isn't aware of this mechanism; they can be certain a document lives in a toctree - but when they build the docs it just does not appear in the sidebar where they expect it to. No warnings are issued at all about this, so it can be difficult to track down.

This PR removes the `FAST` environment variable entirely, reenabling some toctrees. I noted a +10s difference in build time compared to `master` - an acceptable difference for the improved maintainability.

## Related issue number

Closes https://github.com/ray-project/ray/issues/42921.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
