### PR TITLE
[release][tune] Remove deprecated `SyncConfig` usage in `tune_cloud_durable` release test

### DIFF
--- a/release/tune_tests/cloud_tests/workloads/_tune_script.py
+++ b/release/tune_tests/cloud_tests/workloads/_tune_script.py
@@ -68,7 +68,6 @@ class IndicatorCallback(tune.Callback):
 
 
 def run_tune(
-    no_syncer: bool,
     storage_path: Optional[str] = None,
     experiment_name: str = "cloud_test",
     indicator_file: str = "/tmp/tune_cloud_indicator",
@@ -114,8 +113,6 @@ def run_tune(
         config=config,
         storage_path=storage_path,
         sync_config=train.SyncConfig(
-            syncer="auto" if not no_syncer else None,
-            sync_on_checkpoint=True,
             sync_period=0.5,
             sync_artifacts=True,
         ),
@@ -128,27 +125,20 @@ def run_tune(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-
-    parser.add_argument("--no-syncer", action="store_true", default=False)
-
     parser.add_argument("--storage-path", required=False, default=None, type=str)
-
     parser.add_argument("--experiment-name", required=False, default=None, type=str)
-
     parser.add_argument(
         "--indicator-file",
         required=False,
         default="/tmp/tune_cloud_indicator",
         type=str,
     )
-
     args = parser.parse_args()
 
     trainable = str(os.environ.get("TUNE_TRAINABLE", "function"))
     num_cpus_per_trial = int(os.environ.get("TUNE_NUM_CPUS_PER_TRIAL", "2"))
 
     run_kwargs = dict(
-        no_syncer=args.no_syncer or False,
         storage_path=args.storage_path or None,
         experiment_name=args.experiment_name or "cloud_test",
         indicator_file=args.indicator_file,

--- a/release/tune_tests/cloud_tests/workloads/run_cloud_test.py
+++ b/release/tune_tests/cloud_tests/workloads/run_cloud_test.py
@@ -195,15 +195,11 @@ def wait_for_nodes(
 
 
 def start_run(
-    no_syncer: bool,
     storage_path: Optional[str] = None,
     experiment_name: str = "cloud_test",
     indicator_file: str = "/tmp/tune_cloud_indicator",
 ) -> subprocess.Popen:
     args = []
-    if no_syncer:
-        args.append("--no-syncer")
-
     if storage_path:
         args.extend(["--storage-path", storage_path])
 
@@ -297,13 +293,11 @@ def run_tune_script_for_time(
     run_time: int,
     experiment_name: str,
     indicator_file: str,
-    no_syncer: bool,
     storage_path: Optional[str],
     run_start_timeout: int = 30,
 ):
     # Start run
     process = start_run(
-        no_syncer=no_syncer,
         storage_path=storage_path,
         experiment_name=experiment_name,
         indicator_file=indicator_file,
@@ -327,7 +321,6 @@ def run_tune_script_for_time(
 def run_resume_flow(
     experiment_name: str,
     indicator_file: str,
-    no_syncer: bool,
     storage_path: Optional[str],
     first_run_time: int = 33,
     second_run_time: int = 33,
@@ -365,7 +358,6 @@ def run_resume_flow(
         run_time=first_run_time,
         experiment_name=experiment_name,
         indicator_file=indicator_file,
-        no_syncer=no_syncer,
         storage_path=storage_path,
         run_start_timeout=run_start_timeout,
     )
@@ -385,7 +377,6 @@ def run_resume_flow(
         run_time=second_run_time,
         experiment_name=experiment_name,
         indicator_file=indicator_file,
-        no_syncer=no_syncer,
         storage_path=storage_path,
     )
 
@@ -1011,7 +1002,6 @@ def test_durable_upload(bucket: str):
     run_resume_flow(
         experiment_name=experiment_name,
         indicator_file=indicator_file,
-        no_syncer=False,
         storage_path=bucket,
         first_run_time=run_time,
         second_run_time=run_time,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
https://github.com/ray-project/ray/pull/42909 hard deprecated outdated `SyncConfig` parameters, and this release test was not updated along with the rest of the examples. This `syncer` parameter was already being ignored, so it's okay to remove it fully now.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/43008

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
