### PR TITLE
[object_buffer_pool] reduce mutex lock scope in WriteChunk

### DIFF
--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -14,6 +14,8 @@
 
 #include "ray/object_manager/object_buffer_pool.h"
 
+#include <optional>
+
 #include "absl/time/time.h"
 #include "ray/common/status.h"
 #include "ray/util/logging.h"
@@ -119,32 +121,55 @@ void ObjectBufferPool::WriteChunk(const ObjectID &object_id,
                                   uint64_t metadata_size,
                                   const uint64_t chunk_index,
                                   const std::string &data) {
-  absl::MutexLock lock(&pool_mutex_);
-  auto it = create_buffer_state_.find(object_id);
-  if (it == create_buffer_state_.end() || chunk_index >= it->second.chunk_state.size() ||
-      it->second.chunk_state.at(chunk_index) != CreateChunkState::REFERENCED) {
-    RAY_LOG(DEBUG) << "Object " << object_id << " aborted before chunk " << chunk_index
-                   << " could be sealed";
-    return;
+  std::optional<ObjectBufferPool::ChunkInfo> chunk_info;
+  {
+    absl::MutexLock lock(&pool_mutex_);
+    auto it = create_buffer_state_.find(object_id);
+    if (it == create_buffer_state_.end() ||
+        chunk_index >= it->second.chunk_state.size() ||
+        it->second.chunk_state.at(chunk_index) != CreateChunkState::REFERENCED) {
+      RAY_LOG(DEBUG) << "Object " << object_id << " aborted before chunk " << chunk_index
+                     << " could be sealed";
+      return;
+    }
+    if (it->second.data_size != data_size || it->second.metadata_size != metadata_size) {
+      RAY_LOG(DEBUG) << "Object " << object_id << " size mismatch, rejecting chunk";
+      return;
+    }
+    RAY_CHECK(it->second.chunk_info.size() > chunk_index);
+
+    chunk_info = it->second.chunk_info.at(chunk_index);
+    RAY_CHECK(data.size() == chunk_info->buffer_length)
+        << "size mismatch!  data size: " << data.size()
+        << " chunk size: " << chunk_info->buffer_length;
+
+    // Update the state from REFERENCED To SEALED before releasing the lock to ensure
+    // that no other thread sees a REFERENCED state.
+    it->second.chunk_state.at(chunk_index) = CreateChunkState::SEALED;
   }
-  if (it->second.data_size != data_size || it->second.metadata_size != metadata_size) {
-    RAY_LOG(DEBUG) << "Object " << object_id << " size mismatch, rejecting chunk";
-    return;
-  }
-  RAY_CHECK(it->second.chunk_info.size() > chunk_index);
-  auto &chunk_info = it->second.chunk_info.at(chunk_index);
-  RAY_CHECK(data.size() == chunk_info.buffer_length)
-      << "size mismatch!  data size: " << data.size()
-      << " chunk size: " << chunk_info.buffer_length;
-  std::memcpy(chunk_info.data, data.data(), chunk_info.buffer_length);
-  it->second.chunk_state.at(chunk_index) = CreateChunkState::SEALED;
-  it->second.num_seals_remaining--;
-  if (it->second.num_seals_remaining == 0) {
-    RAY_CHECK_OK(store_client_->Seal(object_id));
-    RAY_CHECK_OK(store_client_->Release(object_id));
-    create_buffer_state_.erase(it);
-    RAY_LOG(DEBUG) << "Have received all chunks for object " << object_id
-                   << ", last chunk index: " << chunk_index;
+
+  RAY_CHECK(chunk_info.has_value()) << "chunk_info is not set";
+  // Unguarded copy call
+  std::memcpy(chunk_info->data, data.data(), chunk_info->buffer_length);
+
+  {
+    // Ensure the process of object_id Seal and Release is mutex guarded
+    absl::MutexLock lock(&pool_mutex_);
+    auto it = create_buffer_state_.find(object_id);
+    if (it == create_buffer_state_.end()) {
+      RAY_LOG(DEBUG) << "Object " << object_id << " aborted before chunk " << chunk_index
+                     << " finished copying data";
+      return;
+    }
+
+    it->second.num_seals_remaining--;
+    if (it->second.num_seals_remaining == 0) {
+      RAY_CHECK_OK(store_client_->Seal(object_id));
+      RAY_CHECK_OK(store_client_->Release(object_id));
+      create_buffer_state_.erase(it);
+      RAY_LOG(DEBUG) << "Have received all chunks for object " << object_id
+                     << ", last chunk index: " << chunk_index;
+    }
   }
 }
 


### PR DESCRIPTION
## Why are these changes needed?
Object store network transfer performance is slow, and we observe a periodic burst followed by a gap in the network usage. 

A burst of inbound network traffic occurs at the beginning of each `ray.get(obj_refs)` call, then there is a wide-gap of unused network traffic and then a subsequent burst of network traffic in the next `ray.get(obj_refs) call`.   

This looks like a processing bottleneck when payloads are received over the network on the Pull side. 

We dug into the code in [object_manager](https://github.com/ray-project/ray/tree/91d5af69085897b02d29bc0d15a53849e56eb8e4/src/ray/object_manager) and found the following:

- Objects are transferred in chunks of size: 5 MiB
- When a PushRequest is received for a chunk, it is processed by [ObjectManager::HandlePush](https://github.com/ray-project/ray/blob/7ff3969159d3aeac00415ac26bf96a63f782db86/src/ray/object_manager/object_manager.cc#L562)
- Which internally calls the [ObjectManager::ReceiveObjectChunk](https://github.com/ray-project/ray/blob/7ff3969159d3aeac00415ac26bf96a63f782db86/src/ray/object_manager/object_manager.cc#L623). This results in a call to the function [ObjectBufferPool::WriteChunk](https://github.com/ray-project/ray/blob/91d5af69085897b02d29bc0d15a53849e56eb8e4/src/ray/object_manager/object_buffer_pool.h#L128). 
- The WriteChunk function is [mutex guarded](https://github.com/ray-project/ray/blob/91d5af69085897b02d29bc0d15a53849e56eb8e4/src/ray/object_manager/object_buffer_pool.cc#L122) throughout its execution.  
- This includes the [std::memcpy](https://github.com/ray-project/ray/blob/91d5af69085897b02d29bc0d15a53849e56eb8e4/src/ray/object_manager/object_buffer_pool.cc#L139) call for a 5MiB payload
- This [pool_mutex_](https://github.com/ray-project/ray/blob/91d5af69085897b02d29bc0d15a53849e56eb8e4/src/ray/object_manager/object_buffer_pool.h#L215) lock is shared by all object_ids being received over the network 

Which makes us believe that even if chunks for different ObjectId are received in parallel over the network they are written sequentially. Which would explain why we see a burst in the network usage followed by a hole in the network usage

### Changes

- Transition the chunk from `REFERENCED` to `SEALED` before releasing the lock
- Perform an unguarded memcpy of the chunk into the buffer
- Reacquire the mutex lock and perform object_id level `Seal` and `Release` decisions

### Tests

#### Before

- Sampled network at 1 second frequency

`speedometer.py -i 1 -m 64424509440 -n 1073741824 -rx eth0`
<img width="590" alt="Screenshot 2024-02-13 at 10 26 33 AM" src="https://github.com/ray-project/ray/assets/8691593/7a5497dd-b87d-4bec-a51c-62d629c06c58">

- Sampled network at 100 millisecond frequency

`speedometer.py -i 0.1 -m 64424509440 -n 1073741824 -rx eth0 `
<img width="656" alt="Screenshot 2024-02-13 at 10 26 37 AM" src="https://github.com/ray-project/ray/assets/8691593/5ac229e6-4777-4820-b9e7-ebbd63cafcc9">


#### After

- Sampled network at 1 second frequency

`speedometer.py -i 1 -m 64424509440 -n 1073741824 -rx eth0 `
<img width="596" alt="Screenshot 2024-02-13 at 10 26 42 AM" src="https://github.com/ray-project/ray/assets/8691593/8ebefe12-6e42-4c00-9a52-3f3eaf0a57d2">

- Sampled network at 100 millisecond frequency

`speedometer.py -i 0.1 -m 64424509440 -n 1073741824 -rx eth0 `
<img width="466" alt="Screenshot 2024-02-13 at 10 26 48 AM" src="https://github.com/ray-project/ray/assets/8691593/85aed2eb-6282-490b-87ed-cf597e5abf73">

## Related issue number
Closes #42632 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
