### PR TITLE
[ci] Change release-automation pipeline to use PR & add arm64 queues

### DIFF
--- a/.buildkite/release-automation/config.yml
+++ b/.buildkite/release-automation/config.yml
@@ -1,12 +1,14 @@
 name: ray-release-automation
-artifacts_bucket: ray-ci-artifact-branch-public
-ci_temp: s3://ray-ci-artifact-branch-public/ci-temp/
+artifacts_bucket: ray-ci-artifact-pr-public
+ci_temp: s3://ray-ci-artifact-pr-public/ci-temp/
 ci_work_repo: 029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp
 forge_prefix: cr.ray.io/rayproject/
 builder_queues:
   builder: builder_queue_pr
+  builder-arm64: builder_queue_arm64_pr
 runner_queues:
   default: runner_queue_small_pr
+  medium-arm64: runner_queue_arm64_medium_pr
 buildkite_dirs:
   - .buildkite/release-automation
 env:


### PR DESCRIPTION
- `release-automation` pipeline should use `pr` instead of `branch` .
- Add arm64 builder & runner queue into config. 