### PR TITLE
[serve] test deployment state manager refactor

### DIFF
--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -52,6 +52,7 @@ from ray.serve._private.utils import (
 # loop, so we can't "mark" a replica dead through a method. This global
 # state is cleared after each test that uses the fixtures in this file.
 dead_replicas_context = set()
+TEST_DEPLOYMENT_ID = DeploymentID("test_deployment", "test_app")
 
 
 class FakeRemoteFunction:
@@ -360,6 +361,79 @@ def mock_deployment_state() -> Tuple[DeploymentState, Mock, Mock]:
         dead_replicas_context.clear()
 
 
+@pytest.fixture
+def mock_deployment_state_manager(request) -> Tuple[DeploymentStateManager, Mock, Mock]:
+    timer = MockTimer()
+    with patch(
+        "ray.serve._private.deployment_state.ActorReplicaWrapper",
+        new=MockReplicaActorWrapper,
+    ), patch("time.time", new=timer.time), patch(
+        "ray.serve._private.long_poll.LongPollHost"
+    ) as mock_long_poll:
+        kv_store = MockKVStore()
+        cluster_node_info_cache = MockClusterNodeInfoCache()
+        all_current_actor_names = []
+        all_current_placement_group_names = []
+        deployment_state_manager = DeploymentStateManager(
+            kv_store,
+            mock_long_poll,
+            all_current_actor_names,
+            all_current_placement_group_names,
+            cluster_node_info_cache,
+            head_node_id_override="fake-head-node-id",
+        )
+
+        yield deployment_state_manager, timer, cluster_node_info_cache
+
+        dead_replicas_context.clear()
+
+
+@pytest.fixture
+def mock_deployment_state_manager_full(
+    request,
+) -> Tuple[DeploymentStateManager, MockTimer, Mock]:
+    """Fully mocked deployment state manager.
+
+    i.e kv store and gcs client is mocked so we don't need to initialize
+    ray. Also, since this is used for some recovery tests, this yields a
+    method for creating a new mocked deployment state manager.
+    """
+
+    timer = MockTimer()
+    with patch(
+        "ray.serve._private.deployment_state.ActorReplicaWrapper",
+        new=MockReplicaActorWrapper,
+    ), patch("time.time", new=timer.time), patch(
+        "ray.serve._private.long_poll.LongPollHost"
+    ) as mock_long_poll, patch(
+        "ray.get_runtime_context"
+    ):
+        kv_store = MockKVStore()
+        cluster_node_info_cache = MockClusterNodeInfoCache()
+
+        def create_deployment_state_manager(
+            actor_names=None, placement_group_names=None
+        ):
+            if actor_names is None:
+                actor_names = []
+
+            if placement_group_names is None:
+                placement_group_names = []
+
+            return DeploymentStateManager(
+                kv_store,
+                mock_long_poll,
+                actor_names,
+                placement_group_names,
+                cluster_node_info_cache,
+                head_node_id_override="fake-head-node-id",
+            )
+
+        yield create_deployment_state_manager, timer, cluster_node_info_cache
+
+        dead_replicas_context.clear()
+
+
 def replica(version: Optional[DeploymentVersion] = None) -> VersionedReplica:
     if version is None:
         version = DeploymentVersion(get_random_string(), DeploymentConfig(), {})
@@ -576,14 +650,13 @@ class TestReplicaStateContainer:
 def check_counts(
     deployment_state: DeploymentState,
     total: Optional[int] = None,
-    version: Optional[str] = None,
     by_state: Optional[List[Tuple[ReplicaState, int]]] = None,
 ):
     if total is not None:
-        assert deployment_state._replicas.count(version=version) == total
+        assert deployment_state._replicas.count() == total
 
     if by_state is not None:
-        for state, count in by_state:
+        for state, count, version in by_state:
             assert isinstance(state, ReplicaState)
             assert isinstance(count, int) and count >= 0
             curr_count = deployment_state._replicas.count(
@@ -593,448 +666,327 @@ def check_counts(
             assert curr_count == count, msg
 
 
-def test_create_delete_single_replica(mock_deployment_state):
-    deployment_state: DeploymentState
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {"node-id"}
+def test_create_delete_single_replica(mock_deployment_state_manager_full):
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
-    b_info_1, b_version_1 = deployment_info()
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    info_1, v1 = deployment_info()
+    dsm.deploy(TEST_DEPLOYMENT_ID, info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # Single replica should be created.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
 
     # update() should not transition the state if the replica isn't ready.
-    deployment_state.update()
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
-    deployment_state._replicas.get()[0]._actor.set_ready()
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+    ds._replicas.get()[0]._actor.set_ready()
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Now the replica should be marked running.
-    deployment_state.update()
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Removing the replica should transition it to stopping.
-    deployment_state.delete()
-    deployment_state_update_result = deployment_state.update()
-    replicas_to_stop = deployment_state._deployment_scheduler.schedule(
-        {},
-        {deployment_state._id: deployment_state_update_result.downscale}
-        if deployment_state_update_result.downscale
-        else {},
-    )[deployment_state._id]
-    deployment_state.stop_replicas(replicas_to_stop)
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STOPPING, 1)])
-    assert deployment_state._replicas.get()[0]._actor.stopped
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
-    assert (
-        deployment_state.curr_status_info.status_trigger
-        == DeploymentStatusTrigger.DELETING
-    )
+    ds.delete()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
+    assert ds._replicas.get()[0]._actor.stopped
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status_trigger == DeploymentStatusTrigger.DELETING
 
     # Once it's done stopping, replica should be removed.
-    replica = deployment_state._replicas.get()[0]
+    replica = ds._replicas.get()[0]
     replica._actor.set_done_stopping()
-    deployment_state_update_result = deployment_state.update()
-    assert deployment_state_update_result.deleted
-    check_counts(deployment_state, total=0)
+    dsm.update()
+    check_counts(ds, total=0)
 
 
-def test_force_kill(mock_deployment_state):
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {"node-id"}
+def test_force_kill(mock_deployment_state_manager_full):
+    create_dsm, timer, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
     grace_period_s = 10
-    b_info_1, b_version_1 = deployment_info(graceful_shutdown_timeout_s=grace_period_s)
+    info_1, _ = deployment_info(graceful_shutdown_timeout_s=grace_period_s)
+    dsm.deploy(TEST_DEPLOYMENT_ID, info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    dsm.update()
 
-    # Create and delete the deployment.
-    deployment_state.deploy(b_info_1)
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    deployment_state._replicas.get()[0]._actor.set_ready()
-    deployment_state.update()
-    deployment_state.delete()
-    deployment_state_update_result = deployment_state.update()
-    replicas_to_stop = deployment_state._deployment_scheduler.schedule(
-        {},
-        {deployment_state._id: deployment_state_update_result.downscale}
-        if deployment_state_update_result.downscale
-        else {},
-    )[deployment_state._id]
-    deployment_state.stop_replicas(replicas_to_stop)
+    # Create deployment.
+    ds._replicas.get()[0]._actor.set_ready()
+    dsm.update()
+
+    # Delete deployment.
+    ds.delete()
 
     # Replica should remain in STOPPING until it finishes.
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STOPPING, 1)])
-    assert deployment_state._replicas.get()[0]._actor.stopped
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
+    assert ds._replicas.get()[0]._actor.stopped
 
     for _ in range(10):
-        deployment_state.update()
+        dsm.update()
 
     # force_stop shouldn't be called until after the timer.
-    assert not deployment_state._replicas.get()[0]._actor.force_stopped_counter
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STOPPING, 1)])
+    assert not ds._replicas.get()[0]._actor.force_stopped_counter
+    print(ds._replicas)
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
 
     # Advance the timer, now the replica should be force stopped.
     timer.advance(grace_period_s + 0.1)
-    deployment_state.update()
-    assert deployment_state._replicas.get()[0]._actor.force_stopped_counter == 1
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STOPPING, 1)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
-    assert (
-        deployment_state.curr_status_info.status_trigger
-        == DeploymentStatusTrigger.DELETING
-    )
+    dsm.update()
+    assert ds._replicas.get()[0]._actor.force_stopped_counter == 1
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status_trigger == DeploymentStatusTrigger.DELETING
 
     # Force stop should be called repeatedly until the replica stops.
-    deployment_state.update()
-    assert deployment_state._replicas.get()[0]._actor.force_stopped_counter == 2
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STOPPING, 1)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
-    assert (
-        deployment_state.curr_status_info.status_trigger
-        == DeploymentStatusTrigger.DELETING
-    )
+    dsm.update()
+    assert ds._replicas.get()[0]._actor.force_stopped_counter == 2
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status_trigger == DeploymentStatusTrigger.DELETING
 
     # Once the replica is done stopping, it should be removed.
-    replica = deployment_state._replicas.get()[0]
+    replica = ds._replicas.get()[0]
     replica._actor.set_done_stopping()
-    deployment_state_update_result = deployment_state.update()
-    assert deployment_state_update_result.deleted
-    check_counts(deployment_state, total=0)
+    dsm.update()
+    check_counts(ds, total=0)
 
 
-def test_redeploy_same_version(mock_deployment_state):
+def test_redeploy_same_version(mock_deployment_state_manager_full):
     # Redeploying with the same version and code should do nothing.
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {"node-id"}
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
-    b_info_1, b_version_1 = deployment_info(version="1")
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    info_1, v1 = deployment_info(version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    dsm.update()
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Test redeploying while the initial deployment is still pending.
-    updating = deployment_state.deploy(b_info_1)
+    updating = dsm.deploy(TEST_DEPLOYMENT_ID, info_1)
     assert not updating
     # Redeploying the exact same info shouldn't cause any change in status
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
 
     # Mark the replica ready. After this, the initial goal should be complete.
-    deployment_state._replicas.get()[0]._actor.set_ready()
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    ds._replicas.get()[0]._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Test redeploying after the initial deployment has finished.
-    updating = deployment_state.deploy(b_info_1)
+    updating = dsm.deploy(TEST_DEPLOYMENT_ID, info_1)
     assert not updating
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_redeploy_no_version(mock_deployment_state):
+def test_redeploy_no_version(mock_deployment_state_manager_full):
     # Redeploying with no version specified (`None`) should always redeploy
     # the replicas.
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {"node-id"}
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
-    b_info_1, b_version_1 = deployment_info(version=None)
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    b_info_1, v1 = deployment_info(version=None)
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Test redeploying while the initial deployment is still pending.
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # The initial replica should be stopping. The new replica shouldn't start
     # until the old one has completely stopped.
-    deployment_state.update()
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STOPPING, 1)])
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
 
-    deployment_state.update()
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        0
-    ]._actor.set_done_stopping()
+    dsm.update()
+    ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
     # Now that the old replica has stopped, the new replica should be started.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
-    deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+    ds._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Check that the new replica has started.
-    deployment_state.update()
-    check_counts(deployment_state, total=1)
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
 
-    deployment_state.update()
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Now deploy a third version after the transition has finished.
     b_info_3, b_version_3 = deployment_info(version="3")
-    updating = deployment_state.deploy(b_info_3)
-    assert updating
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_3)
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    deployment_state.update()
-    check_counts(deployment_state, total=1)
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STOPPING, 1)])
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
 
-    deployment_state.update()
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        0
-    ]._actor.set_done_stopping()
+    dsm.update()
+    ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    ds._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    deployment_state_update_result = deployment_state.update()
-    assert not deployment_state_update_result.deleted
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_redeploy_new_version(mock_deployment_state):
+def test_redeploy_new_version(mock_deployment_state_manager_full):
     # Redeploying with a new version should start a new replica.
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {"node-id"}
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
-    b_info_1, b_version_1 = deployment_info(version="1")
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    b_info_1, v1 = deployment_info(version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Test redeploying while the initial deployment is still pending.
-    b_info_2, b_version_2 = deployment_info(version="2")
-    updating = deployment_state.deploy(b_info_2)
-    assert updating
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    b_info_2, v2 = deployment_info(version="2")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # The initial replica should be stopping. The new replica shouldn't start
     # until the old one has completely stopped.
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.STOPPING, 1)],
-    )
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, v1)])
 
-    deployment_state.update()
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        0
-    ]._actor.set_done_stopping()
+    dsm.update()
+    ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
 
     # Now that the old replica has stopped, the new replica should be started.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
-    deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v2)])
+    ds._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
 
     # Check that the new replica has started.
-    deployment_state.update()
-    check_counts(deployment_state, total=1)
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v2)])
 
-    deployment_state.update()
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Now deploy a third version after the transition has finished.
-    b_info_3, b_version_3 = deployment_info(version="3")
-    updating = deployment_state.deploy(b_info_3)
-    assert updating
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    b_info_3, v3 = deployment_info(version="3")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_3)
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    deployment_state.update()
-    check_counts(deployment_state, total=1)
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.STOPPING, 1)],
-    )
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, v2)])
 
-    deployment_state.update()
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        0
-    ]._actor.set_done_stopping()
+    dsm.update()
+    ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
-    check_counts(
-        deployment_state,
-        version=b_version_3,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
+    dsm.update()
+    ds._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v3)])
 
-    deployment_state_update_result = deployment_state.update()
-    assert not deployment_state_update_result.deleted
-    check_counts(
-        deployment_state,
-        version=b_version_3,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v3)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_redeploy_different_num_replicas(mock_deployment_state):
+def test_redeploy_different_num_replicas(mock_deployment_state_manager_full):
     """Tests status changes when redeploying with different num_replicas.
 
     1. Deploys a deployment -> checks if it's UPDATING.
@@ -1044,139 +996,95 @@ def test_redeploy_different_num_replicas(mock_deployment_state):
     4. Makes deployment HEALTHY, and then redeploys with more replicas ->
        check that is becomes DOWNSCALING.
     """
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {"node-id"}
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
     version = "1"
-    b_info_1, info_version = deployment_info(version=version, num_replicas=5)
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    b_info_1, v1 = deployment_info(version=version, num_replicas=5)
+    dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(
-        deployment_state,
-        version=info_version,
-        by_state=[(ReplicaState.STARTING, 5)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, by_state=[(ReplicaState.STARTING, 5, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Test redeploying with a higher num_replicas while the deployment is UPDATING.
-    b_info_2, info_version = deployment_info(version=version, num_replicas=10)
-    updating = deployment_state.deploy(b_info_2)
-    assert updating
+    b_info_2, v1 = deployment_info(version=version, num_replicas=10)
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
     # Redeploying while the deployment is UPDATING shouldn't change status.
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(
-        deployment_state,
-        version=info_version,
-        by_state=[(ReplicaState.STARTING, 10)],
-    )
+    dsm.update()
+    check_counts(ds, by_state=[(ReplicaState.STARTING, 10, v1)])
 
-    for replica in deployment_state._replicas.get():
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
 
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=info_version,
-        by_state=[(ReplicaState.RUNNING, 10)],
-    )
+    dsm.update()
+    check_counts(ds, by_state=[(ReplicaState.RUNNING, 10, v1)])
 
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Redeploy with a higher number of replicas. The status should be UPSCALING.
-    b_info_3, info_version = deployment_info(version=version, num_replicas=20)
-    updating = deployment_state.deploy(b_info_3)
-    assert updating
+    b_info_3, v1 = deployment_info(version=version, num_replicas=20)
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_3)
 
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
+    assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(
-        deployment_state,
-        version=info_version,
-        by_state=[(ReplicaState.STARTING, 10), (ReplicaState.STARTING, 10)],
-    )
+    dsm.update()
+    check_counts(ds, by_state=[(ReplicaState.STARTING, 10, v1)])
 
-    for replica in deployment_state._replicas.get():
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
 
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=info_version,
-        by_state=[(ReplicaState.RUNNING, 20)],
-    )
+    dsm.update()
+    check_counts(ds, by_state=[(ReplicaState.RUNNING, 20, v1)])
 
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
-        == DeploymentStatusTrigger.UPSCALE_COMPLETED
+        ds.curr_status_info.status_trigger == DeploymentStatusTrigger.UPSCALE_COMPLETED
     )
 
     # Redeploy with lower number of replicas. The status should be DOWNSCALING.
-    b_info_4, info_version = deployment_info(version=version, num_replicas=5)
-    updating = deployment_state.deploy(b_info_4)
-    assert updating
+    b_info_4, v1 = deployment_info(version=version, num_replicas=5)
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_4)
 
-    assert deployment_state.curr_status_info.status == DeploymentStatus.DOWNSCALING
+    assert ds.curr_status_info.status == DeploymentStatus.DOWNSCALING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    deployment_state_update_result = deployment_state.update()
-    replicas_to_stop = deployment_state._deployment_scheduler.schedule(
-        {}, {deployment_state._id: deployment_state_update_result.downscale}
-    )[deployment_state._id]
-    deployment_state.stop_replicas(replicas_to_stop)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=info_version,
-        by_state=[(ReplicaState.STOPPING, 15), (ReplicaState.RUNNING, 5)],
+        ds, by_state=[(ReplicaState.STOPPING, 15, v1), (ReplicaState.RUNNING, 5, v1)]
     )
 
-    for replica in deployment_state._replicas.get(states=[ReplicaState.STOPPING]):
+    for replica in ds._replicas.get(states=[ReplicaState.STOPPING]):
         replica._actor.set_done_stopping()
 
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=info_version,
-        total=5,
-        by_state=[(ReplicaState.RUNNING, 5)],
-    )
+    dsm.update()
+    check_counts(ds, total=5, by_state=[(ReplicaState.RUNNING, 5, v1)])
 
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.DOWNSCALE_COMPLETED
     )
 
@@ -1192,248 +1100,182 @@ def test_redeploy_different_num_replicas(mock_deployment_state):
         ("health_check_timeout_s", DEFAULT_HEALTH_CHECK_TIMEOUT_S + 1),
     ],
 )
-def test_deploy_new_config_same_code_version(mock_deployment_state, option, value):
-    # Deploying a new config with the same version should not deploy a new
-    # replica.
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {"node-id"}
+def test_deploy_new_config_same_code_version(
+    mock_deployment_state_manager_full, option, value
+):
+    """Deploying a new config with the same version should not deploy a new replica."""
 
-    b_info_1, b_version_1 = deployment_info(version="1")
-    updated = deployment_state.deploy(b_info_1)
-    assert updated
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
+
+    b_info_1, v1 = deployment_info(version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Create the replica initially.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    deployment_state._replicas.get()[0]._actor.set_ready()
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    ds._replicas.get()[0]._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Update to a new config without changing the code version.
-    b_info_2, b_version_2 = deployment_info(version="1", **{option: value})
-    updated = deployment_state.deploy(b_info_2)
+    b_info_2, v2 = deployment_info(version="1", **{option: value})
+    updated = dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
     assert updated
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
 
     if option in ["user_config", "graceful_shutdown_wait_loop_s"]:
-        deployment_state.update()
-        check_counts(deployment_state, total=1)
+        dsm.update()
+        check_counts(ds, total=1)
         check_counts(
-            deployment_state,
-            version=b_version_2,
+            ds,
             total=1,
-            by_state=[(ReplicaState.UPDATING, 1)],
+            by_state=[(ReplicaState.UPDATING, 1, v2)],
         )
         # Mark the replica as ready.
-        deployment_state._replicas.get()[0]._actor.set_ready()
+        ds._replicas.get()[0]._actor.set_ready()
 
-    deployment_state.update()
-    check_counts(deployment_state, total=1)
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v2)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_deploy_new_config_same_code_version_2(mock_deployment_state):
-    # Make sure we don't transition from STARTING to UPDATING directly.
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {"node-id"}
+def test_deploy_new_config_same_code_version_2(mock_deployment_state_manager_full):
+    """Make sure we don't transition from STARTING to UPDATING directly."""
 
-    b_info_1, b_version_1 = deployment_info(version="1")
-    updated = deployment_state.deploy(b_info_1)
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
+
+    b_info_1, v1 = deployment_info(version="1")
+    updated = dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
     assert updated
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Create the replica initially.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
 
     # Update to a new config without changing the code version.
-    b_info_2, b_version_2 = deployment_info(version="1", user_config={"hello": "world"})
-    updated = deployment_state.deploy(b_info_2)
+    b_info_2, v2 = deployment_info(version="1", user_config={"hello": "world"})
+    updated = dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
     assert updated
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    deployment_state.update()
+    dsm.update()
     # Since it's STARTING, we cannot transition to UPDATING
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
 
-    deployment_state._replicas.get()[0]._actor.set_ready()
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.UPDATING, 1)],
-    )
+    ds._replicas.get()[0]._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.UPDATING, 1, v2)])
 
     # Mark the replica as ready.
-    deployment_state._replicas.get()[0]._actor.set_ready()
-    deployment_state.update()
-    check_counts(deployment_state, total=1)
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    ds._replicas.get()[0]._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=1)
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v2)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_deploy_new_config_new_version(mock_deployment_state):
+def test_deploy_new_config_new_version(mock_deployment_state_manager_full):
     # Deploying a new config with a new version should deploy a new replica.
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {"node-id"}
 
-    b_info_1, b_version_1 = deployment_info(version="1")
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
+
+    b_info_1, v1 = deployment_info(version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # Create the replica initially.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    deployment_state._replicas.get()[0]._actor.set_ready()
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    ds._replicas.get()[0]._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Update to a new config and a new version.
-    b_info_2, b_version_2 = deployment_info(version="2", user_config={"hello": "world"})
-    updating = deployment_state.deploy(b_info_2)
-    assert updating
+    b_info_2, v2 = deployment_info(version="2", user_config={"hello": "world"})
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
 
     # New version shouldn't start until old version is stopped.
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.STOPPING, 1)],
-    )
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        0
-    ]._actor.set_done_stopping()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, v1)])
+    ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
 
     # Now the new version should be started.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    ds._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v2)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Check that the new version is now running.
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v2)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_stop_replicas_on_draining_nodes(mock_deployment_state):
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {"node-1", "node-2"}
+def test_stop_replicas_on_draining_nodes(mock_deployment_state_manager_full):
+    create_dsm, _, cluster_node_info_cache = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
+    cluster_node_info_cache.draining_node_ids = {"node-1", "node-2"}
 
-    b_info_1, b_version_1 = deployment_info(num_replicas=2, version="1")
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    b_info_1, v1 = deployment_info(num_replicas=2, version="1")
+    updated = dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    assert updated
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 2)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
@@ -1442,10 +1284,10 @@ def test_stop_replicas_on_draining_nodes(mock_deployment_state):
 
     # Since the replicas are still starting and we don't know the actor node id
     # yet so nothing happens
-    deployment_state.update()
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 2)])
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, v1)])
 
-    one_replica, another_replica = deployment_state._replicas.get()
+    one_replica, another_replica = ds._replicas.get()
 
     one_replica._actor.set_node_id("node-1")
     one_replica._actor.set_ready()
@@ -1454,11 +1296,11 @@ def test_stop_replicas_on_draining_nodes(mock_deployment_state):
     another_replica._actor.set_ready()
 
     # The replica running on node-2 will be drained.
-    deployment_state.update()
+    dsm.update()
     check_counts(
-        deployment_state,
+        ds,
         total=2,
-        by_state=[(ReplicaState.RUNNING, 1), (ReplicaState.STOPPING, 1)],
+        by_state=[(ReplicaState.RUNNING, 1, v1), (ReplicaState.STOPPING, 1, v1)],
     )
 
     # A new node is started.
@@ -1470,154 +1312,128 @@ def test_stop_replicas_on_draining_nodes(mock_deployment_state):
 
     # The draining replica is stopped and a new one will be started.
     another_replica._actor.set_done_stopping()
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
+    dsm.update()
     check_counts(
-        deployment_state,
+        ds,
         total=2,
-        by_state=[(ReplicaState.STARTING, 1), (ReplicaState.RUNNING, 1)],
+        by_state=[(ReplicaState.STARTING, 1, v1), (ReplicaState.RUNNING, 1, v1)],
     )
 
 
-def test_initial_deploy_no_throttling(mock_deployment_state):
+def test_initial_deploy_no_throttling(mock_deployment_state_manager_full):
     # All replicas should be started at once for a new deployment.
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {str(i) for i in range(10)}
+    create_dsm, _, cluster_node_info_cache = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
+    cluster_node_info_cache.draining_node_ids = {"node-1", "node-2"}
 
-    b_info_1, b_version_1 = deployment_info(num_replicas=10, version="1")
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    b_info_1, v1 = deployment_info(num_replicas=10, version="1")
+    updated = dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    assert updated
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=10, by_state=[(ReplicaState.STARTING, 10)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=10, by_state=[(ReplicaState.STARTING, 10, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    for replica in deployment_state._replicas.get():
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
 
     # Check that the new replicas have started.
-    deployment_state.update()
-    check_counts(deployment_state, total=10, by_state=[(ReplicaState.RUNNING, 10)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=10, by_state=[(ReplicaState.RUNNING, 10, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_new_version_deploy_throttling(mock_deployment_state):
-    # All replicas should be started at once for a new deployment.
-    # When the version is updated, it should be throttled. The throttling
-    # should apply to both code version and user config updates.
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {str(i) for i in range(10)}
+def test_new_version_deploy_throttling(mock_deployment_state_manager_full):
+    """All replicas should be started at once for a new deployment.
 
-    b_info_1, b_version_1 = deployment_info(
-        num_replicas=10, version="1", user_config="1"
-    )
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    When the version is updated, it should be throttled. The throttling
+    should apply to both code version and user config updates.
+    """
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=10, by_state=[(ReplicaState.STARTING, 10)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
+
+    b_info_1, v1 = deployment_info(num_replicas=10, version="1", user_config="1")
+    updated = dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    assert updated
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    dsm.update()
+    check_counts(ds, total=10, by_state=[(ReplicaState.STARTING, 10, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    for replica in deployment_state._replicas.get():
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
 
     # Check that the new replicas have started.
-    deployment_state.update()
-    check_counts(deployment_state, total=10, by_state=[(ReplicaState.RUNNING, 10)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=10, by_state=[(ReplicaState.RUNNING, 10, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Now deploy a new version. Two old replicas should be stopped.
-    b_info_2, b_version_2 = deployment_info(
-        num_replicas=10, version="2", user_config="2"
-    )
-    updating = deployment_state.deploy(b_info_2)
-    assert updating
-    deployment_state.update()
+    b_info_2, v2 = deployment_info(num_replicas=10, version="2", user_config="2")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
+        ds,
         total=10,
-        by_state=[(ReplicaState.RUNNING, 8), (ReplicaState.STOPPING, 2)],
+        by_state=[(ReplicaState.RUNNING, 8, v1), (ReplicaState.STOPPING, 2, v1)],
     )
 
     # Mark only one of the replicas as done stopping.
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        0
-    ]._actor.set_done_stopping()
+    ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
 
     # Now one of the new version replicas should start up.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=10)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=9,
-        by_state=[(ReplicaState.RUNNING, 8), (ReplicaState.STOPPING, 1)],
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
+        ds,
+        total=10,
+        by_state=[
+            (ReplicaState.RUNNING, 8, v1),
+            (ReplicaState.STOPPING, 1, v1),
+            (ReplicaState.STARTING, 1, v2),
+        ],
     )
 
     # Mark the new version replica as ready. Another old version replica
     # should subsequently be stopped.
-    deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
+    ds._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
 
-    deployment_state.update()
-    check_counts(deployment_state, total=10)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=9,
-        by_state=[(ReplicaState.RUNNING, 7), (ReplicaState.STOPPING, 2)],
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
+        ds,
+        total=10,
+        by_state=[
+            (ReplicaState.RUNNING, 7, v1),
+            (ReplicaState.STOPPING, 2, v1),
+            (ReplicaState.RUNNING, 1, v2),
+        ],
     )
 
     # Mark the old replicas as done stopping.
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        0
-    ]._actor.set_done_stopping()
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        1
-    ]._actor.set_done_stopping()
+    ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
+    ds._replicas.get(states=[ReplicaState.STOPPING])[1]._actor.set_done_stopping()
 
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
@@ -1626,507 +1442,366 @@ def test_new_version_deploy_throttling(mock_deployment_state):
     old_replicas = 9
     while old_replicas > 3:
         # Replicas starting up.
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
-        )
-        check_counts(deployment_state, total=10)
+        dsm.update()
         check_counts(
-            deployment_state,
-            version=b_version_1,
-            total=old_replicas - 2,
-            by_state=[(ReplicaState.RUNNING, old_replicas - 2)],
-        )
-        check_counts(
-            deployment_state,
-            version=b_version_2,
-            total=new_replicas + 2,
-            by_state=[(ReplicaState.RUNNING, new_replicas), (ReplicaState.STARTING, 2)],
+            ds,
+            total=10,
+            by_state=[
+                (ReplicaState.RUNNING, old_replicas - 2, v1),
+                (ReplicaState.RUNNING, new_replicas, v2),
+                (ReplicaState.STARTING, 2, v2),
+            ],
         )
 
         # Set both ready.
-        deployment_state._replicas.get(states=[ReplicaState.STARTING])[
-            0
-        ]._actor.set_ready()
-        deployment_state._replicas.get(states=[ReplicaState.STARTING])[
-            1
-        ]._actor.set_ready()
+        ds._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
+        ds._replicas.get(states=[ReplicaState.STARTING])[1]._actor.set_ready()
         new_replicas += 2
 
         # Two more old replicas should be stopped.
         old_replicas -= 2
-        deployment_state.update()
-        check_counts(deployment_state, total=10)
+        dsm.update()
+        check_counts(ds, total=10)
         check_counts(
-            deployment_state,
-            version=b_version_1,
-            total=old_replicas,
+            ds,
+            total=10,
             by_state=[
-                (ReplicaState.RUNNING, old_replicas - 2),
-                (ReplicaState.STOPPING, 2),
+                (ReplicaState.RUNNING, old_replicas - 2, v1),
+                (ReplicaState.STOPPING, 2, v1),
+                (ReplicaState.RUNNING, new_replicas, v2),
             ],
         )
-        check_counts(
-            deployment_state,
-            version=b_version_2,
-            total=new_replicas,
-            by_state=[(ReplicaState.RUNNING, new_replicas)],
-        )
 
-        deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-            0
-        ]._actor.set_done_stopping()
-        deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-            1
-        ]._actor.set_done_stopping()
+        ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
+        ds._replicas.get(states=[ReplicaState.STOPPING])[1]._actor.set_done_stopping()
 
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+        assert ds.curr_status_info.status == DeploymentStatus.UPDATING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
     # 2 left to update.
     # Replicas starting up.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=10)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=9,
-        by_state=[(ReplicaState.RUNNING, 7), (ReplicaState.STARTING, 2)],
+        ds,
+        total=10,
+        by_state=[
+            (ReplicaState.RUNNING, 1, v1),
+            (ReplicaState.RUNNING, 7, v2),
+            (ReplicaState.STARTING, 2, v2),
+        ],
     )
 
     # Set both ready.
-    deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
-    deployment_state._replicas.get(states=[ReplicaState.STARTING])[1]._actor.set_ready()
+    ds._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
+    ds._replicas.get(states=[ReplicaState.STARTING])[1]._actor.set_ready()
 
     # The last replica should be stopped.
-    deployment_state.update()
-    check_counts(deployment_state, total=10)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.STOPPING, 1)],
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=9,
-        by_state=[(ReplicaState.RUNNING, 9)],
+        ds,
+        total=10,
+        by_state=[(ReplicaState.STOPPING, 1, v1), (ReplicaState.RUNNING, 9, v2)],
     )
 
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        0
-    ]._actor.set_done_stopping()
+    ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
 
     # The last replica should start up.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=10)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_2,
+        ds,
         total=10,
-        by_state=[(ReplicaState.RUNNING, 9), (ReplicaState.STARTING, 1)],
+        by_state=[(ReplicaState.RUNNING, 9, v2), (ReplicaState.STARTING, 1, v2)],
     )
 
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Set both ready.
-    deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
-    deployment_state.update()
-    check_counts(deployment_state, total=10)
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=10,
-        by_state=[(ReplicaState.RUNNING, 10)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    ds._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=10, by_state=[(ReplicaState.RUNNING, 10, v2)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_reconfigure_throttling(mock_deployment_state):
-    # All replicas should be started at once for a new deployment.
-    # When the version is updated, it should be throttled.
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {str(i) for i in range(2)}
+def test_reconfigure_throttling(mock_deployment_state_manager_full):
+    """All replicas should be started at once for a new deployment.
+    When the version is updated, it should be throttled.
+    """
 
-    b_info_1, b_version_1 = deployment_info(
-        num_replicas=2, version="1", user_config="1"
-    )
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 2)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    b_info_1, v1 = deployment_info(num_replicas=2, version="1", user_config="1")
+    updated = dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    assert updated
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    for replica in deployment_state._replicas.get():
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
 
     # Check that the new replicas have started.
-    deployment_state.update()
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Now deploy a new user_config. One replica should be updated.
-    b_info_2, b_version_2 = deployment_info(
-        num_replicas=2, version="1", user_config="2"
-    )
-    updating = deployment_state.deploy(b_info_2)
-    assert updating
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    b_info_2, v2 = deployment_info(num_replicas=2, version="1", user_config="2")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    deployment_state.update()
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.UPDATING, 1)],
+        ds,
+        total=2,
+        by_state=[(ReplicaState.RUNNING, 1, v1), (ReplicaState.UPDATING, 1, v2)],
     )
 
     # Mark the updating replica as ready.
-    deployment_state._replicas.get(states=[ReplicaState.UPDATING])[0]._actor.set_ready()
+    ds._replicas.get(states=[ReplicaState.UPDATING])[0]._actor.set_ready()
 
     # The updated replica should now be RUNNING.
     # The second replica should now be updated.
-    deployment_state.update()
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_2,
+        ds,
         total=2,
-        by_state=[(ReplicaState.RUNNING, 1), (ReplicaState.UPDATING, 1)],
+        by_state=[(ReplicaState.RUNNING, 1, v2), (ReplicaState.UPDATING, 1, v2)],
     )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Mark the updating replica as ready.
-    deployment_state._replicas.get(states=[ReplicaState.UPDATING])[0]._actor.set_ready()
+    ds._replicas.get(states=[ReplicaState.UPDATING])[0]._actor.set_ready()
 
     # Both replicas should now be RUNNING.
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=2,
-        by_state=[(ReplicaState.RUNNING, 2)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v2)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_new_version_and_scale_down(mock_deployment_state):
+def test_new_version_and_scale_down(mock_deployment_state_manager_full):
     # Test the case when we reduce the number of replicas and change the
     # version at the same time. First the number of replicas should be
     # turned down, then the rolling update should happen.
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {"node-id"}
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
-    b_info_1, b_version_1 = deployment_info(num_replicas=10, version="1")
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    b_info_1, v1 = deployment_info(num_replicas=10, version="1")
+    updated = dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    assert updated
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=10, by_state=[(ReplicaState.STARTING, 10)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=10, by_state=[(ReplicaState.STARTING, 10, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    for replica in deployment_state._replicas.get():
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
 
     # Check that the new replicas have started.
-    deployment_state.update()
-    check_counts(deployment_state, total=10, by_state=[(ReplicaState.RUNNING, 10)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=10, by_state=[(ReplicaState.RUNNING, 10, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Now deploy a new version and scale down the number of replicas to 2.
     # First, 8 old replicas should be stopped to bring it down to the target.
-    b_info_2, b_version_2 = deployment_info(num_replicas=2, version="2")
-    updating = deployment_state.deploy(b_info_2)
-    assert updating
-    deployment_state_update_result = deployment_state.update()
-    replicas_to_stop = deployment_state._deployment_scheduler.schedule(
-        {}, {deployment_state._id: deployment_state_update_result.downscale}
-    )[deployment_state._id]
-    deployment_state.stop_replicas(replicas_to_stop)
+    b_info_2, v2 = deployment_info(num_replicas=2, version="2")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
+        ds,
         total=10,
-        by_state=[(ReplicaState.RUNNING, 2), (ReplicaState.STOPPING, 8)],
+        by_state=[(ReplicaState.RUNNING, 2, v1), (ReplicaState.STOPPING, 8, v1)],
     )
 
     # Mark only one of the replicas as done stopping.
     # This should not yet trigger the rolling update because there are still
     # stopping replicas.
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        0
-    ]._actor.set_done_stopping()
+    ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
 
-    deployment_state.update()
-    check_counts(deployment_state, total=9)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
+        ds,
         total=9,
-        by_state=[(ReplicaState.RUNNING, 2), (ReplicaState.STOPPING, 7)],
+        by_state=[(ReplicaState.RUNNING, 2, v1), (ReplicaState.STOPPING, 7, v1)],
     )
 
     # Stop the remaining replicas.
-    for replica in deployment_state._replicas.get(states=[ReplicaState.STOPPING]):
+    for replica in ds._replicas.get(states=[ReplicaState.STOPPING]):
         replica._actor.set_done_stopping()
 
     # Now the rolling update should trigger, stopping one of the old replicas.
-    deployment_state.update()
-    check_counts(deployment_state, total=2)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
+        ds,
         total=2,
-        by_state=[(ReplicaState.RUNNING, 1), (ReplicaState.STOPPING, 1)],
+        by_state=[(ReplicaState.RUNNING, 1, v1), (ReplicaState.STOPPING, 1, v1)],
     )
 
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        0
-    ]._actor.set_done_stopping()
+    ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
 
     # Old version stopped, new version should start up.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=2)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
+        ds,
+        total=2,
+        by_state=[(ReplicaState.RUNNING, 1, v1), (ReplicaState.STARTING, 1, v2)],
     )
 
-    deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
+    ds._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
     # New version is started, final old version replica should be stopped.
-    deployment_state.update()
-    check_counts(deployment_state, total=2)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.STOPPING, 1)],
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
+        ds,
+        total=2,
+        by_state=[(ReplicaState.STOPPING, 1, v1), (ReplicaState.RUNNING, 1, v2)],
     )
 
-    deployment_state._replicas.get(states=[ReplicaState.STOPPING])[
-        0
-    ]._actor.set_done_stopping()
+    ds._replicas.get(states=[ReplicaState.STOPPING])[0]._actor.set_done_stopping()
 
     # Final old version replica is stopped, final new version replica
     # should be started.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=2)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_2,
+        ds,
         total=2,
-        by_state=[(ReplicaState.RUNNING, 1), (ReplicaState.STARTING, 1)],
+        by_state=[(ReplicaState.RUNNING, 1, v2), (ReplicaState.STARTING, 1, v2)],
     )
 
-    deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
-    deployment_state.update()
-    check_counts(deployment_state, total=2)
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=2,
-        by_state=[(ReplicaState.RUNNING, 2)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    ds._replicas.get(states=[ReplicaState.STARTING])[0]._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v2)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_new_version_and_scale_up(mock_deployment_state):
+def test_new_version_and_scale_up(mock_deployment_state_manager_full):
     # Test the case when we increase the number of replicas and change the
     # version at the same time. The new replicas should all immediately be
     # turned up. When they're up, rolling update should trigger.
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
-    b_info_1, b_version_1 = deployment_info(num_replicas=2, version="1")
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    b_info_1, v1 = deployment_info(num_replicas=2, version="1")
+    updated = dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    assert updated
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 2)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    for replica in deployment_state._replicas.get():
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
 
     # Check that the new replicas have started.
-    deployment_state.update()
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Now deploy a new version and scale up the number of replicas to 10.
     # 8 new replicas should be started.
-    b_info_2, b_version_2 = deployment_info(num_replicas=10, version="2")
-    updating = deployment_state.deploy(b_info_2)
-    assert updating
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
+    b_info_2, v2 = deployment_info(num_replicas=10, version="2")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=2,
-        by_state=[(ReplicaState.RUNNING, 2)],
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=8,
-        by_state=[(ReplicaState.STARTING, 8)],
+        ds,
+        total=10,
+        by_state=[(ReplicaState.RUNNING, 2, v1), (ReplicaState.STARTING, 8, v2)],
     )
 
     # Mark the new replicas as ready.
-    for replica in deployment_state._replicas.get(states=[ReplicaState.STARTING]):
+    for replica in ds._replicas.get(states=[ReplicaState.STARTING]):
         replica._actor.set_ready()
 
     # Now that the new version replicas are up, rolling update should start.
-    deployment_state.update()
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=2,
-        by_state=[(ReplicaState.RUNNING, 0), (ReplicaState.STOPPING, 2)],
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=8,
-        by_state=[(ReplicaState.RUNNING, 8)],
+        ds,
+        total=10,
+        by_state=[
+            (ReplicaState.RUNNING, 0, v1),
+            (ReplicaState.STOPPING, 2, v1),
+            (ReplicaState.RUNNING, 8, v2),
+        ],
     )
 
     # Mark the replicas as done stopping.
-    for replica in deployment_state._replicas.get(states=[ReplicaState.STOPPING]):
+    for replica in ds._replicas.get(states=[ReplicaState.STOPPING]):
         replica._actor.set_done_stopping()
 
     # The remaining replicas should be started.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=10)
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_2,
+        ds,
         total=10,
-        by_state=[(ReplicaState.RUNNING, 8), (ReplicaState.STARTING, 2)],
+        by_state=[(ReplicaState.RUNNING, 8, v2), (ReplicaState.STARTING, 2, v2)],
     )
 
     # Mark the remaining replicas as ready.
-    for replica in deployment_state._replicas.get(states=[ReplicaState.STARTING]):
+    for replica in ds._replicas.get(states=[ReplicaState.STARTING]):
         replica._actor.set_ready()
 
     # All new replicas should be up and running.
-    deployment_state.update()
-    check_counts(deployment_state, total=10)
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=10,
-        by_state=[(ReplicaState.RUNNING, 10)],
-    )
+    dsm.update()
+    check_counts(ds, total=10, by_state=[(ReplicaState.RUNNING, 10, v2)])
 
-    deployment_state.update()
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
@@ -2148,81 +1823,78 @@ def test_scale_num_replicas(
 
     # State
     version = get_random_string()
-    deployment_id = DeploymentID("test_deployment", "test_app")
 
     # Create deployment state manager
-    create_deployment_state_manager, _, _ = mock_deployment_state_manager_full
-    deployment_state_manager: DeploymentStateManager = create_deployment_state_manager()
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
     # Deploy deployment with 3 replicas
-    info_1, _ = deployment_info(num_replicas=3, version=version)
-    deployment_state_manager.deploy(deployment_id, info_1)
-    deployment_state: DeploymentState = deployment_state_manager._deployment_states[
-        deployment_id
-    ]
+    info_1, v1 = deployment_info(num_replicas=3, version=version)
+    dsm.deploy(TEST_DEPLOYMENT_ID, info_1)
+    ds: DeploymentState = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # status=UPDATING, status_trigger=DEPLOY
-    deployment_state_manager.update()
-    check_counts(deployment_state, total=3, by_state=[(ReplicaState.STARTING, 3)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=3, by_state=[(ReplicaState.STARTING, 3, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Set replicas ready and check statuses
-    for replica in deployment_state._replicas.get():
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
 
     # status=HEALTHY, status_trigger=DEPLOY
-    deployment_state_manager.update()
-    check_counts(deployment_state, total=3, by_state=[(ReplicaState.RUNNING, 3)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # upscale or downscale the number of replicas manually
     new_num_replicas = 5 if target_capacity_direction == "up" else 1
     info_2, _ = deployment_info(num_replicas=new_num_replicas, version=version)
-    deployment_state_manager.deploy(deployment_id, info_2)
-    deployment_state_manager.update()
+    dsm.deploy(TEST_DEPLOYMENT_ID, info_2)
+    dsm.update()
 
     # status=UPSCALING/DOWNSCALING, status_trigger=CONFIG_UPDATE
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
     if target_capacity_direction == "up":
         check_counts(
-            deployment_state,
+            ds,
             total=5,
-            by_state=[(ReplicaState.RUNNING, 3), (ReplicaState.STARTING, 2)],
+            by_state=[(ReplicaState.RUNNING, 3, v1), (ReplicaState.STARTING, 2, v1)],
         )
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
-        for replica in deployment_state._replicas.get():
+        assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
     else:
         check_counts(
-            deployment_state,
+            ds,
             total=3,
-            by_state=[(ReplicaState.RUNNING, 1), (ReplicaState.STOPPING, 2)],
+            by_state=[(ReplicaState.RUNNING, 1, v1), (ReplicaState.STOPPING, 2, v1)],
         )
-        assert deployment_state.curr_status_info.status == DeploymentStatus.DOWNSCALING
-        for replica in deployment_state._replicas.get():
+        assert ds.curr_status_info.status == DeploymentStatus.DOWNSCALING
+        for replica in ds._replicas.get():
             replica._actor.set_done_stopping()
 
     # After the upscaling/downscaling finishes
     # status=HEALTHY, status_trigger=UPSCALING_COMPLETED/DOWNSCALE_COMPLETED
-    deployment_state_manager.update()
+    dsm.update()
     check_counts(
-        deployment_state,
+        ds,
         total=new_num_replicas,
-        by_state=[(ReplicaState.RUNNING, new_num_replicas)],
+        by_state=[(ReplicaState.RUNNING, new_num_replicas, v1)],
     )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
-    assert deployment_state.curr_status_info.status_trigger == (
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
+    assert ds.curr_status_info.status_trigger == (
         DeploymentStatusTrigger.UPSCALE_COMPLETED
         if target_capacity_direction == "up"
         else DeploymentStatusTrigger.DOWNSCALE_COMPLETED
@@ -2243,15 +1915,12 @@ def test_basic_autoscaling(
     5. It becomes healthy with 6 running replicas, status=HEALTHY, trigger=UPSCALE.
     """
 
-    # State
-    deployment_id = DeploymentID("test_deployment", "test_app")
-
     # Create deployment state manager
-    create_deployment_state_manager, timer, _ = mock_deployment_state_manager_full
-    deployment_state_manager: DeploymentStateManager = create_deployment_state_manager()
+    create_dsm, timer, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
     # Deploy deployment with 3 replicas
-    info, _ = deployment_info(
+    info, v1 = deployment_info(
         autoscaling_config={
             "target_num_ongoing_requests_per_replica": 1,
             "min_replicas": 0,
@@ -2261,88 +1930,83 @@ def test_basic_autoscaling(
             "downscale_delay_s": 0,
         }
     )
-    deployment_state_manager.deploy(deployment_id, info)
-    depstate: DeploymentState = deployment_state_manager._deployment_states[
-        deployment_id
-    ]
+    dsm.deploy(TEST_DEPLOYMENT_ID, info)
+    ds: DeploymentState = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # status=UPDATING, status_trigger=DEPLOY
-    deployment_state_manager.update()
-    check_counts(depstate, total=3, by_state=[(ReplicaState.STARTING, 3)])
-    assert depstate.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=3, by_state=[(ReplicaState.STARTING, 3, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        depstate.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Set replicas ready and check statuses
-    for replica in depstate._replicas.get():
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
 
     # status=HEALTHY, status_trigger=DEPLOY
-    deployment_state_manager.update()
-    check_counts(depstate, total=3, by_state=[(ReplicaState.RUNNING, 3)])
-    assert depstate.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        depstate.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
-    for replica in depstate._replicas.get():
-        deployment_state_manager.record_autoscaling_metrics(
+    for replica in ds._replicas.get():
+        dsm.record_autoscaling_metrics(
             replica._actor.replica_tag,
             2 if target_capacity_direction == "up" else 0,
             None,
         )
 
     # status=UPSCALING/DOWNSCALING, status_trigger=AUTOSCALE
-    deployment_state_manager.update()
+    dsm.update()
     if target_capacity_direction == "up":
         check_counts(
-            depstate,
+            ds,
             total=6,
-            by_state=[(ReplicaState.RUNNING, 3), (ReplicaState.STARTING, 3)],
+            by_state=[
+                (ReplicaState.RUNNING, 3, None),
+                (ReplicaState.STARTING, 3, None),
+            ],
         )
-        assert depstate.curr_status_info.status == DeploymentStatus.UPSCALING
-        assert (
-            depstate.curr_status_info.status_trigger
-            == DeploymentStatusTrigger.AUTOSCALING
-        )
+        assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
+        assert ds.curr_status_info.status_trigger == DeploymentStatusTrigger.AUTOSCALING
 
         # Advance timer by 60 seconds; this should exceed the slow startup
         # warning threshold. The message should be updated, but the status
         # should remain upscaling/autoscaling
         timer.advance(60)
-        deployment_state_manager.update()
+        dsm.update()
         check_counts(
-            depstate,
+            ds,
             total=6,
-            by_state=[(ReplicaState.RUNNING, 3), (ReplicaState.STARTING, 3)],
+            by_state=[
+                (ReplicaState.RUNNING, 3, None),
+                (ReplicaState.STARTING, 3, None),
+            ],
         )
-        assert depstate.curr_status_info.status == DeploymentStatus.UPSCALING
-        assert (
-            depstate.curr_status_info.status_trigger
-            == DeploymentStatusTrigger.AUTOSCALING
-        )
-        assert "have taken more than" in depstate.curr_status_info.message
+        assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
+        assert ds.curr_status_info.status_trigger == DeploymentStatusTrigger.AUTOSCALING
+        assert "have taken more than" in ds.curr_status_info.message
 
         # Set replicas ready
-        for replica in depstate._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
     else:
-        check_counts(depstate, total=3, by_state=[(ReplicaState.STOPPING, 3)])
-        assert depstate.curr_status_info.status == DeploymentStatus.DOWNSCALING
-        assert (
-            depstate.curr_status_info.status_trigger
-            == DeploymentStatusTrigger.AUTOSCALING
-        )
-        for replica in depstate._replicas.get():
+        check_counts(ds, total=3, by_state=[(ReplicaState.STOPPING, 3, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.DOWNSCALING
+        assert ds.curr_status_info.status_trigger == DeploymentStatusTrigger.AUTOSCALING
+        for replica in ds._replicas.get():
             replica._actor.set_done_stopping()
 
     # status=HEALTHY, status_trigger=UPSCALE/DOWNSCALE
-    deployment_state_manager.update()
-    assert depstate.curr_status_info.status == DeploymentStatus.HEALTHY
-    assert depstate.curr_status_info.status_trigger == (
+    dsm.update()
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
+    assert ds.curr_status_info.status_trigger == (
         DeploymentStatusTrigger.UPSCALE_COMPLETED
         if target_capacity_direction == "up"
         else DeploymentStatusTrigger.DOWNSCALE_COMPLETED
@@ -2367,14 +2031,9 @@ def test_downscaling_reclaiming_starting_replicas_first(
     https://github.com/ray-project/ray/issues/43034
     """
 
-    app_name = "test_app"
-    deployment_name = "deployment_with_slow_to_start_replicas"
-
-    deployment_id = DeploymentID(deployment_name, app_name)
-
     # Create deployment state manager
-    create_deployment_state_manager, timer, _ = mock_deployment_state_manager_full
-    dsm: DeploymentStateManager = create_deployment_state_manager()
+    create_dsm, timer, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
     # Deploy deployment with 3 replicas
     info, _ = deployment_info(
@@ -2388,13 +2047,13 @@ def test_downscaling_reclaiming_starting_replicas_first(
         }
     )
 
-    dsm.deploy(deployment_id, info)
+    dsm.deploy(TEST_DEPLOYMENT_ID, info)
 
-    deployment_state: DeploymentState = dsm._deployment_states[deployment_id]
+    deployment_state: DeploymentState = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # status=UPDATING, status_trigger=DEPLOY
     dsm.update()
-    check_counts(deployment_state, total=3, by_state=[(ReplicaState.STARTING, 3)])
+    check_counts(deployment_state, total=3, by_state=[(ReplicaState.STARTING, 3, None)])
     assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
         deployment_state.curr_status_info.status_trigger
@@ -2407,7 +2066,7 @@ def test_downscaling_reclaiming_starting_replicas_first(
 
     # status=HEALTHY, status_trigger=DEPLOY
     dsm.update()
-    check_counts(deployment_state, total=3, by_state=[(ReplicaState.RUNNING, 3)])
+    check_counts(deployment_state, total=3, by_state=[(ReplicaState.RUNNING, 3, None)])
     assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
         deployment_state.curr_status_info.status_trigger
@@ -2425,7 +2084,7 @@ def test_downscaling_reclaiming_starting_replicas_first(
     check_counts(
         deployment_state,
         total=6,
-        by_state=[(ReplicaState.RUNNING, 3), (ReplicaState.STARTING, 3)],
+        by_state=[(ReplicaState.RUNNING, 3, None), (ReplicaState.STARTING, 3, None)],
     )
     assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
     assert (
@@ -2446,7 +2105,7 @@ def test_downscaling_reclaiming_starting_replicas_first(
     check_counts(
         deployment_state,
         total=6,
-        by_state=[(ReplicaState.RUNNING, 3), (ReplicaState.STARTING, 3)],
+        by_state=[(ReplicaState.RUNNING, 3, None), (ReplicaState.STARTING, 3, None)],
     )
 
     assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
@@ -2457,15 +2116,14 @@ def test_downscaling_reclaiming_starting_replicas_first(
 
     if target_startup_status == ReplicaStartupStatus.PENDING_INITIALIZATION:
         expected_message = (
-            f"Deployment '{deployment_name}' in application "
-            f"'{app_name}' has 3 replicas "
+            "Deployment 'test_deployment' in application 'test_app' has 3 replicas "
             f"that have taken more than {SLOW_STARTUP_WARNING_S}s to "
             "initialize. This may be caused by a slow __init__ or reconfigure "
             "method."
         )
     elif target_startup_status == ReplicaStartupStatus.PENDING_ALLOCATION:
         expected_message = (
-            "Deployment 'deployment_with_slow_to_start_replicas' in application "
+            "Deployment 'test_deployment' in application "
             "'test_app' 3 replicas that have taken more than 30s to be scheduled. This "
             "may be due to waiting for the cluster to auto-scale or for a runtime "
             "environment to be installed. Resources required for each replica: "
@@ -2486,7 +2144,7 @@ def test_downscaling_reclaiming_starting_replicas_first(
     check_counts(
         deployment_state,
         total=6,
-        by_state=[(ReplicaState.RUNNING, 3), (ReplicaState.STOPPING, 3)],
+        by_state=[(ReplicaState.RUNNING, 3, None), (ReplicaState.STOPPING, 3, None)],
     )
 
     # Assert that no RUNNING replicas are being stopped
@@ -2522,12 +2180,9 @@ def test_update_autoscaling_config(mock_deployment_state_manager_full):
     5. It becomes healthy with 6 running replicas.
     """
 
-    # State
-    deployment_id = DeploymentID("test_deployment", "test_app")
-
     # Create deployment state manager
-    create_deployment_state_manager, timer, _ = mock_deployment_state_manager_full
-    deployment_state_manager: DeploymentStateManager = create_deployment_state_manager()
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
     # Deploy deployment with 3 replicas
     info1, _ = deployment_info(
@@ -2541,34 +2196,30 @@ def test_update_autoscaling_config(mock_deployment_state_manager_full):
         },
         version="1",
     )
-    deployment_state_manager.deploy(deployment_id, info1)
-    depstate: DeploymentState = deployment_state_manager._deployment_states[
-        deployment_id
-    ]
+    dsm.deploy(TEST_DEPLOYMENT_ID, info1)
+    ds: DeploymentState = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # Set replicas ready
-    deployment_state_manager.update()
-    for replica in depstate._replicas.get():
+    dsm.update()
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
 
     # status=HEALTHY, status_trigger=DEPLOY
-    deployment_state_manager.update()
-    check_counts(depstate, total=3, by_state=[(ReplicaState.RUNNING, 3)])
-    assert depstate.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        depstate.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
     # Num ongoing requests = 1, status should remain HEALTHY
-    for replica in depstate._replicas.get():
-        deployment_state_manager.record_autoscaling_metrics(
-            replica._actor.replica_tag, 1, None
-        )
-    check_counts(depstate, total=3, by_state=[(ReplicaState.RUNNING, 3)])
-    assert depstate.curr_status_info.status == DeploymentStatus.HEALTHY
+    for replica in ds._replicas.get():
+        dsm.record_autoscaling_metrics(replica._actor.replica_tag, 1, None)
+    check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        depstate.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
@@ -2583,84 +2234,84 @@ def test_update_autoscaling_config(mock_deployment_state_manager_full):
         },
         version="1",
     )
-    deployment_state_manager.deploy(deployment_id, info2)
+    dsm.deploy(TEST_DEPLOYMENT_ID, info2)
 
     # 3 new replicas should be starting, status should be UPDATING (not upscaling)
-    deployment_state_manager.update()
+    dsm.update()
     check_counts(
-        depstate,
+        ds,
         total=6,
-        by_state=[(ReplicaState.RUNNING, 3), (ReplicaState.STARTING, 3)],
+        by_state=[(ReplicaState.RUNNING, 3, None), (ReplicaState.STARTING, 3, None)],
     )
-    assert depstate.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        depstate.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Set replicas ready
-    deployment_state_manager.update()
-    for replica in depstate._replicas.get():
+    dsm.update()
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
-    deployment_state_manager.update()
-    check_counts(depstate, total=6, by_state=[(ReplicaState.RUNNING, 6)])
-    assert depstate.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=6, by_state=[(ReplicaState.RUNNING, 6, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        depstate.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
 @pytest.mark.parametrize("force_stop_unhealthy_replicas", [False, True])
-def test_health_check(mock_deployment_state, force_stop_unhealthy_replicas: bool):
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    deployment_state.FORCE_STOP_UNHEALTHY_REPLICAS = force_stop_unhealthy_replicas
-    cluster_node_info_cache.alive_node_ids = {str(i) for i in range(2)}
+def test_health_check(
+    mock_deployment_state_manager_full, force_stop_unhealthy_replicas: bool
+):
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
-    b_info_1, b_version_1 = deployment_info(num_replicas=2, version="1")
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
+    b_info_1, v1 = deployment_info(num_replicas=2, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 2)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    ds.FORCE_STOP_UNHEALTHY_REPLICAS = force_stop_unhealthy_replicas
+
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    for replica in deployment_state._replicas.get():
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
         # Health check shouldn't be called until it's ready.
         assert not replica._actor.health_check_called
 
     # Check that the new replicas have started.
-    deployment_state.update()
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
-    deployment_state.update()
-    for replica in deployment_state._replicas.get():
+    dsm.update()
+    for replica in ds._replicas.get():
         # Health check shouldn't be called until it's ready.
         assert replica._actor.health_check_called
 
     # Mark one replica unhealthy; it should be stopped.
-    deployment_state._replicas.get()[0]._actor.set_unhealthy()
-    deployment_state.update()
+    ds._replicas.get()[0]._actor.set_unhealthy()
+    dsm.update()
     check_counts(
-        deployment_state,
+        ds,
         total=2,
-        by_state=[(ReplicaState.RUNNING, 1), (ReplicaState.STOPPING, 1)],
+        by_state=[(ReplicaState.RUNNING, 1, v1), (ReplicaState.STOPPING, 1, v1)],
     )
 
-    stopping_replicas = deployment_state._replicas.get(states=[ReplicaState.STOPPING])
+    stopping_replicas = ds._replicas.get(states=[ReplicaState.STOPPING])
     assert len(stopping_replicas) == 1
     stopping_replica = stopping_replicas[0]
     if force_stop_unhealthy_replicas:
@@ -2668,244 +2319,201 @@ def test_health_check(mock_deployment_state, force_stop_unhealthy_replicas: bool
     else:
         assert stopping_replica._actor.force_stopped_counter == 0
 
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UNHEALTHY
+    assert ds.curr_status_info.status == DeploymentStatus.UNHEALTHY
     # If state transitioned from healthy -> unhealthy, status driver should be none
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.HEALTH_CHECK_FAILED
     )
 
     stopping_replica._actor.set_done_stopping()
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
+    dsm.update()
     check_counts(
-        deployment_state,
+        ds,
         total=2,
-        by_state=[(ReplicaState.RUNNING, 1), (ReplicaState.STARTING, 1)],
+        by_state=[(ReplicaState.RUNNING, 1, v1), (ReplicaState.STARTING, 1, v1)],
     )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UNHEALTHY
+    assert ds.curr_status_info.status == DeploymentStatus.UNHEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.HEALTH_CHECK_FAILED
     )
 
-    replica = deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]
+    replica = ds._replicas.get(states=[ReplicaState.STARTING])[0]
     replica._actor.set_ready()
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UNHEALTHY
+    assert ds.curr_status_info.status == DeploymentStatus.UNHEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.HEALTH_CHECK_FAILED
     )
 
-    deployment_state.update()
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
+    assert ds.curr_status_info.status_trigger == DeploymentStatusTrigger.UNSPECIFIED
+
+
+def test_update_while_unhealthy(mock_deployment_state_manager_full):
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
+
+    b_info_1, v1 = deployment_info(num_replicas=2, version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
-        == DeploymentStatusTrigger.UNSPECIFIED
-    )
-
-
-def test_update_while_unhealthy(mock_deployment_state):
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {str(i) for i in range(2)}
-
-    b_info_1, b_version_1 = deployment_info(num_replicas=2, version="1")
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
-
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 2)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
-    assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    for replica in deployment_state._replicas.get():
+    for replica in ds._replicas.get():
         replica._actor.set_ready()
         # Health check shouldn't be called until it's ready.
         assert not replica._actor.health_check_called
 
     # Check that the new replicas have started.
-    deployment_state.update()
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v1)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
-    deployment_state.update()
-    for replica in deployment_state._replicas.get():
+    dsm.update()
+    for replica in ds._replicas.get():
         # Health check shouldn't be called until it's ready.
         assert replica._actor.health_check_called
 
     # Mark one replica unhealthy. It should be stopped.
-    deployment_state._replicas.get()[0]._actor.set_unhealthy()
-    deployment_state.update()
+    ds._replicas.get()[0]._actor.set_unhealthy()
+    dsm.update()
     check_counts(
-        deployment_state,
+        ds,
         total=2,
-        by_state=[(ReplicaState.RUNNING, 1), (ReplicaState.STOPPING, 1)],
+        by_state=[(ReplicaState.RUNNING, 1, v1), (ReplicaState.STOPPING, 1, v1)],
     )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UNHEALTHY
+    assert ds.curr_status_info.status == DeploymentStatus.UNHEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.HEALTH_CHECK_FAILED
     )
 
-    replica = deployment_state._replicas.get(states=[ReplicaState.STOPPING])[0]
+    replica = ds._replicas.get(states=[ReplicaState.STOPPING])[0]
     replica._actor.set_done_stopping()
 
     # Now deploy a new version (e.g., a rollback). This should update the status
     # to UPDATING and then it should eventually become healthy.
-    b_info_2, b_version_2 = deployment_info(num_replicas=2, version="2")
-    updating = deployment_state.deploy(b_info_2)
-    assert updating
+    b_info_2, v2 = deployment_info(num_replicas=2, version="2")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.RUNNING, 1)],
+        ds,
+        total=2,
+        by_state=[(ReplicaState.RUNNING, 1, v1), (ReplicaState.STARTING, 1, v2)],
     )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Check that a failure in the old version replica does not mark the
     # deployment as UNHEALTHY.
-    deployment_state._replicas.get(states=[ReplicaState.RUNNING])[
-        0
-    ]._actor.set_unhealthy()
-    deployment_state.update()
+    ds._replicas.get(states=[ReplicaState.RUNNING])[0]._actor.set_unhealthy()
+    dsm.update()
     check_counts(
-        deployment_state,
-        version=b_version_1,
-        total=1,
-        by_state=[(ReplicaState.STOPPING, 1)],
+        ds,
+        total=2,
+        by_state=[(ReplicaState.STOPPING, 1, v1), (ReplicaState.STARTING, 1, v2)],
     )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    replica = deployment_state._replicas.get(states=[ReplicaState.STOPPING])[0]
+    replica = ds._replicas.get(states=[ReplicaState.STOPPING])[0]
     replica._actor.set_done_stopping()
 
     # Another replica of the new version should get started.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=2,
-        by_state=[(ReplicaState.STARTING, 2)],
-    )
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, v2)])
 
     # Mark new version replicas as ready.
-    for replica in deployment_state._replicas.get(states=[ReplicaState.STARTING]):
+    for replica in ds._replicas.get(states=[ReplicaState.STARTING]):
         replica._actor.set_ready()
 
     # Both replicas should be RUNNING, deployment should be HEALTHY.
-    deployment_state.update()
-    check_counts(
-        deployment_state,
-        version=b_version_2,
-        total=2,
-        by_state=[(ReplicaState.RUNNING, 2)],
-    )
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v2)])
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def _constructor_failure_loop_two_replica(deployment_state, num_loops):
+def _constructor_failure_loop_two_replica(dsm, ds, num_loops):
     """Helper function to exact constructor failure loops."""
+
     for i in range(num_loops):
         # Two replicas should be created.
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
-        )
-        check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 2)])
+        dsm.update()
+        check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, None)])
 
-        assert deployment_state._replica_constructor_retry_counter == i * 2
+        assert ds._replica_constructor_retry_counter == i * 2
 
-        replica_1 = deployment_state._replicas.get()[0]
-        replica_2 = deployment_state._replicas.get()[1]
+        replica_1 = ds._replicas.get()[0]
+        replica_2 = ds._replicas.get()[1]
 
         replica_1._actor.set_failed_to_start()
         replica_2._actor.set_failed_to_start()
         # Now the replica should be marked SHOULD_STOP after failure.
-        deployment_state.update()
-        check_counts(deployment_state, total=2, by_state=[(ReplicaState.STOPPING, 2)])
+        dsm.update()
+        check_counts(ds, total=2, by_state=[(ReplicaState.STOPPING, 2, None)])
 
         # Once it's done stopping, replica should be removed.
         replica_1._actor.set_done_stopping()
         replica_2._actor.set_done_stopping()
 
 
-def test_deploy_with_consistent_constructor_failure(mock_deployment_state):
+def test_deploy_with_consistent_constructor_failure(mock_deployment_state_manager_full):
     """
     Test deploy() multiple replicas with consistent constructor failure.
 
     The deployment should get marked FAILED.
     """
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {str(i) for i in range(2)}
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
-    b_info_1, b_version_1 = deployment_info(num_replicas=2)
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    b_info_1, _ = deployment_info(num_replicas=2)
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
-    _constructor_failure_loop_two_replica(deployment_state, 3)
+    _constructor_failure_loop_two_replica(dsm, ds, 3)
 
-    assert deployment_state._replica_constructor_retry_counter == 6
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UNHEALTHY
+    assert ds._replica_constructor_retry_counter == 6
+    assert ds.curr_status_info.status == DeploymentStatus.UNHEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.REPLICA_STARTUP_FAILED
     )
-    check_counts(deployment_state, total=2)
-    assert deployment_state.curr_status_info.message != ""
+    check_counts(ds, total=2)
+    assert ds.curr_status_info.message != ""
 
 
-def test_deploy_with_partial_constructor_failure(mock_deployment_state):
+def test_deploy_with_partial_constructor_failure(mock_deployment_state_manager_full):
     """
     Test deploy() multiple replicas with constructor failure exceedining
     pre-set limit but achieved partial success with at least 1 running replica.
@@ -2919,106 +2527,115 @@ def test_deploy_with_partial_constructor_failure(mock_deployment_state):
 
     Same testing for same test case in test_deploy.py.
     """
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {str(i) for i in range(2)}
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
 
-    b_info_1, b_version_1 = deployment_info(num_replicas=2)
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    b_info_1, _ = deployment_info(num_replicas=2)
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    _constructor_failure_loop_two_replica(deployment_state, 2)
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    _constructor_failure_loop_two_replica(dsm, ds, 2)
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 2)])
-    assert deployment_state._replica_constructor_retry_counter == 4
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, None)])
+    assert ds._replica_constructor_retry_counter == 4
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Let one replica reach RUNNING state while the other still fails
-    replica_1 = deployment_state._replicas.get()[0]
-    replica_2 = deployment_state._replicas.get()[1]
+    replica_1 = ds._replicas.get()[0]
+    replica_2 = ds._replicas.get()[1]
     replica_1._actor.set_ready()
     replica_2._actor.set_failed_to_start()
 
-    deployment_state.update()
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 1)])
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STOPPING, 1)])
+    dsm.update()
+    check_counts(
+        ds,
+        total=2,
+        by_state=[(ReplicaState.RUNNING, 1, None), (ReplicaState.STOPPING, 1, None)],
+    )
 
     # Ensure failed to start replica is removed
-    deployment_state.update()
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 1)])
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STOPPING, 1)])
+    dsm.update()
+    check_counts(
+        ds,
+        total=2,
+        by_state=[(ReplicaState.RUNNING, 1, None), (ReplicaState.STOPPING, 1, None)],
+    )
 
     replica_2._actor.set_done_stopping()
     # New update cycle should spawn new replica after previous one is removed
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
+    dsm.update()
+    check_counts(
+        ds,
+        total=2,
+        by_state=[(ReplicaState.RUNNING, 1, None), (ReplicaState.STARTING, 1, None)],
     )
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 1)])
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 1)])
 
     # Set the starting one to fail again and trigger retry limit
-    starting_replica = deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]
+    starting_replica = ds._replicas.get(states=[ReplicaState.STARTING])[0]
     starting_replica._actor.set_failed_to_start()
 
-    deployment_state.update()
+    dsm.update()
     # Ensure our goal returned with construtor start counter reset
-    assert deployment_state._replica_constructor_retry_counter == -1
+    assert ds._replica_constructor_retry_counter == -1
     # Deployment should NOT be considered complete yet
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 1)])
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STOPPING, 1)])
+    check_counts(
+        ds,
+        total=2,
+        by_state=[(ReplicaState.RUNNING, 1, None), (ReplicaState.STOPPING, 1, None)],
+    )
 
-    deployment_state.update()
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 1)])
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STOPPING, 1)])
-    starting_replica = deployment_state._replicas.get(states=[ReplicaState.STOPPING])[0]
+    dsm.update()
+    check_counts(
+        ds,
+        total=2,
+        by_state=[(ReplicaState.RUNNING, 1, None), (ReplicaState.STOPPING, 1, None)],
+    )
+    starting_replica = ds._replicas.get(states=[ReplicaState.STOPPING])[0]
     starting_replica._actor.set_done_stopping()
 
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
+    dsm.update()
+    check_counts(
+        ds,
+        total=2,
+        by_state=[(ReplicaState.RUNNING, 1, None), (ReplicaState.STARTING, 1, None)],
     )
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 1)])
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 1)])
-
-    starting_replica = deployment_state._replicas.get(states=[ReplicaState.STARTING])[0]
+    starting_replica = ds._replicas.get(states=[ReplicaState.STARTING])[0]
     starting_replica._actor.set_ready()
 
-    deployment_state.update()
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
 
     # Deployment should be considered complete
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_deploy_with_transient_constructor_failure(mock_deployment_state):
+def test_deploy_with_transient_constructor_failure(mock_deployment_state_manager_full):
     """
     Test deploy() multiple replicas with transient constructor failure.
     Ensures:
@@ -3030,224 +2647,148 @@ def test_deploy_with_transient_constructor_failure(mock_deployment_state):
 
     Same testing for same test case in test_deploy.py.
     """
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {str(i) for i in range(2)}
 
-    b_info_1, b_version_1 = deployment_info(num_replicas=2)
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
+
+    b_info_1, _ = deployment_info(num_replicas=2)
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Burn 4 retries from both replicas.
-    _constructor_failure_loop_two_replica(deployment_state, 2)
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    _constructor_failure_loop_two_replica(dsm, ds, 2)
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
     # Let both replicas succeed in last try.
-    deployment_state_update_result = deployment_state.update()
-    deployment_state._deployment_scheduler.schedule(
-        {deployment_state._id: deployment_state_update_result.upscale}, {}
-    )
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 2)])
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.STARTING, 2, None)])
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    assert deployment_state._replica_constructor_retry_counter == 4
-    replica_1 = deployment_state._replicas.get()[0]
-    replica_2 = deployment_state._replicas.get()[1]
+    assert ds._replica_constructor_retry_counter == 4
+    replica_1 = ds._replicas.get()[0]
+    replica_2 = ds._replicas.get()[1]
 
     replica_1._actor.set_ready()
     replica_2._actor.set_ready()
-    deployment_state.update()
-    check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
 
-    assert deployment_state._replica_constructor_retry_counter == 4
-    assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+    assert ds._replica_constructor_retry_counter == 4
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
 
 
-def test_exponential_backoff(mock_deployment_state):
+def test_exponential_backoff(mock_deployment_state_manager_full):
     """Test exponential backoff."""
-    deployment_state, timer, cluster_node_info_cache = mock_deployment_state
-    cluster_node_info_cache.alive_node_ids = {str(i) for i in range(2)}
 
-    b_info_1, b_version_1 = deployment_info(num_replicas=2)
-    updating = deployment_state.deploy(b_info_1)
-    assert updating
-    assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+    create_dsm, timer, _ = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
+
+    b_info_1, _ = deployment_info(num_replicas=2)
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
-        deployment_state.curr_status_info.status_trigger
+        ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
 
-    _constructor_failure_loop_two_replica(deployment_state, 3)
-    assert deployment_state._replica_constructor_retry_counter == 6
+    _constructor_failure_loop_two_replica(dsm, ds, 3)
+    assert ds._replica_constructor_retry_counter == 6
     last_retry = timer.time()
 
     for i in range(7):
         while timer.time() - last_retry < 2**i:
-            deployment_state.update()
-            assert deployment_state._replica_constructor_retry_counter == 6 + 2 * i
+            dsm.update()
+            assert ds._replica_constructor_retry_counter == 6 + 2 * i
             # Check that during backoff time, no replicas are created
-            check_counts(deployment_state, total=0)
+            check_counts(ds, total=0)
             timer.advance(0.1)  # simulate time passing between each call to udpate
 
         # Skip past random additional backoff time used to avoid synchronization
         timer.advance(5)
 
         # Set new replicas to fail consecutively
-        check_counts(deployment_state, total=0)  # No replicas
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
-        )
+        check_counts(ds, total=0)  # No replicas
+        dsm.update()
         last_retry = timer.time()  # This should be time at which replicas were retried
-        check_counts(deployment_state, total=2)  # Two new replicas
-        replica_1 = deployment_state._replicas.get()[0]
-        replica_2 = deployment_state._replicas.get()[1]
+        check_counts(ds, total=2)  # Two new replicas
+        replica_1 = ds._replicas.get()[0]
+        replica_2 = ds._replicas.get()[1]
         replica_1._actor.set_failed_to_start()
         replica_2._actor.set_failed_to_start()
         timer.advance(0.1)  # simulate time passing between each call to udpate
 
         # Now the replica should be marked STOPPING after failure.
-        deployment_state.update()
-        check_counts(deployment_state, total=2, by_state=[(ReplicaState.STOPPING, 2)])
+        dsm.update()
+        check_counts(ds, total=2, by_state=[(ReplicaState.STOPPING, 2, None)])
         timer.advance(0.1)  # simulate time passing between each call to udpate
 
         # Once it's done stopping, replica should be removed.
         replica_1._actor.set_done_stopping()
         replica_2._actor.set_done_stopping()
-        deployment_state.update()
-        check_counts(deployment_state, total=0)
+        dsm.update()
+        check_counts(ds, total=0)
         timer.advance(0.1)  # simulate time passing between each call to udpate
-
-
-@pytest.fixture
-def mock_deployment_state_manager_full(
-    request,
-) -> Tuple[DeploymentStateManager, MockTimer, Mock]:
-    """Fully mocked deployment state manager.
-
-    i.e kv store and gcs client is mocked so we don't need to initialize
-    ray. Also, since this is used for some recovery tests, this yields a
-    method for creating a new mocked deployment state manager.
-    """
-
-    timer = MockTimer()
-    with patch(
-        "ray.serve._private.deployment_state.ActorReplicaWrapper",
-        new=MockReplicaActorWrapper,
-    ), patch("time.time", new=timer.time), patch(
-        "ray.serve._private.long_poll.LongPollHost"
-    ) as mock_long_poll, patch(
-        "ray.get_runtime_context"
-    ):
-        kv_store = MockKVStore()
-        cluster_node_info_cache = MockClusterNodeInfoCache()
-
-        def create_deployment_state_manager(
-            actor_names=None, placement_group_names=None
-        ):
-            if actor_names is None:
-                actor_names = []
-
-            if placement_group_names is None:
-                placement_group_names = []
-
-            return DeploymentStateManager(
-                kv_store,
-                mock_long_poll,
-                actor_names,
-                placement_group_names,
-                cluster_node_info_cache,
-                head_node_id_override="fake-head-node-id",
-            )
-
-        yield create_deployment_state_manager, timer, cluster_node_info_cache
-
-        dead_replicas_context.clear()
 
 
 def test_recover_state_from_replica_names(mock_deployment_state_manager_full):
     """Test recover deployment state."""
-    deployment_id = DeploymentID("test_deployment", "test_app")
-    (
-        create_deployment_state_manager,
-        _,
-        cluster_node_info_cache,
-    ) = mock_deployment_state_manager_full
-    deployment_state_manager = create_deployment_state_manager()
+    create_dsm, _, cluster_node_info_cache = mock_deployment_state_manager_full
+    dsm: DeploymentStateManager = create_dsm()
     cluster_node_info_cache.alive_node_ids = {"node-id"}
 
     # Deploy deployment with version "1" and one replica
-    info1, version1 = deployment_info(version="1")
-    updating = deployment_state_manager.deploy(deployment_id, info1)
-    deployment_state = deployment_state_manager._deployment_states[deployment_id]
-    assert updating
+    info1, v1 = deployment_info(version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # Single replica of version `version1` should be created and in STARTING state
-    deployment_state_manager.update()
-    check_counts(
-        deployment_state,
-        total=1,
-        version=version1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
-    mocked_replica = deployment_state._replicas.get()[0]
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
+    mocked_replica = ds._replicas.get()[0]
 
     # The same replica should transition to RUNNING
     mocked_replica._actor.set_ready()
-    deployment_state_manager.update()
-    check_counts(
-        deployment_state,
-        total=1,
-        version=version1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
 
     # (simulate controller crashed!) Create a new deployment state
     # manager, and it should call _recover_from_checkpoint
-    new_deployment_state_manager = create_deployment_state_manager(
+    new_dsm: DeploymentStateManager = create_dsm(
         [ReplicaName.prefix + mocked_replica.replica_tag]
     )
 
     # New deployment state should be created and one replica should
     # be RECOVERING with last-checkpointed target version `version1`
-    new_deployment_state = new_deployment_state_manager._deployment_states[
-        deployment_id
-    ]
-    check_counts(
-        new_deployment_state,
-        total=1,
-        version=version1,
-        by_state=[(ReplicaState.RECOVERING, 1)],
-    )
+    new_ds = new_dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    check_counts(new_ds, total=1, by_state=[(ReplicaState.RECOVERING, 1, v1)])
 
     # Get the new mocked replica. Note that this represents a newly
     # instantiated class keeping track of the state of the replica,
     # but pointing to the same replica actor
-    new_mocked_replica = new_deployment_state._replicas.get()[0]
-    new_mocked_replica._actor.set_ready(version1)
-    any_recovering = new_deployment_state_manager.update()
-    check_counts(
-        new_deployment_state,
-        total=1,
-        version=version1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
+    new_mocked_replica = new_ds._replicas.get()[0]
+    new_mocked_replica._actor.set_ready(v1)
+    any_recovering = new_dsm.update()
+    check_counts(new_ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
     assert not any_recovering
     # Make sure replica name is the same, meaning the actor is the same
     assert mocked_replica.replica_tag == new_mocked_replica.replica_tag
@@ -3261,111 +2802,65 @@ def test_recover_during_rolling_update(mock_deployment_state_manager_full):
     has an outdated version, it should be stopped and a new replica should be started
     with the target version.
     """
-    deployment_id = DeploymentID("test_deployment", "test_app")
-    (
-        create_deployment_state_manager,
-        _,
-        cluster_node_info_cache,
-    ) = mock_deployment_state_manager_full
-    deployment_state_manager = create_deployment_state_manager()
+    create_dsm, _, cluster_node_info_cache = mock_deployment_state_manager_full
+    dsm = create_dsm()
     cluster_node_info_cache.alive_node_ids = {"node-id"}
 
     # Step 1: Create some deployment info with actors in running state
-    info1, version1 = deployment_info(version="1")
-    updating = deployment_state_manager.deploy(deployment_id, info1)
-    deployment_state = deployment_state_manager._deployment_states[deployment_id]
-    assert updating
+    info1, v1 = deployment_info(version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # Single replica of version `version1` should be created and in STARTING state
-    deployment_state_manager.update()
-    check_counts(
-        deployment_state,
-        total=1,
-        version=version1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
-    mocked_replica = deployment_state._replicas.get()[0]
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
+    mocked_replica = ds._replicas.get()[0]
 
     # The same replica should transition to RUNNING
     mocked_replica._actor.set_ready()
-    deployment_state_manager.update()
-    check_counts(
-        deployment_state,
-        total=1,
-        version=version1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
 
     # Now execute a rollout: upgrade the version to "2".
-    info2, version2 = deployment_info(version="2")
-    updating = deployment_state_manager.deploy(deployment_id, info2)
-    assert updating
+    info2, v2 = deployment_info(version="2")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info2)
 
     # Before the replica could be stopped and restarted, simulate
     # controller crashed! A new deployment state manager should be
     # created, and it should call _recover_from_checkpoint
-    new_deployment_state_manager = create_deployment_state_manager(
-        [ReplicaName.prefix + mocked_replica.replica_tag]
-    )
+    new_dsm = create_dsm([ReplicaName.prefix + mocked_replica.replica_tag])
     cluster_node_info_cache.alive_node_ids = {"node-id"}
 
     # New deployment state should be created and one replica should
     # be RECOVERING with last-checkpointed target version "2"
-    new_deployment_state = new_deployment_state_manager._deployment_states[
-        deployment_id
-    ]
-    check_counts(
-        new_deployment_state,
-        total=1,
-        version=version2,
-        by_state=[(ReplicaState.RECOVERING, 1)],
-    )
+    new_ds = new_dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    check_counts(new_ds, total=1, by_state=[(ReplicaState.RECOVERING, 1, v2)])
 
     for _ in range(3):
-        new_deployment_state_manager.update()
-        check_counts(
-            new_deployment_state,
-            total=1,
-            version=version2,
-            by_state=[(ReplicaState.RECOVERING, 1)],
-        )
+        new_dsm.update()
+        check_counts(new_ds, total=1, by_state=[(ReplicaState.RECOVERING, 1, v2)])
 
     # Get the new mocked replica. Note that this represents a newly
     # instantiated class keeping track of the state of the replica,
     # but pointing to the same replica actor
-    new_mocked_replica = new_deployment_state._replicas.get()[0]
+    new_mocked_replica = new_ds._replicas.get()[0]
     # Recover real version "1" (simulate previous actor not yet stopped)
-    new_mocked_replica._actor.set_ready(version1)
+    new_mocked_replica._actor.set_ready(v1)
     # At this point the replica is running
-    new_deployment_state_manager.update()
+    new_dsm.update()
     # Then deployment state manager notices the replica has outdated version -> stops it
-    new_deployment_state_manager.update()
-    check_counts(
-        new_deployment_state,
-        total=1,
-        version=version1,
-        by_state=[(ReplicaState.STOPPING, 1)],
-    )
+    new_dsm.update()
+    check_counts(new_ds, total=1, by_state=[(ReplicaState.STOPPING, 1, v1)])
     new_mocked_replica._actor.set_done_stopping()
 
     # Now that the replica of version "1" has been stopped, a new
     # replica of version "2" should be started
-    new_deployment_state_manager.update()
-    check_counts(
-        new_deployment_state,
-        total=1,
-        version=version2,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
-    new_mocked_replica_version2 = new_deployment_state._replicas.get()[0]
+    new_dsm.update()
+    check_counts(new_ds, total=1, by_state=[(ReplicaState.STARTING, 1, v2)])
+    new_mocked_replica_version2 = new_ds._replicas.get()[0]
     new_mocked_replica_version2._actor.set_ready()
-    new_deployment_state_manager.update()
-    check_counts(
-        new_deployment_state,
-        total=1,
-        version=version2,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
+    new_dsm.update()
+    check_counts(new_ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v2)])
     # Make sure replica name is different, meaning a different "actor" was started
     assert mocked_replica.replica_tag != new_mocked_replica_version2.replica_tag
 
@@ -3382,36 +2877,25 @@ def test_actor_died_before_recover(mock_deployment_state_manager_full):
     * In the following control loop update cycle, the controller adds a
       new replica to match target state.
     """
-    deployment_id = DeploymentID("test_deployment", "test_app")
-    create_deployment_state_manager, _, _ = mock_deployment_state_manager_full
-    deployment_state_manager = create_deployment_state_manager()
+
+    create_dsm, _, _ = mock_deployment_state_manager_full
+    dsm = create_dsm()
 
     # Create some deployment info with actors in running state
-    info1, version1 = deployment_info(version="1")
-    updating = deployment_state_manager.deploy(deployment_id, info1)
-    deployment_state = deployment_state_manager._deployment_states[deployment_id]
-    assert updating
+    info1, v1 = deployment_info(version="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # Single replica of version `version1` should be created and in STARTING state
-    deployment_state_manager.update()
-    check_counts(
-        deployment_state,
-        total=1,
-        version=version1,
-        by_state=[(ReplicaState.STARTING, 1)],
-    )
-    mocked_replica = deployment_state._replicas.get()[0]
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
+    mocked_replica = ds._replicas.get()[0]
     replica_tag = mocked_replica.replica_tag
 
     # The same replica should transition to RUNNING
     mocked_replica._actor.set_ready()
-    deployment_state_manager.update()
-    check_counts(
-        deployment_state,
-        total=1,
-        version=version1,
-        by_state=[(ReplicaState.RUNNING, 1)],
-    )
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
 
     # Set dead replicas context. When the controller recovers and tries
     # to recover replicas from actor names, the replica actor wrapper
@@ -3420,50 +2904,19 @@ def test_actor_died_before_recover(mock_deployment_state_manager_full):
 
     # Simulate controller crashed! A new deployment state manager should
     # be created, and it should call _recover_from_checkpoint
-    new_deployment_state_manager = create_deployment_state_manager(
-        [ReplicaName.prefix + replica_tag]
-    )
+    new_dsm = create_dsm([ReplicaName.prefix + replica_tag])
 
     # Replica should fail to recover (simulate failed to get handle to
     # actor), meaning replica has died.
-    new_deployment_state = new_deployment_state_manager._deployment_states[
-        deployment_id
-    ]
-    check_counts(new_deployment_state, total=0)
+    new_ds = new_dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    check_counts(new_ds, total=0)
 
     # Since the previous replica is now marked dead (because controller
     # failed to recover it), a new replica should be added to meet
     # target state.
-    new_deployment_state_manager.update()
-    check_counts(new_deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
+    new_dsm.update()
+    check_counts(new_ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
     dead_replicas_context.remove(replica_tag)
-
-
-@pytest.fixture
-def mock_deployment_state_manager(request) -> Tuple[DeploymentStateManager, Mock, Mock]:
-    timer = MockTimer()
-    with patch(
-        "ray.serve._private.deployment_state.ActorReplicaWrapper",
-        new=MockReplicaActorWrapper,
-    ), patch("time.time", new=timer.time), patch(
-        "ray.serve._private.long_poll.LongPollHost"
-    ) as mock_long_poll:
-        kv_store = MockKVStore()
-        cluster_node_info_cache = MockClusterNodeInfoCache()
-        all_current_actor_names = []
-        all_current_placement_group_names = []
-        deployment_state_manager = DeploymentStateManager(
-            kv_store,
-            mock_long_poll,
-            all_current_actor_names,
-            all_current_placement_group_names,
-            cluster_node_info_cache,
-            head_node_id_override="fake-head-node-id",
-        )
-
-        yield deployment_state_manager, timer, cluster_node_info_cache
-
-        dead_replicas_context.clear()
 
 
 def test_shutdown(mock_deployment_state_manager):
@@ -3472,56 +2925,53 @@ def test_shutdown(mock_deployment_state_manager):
     are force-killed without a grace period.
     """
     (
-        deployment_state_manager,
+        dsm,
         timer,
         cluster_node_info_cache,
     ) = mock_deployment_state_manager
     cluster_node_info_cache.alive_node_ids = {"node-id"}
 
-    deployment_id = DeploymentID("test_deployment", "test_app")
-
     grace_period_s = 10
     b_info_1, _ = deployment_info(
         graceful_shutdown_timeout_s=grace_period_s,
     )
-    updating = deployment_state_manager.deploy(deployment_id, b_info_1)
-    assert updating
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
 
-    deployment_state = deployment_state_manager._deployment_states[deployment_id]
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # Single replica should be created.
-    deployment_state_manager.update()
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
-    deployment_state._replicas.get()[0]._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+    ds._replicas.get()[0]._actor.set_ready()
 
     # Now the replica should be marked running.
-    deployment_state_manager.update()
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
 
     # Test shutdown flow
-    assert not deployment_state._replicas.get()[0]._actor.stopped
+    assert not ds._replicas.get()[0]._actor.stopped
 
     # Before shutdown, `is_ready_for_shutdown()` should return False
-    assert not deployment_state_manager.is_ready_for_shutdown()
+    assert not dsm.is_ready_for_shutdown()
 
-    deployment_state_manager.shutdown()
+    dsm.shutdown()
 
     timer.advance(grace_period_s + 0.1)
-    deployment_state_manager.update()
+    dsm.update()
 
-    check_counts(deployment_state, total=1, by_state=[(ReplicaState.STOPPING, 1)])
-    assert deployment_state._replicas.get()[0]._actor.stopped
-    assert len(deployment_state_manager.get_deployment_statuses()) > 0
+    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
+    assert ds._replicas.get()[0]._actor.stopped
+    assert len(dsm.get_deployment_statuses()) > 0
 
     # Once it's done stopping, replica should be removed.
-    replica = deployment_state._replicas.get()[0]
+    replica = ds._replicas.get()[0]
     replica._actor.set_done_stopping()
-    deployment_state_manager.update()
-    check_counts(deployment_state, total=0)
-    assert len(deployment_state_manager.get_deployment_statuses()) == 0
+    dsm.update()
+    check_counts(ds, total=0)
+    assert len(dsm.get_deployment_statuses()) == 0
 
     # After all deployments shutdown, `is_ready_for_shutdown()` should return True
-    assert deployment_state_manager.is_ready_for_shutdown()
+    assert dsm.is_ready_for_shutdown()
 
 
 def test_resource_requirements_none():
@@ -3567,63 +3017,42 @@ def test_get_active_node_ids(mock_deployment_state_manager_full):
     """
     node_ids = ("node1", "node2", "node2")
 
-    deployment_id = DeploymentID("test_deployment", "test_app")
-    (
-        create_deployment_state_manager,
-        _,
-        cluster_node_info_cache,
-    ) = mock_deployment_state_manager_full
-    deployment_state_manager = create_deployment_state_manager()
+    create_dsm, _, cluster_node_info_cache = mock_deployment_state_manager_full
+    dsm = create_dsm()
     cluster_node_info_cache.alive_node_ids = set(node_ids)
 
     # Deploy deployment with version "1" and 3 replicas
-    info1, version1 = deployment_info(version="1", num_replicas=3)
-    updating = deployment_state_manager.deploy(deployment_id, info1)
-    deployment_state = deployment_state_manager._deployment_states[deployment_id]
-    assert updating
+    info1, v1 = deployment_info(version="1", num_replicas=3)
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # When the replicas are in the STARTING state, `get_active_node_ids()` should
     # return a set of node ids.
-    deployment_state_manager.update()
-    check_counts(
-        deployment_state,
-        total=3,
-        version=version1,
-        by_state=[(ReplicaState.STARTING, 3)],
-    )
-    mocked_replicas = deployment_state._replicas.get()
+    dsm.update()
+    check_counts(ds, total=3, by_state=[(ReplicaState.STARTING, 3, v1)])
+    mocked_replicas = ds._replicas.get()
     for idx, mocked_replica in enumerate(mocked_replicas):
         mocked_replica._actor.set_node_id(node_ids[idx])
-    assert deployment_state.get_active_node_ids() == set(node_ids)
-    assert deployment_state_manager.get_active_node_ids() == set(node_ids)
+    assert ds.get_active_node_ids() == set(node_ids)
+    assert dsm.get_active_node_ids() == set(node_ids)
 
     # When the replicas are in RUNNING state, `get_active_node_ids()` should
     # return a set of `node_ids`.
     for mocked_replica in mocked_replicas:
         mocked_replica._actor.set_ready()
-    deployment_state_manager.update()
-    check_counts(
-        deployment_state,
-        total=3,
-        version=version1,
-        by_state=[(ReplicaState.RUNNING, 3)],
-    )
-    assert deployment_state.get_active_node_ids() == set(node_ids)
-    assert deployment_state_manager.get_active_node_ids() == set(node_ids)
+    dsm.update()
+    check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, v1)])
+    assert ds.get_active_node_ids() == set(node_ids)
+    assert dsm.get_active_node_ids() == set(node_ids)
 
     # When the replicas are in the STOPPING state, `get_active_node_ids()` should
     # return empty set.
     for _ in mocked_replicas:
-        deployment_state._stop_one_running_replica_for_testing()
-    deployment_state_manager.update()
-    check_counts(
-        deployment_state,
-        total=3,
-        version=version1,
-        by_state=[(ReplicaState.STOPPING, 3)],
-    )
-    assert deployment_state.get_active_node_ids() == set()
-    assert deployment_state_manager.get_active_node_ids() == set()
+        ds._stop_one_running_replica_for_testing()
+    dsm.update()
+    check_counts(ds, total=3, by_state=[(ReplicaState.STOPPING, 3, v1)])
+    assert ds.get_active_node_ids() == set()
+    assert dsm.get_active_node_ids() == set()
 
 
 def test_get_active_node_ids_none(mock_deployment_state_manager_full):
@@ -3634,50 +3063,34 @@ def test_get_active_node_ids_none(mock_deployment_state_manager_full):
     """
     node_ids = ("node1", "node2", "node2")
 
-    deployment_id = DeploymentID("test_deployment", "test_app")
-    (
-        create_deployment_state_manager,
-        _,
-        cluster_node_info_cache,
-    ) = mock_deployment_state_manager_full
-    deployment_state_manager = create_deployment_state_manager()
+    create_dsm, _, cluster_node_info_cache = mock_deployment_state_manager_full
+    dsm = create_dsm()
     cluster_node_info_cache.alive_node_ids = set(node_ids)
 
     # Deploy deployment with version "1" and 3 replicas
-    info1, version1 = deployment_info(version="1", num_replicas=3)
-    updating = deployment_state_manager.deploy(deployment_id, info1)
-    deployment_state = deployment_state_manager._deployment_states[deployment_id]
-    assert updating
+    info1, v1 = deployment_info(version="1", num_replicas=3)
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, info1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
     # When the replicas are in the STARTING state, `get_active_node_ids()` should
     # return a set of node ids.
-    deployment_state_manager.update()
-    check_counts(
-        deployment_state,
-        total=3,
-        version=version1,
-        by_state=[(ReplicaState.STARTING, 3)],
-    )
-    mocked_replicas = deployment_state._replicas.get()
+    dsm.update()
+    check_counts(ds, total=3, by_state=[(ReplicaState.STARTING, 3, v1)])
+    mocked_replicas = ds._replicas.get()
     for idx, mocked_replica in enumerate(mocked_replicas):
         mocked_replica._actor.set_node_id(node_ids[idx])
-    assert deployment_state.get_active_node_ids() == set(node_ids)
-    assert deployment_state_manager.get_active_node_ids() == set(node_ids)
+    assert ds.get_active_node_ids() == set(node_ids)
+    assert dsm.get_active_node_ids() == set(node_ids)
 
     # When the replicas are in the RUNNING state and are having None node id,
     # `get_active_node_ids()` should return empty set.
     for mocked_replica in mocked_replicas:
         mocked_replica._actor.set_node_id(None)
         mocked_replica._actor.set_ready()
-    deployment_state_manager.update()
-    check_counts(
-        deployment_state,
-        total=3,
-        version=version1,
-        by_state=[(ReplicaState.RUNNING, 3)],
-    )
-    assert None not in deployment_state.get_active_node_ids()
-    assert None not in deployment_state_manager.get_active_node_ids()
+    dsm.update()
+    check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, v1)])
+    assert None not in ds.get_active_node_ids()
+    assert None not in dsm.get_active_node_ids()
 
 
 class TestTargetCapacity:
@@ -3753,18 +3166,24 @@ class TestTargetCapacity:
         deployment_state._deployment_scheduler.schedule(
             {deployment_state._id: deployment_state_update_result.upscale}, {}
         )
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
+        check_counts(
+            deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1, None)]
+        )
         assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
 
         for replica in deployment_state._replicas.get():
             replica._actor.set_ready()
 
         deployment_state.update()
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
+        check_counts(
+            deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1, None)]
+        )
         assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
 
         deployment_state.update()
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
+        check_counts(
+            deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1, None)]
+        )
         assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
 
     def test_target_capacity_100_no_effect(
@@ -3792,18 +3211,24 @@ class TestTargetCapacity:
         deployment_state._deployment_scheduler.schedule(
             {deployment_state._id: deployment_state_update_result.upscale}, {}
         )
-        check_counts(deployment_state, total=2, by_state=[(ReplicaState.STARTING, 2)])
+        check_counts(
+            deployment_state, total=2, by_state=[(ReplicaState.STARTING, 2, None)]
+        )
         assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
 
         for replica in deployment_state._replicas.get():
             replica._actor.set_ready()
 
         deployment_state.update()
-        check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
+        check_counts(
+            deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2, None)]
+        )
         assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
 
         deployment_state.update()
-        check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
+        check_counts(
+            deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2, None)]
+        )
         assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Now update target_capacity to 100, should have no effect.
@@ -3815,7 +3240,9 @@ class TestTargetCapacity:
         )
 
         deployment_state.update()
-        check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
+        check_counts(
+            deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2, None)]
+        )
         assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Now update target_capacity back to None, should have no effect.
@@ -3827,7 +3254,9 @@ class TestTargetCapacity:
         )
 
         deployment_state.update()
-        check_counts(deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2)])
+        check_counts(
+            deployment_state, total=2, by_state=[(ReplicaState.RUNNING, 2, None)]
+        )
         assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
 
     def test_target_capacity_0(
@@ -3836,23 +3265,23 @@ class TestTargetCapacity:
         """
         Deploy with target_capacity set to 0. Should have no replicas.
         """
-        deployment_state, _, _ = mock_deployment_state
+        ds, _, _ = mock_deployment_state
 
         b_info_1, _ = deployment_info(num_replicas=100)
 
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=0,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
-        check_counts(deployment_state, total=0)
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
     def test_reduce_target_capacity(
         self, mock_deployment_state: Tuple[DeploymentState, Mock, Mock]
@@ -3860,123 +3289,129 @@ class TestTargetCapacity:
         """
         Deploy with target capacity set to 100, then reduce to 50, then reduce to 0.
         """
-        deployment_state, _, _ = mock_deployment_state
+        ds, _, _ = mock_deployment_state
 
         code_version = "arbitrary_version"
         b_info_1, _ = deployment_info(num_replicas=10, version=code_version)
 
         # Start with target_capacity 100.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=100,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
-        check_counts(deployment_state, total=10, by_state=[(ReplicaState.STARTING, 10)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+        check_counts(ds, total=10, by_state=[(ReplicaState.STARTING, 10, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.UPDATING
 
-        for replica in deployment_state._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=10, by_state=[(ReplicaState.RUNNING, 10)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=10, by_state=[(ReplicaState.RUNNING, 10, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Reduce target_capacity to 50, half the replicas should be stopped.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=50,
             target_capacity_direction=TargetCapacityDirection.DOWN,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        replicas_to_stop = deployment_state._deployment_scheduler.schedule(
-            {}, {deployment_state._id: deployment_state_update_result.downscale}
-        )[deployment_state._id]
-        deployment_state.stop_replicas(replicas_to_stop)
+        deployment_state_update_result = ds.update()
+        replicas_to_stop = ds._deployment_scheduler.schedule(
+            {}, {ds._id: deployment_state_update_result.downscale}
+        )[ds._id]
+        ds.stop_replicas(replicas_to_stop)
         check_counts(
-            deployment_state,
+            ds,
             total=10,
-            by_state=[(ReplicaState.RUNNING, 5), (ReplicaState.STOPPING, 5)],
+            by_state=[
+                (ReplicaState.RUNNING, 5, None),
+                (ReplicaState.STOPPING, 5, None),
+            ],
         )
 
-        assert deployment_state.curr_status_info.status == DeploymentStatus.DOWNSCALING
+        assert ds.curr_status_info.status == DeploymentStatus.DOWNSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get([ReplicaState.STOPPING]):
+        for replica in ds._replicas.get([ReplicaState.STOPPING]):
             replica._actor.set_done_stopping()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=5, by_state=[(ReplicaState.RUNNING, 5)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=5, by_state=[(ReplicaState.RUNNING, 5, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Reduce target_capacity to 1, all but 1 of the replicas should be stopped.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=1,
             target_capacity_direction=TargetCapacityDirection.DOWN,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        replicas_to_stop = deployment_state._deployment_scheduler.schedule(
-            {}, {deployment_state._id: deployment_state_update_result.downscale}
-        )[deployment_state._id]
-        deployment_state.stop_replicas(replicas_to_stop)
+        deployment_state_update_result = ds.update()
+        replicas_to_stop = ds._deployment_scheduler.schedule(
+            {}, {ds._id: deployment_state_update_result.downscale}
+        )[ds._id]
+        ds.stop_replicas(replicas_to_stop)
         check_counts(
-            deployment_state,
+            ds,
             total=5,
-            by_state=[(ReplicaState.RUNNING, 1), (ReplicaState.STOPPING, 4)],
+            by_state=[
+                (ReplicaState.RUNNING, 1, None),
+                (ReplicaState.STOPPING, 4, None),
+            ],
         )
 
-        assert deployment_state.curr_status_info.status == DeploymentStatus.DOWNSCALING
+        assert ds.curr_status_info.status == DeploymentStatus.DOWNSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get([ReplicaState.STOPPING]):
+        for replica in ds._replicas.get([ReplicaState.STOPPING]):
             replica._actor.set_done_stopping()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
+        ds.update()
+        check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
 
         # Reduce target_capacity to 0, all replicas should be stopped.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=0,
             target_capacity_direction=TargetCapacityDirection.DOWN,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        replicas_to_stop = deployment_state._deployment_scheduler.schedule(
-            {}, {deployment_state._id: deployment_state_update_result.downscale}
-        )[deployment_state._id]
-        deployment_state.stop_replicas(replicas_to_stop)
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.STOPPING, 1)])
+        deployment_state_update_result = ds.update()
+        replicas_to_stop = ds._deployment_scheduler.schedule(
+            {}, {ds._id: deployment_state_update_result.downscale}
+        )[ds._id]
+        ds.stop_replicas(replicas_to_stop)
+        check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
 
-        assert deployment_state.curr_status_info.status == DeploymentStatus.DOWNSCALING
+        assert ds.curr_status_info.status == DeploymentStatus.DOWNSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get([ReplicaState.STOPPING]):
+        for replica in ds._replicas.get([ReplicaState.STOPPING]):
             replica._actor.set_done_stopping()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=0)
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
     def test_increase_target_capacity(
         self, mock_deployment_state: Tuple[DeploymentState, Mock, Mock]
@@ -3985,108 +3420,114 @@ class TestTargetCapacity:
         Deploy with target_capacity set to 0, then increase to 1, then increase to 50,
         then increase to 100.
         """
-        deployment_state, _, _ = mock_deployment_state
+        ds, _, _ = mock_deployment_state
 
         code_version = "arbitrary_version"
         b_info_1, _ = deployment_info(num_replicas=10, version=code_version)
 
         # Start with target_capacity set to 0, should have no replicas start up.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=0,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state.update()
-        check_counts(deployment_state, total=0)
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Increase target_capacity to 1, should have 1 replica start up.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=1,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
+        check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Set target_capacity to 50, should have 4 more replicas start up.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=50,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
         check_counts(
-            deployment_state,
+            ds,
             total=5,
-            by_state=[(ReplicaState.RUNNING, 1), (ReplicaState.STARTING, 4)],
+            by_state=[
+                (ReplicaState.RUNNING, 1, None),
+                (ReplicaState.STARTING, 4, None),
+            ],
         )
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
+        assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=5, by_state=[(ReplicaState.RUNNING, 5)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=5, by_state=[(ReplicaState.RUNNING, 5, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Set target_capacity to 100, should have 5 more replicas start up.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=100,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
         check_counts(
-            deployment_state,
+            ds,
             total=10,
-            by_state=[(ReplicaState.RUNNING, 5), (ReplicaState.STARTING, 5)],
+            by_state=[
+                (ReplicaState.RUNNING, 5, None),
+                (ReplicaState.STARTING, 5, None),
+            ],
         )
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
+        assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=10, by_state=[(ReplicaState.RUNNING, 10)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=10, by_state=[(ReplicaState.RUNNING, 10, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
     def test_clear_target_capacity(
         self, mock_deployment_state: Tuple[DeploymentState, Mock, Mock]
@@ -4094,62 +3535,65 @@ class TestTargetCapacity:
         """
         Deploy with target_capacity set, should apply immediately.
         """
-        deployment_state, _, _ = mock_deployment_state
+        ds, _, _ = mock_deployment_state
 
         code_version = "arbitrary_version"
         b_info_1, _ = deployment_info(num_replicas=10, version=code_version)
 
         # Start with target_capacity set to 50, should have 5 replicas start up.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=50,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
-        check_counts(deployment_state, total=5, by_state=[(ReplicaState.STARTING, 5)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPDATING
+        check_counts(ds, total=5, by_state=[(ReplicaState.STARTING, 5, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.UPDATING
 
-        for replica in deployment_state._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=5, by_state=[(ReplicaState.RUNNING, 5)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=5, by_state=[(ReplicaState.RUNNING, 5, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Clear target_capacity, should have 5 more replicas start up.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=None,
             target_capacity_direction=None,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
         check_counts(
-            deployment_state,
+            ds,
             total=10,
-            by_state=[(ReplicaState.RUNNING, 5), (ReplicaState.STARTING, 5)],
+            by_state=[
+                (ReplicaState.RUNNING, 5, None),
+                (ReplicaState.STARTING, 5, None),
+            ],
         )
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
+        assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=10, by_state=[(ReplicaState.RUNNING, 10)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=10, by_state=[(ReplicaState.RUNNING, 10, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
     def test_target_num_replicas_is_zero(
         self, mock_deployment_state: Tuple[DeploymentState, Mock, Mock]
@@ -4159,7 +3603,7 @@ class TestTargetCapacity:
         autoscaled down), then replicas should remain at zero regardless of
         target_capacity.
         """
-        deployment_state, _, _ = mock_deployment_state
+        ds, _, _ = mock_deployment_state
 
         # Set num_replicas to 0.
         code_version = "arbitrary_version"
@@ -4167,107 +3611,107 @@ class TestTargetCapacity:
 
         # Start with target_capacity of 50.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=50,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
-        check_counts(deployment_state, total=0)
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
-        for replica in deployment_state._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=0)
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
-        deployment_state.update()
-        check_counts(deployment_state, total=0)
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Regardless of target_capacity, should stay at 0 replicas.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=None,
             target_capacity_direction=None,
         )
 
-        deployment_state_update_result = deployment_state.update()
+        deployment_state_update_result = ds.update()
         assert not deployment_state_update_result.upscale
         assert not deployment_state_update_result.downscale
-        check_counts(deployment_state, total=0)
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=0,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
-        deployment_state_update_result = deployment_state.update()
+        deployment_state_update_result = ds.update()
         assert not deployment_state_update_result.upscale
         assert not deployment_state_update_result.downscale
-        check_counts(deployment_state, total=0)
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=50,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
-        deployment_state_update_result = deployment_state.update()
+        deployment_state_update_result = ds.update()
         assert not deployment_state_update_result.upscale
         assert not deployment_state_update_result.downscale
-        check_counts(deployment_state, total=0)
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=100,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
         assert not deployment_state_update_result.upscale
         assert not deployment_state_update_result.downscale
-        check_counts(deployment_state, total=0)
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Now scale back up to 1 replica.
         b_info_2, _ = deployment_info(num_replicas=1, version=code_version)
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_2,
             target_capacity=100,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state._target_state.num_replicas = 1
-        deployment_state_update_result = deployment_state.update()
+        ds._target_state.num_replicas = 1
+        deployment_state_update_result = ds.update()
 
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
+        check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
     # TODO(edoakes): this test should be updated to go through the autoscaling policy.
     def test_target_capacity_with_changing_num_replicas(
@@ -4277,7 +3721,7 @@ class TestTargetCapacity:
         Test that target_capacity works with changing num_replicas (emulating
         autoscaling).
         """
-        deployment_state, _, _ = mock_deployment_state
+        ds, _, _ = mock_deployment_state
 
         code_version = "arbitrary_version"
         b_info_1, _ = deployment_info(num_replicas=2, version=code_version)
@@ -4285,183 +3729,192 @@ class TestTargetCapacity:
         # Start with target_capacity set to 0, should have 0 replica start up
         # regardless of the autoscaling decision.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=0,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state.update()
-        check_counts(deployment_state, total=0)
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_1,
             target_capacity=1,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.STARTING, 1)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
+        check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
         # TODO (shrekris): once this test uses the autoscaling logic, this
         # status trigger should be DeploymentStatusTrigger.AUTOSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Increase the target number of replicas. Should still only have 1.
         b_info_2, _ = deployment_info(num_replicas=10, version=code_version)
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_2,
             target_capacity=1,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state.update()
-        check_counts(deployment_state, total=1, by_state=[(ReplicaState.RUNNING, 1)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Increase target_capacity to 50, should have 4 more replicas start up.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_2,
             target_capacity=50,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
         check_counts(
-            deployment_state,
+            ds,
             total=5,
-            by_state=[(ReplicaState.RUNNING, 1), (ReplicaState.STARTING, 4)],
+            by_state=[
+                (ReplicaState.RUNNING, 1, None),
+                (ReplicaState.STARTING, 4, None),
+            ],
         )
 
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
+        assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
         # TODO (shrekris): once this test uses the autoscaling logic, this
         # status trigger should be DeploymentStatusTrigger.AUTOSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=5, by_state=[(ReplicaState.RUNNING, 5)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=5, by_state=[(ReplicaState.RUNNING, 5, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Reduce num_replicas and remove target_capacity, should stay the same.
         b_info_3, _ = deployment_info(num_replicas=5, version=code_version)
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_3,
             target_capacity=None,
             target_capacity_direction=None,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
         check_counts(
-            deployment_state,
+            ds,
             total=5,
-            by_state=[(ReplicaState.RUNNING, 5)],
+            by_state=[(ReplicaState.RUNNING, 5, None)],
         )
 
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.UPSCALE_COMPLETED
         )
 
-        deployment_state.update()
-        check_counts(deployment_state, total=5, by_state=[(ReplicaState.RUNNING, 5)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=5, by_state=[(ReplicaState.RUNNING, 5, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Set target_capacity to 50 and increase num_replicas to 6, should have 2 stop.
         b_info_4, _ = deployment_info(num_replicas=6, version=code_version)
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_4,
             target_capacity=50,
             target_capacity_direction=TargetCapacityDirection.UP,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        replicas_to_stop = deployment_state._deployment_scheduler.schedule(
-            {}, {deployment_state._id: deployment_state_update_result.downscale}
-        )[deployment_state._id]
-        deployment_state.stop_replicas(replicas_to_stop)
+        deployment_state_update_result = ds.update()
+        replicas_to_stop = ds._deployment_scheduler.schedule(
+            {}, {ds._id: deployment_state_update_result.downscale}
+        )[ds._id]
+        ds.stop_replicas(replicas_to_stop)
         check_counts(
-            deployment_state,
+            ds,
             total=5,
-            by_state=[(ReplicaState.RUNNING, 3), (ReplicaState.STOPPING, 2)],
+            by_state=[
+                (ReplicaState.RUNNING, 3, None),
+                (ReplicaState.STOPPING, 2, None),
+            ],
         )
 
-        assert deployment_state.curr_status_info.status == DeploymentStatus.DOWNSCALING
+        assert ds.curr_status_info.status == DeploymentStatus.DOWNSCALING
         # TODO (shrekris): once this test uses the autoscaling logic, this
         # status trigger should be DeploymentStatusTrigger.AUTOSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get([ReplicaState.STOPPING]):
+        for replica in ds._replicas.get([ReplicaState.STOPPING]):
             replica._actor.set_done_stopping()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=3, by_state=[(ReplicaState.RUNNING, 3)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
         # Unset target capacity, should scale back up to 6.
         self.update_target_capacity(
-            deployment_state,
+            ds,
             b_info_4,
             target_capacity=None,
             target_capacity_direction=None,
         )
 
-        deployment_state_update_result = deployment_state.update()
-        deployment_state._deployment_scheduler.schedule(
-            {deployment_state._id: deployment_state_update_result.upscale}, {}
+        deployment_state_update_result = ds.update()
+        ds._deployment_scheduler.schedule(
+            {ds._id: deployment_state_update_result.upscale}, {}
         )
         check_counts(
-            deployment_state,
+            ds,
             total=6,
-            by_state=[(ReplicaState.RUNNING, 3), (ReplicaState.STARTING, 3)],
+            by_state=[
+                (ReplicaState.RUNNING, 3, None),
+                (ReplicaState.STARTING, 3, None),
+            ],
         )
-        assert deployment_state.curr_status_info.status == DeploymentStatus.UPSCALING
+        assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
         # TODO (shrekris): once this test uses the autoscaling logic, this
         # status trigger should be DeploymentStatusTrigger.AUTOSCALING
         assert (
-            deployment_state.curr_status_info.status_trigger
+            ds.curr_status_info.status_trigger
             == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
         )
 
-        for replica in deployment_state._replicas.get():
+        for replica in ds._replicas.get():
             replica._actor.set_ready()
 
-        deployment_state.update()
-        check_counts(deployment_state, total=6, by_state=[(ReplicaState.RUNNING, 6)])
-        assert deployment_state.curr_status_info.status == DeploymentStatus.HEALTHY
+        ds.update()
+        check_counts(ds, total=6, by_state=[(ReplicaState.RUNNING, 6, None)])
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[serve] test deployment state manager refactor

General improvments to `test_deployment_state` that will help my sanity for upcoming PRs:
* Change `check_counts` to take deployment version for each item in `by_state`, instead of as a high-level parameter. This allows checking for the complete current state, instead of having to call `check_counts` separately for each version that might have running replicas.
* Change most tests to use `mock_deployment_state_manager_full` instead of `mock_deployment_state`. With the introduction of the deployment scheduler, mocking only deployment state requires a manual call to deployment scheduler to schedule replicas as part of the unit tests, which is both cumbersome and makes the test have incomplete coverage (e.g. if the way we call deployment scheduler changes, we'd have to modify it for 50 unit tests as well).
* Rename deployment_state_manager -> dsm
* Rename deployment_state -> ds

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/ray-project/ray/pull/43186).
* #43187
* __->__ #43186