### PR TITLE
[Serve] Config Serve's gRPC proxy to allow large payload

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -302,3 +302,15 @@ RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE = (
 RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE = (
     os.environ.get("RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE", "1") == "1"
 )
+
+
+# Default is 2GiB, the max for a signed int.
+RAY_SERVE_GRPC_MAX_MESSAGE_SIZE = int(
+    os.environ.get("RAY_SERVE_GRPC_MAX_MESSAGE_SIZE", (2 * 1024 * 1024 * 1024) - 1)
+)
+
+# Serve's gRPC server options.
+SERVE_GRPC_OPTIONS = [
+    ("grpc.max_send_message_length", RAY_SERVE_GRPC_MAX_MESSAGE_SIZE),
+    ("grpc.max_receive_message_length", RAY_SERVE_GRPC_MAX_MESSAGE_SIZE),
+]

--- a/python/ray/serve/_private/grpc_util.py
+++ b/python/ray/serve/_private/grpc_util.py
@@ -3,6 +3,8 @@ from typing import Sequence
 import grpc
 from grpc.aio._server import Server
 
+from ray.util.client.common import GRPC_OPTIONS
+
 
 class gRPCServer(Server):
     """Custom gRPC server to override gRPC method methods.
@@ -61,7 +63,7 @@ def create_serve_grpc_server(service_handler_factory):
         thread_pool=None,
         generic_handlers=(),
         interceptors=(),
-        options=(),
+        options=GRPC_OPTIONS,
         maximum_concurrent_rpcs=None,
         compression=None,
         service_handler_factory=service_handler_factory,

--- a/python/ray/serve/_private/grpc_util.py
+++ b/python/ray/serve/_private/grpc_util.py
@@ -3,7 +3,7 @@ from typing import Sequence
 import grpc
 from grpc.aio._server import Server
 
-from ray.util.client.common import GRPC_OPTIONS
+from ray.serve._private.constants import SERVE_GRPC_OPTIONS
 
 
 class gRPCServer(Server):
@@ -63,7 +63,7 @@ def create_serve_grpc_server(service_handler_factory):
         thread_pool=None,
         generic_handlers=(),
         interceptors=(),
-        options=GRPC_OPTIONS,
+        options=SERVE_GRPC_OPTIONS,
         maximum_concurrent_rpcs=None,
         compression=None,
         service_handler_factory=service_handler_factory,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A user reported a bug unable to send large payloads with Serve's gRPC proxy. This PR configs Serve's gRPC proxy ] to allow the clients to setup larger message limits. Also, add a test to ensure this case will be caught in the future.  

## Related issue number

Closes https://github.com/ray-project/ray/issues/43109

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
