### PR TITLE
[serve] change metrics pusher process func to take kwargs

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -254,15 +254,31 @@ class ServeController:
     def get_pid(self) -> int:
         return os.getpid()
 
-    def record_autoscaling_metrics(self, data: Dict[str, float], send_timestamp: float):
+    def record_autoscaling_metrics(
+        self, replica_id: str, window_avg: float, send_timestamp: float
+    ):
         logger.debug(
-            f"Received autoscaling metrics: {data} at timestamp {send_timestamp}"
+            f"Received metrics from replica {replica_id}: {window_avg} running requests"
         )
-        self.deployment_state_manager.record_autoscaling_metrics(data, send_timestamp)
+        self.deployment_state_manager.record_autoscaling_metrics(
+            replica_id, window_avg, send_timestamp
+        )
 
-    def record_handle_metrics(self, data, send_timestamp: float):
-        logger.debug(f"Received handle metrics: {data} at timestamp {send_timestamp}")
-        self.deployment_state_manager.record_handle_metrics(data, send_timestamp)
+    def record_handle_metrics(
+        self,
+        deployment_id: str,
+        handle_id: str,
+        queued_requests: float,
+        running_requests: Dict[str, float],
+        send_timestamp: float,
+    ):
+        logger.debug(
+            f"Received metrics from handle {handle_id} for deployment {deployment_id}: "
+            f"{queued_requests} queued requests and {running_requests} running requests"
+        )
+        self.deployment_state_manager.record_handle_metrics(
+            deployment_id, handle_id, queued_requests, running_requests, send_timestamp
+        )
 
     def _dump_autoscaling_metrics_for_testing(self):
         return self.deployment_state_manager.get_autoscaling_metrics()

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2393,16 +2393,23 @@ class DeploymentStateManager:
             self._save_checkpoint_func,
         )
 
-    def record_autoscaling_metrics(self, data, send_timestamp: float):
-        replica_tag, window_avg = data
+    def record_autoscaling_metrics(
+        self, replica_id: str, window_avg: float, send_timestamp: float
+    ):
         if window_avg is not None:
-            replica_name = ReplicaName.from_replica_tag(replica_tag)
+            replica_name = ReplicaName.from_replica_tag(replica_id)
             self._deployment_states[
                 replica_name.deployment_id
-            ].record_autoscaling_metrics(replica_tag, window_avg, send_timestamp)
+            ].record_autoscaling_metrics(replica_id, window_avg, send_timestamp)
 
-    def record_handle_metrics(self, data, send_timestamp: float):
-        deployment_id, handle_id, queued_requests, running_requests = data
+    def record_handle_metrics(
+        self,
+        deployment_id: str,
+        handle_id: str,
+        queued_requests: float,
+        running_requests: Dict[str, float],
+        send_timestamp: float,
+    ):
         # NOTE(zcin): There can be handles to deleted deployments still
         # sending metrics to the controller
         if deployment_id in self._deployment_states:

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -2313,7 +2313,8 @@ def test_autoscale(mock_deployment_state_manager_full, target_capacity_direction
 
     for replica in depstate._replicas.get():
         deployment_state_manager.record_autoscaling_metrics(
-            (replica._actor.replica_tag, 2 if target_capacity_direction == "up" else 0),
+            replica._actor.replica_tag,
+            2 if target_capacity_direction == "up" else 0,
             None,
         )
 
@@ -2422,7 +2423,7 @@ def test_update_autoscaling_config(mock_deployment_state_manager_full):
     # Num ongoing requests = 1, status should remain HEALTHY
     for replica in depstate._replicas.get():
         deployment_state_manager.record_autoscaling_metrics(
-            (replica._actor.replica_tag, 1), None
+            replica._actor.replica_tag, 1, None
         )
     check_counts(depstate, total=3, by_state=[(ReplicaState.RUNNING, 3)])
     assert depstate.curr_status_info.status == DeploymentStatus.HEALTHY


### PR DESCRIPTION
[serve] change metrics pusher process func to take kwargs

Small improvement so we can call the process/callback functions in metrics pusher with more complicated arguments

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
