### PR TITLE
[ci] add oss tag to min install tests

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -234,6 +234,7 @@ steps:
   - label: ":ray: core: minimal tests {{matrix}}"
     tags:
       - python
+      - oss
       - skip-on-premerge
     instance_type: medium
     commands:


### PR DESCRIPTION
the test is oss `setup.py` related, only meaningful when there is an installable wheel.