### PR TITLE
[data] fix a race condition issue in OpBufferQueue

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -130,8 +130,8 @@ class OpBufferQueue:
                 # Note, the reason why we do indexing here instead of in the append
                 # is because only the last `OpBufferQueue` in the DAG, which will call
                 # pop with output_split_idx, needs indexing.
-                # If we also index the `OpBufferQueue`s in the middle, we cannot preserve
-                # the order of ref bundles with different output splits.
+                # If we also index the `OpBufferQueue`s in the middle, we cannot
+                # preserve the order of ref bundles with different output splits.
                 with self._lock:
                     while len(self._queue) > 0:
                         ref = self._queue.popleft()

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -67,6 +67,8 @@ class OpBufferQueue:
         self._queue = deque()
         self._num_per_split = defaultdict(int)
         self._lock = threading.Lock()
+        # Used to buffer output RefBundles by split index.
+        self._outputs_by_split = defaultdict(deque)
         super().__init__()
 
     @property
@@ -121,14 +123,18 @@ class OpBufferQueue:
             except IndexError:
                 pass
         else:
-            # TODO(hchen): Index the queue by output_split_idx to
-            # avoid linear scan.
-            for i in range(len(self._queue)):
-                ref = self._queue[i]
-                if ref.output_split_idx == output_split_idx:
-                    ret = ref
-                    del self._queue[i]
-                    break
+            with self._lock:
+                split_queue = self._outputs_by_split[output_split_idx]
+            if len(split_queue) == 0:
+                # Move all ref bundles to corresponding split queue.
+                with self._lock:
+                    while len(self._queue) > 0:
+                        ref = self._queue.popleft()
+                        self._outputs_by_split[ref.output_split_idx].append(ref)
+            try:
+                ret = split_queue.popleft()
+            except IndexError:
+                pass
         if ret is None:
             return None
         with self._lock:

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1,5 +1,3 @@
-import random
-import threading
 import time
 import unittest
 from concurrent.futures import ThreadPoolExecutor
@@ -775,7 +773,7 @@ class OpBufferQueueTest(unittest.TestCase):
             futures = [executor.submit(consume, i) for i in range(num_splits)]
 
         for f in futures:
-            assert f.result() == True, f.result()
+            assert f.result() is True, f.result()
 
 
 def test_exception_concise_stacktrace():

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1,4 +1,8 @@
+import random
+import threading
 import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,6 +26,7 @@ from ray.data._internal.execution.streaming_executor import (
 )
 from ray.data._internal.execution.streaming_executor_state import (
     AutoscalingState,
+    OpBufferQueue,
     OpState,
     _execution_allowed,
     build_streaming_topology,
@@ -740,6 +745,37 @@ def test_execution_allowed_nothrottle():
             downstream_object_store_memory=1000,
         ),
     )
+
+
+class OpBufferQueueTest(unittest.TestCase):
+    def test_multi_threading(self):
+        num_blocks = 5_000
+        num_splits = 8
+        num_per_split = num_blocks // num_splits
+        ref_bundles = make_ref_bundles([[[i]] for i in range(num_blocks)])
+
+        queue = OpBufferQueue()
+        for i, ref_bundle in enumerate(ref_bundles):
+            ref_bundle.output_split_idx = i % num_splits
+            queue.append(ref_bundle)
+
+        def consume(output_split_idx):
+            nonlocal queue
+
+            count = 0
+            while queue.has_next(output_split_idx):
+                ref_bundle = queue.pop(output_split_idx)
+                count += 1
+                assert ref_bundle is not None
+                assert ref_bundle.output_split_idx == output_split_idx
+            assert count == num_per_split
+            return True
+
+        with ThreadPoolExecutor(max_workers=num_splits) as executor:
+            futures = [executor.submit(consume, i) for i in range(num_splits)]
+
+        for f in futures:
+            assert f.result() == True, f.result()
 
 
 def test_exception_concise_stacktrace():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix the following error.
```python
            # TODO(hchen): Index the queue by output_split_idx to
            # avoid linear scan.
            for i in range(len(self._queue)):
>               ref = self._queue[i]
E               IndexError: deque index out of range
```

This is a race condition bug introduced by https://github.com/ray-project/ray/pull/42601

This PR fixes the bug and also adds indexing to avoid inefficient linear scans. 



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
