### PR TITLE
[Data] Remove positional `ActorPoolStrategy` arguments

### DIFF
--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -83,9 +83,6 @@ class ActorPoolStrategy(ComputeStrategy):
 
     def __init__(
         self,
-        # Deprecated: kwargs will be required for all args in a future release.
-        legacy_min_size: Optional[int] = None,
-        legacy_max_size: Optional[int] = None,
         *,
         size: Optional[int] = None,
         min_size: Optional[int] = None,
@@ -105,11 +102,6 @@ class ActorPoolStrategy(ComputeStrategy):
                 computation and avoiding actor startup delays, but will also increase
                 queueing delay.
         """
-        if legacy_min_size is not None or legacy_max_size is not None:
-            raise ValueError(
-                "In Ray 2.5, ActorPoolStrategy requires min_size and "
-                "max_size to be explicit kwargs."
-            )
         if size:
             if size < 1:
                 raise ValueError("size must be >= 1", size)

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -172,10 +172,6 @@ def test_strict_compute(ray_start_regular_shared):
     with pytest.raises(ValueError):
         ray.data.range(10).map(lambda x: x, compute="actors").show()
     with pytest.raises(ValueError):
-        ray.data.range(10).map(
-            lambda x: x, compute=ray.data.ActorPoolStrategy(1, 1)
-        ).show()
-    with pytest.raises(ValueError):
         ray.data.range(10).map(lambda x: x, compute="tasks").show()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The positional size arguments of `ActorPoolStrategy` were hard deprecated in Ray 2.5. This PR removes them.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
