### PR TITLE
[ci] fix test summary file path

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -1173,7 +1173,7 @@ def _get_repo_github_path_and_link(file: str, lineno: int) -> Tuple[str, str]:
     if not commit:
         return file, ""
 
-    path = os.path.relpath(file, "/ray")
+    path = file.split("com_github_ray_project_ray/")[-1]
 
     return path, base_url.format(commit=commit, path=path, lineno=lineno)
 


### PR DESCRIPTION
The function `_get_repo_github_path_and_link` attempts to get the relative path to the test source code. It does that by using `os.path.relpath` from top level folder `/ray`. However `/ray` neither exists in linux or window CI, since both run under bazel. This PR computes the path by getting the path under the `com_github_ray_project_ray` which is the bazel runfile folder.

This also fixes the test summary file for windows, e.g. https://ray-ci-artifact-pr-public.s3.amazonaws.com/9e8737c25167c42f9e6cdb6fc31da975d4708402/tmp%5Cartifacts%5Ctest-summaries%5C$$test_actor_creation_task_ok.txt, which I think has the same content as the attempt.log file that you wants @rickyyx 

Test:
- CI