### PR TITLE
[Data] Use `ResourceManager` to estimate object store memory in progress bar

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -226,19 +226,16 @@ class OpState:
         if self.progress_bar:
             self.progress_bar.update(1, self.op._estimated_output_blocks)
 
-    def refresh_progress_bar(self) -> None:
+    def refresh_progress_bar(self, resource_manager: ResourceManager) -> None:
         """Update the console with the latest operator progress."""
         if self.progress_bar:
-            self.progress_bar.set_description(self.summary_str())
+            self.progress_bar.set_description(self.summary_str(resource_manager))
 
-    def summary_str(self) -> str:
+    def summary_str(self, resource_manager: ResourceManager) -> str:
         queued = self.num_queued() + self.op.internal_queue_size()
         active = self.op.num_active_tasks()
         desc = f"- {self.op.name}: {active} active, {queued} queued"
-        mem = memory_string(
-            (self.op.current_resource_usage().object_store_memory or 0)
-            + self.inqueue_memory_usage()
-        )
+        mem = memory_string(resource_manager.get_op_usage(self.op).object_store_memory)
         desc += f", {mem} objects"
         suffix = self.op.progress_str()
         if suffix:

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -16,6 +16,7 @@ from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.map_transformer import (
     create_map_transformer_from_block_fn,
 )
+from ray.data._internal.execution.resource_manager import ResourceManager
 from ray.data._internal.execution.streaming_executor import (
     _debug_dump_topology,
     _validate_dag,
@@ -288,8 +289,10 @@ def test_debug_dump_topology():
         make_map_transformer(lambda block: [b * 2 for b in block]), o2
     )
     topo, _ = build_streaming_topology(o3, opt)
+    resource_manager = ResourceManager(topo, ExecutionOptions())
+    resource_manager.update_usages()
     # Just a sanity check to ensure it doesn't crash.
-    _debug_dump_topology(topo, mock_resource_manager())
+    _debug_dump_topology(topo, resource_manager)
 
 
 def test_validate_dag():

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -289,7 +289,7 @@ def test_debug_dump_topology():
     )
     topo, _ = build_streaming_topology(o3, opt)
     # Just a sanity check to ensure it doesn't crash.
-    _debug_dump_topology(topo)
+    _debug_dump_topology(topo, mock_resource_manager())
 
 
 def test_validate_dag():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

https://github.com/ray-project/ray/pull/42817 introduced a new `ResourceManager` abstraction for estimating operator resource usage, but the code for the progress bar still uses the lower-level `current_resource_usage` abstraction. 

https://github.com/ray-project/ray/blob/9a09d2d0d84e84af26d29d0de981c9552a47d875/python/ray/data/_internal/execution/streaming_executor_state.py#L238

This PR updates the logic to use the higher-level `ResourceManager` abstraction.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
