### PR TITLE
[Data] Remove references to strict mode

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -87,23 +87,22 @@ BlockPartitionMetadata = List["BlockMetadata"]
 # is on by default. When block splitting is off, the type is a plain block.
 MaybeBlockPartition = Union[Block, DynamicObjectRefGenerator]
 
-VALID_BATCH_FORMATS = ["default", "native", "pandas", "pyarrow", "numpy", None]
+VALID_BATCH_FORMATS = ["pandas", "pyarrow", "numpy", None]
+DEFAULT_BATCH_FORMAT = "numpy"
 
-VALID_BATCH_FORMATS_STRICT_MODE = ["pandas", "pyarrow", "numpy", None]
 
-
-def _apply_strict_mode_batch_format(given_batch_format: Optional[str]) -> str:
+def _apply_batch_format(given_batch_format: Optional[str]) -> str:
     if given_batch_format == "default":
-        given_batch_format = "numpy"
-    if given_batch_format not in VALID_BATCH_FORMATS_STRICT_MODE:
+        given_batch_format = DEFAULT_BATCH_FORMAT
+    if given_batch_format not in VALID_BATCH_FORMATS:
         raise ValueError(
-            f"The given batch format {given_batch_format} is not allowed "
-            f"in Ray 2.5 (must be one of {VALID_BATCH_FORMATS_STRICT_MODE})."
+            f"The given batch format {given_batch_format} isn't allowed (must be one of"
+            f" {VALID_BATCH_FORMATS})."
         )
     return given_batch_format
 
 
-def _apply_strict_mode_batch_size(
+def _apply_batch_size(
     given_batch_size: Optional[Union[int, Literal["default"]]], use_gpu: bool
 ) -> Optional[int]:
     if use_gpu and (not given_batch_size or given_batch_size == "default"):
@@ -115,7 +114,7 @@ def _apply_strict_mode_batch_size(
             "usage via the Ray dashboard."
         )
     elif given_batch_size == "default":
-        return ray.data.context.STRICT_MODE_DEFAULT_BATCH_SIZE
+        return ray.data.context.DEFAULT_BATCH_SIZE
     else:
         return given_batch_size
 

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -117,10 +117,7 @@ WARN_PREFIX = "⚠️ "
 OK_PREFIX = "✔️ "
 
 # Default batch size for batch transformations.
-DEFAULT_BATCH_SIZE = 4096
-
-# Default batch size for batch transformations in strict mode.
-STRICT_MODE_DEFAULT_BATCH_SIZE = 1024
+DEFAULT_BATCH_SIZE = 1024
 
 # Whether to enable progress bars.
 DEFAULT_ENABLE_PROGRESS_BARS = not bool(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4236,6 +4236,8 @@ class Dataset:
         refs = self.to_pandas_refs()
         # remove this when https://github.com/mars-project/mars/issues/2945 got fixed
         schema = self.schema()
+        if isinstance(schema, Schema):
+            schema = schema.base_schema
         if isinstance(schema, PandasBlockSchema):
             dtypes = pd.Series(schema.types, index=schema.names)
         elif isinstance(schema, pa.Schema):
@@ -4292,6 +4294,8 @@ class Dataset:
         import raydp
 
         schema = self.schema()
+        if isinstance(schema, Schema):
+            schema = schema.base_schema
         return raydp.spark.ray_dataset_to_spark_dataframe(
             spark, schema, self.get_internal_block_refs()
         )
@@ -4435,6 +4439,8 @@ class Dataset:
         # Schema is safe to call since we have already triggered execution with
         # get_internal_block_refs.
         schema = self.schema(fetch_if_missing=True)
+        if isinstance(schema, Schema):
+            schema = schema.base_schema
         if isinstance(schema, pa.Schema):
             # Zero-copy path.
             return blocks

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -563,8 +563,6 @@ class Dataset:
             ray_remote_args["num_gpus"] = num_gpus
 
         batch_format = _apply_batch_format(batch_format)
-        if batch_format == "native":
-            logger.warning("The 'native' batch format has been renamed 'default'.")
 
         min_rows_per_bundled_input = None
         if batch_size is not None and batch_size != "default":
@@ -3657,8 +3655,6 @@ class Dataset:
             An iterable over batches of data.
         """
         batch_format = _apply_batch_format(batch_format)
-        if batch_format == "native":
-            logger.warning("The 'native' batch format has been renamed 'default'.")
         return self.iterator().iter_batches(
             prefetch_batches=prefetch_batches,
             prefetch_blocks=prefetch_blocks,

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -23,7 +23,7 @@ from ray.data.block import (
     BlockAccessor,
     BlockMetadata,
     DataBatch,
-    _apply_strict_mode_batch_format,
+    _apply_batch_format,
 )
 from ray.types import ObjectRef
 from ray.util.annotations import PublicAPI
@@ -153,7 +153,7 @@ class DataIterator(abc.ABC):
                 "prefetching in terms of batches instead of blocks."
             )
 
-        batch_format = _apply_strict_mode_batch_format(batch_format)
+        batch_format = _apply_batch_format(batch_format)
 
         def _create_iterator() -> Iterator[DataBatch]:
             time_start = time.perf_counter()

--- a/python/ray/data/tests/test_webdataset.py
+++ b/python/ray/data/tests/test_webdataset.py
@@ -142,7 +142,6 @@ def test_webdataset_coding(ray_start_2_cpus, tmp_path):
     image = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)
     gray = np.random.randint(0, 255, (100, 100), dtype=np.uint8)
     dstruct = dict(a=[1], b=dict(c=2), d="hello")
-    # Note: tensors are supported as numpy format only in strict mode.
     ttensor = torch.tensor([1, 2, 3]).numpy()
 
     sample = {

--- a/python/ray/train/tests/lightning_test_utils.py
+++ b/python/ray/train/tests/lightning_test_utils.py
@@ -20,9 +20,6 @@ class LinearModule(pl.LightningModule):
         self.fail_epoch = fail_epoch
 
     def forward(self, input):
-        # Backwards compat for Ray data strict mode.
-        if isinstance(input, dict) and len(input) == 1:
-            input = list(input.values())[0]
         return self.linear(input)
 
     def training_step(self, batch):

--- a/python/ray/train/tests/lightning_test_utils.py
+++ b/python/ray/train/tests/lightning_test_utils.py
@@ -20,6 +20,8 @@ class LinearModule(pl.LightningModule):
         self.fail_epoch = fail_epoch
 
     def forward(self, input):
+        if isinstance(input, dict) and len(input) == 1:
+            input = list(input.values())[0]
         return self.linear(input)
 
     def training_step(self, batch):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In Ray 2.4, we made all datasets tabular (previously, they could represent an unstructured collection of data). This change was called "strict mode." Since it's been several releases since then, it's not obvious what "strict mode" means, so this PR removes it from the code base.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
