### PR TITLE
[Core] Fix placement group leaks (#42942)

### DIFF
--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -1,11 +1,16 @@
+import asyncio
 import sys
+import time
 
 import pytest
 
 import ray
 from ray.tests.test_placement_group import are_pairwise_unique
+from ray.util.state import list_actors, list_placement_groups
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray._private.test_utils import wait_for_condition
 
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
@@ -255,6 +260,93 @@ def test_placement_group_parallel_submission(ray_start_cluster, scheduling_strat
 
     # Test all tasks will not hang
     ray.get([manage_tasks.remote(i) for i in range(20)], timeout=50)
+
+
+MyPlugin = "MyPlugin"
+MY_PLUGIN_CLASS_PATH = "ray.tests.test_placement_group_5.HangPlugin"
+PLUGIN_TIMEOUT = 10
+
+
+class HangPlugin(RuntimeEnvPlugin):
+    name = MyPlugin
+
+    async def create(
+        self,
+        uri,
+        runtime_env,
+        ctx,
+        logger,  # noqa: F821
+    ) -> float:
+        await asyncio.sleep(PLUGIN_TIMEOUT)
+
+
+@staticmethod
+def validate(runtime_env_dict: dict) -> str:
+    return 1
+
+
+@pytest.mark.parametrize(
+    "set_runtime_env_plugins",
+    [
+        '[{"class":"' + MY_PLUGIN_CLASS_PATH + '"}]',
+    ],
+    indirect=True,
+)
+def test_placement_group_leaks(set_runtime_env_plugins, shutdown_only):
+    """Handles https://github.com/ray-project/ray/pull/42942
+
+    Handle an edge case where if a task is scheduled & worker is not
+    started before pg is removed, it leaks.
+    """
+    ray.init(num_cpus=1, _system_config={"prestart_worker_first_driver": False})
+
+    @ray.remote
+    class Actor:
+        pass
+
+    @ray.remote
+    def f():
+        pass
+
+    pg = ray.util.placement_group(bundles=[{"CPU": 1}])
+    actor = Actor.options(  # noqa
+        num_cpus=1,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=pg,
+        ),
+        runtime_env={MyPlugin: {"name": "f2"}},
+    ).remote()
+
+    # The race condition is triggered
+    # if scheduling succeeds, but a worker is not started.
+    # So we should make sure to wait until actor is scheduled.
+    # Since there's no API to get that timing, we just wait sufficient time.
+    time.sleep(PLUGIN_TIMEOUT // 2)
+
+    # Verify pg resources are created.
+    def verify_pg_resources_created():
+        r_keys = ray.available_resources().keys()
+        return any("group" in k for k in r_keys)
+
+    wait_for_condition(verify_pg_resources_created)
+
+    ray.util.remove_placement_group(pg)
+    wait_for_condition(lambda: list_placement_groups()[0].state == "REMOVED")
+
+    # Verify pg resources are cleaned up.
+    def verify_pg_resources_cleaned():
+        r_keys = ray.available_resources().keys()
+        return all("group" not in k for k in r_keys)
+
+    wait_for_condition(verify_pg_resources_cleaned, timeout=30)
+
+    # Verify an actor is killed properly.
+
+    def verify_actor_killed():
+        state = list_actors()[0].state
+        return state == "DEAD"
+
+    wait_for_condition(verify_actor_killed)
 
 
 if __name__ == "__main__":

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -14,6 +14,7 @@
 
 #include "ray/gcs/gcs_server/gcs_placement_group_scheduler.h"
 
+#include "ray/common/asio/asio_util.h"
 #include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
@@ -26,7 +27,8 @@ GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
     const gcs::GcsNodeManager &gcs_node_manager,
     ClusterResourceScheduler &cluster_resource_scheduler,
     std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool)
-    : return_timer_(io_context),
+    : io_context_(io_context),
+      return_timer_(io_context),
       gcs_table_storage_(std::move(gcs_table_storage)),
       gcs_node_manager_(gcs_node_manager),
       cluster_resource_scheduler_(cluster_resource_scheduler),
@@ -227,24 +229,50 @@ void GcsPlacementGroupScheduler::CommitResources(
 
 void GcsPlacementGroupScheduler::CancelResourceReserve(
     const std::shared_ptr<const BundleSpecification> &bundle_spec,
-    const absl::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node) {
+    const absl::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
+    int max_retry,
+    int current_retry_cnt) {
   if (!node.has_value()) {
     RAY_LOG(INFO) << "Node for a placement group id " << bundle_spec->PlacementGroupId()
                   << " and a bundle index, " << bundle_spec->Index()
                   << " has already removed. Cancellation request will be ignored.";
     return;
   }
+
   auto node_id = NodeID::FromBinary(node.value()->node_id());
+
+  if (max_retry == current_retry_cnt) {
+    RAY_LOG(INFO) << "Failed to cancel resource reserved for bundle because the max "
+                     "retry count is reached. "
+                  << bundle_spec->DebugString() << " at node " << node_id;
+    return;
+  }
+
   RAY_LOG(DEBUG) << "Cancelling the resource reserved for bundle: "
                  << bundle_spec->DebugString() << " at node " << node_id;
   const auto return_client = GetLeaseClientFromNode(node.value());
 
   return_client->CancelResourceReserve(
       *bundle_spec,
-      [bundle_spec, node_id](const Status &status,
-                             const rpc::CancelResourceReserveReply &reply) {
-        RAY_LOG(DEBUG) << "Finished cancelling the resource reserved for bundle: "
-                       << bundle_spec->DebugString() << " at node " << node_id;
+      [this, bundle_spec, node_id, node, max_retry, current_retry_cnt](
+          const Status &status, const rpc::CancelResourceReserveReply &reply) {
+        if (status.ok()) {
+          RAY_LOG(INFO) << "Finished cancelling the resource reserved for bundle: "
+                        << bundle_spec->DebugString() << " at node " << node_id;
+        } else {
+          // We couldn't delete the pg resources either becuase it is in use
+          // or network issue. Retry.
+          RAY_LOG(INFO) << "Failed to cancel the resource reserved for bundle: "
+                        << bundle_spec->DebugString() << " at node " << node_id
+                        << ". Status: " << status;
+          execute_after(
+              io_context_,
+              [this, bundle_spec, node, max_retry, current_retry_cnt] {
+                CancelResourceReserve(
+                    bundle_spec, node, max_retry, current_retry_cnt + 1);
+              },
+              std::chrono::milliseconds(1000) /* milliseconds */);
+        }
       });
 }
 
@@ -544,7 +572,14 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupPreparedBundleResources(
     for (const auto &iter : *(leasing_bundle_locations)) {
       auto &bundle_spec = iter.second.second;
       auto &node_id = iter.second.first;
-      CancelResourceReserve(bundle_spec, gcs_node_manager_.GetAliveNode(node_id));
+      CancelResourceReserve(
+          bundle_spec,
+          gcs_node_manager_.GetAliveNode(node_id),
+          // Retry 10 * worker registeration timeout to avoid race condition.
+          // See https://github.com/ray-project/ray/pull/42942
+          // for more details.
+          /*max_retry*/ RayConfig::instance().worker_register_timeout_seconds() * 10,
+          /*num_retry*/ 0);
     }
   }
 }
@@ -563,7 +598,14 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupCommittedBundleResources(
     for (const auto &iter : *(committed_bundle_locations)) {
       auto &bundle_spec = iter.second.second;
       auto &node_id = iter.second.first;
-      CancelResourceReserve(bundle_spec, gcs_node_manager_.GetAliveNode(node_id));
+      CancelResourceReserve(
+          bundle_spec,
+          gcs_node_manager_.GetAliveNode(node_id),
+          // Retry 10 * worker registeration timeout to avoid race condition.
+          // See https://github.com/ray-project/ray/pull/42942
+          // for more details.
+          /*max_retry*/ RayConfig::instance().worker_register_timeout_seconds() * 10,
+          /*num_retry*/ 0);
     }
     committed_bundle_location_index_.Erase(placement_group_id);
     cluster_resource_scheduler_.GetClusterResourceManager()

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -387,9 +387,13 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   ///
   /// \param bundle A description of the bundle to return.
   /// \param node The node that the worker will be returned for.
+  /// \param max_retry The maximum times cancel request can be retried.
+  /// \param retry_cnt The number of times the cancel request is retried.
   void CancelResourceReserve(
       const std::shared_ptr<const BundleSpecification> &bundle_spec,
-      const absl::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node);
+      const absl::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
+      int max_retry,
+      int current_retry_cnt);
 
   /// Get an existing lease client or connect a new one or connect a new one.
   std::shared_ptr<ResourceReserveInterface> GetOrConnectLeaseClient(
@@ -465,6 +469,8 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// {original_resource_name}_group_{placement_group_id}, which means
   /// wildcard resource.
   bool IsPlacementGroupWildcardResource(const std::string &resource_name);
+
+  instrumented_io_context &io_context_;
 
   /// A timer that ticks every cancel resource failure milliseconds.
   boost::asio::deadline_timer return_timer_;

--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -230,7 +230,6 @@ void LocalTaskManager::DispatchScheduledTasksToWorkers() {
           cluster_resource_scheduler_->GetLocalResourceManager()
               .AllocateLocalTaskResources(spec.GetRequiredResources().GetResourceMap(),
                                           allocated_instances);
-
       if (!schedulable) {
         ReleaseTaskArgs(task_id);
         // The local node currently does not have the resources to run the task, so we

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1882,10 +1882,12 @@ void NodeManager::HandleCancelResourceReserve(
     DestroyWorker(worker, rpc::WorkerExitType::INTENDED_SYSTEM_EXIT, message);
   }
 
-  // Return bundle resources.
-  placement_group_resource_manager_->ReturnBundle(bundle_spec);
+  // Return bundle resources. If it fails to return a bundle,
+  // it will return none-ok status. They are transient state,
+  // and GCS should retry.
+  auto status = placement_group_resource_manager_->ReturnBundle(bundle_spec);
   cluster_task_manager_->ScheduleAndDispatchTasks();
-  send_reply_callback(Status::OK(), nullptr, nullptr);
+  send_reply_callback(status, nullptr, nullptr);
 }
 
 void NodeManager::HandleReturnWorker(rpc::ReturnWorkerRequest request,

--- a/src/ray/raylet/placement_group_resource_manager.cc
+++ b/src/ray/raylet/placement_group_resource_manager.cc
@@ -26,7 +26,7 @@ void PlacementGroupResourceManager::ReturnUnusedBundle(
     const std::unordered_set<BundleID, pair_hash> &in_use_bundles) {
   for (auto iter = bundle_spec_map_.begin(); iter != bundle_spec_map_.end();) {
     if (0 == in_use_bundles.count(iter->first)) {
-      ReturnBundle(*iter->second);
+      RAY_CHECK(ReturnBundle(*iter->second).ok());
       bundle_spec_map_.erase(iter++);
     } else {
       iter++;
@@ -51,7 +51,7 @@ bool NewPlacementGroupResourceManager::PrepareBundle(
     } else {
       // If there was a bundle in prepare state, it already locked resources, we will
       // return bundle resources so that we can start from the prepare phase again.
-      ReturnBundle(bundle_spec);
+      RAY_CHECK(ReturnBundle(bundle_spec).ok());
     }
   }
 
@@ -94,7 +94,7 @@ bool NewPlacementGroupResourceManager::PrepareBundles(
     RAY_LOG(DEBUG) << "There are one or more bundles request resource failed, will "
                       "release the requested resources before.";
     for (const auto &bundle : prepared_bundles) {
-      ReturnBundle(*bundle);
+      RAY_CHECK(ReturnBundle(*bundle).ok());
       // Erase from `bundle_spec_map_`.
       const auto &iter = bundle_spec_map_.find(bundle->BundleId());
       if (iter != bundle_spec_map_.end()) {
@@ -152,13 +152,14 @@ void NewPlacementGroupResourceManager::CommitBundles(
   }
 }
 
-void NewPlacementGroupResourceManager::ReturnBundle(
+Status NewPlacementGroupResourceManager::ReturnBundle(
     const BundleSpecification &bundle_spec) {
   auto it = pg_bundles_.find(bundle_spec.BundleId());
   if (it == pg_bundles_.end()) {
     RAY_LOG(DEBUG) << "Duplicate cancel request, skip it directly.";
-    return;
+    return Status::OK();
   }
+
   const auto &bundle_state = it->second;
   if (bundle_state->state_ == CommitState::PREPARED) {
     // Commit bundle first so that we can remove the bundle with consistent
@@ -166,17 +167,26 @@ void NewPlacementGroupResourceManager::ReturnBundle(
     CommitBundle(bundle_spec);
   }
 
-  // Return original resources to resource allocator `ClusterResourceScheduler`.
-  auto original_resources = it->second->resources_;
-  cluster_resource_scheduler_->GetLocalResourceManager().ReleaseWorkerResources(
-      original_resources);
-
   // Substract placement group resources from resource allocator
   // `ClusterResourceScheduler`.
   const auto &placement_group_resources = bundle_spec.GetFormattedResources();
   auto resource_instances = std::make_shared<TaskResourceInstances>();
-  cluster_resource_scheduler_->GetLocalResourceManager().AllocateLocalTaskResources(
-      placement_group_resources, resource_instances);
+  auto allocated =
+      cluster_resource_scheduler_->GetLocalResourceManager().AllocateLocalTaskResources(
+          placement_group_resources, resource_instances);
+
+  if (!allocated) {
+    RAY_LOG(WARNING) << "Bundle resources are still in use. GCS should retry to release "
+                        "a bundle. It only happens if a scheduler allocated resources, "
+                        "but a worker hasn't been started. "
+                     << bundle_spec.DebugString();
+    return Status::Invalid("Bundle resources are still in use. Retry again.");
+  } else {
+    // Return original resources to resource allocator `ClusterResourceScheduler`.
+    auto original_resources = it->second->resources_;
+    cluster_resource_scheduler_->GetLocalResourceManager().ReleaseWorkerResources(
+        original_resources);
+  }
 
   for (const auto &resource : placement_group_resources) {
     auto resource_id = scheduling::ResourceID{resource.first};
@@ -194,6 +204,7 @@ void NewPlacementGroupResourceManager::ReturnBundle(
     }
   }
   pg_bundles_.erase(it);
+  return Status::OK();
 }
 
 }  // namespace raylet

--- a/src/ray/raylet/placement_group_resource_manager.h
+++ b/src/ray/raylet/placement_group_resource_manager.h
@@ -64,7 +64,10 @@ class PlacementGroupResourceManager {
   /// Return back all the bundle resource.
   ///
   /// \param bundle_spec Specification of bundle whose resources will be returned.
-  virtual void ReturnBundle(const BundleSpecification &bundle_spec) = 0;
+  /// \return ok status if it succeeds to return a bundle. Invalid if it is
+  /// in a transient state that cannot return a bundle. The caller should
+  /// retry in this case.
+  virtual Status ReturnBundle(const BundleSpecification &bundle_spec) = 0;
 
   /// Return back all the bundle(which is unused) resource.
   ///
@@ -96,7 +99,7 @@ class NewPlacementGroupResourceManager : public PlacementGroupResourceManager {
   void CommitBundles(const std::vector<std::shared_ptr<const BundleSpecification>>
                          &bundle_specs) override;
 
-  void ReturnBundle(const BundleSpecification &bundle_spec) override;
+  Status ReturnBundle(const BundleSpecification &bundle_spec) override;
 
   const std::shared_ptr<ClusterResourceScheduler> GetResourceScheduler() const {
     return cluster_resource_scheduler_;

--- a/src/ray/raylet/placement_group_resource_manager_test.cc
+++ b/src/ray/raylet/placement_group_resource_manager_test.cc
@@ -258,7 +258,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewReturnBundleResource) {
   new_placement_group_resource_manager_->CommitBundles(
       ConvertSingleSpecToVectorPtrs(bundle_spec));
   /// 4. return bundle resource.
-  new_placement_group_resource_manager_->ReturnBundle(bundle_spec);
+  ASSERT_TRUE(new_placement_group_resource_manager_->ReturnBundle(bundle_spec).ok());
   /// 5. check remaining resources is correct.
   auto remaining_resource_scheduler = std::make_shared<ClusterResourceScheduler>(
       io_context, scheduling::NodeID("remaining"), unit_resource, is_node_available_fn_);
@@ -313,7 +313,8 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewMultipleBundlesCommitAndRetu
 
   CheckRemainingResourceCorrect(remaining_resource_instance);
   /// 5. return second bundle.
-  new_placement_group_resource_manager_->ReturnBundle(second_bundle_spec);
+  ASSERT_TRUE(
+      new_placement_group_resource_manager_->ReturnBundle(second_bundle_spec).ok());
   /// 6. check remaining resources is correct after return second bundle.
   remaining_resources = {{"CPU_group_" + group_id.Hex(), 2.0},
                          {"CPU_group_1_" + group_id.Hex(), 1.0},
@@ -336,7 +337,8 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewMultipleBundlesCommitAndRetu
           scheduling::NodeID("remaining"));
   CheckRemainingResourceCorrect(remaining_resource_instance);
   /// 7. return first bundle.
-  new_placement_group_resource_manager_->ReturnBundle(first_bundle_spec);
+  ASSERT_TRUE(
+      new_placement_group_resource_manager_->ReturnBundle(first_bundle_spec).ok());
   /// 8. check remaining resources is correct after all bundle returned.
   remaining_resources = {{"CPU", 2.0}};
   remaining_resource_scheduler =
@@ -420,7 +422,7 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewIdempotencyWithRandomOrder) 
       remaining_resource_scheduler->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID("remaining"));
   CheckRemainingResourceCorrect(remaining_resource_instance);
-  new_placement_group_resource_manager_->ReturnBundle(bundle_spec);
+  ASSERT_TRUE(new_placement_group_resource_manager_->ReturnBundle(bundle_spec).ok());
   // 5. prepare bundle -> commit bundle -> commit bundle.
   ASSERT_TRUE(new_placement_group_resource_manager_->PrepareBundles(
       ConvertSingleSpecToVectorPtrs(bundle_spec)));
@@ -430,11 +432,11 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestNewIdempotencyWithRandomOrder) 
       ConvertSingleSpecToVectorPtrs(bundle_spec));
   // 6. check remaining resources is correct.
   CheckRemainingResourceCorrect(remaining_resource_instance);
-  new_placement_group_resource_manager_->ReturnBundle(bundle_spec);
+  ASSERT_TRUE(new_placement_group_resource_manager_->ReturnBundle(bundle_spec).ok());
   // 7. prepare bundle -> return bundle -> commit bundle.
   ASSERT_TRUE(new_placement_group_resource_manager_->PrepareBundles(
       ConvertSingleSpecToVectorPtrs(bundle_spec)));
-  new_placement_group_resource_manager_->ReturnBundle(bundle_spec);
+  ASSERT_TRUE(new_placement_group_resource_manager_->ReturnBundle(bundle_spec).ok());
   new_placement_group_resource_manager_->CommitBundles(
       ConvertSingleSpecToVectorPtrs(bundle_spec));
   // 8. check remaining resources is correct.
@@ -561,6 +563,30 @@ TEST_F(NewPlacementGroupResourceManagerTest, TestCommiteResourceBatched) {
   RAY_LOG(INFO) << "The current local resource view: "
                 << cluster_resource_scheduler_->DebugString();
   CheckRemainingResourceCorrect(remaining_resource_instance);
+}
+
+TEST_F(NewPlacementGroupResourceManagerTest, TestNewReturnBundleFailure) {
+  // create bundle spec.
+  auto group_id = PlacementGroupID::Of(JobID::FromInt(1));
+  absl::flat_hash_map<std::string, double> unit_resource;
+  unit_resource.insert({"CPU", 1.0});
+  auto bundle_spec = Mocker::GenBundleCreation(group_id, 1, unit_resource);
+  /// init local available resource.
+  InitLocalAvailableResource(unit_resource);
+  /// prepare and commit bundle resource.
+  ASSERT_TRUE(new_placement_group_resource_manager_->PrepareBundles(
+      ConvertSingleSpecToVectorPtrs(bundle_spec)));
+  new_placement_group_resource_manager_->CommitBundles(
+      ConvertSingleSpecToVectorPtrs(bundle_spec));
+  /// Occupy resources.
+  const auto &placement_group_resources = bundle_spec.GetFormattedResources();
+  auto resource_instances = std::make_shared<TaskResourceInstances>();
+  ASSERT_TRUE(
+      cluster_resource_scheduler_->GetLocalResourceManager().AllocateLocalTaskResources(
+          placement_group_resources, resource_instances));
+  /// return bundle resource failed with invalid error.
+  ASSERT_TRUE(
+      new_placement_group_resource_manager_->ReturnBundle(bundle_spec).IsInvalid());
 }
 
 }  // namespace ray

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -59,8 +59,6 @@ void ClusterResourceManager::AddOrUpdateNode(
 
 void ClusterResourceManager::AddOrUpdateNode(scheduling::NodeID node_id,
                                              const NodeResources &node_resources) {
-  RAY_LOG(DEBUG) << "Update node info, node_id: " << node_id.ToInt()
-                 << ", node_resources: " << node_resources.DebugString();
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {
     // This node is new, so add it to the map.


### PR DESCRIPTION
Root cause: When we schedule a task, we allocate resources and start a worker. If cancel bundle request is received before a worker is started, there's a leak because cancel bundle kills a worker and returns resources from "workers that are already started".

It fixes the issue by retrying cancellation. This also means

If a worker starts late (it has 60 seconds timeout), retry can fail as we have max number of retry. We retry for a very long time (10 * registration timeout), so it is unlikely to happen Alternatively, to improve the consistency, we can also do

register removed pg and keep deleting resources (with a reconciler) until it is fully gone. register leased workers before workers are started. This can be a better solution, but the implication of this change is unknown. I chose the current solution as it is needed for a network issue as well.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
