### PR TITLE
[core] Reserve memory for system operations

### DIFF
--- a/doc/source/ray-core/scheduling/memory-management.rst
+++ b/doc/source/ray-core/scheduling/memory-management.rst
@@ -243,7 +243,7 @@ In the output of ``ray memory``, we see that the second object displays as a nor
 Memory Aware Scheduling
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, Ray does not take into account the potential memory usage of a task or actor when scheduling. This is simply because it cannot estimate ahead of time how much memory is required. However, if you know how much memory a task or actor requires, you can specify it in the resource requirements of its ``ray.remote`` decorator to enable memory-aware scheduling:
+By default, Ray does not take into account the potential memory usage of a task or actor when scheduling. This is simply because it cannot estimate ahead of time how much memory is required. However, if you know how much memory a task or actor requires, you can specify it in the resource requirements of its ``ray.remote`` decorator to enable memory-aware scheduling.
 
 .. important::
 
@@ -273,6 +273,11 @@ In the above example, the memory quota is specified statically by the decorator,
 
   # override the memory quota to 1GiB when creating the actor
   SomeActor.options(memory=1000 * 1024 * 1024).remote(a=1, b=2)
+
+Ray reserves some amount of memory on each node for system operations, so the application memory available for task and actor scheduling will be less than the total memory on the node.
+By default, Ray reserves system memory equal to the object store capacity (default 30% of available memory).
+To adjust the amount of system memory that Ray should reserve, set the environment variable `RAY_system_memory_reservation_bytes` when starting each Ray node.
+
 
 Questions or Issues?
 --------------------

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -84,6 +84,12 @@ RAY_CONFIG(uint64_t, memory_monitor_refresh_ms, 250)
 /// means 6.4 GB of the memory will not be usable.
 RAY_CONFIG(int64_t, min_memory_free_bytes, (int64_t)-1)
 
+/// The amount of the "memory" logical resource to reserve for system use.  If
+/// -1, each raylet will reserve memory equal to its local object store
+/// capacity. The object store usually makes up the bulk of system memory
+/// usage, although the raylet process will use some additional heap memory.
+RAY_CONFIG(int64_t, system_memory_reservation_bytes, (int64_t)-1)
+
 /// The TTL for when the task failure entry is considered
 /// eligble for garbage colletion.
 RAY_CONFIG(uint64_t, task_failure_entry_ttl_ms, 15 * 60 * 1000)

--- a/src/ray/raylet/scheduling/local_resource_manager.h
+++ b/src/ray/raylet/scheduling/local_resource_manager.h
@@ -105,9 +105,8 @@ class LocalResourceManager : public syncer::ReporterInterface {
   /// the local node. This function also updates the local node resources at the instance
   /// granularity.
   ///
-  /// \param task_resources Task for which we allocate resources.
-  /// \param task_allocation Resources allocated to the task at instance granularity.
-  /// This is a return parameter.
+  /// \param[in] task_resources Task for which we allocate resources.
+  /// \param[out] task_allocation Resources allocated to the task at instance granularity.
   ///
   /// \return True if local node has enough resources to satisfy the resource request.
   /// False otherwise.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

On startup, reserve enough `memory` logical resource for system operations. By default, Ray will reserve memory equal to the local object store capacity.

## Related issue number

Closes #41192.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
