### PR TITLE
[serve] Broadcast full deployment config to routers instead of just autoscaling config

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1274,8 +1274,8 @@ class DeploymentState:
         # time we checked.
         self._multiplexed_model_ids_updated = False
 
-        self._last_notified_running_replica_infos: List[RunningReplicaInfo] = []
-        self._last_notified_autoscaling_config = None
+        self._last_broadcasted_running_replica_infos: List[RunningReplicaInfo] = []
+        self._last_broadcasted_deployment_config = None
 
     @property
     def autoscaling_policy_manager(self) -> AutoscalingPolicyManager:
@@ -1396,10 +1396,19 @@ class DeploymentState:
     def list_replica_details(self) -> List[ReplicaDetails]:
         return [replica.actor_details for replica in self._replicas.get()]
 
-    def notify_running_replicas_changed(self) -> None:
+    def broadcast_running_replicas_if_changed(self) -> None:
+        """Broadcasts the set of running replicas over long poll if it has changed.
+
+        Keeps an in-memory record of the last set of running replicas that was broadcast
+        to determine if it has changed.
+
+        The set will also be broadcast if any replicas have an updated set of
+        multiplexed model IDs.
+        """
         running_replica_infos = self.get_running_replica_infos()
         if (
-            set(self._last_notified_running_replica_infos) == set(running_replica_infos)
+            set(self._last_broadcasted_running_replica_infos)
+            == set(running_replica_infos)
             and not self._multiplexed_model_ids_updated
         ):
             return
@@ -1416,22 +1425,25 @@ class DeploymentState:
             (LongPollNamespace.RUNNING_REPLICAS, self._id.name),
             running_replica_infos,
         )
-        self._last_notified_running_replica_infos = running_replica_infos
+        self._last_broadcasted_running_replica_infos = running_replica_infos
         self._multiplexed_model_ids_updated = False
 
-    def notify_autoscaling_config_changed(self) -> None:
-        current_autoscaling_config = (
-            self._target_state.info.deployment_config.autoscaling_config
-        )
-        if self._last_notified_autoscaling_config == current_autoscaling_config:
+    def broadcast_deployment_config_if_changed(self) -> None:
+        """Broadcasts the deployment config over long poll if it has changed.
+
+        Keeps an in-memory record of the last config that was broadcast to determine
+        if it has changed.
+        """
+        current_deployment_config = self._target_state.info.deployment_config
+        if self._last_broadcasted_deployment_config == current_deployment_config:
             return
 
         self._long_poll_host.notify_changed(
-            (LongPollNamespace.AUTOSCALING_CONFIG, self._id),
-            current_autoscaling_config,
+            (LongPollNamespace.DEPLOYMENT_CONFIG, self._id),
+            current_deployment_config,
         )
 
-        self._last_notified_autoscaling_config = current_autoscaling_config
+        self._last_broadcasted_deployment_config = current_deployment_config
 
     def _set_target_state_deleting(self) -> None:
         """Set the target state for the deployment to be deleted."""
@@ -2712,8 +2724,8 @@ class DeploymentStateManager:
             self._deployment_states[deployment_id].stop_replicas(replicas_to_stop)
 
         for deployment_state in self._deployment_states.values():
-            deployment_state.notify_running_replicas_changed()
-            deployment_state.notify_autoscaling_config_changed()
+            deployment_state.broadcast_running_replicas_if_changed()
+            deployment_state.broadcast_deployment_config_if_changed()
 
         for deployment_id in deleted_ids:
             self._deployment_scheduler.on_deployment_deleted(deployment_id)

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -41,7 +41,7 @@ class LongPollNamespace(Enum):
     RUNNING_REPLICAS = auto()
     ROUTE_TABLE = auto()
     GLOBAL_LOGGING_CONFIG = auto()
-    AUTOSCALING_CONFIG = auto()
+    DEPLOYMENT_CONFIG = auto()
 
 
 @dataclass

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -10,7 +10,6 @@ import ray
 from ray._private.utils import load_class
 from ray.actor import ActorHandle
 from ray.dag.py_obj_scanner import _PyObjScanner
-from ray.serve.exceptions import BackPressureError
 from ray.serve._private.common import DeploymentID, RequestMetadata, RunningReplicaInfo
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
@@ -220,9 +219,7 @@ class Router:
         running_requests = dict()
         autoscaling_config = self.curr_autoscaling_config
         if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE and autoscaling_config:
-            look_back_period = (
-                autoscaling_config.look_back_period_s
-            )
+            look_back_period = autoscaling_config.look_back_period_s
             running_requests = {
                 replica_id: self.metrics_store.window_average(
                     replica_id, time.time() - look_back_period

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -11,6 +11,7 @@ from ray._private.utils import load_class
 from ray.actor import ActorHandle
 from ray.dag.py_obj_scanner import _PyObjScanner
 from ray.serve._private.common import DeploymentID, RequestMetadata, RunningReplicaInfo
+from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
     HANDLE_METRIC_PUSH_INTERVAL_S,
     RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
@@ -108,15 +109,17 @@ class Router:
                     deployment_id,
                 ): self.update_running_replicas,
                 (
-                    LongPollNamespace.AUTOSCALING_CONFIG,
+                    LongPollNamespace.DEPLOYMENT_CONFIG,
                     deployment_id,
-                ): self.update_autoscaling_config,
+                ): self.update_deployment_config,
             },
             call_in_event_loop=event_loop,
         )
 
-        # For autoscaling deployments.
-        self.autoscaling_config = None
+        # The config for the deployment this router sends requests to will be broadcast
+        # by the controller. That means it is not available until we get the first
+        # update. This includes an optional autoscaling config.
+        self.deployment_config: Optional[DeploymentConfig] = None
         # Track queries sent to replicas for the autoscaling algorithm.
         self.num_requests_sent_to_replicas = defaultdict(int)
         # We use Ray object ref callbacks to update state when tracking
@@ -148,11 +151,13 @@ class Router:
                 },
             )
 
-    def update_autoscaling_config(self, autoscaling_config: AutoscalingConfig):
-        self.autoscaling_config = autoscaling_config
+    def update_deployment_config(self, deployment_config: DeploymentConfig):
+        """Update the config for the deployment this router sends requests to."""
+        self.deployment_config = deployment_config
 
         # Start the metrics pusher if autoscaling is enabled.
-        if self.autoscaling_config:
+        autoscaling_config: AutoscalingConfig = deployment_config.autoscaling_config
+        if autoscaling_config:
             # Optimization for autoscaling cold start time. If there are
             # currently 0 replicas for the deployment, and there is at
             # least one queued request on this router, then immediately
@@ -171,13 +176,13 @@ class Router:
                 self.metrics_pusher.register_or_update_task(
                     RECORD_METRICS_TASK_NAME,
                     self._add_autoscaling_metrics_point,
-                    min(0.5, self.autoscaling_config.metrics_interval_s),
+                    min(0.5, autoscaling_config.metrics_interval_s),
                 )
                 # Push metrics to the controller periodically.
                 self.metrics_pusher.register_or_update_task(
                     PUSH_METRICS_TO_CONTROLLER_TASK_NAME,
                     self._get_aggregated_requests,
-                    self.autoscaling_config.metrics_interval_s,
+                    autoscaling_config.metrics_interval_s,
                     self.push_metrics_to_controller,
                 )
             else:
@@ -206,7 +211,9 @@ class Router:
     def _get_aggregated_requests(self):
         running_requests = dict()
         if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
-            look_back_period = self.autoscaling_config.look_back_period_s
+            look_back_period = (
+                self.deployment_config.autoscaling_config.look_back_period_s
+            )
             running_requests = {
                 replica_id: self.metrics_store.window_average(
                     replica_id, time.time() - look_back_period
@@ -329,7 +336,7 @@ class Router:
         # you need to yield the event loop above this conditional, you
         # will need to remove the check "self.num_queued_queries == 1"
         if (
-            self.autoscaling_config
+            self.deployment_config.autoscaling_config
             and len(self._replica_scheduler.curr_replicas) == 0
             and self.num_queued_queries == 1
         ):

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -10,6 +10,7 @@ import ray
 from ray._private.utils import load_class
 from ray.actor import ActorHandle
 from ray.dag.py_obj_scanner import _PyObjScanner
+from ray.serve.exceptions import BackPressureError
 from ray.serve._private.common import DeploymentID, RequestMetadata, RunningReplicaInfo
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
@@ -151,12 +152,19 @@ class Router:
                 },
             )
 
+    @property
+    def curr_autoscaling_config(self) -> Optional[AutoscalingConfig]:
+        if self.deployment_config is None:
+            return None
+
+        return self.deployment_config.autoscaling_config
+
     def update_deployment_config(self, deployment_config: DeploymentConfig):
         """Update the config for the deployment this router sends requests to."""
         self.deployment_config = deployment_config
 
         # Start the metrics pusher if autoscaling is enabled.
-        autoscaling_config: AutoscalingConfig = deployment_config.autoscaling_config
+        autoscaling_config: AutoscalingConfig = self.curr_autoscaling_config
         if autoscaling_config:
             # Optimization for autoscaling cold start time. If there are
             # currently 0 replicas for the deployment, and there is at
@@ -210,9 +218,10 @@ class Router:
 
     def _get_aggregated_requests(self):
         running_requests = dict()
-        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
+        autoscaling_config = self.curr_autoscaling_config
+        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE and autoscaling_config:
             look_back_period = (
-                self.deployment_config.autoscaling_config.look_back_period_s
+                autoscaling_config.look_back_period_s
             )
             running_requests = {
                 replica_id: self.metrics_store.window_average(
@@ -336,7 +345,7 @@ class Router:
         # you need to yield the event loop above this conditional, you
         # will need to remove the check "self.num_queued_queries == 1"
         if (
-            self.deployment_config.autoscaling_config
+            self.curr_autoscaling_config
             and len(self._replica_scheduler.curr_replicas) == 0
             and self.num_queued_queries == 1
         ):

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -256,7 +256,7 @@ class _DeploymentHandleBase:
         # loop running in another thread to avoid user code blocking the router, so we
         # use the `concurrent.futures.Future` thread safe API.
         return asyncio.run_coroutine_threadsafe(
-            router.assign_request(request_metadata, *args, **kwargs),
+            router.assign_request(request_metadata, list(args), kwargs),
             loop=event_loop,
         )
 

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -256,7 +256,7 @@ class _DeploymentHandleBase:
         # loop running in another thread to avoid user code blocking the router, so we
         # use the `concurrent.futures.Future` thread safe API.
         return asyncio.run_coroutine_threadsafe(
-            router.assign_request(request_metadata, list(args), kwargs),
+            router.assign_request(request_metadata, *args, **kwargs),
             loop=event_loop,
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This will be needed to implement `max_queued_requests` as the handle will need to know the config option (and it may change).

Also updated some naming/comments to clarify questions I had while reading the code.

## Related issue number

Towards https://github.com/ray-project/ray/issues/42950

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
