### PR TITLE
[Data] Hard deprecate `FileExtensionFilter`

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -77,50 +77,15 @@ OPEN_FILE_MAX_ATTEMPTS = 10
 @Deprecated
 @PublicAPI(stability="beta")
 class FileExtensionFilter(PathPartitionFilter):
-    """A file-extension-based path filter that filters files that don't end
-    with the provided extension(s).
-
-    Attributes:
-        file_extensions: File extension(s) of files to be included in reading.
-        allow_if_no_extension: If this is True, files without any extensions
-            will be included in reading.
-
-    """
-
     def __init__(
         self,
         file_extensions: Union[str, List[str]],
         allow_if_no_extension: bool = False,
     ):
-        warnings.warn(
+        raise DeprecationWarning(
             "`FileExtensionFilter` is deprecated. Instead, set the `file_extensions` "
-            "parameter of `read_xxx()` APIs.",
-            DeprecationWarning,
+            "parameter of `read_xxx()` APIs."
         )
-
-        if isinstance(file_extensions, str):
-            file_extensions = [file_extensions]
-
-        self.extensions = [f".{ext.lower()}" for ext in file_extensions]
-        self.allow_if_no_extension = allow_if_no_extension
-
-    def _file_has_extension(self, path: str):
-        suffixes = [suffix.lower() for suffix in pathlib.Path(path).suffixes]
-        if not suffixes:
-            return self.allow_if_no_extension
-        return any(ext in suffixes for ext in self.extensions)
-
-    def __call__(self, paths: List[str]) -> List[str]:
-        return [path for path in paths if self._file_has_extension(path)]
-
-    def __str__(self):
-        return (
-            f"{type(self).__name__}(extensions={self.extensions}, "
-            f"allow_if_no_extensions={self.allow_if_no_extension})"
-        )
-
-    def __repr__(self):
-        return str(self)
 
 
 @DeveloperAPI

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -1,5 +1,4 @@
 import io
-import pathlib
 import posixpath
 import warnings
 from typing import (

--- a/python/ray/data/tests/test_partitioning.py
+++ b/python/ray/data/tests/test_partitioning.py
@@ -67,7 +67,7 @@ def read_csv(
 
 
 def test_file_extension_filter_is_deprecated():
-    with pytest.warns(DeprecationWarning):
+    with pytest.raises(DeprecationWarning):
         FileExtensionFilter("csv")
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In Ray 2.9, we deprecated the `FileExtensionFilter` path partition filter in favor of a `file_extensions` parameter. This PR hard deprecates the API.

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/ray/pull/41120
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
