### PR TITLE
[data] Fix early stop for multiple limit ops.

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -178,10 +178,10 @@ class PhysicalOperator(Operator):
             assert isinstance(x, PhysicalOperator), x
         self._inputs_complete = not input_dependencies
         self._target_max_block_size = target_max_block_size
-        self._dependents_complete = False
         self._started = False
         self._metrics = OpRuntimeMetrics(self)
         self._estimated_output_blocks = None
+        self._completed = False
 
     def __reduce__(self):
         raise ValueError("Operator is not serializable.")
@@ -207,6 +207,10 @@ class PhysicalOperator(Operator):
     def set_target_max_block_size(self, target_max_block_size: Optional[int]):
         self._target_max_block_size = target_max_block_size
 
+    def mark_completed(self):
+        """Manually mark this operator as completed."""
+        self._completed = True
+
     def completed(self) -> bool:
         """Return True when this operator is completed.
 
@@ -214,11 +218,16 @@ class PhysicalOperator(Operator):
         - All upstream operators are completed and all outputs are taken.
         - All downstream operators are completed.
         """
-        return (
+        if self._completed:
+            return True
+
+        if (
             self._inputs_complete
             and self.num_active_tasks() == 0
             and not self.has_next()
-        ) or self._dependents_complete
+        ):
+            self._completed = True
+        return self._completed
 
     def get_stats(self) -> StatsDict:
         """Return recorded execution stats for use with DatasetStats."""
@@ -270,13 +279,6 @@ class PhysicalOperator(Operator):
         """
         return True
 
-    def need_more_inputs(self) -> bool:
-        """Return true if the operator still needs more inputs.
-
-        Once this return false, it should never return true again.
-        """
-        return True
-
     def add_input(self, refs: RefBundle, input_index: int) -> None:
         """Called when an upstream result is available.
 
@@ -313,13 +315,6 @@ class PhysicalOperator(Operator):
         via `add_input` for any input index.
         """
         self._inputs_complete = True
-
-    def all_dependents_complete(self) -> None:
-        """Called when all downstream operators have completed().
-
-        After this is called, the operator is marked as completed.
-        """
-        self._dependents_complete = True
 
     def has_next(self) -> bool:
         """Returns when a downstream output is available.

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -218,10 +218,7 @@ class PhysicalOperator(Operator):
         outputs are taken.
         """
         if not self._execution_completed:
-            if (
-                self._inputs_complete
-                and self.num_active_tasks() == 0
-            ):
+            if self._inputs_complete and self.num_active_tasks() == 0:
                 # If all inputs are complete and there are no active tasks,
                 # then the operator has completed execution.
                 self._execution_completed = True

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -29,8 +29,7 @@ class LimitOperator(OneToOneOperator):
         self._cur_output_bundles = 0
         super().__init__(self._name, input_op, target_max_block_size=None)
         if self._limit <= 0:
-            self.all_inputs_done()
-            self.mark_completed()
+            self.mark_execution_completed()
 
     def _limit_reached(self) -> bool:
         return self._consumed_rows >= self._limit
@@ -77,8 +76,7 @@ class LimitOperator(OneToOneOperator):
         )
         self._buffer.append(out_refs)
         if self._limit_reached():
-            self.all_inputs_done()
-            self.mark_completed()
+            self.mark_execution_completed()
 
         # We cannot estimate if we have only consumed empty blocks
         if self._consumed_rows > 0:

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -30,12 +30,10 @@ class LimitOperator(OneToOneOperator):
         super().__init__(self._name, input_op, target_max_block_size=None)
         if self._limit <= 0:
             self.all_inputs_done()
+            self.mark_completed()
 
     def _limit_reached(self) -> bool:
         return self._consumed_rows >= self._limit
-
-    def need_more_inputs(self) -> bool:
-        return not self._limit_reached()
 
     def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:
         assert not self.completed()
@@ -80,6 +78,7 @@ class LimitOperator(OneToOneOperator):
         self._buffer.append(out_refs)
         if self._limit_reached():
             self.all_inputs_done()
+            self.mark_completed()
 
         # We cannot estimate if we have only consumed empty blocks
         if self._consumed_rows > 0:
@@ -116,3 +115,6 @@ class LimitOperator(OneToOneOperator):
             return self._estimated_output_blocks
         else:
             return self.input_dependencies[0].num_outputs_total()
+
+    def throttling_disabled(self) -> bool:
+        return True

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -104,10 +104,9 @@ class LimitOperator(OneToOneOperator):
         return {self._name: self._output_metadata}
 
     def num_outputs_total(self) -> int:
-        # Before inputs are completed (either because the limit is reached or
-        # because the inputs operators are done), we don't know how many output
+        # Before execution is completed, we don't know how many output
         # bundles we will have. We estimate based off the consumption so far.
-        if self._inputs_complete:
+        if self._execution_completed:
             return self._cur_output_bundles
         elif self._estimated_output_blocks is not None:
             return self._estimated_output_blocks

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -316,7 +316,7 @@ class StreamingExecutor(Executor, threading.Thread):
                 self._has_op_completed[op] = True
 
         # Keep going until all operators run to completion.
-        return not all(op.completed() for op in topology)
+        return not all(op.completed() and not op.has_next() for op in topology)
 
     def _consumer_idling(self) -> bool:
         """Returns whether the user thread is blocked on topology execution."""

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -316,7 +316,7 @@ class StreamingExecutor(Executor, threading.Thread):
                 self._has_op_completed[op] = True
 
         # Keep going until all operators run to completion.
-        return not all(op.completed() and not op.has_next() for op in topology)
+        return not all(op.completed() for op in topology)
 
     def _consumer_idling(self) -> bool:
         """Returns whether the user thread is blocked on topology execution."""

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -478,8 +478,8 @@ def update_operator_states(topology: Topology) -> None:
             op_state.inputs_done_called = True
 
     # Traverse the topology in reverse topological order.
-    # For each op, if all of its downstream operators don't need any more inputs,
-    # call all_dependents_complete() to also complete this op.
+    # For each op, if all of its downstream operators have completed.
+    # call mark_execution_completed() to also complete this op.
     for op, op_state in reversed(list(topology.items())):
         if op.completed():
             continue

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -466,7 +466,7 @@ def update_operator_states(topology: Topology) -> None:
             continue
         all_inputs_done = True
         for idx, dep in enumerate(op.input_dependencies):
-            if dep.completed() and not topology[dep].outqueue and not dep.has_next():
+            if dep.completed() and not topology[dep].outqueue:
                 if not op_state.input_done_called[idx]:
                     op.input_done(idx)
                     op_state.input_done_called[idx] = True
@@ -487,7 +487,7 @@ def update_operator_states(topology: Topology) -> None:
             dep.completed() for dep in op.output_dependencies
         )
         if dependents_completed:
-            op.mark_completed()
+            op.mark_execution_completed()
 
 
 def select_operator_to_run(

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -173,7 +173,6 @@ class OpState:
         self.inputs_done_called = False
         # Tracks whether `input_done` is called for each input op.
         self.input_done_called = [False] * len(op.input_dependencies)
-        self.dependents_completed_called = False
         # Used for StreamingExecutor to signal exception or end of execution
         self._finished: bool = False
         self._exception: Optional[Exception] = None
@@ -467,7 +466,7 @@ def update_operator_states(topology: Topology) -> None:
             continue
         all_inputs_done = True
         for idx, dep in enumerate(op.input_dependencies):
-            if dep.completed() and not topology[dep].outqueue:
+            if dep.completed() and not topology[dep].outqueue and not dep.has_next():
                 if not op_state.input_done_called[idx]:
                     op.input_done(idx)
                     op_state.input_done_called[idx] = True
@@ -482,14 +481,13 @@ def update_operator_states(topology: Topology) -> None:
     # For each op, if all of its downstream operators don't need any more inputs,
     # call all_dependents_complete() to also complete this op.
     for op, op_state in reversed(list(topology.items())):
-        if op_state.dependents_completed_called:
+        if op.completed():
             continue
         dependents_completed = len(op.output_dependencies) > 0 and all(
-            not dep.need_more_inputs() for dep in op.output_dependencies
+            dep.completed() for dep in op.output_dependencies
         )
         if dependents_completed:
-            op.all_dependents_complete()
-            op_state.dependents_completed_called = True
+            op.mark_completed()
 
 
 def select_operator_to_run(
@@ -518,11 +516,10 @@ def select_operator_to_run(
     for op, state in topology.items():
         under_resource_limits = _execution_allowed(op, resource_manager)
         if (
-            op.need_more_inputs()
+            under_resource_limits
+            and not op.completed()
             and state.num_queued() > 0
             and op.should_add_input()
-            and under_resource_limits
-            and not op.completed()
             and all(p.can_add_input(op) for p in backpressure_policies)
         ):
             ops.append(op)
@@ -551,7 +548,7 @@ def select_operator_to_run(
         ops = [
             op
             for op, state in topology.items()
-            if op.need_more_inputs() and state.num_queued() > 0 and not op.completed()
+            if state.num_queued() > 0 and not op.completed()
         ]
 
     # Nothing to run.

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -614,7 +614,9 @@ def test_limit_operator(ray_start_regular_shared):
         refs = make_ref_bundles([[i] * num_rows_per_block for i in range(num_refs)])
         input_op = InputDataBuffer(refs)
         limit_op = LimitOperator(limit, input_op)
-        limit_op.all_inputs_done = MagicMock(wraps=limit_op.all_inputs_done)
+        limit_op.mark_execution_completed = MagicMock(
+            wraps=limit_op.mark_execution_completed
+        )
         if limit == 0:
             # If the limit is 0, the operator should be completed immediately.
             assert limit_op.completed()
@@ -624,7 +626,7 @@ def test_limit_operator(ray_start_regular_shared):
         while input_op.has_next() and not limit_op._limit_reached():
             loop_count += 1
             assert not limit_op.completed(), limit
-            assert limit_op.need_more_inputs(), limit
+            assert not limit_op._execution_completed, limit
             limit_op.add_input(input_op.get_next(), 0)
             while limit_op.has_next():
                 # Drain the outputs. So the limit operator
@@ -632,16 +634,16 @@ def test_limit_operator(ray_start_regular_shared):
                 limit_op.get_next()
             cur_rows += num_rows_per_block
             if cur_rows >= limit:
-                assert limit_op.all_inputs_done.call_count == 1, limit
+                assert limit_op.mark_execution_completed.call_count == 1, limit
                 assert limit_op.completed(), limit
                 assert limit_op._limit_reached(), limit
-                assert not limit_op.need_more_inputs(), limit
+                assert limit_op._execution_completed, limit
             else:
-                assert limit_op.all_inputs_done.call_count == 0, limit
+                assert limit_op.mark_execution_completed.call_count == 0, limit
                 assert not limit_op.completed(), limit
                 assert not limit_op._limit_reached(), limit
-                assert limit_op.need_more_inputs(), limit
-        limit_op.all_inputs_done()
+                assert not limit_op._execution_completed, limit
+        limit_op.mark_execution_completed()
         # After inputs done, the number of output bundles
         # should be the same as the number of `add_input`s.
         assert limit_op.num_outputs_total() == loop_count, limit


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* When there are multiple limit ops, the dataset should stop when the smallest limit is reached. For example, `ds.limit(1000).limit(1)` should stop when 1 row is outputted. But the current implementation won't. This PR fixes this issue. 
* Also mark LimitOp as `throttling_disabled`, so it will be prioritized in the scheduler. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
