### PR TITLE
[ray/object_buffer_pool] reduce lock mutex scope

### DIFF
--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -156,6 +156,11 @@ void ObjectBufferPool::WriteChunk(const ObjectID &object_id,
     // Ensure the process of object_id SEALS and RELEASES is mutex guarded
     absl::MutexLock lock(&pool_mutex_);
     auto it = create_buffer_state_.find(object_id);
+    if (it == create_buffer_state_.end()) {
+      RAY_LOG(DEBUG) << "Object " << object_id << " aborted before chunk " << chunk_index
+                     << " finished copying data";
+      return;
+    }
 
     it->second.num_seals_remaining--;
     if (it->second.num_seals_remaining == 0) {

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-
+//
 //  http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+
 //  http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "ray/object_manager/object_buffer_pool.h"
+
+#include <optional>
 
 #include "absl/time/time.h"
 #include "ray/common/status.h"
@@ -119,51 +121,51 @@ void ObjectBufferPool::WriteChunk(const ObjectID &object_id,
                                   uint64_t metadata_size,
                                   const uint64_t chunk_index,
                                   const std::string &data) {
+  std::optional<ChunkInfo> chunk_info;
+  {
+    absl::MutexLock lock(&pool_mutex_);
+    auto it = create_buffer_state_.find(object_id);
+    if (it == create_buffer_state_.end() ||
+        chunk_index >= it->second.chunk_state.size() ||
+        it->second.chunk_state.at(chunk_index) != CreateChunkState::REFERENCED) {
+      RAY_LOG(DEBUG) << "Object " << object_id << " aborted before chunk "
+                     << chunk_index << " could be sealed";
+      return;
+    }
+    if (it->second.data_size != data_size ||
+        it->second.metadata_size != metadata_size) {
+      RAY_LOG(DEBUG) << "Object " << object_id << " size mismatch, rejecting chunk";
+      return;
+    }
+    RAY_CHECK(it->second.chunk_info.size() > chunk_index);
 
+    chunk_info = it->second.chunk_info.at(chunk_index);
+    RAY_CHECK(data.size() == chunk_info.buffer_length)
+        << "size mismatch!  data size: " << data.size()
+        << " chunk size: " << chunk_info.buffer_length;
 
-  absl::MutexLock lock(&pool_mutex_);
-  auto it = create_buffer_state_.find(object_id);
-  if (it == create_buffer_state_.end() || chunk_index >= it->second.chunk_state.size() ||
-      it->second.chunk_state.at(chunk_index) != CreateChunkState::REFERENCED) {
-    RAY_LOG(DEBUG) << "Object " << object_id << " aborted before chunk " << chunk_index
-                  << " could be sealed";
-    return;
-  }
-  if (it->second.data_size != data_size || it->second.metadata_size != metadata_size) {
-    RAY_LOG(DEBUG) << "Object " << object_id << " size mismatch, rejecting chunk";
-    return;
-  }
-  RAY_CHECK(it->second.chunk_info.size() > chunk_index);
-  auto &chunk_info = it->second.chunk_info.at(chunk_index);
-  RAY_CHECK(data.size() == chunk_info.buffer_length)
-      << "size mismatch!  data size: " << data.size()
-      << " chunk size: " << chunk_info.buffer_length;
-
-  uint8_t* data_ptr = chunk_info.data;
-  uint64_t data_size_bytes = chunk_info.buffer_length;
-  
-  // Release pool_mutex_ during the copy call
-  pool_mutex_.Unlock();
-  std::memcpy(data_ptr, data.data(), data_size_bytes);
-  pool_mutex_.Lock();
-
-  // Itertor needs to be re-created after the lock release
-  it = create_buffer_state_.find(object_id);
-  if (it == create_buffer_state_.end() || chunk_index >= it->second.chunk_state.size() ||
-      it->second.chunk_state.at(chunk_index) != CreateChunkState::REFERENCED) {
-    RAY_LOG(DEBUG) << "Object " << object_id << " aborted before chunk " << chunk_index
-                  << " could be sealed";
-    return;
+    // Update the state from REFERENCED To SEALED before releasing the lock to ensure
+    // that only 1 thread sees the REFERENCED to SEALED transition.
+    it->second.chunk_state.at(chunk_index) = CreateChunkState::SEALED;
   }
 
-  it->second.chunk_state.at(chunk_index) = CreateChunkState::SEALED;
-  it->second.num_seals_remaining--;
-  if (it->second.num_seals_remaining == 0) {
-    RAY_CHECK_OK(store_client_->Seal(object_id));
-    RAY_CHECK_OK(store_client_->Release(object_id));
-    create_buffer_state_.erase(it);
-    RAY_LOG(DEBUG) << "Have received all chunks for object " << object_id
-                   << ", last chunk index: " << chunk_index;
+  RAY_CHECK(chunk_info.has_value());
+  // Unguarded copy call
+  std::memcpy(chunk_info->data, data.data(), chunk_info->buffer_length);
+
+  {
+    // Ensure the process of object_id SEALS and RELEASES is mutex guarded
+    absl::MutexLock lock(&pool_mutex_);
+    auto it = create_buffer_state_.find(object_id);
+
+    it->second.num_seals_remaining--;
+    if (it->second.num_seals_remaining == 0) {
+      RAY_CHECK_OK(store_client_->Seal(object_id));
+      RAY_CHECK_OK(store_client_->Release(object_id));
+      create_buffer_state_.erase(it);
+      RAY_LOG(DEBUG) << "Have received all chunks for object " << object_id
+                     << ", last chunk index: " << chunk_index;
+    }
   }
 }
 

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -139,9 +139,9 @@ void ObjectBufferPool::WriteChunk(const ObjectID &object_id,
     RAY_CHECK(it->second.chunk_info.size() > chunk_index);
 
     chunk_info = it->second.chunk_info.at(chunk_index);
-    RAY_CHECK(data.size() == chunk_info.buffer_length)
+    RAY_CHECK(data.size() == chunk_info->buffer_length)
         << "size mismatch!  data size: " << data.size()
-        << " chunk size: " << chunk_info.buffer_length;
+        << " chunk size: " << chunk_info->buffer_length;
 
     // Update the state from REFERENCED To SEALED before releasing the lock to ensure
     // that no other thread sees a REFERENCED state.

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -128,12 +128,11 @@ void ObjectBufferPool::WriteChunk(const ObjectID &object_id,
     if (it == create_buffer_state_.end() ||
         chunk_index >= it->second.chunk_state.size() ||
         it->second.chunk_state.at(chunk_index) != CreateChunkState::REFERENCED) {
-      RAY_LOG(DEBUG) << "Object " << object_id << " aborted before chunk "
-                     << chunk_index << " could be sealed";
+      RAY_LOG(DEBUG) << "Object " << object_id << " aborted before chunk " << chunk_index
+                     << " could be sealed";
       return;
     }
-    if (it->second.data_size != data_size ||
-        it->second.metadata_size != metadata_size) {
+    if (it->second.data_size != data_size || it->second.metadata_size != metadata_size) {
       RAY_LOG(DEBUG) << "Object " << object_id << " size mismatch, rejecting chunk";
       return;
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
