### PR TITLE
[Data] Add concurrency for write APIs

### DIFF
--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Optional, Union
 
-from ray.data._internal.compute import TaskPoolStrategy
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.logical.operators.map_operator import AbstractMap
 from ray.data.datasource.datasink import Datasink
@@ -15,6 +14,7 @@ class Write(AbstractMap):
         input_op: LogicalOperator,
         datasink_or_legacy_datasource: Union[Datasink, Datasource],
         ray_remote_args: Optional[Dict[str, Any]] = None,
+        concurrency: Optional[int] = None,
         **write_args,
     ):
         if isinstance(datasink_or_legacy_datasource, Datasink):
@@ -32,5 +32,4 @@ class Write(AbstractMap):
         )
         self._datasink_or_legacy_datasource = datasink_or_legacy_datasource
         self._write_args = write_args
-        # Always use task to write.
-        self._compute = TaskPoolStrategy()
+        self._concurrency = concurrency

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -1,5 +1,6 @@
 from typing import Callable, Iterator, Union
 
+from ray.data._internal.compute import TaskPoolStrategy
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_operator import MapOperator
@@ -51,4 +52,5 @@ def plan_write_op(op: Write, input_physical_dag: PhysicalOperator) -> PhysicalOp
         target_max_block_size=None,
         ray_remote_args=op._ray_remote_args,
         min_rows_per_bundle=op._min_rows_per_bundled_input,
+        compute_strategy=TaskPoolStrategy(op._concurrency),
     )

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2672,6 +2672,7 @@ class Dataset:
         arrow_parquet_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
         num_rows_per_file: Optional[int] = None,
         ray_remote_args: Dict[str, Any] = None,
+        concurrency: Optional[int] = None,
         **arrow_parquet_args,
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to parquet files under the provided ``path``.
@@ -2729,6 +2730,10 @@ class Dataset:
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
             ray_remote_args: Kwargs passed to :meth:`~ray.remote` in the write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set this
+                to control number of tasks to run concurrently. This doesn't change the
+                total number of tasks run. By default, concurrency is dynamically
+                decided based on the available resources.
             arrow_parquet_args: Options to pass to
                 `pyarrow.parquet.write_table() <https://arrow.apache.org/docs/python\
                     /generated/pyarrow.parquet.write_table.html\
@@ -2747,7 +2752,11 @@ class Dataset:
             block_path_provider=block_path_provider,
             dataset_uuid=self._uuid,
         )
-        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
 
     @ConsumptionAPI
     def write_json(
@@ -2762,6 +2771,7 @@ class Dataset:
         pandas_json_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
         num_rows_per_file: Optional[int] = None,
         ray_remote_args: Dict[str, Any] = None,
+        concurrency: Optional[int] = None,
         **pandas_json_args,
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to JSON and JSONL files.
@@ -2828,6 +2838,10 @@ class Dataset:
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set this
+                to control number of tasks to run concurrently. This doesn't change the
+                total number of tasks run. By default, concurrency is dynamically
+                decided based on the available resources.
             pandas_json_args: These args are passed to
                 `pandas.DataFrame.to_json() <https://pandas.pydata.org/docs/reference/\
                     api/pandas.DataFrame.to_json.html>`_,
@@ -2847,7 +2861,11 @@ class Dataset:
             block_path_provider=block_path_provider,
             dataset_uuid=self._uuid,
         )
-        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
 
     @PublicAPI(stability="alpha")
     @ConsumptionAPI
@@ -2862,6 +2880,7 @@ class Dataset:
         arrow_open_stream_args: Optional[Dict[str, Any]] = None,
         filename_provider: Optional[FilenameProvider] = None,
         ray_remote_args: Dict[str, Any] = None,
+        concurrency: Optional[int] = None,
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to images.
 
@@ -2899,6 +2918,10 @@ class Dataset:
                 implementation. Use this parameter to customize what your filenames
                 look like.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set this
+                to control number of tasks to run concurrently. This doesn't change the
+                total number of tasks run. By default, concurrency is dynamically
+                decided based on the available resources.
         """  # noqa: E501
         datasink = _ImageDatasink(
             path,
@@ -2910,7 +2933,11 @@ class Dataset:
             filename_provider=filename_provider,
             dataset_uuid=self._uuid,
         )
-        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
 
     @ConsumptionAPI
     def write_csv(
@@ -2925,6 +2952,7 @@ class Dataset:
         arrow_csv_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
         num_rows_per_file: Optional[int] = None,
         ray_remote_args: Dict[str, Any] = None,
+        concurrency: Optional[int] = None,
         **arrow_csv_args,
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to CSV files.
@@ -2990,6 +3018,10 @@ class Dataset:
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set this
+                to control number of tasks to run concurrently. This doesn't change the
+                total number of tasks run. By default, concurrency is dynamically
+                decided based on the available resources.
             arrow_csv_args: Options to pass to `pyarrow.write.write_csv <https://\
                 arrow.apache.org/docs/python/generated/pyarrow.csv.write_csv.html\
                     #pyarrow.csv.write_csv>`_
@@ -3007,7 +3039,11 @@ class Dataset:
             block_path_provider=block_path_provider,
             dataset_uuid=self._uuid,
         )
-        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
 
     @ConsumptionAPI
     def write_tfrecords(
@@ -3022,6 +3058,7 @@ class Dataset:
         block_path_provider: Optional[BlockWritePathProvider] = None,
         num_rows_per_file: Optional[int] = None,
         ray_remote_args: Dict[str, Any] = None,
+        concurrency: Optional[int] = None,
     ) -> None:
         """Write the :class:`~ray.data.Dataset` to TFRecord files.
 
@@ -3081,6 +3118,10 @@ class Dataset:
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set this
+                to control number of tasks to run concurrently. This doesn't change the
+                total number of tasks run. By default, concurrency is dynamically
+                decided based on the available resources.
 
         """
         datasink = _TFRecordDatasink(
@@ -3094,7 +3135,11 @@ class Dataset:
             block_path_provider=block_path_provider,
             dataset_uuid=self._uuid,
         )
-        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
 
     @PublicAPI(stability="alpha")
     @ConsumptionAPI
@@ -3110,6 +3155,7 @@ class Dataset:
         num_rows_per_file: Optional[int] = None,
         ray_remote_args: Dict[str, Any] = None,
         encoder: Optional[Union[bool, str, callable, list]] = True,
+        concurrency: Optional[int] = None,
     ) -> None:
         """Writes the dataset to `WebDataset <https://webdataset.github.io/webdataset/>`_ files.
 
@@ -3156,6 +3202,10 @@ class Dataset:
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
             ray_remote_args: Kwargs passed to ``ray.remote`` in the write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set this
+                to control number of tasks to run concurrently. This doesn't change the
+                total number of tasks run. By default, concurrency is dynamically
+                decided based on the available resources.
 
         """
         datasink = _WebDatasetDatasink(
@@ -3169,7 +3219,11 @@ class Dataset:
             block_path_provider=block_path_provider,
             dataset_uuid=self._uuid,
         )
-        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
 
     @ConsumptionAPI
     def write_numpy(
@@ -3184,6 +3238,7 @@ class Dataset:
         block_path_provider: Optional[BlockWritePathProvider] = None,
         num_rows_per_file: Optional[int] = None,
         ray_remote_args: Dict[str, Any] = None,
+        concurrency: Optional[int] = None,
     ) -> None:
         """Writes a column of the :class:`~ray.data.Dataset` to .npy files.
 
@@ -3234,6 +3289,10 @@ class Dataset:
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set this
+                to control number of tasks to run concurrently. This doesn't change the
+                total number of tasks run. By default, concurrency is dynamically
+                decided based on the available resources.
         """
 
         datasink = _NumpyDatasink(
@@ -3247,7 +3306,11 @@ class Dataset:
             block_path_provider=block_path_provider,
             dataset_uuid=self._uuid,
         )
-        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
 
     @ConsumptionAPI
     def write_sql(
@@ -3255,6 +3318,7 @@ class Dataset:
         sql: str,
         connection_factory: Callable[[], Connection],
         ray_remote_args: Optional[Dict[str, Any]] = None,
+        concurrency: Optional[int] = None,
     ) -> None:
         """Write to a database that provides a
         `Python DB API2-compliant <https://peps.python.org/pep-0249/>`_ connector.
@@ -3304,9 +3368,17 @@ class Dataset:
                 `Connection object <https://peps.python.org/pep-0249/#connection-objects>`_.
             ray_remote_args: Keyword arguments passed to :meth:`~ray.remote` in the
                 write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set this
+                to control number of tasks to run concurrently. This doesn't change the
+                total number of tasks run. By default, concurrency is dynamically
+                decided based on the available resources.
         """  # noqa: E501
         datasink = _SQLDatasink(sql=sql, connection_factory=connection_factory)
-        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
 
     @PublicAPI(stability="alpha")
     @ConsumptionAPI
@@ -3316,6 +3388,7 @@ class Dataset:
         database: str,
         collection: str,
         ray_remote_args: Dict[str, Any] = None,
+        concurrency: Optional[int] = None,
     ) -> None:
         """Writes the :class:`~ray.data.Dataset` to a MongoDB database.
 
@@ -3362,6 +3435,10 @@ class Dataset:
             collection: The name of the collection in the database. This collection
                 must exist otherwise a ValueError is raised.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set this
+                to control number of tasks to run concurrently. This doesn't change the
+                total number of tasks run. By default, concurrency is dynamically
+                decided based on the available resources.
 
         Raises:
             ValueError: if ``database`` doesn't exist.
@@ -3372,7 +3449,11 @@ class Dataset:
             database=database,
             collection=collection,
         )
-        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
 
     @ConsumptionAPI
     def write_bigquery(
@@ -3382,6 +3463,7 @@ class Dataset:
         max_retry_cnt: int = 10,
         overwrite_table: Optional[bool] = True,
         ray_remote_args: Dict[str, Any] = None,
+        concurrency: Optional[int] = None,
     ) -> None:
         """Write the dataset to a BigQuery dataset table.
 
@@ -3417,6 +3499,10 @@ class Dataset:
                 exists. The default behavior is to overwrite the table.
                 ``overwrite_table=False`` will append to the table if it exists.
             ray_remote_args: Kwargs passed to ray.remote in the write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set this
+                to control number of tasks to run concurrently. This doesn't change the
+                total number of tasks run. By default, concurrency is dynamically
+                decided based on the available resources.
         """  # noqa: E501
         if ray_remote_args is None:
             ray_remote_args = {}
@@ -3437,7 +3523,11 @@ class Dataset:
             max_retry_cnt=max_retry_cnt,
             overwrite_table=overwrite_table,
         )
-        self.write_datasink(datasink, ray_remote_args=ray_remote_args)
+        self.write_datasink(
+            datasink,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+        )
 
     @Deprecated
     @ConsumptionAPI(pattern="Time complexity:")
@@ -3508,6 +3598,7 @@ class Dataset:
         datasink: Datasink,
         *,
         ray_remote_args: Dict[str, Any] = None,
+        concurrency: Optional[int] = None,
     ) -> None:
         """Writes the dataset to a custom :class:`~ray.data.Datasink`.
 
@@ -3516,6 +3607,10 @@ class Dataset:
         Args:
             datasink: The :class:`~ray.data.Datasink` to write to.
             ray_remote_args: Kwargs passed to ``ray.remote`` in the write tasks.
+            concurrency: The maximum number of Ray tasks to run concurrently. Set this
+                to control number of tasks to run concurrently. This doesn't change the
+                total number of tasks run. By default, concurrency is dynamically
+                decided based on the available resources.
         """  # noqa: E501
         if ray_remote_args is None:
             ray_remote_args = {}
@@ -3536,6 +3631,7 @@ class Dataset:
             self._logical_plan.dag,
             datasink,
             ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
         )
         logical_plan = LogicalPlan(write_op)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to add `concurrency` parameter to write APIs. This makes write to be consistent with read and map-like APIs. So users can control concurrency through read-map-write workflow.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
