### PR TITLE
[Data] Avoid `TypeError` when destructing `Dataset` object

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5066,12 +5066,10 @@ class Dataset:
         # This value is truthy and not `None`, so we use a try-catch rather than
         # something like `if ray is not None`. For more information, see #42382.
         try:
-            is_ray_initialized = ray.is_initialized()
+            if ray.is_initialized():
+                self._current_executor.shutdown()
         except TypeError:
-            is_ray_initialized = False
-
-        if is_ray_initialized:
-            self._current_executor.shutdown()
+            pass
 
 
 @PublicAPI

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5063,10 +5063,10 @@ class Dataset:
             return
 
         # When Python shuts down, `ray` might evaluate to `<module None from None>`.
-        # This value is truthy and not `None`, so we use a try-catch rather than
-        # something like `if ray is not None`. For more information, see #42382.
+        # This value is truthy and not `None`, so we use a try-catch in addition to
+        # `if ray is not None`. For more information, see #42382.
         try:
-            if ray.is_initialized():
+            if ray is not None and ray.is_initialized():
                 self._current_executor.shutdown()
         except TypeError:
             pass


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

You might see a `TypeError` when your Ray Data program exits:

```
Exception ignored in: <function Dataset.__del__ at 0x2aad7d3a0>
Traceback (most recent call last):
  File "/Users/arun/Applications/miniconda3/envs/dc/lib/python3.9/site-packages/ray/data/dataset.py", line 5148, in __del__
TypeError: 'NoneType' object is not callable
```

The reason for this is that we don't correctly check if the `ray` module exists. Currently, we check if `ray is not None`:

https://github.com/ray-project/ray/blob/ba3cfa0eb0daaf9ecdb17edc1c4fa4bbeb4d9dd8/python/ray/data/dataset.py#L5062

But `ray` might evaluate to `<module None from None>`, which is not `None`. So, we evaluate `ray.is_initialized()` and get a `TypeError`. This PR fixes the issue by adding a more robust check.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/42382
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
