### PR TITLE
[serve] Don't pass proxy health check until routes are updated

### DIFF
--- a/python/ray/serve/_private/proxy_request_response.py
+++ b/python/ray/serve/_private/proxy_request_response.py
@@ -198,5 +198,4 @@ class ResponseHandlerInfo:
     response_generator: ResponseGenerator
     metadata: HandlerMetadata
     should_record_access_log: bool
-    should_record_request_metrics: bool
     should_increment_ongoing_requests: bool

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -14,7 +14,7 @@ from ray import serve
 from ray.actor import ActorHandle
 from ray.serve._private.common import DeploymentID, DeploymentStatus
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_NAMESPACE
-from ray.serve._private.proxy import DRAINED_MESSAGE
+from ray.serve._private.proxy import DRAINING_MESSAGE
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import TimerBase
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
@@ -205,7 +205,7 @@ def ping_grpc_list_applications(channel, app_names, test_draining=False):
             _, _ = stub.ListApplications.with_call(request=request)
         rpc_error = exception_info.value
         assert rpc_error.code() == grpc.StatusCode.UNAVAILABLE
-        assert rpc_error.details() == DRAINED_MESSAGE
+        assert rpc_error.details() == DRAINING_MESSAGE
     else:
         response, call = stub.ListApplications.with_call(request=request)
         assert call.code() == grpc.StatusCode.OK
@@ -221,7 +221,7 @@ def ping_grpc_healthz(channel, test_draining=False):
             _, _ = stub.Healthz.with_call(request=request)
         rpc_error = exception_info.value
         assert rpc_error.code() == grpc.StatusCode.UNAVAILABLE
-        assert rpc_error.details() == DRAINED_MESSAGE
+        assert rpc_error.details() == DRAINING_MESSAGE
     else:
         response, call = stub.Healthz.with_call(request=request)
         assert call.code() == grpc.StatusCode.OK

--- a/python/ray/serve/tests/test_proxy.py
+++ b/python/ray/serve/tests/test_proxy.py
@@ -300,7 +300,7 @@ class TestgRPCProxy:
             assert status.code == grpc.StatusCode.UNAVAILABLE
             assert status.message == DRAINING_MESSAGE
             assert status.is_error is True
-            assert response.application_names == []
+            assert response.application_names == ["app"]
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("is_draining", [False, True])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Updating the route table is async via the long poll client, so we can errantly reject requests if one reaches the proxy before a route table update (e.g., if the controller is down).

This change doesn't return a healthy response until after we've received at least one route table update.

I've also refactored the unit tests so we can test various proxy responses end to end (the existing tests were basically verifying implementation details).

## Related issue number

Closes https://github.com/ray-project/ray/issues/43076

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
