### PR TITLE
WIP: shuffle operation optimization uses smaller dtype for building i…

### DIFF
--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -19,6 +19,18 @@ def test_append_column(ray_start_regular_shared):
     assert actual_block.equals(expected_block)
 
 
+def test_random_shuffle(ray_start_regular_shared):
+
+    random_seed = 1234
+    n_legs = pa.array([2, 4, 5, 100])
+    animals = pa.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
+    names = ["n_legs", "animals"]
+
+    table = pa.Table.from_arrays([n_legs, animals], names=names)
+    actual_block = ArrowBlockAccessor.random_shuffle(table, random_seed)
+    assert actual_block.column(0) != n_legs
+
+
 def test_register_arrow_types(tmp_path):
     # Test that our custom arrow extension types are registered on initialization.
     ds = ray.data.from_items(np.zeros((8, 8, 8), dtype=np.int64))


### PR DESCRIPTION
## Why are these changes needed?

The problem is limited to the sort and random_shuffle functions, which both build a `numpy.array` to reorder the rows in a block. Memory overhead exists during index creation if the size of each row is tiny (i.e. not many columns). 

## Related issue number

Closes #42146

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
- [ ] Evaluate and Benchmark Two Approaches 
