### PR TITLE
[Data] Add concurrency and deprecate parallelism for all read APIs

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -105,6 +105,8 @@ def from_items(
     items: List[Any],
     *,
     parallelism: int = -1,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
 ) -> MaterializedDataset:
     """Create a :class:`~ray.data.Dataset` from a list of local Python objects.
 
@@ -130,6 +132,14 @@ def from_items(
             on how to tune it, see
             :ref:`Tuning read parallelism <read_parallelism>`.
             Parallelism is upper bounded by ``len(items)``.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         A :class:`~ray.data.Dataset` holding the items.
@@ -187,7 +197,13 @@ def from_items(
 
 
 @PublicAPI
-def range(n: int, *, parallelism: int = -1) -> Dataset:
+def range(
+    n: int,
+    *,
+    parallelism: int = -1,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
+) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from a range of integers [0..n).
 
     This function allows for easy creation of synthetic datasets for testing or
@@ -211,6 +227,14 @@ def range(n: int, *, parallelism: int = -1) -> Dataset:
             on how to tune it, see
             :ref:`Tuning read parallelism <read_parallelism>`.
             Parallelism is upper bounded by n.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         A :class:`~ray.data.Dataset` producing the integers from the range 0 to n.
@@ -222,11 +246,23 @@ def range(n: int, *, parallelism: int = -1) -> Dataset:
 
     """
     datasource = RangeDatasource(n=n, block_format="arrow", column_name="id")
-    return read_datasource(datasource, parallelism=parallelism)
+    return read_datasource(
+        datasource,
+        parallelism=parallelism,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
+    )
 
 
 @PublicAPI
-def range_tensor(n: int, *, shape: Tuple = (1,), parallelism: int = -1) -> Dataset:
+def range_tensor(
+    n: int,
+    *,
+    shape: Tuple = (1,),
+    parallelism: int = -1,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
+) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` tensors of the provided shape from range
     [0...n].
 
@@ -258,6 +294,14 @@ def range_tensor(n: int, *, shape: Tuple = (1,), parallelism: int = -1) -> Datas
             on how to tune it, see
             :ref:`Tuning read parallelism <read_parallelism>`.
             Parallelism is upper bounded by n.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         A :class:`~ray.data.Dataset` producing the tensor data from range 0 to n.
@@ -271,7 +315,12 @@ def range_tensor(n: int, *, shape: Tuple = (1,), parallelism: int = -1) -> Datas
     datasource = RangeDatasource(
         n=n, block_format="tensor", column_name="data", tensor_shape=tuple(shape)
     )
-    return read_datasource(datasource, parallelism=parallelism)
+    return read_datasource(
+        datasource,
+        parallelism=parallelism,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
+    )
 
 
 @PublicAPI
@@ -394,6 +443,7 @@ def read_datasource(
         inmemory_size,
         block_list._estimated_num_blocks,
         ray_remote_args,
+        concurrency,
     )
 
     logical_plan = LogicalPlan(read_op)
@@ -414,6 +464,8 @@ def read_mongo(
     schema: Optional["pymongoarrow.api.Schema"] = None,
     parallelism: int = -1,
     ray_remote_args: Dict[str, Any] = None,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
     **mongo_args,
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from a MongoDB database.
@@ -470,6 +522,14 @@ def read_mongo(
             on how to tune it, see :ref:`Tuning read parallelism
             <read_parallelism>`.
         ray_remote_args: kwargs passed to :meth:`~ray.remote` in the read tasks.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
         mongo_args: kwargs passed to `aggregate_arrow_all() <https://mongo-arrow\
             .readthedocs.io/en/latest/api/api.html#pymongoarrow.api\
             aggregate_arrow_all>`_ in pymongoarrow in producing
@@ -491,7 +551,11 @@ def read_mongo(
         **mongo_args,
     )
     return read_datasource(
-        datasource, parallelism=parallelism, ray_remote_args=ray_remote_args
+        datasource,
+        parallelism=parallelism,
+        ray_remote_args=ray_remote_args,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
     )
 
 
@@ -503,6 +567,8 @@ def read_bigquery(
     *,
     parallelism: int = -1,
     ray_remote_args: Dict[str, Any] = None,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
 ) -> Dataset:
     """Create a dataset from BigQuery.
 
@@ -547,6 +613,14 @@ def read_bigquery(
             automatically chosen based on the available cluster resources and estimated
             in-memory data size.
         ray_remote_args: kwargs passed to ray.remote in the read tasks.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         Dataset producing rows from the results of executing the query (or reading the entire dataset)
@@ -557,6 +631,8 @@ def read_bigquery(
         datasource,
         parallelism=parallelism,
         ray_remote_args=ray_remote_args,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
     )
 
 
@@ -748,6 +824,8 @@ def read_images(
     ignore_missing_paths: bool = False,
     shuffle: Union[Literal["files"], None] = None,
     file_extensions: Optional[List[str]] = ImageDatasource._FILE_EXTENSIONS,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
 ) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from image files.
 
@@ -843,6 +921,14 @@ def read_images(
         shuffle: If setting to "files", randomly shuffle input files order before read.
             Defaults to not shuffle with ``None``.
         file_extensions: A list of file extensions to filter files by.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         A :class:`~ray.data.Dataset` producing tensors that represent the images at
@@ -871,7 +957,11 @@ def read_images(
         file_extensions=file_extensions,
     )
     return read_datasource(
-        datasource, parallelism=parallelism, ray_remote_args=ray_remote_args
+        datasource,
+        parallelism=parallelism,
+        ray_remote_args=ray_remote_args,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
     )
 
 
@@ -890,6 +980,8 @@ def read_parquet_bulk(
     shuffle: Union[Literal["files"], None] = None,
     include_paths: bool = False,
     file_extensions: Optional[List[str]] = ParquetBaseDatasource._FILE_EXTENSIONS,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
     **arrow_parquet_args,
 ) -> Dataset:
     """Create :class:`~ray.data.Dataset` from parquet files without reading metadata.
@@ -967,6 +1059,14 @@ def read_parquet_bulk(
         include_paths: If ``True``, include the path to each file. File paths are
             stored in the ``'path'`` column.
         file_extensions: A list of file extensions to filter files by.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
        :class:`~ray.data.Dataset` producing records read from the specified paths.
@@ -995,6 +1095,8 @@ def read_parquet_bulk(
         datasource,
         parallelism=parallelism,
         ray_remote_args=ray_remote_args,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
     )
 
 
@@ -1013,6 +1115,8 @@ def read_json(
     ignore_missing_paths: bool = False,
     shuffle: Union[Literal["files"], None] = None,
     file_extensions: Optional[List[str]] = JSONDatasource._FILE_EXTENSIONS,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
     **arrow_json_args,
 ) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from JSON and JSONL files.
@@ -1106,6 +1210,14 @@ def read_json(
             arrow.apache.org/docs/python/generated/pyarrow.json.read_json.html#pyarrow.\
             json.read_json>`_.
         file_extensions: A list of file extensions to filter files by.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         :class:`~ray.data.Dataset` producing records read from the specified paths.
@@ -1127,7 +1239,11 @@ def read_json(
         file_extensions=file_extensions,
     )
     return read_datasource(
-        datasource, parallelism=parallelism, ray_remote_args=ray_remote_args
+        datasource,
+        parallelism=parallelism,
+        ray_remote_args=ray_remote_args,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
     )
 
 
@@ -1146,6 +1262,8 @@ def read_csv(
     ignore_missing_paths: bool = False,
     shuffle: Union[Literal["files"], None] = None,
     file_extensions: Optional[List[str]] = None,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
     **arrow_csv_args,
 ) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from CSV files.
@@ -1264,6 +1382,14 @@ def read_csv(
             pyarrow.csv.open_csv.html#pyarrow.csv.open_csv>`_
             when opening CSV files.
         file_extensions: A list of file extensions to filter files by.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         :class:`~ray.data.Dataset` producing records read from the specified paths.
@@ -1288,6 +1414,8 @@ def read_csv(
         datasource,
         parallelism=parallelism,
         ray_remote_args=ray_remote_args,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
     )
 
 
@@ -1308,6 +1436,8 @@ def read_text(
     ignore_missing_paths: bool = False,
     shuffle: Union[Literal["files"], None] = None,
     file_extensions: Optional[List[str]] = None,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from lines stored in text files.
 
@@ -1368,6 +1498,14 @@ def read_text(
         shuffle: If setting to "files", randomly shuffle input files order before read.
             Defaults to not shuffle with ``None``.
         file_extensions: A list of file extensions to filter files by.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         :class:`~ray.data.Dataset` producing lines of text read from the specified
@@ -1391,7 +1529,11 @@ def read_text(
         file_extensions=file_extensions,
     )
     return read_datasource(
-        datasource, parallelism=parallelism, ray_remote_args=ray_remote_args
+        datasource,
+        parallelism=parallelism,
+        ray_remote_args=ray_remote_args,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
     )
 
 
@@ -1409,6 +1551,8 @@ def read_numpy(
     ignore_missing_paths: bool = False,
     shuffle: Union[Literal["files"], None] = None,
     file_extensions: Optional[List[str]] = NumpyDatasource._FILE_EXTENSIONS,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
     **numpy_load_args,
 ) -> Dataset:
     """Create an Arrow dataset from numpy files.
@@ -1453,6 +1597,14 @@ def read_numpy(
         shuffle: If setting to "files", randomly shuffle input files order before read.
             Defaults to not shuffle with ``None``.
         file_extensions: A list of file extensions to filter files by.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         Dataset holding Tensor records read from the specified paths.
@@ -1476,6 +1628,8 @@ def read_numpy(
     return read_datasource(
         datasource,
         parallelism=parallelism,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
     )
 
 
@@ -1493,6 +1647,8 @@ def read_tfrecords(
     tf_schema: Optional["schema_pb2.Schema"] = None,
     shuffle: Union[Literal["files"], None] = None,
     file_extensions: Optional[List[str]] = None,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from TFRecord files that contain
     `tf.train.Example <https://www.tensorflow.org/api_docs/python/tf/train/Example>`_
@@ -1567,6 +1723,14 @@ def read_tfrecords(
         shuffle: If setting to "files", randomly shuffle input files order before read.
             Defaults to not shuffle with ``None``.
         file_extensions: A list of file extensions to filter files by.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         A :class:`~ray.data.Dataset` that contains the example features.
@@ -1591,7 +1755,12 @@ def read_tfrecords(
         include_paths=include_paths,
         file_extensions=file_extensions,
     )
-    return read_datasource(datasource, parallelism=parallelism)
+    return read_datasource(
+        datasource,
+        parallelism=parallelism,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
+    )
 
 
 @PublicAPI(stability="alpha")
@@ -1611,6 +1780,8 @@ def read_webdataset(
     shuffle: Union[Literal["files"], None] = None,
     include_paths: bool = False,
     file_extensions: Optional[List[str]] = None,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from
     `WebDataset <https://webdataset.github.io/webdataset/>`_ files.
@@ -1641,6 +1812,14 @@ def read_webdataset(
         include_paths: If ``True``, include the path to each file. File paths are
             stored in the ``'path'`` column.
         file_extensions: A list of file extensions to filter files by.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         A :class:`~ray.data.Dataset` that contains the example features.
@@ -1670,7 +1849,12 @@ def read_webdataset(
         include_paths=include_paths,
         file_extensions=file_extensions,
     )
-    return read_datasource(datasource, parallelism=parallelism)
+    return read_datasource(
+        datasource,
+        parallelism=parallelism,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
+    )
 
 
 @PublicAPI
@@ -1688,6 +1872,8 @@ def read_binary_files(
     ignore_missing_paths: bool = False,
     shuffle: Union[Literal["files"], None] = None,
     file_extensions: Optional[List[str]] = None,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from binary files of arbitrary contents.
 
@@ -1755,6 +1941,14 @@ def read_binary_files(
         shuffle: If setting to "files", randomly shuffle input files order before read.
             Defaults to not shuffle with ``None``.
         file_extensions: A list of file extensions to filter files by.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         :class:`~ray.data.Dataset` producing rows read from the specified paths.
@@ -1775,7 +1969,11 @@ def read_binary_files(
         file_extensions=file_extensions,
     )
     return read_datasource(
-        datasource, parallelism=parallelism, ray_remote_args=ray_remote_args
+        datasource,
+        parallelism=parallelism,
+        ray_remote_args=ray_remote_args,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
     )
 
 
@@ -1786,6 +1984,8 @@ def read_sql(
     *,
     parallelism: int = -1,
     ray_remote_args: Optional[Dict[str, Any]] = None,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
 ) -> Dataset:
     """Read from a database that provides a
     `Python DB API2-compliant <https://peps.python.org/pep-0249/>`_ connector.
@@ -1859,6 +2059,14 @@ def read_sql(
             on how to tune it, see :ref:`Tuning read parallelism
             <read_parallelism>`.
         ray_remote_args: kwargs passed to :meth:`~ray.remote` in the read tasks.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         A :class:`Dataset` containing the queried data.
@@ -1868,6 +2076,8 @@ def read_sql(
         datasource,
         parallelism=parallelism,
         ray_remote_args=ray_remote_args,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
     )
 
 
@@ -1881,6 +2091,8 @@ def read_databricks_tables(
     schema: Optional[str] = None,
     parallelism: int = -1,
     ray_remote_args: Optional[Dict[str, Any]] = None,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
 ) -> Dataset:
     """Read a Databricks unity catalog table or Databricks SQL execution result.
 
@@ -1934,6 +2146,14 @@ def read_databricks_tables(
             on how to tune it, see :ref:`Tuning read parallelism
             <read_parallelism>`.
         ray_remote_args: kwargs passed to :meth:`~ray.remote` in the read tasks.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         A :class:`Dataset` containing the queried data.
@@ -2001,7 +2221,11 @@ def read_databricks_tables(
         query=query,
     )
     return read_datasource(
-        datasource=datasource, parallelism=parallelism, ray_remote_args=ray_remote_args
+        datasource=datasource,
+        parallelism=parallelism,
+        ray_remote_args=ray_remote_args,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
     )
 
 
@@ -2354,7 +2578,11 @@ def from_arrow_refs(
 
 @PublicAPI
 def from_spark(
-    df: "pyspark.sql.DataFrame", *, parallelism: Optional[int] = None
+    df: "pyspark.sql.DataFrame",
+    *,
+    parallelism: Optional[int] = None,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
 ) -> MaterializedDataset:
     """Create a :class:`~ray.data.Dataset` from a
     `Spark DataFrame <https://spark.apache.org/docs/3.1.1/api/python/reference/api/pyspark.sql.DataFrame.html>`_.
@@ -2364,6 +2592,14 @@ def from_spark(
         parallelism: The amount of parallelism to use for the dataset. If
             not provided, the parallelism is equal to the number of partitions of
             the original Spark DataFrame.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         A :class:`~ray.data.MaterializedDataset` holding rows read from the DataFrame.
@@ -2375,7 +2611,10 @@ def from_spark(
 
 @PublicAPI
 def from_huggingface(
-    dataset: Union["datasets.Dataset", "datasets.IterableDataset"], parallelism=-1
+    dataset: Union["datasets.Dataset", "datasets.IterableDataset"],
+    parallelism: int = -1,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
 ) -> Union[MaterializedDataset, Dataset]:
     """Create a :class:`~ray.data.MaterializedDataset` from a
     `Hugging Face Datasets Dataset <https://huggingface.co/docs/datasets/package_reference/main_classes#datasets.Dataset/>`_
@@ -2433,6 +2672,14 @@ def from_huggingface(
             on how to tune it, see :ref:`Tuning read parallelism
             <read_parallelism>`. Parallelism is upper bounded by the total number of
             records in all the parquet files.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on available resource.
+        override_num_blocks: Override the number of output blocks of read tasks. By
+            default, the number of output blocks is dynamically decided based on
+            input data size and available resource. You should not need to manually
+            set this value in most cases.
 
     Returns:
         A :class:`~ray.data.Dataset` holding rows from the `Hugging Face Datasets Dataset`_.
@@ -2452,7 +2699,13 @@ def from_huggingface(
             import fsspec.implementations.http
 
             http = fsspec.implementations.http.HTTPFileSystem()
-            return read_parquet(file_urls, parallelism=parallelism, filesystem=http)
+            return read_parquet(
+                file_urls,
+                parallelism=parallelism,
+                filesystem=http,
+                concurrency=concurrency,
+                override_num_blocks=override_num_blocks,
+            )
 
     if isinstance(dataset, datasets.IterableDataset):
         # For an IterableDataset, we can use a streaming implementation to read data.
@@ -2579,9 +2832,9 @@ def from_torch(
     }
     return read_datasource(
         TorchDatasource(dataset=dataset),
-        # Only non-parallel, streaming read is currently supported
-        parallelism=1,
         ray_remote_args=ray_remote_args,
+        # Only non-parallel, streaming read is currently supported
+        override_num_blocks=1,
     )
 
 

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -14,6 +14,7 @@ import pytest
 import ray
 from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
+from ray.data.tests.test_util import ConcurrencyCounter  # noqa
 from ray.data.tests.util import column_udf, column_udf_class, extract_values
 from ray.tests.conftest import *  # noqa
 
@@ -646,25 +647,6 @@ def test_map_with_memory_resources(shutdown_only):
     memory_per_task = 100 * 1024**2
     max_concurrency = 5
     ray.init(num_cpus=num_blocks, _memory=memory_per_task * max_concurrency)
-
-    @ray.remote
-    class ConcurrencyCounter:
-        def __init__(self):
-            self.concurrency = 0
-            self.max_concurrency = 0
-
-        def inc(self):
-            self.concurrency += 1
-            if self.concurrency > self.max_concurrency:
-                self.max_concurrency = self.concurrency
-            return self.concurrency
-
-        def decr(self):
-            self.concurrency -= 1
-            return self.concurrency
-
-        def get_max_concurrency(self):
-            return self.max_concurrency
 
     concurrency_counter = ConcurrencyCounter.remote()
 

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import time
 from typing import Any
 
 import numpy as np
@@ -28,6 +29,7 @@ from ray.data.datasource.parquet_datasource import (
 from ray.data.datasource.path_util import _unwrap_protocol
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
+from ray.data.tests.test_util import ConcurrencyCounter  # noqa
 from ray.tests.conftest import *  # noqa
 
 
@@ -1176,6 +1178,48 @@ def test_parquet_datasource_names(ray_start_regular_shared, tmp_path):
 
     assert ParquetBaseDatasource(path).get_name() == "ParquetBulk"
     assert ParquetDatasource(path).get_name() == "Parquet"
+
+
+@pytest.mark.parametrize(
+    "fs,data_path",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+    ],
+)
+def test_parquet_concurrency(ray_start_regular_shared, fs, data_path):
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    table = pa.Table.from_pandas(df1)
+    setup_data_path = _unwrap_protocol(data_path)
+    path1 = os.path.join(setup_data_path, "test1.parquet")
+    pq.write_table(table, path1, filesystem=fs)
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    table = pa.Table.from_pandas(df2)
+    path2 = os.path.join(setup_data_path, "test2.parquet")
+    pq.write_table(table, path2, filesystem=fs)
+
+    concurrency_counter = ConcurrencyCounter.remote()
+
+    def map_batches(batch):
+        ray.get(concurrency_counter.inc.remote())
+        time.sleep(0.5)
+        ray.get(concurrency_counter.decr.remote())
+        return batch
+
+    concurrency = 1
+    ds = ray.data.read_parquet(
+        data_path,
+        filesystem=fs,
+        concurrency=concurrency,
+        override_num_blocks=2,
+    )
+    ds = ds.map_batches(
+        map_batches,
+        batch_size=None,
+        concurrency=concurrency,
+    )
+    assert ds.count() == 6
+    actual_max_concurrency = ray.get(concurrency_counter.get_max_concurrency.remote())
+    assert actual_max_concurrency <= concurrency
 
 
 # NOTE: All tests above share a Ray cluster, while the tests below do not. These

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -111,6 +111,26 @@ def get_parquet_read_logical_op(
     return read_op
 
 
+@ray.remote(num_cpus=0)
+class ConcurrencyCounter:
+    def __init__(self):
+        self.concurrency = 0
+        self.max_concurrency = 0
+
+    def inc(self):
+        self.concurrency += 1
+        if self.concurrency > self.max_concurrency:
+            self.max_concurrency = self.concurrency
+        return self.concurrency
+
+    def decr(self):
+        self.concurrency -= 1
+        return self.concurrency
+
+    def get_max_concurrency(self):
+        return self.max_concurrency
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to add concurrency and deprecate parallelism w/ override_num_blocks for all read APIs.

In addition, adding a unit test for read_parquet for concurrency.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
