### PR TITLE
[Core] ray.remote raises ValueError when used on torch IterableDataset

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -2119,10 +2119,6 @@ def skip_flaky_core_test_premerge(reason: str):
     return wrapper
 
 
-def is_python_version_older_than(major: int, minor: int) -> bool:
-    return sys.version_info < (major, minor)
-
-
 def get_ray_default_worker_file_path():
     py_version = f"{sys.version_info[0]}.{sys.version_info[1]}"
     return (

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -2118,8 +2118,10 @@ def skip_flaky_core_test_premerge(reason: str):
 
     return wrapper
 
+
 def is_python_version_older_than(major: int, minor: int) -> bool:
     return sys.version_info < (major, minor)
+
 
 def get_ray_default_worker_file_path():
     py_version = f"{sys.version_info[0]}.{sys.version_info[1]}"

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -2118,6 +2118,8 @@ def skip_flaky_core_test_premerge(reason: str):
 
     return wrapper
 
+def is_python_version_older_than(major: int, minor: int) -> bool:
+    return sys.version_info < (major, minor)
 
 def get_ray_default_worker_file_path():
     py_version = f"{sys.version_info[0]}.{sys.version_info[1]}"

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -422,10 +422,6 @@ class _ActorClassMethodMetadata(object):
             ):
                 method = method.__init__
 
-            # Print a warning message if the method signature is not
-            # supported. We don't raise an exception because if the actor
-            # inherits from a class that has a method whose signature we
-            # don't support, there may not be much the user can do about it.
             self.signatures[method_name] = signature.extract_signature(
                 method, ignore_first=not is_bound
             )

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -421,6 +421,7 @@ class _ActorClassMethodMetadata(object):
                 )
             ):
                 method = method.__init__
+                assert 1 == 2
 
             self.signatures[method_name] = signature.extract_signature(
                 method, ignore_first=not is_bound

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -421,6 +421,7 @@ class _ActorClassMethodMetadata(object):
                 )
             ):
                 method = method.__init__
+                assert type(method) == type(all.__call__)
                 assert 1 == 2
 
             self.signatures[method_name] = signature.extract_signature(

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -417,7 +417,7 @@ class _ActorClassMethodMetadata(object):
             if GenericAlias and any(
                 (
                     method is GenericAlias,
-                    getattr(method, '__func__', None) is GenericAlias,
+                    getattr(method, "__func__", None) is GenericAlias,
                 )
             ):
                 method = method.__init__

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1,8 +1,8 @@
 import inspect
 import logging
+import sys
 import weakref
 from typing import Any, Dict, List, Optional, Union
-import sys
 
 import ray._private.ray_constants as ray_constants
 import ray._private.signature as signature
@@ -417,7 +417,7 @@ class _ActorClassMethodMetadata(object):
             if GenericAlias and any(
                 (
                     method is GenericAlias,
-                    getattr(method, '__func__', None) is GenericAlias
+                    getattr(method, '__func__', None) is GenericAlias,
                 )
             ):
                 method = method.__init__

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -412,10 +412,14 @@ class _ActorClassMethodMetadata(object):
                 modified_class, method_name
             )
 
-            if GenericAlias and any((
-                method is GenericAlias,
-                getattr(method, '__func__', None) is GenericAlias
-            )):
+            # Hotfix: This should be removed once GenericAlias includes signatures.
+            # See https://github.com/ray-project/ray/pull/43117 for more details.
+            if GenericAlias and any(
+                (
+                    method is GenericAlias,
+                    getattr(method, '__func__', None) is GenericAlias
+                )
+            ):
                 method = method.__init__
 
             # Print a warning message if the method signature is not

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1399,14 +1399,16 @@ def test_actor_equal(ray_start_regular_shared):
 def test_classmethod_genericalias():
     """
     The Python built-in function `inspect.signature` doesn't support
-    classmethod(GenericAlias). Hence, if we call `inspect.signature(MyClass.__class_getitem__)`,
-    it will raise a ValueError.
+    classmethod(GenericAlias). Hence, passing the `__class_getitem__`
+    to the function `inspect.signature` will raise a ValueError.
     """
     from types import GenericAlias
 
     @ray.remote
     class MyClass:
         __class_getitem__ = classmethod(GenericAlias)
+
+    assert getattr(MyClass.__class_getitem__, "__func__", None) is GenericAlias
 
     # This would allow MyClass[int] to behave similarly to specifying a generic type
     myClass = MyClass.remote()

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -12,7 +12,6 @@ from ray import cloudpickle as pickle
 from ray._private import ray_constants
 from ray._private.test_utils import (
     client_test_enabled,
-    is_python_version_older_than,
     wait_for_condition,
     wait_for_pid_to_exit,
 )
@@ -1395,7 +1394,7 @@ def test_actor_equal(ray_start_regular_shared):
 
 
 @pytest.mark.skipif(
-    is_python_version_older_than(3, 9), reason="GenericAlias is new in Python 3.9"
+    sys.version_info < (3, 9), reason="GenericAlias is new in Python 3.9"
 )
 def test_classmethod_genericalias():
     """

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1399,7 +1399,7 @@ def test_actor_equal(ray_start_regular_shared):
 def test_classmethod_genericalias():
     """
     The Python built-in function `inspect.signature` doesn't support
-    classmethod(GenericAlias). Hence, if we call `inspect.signature(MyClass)`,
+    classmethod(GenericAlias). Hence, if we call `inspect.signature(MyClass.__class_getitem__)`,
     it will raise a ValueError.
     """
     from types import GenericAlias

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1392,7 +1392,10 @@ def test_actor_equal(ray_start_regular_shared):
     remote = ray.get(get_actor.remote(origin))
     assert origin == remote
 
-@pytest.mark.skipif(is_python_version_older_than(3,9), reason="GenericAlias is new in Python 3.9")
+
+@pytest.mark.skipif(
+    is_python_version_older_than(3,9), reason="GenericAlias is new in Python 3.9"
+)
 def test_classmethod_genericalias():
     """
     The Python built-in function `inspect.signature` doesn't support

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1395,9 +1395,9 @@ def test_actor_equal(ray_start_regular_shared):
 @pytest.mark.skipif(is_python_version_older_than(3,9), reason="GenericAlias is new in Python 3.9")
 def test_classmethod_genericalias():
     """
-    The Python built-in function `inspect.signature` doesn't support classmethod(GenericAlias).
-    Hence, if we call `inspect.signature(MyClass)`, it will raise a ValueError. In #43117, we
-    have a workaround to bypass this issue.
+    The Python built-in function `inspect.signature` doesn't support
+    classmethod(GenericAlias). Hence, if we call `inspect.signature(MyClass)`,
+    it will raise a ValueError.
     """
     from types import GenericAlias
 

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -29,6 +29,7 @@ try:
 except ImportError:
     pytest_timeout = None
 
+
 @pytest.mark.parametrize("set_enable_auto_connect", [True, False], indirect=True)
 def test_caching_actors(shutdown_only, set_enable_auto_connect):
     # Test defining actors before ray.init() has been called.
@@ -1394,7 +1395,7 @@ def test_actor_equal(ray_start_regular_shared):
 
 
 @pytest.mark.skipif(
-    is_python_version_older_than(3,9), reason="GenericAlias is new in Python 3.9"
+    is_python_version_older_than(3, 9), reason="GenericAlias is new in Python 3.9"
 )
 def test_classmethod_genericalias():
     """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* If a class has `__class_getitems__` which should return a `GenericAlias` object, the `inspect.signature(...)` will throw an exception said that `ValueError: no signature found for builtin type <class 'types.GenericAlias'>`.
  * https://docs.python.org/3/reference/datamodel.html#class-getitem-versus-getitem 
    > __class_getitem__() should return a [GenericAlias](https://docs.python.org/3/library/stdtypes.html#types-genericalias) object if it is properly defined.
  * Note that `__class_getitems__` is not necessary to return a `GenericAlias`.

* https://docs.python.org/3.10/library/inspect.html#inspect.Signature
  > Note Some callables may not be introspectable in certain implementations of Python. For example, in CPython, some built-in functions defined in C provide no metadata about their arguments.

## Why can this PR avoid the ValueError?

```python
from types import GenericAlias

@ray.remote
class MyClass:
    __class_getitem__ = classmethod(GenericAlias)

# This would allow MyClass[int] to behave similarly to specifying a generic type
myClass = MyClass.remote()
obj_ref = myClass.__class_getitem__.remote(int)
print(ray.get(obj_ref))
```

* Without this PR, the type of the `__class_getitem__` is `method`. 
  * `_signature_from_callable` 
    * `isinstance(obj, types.MethodType)` -> True ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2398))
      * `_get_signature_of` (i.e. partial `_signature_from_callable`)
        * `isinstance(obj, types.MethodType)` -> False ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2398)) (`type(obj)` -> `types.GenericAlias`)
        * `unwrap` ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2412)) 
        * No `obj.__signature__` or `obj._partialmethod` ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2423), [code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2435))
        * `isfunction(obj) or _signature_is_functionlike(obj)` => False ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2460))
        * `_signature_is_builtin(obj)` => False ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2467C8-L2467C34))
        * `isinstance(obj, functools.partial)` => False ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2471))
        * `isinstance(obj, type)` => True ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2476))
          * There is no `__call__` or `__new__` or `__init__`.
          * Throw an `ValueError`. ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2536))

* With this PR, the type of the `__class_getitem__` is `method-wrapper`. 
  * `_signature_from_callable` 
    * `isinstance(obj, types.MethodType)` -> False ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2398))
    * `unwrap` ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2412)) => `type(obj)` is still `method-wrapper`.
    * No `obj.__signature__` or `obj._partialmethod` ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2423), [code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2435))
    * `isfunction(obj) or _signature_is_functionlike(obj)` => False ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2460))
    * `_signature_is_builtin(obj)` => True ([code](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L2467C8-L2467C34)) because `method-wrapper` is one of [_NonUserDefinedCallables](https://github.com/python/cpython/blob/c3108e12146f1d3f089e013a0764e05b6ba877af/Lib/inspect.py#L1861).

## Why `method = method.__init__`?

Honestly, I am not 100% sure whether it will cause some potential issues or not, but
* https://github.com/ets-labs/python-dependency-injector/commit/8cc2c1188bc92f0eeaaa212641ae659723009f26 has been merged for 3 years and has never been reverted, indicating that this solution works well.
* The manual test below works well.
* If any issues arise, users can define `__getitem__` themselves as a workaround.

## Useful links

* https://github.com/ets-labs/python-dependency-injector/issues/398
* https://github.com/ets-labs/python-dependency-injector/commit/8cc2c1188bc92f0eeaaa212641ae659723009f26
* https://github.com/ets-labs/python-dependency-injector/issues/362
* https://github.com/ets-labs/python-dependency-injector/commit/4991c5d4b0d6230a395ac90ba675502296c50619

## Related issue number

Closes #42914

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

```python
from torch.utils.data import IterableDataset
import ray

@ray.remote
class SyncDataCollector(IterableDataset):
    def __iter__(self):
        return iter(range(3, 10))

ray.init()
sdc = SyncDataCollector.remote()
obj_ref = sdc.__iter__.remote()
it = ray.get(obj_ref)
for i in it:
    print(i)
# 3 4 5 6 7 8 9
```
* `IterableDataset` inherits from `Iterable`, which defines `__class_getitem__ = classmethod(GenericAlias)`. ([code](https://github.com/python/cpython/blob/206f73dc5f1b4c3c81119808aa7fd9038661cf90/Lib/_collections_abc.py#L294))
