### PR TITLE
[core][test] Deflake test_output by removing unblocking runs. (#43141)

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -19,7 +19,7 @@ import timeit
 import traceback
 from collections import defaultdict
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 import uuid
 from dataclasses import dataclass
 
@@ -421,6 +421,40 @@ def run_string_as_driver(driver_script: str, env: Dict = None, encode: str = "ut
             )
         out = ray._private.utils.decode(output, encode_type=encode)
     return out
+
+
+def run_string_as_driver_stdout_stderr(
+    driver_script: str, env: Dict = None, encode: str = "utf-8"
+) -> Tuple[str, str]:
+    """Run a driver as a separate process.
+
+    Args:
+        driver_script: A string to run as a Python script.
+        env: The environment variables for the driver.
+
+    Returns:
+        The script's stdout and stderr.
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    with proc:
+        outputs_bytes = proc.communicate(driver_script.encode(encoding=encode))
+        out_str, err_str = [
+            ray._private.utils.decode(output, encode_type=encode)
+            for output in outputs_bytes
+        ]
+        if proc.returncode:
+            print(out_str)
+            print(err_str)
+            raise subprocess.CalledProcessError(
+                proc.returncode, proc.args, out_str, err_str
+            )
+        return out_str, err_str
 
 
 def run_string_as_driver_nonblocking(driver_script, env: Dict = None):

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -11,7 +11,7 @@ import ray
 from ray._private.test_utils import (
     run_string_as_driver,
     run_string_as_driver_nonblocking,
-    wait_for_condition,
+    run_string_as_driver_stdout_stderr,
 )
 
 
@@ -188,13 +188,10 @@ x = foo.remote()
 time.sleep(15)
     """
 
-    proc = run_string_as_driver_nonblocking(script)
-    out_str = proc.stdout.read().decode("ascii")
-    err_str = proc.stderr.read().decode("ascii")
-
+    out_str, err_str = run_string_as_driver_stdout_stderr(script)
     print(out_str, err_str)
-    assert "Tip:" in out_str
-    assert "Error: No available node types can fulfill" in out_str
+    assert "Tip:" in out_str, (out_str, err_str)
+    assert "Error: No available node types can fulfill" in out_str, (out_str, err_str)
 
 
 @pytest.mark.parametrize(
@@ -231,13 +228,14 @@ b = A.remote()
 time.sleep(25)
     """
 
-    proc = run_string_as_driver_nonblocking(script)
-    out_str = proc.stdout.read().decode("ascii")
-    err_str = proc.stderr.read().decode("ascii")
+    out_str, err_str = run_string_as_driver_stdout_stderr(script)
 
     print(out_str, err_str)
-    assert "Tip:" in out_str
-    assert "Warning: The following resource request cannot" in out_str
+    assert "Tip:" in out_str, (out_str, err_str)
+    assert "Warning: The following resource request cannot" in out_str, (
+        out_str,
+        err_str,
+    )
 
 
 # TODO(rickyx): Remove this after migration
@@ -344,16 +342,10 @@ event_logger.info("Test autoscaler event")
 # Block and sleep
 time.sleep(3)
     """
-
-    proc = run_string_as_driver_nonblocking(script)
-
-    def verify():
-        out_str = proc.stdout.read().decode("ascii")
-        print(out_str)
-        assert out_str and "Test autoscaler event" in out_str
-        return True
-
-    wait_for_condition(verify)
+    out_str, err_str = run_string_as_driver_stdout_stderr(script)
+    print(out_str)
+    print(err_str)
+    assert "Test autoscaler event" in out_str, (out_str, err_str)
 
 
 @pytest.mark.parametrize(
@@ -401,25 +393,20 @@ time.sleep(3)
 
     env = os.environ.copy()
     env["RAY_LOG_TO_DRIVER_EVENT_LEVEL"] = event_level
-    proc = run_string_as_driver_nonblocking(script, env=env)
 
-    def verify():
-        out_str = proc.stdout.read().decode("ascii")
-        print(out_str)
-        # Filter only autoscaler prints.
-        assert out_str
+    out_str, err_str = run_string_as_driver_stdout_stderr(script, env=env)
+    print(out_str)
+    print(err_str)
 
-        out_str = "".join(
-            [line for line in out_str.splitlines() if "autoscaler" in line]
-        )
-        for expected in expected_msg.split(","):
-            assert expected in out_str
-        if unexpected_msg:
-            for unexpected in unexpected_msg.split(","):
-                assert unexpected not in out_str
-        return True
+    # Filter only autoscaler prints.
+    assert out_str
 
-    wait_for_condition(verify)
+    out_str = "".join([line for line in out_str.splitlines() if "autoscaler" in line])
+    for expected in expected_msg.split(","):
+        assert expected in out_str
+    if unexpected_msg:
+        for unexpected in unexpected_msg.split(","):
+            assert unexpected not in out_str
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")


### PR DESCRIPTION
The test_output test reads a Ray driver process's stdout and finds certain strings. However in Autoscaler v2 it's not flushed properly so the reader never gets it. This PR removed the unblocking process runs and reads all.

cherry-picked from #43141