### PR TITLE
[Data] Remove `Preprocessor.transform_stats`

### DIFF
--- a/doc/source/data/api/preprocessor.rst
+++ b/doc/source/data/api/preprocessor.rst
@@ -28,7 +28,6 @@ Fit/Transform APIs
     ~preprocessor.Preprocessor.fit_transform
     ~preprocessor.Preprocessor.transform
     ~preprocessor.Preprocessor.transform_batch
-    ~preprocessor.Preprocessor.transform_stats
 
 
 Generic Preprocessors

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -85,20 +85,6 @@ class Preprocessor(abc.ABC):
         else:
             return Preprocessor.FitStatus.NOT_FITTED
 
-    @Deprecated
-    def transform_stats(self) -> Optional[str]:
-        """Return Dataset stats for the most recent transform call, if any."""
-
-        raise DeprecationWarning(
-            "`preprocessor.transform_stats()` is no longer supported in Ray 2.4. "
-            "With Dataset now lazy by default, the stats are only populated "
-            "after execution. Once the dataset transform is executed, the "
-            "stats can be accessed directly from the transformed dataset "
-            "(`ds.stats()`), or can be viewed in the ray-data.log "
-            "file saved in the Ray logs directory "
-            "(defaults to /tmp/ray/session_{SESSION_ID}/logs/)."
-        )
-
     def fit(self, ds: "Dataset") -> "Preprocessor":
         """Fit this Preprocessor to the Dataset.
 

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -4,10 +4,10 @@ import collections
 import pickle
 import warnings
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from ray.air.util.data_batch_conversion import BatchFormat
-from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
+from ray.util.annotations import DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
     import numpy as np

--- a/python/ray/data/tests/preprocessors/test_preprocessors.py
+++ b/python/ray/data/tests/preprocessors/test_preprocessors.py
@@ -406,13 +406,6 @@ def test_numpy_pandas_support_transform_batch_tensor(create_dummy_preprocessors)
     )
 
 
-def test_transform_stats_raises_deprecation_warning(create_dummy_preprocessors):
-    with_nothing, _, _, _, _ = create_dummy_preprocessors
-
-    with pytest.raises(DeprecationWarning):
-        with_nothing.transform_stats()
-
-
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`Preprocessor.transform_stats` has been hard deprecated since Ray 2.4. This PR removes it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
