### PR TITLE
[ray dashboard] Fix sorting order on cluster page

### DIFF
--- a/dashboard/client/src/pages/node/hook/useNodeList.ts
+++ b/dashboard/client/src/pages/node/hook/useNodeList.ts
@@ -51,13 +51,17 @@ export const useNodeList = () => {
       logicalResources: nodeLogicalResources[e.raylet.nodeId],
     }))
     .sort(sorterFunc);
-
-  const sortedList = _.sortBy(nodeListWithAdditionalInfo, [
-    (obj) => !obj.raylet.isHeadNode,
-    // sort by alive first, then alphabetically for other states
-    (obj) => (obj.raylet.state === "ALIVE" ? "0" : obj.raylet.state),
-    (obj) => obj.raylet.nodeId,
-  ]);
+  
+  const sortedList = _.sortBy(nodeListWithAdditionalInfo, (node) => {
+    // After sorting by user specified field, stable sort by 
+    // 1) Alive nodes first then alphabetically for other states
+    // 2) Head node
+    // 3) Alphabetical by node id
+    const nodeStateOrder = node.raylet.state === "ALIVE" ? "0" : node.raylet.state;
+    const isHeadNodeOrder = node.raylet.isHeadNode ? "0" : "1";
+    const nodeIdOrder = node.raylet.nodeId;
+    return [nodeStateOrder, isHeadNodeOrder, nodeIdOrder];
+  });
 
   return {
     nodeList: sortedList.filter((node) =>

--- a/dashboard/client/src/pages/node/hook/useNodeList.ts
+++ b/dashboard/client/src/pages/node/hook/useNodeList.ts
@@ -51,13 +51,14 @@ export const useNodeList = () => {
       logicalResources: nodeLogicalResources[e.raylet.nodeId],
     }))
     .sort(sorterFunc);
-  
+
   const sortedList = _.sortBy(nodeListWithAdditionalInfo, (node) => {
-    // After sorting by user specified field, stable sort by 
+    // After sorting by user specified field, stable sort by
     // 1) Alive nodes first then alphabetically for other states
     // 2) Head node
     // 3) Alphabetical by node id
-    const nodeStateOrder = node.raylet.state === "ALIVE" ? "0" : node.raylet.state;
+    const nodeStateOrder =
+      node.raylet.state === "ALIVE" ? "0" : node.raylet.state;
     const isHeadNodeOrder = node.raylet.isHeadNode ? "0" : "1";
     const nodeIdOrder = node.raylet.nodeId;
     return [nodeStateOrder, isHeadNodeOrder, nodeIdOrder];

--- a/dashboard/client/src/pages/node/useNodeList.component.test.tsx
+++ b/dashboard/client/src/pages/node/useNodeList.component.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, within } from "@testing-library/react";
+import { noop } from "lodash";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { NodeDetail } from "../../type/node";
+import { CoreWorkerStats, Worker } from "../../type/worker";
+import { NodeRow, WorkerRow } from "./NodeRow";
+import { useNodeList } from "./hook/useNodeList";
+import useSWR from "swr";
+
+jest.mock("swr");
+const useSWRMocked = jest.mocked(useSWR);
+
+const NODE: NodeDetail = {
+    hostname: "test-hostname",
+    ip: "192.168.0.1",
+    cpu: 15,
+    mem: [100, 95, 5],
+    state: "ALIVE",
+    disk: {
+      "/": {
+        used: 20000000,
+        total: 200000000,
+        free: 180000000,
+        percent: 10,
+      },
+      "/tmp": {
+        used: 0,
+        total: 200,
+        free: 200,
+        percent: 0,
+      },
+    },
+    networkSpeed: [5, 10],
+    raylet: {
+      state: "ALIVE",
+      nodeId: "1234567890ab",
+      isHeadNode: true,
+      numWorkers: 0,
+      pid: 2345,
+      startTime: 100,
+      terminateTime: -1,
+      brpcPort: 3456,
+      nodeManagerPort: 5890,
+      objectStoreAvailableMemory: 40,
+      objectStoreUsedMemory: 10,
+    },
+  } as NodeDetail;
+
+  const aliveHeadNode = { ...NODE, hostname: "test-hostname-alive-head-node"};
+  const deadHeadNode = { ...NODE, hostname: "test-hostname-dead-head-node", state: "DEAD", raylet: {
+    state: "DEAD",
+    nodeId: "1234567890ab",
+    isHeadNode: false,
+    numWorkers: 0,
+    pid: 2345,
+    startTime: 100,
+    terminateTime: -1,
+    brpcPort: 3456,
+    nodeManagerPort: 5890,
+    objectStoreAvailableMemory: 40,
+    objectStoreUsedMemory: 10,
+  },};
+  const aliveWorkerNode1 = { ...NODE, hostname: "test-hostname-worker1", raylet: {
+    state: "ALIVE",
+    nodeId: "1234567890ab",
+    isHeadNode: false,
+    numWorkers: 0,
+    pid: 2345,
+    startTime: 100,
+    terminateTime: -1,
+    brpcPort: 3456,
+    nodeManagerPort: 5890,
+    objectStoreAvailableMemory: 40,
+    objectStoreUsedMemory: 10,
+  },};
+  const aliveWorkerNode2 = { ...NODE, hostname: "test-hostname-worker2", raylet: {
+    state: "ALIVE",
+    nodeId: "1234567890ac",
+    isHeadNode: false,
+    numWorkers: 0,
+    pid: 2345,
+    startTime: 100,
+    terminateTime: -1,
+    brpcPort: 3456,
+    nodeManagerPort: 5890,
+    objectStoreAvailableMemory: 40,
+    objectStoreUsedMemory: 10,
+  },};
+
+describe("useNodeList", () => {
+    it("verify default sort order of useNodeList", () => {
+        useSWRMocked.mockReturnValue({
+            data: {
+                summary: [deadHeadNode, aliveWorkerNode2, aliveHeadNode, aliveWorkerNode1,],
+                nodeLogicalResources: undefined,
+            },
+            isLoading: false,
+          } as any);
+
+          function TestComponent() {
+            const {
+                msg,
+                isLoading,
+                isRefreshing,
+                onSwitchChange,
+                nodeList,
+                changeFilter,
+                page,
+                setPage,
+                setSortKey,
+                setOrderDesc,
+                mode,
+                setMode,
+              } = useNodeList();
+            const nodeHostNames = nodeList
+              .map((e) => (e.hostname))
+            return <div data-testid="nodeHostNames">{nodeHostNames}</div>;
+          }
+
+          const { getByRole } = render(
+            <MemoryRouter>
+              <TestComponent />
+            </MemoryRouter>,
+          );
+          screen.debug(undefined, Infinity);
+          screen.logTestingPlaygroundURL()
+
+          const nodeHostNames = screen.getByTestId("nodeHostNames");
+          const expectedOrderNodeList = [aliveHeadNode.hostname, aliveWorkerNode1.hostname, aliveWorkerNode2.hostname, deadHeadNode.hostname,];
+          expect(nodeHostNames.textContent).toEqual(expectedOrderNodeList.join(""));
+    })
+})

--- a/dashboard/client/src/pages/node/useNodeList.component.test.tsx
+++ b/dashboard/client/src/pages/node/useNodeList.component.test.tsx
@@ -1,54 +1,55 @@
-import { render, screen, within } from "@testing-library/react";
-import { noop } from "lodash";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
-import { NodeDetail } from "../../type/node";
-import { CoreWorkerStats, Worker } from "../../type/worker";
-import { NodeRow, WorkerRow } from "./NodeRow";
-import { useNodeList } from "./hook/useNodeList";
 import useSWR from "swr";
+import { NodeDetail } from "../../type/node";
+import { useNodeList } from "./hook/useNodeList";
 
 jest.mock("swr");
 const useSWRMocked = jest.mocked(useSWR);
 
 const NODE: NodeDetail = {
-    hostname: "test-hostname",
-    ip: "192.168.0.1",
-    cpu: 15,
-    mem: [100, 95, 5],
+  hostname: "test-hostname",
+  ip: "192.168.0.1",
+  cpu: 15,
+  mem: [100, 95, 5],
+  state: "ALIVE",
+  disk: {
+    "/": {
+      used: 20000000,
+      total: 200000000,
+      free: 180000000,
+      percent: 10,
+    },
+    "/tmp": {
+      used: 0,
+      total: 200,
+      free: 200,
+      percent: 0,
+    },
+  },
+  networkSpeed: [5, 10],
+  raylet: {
     state: "ALIVE",
-    disk: {
-      "/": {
-        used: 20000000,
-        total: 200000000,
-        free: 180000000,
-        percent: 10,
-      },
-      "/tmp": {
-        used: 0,
-        total: 200,
-        free: 200,
-        percent: 0,
-      },
-    },
-    networkSpeed: [5, 10],
-    raylet: {
-      state: "ALIVE",
-      nodeId: "1234567890ab",
-      isHeadNode: true,
-      numWorkers: 0,
-      pid: 2345,
-      startTime: 100,
-      terminateTime: -1,
-      brpcPort: 3456,
-      nodeManagerPort: 5890,
-      objectStoreAvailableMemory: 40,
-      objectStoreUsedMemory: 10,
-    },
-  } as NodeDetail;
+    nodeId: "1234567890ab",
+    isHeadNode: true,
+    numWorkers: 0,
+    pid: 2345,
+    startTime: 100,
+    terminateTime: -1,
+    brpcPort: 3456,
+    nodeManagerPort: 5890,
+    objectStoreAvailableMemory: 40,
+    objectStoreUsedMemory: 10,
+  },
+} as NodeDetail;
 
-  const aliveHeadNode = { ...NODE, hostname: "test-hostname-alive-head-node"};
-  const deadHeadNode = { ...NODE, hostname: "test-hostname-dead-head-node", state: "DEAD", raylet: {
+const aliveHeadNode = { ...NODE, hostname: "test-hostname-alive-head-node" };
+const deadHeadNode = {
+  ...NODE,
+  hostname: "test-hostname-dead-head-node",
+  state: "DEAD",
+  raylet: {
     state: "DEAD",
     nodeId: "1234567890ab",
     isHeadNode: false,
@@ -60,8 +61,12 @@ const NODE: NodeDetail = {
     nodeManagerPort: 5890,
     objectStoreAvailableMemory: 40,
     objectStoreUsedMemory: 10,
-  },};
-  const aliveWorkerNode1 = { ...NODE, hostname: "test-hostname-worker1", raylet: {
+  },
+};
+const aliveWorkerNode1 = {
+  ...NODE,
+  hostname: "test-hostname-worker1",
+  raylet: {
     state: "ALIVE",
     nodeId: "1234567890ab",
     isHeadNode: false,
@@ -73,8 +78,12 @@ const NODE: NodeDetail = {
     nodeManagerPort: 5890,
     objectStoreAvailableMemory: 40,
     objectStoreUsedMemory: 10,
-  },};
-  const aliveWorkerNode2 = { ...NODE, hostname: "test-hostname-worker2", raylet: {
+  },
+};
+const aliveWorkerNode2 = {
+  ...NODE,
+  hostname: "test-hostname-worker2",
+  raylet: {
     state: "ALIVE",
     nodeId: "1234567890ac",
     isHeadNode: false,
@@ -86,48 +95,43 @@ const NODE: NodeDetail = {
     nodeManagerPort: 5890,
     objectStoreAvailableMemory: 40,
     objectStoreUsedMemory: 10,
-  },};
+  },
+};
 
 describe("useNodeList", () => {
-    it("verify default sort order of useNodeList", () => {
-        useSWRMocked.mockReturnValue({
-            data: {
-                summary: [deadHeadNode, aliveWorkerNode2, aliveHeadNode, aliveWorkerNode1,],
-                nodeLogicalResources: undefined,
-            },
-            isLoading: false,
-          } as any);
+  it("verify default sort order of useNodeList", () => {
+    useSWRMocked.mockReturnValue({
+      data: {
+        summary: [
+          deadHeadNode,
+          aliveWorkerNode2,
+          aliveHeadNode,
+          aliveWorkerNode1,
+        ],
+        nodeLogicalResources: undefined,
+      },
+      isLoading: false,
+    } as any);
 
-          function TestComponent() {
-            const {
-                msg,
-                isLoading,
-                isRefreshing,
-                onSwitchChange,
-                nodeList,
-                changeFilter,
-                page,
-                setPage,
-                setSortKey,
-                setOrderDesc,
-                mode,
-                setMode,
-              } = useNodeList();
-            const nodeHostNames = nodeList
-              .map((e) => (e.hostname))
-            return <div data-testid="nodeHostNames">{nodeHostNames}</div>;
-          }
+    const TestComponent = () => {
+      const { nodeList } = useNodeList();
+      const nodeHostNames = nodeList.map((e) => e.hostname);
+      return <div data-testid="nodeHostNames">{nodeHostNames}</div>;
+    };
 
-          const { getByRole } = render(
-            <MemoryRouter>
-              <TestComponent />
-            </MemoryRouter>,
-          );
-          screen.debug(undefined, Infinity);
-          screen.logTestingPlaygroundURL()
+    render(
+      <MemoryRouter>
+        <TestComponent />
+      </MemoryRouter>,
+    );
 
-          const nodeHostNames = screen.getByTestId("nodeHostNames");
-          const expectedOrderNodeList = [aliveHeadNode.hostname, aliveWorkerNode1.hostname, aliveWorkerNode2.hostname, deadHeadNode.hostname,];
-          expect(nodeHostNames.textContent).toEqual(expectedOrderNodeList.join(""));
-    })
-})
+    const nodeHostNames = screen.getByTestId("nodeHostNames");
+    const expectedOrderNodeList = [
+      aliveHeadNode.hostname,
+      aliveWorkerNode1.hostname,
+      aliveWorkerNode2.hostname,
+      deadHeadNode.hostname,
+    ];
+    expect(nodeHostNames.textContent).toEqual(expectedOrderNodeList.join(""));
+  });
+});


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Sets the default sorting order of nodes on the clusters page to (1) alive nodes first then alphabetically for other states (2) head node before worker nodes (3) alphabetical by node ID.

## Related issue number

Closes https://github.com/ray-project/ray/issues/42666

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
