### PR TITLE
[serve] rename max concurrent queries

### DIFF
--- a/dashboard/client/src/type/serve.ts
+++ b/dashboard/client/src/type/serve.ts
@@ -39,7 +39,7 @@ export type ServeDeployment = {
 export type ServeDeploymentConfig = {
   name: string;
   num_replicas: number;
-  max_concurrent_queries: number;
+  max_ongoing_requests: number;
   user_config: Record<string, any> | null;
   autoscaling_config: ServeAutoscalingConfig | null;
   graceful_shutdown_wait_loop_s: number;

--- a/doc/source/serve/advanced-guides/inplace-updates.md
+++ b/doc/source/serve/advanced-guides/inplace-updates.md
@@ -12,7 +12,7 @@ Lightweight config updates modify running deployment replicas without tearing th
 - `num_replicas`
 - `autoscaling_config`
 - `user_config`
-- `max_concurrent_queries`
+- `max_ongoing_requests`
 - `graceful_shutdown_timeout_s`
 - `graceful_shutdown_wait_loop_s`
 - `health_check_period_s`

--- a/doc/source/serve/advanced-guides/performance.md
+++ b/doc/source/serve/advanced-guides/performance.md
@@ -46,9 +46,9 @@ According to the [FastAPI documentation](https://fastapi.tiangolo.com/async/#ver
 
 Are you using `async def` in your callable? If you are using `asyncio` and
 hitting the same queuing issue mentioned above, you might want to increase
-`max_concurrent_queries`. Serve sets a low number (100) by default so the client gets
+`max_ongoing_requests`. Serve sets a low number (100) by default so the client gets
 proper backpressure. You can increase the value in the deployment decorator; e.g.
-`@serve.deployment(max_concurrent_queries=1000)`.
+`@serve.deployment(max_ongoing_requests=1000)`.
 
 (serve-performance-e2e-timeout)=
 ### Set an end-to-end request timeout

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -236,7 +236,7 @@ Content-Type: application/json
                     "deployment_config": {
                         "name": "Translator",
                         "num_replicas": 1,
-                        "max_concurrent_queries": 100,
+                        "max_ongoing_requests": 100,
                         "user_config": {
                             "language": "german"
                         },
@@ -274,7 +274,7 @@ Content-Type: application/json
                     "deployment_config": {
                         "name": "Summarizer",
                         "num_replicas": 1,
-                        "max_concurrent_queries": 100,
+                        "max_ongoing_requests": 100,
                         "user_config": null,
                         "graceful_shutdown_wait_loop_s": 2.0,
                         "graceful_shutdown_timeout_s": 20.0,

--- a/doc/source/serve/architecture.md
+++ b/doc/source/serve/architecture.md
@@ -46,7 +46,7 @@ When an HTTP or gRPC request is sent to the corresponding HTTP or gRPC proxy, th
   application name metadata. Serve places the request in a queue.
 3. For each request in a deployment's queue, an available replica is looked up
   and the request is sent to it. If no replicas are available (that is, more
-  than `max_concurrent_queries` requests are outstanding at each replica), the request
+  than `max_ongoing_requests` requests are outstanding at each replica), the request
   is left in the queue until a replica becomes available.
 
 Each replica maintains a queue of requests and executes requests one at a time, possibly
@@ -88,7 +88,7 @@ Ray Serve's autoscaling feature automatically increases or decreases a deploymen
 - The Serve Autoscaler runs in the Serve Controller actor.
 - Each `DeploymentHandle` and each replica periodically pushes its metrics to the autoscaler.
 - For each deployment, the autoscaler periodically checks `DeploymentHandle` queues and in-flight queries on replicas to decide whether or not to scale the number of replicas.
-- Each `DeploymentHandle` continuously polls the controller to check for new deployment replicas. Whenever new replicas are discovered, it sends any buffered or new queries to the replica until `max_concurrent_queries` is reached.  Queries are sent to replicas in round-robin fashion, subject to the constraint that no replica is handling more than `max_concurrent_queries` requests at a time.
+- Each `DeploymentHandle` continuously polls the controller to check for new deployment replicas. Whenever new replicas are discovered, it sends any buffered or new queries to the replica until `max_ongoing_requests` is reached.  Queries are sent to replicas in round-robin fashion, subject to the constraint that no replica is handling more than `max_ongoing_requests` requests at a time.
 
 :::{note}
 When the controller dies, requests can still be sent via HTTP, gRPC and `DeploymentHandle`, but autoscaling is paused. When the controller recovers, the autoscaling resumes, but all previous metrics collected are lost.

--- a/doc/source/serve/autoscaling-guide.md
+++ b/doc/source/serve/autoscaling-guide.md
@@ -25,14 +25,14 @@ deployments:
 Instead of setting a fixed number of replicas for a deployment and manually updating it, you can configure a deployment to autoscale based on incoming traffic. The Serve autoscaler reacts to traffic spikes by monitoring queue sizes and making scaling decisions to add or remove replicas. Configure it by setting the [autoscaling_config](../serve/api/doc/ray.serve.config.AutoscalingConfig.rst) field in deployment options. The following is a quick guide on how to configure autoscaling.
 
 * **target_num_ongoing_requests_per_replica** is the average number of ongoing requests per replica that the Serve autoscaler will try to ensure. Set this to a reasonable number (for example, 5) and adjust it based on your request processing length (the longer the requests, the smaller this number should be) as well as your latency objective (the shorter you want your latency to be, the smaller this number should be).
-* **max_concurrent_queries** (not in autoscaling config) is the maximum number of ongoing requests allowed for a replica. Set this to a value ~20-50% greater than `target_num_ongoing_requests_per_replica`. Note this is not part of the autoscaling config since it is relevant to all deployments, but it is important to set it relative to the target value if autoscaling is turned on for your deployment.
+* **max_ongoing_requests** (replaces the deprecated `max_concurrent_queries`) is the maximum number of ongoing requests allowed for a replica. Set this to a value ~20-50% greater than `target_num_ongoing_requests_per_replica`. Note this is not part of the autoscaling config since it is relevant to all deployments, but it is important to set it relative to the target value if autoscaling is turned on for your deployment.
 * **min_replicas** is the minimum number of replicas for the deployment. Set this to 0 if there are long periods of no traffic and some extra tail latency during upscale is acceptable. Otherwise, set this to what you think you need for low traffic.
 * **max_replicas** is the maximum number of replicas for the deployment. Set this to ~20% higher than what you think you need for peak traffic.
 
 An example deployment config with autoscaling configured would be:
 ```yaml
 - name: Model
-  max_concurrent_queries: 14
+  max_ongoing_requests: 14
   autoscaling_config:
     target_num_ongoing_requests_per_replica: 10
     min_replicas: 0
@@ -64,7 +64,7 @@ applications:
     import_path: resnet:app
     deployments:
     - name: Model
-      max_concurrent_queries: 5
+      max_ongoing_requests: 5
       autoscaling_config:
         target_num_ongoing_requests_per_replica: 1
         min_replicas: 0

--- a/doc/source/serve/configure-serve-deployment.md
+++ b/doc/source/serve/configure-serve-deployment.md
@@ -15,7 +15,7 @@ You can also refer to the [API reference](../serve/api/doc/ray.serve.deployment_
 - `name` - Name uniquely identifying this deployment within the application. If not provided, the name of the class or function is used.
 - `num_replicas` - Number of replicas to run that handle requests to this deployment. Defaults to 1.
 - `ray_actor_options` - Options to pass to the Ray Actor decorator, such as resource requirements. Valid options are: `accelerator_type`, `memory`, `num_cpus`, `num_gpus`, `object_store_memory`, `resources`, and `runtime_env` For more details - [Resource management in Serve](serve-cpus-gpus)
-- `max_concurrent_queries` - Maximum number of queries that are sent to a replica of this deployment without receiving a response. Defaults to 100. This may be an important parameter to configure for [performance tuning](serve-perf-tuning).
+- `max_ongoing_requests` (replaces the deprecated `max_concurrent_queries`) - Maximum number of queries that are sent to a replica of this deployment without receiving a response. Defaults to 100. This may be an important parameter to configure for [performance tuning](serve-perf-tuning).
 - `autoscaling_config` - Parameters to configure autoscaling behavior. If this is set, you can't set `num_replicas`. For more details on configurable parameters for autoscaling, see [Ray Serve Autoscaling](serve-autoscaling). 
 - `user_config` -  Config to pass to the reconfigure method of the deployment. This can be updated dynamically without restarting the replicas of the deployment. The user_config must be fully JSON-serializable. For more details, see [Serve User Config](serve-user-config). 
 - `health_check_period_s` - Duration between health check calls for the replica. Defaults to 10s. The health check is by default a no-op Actor call to the replica, but you can define your own health check using the "check_health" method in your deployment that raises an exception when unhealthy.
@@ -63,7 +63,7 @@ applications:
   deployments:
   - name: Translator
     num_replicas: 2
-    max_concurrent_queries: 100
+    max_ongoing_requests: 100
     graceful_shutdown_wait_loop_s: 2.0
     graceful_shutdown_timeout_s: 20.0
     health_check_period_s: 10.0

--- a/doc/source/serve/doc_code/configure_serve_deployment/model_deployment.py
+++ b/doc/source/serve/doc_code/configure_serve_deployment/model_deployment.py
@@ -12,7 +12,7 @@ from ray import serve
     name="Translator",
     num_replicas=2,
     ray_actor_options={"num_cpus": 0.2, "num_gpus": 0},
-    max_concurrent_queries=100,
+    max_ongoing_requests=100,
     health_check_period_s=10,
     health_check_timeout_s=30,
     graceful_shutdown_timeout_s=20,

--- a/doc/source/serve/doc_code/resnet50_example.py
+++ b/doc/source/serve/doc_code/resnet50_example.py
@@ -14,7 +14,7 @@ from ray import serve
 
 @serve.deployment(
     ray_actor_options={"num_cpus": 1},
-    max_concurrent_queries=5,
+    max_ongoing_requests=5,
     autoscaling_config={
         "target_num_ongoing_requests_per_replica": 1,
         "min_replicas": 0,

--- a/doc/source/templates/03_serving_stable_diffusion/app.py
+++ b/doc/source/templates/03_serving_stable_diffusion/app.py
@@ -33,7 +33,7 @@ class APIIngress:
 
 @serve.deployment(
     ray_actor_options={"num_gpus": 1, "num_cpus": 1},
-    max_concurrent_queries=2,
+    max_ongoing_requests=2,
     autoscaling_config={
         "min_replicas": 1,
         "max_replicas": 3,

--- a/java/serve/src/main/java/io/ray/serve/config/DeploymentConfig.java
+++ b/java/serve/src/main/java/io/ray/serve/config/DeploymentConfig.java
@@ -23,10 +23,16 @@ public class DeploymentConfig implements Serializable {
   private Integer numReplicas = 1;
 
   /**
-   * The maximum number of queries that can be sent to a replica of this deployment without
-   * receiving a response. Defaults to 100.
+   * [DEPRECATED] The maximum number of queries that can be sent to a replica of this deployment
+   * without receiving a response. Defaults to 100.
    */
   private Integer maxConcurrentQueries = 100;
+
+  /**
+   * The maximum number of requests that can be sent to a replica of this deployment without
+   * receiving a response. Defaults to 100.
+   */
+  private Integer maxOngoingRequests = 100;
 
   /**
    * Arguments to pass to the reconfigure method of the deployment. The reconfigure method is called
@@ -79,10 +85,22 @@ public class DeploymentConfig implements Serializable {
     return maxConcurrentQueries;
   }
 
+  public Integer getMaxOngoingRequests() {
+    return maxOngoingRequests;
+  }
+
   public DeploymentConfig setMaxConcurrentQueries(Integer maxConcurrentQueries) {
     if (maxConcurrentQueries != null) {
       Preconditions.checkArgument(maxConcurrentQueries > 0, "max_concurrent_queries must be > 0");
       this.maxConcurrentQueries = maxConcurrentQueries;
+    }
+    return this;
+  }
+
+  public DeploymentConfig setMaxOngoingRequests(Integer maxOngoingRequests) {
+    if (maxOngoingRequests != null) {
+      Preconditions.checkArgument(maxOngoingRequests > 0, "max_ongoing_requests must be > 0");
+      this.maxOngoingRequests = maxOngoingRequests;
     }
     return this;
   }
@@ -190,10 +208,16 @@ public class DeploymentConfig implements Serializable {
   }
 
   public byte[] toProtoBytes() {
+    Integer maxOngoingRequests;
+    if (this.maxOngoingRequests == null) {
+      maxOngoingRequests = this.maxConcurrentQueries;
+    } else {
+      maxOngoingRequests = this.maxOngoingRequests;
+    }
     io.ray.serve.generated.DeploymentConfig.Builder builder =
         io.ray.serve.generated.DeploymentConfig.newBuilder()
             .setNumReplicas(numReplicas)
-            .setMaxConcurrentQueries(maxConcurrentQueries)
+            .setMaxOngoingRequests(maxOngoingRequests)
             .setMaxQueuedRequests(-1)
             .setGracefulShutdownWaitLoopS(gracefulShutdownWaitLoopS)
             .setGracefulShutdownTimeoutS(gracefulShutdownTimeoutS)
@@ -215,7 +239,7 @@ public class DeploymentConfig implements Serializable {
     io.ray.serve.generated.DeploymentConfig.Builder builder =
         io.ray.serve.generated.DeploymentConfig.newBuilder()
             .setNumReplicas(numReplicas)
-            .setMaxConcurrentQueries(maxConcurrentQueries)
+            .setMaxOngoingRequests(maxOngoingRequests)
             .setGracefulShutdownWaitLoopS(gracefulShutdownWaitLoopS)
             .setGracefulShutdownTimeoutS(gracefulShutdownTimeoutS)
             .setHealthCheckPeriodS(healthCheckPeriodS)
@@ -238,7 +262,8 @@ public class DeploymentConfig implements Serializable {
       return deploymentConfig;
     }
     deploymentConfig.setNumReplicas(proto.getNumReplicas());
-    deploymentConfig.setMaxConcurrentQueries(proto.getMaxConcurrentQueries());
+    deploymentConfig.setMaxConcurrentQueries(proto.getMaxOngoingRequests());
+    deploymentConfig.setMaxOngoingRequests(proto.getMaxOngoingRequests());
     deploymentConfig.setGracefulShutdownWaitLoopS(proto.getGracefulShutdownWaitLoopS());
     deploymentConfig.setGracefulShutdownTimeoutS(proto.getGracefulShutdownTimeoutS());
     deploymentConfig.setCrossLanguage(proto.getIsCrossLanguage());

--- a/python/ray/serve/_private/benchmarks/microbenchmark.py
+++ b/python/ray/serve/_private/benchmarks/microbenchmark.py
@@ -42,9 +42,9 @@ def build_app(
     intermediate_handles: bool,
     num_replicas: int,
     max_batch_size: int,
-    max_concurrent_queries: int,
+    max_ongoing_requests: int,
 ):
-    @serve.deployment(max_concurrent_queries=1000)
+    @serve.deployment(max_ongoing_requests=1000)
     class Upstream:
         def __init__(self, handle: DeploymentHandle):
             self._handle = handle
@@ -57,7 +57,7 @@ def build_app(
 
     @serve.deployment(
         num_replicas=num_replicas,
-        max_concurrent_queries=max_concurrent_queries,
+        max_ongoing_requests=max_ongoing_requests,
     )
     class Downstream:
         def __init__(self):
@@ -84,14 +84,14 @@ async def trial(
     intermediate_handles: bool,
     num_replicas: int,
     max_batch_size: int,
-    max_concurrent_queries: int,
+    max_ongoing_requests: int,
     data_size: str,
 ) -> Dict[str, float]:
     results = {}
 
     trial_key_base = (
         f"replica:{num_replicas}/batch_size:{max_batch_size}/"
-        f"concurrent_queries:{max_concurrent_queries}/"
+        f"concurrent_queries:{max_ongoing_requests}/"
         f"data_size:{data_size}/intermediate_handle:{intermediate_handles}"
     )
 
@@ -99,12 +99,12 @@ async def trial(
         f"intermediate_handles={intermediate_handles},"
         f"num_replicas={num_replicas},"
         f"max_batch_size={max_batch_size},"
-        f"max_concurrent_queries={max_concurrent_queries},"
+        f"max_ongoing_requests={max_ongoing_requests},"
         f"data_size={data_size}"
     )
 
     app = build_app(
-        intermediate_handles, num_replicas, max_batch_size, max_concurrent_queries
+        intermediate_handles, num_replicas, max_batch_size, max_ongoing_requests
     )
     serve.run(app)
 
@@ -154,7 +154,7 @@ async def main():
     results = {}
     for intermediate_handles in [False, True]:
         for num_replicas in [1, 8]:
-            for max_batch_size, max_concurrent_queries in [
+            for max_batch_size, max_ongoing_requests in [
                 (1, 1),
                 (1, 10000),
                 (10000, 10000),
@@ -166,7 +166,7 @@ async def main():
                             intermediate_handles,
                             num_replicas,
                             max_batch_size,
-                            max_concurrent_queries,
+                            max_ongoing_requests,
                             data_size,
                         )
                     )

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -578,7 +578,7 @@ class RunningReplicaInfo:
     node_id: Optional[str]
     availability_zone: Optional[str]
     actor_handle: ActorHandle
-    max_concurrent_queries: int
+    max_ongoing_requests: int
     is_cross_language: bool = False
     multiplexed_model_ids: List[str] = field(default_factory=list)
 
@@ -596,7 +596,7 @@ class RunningReplicaInfo:
                     self.replica_tag,
                     self.node_id if self.node_id else "",
                     str(self.actor_handle._actor_id),
-                    str(self.max_concurrent_queries),
+                    str(self.max_ongoing_requests),
                     str(self.is_cross_language),
                     str(self.multiplexed_model_ids),
                 ]

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -23,9 +23,9 @@ from ray.serve._private.constants import (
     DEFAULT_GRACEFUL_SHUTDOWN_WAIT_LOOP_S,
     DEFAULT_HEALTH_CHECK_PERIOD_S,
     DEFAULT_HEALTH_CHECK_TIMEOUT_S,
-    DEFAULT_MAX_CONCURRENT_QUERIES,
+    DEFAULT_MAX_ONGOING_REQUESTS,
     MAX_REPLICAS_PER_NODE_MAX_VALUE,
-    NEW_DEFAULT_MAX_CONCURRENT_QUERIES,
+    NEW_DEFAULT_MAX_ONGOING_REQUESTS,
 )
 from ray.serve._private.utils import DEFAULT, DeploymentOptionUpdateType
 from ray.serve.config import AutoscalingConfig
@@ -85,7 +85,7 @@ class DeploymentConfig(BaseModel):
     Args:
         num_replicas: The number of processes to start up that
             handles requests to this deployment. Defaults to 1.
-        max_concurrent_queries: The maximum number of queries
+        max_ongoing_requests: The maximum number of queries
             that is sent to a replica of this deployment without receiving
             a response. Defaults to 100.
         max_queued_requests: Maximum number of requests to this deployment that will be
@@ -115,8 +115,8 @@ class DeploymentConfig(BaseModel):
     num_replicas: Optional[NonNegativeInt] = Field(
         default=1, update_type=DeploymentOptionUpdateType.LightWeight
     )
-    max_concurrent_queries: PositiveInt = Field(
-        default=DEFAULT_MAX_CONCURRENT_QUERIES,
+    max_ongoing_requests: PositiveInt = Field(
+        default=DEFAULT_MAX_ONGOING_REQUESTS,
         update_type=DeploymentOptionUpdateType.NeedsReconfigure,
     )
     max_queued_requests: int = Field(
@@ -320,15 +320,15 @@ class DeploymentConfig(BaseModel):
 
 
 def handle_num_replicas_auto(
-    max_concurrent_queries: Union[int, DEFAULT],
+    max_ongoing_requests: Union[int, DEFAULT],
     autoscaling_config: Optional[Union[Dict, AutoscalingConfig, DEFAULT]],
 ):
-    """Return modified `max_concurrent_queries` and `autoscaling_config`
+    """Return modified `max_ongoing_requests` and `autoscaling_config`
     for when num_replicas="auto".
 
-    If `max_concurrent_queries` is unspecified (DEFAULT.VALUE), returns
-    the modified value NEW_DEFAULT_MAX_CONCURRENT_QUERIES. Otherwise,
-    doesn't change `max_concurrent_queries`.
+    If `max_ongoing_requests` is unspecified (DEFAULT.VALUE), returns
+    the modified value NEW_DEFAULT_MAX_ONGOING_REQUESTS. Otherwise,
+    doesn't change `max_ongoing_requests`.
 
     If `autoscaling_config` is unspecified, returns the modified value
     AutoscalingConfig.default().
@@ -336,8 +336,8 @@ def handle_num_replicas_auto(
     override that of AutoscalingConfig.default().
     """
 
-    if max_concurrent_queries is DEFAULT.VALUE:
-        max_concurrent_queries = NEW_DEFAULT_MAX_CONCURRENT_QUERIES
+    if max_ongoing_requests is DEFAULT.VALUE:
+        max_ongoing_requests = NEW_DEFAULT_MAX_ONGOING_REQUESTS
 
     if autoscaling_config in [DEFAULT.VALUE, None]:
         # If autoscaling config wasn't specified, use default
@@ -355,7 +355,7 @@ def handle_num_replicas_auto(
         default_config.update(autoscaling_config)
         autoscaling_config = AutoscalingConfig(**default_config)
 
-    return max_concurrent_queries, autoscaling_config
+    return max_ongoing_requests, autoscaling_config
 
 
 class ReplicaConfig:

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -97,8 +97,8 @@ DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_S = 20
 DEFAULT_GRACEFUL_SHUTDOWN_WAIT_LOOP_S = 2
 DEFAULT_HEALTH_CHECK_PERIOD_S = 10
 DEFAULT_HEALTH_CHECK_TIMEOUT_S = 30
-DEFAULT_MAX_CONCURRENT_QUERIES = 100
-NEW_DEFAULT_MAX_CONCURRENT_QUERIES = 5
+DEFAULT_MAX_ONGOING_REQUESTS = 100
+NEW_DEFAULT_MAX_ONGOING_REQUESTS = 5
 
 # HTTP Proxy health check configs
 PROXY_HEALTH_CHECK_TIMEOUT_S = (
@@ -268,10 +268,10 @@ RAY_SERVE_ENABLE_QUEUE_LENGTH_CACHE = (
     os.environ.get("RAY_SERVE_ENABLE_QUEUE_LENGTH_CACHE", "1") == "1"
 )
 
-# Feature flag for strictly enforcing max_concurrent_queries (replicas will reject
+# Feature flag for strictly enforcing max_ongoing_requests (replicas will reject
 # requests).
-RAY_SERVE_ENABLE_STRICT_MAX_CONCURRENT_QUERIES = (
-    os.environ.get("RAY_SERVE_ENABLE_STRICT_MAX_CONCURRENT_QUERIES", "0") == "1"
+RAY_SERVE_ENABLE_STRICT_MAX_ONGOING_REQUESTS = (
+    os.environ.get("RAY_SERVE_ENABLE_STRICT_MAX_ONGOING_REQUESTS", "0") == "1"
     # Strict enforcement path must be enabled for the queue length cache.
     or RAY_SERVE_ENABLE_QUEUE_LENGTH_CACHE
 )

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -333,8 +333,8 @@ class ActorReplicaWrapper:
         return self._version.deployment_config
 
     @property
-    def max_concurrent_queries(self) -> int:
-        return self.deployment_config.max_concurrent_queries
+    def max_ongoing_requests(self) -> int:
+        return self.deployment_config.max_ongoing_requests
 
     @property
     def max_queued_requests(self) -> int:
@@ -916,7 +916,7 @@ class DeploymentReplica(VersionedReplica):
             node_id=self.actor_node_id,
             availability_zone=cluster_node_info_cache.get_node_az(self.actor_node_id),
             actor_handle=self._actor.actor_handle,
-            max_concurrent_queries=self._actor.max_concurrent_queries,
+            max_ongoing_requests=self._actor.max_ongoing_requests,
             is_cross_language=self._actor.is_cross_language,
             multiplexed_model_ids=self.multiplexed_model_ids,
         )

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -493,11 +493,11 @@ class ReplicaActor:
         *request_args,
         **request_kwargs,
     ) -> AsyncGenerator[Any, None]:
-        """Entrypoint for all requests with strict max_concurrent_queries enforcement.
+        """Entrypoint for all requests with strict max_ongoing_requests enforcement.
 
         The first response from this generator is always a system message indicating
         if the request was accepted (the replica has capacity for the request) or
-        rejected (the replica is already at max_concurrent_queries).
+        rejected (the replica is already at max_ongoing_requests).
 
         For non-streaming requests, there will only be one more message, the unary
         result of the user request handler.
@@ -506,11 +506,11 @@ class ReplicaActor:
         user request handler (which must be a generator).
         """
         request_metadata = pickle.loads(pickled_request_metadata)
-        limit = self._deployment_config.max_concurrent_queries
+        limit = self._deployment_config.max_ongoing_requests
         num_ongoing_requests = self.get_num_ongoing_requests()
         if num_ongoing_requests >= limit:
             logger.warning(
-                f"Replica at capacity of max_concurrent_queries={limit}, "
+                f"Replica at capacity of max_ongoing_requests={limit}, "
                 f"rejecting request {request_metadata.request_id}.",
                 extra={"log_to_stderr": False},
             )

--- a/python/ray/serve/_private/replica_scheduler/common.py
+++ b/python/ray/serve/_private/replica_scheduler/common.py
@@ -60,7 +60,7 @@ class ReplicaWrapper(ABC):
         pass
 
     @property
-    def max_concurrent_requests(self) -> int:
+    def max_ongoing_requests(self) -> int:
         """Max concurrent requests that can be sent to this replica."""
         pass
 
@@ -119,8 +119,8 @@ class ActorReplicaWrapper:
         return self._multiplexed_model_ids
 
     @property
-    def max_concurrent_requests(self) -> int:
-        return self._replica_info.max_concurrent_queries
+    def max_ongoing_requests(self) -> int:
+        return self._replica_info.max_ongoing_requests
 
     @property
     def is_cross_language(self) -> bool:

--- a/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
@@ -568,7 +568,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                 # Include replicas whose queues are full as not in the cache so we will
                 # actively probe them. Otherwise we may end up in "deadlock" until their
                 # cache entries expire.
-                if queue_len is None or queue_len >= r.max_concurrent_requests:
+                if queue_len is None or queue_len >= r.max_ongoing_requests:
                     not_in_cache.append(r)
                 elif queue_len < lowest_queue_len:
                     lowest_queue_len = queue_len
@@ -587,10 +587,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                     # None is returned if we failed to get the queue len.
                     continue
 
-                if (
-                    queue_len < r.max_concurrent_requests
-                    and queue_len < lowest_queue_len
-                ):
+                if queue_len < r.max_ongoing_requests and queue_len < lowest_queue_len:
                     lowest_queue_len = queue_len
                     chosen_replica_id = r.replica_id
         elif len(not_in_cache) > 0:

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -17,7 +17,7 @@ from ray.serve._private.constants import (
     HANDLE_METRIC_PUSH_INTERVAL_S,
     RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
     RAY_SERVE_ENABLE_QUEUE_LENGTH_CACHE,
-    RAY_SERVE_ENABLE_STRICT_MAX_CONCURRENT_QUERIES,
+    RAY_SERVE_ENABLE_STRICT_MAX_ONGOING_REQUESTS,
     RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING,
     SERVE_LOGGER_NAME,
 )
@@ -269,7 +269,7 @@ class Router:
         _prefer_local_node_routing: bool = False,
         _router_cls: Optional[str] = None,
         enable_queue_len_cache: bool = RAY_SERVE_ENABLE_QUEUE_LENGTH_CACHE,
-        enable_strict_max_concurrent_queries: bool = RAY_SERVE_ENABLE_STRICT_MAX_CONCURRENT_QUERIES,  # noqa: E501
+        enable_strict_max_ongoing_requests: bool = RAY_SERVE_ENABLE_STRICT_MAX_ONGOING_REQUESTS,  # noqa: E501
     ):
         """Used to assign requests to downstream replicas for a deployment.
 
@@ -284,11 +284,11 @@ class Router:
             # Streaming ObjectRefGenerators are not supported in Ray Client, so we need
             # to override the behavior.
             self._enable_queue_len_cache = False
-            self._enable_strict_max_concurrent_queries = False
+            self._enable_strict_max_ongoing_requests = False
         else:
             self._enable_queue_len_cache = enable_queue_len_cache
-            self._enable_strict_max_concurrent_queries = (
-                enable_strict_max_concurrent_queries
+            self._enable_strict_max_ongoing_requests = (
+                enable_strict_max_ongoing_requests
             )
 
         if _router_cls:
@@ -416,7 +416,7 @@ class Router:
         # If the queue len cache is disabled or we're sending a request to Java,
         # then directly send the query and hand the response back. The replica will
         # never reject requests in this code path.
-        if not self._enable_strict_max_concurrent_queries or replica.is_cross_language:
+        if not self._enable_strict_max_ongoing_requests or replica.is_cross_language:
             return replica.send_request(pr), replica.replica_id
 
         while True:

--- a/python/ray/serve/_private/version.py
+++ b/python/ray/serve/_private/version.py
@@ -79,8 +79,8 @@ class DeploymentVersion:
         changed.
         """
         return (
-            self.deployment_config.max_concurrent_queries
-            != new_version.deployment_config.max_concurrent_queries
+            self.deployment_config.max_ongoing_requests
+            != new_version.deployment_config.max_ongoing_requests
         )
 
     def compute_hashes(self):

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -38,18 +38,13 @@ class AutoscalingConfig(BaseModel):
     min_replicas: NonNegativeInt = 1
     initial_replicas: Optional[NonNegativeInt] = None
     max_replicas: PositiveInt = 1
+
     target_num_ongoing_requests_per_replica: PositiveFloat = 1.0
-
-    # Private options below.
-
-    # Metrics scraping options
 
     # How often to scrape for metrics
     metrics_interval_s: PositiveFloat = 10.0
     # Time window to average over for metrics.
     look_back_period_s: PositiveFloat = 30.0
-
-    # Internal autoscaling configuration options
 
     # Multiplicative "gain" factor to limit scaling decisions
     smoothing_factor: PositiveFloat = 1.0

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -1,6 +1,5 @@
 import inspect
 import logging
-import warnings
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -17,7 +16,7 @@ from ray.serve._private.utils import DEFAULT, Default
 from ray.serve.config import AutoscalingConfig
 from ray.serve.context import _get_global_client
 from ray.serve.schema import DeploymentSchema, LoggingConfig, RayActorOptionsSchema
-from ray.util.annotations import Deprecated, PublicAPI
+from ray.util.annotations import PublicAPI
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -183,8 +182,18 @@ class Deployment:
 
     @property
     def max_concurrent_queries(self) -> int:
+        """[DEPRECATED] Max number of requests a replica can handle at once."""
+
+        logger.warning(
+            "DeprecationWarning: `max_concurrent_queries` is deprecated, please use "
+            "`max_ongoing_requests` instead."
+        )
+        return self._deployment_config.max_ongoing_requests
+
+    @property
+    def max_ongoing_requests(self) -> int:
         """Max number of requests a replica can handle at once."""
-        return self._deployment_config.max_concurrent_queries
+        return self._deployment_config.max_ongoing_requests
 
     @property
     def max_queued_requests(self) -> int:
@@ -317,6 +326,7 @@ class Deployment:
         max_replicas_per_node: Optional[int] = DEFAULT.VALUE,
         user_config: Default[Optional[Any]] = DEFAULT.VALUE,
         max_concurrent_queries: Default[int] = DEFAULT.VALUE,
+        max_ongoing_requests: Default[int] = DEFAULT.VALUE,
         max_queued_requests: Default[int] = DEFAULT.VALUE,
         autoscaling_config: Default[
             Union[Dict, AutoscalingConfig, None]
@@ -338,12 +348,17 @@ class Deployment:
         Refer to the `@serve.deployment` decorator docs for available arguments.
         """
 
-        # Modify max_concurrent_queries and autoscaling_config if
+        # Modify max_ongoing_requests and autoscaling_config if
         # `num_replicas="auto"`
+        max_ongoing_requests = (
+            max_ongoing_requests
+            if max_ongoing_requests is not DEFAULT.VALUE
+            else max_concurrent_queries
+        )
         if num_replicas == "auto":
             num_replicas = None
-            max_concurrent_queries, autoscaling_config = handle_num_replicas_auto(
-                max_concurrent_queries, autoscaling_config
+            max_ongoing_requests, autoscaling_config = handle_num_replicas_auto(
+                max_ongoing_requests, autoscaling_config
             )
 
         # NOTE: The user_configured_option_names should be the first thing that's
@@ -393,14 +408,20 @@ class Deployment:
                 "into `serve.run` instead."
             )
 
+        if not _internal and max_concurrent_queries is not DEFAULT.VALUE:
+            logger.warning(
+                "DeprecationWarning: `max_concurrent_queries` in `@serve.deployment` "
+                "has been deprecated and replaced by `max_ongoing_requests`."
+            )
+
         elif num_replicas not in [DEFAULT.VALUE, None]:
             new_deployment_config.num_replicas = num_replicas
 
         if user_config is not DEFAULT.VALUE:
             new_deployment_config.user_config = user_config
 
-        if max_concurrent_queries is not DEFAULT.VALUE:
-            new_deployment_config.max_concurrent_queries = max_concurrent_queries
+        if max_ongoing_requests is not DEFAULT.VALUE:
+            new_deployment_config.max_ongoing_requests = max_ongoing_requests
 
         if max_queued_requests is not DEFAULT.VALUE:
             new_deployment_config.max_queued_requests = max_queued_requests
@@ -479,68 +500,6 @@ class Deployment:
             _internal=True,
         )
 
-    @Deprecated(
-        message=(
-            "This was intended for use with the `serve.build` Python API "
-            "(which has been deprecated). Use `.options()` instead."
-        )
-    )
-    def set_options(
-        self,
-        func_or_class: Optional[Callable] = None,
-        name: Default[str] = DEFAULT.VALUE,
-        version: Default[str] = DEFAULT.VALUE,
-        num_replicas: Default[Optional[int]] = DEFAULT.VALUE,
-        route_prefix: Default[Union[str, None]] = DEFAULT.VALUE,
-        ray_actor_options: Default[Optional[Dict]] = DEFAULT.VALUE,
-        user_config: Default[Optional[Any]] = DEFAULT.VALUE,
-        max_concurrent_queries: Default[int] = DEFAULT.VALUE,
-        autoscaling_config: Default[
-            Union[Dict, AutoscalingConfig, None]
-        ] = DEFAULT.VALUE,
-        graceful_shutdown_wait_loop_s: Default[float] = DEFAULT.VALUE,
-        graceful_shutdown_timeout_s: Default[float] = DEFAULT.VALUE,
-        health_check_period_s: Default[float] = DEFAULT.VALUE,
-        health_check_timeout_s: Default[float] = DEFAULT.VALUE,
-        _internal: bool = False,
-    ) -> None:
-        """Overwrite this deployment's options in-place.
-
-        Only those options passed in will be updated, all others will remain
-        unchanged.
-
-        Refer to the @serve.deployment decorator docstring for all non-private
-        arguments.
-        """
-        if not _internal:
-            warnings.warn(
-                "`.set_options()` is deprecated. "
-                "Use `.options()` or an application builder function instead."
-            )
-
-        validated = self.options(
-            func_or_class=func_or_class,
-            name=name,
-            version=version,
-            route_prefix=route_prefix,
-            num_replicas=num_replicas,
-            ray_actor_options=ray_actor_options,
-            user_config=user_config,
-            max_concurrent_queries=max_concurrent_queries,
-            autoscaling_config=autoscaling_config,
-            graceful_shutdown_wait_loop_s=graceful_shutdown_wait_loop_s,
-            graceful_shutdown_timeout_s=graceful_shutdown_timeout_s,
-            health_check_period_s=health_check_period_s,
-            health_check_timeout_s=health_check_timeout_s,
-            _internal=_internal,
-        )
-
-        self._name = validated._name
-        self._version = validated._version
-        self._route_prefix = validated._route_prefix
-        self._deployment_config = validated._deployment_config
-        self._replica_config = validated._replica_config
-
     def __eq__(self, other):
         return all(
             [
@@ -591,6 +550,7 @@ def deployment_to_schema(
         if d._deployment_config.autoscaling_config
         else d.num_replicas,
         "max_concurrent_queries": d.max_concurrent_queries,
+        "max_ongoing_requests": d.max_ongoing_requests,
         "max_queued_requests": d.max_queued_requests,
         "user_config": d.user_config,
         "autoscaling_config": d._deployment_config.autoscaling_config,
@@ -658,7 +618,7 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
     deployment_config = DeploymentConfig.from_default(
         num_replicas=s.num_replicas,
         user_config=s.user_config,
-        max_concurrent_queries=s.max_concurrent_queries,
+        max_ongoing_requests=s.max_ongoing_requests or s.max_concurrent_queries,
         max_queued_requests=s.max_queued_requests,
         autoscaling_config=s.autoscaling_config,
         graceful_shutdown_wait_loop_s=s.graceful_shutdown_wait_loop_s,

--- a/python/ray/serve/tests/test_actor_replica_wrapper.py
+++ b/python/ray/serve/tests/test_actor_replica_wrapper.py
@@ -95,7 +95,7 @@ def setup_fake_replica(ray_instance) -> Tuple[ActorReplicaWrapper, ActorHandle]:
                 node_id=None,
                 availability_zone=None,
                 actor_handle=actor_handle,
-                max_concurrent_queries=10,
+                max_ongoing_requests=10,
                 is_cross_language=False,
             )
         ),

--- a/python/ray/serve/tests/test_advanced.py
+++ b/python/ray/serve/tests/test_advanced.py
@@ -28,7 +28,7 @@ def test_serve_graceful_shutdown(serve_instance):
 
     @serve.deployment(
         name="wait",
-        max_concurrent_queries=10,
+        max_ongoing_requests=10,
         graceful_shutdown_timeout_s=1000,
         graceful_shutdown_wait_loop_s=0.5,
     )

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -335,41 +335,6 @@ def test_run_get_ingress_node(serve_instance):
     assert handle.remote().result() == "got f"
 
 
-class TestSetOptions:
-    def test_set_options_basic(self):
-        @serve.deployment(
-            num_replicas=4,
-            max_concurrent_queries=3,
-            ray_actor_options={"num_cpus": 2},
-            health_check_timeout_s=17,
-        )
-        def f():
-            pass
-
-        f.set_options(
-            num_replicas=9,
-            version="efgh",
-            ray_actor_options={"num_gpus": 3},
-        )
-
-        assert f.num_replicas == 9
-        assert f.max_concurrent_queries == 3
-        assert f.version == "efgh"
-        assert f.ray_actor_options == {"num_cpus": 1, "num_gpus": 3}
-        assert f._deployment_config.health_check_timeout_s == 17
-
-    def test_set_options_validation(self):
-        @serve.deployment
-        def f():
-            pass
-
-        with pytest.raises(TypeError):
-            f.set_options(init_args=-4)
-
-        with pytest.raises(ValueError):
-            f.set_options(max_concurrent_queries=-4)
-
-
 def test_deploy_application_basic(serve_instance):
     """Test deploy multiple applications"""
 

--- a/python/ray/serve/tests/test_cancellation.py
+++ b/python/ray/serve/tests/test_cancellation.py
@@ -69,7 +69,7 @@ def test_cancel_on_http_client_disconnect_during_assignment(serve_instance):
     """Test the client disconnecting while the proxy is assigning the request."""
     signal_actor = SignalActor.remote()
 
-    @serve.deployment(max_concurrent_queries=1)
+    @serve.deployment(max_ongoing_requests=1)
     class Ingress:
         def __init__(self):
             self._num_requests = 0
@@ -128,7 +128,7 @@ def test_cancel_sync_handle_call_during_assignment(serve_instance):
     """Test cancelling handle request during assignment (sync context)."""
     signal_actor = SignalActor.remote()
 
-    @serve.deployment(max_concurrent_queries=1)
+    @serve.deployment(max_ongoing_requests=1)
     class Ingress:
         def __init__(self):
             self._num_requests = 0
@@ -196,7 +196,7 @@ def test_cancel_async_handle_call_during_assignment(serve_instance):
     """Test cancelling handle request during assignment (async context)."""
     signal_actor = SignalActor.remote()
 
-    @serve.deployment(max_concurrent_queries=1)
+    @serve.deployment(max_ongoing_requests=1)
     class Downstream:
         def __init__(self):
             self._num_requests = 0

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -157,6 +157,7 @@ def test_get_serve_instance_details_json_serializable(serve_instance, policy):
                             "deployment_config": {
                                 "name": "autoscaling_app",
                                 "max_concurrent_queries": 100,
+                                "max_ongoing_requests": 100,
                                 "max_queued_requests": -1,
                                 "user_config": None,
                                 "autoscaling_config": {

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -365,7 +365,7 @@ def test_reconfigure_multiple_replicas(serve_instance, use_handle):
 def test_reconfigure_with_queries(serve_instance):
     signal = SignalActor.remote()
 
-    @serve.deployment(max_concurrent_queries=10, num_replicas=3)
+    @serve.deployment(max_ongoing_requests=10, num_replicas=3)
     class A:
         def __init__(self):
             self.state = None
@@ -612,30 +612,30 @@ def test_input_validation():
 
     with pytest.raises(ValidationError):
 
-        @serve.deployment(max_concurrent_queries="hi")
+        @serve.deployment(max_ongoing_requests="hi")
         class BadMaxQueries:
             pass
 
     with pytest.raises(ValidationError):
-        Base.options(max_concurrent_queries=[1])
+        Base.options(max_ongoing_requests=[1])
 
     with pytest.raises(ValueError):
 
-        @serve.deployment(max_concurrent_queries=0)
+        @serve.deployment(max_ongoing_requests=0)
         class ZeroMaxQueries:
             pass
 
     with pytest.raises(ValueError):
-        Base.options(max_concurrent_queries=0)
+        Base.options(max_ongoing_requests=0)
 
     with pytest.raises(ValueError):
 
-        @serve.deployment(max_concurrent_queries=-1)
+        @serve.deployment(max_ongoing_requests=-1)
         class NegativeMaxQueries:
             pass
 
     with pytest.raises(ValueError):
-        Base.options(max_concurrent_queries=-1)
+        Base.options(max_ongoing_requests=-1)
 
 
 def test_deployment_properties():
@@ -647,7 +647,7 @@ def test_deployment_properties():
         version="version",
         num_replicas=2,
         user_config="hi",
-        max_concurrent_queries=100,
+        max_ongoing_requests=100,
         route_prefix="/hello",
         ray_actor_options={"num_cpus": 2},
     )(DClass)
@@ -656,7 +656,7 @@ def test_deployment_properties():
     assert D.version == "version"
     assert D.num_replicas == 2
     assert D.user_config == "hi"
-    assert D.max_concurrent_queries == 100
+    assert D.max_ongoing_requests == 100
     assert D.route_prefix == "/hello"
     assert D.ray_actor_options == {"num_cpus": 2}
 

--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -120,7 +120,7 @@ def test_http_proxy_request_cancellation(serve_instance):
     # https://github.com/ray-project/ray/issues/21425
     s = SignalActor.remote()
 
-    @serve.deployment(max_concurrent_queries=1)
+    @serve.deployment(max_ongoing_requests=1)
     class A:
         def __init__(self) -> None:
             self.counter = 0
@@ -327,7 +327,7 @@ def test_num_replicas_auto(serve_instance, use_options):
     deployment_config = app_details["deployments"]["A"]["deployment_config"]
     # Set by `num_replicas="auto"`
     assert "num_replicas" not in deployment_config
-    assert deployment_config["max_concurrent_queries"] == 5
+    assert deployment_config["max_ongoing_requests"] == 5
     assert deployment_config["autoscaling_config"] == {
         # Set by `num_replicas="auto"`
         "target_num_ongoing_requests_per_replica": 2.0,

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -683,13 +683,22 @@ def test_update_config_graceful_shutdown_timeout(client: ServeControllerClient):
     wait_for_condition(partial(check_deployments_dead, [DeploymentID(name="f")]))
 
 
-def test_update_config_max_concurrent_queries(client: ServeControllerClient):
-    """Check that replicas stay alive when max_concurrent_queries is updated."""
+@pytest.mark.parametrize("use_max_concurrent_queries", [True, False])
+def test_update_config_max_ongoing_requests(
+    client: ServeControllerClient, use_max_concurrent_queries
+):
+    """Check that replicas stay alive when max_ongoing_requests is updated."""
 
+    max_ongoing_requests_field_name = (
+        "max_concurrent_queries"
+        if use_max_concurrent_queries
+        else "max_ongoing_requests"
+    )
     config_template = {
         "import_path": "ray.serve.tests.test_config_files.pid.node",
-        "deployments": [{"name": "f", "max_concurrent_queries": 1000}],
+        "deployments": [{"name": "f"}],
     }
+    config_template["deployments"][0][max_ongoing_requests_field_name] = 1000
 
     # Deploy first time, max_concurent_queries set to 1000.
     client.deploy_apps(ServeDeploySchema.parse_obj({"applications": [config_template]}))
@@ -697,7 +706,7 @@ def test_update_config_max_concurrent_queries(client: ServeControllerClient):
 
     all_replicas = ray.get(client._controller._all_running_replicas.remote())
     assert len(all_replicas) == 1
-    assert all_replicas[list(all_replicas.keys())[0]][0].max_concurrent_queries == 1000
+    assert all_replicas[list(all_replicas.keys())[0]][0].max_ongoing_requests == 1000
 
     handle = serve.get_app_handle(SERVE_DEFAULT_APP_NAME)
 
@@ -706,7 +715,7 @@ def test_update_config_max_concurrent_queries(client: ServeControllerClient):
     assert len(pids1) == 1
 
     # Redeploy with max concurrent queries set to 2.
-    config_template["deployments"][0]["max_concurrent_queries"] = 2
+    config_template["deployments"][0][max_ongoing_requests_field_name] = 2
     client.deploy_apps(ServeDeploySchema.parse_obj({"applications": [config_template]}))
     wait_for_condition(check_running, timeout=15)
 
@@ -717,7 +726,7 @@ def test_update_config_max_concurrent_queries(client: ServeControllerClient):
 
 
 def test_update_config_health_check_period(client: ServeControllerClient):
-    """Check that replicas stay alive when max_concurrent_queries is updated."""
+    """Check that replicas stay alive when max_ongoing_requests is updated."""
 
     config_template = {
         "import_path": "ray.serve.tests.test_config_files.pid.async_node",
@@ -755,7 +764,7 @@ def test_update_config_health_check_period(client: ServeControllerClient):
 
 
 def test_update_config_health_check_timeout(client: ServeControllerClient):
-    """Check that replicas stay alive when max_concurrent_queries is updated."""
+    """Check that replicas stay alive when max_ongoing_requests is updated."""
 
     # Deploy with a very long initial health_check_timeout_s
     # Also set small health_check_period_s to make test run faster
@@ -1269,7 +1278,7 @@ def test_num_replicas_auto(client: ServeControllerClient):
     deployment_config = app_details["deployments"]["A"]["deployment_config"]
     # Set by `num_replicas="auto"`
     assert "num_replicas" not in deployment_config
-    assert deployment_config["max_concurrent_queries"] == 5
+    assert deployment_config["max_ongoing_requests"] == 5
     assert deployment_config["autoscaling_config"] == {
         # Set by `num_replicas="auto"`
         "target_num_ongoing_requests_per_replica": 2.0,

--- a/python/ray/serve/tests/test_deployment_version.py
+++ b/python/ray/serve/tests/test_deployment_version.py
@@ -156,10 +156,10 @@ def test_autoscaling_config():
     assert hash(v1) != hash(v3)
 
 
-def test_max_concurrent_queries():
-    v1 = DeploymentVersion("1", DeploymentConfig(max_concurrent_queries=5), {})
-    v2 = DeploymentVersion("1", DeploymentConfig(max_concurrent_queries=5), {})
-    v3 = DeploymentVersion("1", DeploymentConfig(max_concurrent_queries=10), {})
+def test_max_ongoing_requests():
+    v1 = DeploymentVersion("1", DeploymentConfig(max_ongoing_requests=5), {})
+    v2 = DeploymentVersion("1", DeploymentConfig(max_ongoing_requests=5), {})
+    v3 = DeploymentVersion("1", DeploymentConfig(max_ongoing_requests=10), {})
 
     assert v1 == v2
     assert hash(v1) == hash(v2)
@@ -394,8 +394,8 @@ def test_requires_actor_reconfigure():
 def test_requires_long_poll_broadcast():
     # If max concurrent queries is updated, it needs to be broadcasted
     # to all routers.
-    v1 = DeploymentVersion("1", DeploymentConfig(max_concurrent_queries=5), {})
-    v2 = DeploymentVersion("1", DeploymentConfig(max_concurrent_queries=10), {})
+    v1 = DeploymentVersion("1", DeploymentConfig(max_ongoing_requests=5), {})
+    v2 = DeploymentVersion("1", DeploymentConfig(max_ongoing_requests=10), {})
     assert v1.requires_long_poll_broadcast(v2)
 
     # Something random like health check timeout doesn't require updating

--- a/python/ray/serve/tests/test_handle_api.py
+++ b/python/ray/serve/tests/test_handle_api.py
@@ -8,7 +8,7 @@ import ray
 from ray import serve
 from ray._private.test_utils import SignalActor, async_wait_for_condition
 from ray._private.utils import get_or_create_event_loop
-from ray.serve._private.constants import RAY_SERVE_ENABLE_STRICT_MAX_CONCURRENT_QUERIES
+from ray.serve._private.constants import RAY_SERVE_ENABLE_STRICT_MAX_ONGOING_REQUESTS
 from ray.serve.handle import (
     DeploymentHandle,
     DeploymentResponse,
@@ -291,7 +291,7 @@ def test_handle_eager_execution(serve_instance):
 
 
 @pytest.mark.skipif(
-    not RAY_SERVE_ENABLE_STRICT_MAX_CONCURRENT_QUERIES,
+    not RAY_SERVE_ENABLE_STRICT_MAX_ONGOING_REQUESTS,
     reason="Strict enforcement must be enabled.",
 )
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/test_long_poll.py
+++ b/python/ray/serve/tests/test_long_poll.py
@@ -227,7 +227,7 @@ def test_listen_for_change_java(serve_instance):
             node_id="node_id",
             availability_zone="some-az",
             actor_handle=host,
-            max_concurrent_queries=1,
+            max_ongoing_requests=1,
         )
         for i in range(2)
     ]

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -1076,7 +1076,7 @@ def test_queued_queries_disconnected(serve_start_shutdown):
     signal = SignalActor.remote()
 
     @serve.deployment(
-        max_concurrent_queries=1,
+        max_ongoing_requests=1,
     )
     async def hang_on_first_request():
         await signal.wait.remote()

--- a/python/ray/serve/tests/test_multiplex.py
+++ b/python/ray/serve/tests/test_multiplex.py
@@ -440,7 +440,7 @@ def test_multiplexed_multiple_replicas(serve_instance):
     """Test multiplexed traffic can be sent to multiple replicas"""
     signal = SignalActor.remote()
 
-    @serve.deployment(num_replicas=2, max_concurrent_queries=1)
+    @serve.deployment(num_replicas=2, max_ongoing_requests=1)
     class Model:
         @serve.multiplexed(max_num_models_per_replica=2)
         async def get_model(self, tag):

--- a/python/ray/serve/tests/test_proxy_response_generator.py
+++ b/python/ray/serve/tests/test_proxy_response_generator.py
@@ -72,7 +72,7 @@ class TestUnary:
     async def test_timeout_while_assigning(self, serve_instance):
         signal_actor = SignalActor.remote()
 
-        @serve.deployment(max_concurrent_queries=1)
+        @serve.deployment(max_ongoing_requests=1)
         class D:
             async def __call__(self):
                 await signal_actor.wait.remote()
@@ -123,7 +123,7 @@ class TestUnary:
         signal_actor = SignalActor.remote()
         disconnect_event, disconnect_task = disconnect_task_and_event()
 
-        @serve.deployment(max_concurrent_queries=1)
+        @serve.deployment(max_ongoing_requests=1)
         class D:
             async def __call__(self):
                 await signal_actor.wait.remote()
@@ -246,7 +246,7 @@ class TestStreaming:
     async def test_timeout_while_assigning(self, serve_instance):
         signal_actor = SignalActor.remote()
 
-        @serve.deployment(max_concurrent_queries=1)
+        @serve.deployment(max_ongoing_requests=1)
         class D:
             async def __call__(self) -> AsyncIterator[str]:
                 yield "hi"
@@ -299,7 +299,7 @@ class TestStreaming:
         signal_actor = SignalActor.remote()
         disconnect_event, disconnect_task = disconnect_task_and_event()
 
-        @serve.deployment(max_concurrent_queries=1)
+        @serve.deployment(max_ongoing_requests=1)
         class D:
             async def __call__(self) -> AsyncIterator[str]:
                 yield "hi"

--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -172,7 +172,7 @@ def test_request_hangs_in_assignment(ray_instance, shutdown_serve):
     """
     signal_actor = SignalActor.remote()
 
-    @serve.deployment(graceful_shutdown_timeout_s=0, max_concurrent_queries=1)
+    @serve.deployment(graceful_shutdown_timeout_s=0, max_ongoing_requests=1)
     class HangsOnFirstRequest:
         def __init__(self):
             self._saw_first_request = False
@@ -207,7 +207,7 @@ def test_streaming_request_already_sent_and_timed_out(ray_instance, shutdown_ser
     been sent.
     """
 
-    @serve.deployment(graceful_shutdown_timeout_s=0, max_concurrent_queries=1)
+    @serve.deployment(graceful_shutdown_timeout_s=0, max_ongoing_requests=1)
     class SleepForNSeconds:
         def __init__(self, sleep_s: int):
             self.sleep_s = sleep_s
@@ -345,7 +345,7 @@ def test_cancel_on_http_timeout_during_assignment(ray_instance, shutdown_serve):
     """Test the client disconnecting while the proxy is assigning the request."""
     signal_actor = SignalActor.remote()
 
-    @serve.deployment(max_concurrent_queries=1)
+    @serve.deployment(max_ongoing_requests=1)
     class Ingress:
         def __init__(self):
             self._num_requests = 0

--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -286,7 +286,7 @@ def test_controller_recover_target_capacity(
         "smoothing_factor": 4,
         "metrics_interval_s": 1,
     },
-    max_concurrent_queries=2,
+    max_ongoing_requests=2,
     graceful_shutdown_timeout_s=0,
 )
 class ScaleToZeroDeployment:
@@ -851,7 +851,7 @@ class TestTargetCapacityUpdateAndServeStatus:
 
 @serve.deployment(
     ray_actor_options={"num_cpus": 0},
-    max_concurrent_queries=2,
+    max_ongoing_requests=2,
     graceful_shutdown_timeout_s=0,
 )
 class HangDeployment:

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -879,7 +879,7 @@ class TestOverrideDeploymentInfo:
                 DeploymentSchema(
                     name="A",
                     num_replicas=3,
-                    max_concurrent_queries=200,
+                    max_ongoing_requests=200,
                     user_config={"price": "4"},
                     graceful_shutdown_wait_loop_s=4,
                     graceful_shutdown_timeout_s=40,
@@ -893,7 +893,7 @@ class TestOverrideDeploymentInfo:
         updated_info = updated_infos["A"]
         assert updated_info.route_prefix == "/"
         assert updated_info.version == "123"
-        assert updated_info.deployment_config.max_concurrent_queries == 200
+        assert updated_info.deployment_config.max_ongoing_requests == 200
         assert updated_info.deployment_config.user_config == {"price": "4"}
         assert updated_info.deployment_config.graceful_shutdown_wait_loop_s == 4
         assert updated_info.deployment_config.graceful_shutdown_timeout_s == 40

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -85,17 +85,17 @@ class TestDeploymentConfig:
         with pytest.raises(ValidationError, match="value_error"):
             DeploymentConfig(num_replicas=-1)
 
-        # Test dynamic default for max_concurrent_queries.
-        assert DeploymentConfig().max_concurrent_queries == 100
+        # Test dynamic default for max_ongoing_requests.
+        assert DeploymentConfig().max_ongoing_requests == 100
 
     def test_deployment_config_update(self):
-        b = DeploymentConfig(num_replicas=1, max_concurrent_queries=1)
+        b = DeploymentConfig(num_replicas=1, max_ongoing_requests=1)
 
         # Test updating a key works.
         b.num_replicas = 2
         assert b.num_replicas == 2
         # Check that not specifying a key doesn't update it.
-        assert b.max_concurrent_queries == 1
+        assert b.max_ongoing_requests == 1
 
         # Check that input is validated.
         with pytest.raises(ValidationError):
@@ -442,7 +442,7 @@ def test_http_options():
 
 def test_with_proto():
     # Test roundtrip
-    config = DeploymentConfig(num_replicas=100, max_concurrent_queries=16)
+    config = DeploymentConfig(num_replicas=100, max_ongoing_requests=16)
     assert config == DeploymentConfig.from_proto_bytes(config.to_proto_bytes())
 
     # Test user_config object
@@ -614,7 +614,7 @@ class TestProtoToDict:
 
         # Defaults are filled.
         assert result["num_replicas"] == 0
-        assert result["max_concurrent_queries"] == 0
+        assert result["max_ongoing_requests"] == 0
         assert result["user_config"] == b""
         assert result["user_configured_option_names"] == []
 
@@ -624,16 +624,16 @@ class TestProtoToDict:
     def test_non_empty_fields(self):
         """Test _proto_to_dict() to deserialize protobuf with non-empty fields"""
         num_replicas = 111
-        max_concurrent_queries = 222
+        max_ongoing_requests = 222
         proto = DeploymentConfigProto(
             num_replicas=num_replicas,
-            max_concurrent_queries=max_concurrent_queries,
+            max_ongoing_requests=max_ongoing_requests,
         )
         result = _proto_to_dict(proto)
 
         # Fields with non-empty values are filled correctly.
         assert result["num_replicas"] == num_replicas
-        assert result["max_concurrent_queries"] == max_concurrent_queries
+        assert result["max_ongoing_requests"] == max_ongoing_requests
 
         # Empty fields are continue to be filled with default values.
         assert result["user_config"] == b""
@@ -641,11 +641,11 @@ class TestProtoToDict:
     def test_nested_protobufs(self):
         """Test _proto_to_dict() to deserialize protobuf with nested protobufs"""
         num_replicas = 111
-        max_concurrent_queries = 222
+        max_ongoing_requests = 222
         min_replicas = 333
         proto = DeploymentConfigProto(
             num_replicas=num_replicas,
-            max_concurrent_queries=max_concurrent_queries,
+            max_ongoing_requests=max_ongoing_requests,
             autoscaling_config=AutoscalingConfigProto(
                 min_replicas=min_replicas,
             ),
@@ -654,7 +654,7 @@ class TestProtoToDict:
 
         # Non-empty field is filled correctly.
         assert result["num_replicas"] == num_replicas
-        assert result["max_concurrent_queries"] == max_concurrent_queries
+        assert result["max_ongoing_requests"] == max_ongoing_requests
 
         # Nested protobuf is filled correctly.
         assert result["autoscaling_config"]["min_replicas"] == min_replicas

--- a/python/ray/serve/tests/unit/test_deployment_class.py
+++ b/python/ray/serve/tests/unit/test_deployment_class.py
@@ -84,7 +84,7 @@ class TestDeploymentOptions:
         "route_prefix": "/",
         "ray_actor_options": {},
         "user_config": {},
-        "max_concurrent_queries": 10,
+        "max_ongoing_requests": 10,
         "autoscaling_config": None,
         "graceful_shutdown_wait_loop_s": 10,
         "graceful_shutdown_timeout_s": 10,
@@ -213,13 +213,6 @@ class TestDeploymentOptions:
 
         f = f.options(**options)
         assert f._deployment_config.user_configured_option_names == set(options.keys())
-
-        @serve.deployment
-        def g():
-            pass
-
-        g.set_options(**options)
-        assert g._deployment_config.user_configured_option_names == set(options.keys())
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -20,7 +20,7 @@ from ray.serve._private.constants import (
     DEFAULT_GRACEFUL_SHUTDOWN_WAIT_LOOP_S,
     DEFAULT_HEALTH_CHECK_PERIOD_S,
     DEFAULT_HEALTH_CHECK_TIMEOUT_S,
-    DEFAULT_MAX_CONCURRENT_QUERIES,
+    DEFAULT_MAX_ONGOING_REQUESTS,
     RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS,
 )
 from ray.serve._private.deployment_info import DeploymentInfo
@@ -132,8 +132,8 @@ class MockReplicaActorWrapper:
         return self._actor_handle
 
     @property
-    def max_concurrent_queries(self) -> int:
-        return self.version.deployment_config.max_concurrent_queries
+    def max_ongoing_requests(self) -> int:
+        return self.version.deployment_config.max_ongoing_requests
 
     @property
     def graceful_shutdown_timeout_s(self) -> float:
@@ -1103,7 +1103,7 @@ def test_redeploy_different_num_replicas(mock_deployment_state_manager):
     "option,value",
     [
         ("user_config", {"hello": "world"}),
-        ("max_concurrent_queries", 10),
+        ("max_ongoing_requests", 10),
         ("graceful_shutdown_timeout_s", DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_S + 1),
         ("graceful_shutdown_wait_loop_s", DEFAULT_GRACEFUL_SHUTDOWN_WAIT_LOOP_S + 1),
         ("health_check_period_s", DEFAULT_HEALTH_CHECK_PERIOD_S + 1),
@@ -3216,7 +3216,7 @@ class TestActorReplicaWrapper:
             actor_replica.graceful_shutdown_timeout_s
             == DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_S
         )
-        assert actor_replica.max_concurrent_queries == DEFAULT_MAX_CONCURRENT_QUERIES
+        assert actor_replica.max_ongoing_requests == DEFAULT_MAX_ONGOING_REQUESTS
         assert actor_replica.health_check_period_s == DEFAULT_HEALTH_CHECK_PERIOD_S
         assert actor_replica.health_check_timeout_s == DEFAULT_HEALTH_CHECK_TIMEOUT_S
 

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -170,8 +170,8 @@ def setup_router(request) -> Tuple[Router, FakeReplicaScheduler]:
         # TODO(edoakes): just pass a class instance here.
         _router_cls="ray.serve.tests.unit.test_router.FakeReplicaScheduler",
         enable_queue_len_cache=request.param.get("enable_queue_len_cache", False),
-        enable_strict_max_concurrent_queries=request.param.get(
-            "enable_strict_max_concurrent_queries", False
+        enable_strict_max_ongoing_requests=request.param.get(
+            "enable_strict_max_ongoing_requests", False
         ),
     )
     return router, router._replica_scheduler
@@ -204,11 +204,11 @@ class TestAssignRequest:
         "setup_router",
         [
             {
-                "enable_strict_max_concurrent_queries": True,
+                "enable_strict_max_ongoing_requests": True,
                 "enable_queue_len_cache": False,
             },
             {
-                "enable_strict_max_concurrent_queries": True,
+                "enable_strict_max_ongoing_requests": True,
                 "enable_queue_len_cache": True,
             },
         ],
@@ -247,11 +247,11 @@ class TestAssignRequest:
         "setup_router",
         [
             {
-                "enable_strict_max_concurrent_queries": True,
+                "enable_strict_max_ongoing_requests": True,
                 "enable_queue_len_cache": False,
             },
             {
-                "enable_strict_max_concurrent_queries": True,
+                "enable_strict_max_ongoing_requests": True,
                 "enable_queue_len_cache": True,
             },
         ],
@@ -299,9 +299,7 @@ class TestAssignRequest:
 
     @pytest.mark.parametrize(
         "setup_router",
-        [
-            {"enable_strict_max_concurrent_queries": True},
-        ],
+        [{"enable_strict_max_ongoing_requests": True}],
         indirect=True,
     )
     async def test_cross_lang_no_rejection(
@@ -502,7 +500,7 @@ def running_replica_info(replica_tag: str) -> RunningReplicaInfo:
         node_id="node_id",
         availability_zone="some-az",
         actor_handle=Mock(),
-        max_concurrent_queries=1,
+        max_ongoing_requests=1,
     )
 
 

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -201,14 +201,17 @@ class TestDeploymentSchema:
 
         return {"name": "deep"}
 
-    def test_valid_deployment_schema(self):
+    @pytest.mark.parametrize("use_max_concurrent_queries", [True, False])
+    @pytest.mark.parametrize("use_max_ongoing_requests", [True, False])
+    def test_valid_deployment_schema(
+        self, use_max_concurrent_queries, use_max_ongoing_requests
+    ):
         # Ensure a valid DeploymentSchema can be generated
 
         deployment_schema = {
             "name": "shallow",
             "num_replicas": 2,
             "route_prefix": "/shallow",
-            "max_concurrent_queries": 32,
             "max_queued_requests": 12,
             "user_config": {"threshold": 0.2, "pattern": "rainbow"},
             "autoscaling_config": None,
@@ -230,6 +233,11 @@ class TestDeploymentSchema:
             },
         }
 
+        if use_max_concurrent_queries:
+            deployment_schema["max_concurrent_queries"] = 32
+        if use_max_ongoing_requests:
+            deployment_schema["max_ongoing_requests"] = 32
+
         DeploymentSchema.parse_obj(deployment_schema)
 
     def test_gt_zero_deployment_schema(self):
@@ -241,6 +249,7 @@ class TestDeploymentSchema:
         gt_zero_fields = [
             "num_replicas",
             "max_concurrent_queries",
+            "max_ongoing_requests",
             "health_check_period_s",
             "health_check_timeout_s",
         ]
@@ -417,7 +426,7 @@ class TestServeApplicationSchema:
                     "name": "shallow",
                     "num_replicas": 2,
                     "route_prefix": "/shallow",
-                    "max_concurrent_queries": 32,
+                    "max_ongoing_requests": 32,
                     "user_config": None,
                     "autoscaling_config": None,
                     "graceful_shutdown_wait_loop_s": 17,
@@ -771,7 +780,9 @@ def test_deployment_to_schema_to_deployment():
         pass
 
     deployment = schema_to_deployment(deployment_to_schema(f))
-    deployment.set_options(func_or_class="ray.serve.tests.test_schema.global_f")
+    deployment = deployment.options(
+        func_or_class="ray.serve.tests.test_schema.global_f"
+    )
 
     assert deployment.num_replicas == 3
     assert deployment.route_prefix == "/hello"
@@ -797,7 +808,9 @@ def test_unset_fields_schema_to_deployment_ray_actor_options():
         pass
 
     deployment = schema_to_deployment(deployment_to_schema(f))
-    deployment.set_options(func_or_class="ray.serve.tests.test_schema.global_f")
+    deployment = deployment.options(
+        func_or_class="ray.serve.tests.test_schema.global_f"
+    )
 
     # Serve will set num_cpus to 1 if it's not set.
     assert len(deployment.ray_actor_options) == 1

--- a/python/ray/tests/test_streaming_generator_3.py
+++ b/python/ray/tests/test_streaming_generator_3.py
@@ -308,7 +308,7 @@ def test_completed_next_ready_is_finished(shutdown_only):
 def test_streaming_generator_load(shutdown_only):
     app = FastAPI()
 
-    @serve.deployment(max_concurrent_queries=1000)
+    @serve.deployment(max_ongoing_requests=1000)
     @serve.ingress(app)
     class Router:
         def __init__(self, handle) -> None:
@@ -326,7 +326,7 @@ def test_streaming_generator_load(shutdown_only):
 
             return StreamingResponse(consume_obj_ref_gen(), media_type="text/plain")
 
-    @serve.deployment(max_concurrent_queries=1000)
+    @serve.deployment(max_ongoing_requests=1000)
     class SimpleGenerator:
         async def hi_gen(self):
             for i in range(100):

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -92,7 +92,7 @@ message DeploymentConfig {
 
   // The maximum number of queries that will be sent to a replica of this deployment
   // without receiving a response.
-  int32 max_concurrent_queries = 2;
+  int32 max_ongoing_requests = 2;
 
   // The maximum number of requests that will be queued in deployment handles.
   int32 max_queued_requests = 3;


### PR DESCRIPTION
[serve] rename max concurrent queries

Rename `max_concurrent_queries` to `max_ongoing_requests`.

All tests have been migrated to use `max_ongoing_requests` except for a few tests that are parametrized to ensure `max_concurrent_queries` still works:
* `test_max_ongoing_requests_set_to_one` (e2e test)
* `test_update_config_max_ongoing_requests` (e2e test)
* `test_valid_deployment_schema` (unit test)

**Rollout plan**: support both and deprecate `max_concurrent_queries` for 2.10. Remove `max_concurrent_queries` next release.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/ray-project/ray/pull/43007).
* #43454
* __->__ #43007