### PR TITLE
[train] support memory per worker

### DIFF
--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -90,14 +90,13 @@ class BackendExecutor:
         max_retries: int = 3,
     ):
         if resources_per_worker is None:
-            resources_per_worker = {"CPU": 1}
+            self._resources_per_worker = {"CPU": 1}
         else:
-            resources_per_worker = resources_per_worker.copy()
+            self._resources_per_worker = resources_per_worker.copy()
 
         self._backend_config = backend_config
         self._backend = backend_config.backend_cls()
         self._num_workers = num_workers
-        self._resources_per_worker = resources_per_worker
         self._max_failures = max_retries
         if self._max_failures < 0:
             self._max_failures = float("inf")

--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -73,12 +73,9 @@ class BackendExecutor:
         backend_config: The configurations for this
             specific backend.
         num_workers: Number of workers to use for training.
-        num_cpus_per_worker: Number of CPUs to use per worker.
-        num_gpus_per_worker: Number of GPUs to use per worker.
-        additional_resources_per_worker (Optional[Dict[str, float]]):
-            Dictionary specifying the extra resources that will be
-            requested for each worker in addition to ``num_cpus_per_worker``
-            and ``num_gpus_per_worker``.
+        resources_per_worker (Optional[Dict[str, float]]):
+            Dictionary specifying the resources that will be
+            requested for each worker. Defaults to {"CPU": 1}.
         max_retries: Number of retries when Ray actors fail.
             Defaults to 3. Set to -1 for unlimited retries.
     """
@@ -89,17 +86,18 @@ class BackendExecutor:
         # TODO(xwjiang): Legacy Ray Train trainer clean up!
         trial_info: Optional[TrialInfo] = None,
         num_workers: int = 1,
-        num_cpus_per_worker: float = 1,
-        num_gpus_per_worker: float = 0,
-        additional_resources_per_worker: Optional[Dict[str, float]] = None,
+        resources_per_worker: Optional[Dict[str, float]] = None,
         max_retries: int = 3,
     ):
+        if resources_per_worker is None:
+            resources_per_worker = {"CPU": 1}
+        else:
+            resources_per_worker = resources_per_worker.copy()
+
         self._backend_config = backend_config
         self._backend = backend_config.backend_cls()
         self._num_workers = num_workers
-        self._num_cpus_per_worker = num_cpus_per_worker
-        self._num_gpus_per_worker = num_gpus_per_worker
-        self._additional_resources_per_worker = additional_resources_per_worker
+        self._resources_per_worker = resources_per_worker
         self._max_failures = max_retries
         if self._max_failures < 0:
             self._max_failures = float("inf")
@@ -133,9 +131,7 @@ class BackendExecutor:
         placement_group = self._placement_group or "default"
         self.worker_group = WorkerGroup(
             num_workers=self._num_workers,
-            num_cpus_per_worker=self._num_cpus_per_worker,
-            num_gpus_per_worker=self._num_gpus_per_worker,
-            additional_resources_per_worker=self._additional_resources_per_worker,
+            resources_per_worker=self._resources_per_worker,
             actor_cls=train_cls,
             actor_cls_args=train_cls_args,
             actor_cls_kwargs=train_cls_kwargs,
@@ -175,18 +171,20 @@ class BackendExecutor:
                 )
             )
 
-            if self._num_gpus_per_worker > 0 and share_cuda_visible_devices_enabled:
+            if (
+                self._resources_per_worker.get("GPU", 0) > 0
+                and share_cuda_visible_devices_enabled
+            ):
                 self._share_cuda_visible_devices()
-            elif self._additional_resources_per_worker:
-                for resource_config in self._resource_configs:
-                    if self._is_share_resources_enabled(
+            for resource_config in self._resource_configs:
+                if self._is_share_resources_enabled(
+                    resource_config.resource_name,
+                    resource_config.resource_enable_sharing_env_var,
+                ):
+                    self._share_resource_ids(
                         resource_config.resource_name,
-                        resource_config.resource_enable_sharing_env_var,
-                    ):
-                        self._share_resource_ids(
-                            resource_config.resource_name,
-                            resource_config.share_resource_ids_env_var,
-                        )
+                        resource_config.share_resource_ids_env_var,
+                    )
             self._backend.on_start(self.worker_group, self._backend_config)
         except RayActorError as exc:
             logger.exception(str(exc))
@@ -221,15 +219,9 @@ class BackendExecutor:
         )
 
         if should_create_placement_group:
-            additional_resources_per_worker = (
-                self._additional_resources_per_worker or {}
-            )
-            bundle = {
-                "CPU": self._num_cpus_per_worker,
-                "GPU": self._num_gpus_per_worker,
-                **additional_resources_per_worker,
-            }
-            bundles = [bundle.copy() for _ in range(self._num_workers)]
+            bundles = [
+                self._resources_per_worker.copy() for _ in range(self._num_workers)
+            ]
 
             use_spread = bool(env_integer(TRAIN_ENABLE_WORKER_SPREAD_ENV, 0))
             strategy = "SPREAD" if use_spread else "PACK"
@@ -348,9 +340,7 @@ class BackendExecutor:
             enable_sharing_env: The name of the environment variable
                 to check.
         """
-        has_resource_requested = (
-            self._additional_resources_per_worker.get(resource_name, 0) > 0
-        )
+        has_resource_requested = self._resources_per_worker.get(resource_name, 0) > 0
         return has_resource_requested and ray_constants.env_bool(
             enable_sharing_env, True
         )

--- a/python/ray/train/_internal/worker_group.py
+++ b/python/ray/train/_internal/worker_group.py
@@ -155,6 +155,12 @@ class WorkerGroup:
                 f"instead."
             )
 
+        if any(v < 0 for v in resources_per_worker.values()):
+            raise ValueError(
+                "The number of resources per worker must not be negative. "
+                f"Received resources_per_worker={resources_per_worker}."
+            )
+
         if (actor_cls_args or actor_cls_kwargs) and not actor_cls:
             raise ValueError(
                 "`actor_cls_args` or `actor_class_kwargs` are "

--- a/python/ray/train/_internal/worker_group.py
+++ b/python/ray/train/_internal/worker_group.py
@@ -169,11 +169,13 @@ class WorkerGroup:
                 "`actor_cls_args` or `actor_class_kwargs` are "
                 "passed in but no `actor_cls` is passed in."
             )
-
+        
         self.num_workers = num_workers
         self.num_cpus_per_worker = num_cpus_per_worker
         self.num_gpus_per_worker = num_gpus_per_worker
         self.additional_resources_per_worker = additional_resources_per_worker
+        self.memory_per_worker = self.additional_resources_per_worker.pop("memory", None)
+
         self.workers = []
         self._base_cls = create_executable_class(actor_cls)
         assert issubclass(self._base_cls, RayTrainWorker)
@@ -188,6 +190,7 @@ class WorkerGroup:
         self._remote_cls = ray.remote(
             num_cpus=self.num_cpus_per_worker,
             num_gpus=self.num_gpus_per_worker,
+            memory=self.memory_per_worker,
             resources=self.additional_resources_per_worker,
         )(self._base_cls)
         self.start()

--- a/python/ray/train/_internal/worker_group.py
+++ b/python/ray/train/_internal/worker_group.py
@@ -174,7 +174,7 @@ class WorkerGroup:
         self.num_cpus_per_worker = num_cpus_per_worker
         self.num_gpus_per_worker = num_gpus_per_worker
         self.additional_resources_per_worker = additional_resources_per_worker
-        
+
         self.memory_per_worker = None
         if self.additional_resources_per_worker is not None:
             self.memory_per_worker = self.additional_resources_per_worker.pop(

--- a/python/ray/train/_internal/worker_group.py
+++ b/python/ray/train/_internal/worker_group.py
@@ -169,12 +169,14 @@ class WorkerGroup:
                 "`actor_cls_args` or `actor_class_kwargs` are "
                 "passed in but no `actor_cls` is passed in."
             )
-        
+
         self.num_workers = num_workers
         self.num_cpus_per_worker = num_cpus_per_worker
         self.num_gpus_per_worker = num_gpus_per_worker
         self.additional_resources_per_worker = additional_resources_per_worker
-        self.memory_per_worker = self.additional_resources_per_worker.pop("memory", None)
+        self.memory_per_worker = self.additional_resources_per_worker.pop(
+            "memory", None
+        )
 
         self.workers = []
         self._base_cls = create_executable_class(actor_cls)

--- a/python/ray/train/_internal/worker_group.py
+++ b/python/ray/train/_internal/worker_group.py
@@ -174,9 +174,12 @@ class WorkerGroup:
         self.num_cpus_per_worker = num_cpus_per_worker
         self.num_gpus_per_worker = num_gpus_per_worker
         self.additional_resources_per_worker = additional_resources_per_worker
-        self.memory_per_worker = self.additional_resources_per_worker.pop(
-            "memory", None
-        )
+        
+        self.memory_per_worker = None
+        if self.additional_resources_per_worker is not None:
+            self.memory_per_worker = self.additional_resources_per_worker.pop(
+                "memory", None
+            )
 
         self.workers = []
         self._base_cls = create_executable_class(actor_cls)

--- a/python/ray/train/_internal/worker_group.py
+++ b/python/ray/train/_internal/worker_group.py
@@ -112,14 +112,9 @@ class WorkerGroup:
     Args:
         num_workers: The number of workers (Ray actors) to launch.
             Defaults to 1.
-        num_cpus_per_worker: The number of CPUs to reserve for each
-            worker. Fractional values are allowed. Defaults to 1.
-        num_gpus_per_worker: The number of GPUs to reserve for each
-            worker. Fractional values are allowed. Defaults to 0.
-        additional_resources_per_worker (Optional[Dict[str, float]]):
-            Dictionary specifying the extra resources that will be
-            requested for each worker in addition to ``num_cpus_per_worker``
-            and ``num_gpus_per_worker``.
+        resources_per_worker (Optional[Dict[str, float]]):
+            Dictionary specifying the resources that will be
+            requested for each worker. Defaults to {"CPU": 1}.
         actor_cls (Optional[Type]): If specified use this class as the
             remote actors.
         remote_cls_args, remote_cls_kwargs: If ``remote_cls`` is provided,
@@ -142,26 +137,22 @@ class WorkerGroup:
     def __init__(
         self,
         num_workers: int = 1,
-        num_cpus_per_worker: float = 1,
-        num_gpus_per_worker: float = 0,
-        additional_resources_per_worker: Optional[Dict[str, float]] = None,
+        resources_per_worker: Optional[Dict[str, float]] = None,
         actor_cls: Type = None,
         actor_cls_args: Optional[Tuple] = None,
         actor_cls_kwargs: Optional[Dict] = None,
         placement_group: Union[PlacementGroup, str] = "default",
     ):
+        if resources_per_worker is None:
+            resources_per_worker = {"CPU": 1}
+        else:
+            resources_per_worker = resources_per_worker.copy()
+
         if num_workers <= 0:
             raise ValueError(
                 "The provided `num_workers` must be greater "
                 f"than 0. Received num_workers={num_workers} "
                 f"instead."
-            )
-        if num_cpus_per_worker < 0 or num_gpus_per_worker < 0:
-            raise ValueError(
-                "The number of CPUs and GPUs per worker must "
-                "not be negative. Received "
-                f"num_cpus_per_worker={num_cpus_per_worker} and "
-                f"num_gpus_per_worker={num_gpus_per_worker}."
             )
 
         if (actor_cls_args or actor_cls_kwargs) and not actor_cls:
@@ -171,16 +162,9 @@ class WorkerGroup:
             )
 
         self.num_workers = num_workers
-        self.num_cpus_per_worker = num_cpus_per_worker
-        self.num_gpus_per_worker = num_gpus_per_worker
-        self.additional_resources_per_worker = additional_resources_per_worker
-
-        self.memory_per_worker = None
-        if self.additional_resources_per_worker is not None:
-            self.memory_per_worker = self.additional_resources_per_worker.pop(
-                "memory", None
-            )
-
+        self.num_cpus_per_worker = resources_per_worker.pop("CPU", 0)
+        self.num_gpus_per_worker = resources_per_worker.pop("GPU", 0)
+        self.memory_per_worker = resources_per_worker.pop("memory", 0)
         self.workers = []
         self._base_cls = create_executable_class(actor_cls)
         assert issubclass(self._base_cls, RayTrainWorker)
@@ -196,7 +180,7 @@ class WorkerGroup:
             num_cpus=self.num_cpus_per_worker,
             num_gpus=self.num_gpus_per_worker,
             memory=self.memory_per_worker,
-            resources=self.additional_resources_per_worker,
+            resources=resources_per_worker,
         )(self._base_cls)
         self.start()
 

--- a/python/ray/train/data_parallel_trainer.py
+++ b/python/ray/train/data_parallel_trainer.py
@@ -439,8 +439,6 @@ class DataParallelTrainer(BaseTrainer):
             discard_returns=True,
         )
 
-        additional_resources_per_worker = scaling_config.additional_resources_per_worker
-
         trial_info = TrialInfo(
             name=session.get_trial_name(),
             id=session.get_trial_id(),
@@ -454,9 +452,7 @@ class DataParallelTrainer(BaseTrainer):
             backend_config=self._backend_config,
             trial_info=trial_info,
             num_workers=scaling_config.num_workers,
-            num_cpus_per_worker=scaling_config.num_cpus_per_worker,
-            num_gpus_per_worker=scaling_config.num_gpus_per_worker,
-            additional_resources_per_worker=additional_resources_per_worker,
+            resources_per_worker=scaling_config._resources_per_worker_not_none,
             max_retries=0,
         )
 

--- a/python/ray/train/tests/test_backend.py
+++ b/python/ray/train/tests/test_backend.py
@@ -323,7 +323,7 @@ def test_cuda_visible_devices(ray_2_node_2_gpu, worker_results):
 
     os.environ[ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV] = "1"
     e = BackendExecutor(
-        config, num_workers=num_workers, num_cpus_per_worker=0, num_gpus_per_worker=1
+        config, num_workers=num_workers, resources_per_worker={"GPU": 1}
     )
     e.start()
     _start_training(e, get_resources)
@@ -369,7 +369,7 @@ def test_cuda_visible_devices_fractional(ray_2_node_2_gpu, worker_results):
 
     os.environ[ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV] = "1"
     e = BackendExecutor(
-        config, num_workers=num_workers, num_cpus_per_worker=0, num_gpus_per_worker=0.5
+        config, num_workers=num_workers, resources_per_worker={"GPU": 0.5}
     )
     e.start()
     _start_training(e, get_resources)
@@ -408,7 +408,7 @@ def test_cuda_visible_devices_multiple(ray_2_node_4_gpu, worker_results):
 
     os.environ[ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV] = "1"
     e = BackendExecutor(
-        config, num_workers=num_workers, num_cpus_per_worker=0, num_gpus_per_worker=2
+        config, num_workers=num_workers, resources_per_worker={"GPU": 2}
     )
     e.start()
     _start_training(e, get_resources)
@@ -443,8 +443,7 @@ def test_neuron_core_accelerator_ids(ray_2_node_2_neuron_cores, worker_results):
     e = BackendExecutor(
         config,
         num_workers=num_workers,
-        num_cpus_per_worker=0,
-        additional_resources_per_worker={"neuron_cores": 1},
+        resources_per_worker={"neuron_cores": 1},
     )
     e.start()
     _start_training(e, get_resources)
@@ -481,8 +480,7 @@ def test_neuron_core_accelerator_ids_sharing_disabled(
     e = BackendExecutor(
         config,
         num_workers=num_workers,
-        num_cpus_per_worker=0,
-        additional_resources_per_worker={"neuron_cores": 1},
+        resources_per_worker={"neuron_cores": 1},
     )
     e.start()
     _start_training(e, get_resources)

--- a/python/ray/train/tests/test_worker_group.py
+++ b/python/ray/train/tests/test_worker_group.py
@@ -59,9 +59,11 @@ def test_worker_creation_num_cpus(ray_start_2_cpus):
     assert "CPU" not in ray.available_resources()
     wg.shutdown()
 
+
 def test_worker_creation_with_memory(ray_start_2_cpus_and_10kb_memory):
     wg = WorkerGroup(num_workers=2, additional_resources_per_worker={"memory": 1_000})
     assert len(wg.workers) == 2
+
 
 def test_worker_shutdown(ray_start_2_cpus):
     assert ray.available_resources()["CPU"] == 2

--- a/python/ray/train/tests/test_worker_group.py
+++ b/python/ray/train/tests/test_worker_group.py
@@ -52,7 +52,7 @@ def test_worker_creation(ray_start_2_cpus):
 
 def test_worker_creation_num_cpus(ray_start_2_cpus):
     assert ray.available_resources()["CPU"] == 2
-    wg = WorkerGroup(num_cpus_per_worker=2)
+    wg = WorkerGroup(resources_per_worker={"CPU": 2})
     time.sleep(1)
     assert len(wg.workers) == 1
     # Make sure both CPUs are being used by the actor.
@@ -61,7 +61,7 @@ def test_worker_creation_num_cpus(ray_start_2_cpus):
 
 
 def test_worker_creation_with_memory(ray_start_2_cpus_and_10kb_memory):
-    wg = WorkerGroup(num_workers=2, additional_resources_per_worker={"memory": 1_000})
+    wg = WorkerGroup(num_workers=2, resources_per_worker={"memory": 1_000})
     assert len(wg.workers) == 2
 
 
@@ -92,7 +92,7 @@ def test_worker_restart(ray_start_2_cpus):
 
 def test_worker_with_gpu_ids(ray_start_2_cpus_and_gpus):
     num_gpus = 2
-    wg = WorkerGroup(num_workers=2, num_gpus_per_worker=1)
+    wg = WorkerGroup(num_workers=2, resources_per_worker={"GPU": 1})
     assert len(wg.workers) == 2
     time.sleep(1)
     assert ray_constants.GPU not in ray.available_resources()
@@ -111,7 +111,7 @@ def test_worker_with_neuron_core_accelerator_ids(
 ):
     num_nc = 2
     wg = WorkerGroup(
-        num_workers=2, additional_resources_per_worker={ray_constants.NEURON_CORES: 1}
+        num_workers=2, resources_per_worker={ray_constants.NEURON_CORES: 1}
     )
     assert len(wg.workers) == 2
     time.sleep(1)
@@ -284,10 +284,13 @@ def test_bad_resources(ray_start_2_cpus):
         WorkerGroup(num_workers=-1)
 
     with pytest.raises(ValueError):
-        WorkerGroup(num_cpus_per_worker=-1)
+        WorkerGroup(resources_per_worker={"CPU": -1})
 
     with pytest.raises(ValueError):
-        WorkerGroup(num_gpus_per_worker=-1)
+        WorkerGroup(resources_per_worker={"GPU": -1})
+
+    with pytest.raises(ValueError):
+        WorkerGroup(resources_per_worker={"memory": -1})
 
 
 def test_placement_group(ray_start_2_cpus):

--- a/python/ray/train/tests/test_worker_group.py
+++ b/python/ray/train/tests/test_worker_group.py
@@ -32,6 +32,14 @@ def ray_start_2_cpus_and_neuron_core_accelerator():
     ray.shutdown()
 
 
+@pytest.fixture
+def ray_start_2_cpus_and_10kb_memory():
+    address_info = ray.init(num_cpus=2, _memory=10_000)
+    yield address_info
+    # The code after the yield will run as teardown code.
+    ray.shutdown()
+
+
 def test_worker_creation(ray_start_2_cpus):
     assert ray.available_resources()["CPU"] == 2
     wg = WorkerGroup(num_workers=2)
@@ -51,6 +59,9 @@ def test_worker_creation_num_cpus(ray_start_2_cpus):
     assert "CPU" not in ray.available_resources()
     wg.shutdown()
 
+def test_worker_creation_with_memory(ray_start_2_cpus_and_10kb_memory):
+    wg = WorkerGroup(num_workers=2, additional_resources_per_worker={"memory": 1_000})
+    assert len(wg.workers) == 2
 
 def test_worker_shutdown(ray_start_2_cpus):
     assert ray.available_resources()["CPU"] == 2

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -158,7 +158,7 @@ class LearnerGroup:
             num_gpus_per_worker = self.config.num_gpus_per_learner_worker
             resources_per_worker = {
                 "CPU": num_cpus_per_worker,
-                "GPU": num_gpus_per_worker
+                "GPU": num_gpus_per_worker,
             }
 
             backend_executor = BackendExecutor(

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -151,16 +151,14 @@ class LearnerGroup:
             #  to issues with placement group fragmentation. See
             #  https://github.com/ray-project/ray/issues/35409 for more details.
             num_cpus_per_worker = (
-                (
-                    self.config.num_cpus_per_learner_worker
-                    if not self.config.num_gpus_per_learner_worker
-                    else 0
-                ),
+                self.config.num_cpus_per_learner_worker
+                if not self.config.num_gpus_per_learner_worker
+                else 0
             )
             num_gpus_per_worker = self.config.num_gpus_per_learner_worker
             resources_per_worker = {
                 "CPU": num_cpus_per_worker,
-                "GPU": num_gpus_per_worker,
+                "GPU": num_gpus_per_worker
             }
 
             backend_executor = BackendExecutor(

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -157,7 +157,7 @@ class LearnerGroup:
                     else 0
                 ),
             )
-            num_gpus_per_worker = (self.config.num_gpus_per_learner_worker,)
+            num_gpus_per_worker = self.config.num_gpus_per_learner_worker
             resources_per_worker = {
                 "CPU": num_cpus_per_worker,
                 "GPU": num_gpus_per_worker,

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -145,19 +145,28 @@ class LearnerGroup:
         # N remote Learner workers.
         else:
             backend_config = _get_backend_config(learner_class)
-            backend_executor = BackendExecutor(
-                backend_config=backend_config,
-                num_workers=self.config.num_learner_workers,
-                # TODO (sven): Cannot set both `num_cpus_per_learner_worker`>1 and
-                #  `num_gpus_per_learner_worker`>0! Users must set one or the other due
-                #  to issues with placement group fragmentation. See
-                #  https://github.com/ray-project/ray/issues/35409 for more details.
-                num_cpus_per_worker=(
+
+            # TODO (sven): Cannot set both `num_cpus_per_learner_worker`>1 and
+            #  `num_gpus_per_learner_worker`>0! Users must set one or the other due
+            #  to issues with placement group fragmentation. See
+            #  https://github.com/ray-project/ray/issues/35409 for more details.
+            num_cpus_per_worker = (
+                (
                     self.config.num_cpus_per_learner_worker
                     if not self.config.num_gpus_per_learner_worker
                     else 0
                 ),
-                num_gpus_per_worker=self.config.num_gpus_per_learner_worker,
+            )
+            num_gpus_per_worker = (self.config.num_gpus_per_learner_worker,)
+            resources_per_worker = {
+                "CPU": num_cpus_per_worker,
+                "GPU": num_gpus_per_worker,
+            }
+
+            backend_executor = BackendExecutor(
+                backend_config=backend_config,
+                num_workers=self.config.num_learner_workers,
+                resources_per_worker=resources_per_worker,
                 max_retries=0,
             )
             backend_executor.start(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This enables scheduling Ray Train Workers by specifying `"memory"` in `ScalingConfig.resources_per_worker`. This additional logic is necessary because Ray Actors require the special `memory` kwarg rather than  a `"memory"` entry in the `resources` dictionary.

As part of this change, I am also changing the interface of `BackendExecutor` and `WorkerGroup` to simply take a dictionary for all `resources`. This matches the interface of `ScalingConfig` and `PlacementGroup`, and centralizes all logic to convert to Ray Actor/Task kwargs in `WorkerGroup`. 

**Example:**
```python
from ray.train import ScalingConfig
from ray.train.torch import TorchTrainer


scaling_config = ScalingConfig(num_workers=2, resources_per_worker={"memory": 10_000})


def train_func(): 
    ...


trainer = TorchTrainer(train_func, scaling_config=scaling_config)
trainer.fit()
```

**Before:**
```
ValueError: The resources dictionary must not contain the key 'memory' or 'object_store_memory'
```

**After:**
```

(TorchTrainer pid=67598) Started distributed worker processes: 
(TorchTrainer pid=67598) - (ip=127.0.0.1, pid=67604) world_rank=0, local_rank=0, node_rank=0
(TorchTrainer pid=67598) - (ip=127.0.0.1, pid=67605) world_rank=1, local_rank=1, node_rank=0
(RayTrainWorker pid=67604) Setting up process group for: env:// [rank=0, world_size=2]
```


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
