### PR TITLE
[ci][core] Skip flaky autoscaler v2 tests in `test_output` on premerge

### DIFF
--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -11,6 +11,7 @@ import ray
 from ray._private.test_utils import (
     run_string_as_driver,
     run_string_as_driver_nonblocking,
+    skip_flaky_core_test_premerge,
     wait_for_condition,
 )
 
@@ -162,6 +163,7 @@ def test_env_hook_skipped_for_ray_client(start_cluster, monkeypatch):
         assert ray.get(f.remote()) == "HOOK_VALUE"
 
 
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/43099")
 @pytest.mark.parametrize(
     "ray_start_cluster_head_with_env_vars",
     [
@@ -181,6 +183,9 @@ def test_env_hook_skipped_for_ray_client(start_cluster, monkeypatch):
     indirect=True,
 )
 def test_autoscaler_infeasible(ray_start_cluster_head_with_env_vars):
+    if os.environ.get("RAY_enable_autoscaler_v2") == "1":
+        pytest.skip("Autoscaler v2 events tests are flaky.")
+
     script = """
 import ray
 import time
@@ -204,6 +209,7 @@ time.sleep(15)
     assert "Error: No available node types can fulfill" in out_str
 
 
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/43099")
 @pytest.mark.parametrize(
     "ray_start_cluster_head_with_env_vars",
     [
@@ -248,6 +254,7 @@ time.sleep(25)
 
 
 # TODO(rickyx): Remove this after migration
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/43099")
 @pytest.mark.parametrize(
     "ray_start_cluster_head_with_env_vars",
     [
@@ -318,6 +325,7 @@ time.sleep(25)
 
 
 # TODO(rickyx): Remove this after migration
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/43099")
 @pytest.mark.parametrize(
     "ray_start_cluster_head_with_env_vars",
     [
@@ -363,6 +371,7 @@ time.sleep(3)
     wait_for_condition(verify)
 
 
+@skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/43099")
 @pytest.mark.parametrize(
     "event_level,expected_msg,unexpected_msg",
     [

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -183,9 +183,6 @@ def test_env_hook_skipped_for_ray_client(start_cluster, monkeypatch):
     indirect=True,
 )
 def test_autoscaler_infeasible(ray_start_cluster_head_with_env_vars):
-    if os.environ.get("RAY_enable_autoscaler_v2") == "1":
-        pytest.skip("Autoscaler v2 events tests are flaky.")
-
     script = """
 import ray
 import time


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See https://github.com/ray-project/ray/issues/43099

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
