### PR TITLE
[Core] Bumping up task failure logs to warnings to make sure failures could be traced in Ray Core logs

### DIFF
--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1047,9 +1047,11 @@ bool TaskManager::FailOrRetryPendingTask(const TaskID &task_id,
   // loudly with ERROR here.
   RAY_LOG(WARNING) << "Task attempt " << task_id << " failed with error "
                    << rpc::ErrorType_Name(error_type) << " Fail immediately? "
-                   << fail_immediately << ", status " << *status << ", error info "
-                   << (ray_error_info == nullptr ? "nullptr"
+                   << fail_immediately << ", status "
+                   << (status == nullptr ? "null" : *status) << ", error info "
+                   << (ray_error_info == nullptr ? "null"
                                                  : ray_error_info->DebugString());
+
   bool will_retry = false;
   if (!fail_immediately) {
     will_retry = RetryTaskIfPossible(

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1048,7 +1048,7 @@ bool TaskManager::FailOrRetryPendingTask(const TaskID &task_id,
   RAY_LOG(WARNING) << "Task attempt " << task_id << " failed with error "
                    << rpc::ErrorType_Name(error_type) << " Fail immediately? "
                    << fail_immediately << ", status "
-                   << (status == nullptr ? "null" : *status) << ", error info "
+                   << (status == nullptr ? "null" : status->ToString()) << ", error info "
                    << (ray_error_info == nullptr ? "null"
                                                  : ray_error_info->DebugString());
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1045,11 +1045,11 @@ bool TaskManager::FailOrRetryPendingTask(const TaskID &task_id,
                                          bool fail_immediately) {
   // Note that this might be the __ray_terminate__ task, so we don't log
   // loudly with ERROR here.
-  RAY_LOG(DEBUG) << "Task attempt " << task_id << " failed with error "
-                 << rpc::ErrorType_Name(error_type) << " Fail immediately? "
-                 << fail_immediately << ", status " << *status << ", error info "
-                 << (ray_error_info == nullptr ? "nullptr"
-                                               : ray_error_info->DebugString());
+  RAY_LOG(WARNING) << "Task attempt " << task_id << " failed with error "
+                   << rpc::ErrorType_Name(error_type) << " Fail immediately? "
+                   << fail_immediately << ", status " << *status << ", error info "
+                   << (ray_error_info == nullptr ? "nullptr"
+                                                 : ray_error_info->DebugString());
   bool will_retry = false;
   if (!fail_immediately) {
     will_retry = RetryTaskIfPossible(

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -709,11 +709,11 @@ void CoreWorkerDirectTaskSubmitter::HandleGetTaskFailureCause(
   std::unique_ptr<rpc::RayErrorInfo> error_info;
   bool fail_immediately = false;
   if (get_task_failure_cause_reply_status.ok()) {
-    RAY_LOG(DEBUG) << "Task failure cause for task " << task_id << ": "
-                   << ray::gcs::RayErrorInfoToString(
-                          get_task_failure_cause_reply.failure_cause())
-                   << " fail immedediately: "
-                   << get_task_failure_cause_reply.fail_task_immediately();
+    RAY_LOG(WARNING) << "Task failure cause for task " << task_id << ": "
+                     << ray::gcs::RayErrorInfoToString(
+                            get_task_failure_cause_reply.failure_cause())
+                     << " fail immedediately: "
+                     << get_task_failure_cause_reply.fail_task_immediately();
     if (get_task_failure_cause_reply.has_failure_cause()) {
       task_error_type = get_task_failure_cause_reply.failure_cause().error_type();
       error_info = std::make_unique<rpc::RayErrorInfo>(
@@ -722,10 +722,10 @@ void CoreWorkerDirectTaskSubmitter::HandleGetTaskFailureCause(
     }
     fail_immediately = get_task_failure_cause_reply.fail_task_immediately();
   } else {
-    RAY_LOG(DEBUG) << "Failed to fetch task result with status "
-                   << get_task_failure_cause_reply_status.ToString()
-                   << " node id: " << NodeID::FromBinary(addr.raylet_id())
-                   << " ip: " << addr.ip_address();
+    RAY_LOG(WARNING) << "Failed to fetch task result with status "
+                     << get_task_failure_cause_reply_status.ToString()
+                     << " node id: " << NodeID::FromBinary(addr.raylet_id())
+                     << " ip: " << addr.ip_address();
     task_error_type = rpc::ErrorType::NODE_DIED;
     std::stringstream buffer;
     buffer << "Task failed due to the node dying.\n\nThe node (IP: " << addr.ip_address()


### PR DESCRIPTION
…troubleshooted

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, we observe a lot of failures like following in our production deployment:

```
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/serve/handle.py", line 781, in __anext__
    return await next_obj_ref
ray.exceptions.RayActorError: The actor died unexpectedly before finishing this task.
```

However, we can't find any logs in Ray Core corresponding to this failure. Checking around i've realized that all of the log statements we have are DEBUG logs, which necessitates us to switch to DEBUG mode which will drown our logging infra.

Hence bumping failure logs to WARNING at least to make sure any failures are traceable in Ray Core logs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
