### PR TITLE
[ci] Add dependencies for filter_test module

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -22,7 +22,12 @@ py_binary(
 py_binary(
     name = "filter_tests",
     srcs = ["filter_tests.py"],
-    deps = ["//ci/ray_ci:ray_ci_lib"],
+    exec_compatible_with = ["//:hermetic_python"],
+    deps = [
+        ci_require("click"),
+        "//ci/ray_ci:ray_ci_lib",
+        "//release:ray_release",
+    ],
 )
 
 py_library(


### PR DESCRIPTION
## Why are these changes needed?
- `filter_test` module does not have its own dependencies list in `BUILD` but relies on `ray_ci_lib`.
- It should have its own dependencies listed in `BUILD` on top of `ray_ci_lib`, accounting for potential changes in the future.

Ran the module with `bazel run`, with & without `ray_ci_lib` as dependency and script still works. 