### PR TITLE
[core] Fix protobuf breaking change by adding a compat layer. (#43172)

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -168,7 +168,9 @@ steps:
     job_env: forge-aarch64
 
   - label: ":ray: core: minimal tests {{matrix}}"
-    tags: python
+    tags:
+      - python
+      - oss
     instance_type: medium
     commands:
       # validate minimal installation

--- a/dashboard/modules/actor/actor_head.py
+++ b/dashboard/modules/actor/actor_head.py
@@ -39,7 +39,7 @@ def actor_table_data_to_dict(message):
             "parentTaskId",
             "sourceActorId",
         },
-        including_default_value_fields=True,
+        always_print_fields_with_no_presence=True,
     )
     # The complete schema for actor table is here:
     #     src/ray/protobuf/gcs.proto

--- a/dashboard/modules/actor/tests/test_actor.py
+++ b/dashboard/modules/actor/tests/test_actor.py
@@ -173,7 +173,7 @@ def test_actor_pubsub(disable_aiohttp_cache, ray_start_with_dashboard):
                 "sourceActorId",
                 "placementGroupId",
             },
-            including_default_value_fields=False,
+            always_print_fields_with_no_presence=False,
         )
 
     non_state_keys = ("actorId", "jobId")

--- a/dashboard/modules/node/node_head.py
+++ b/dashboard/modules/node/node_head.py
@@ -43,7 +43,7 @@ routes = dashboard_optional_utils.DashboardHeadRouteTable
 
 def gcs_node_info_to_dict(message):
     return dashboard_utils.message_to_dict(
-        message, {"nodeId"}, including_default_value_fields=True
+        message, {"nodeId"}, always_print_fields_with_no_presence=True
     )
 
 
@@ -80,7 +80,7 @@ def node_stats_to_dict(message):
         result = dashboard_utils.message_to_dict(message, decode_keys)
         result["coreWorkersStats"] = [
             dashboard_utils.message_to_dict(
-                m, decode_keys, including_default_value_fields=True
+                m, decode_keys, always_print_fields_with_no_presence=True
             )
             for m in core_workers_stats
         ]

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -20,7 +20,7 @@ from ray._private.utils import split_address
 
 import aiosignal  # noqa: F401
 
-from google.protobuf.json_format import MessageToDict
+import ray._private.protobuf_compat
 from frozenlist import FrozenList  # noqa: F401
 
 from ray._private.utils import binary_to_hex, check_dashboard_dependencies_installed
@@ -217,12 +217,13 @@ def message_to_dict(message, decode_keys=None, **kwargs):
                     d[k] = v
         return d
 
+    d = ray._private.protobuf_compat.message_to_dict(
+        message, use_integers_for_enums=False, **kwargs
+    )
     if decode_keys:
-        return _decode_keys(
-            MessageToDict(message, use_integers_for_enums=False, **kwargs)
-        )
+        return _decode_keys(d)
     else:
-        return MessageToDict(message, use_integers_for_enums=False, **kwargs)
+        return d
 
 
 class SignalManager:

--- a/python/ray/_private/event/event_logger.py
+++ b/python/ray/_private/event/event_logger.py
@@ -10,9 +10,10 @@ import threading
 from typing import Dict, Optional
 from datetime import datetime
 
-from google.protobuf.json_format import MessageToDict, Parse
+from google.protobuf.json_format import Parse
 
 from ray.core.generated.event_pb2 import Event
+from ray._private.protobuf_compat import message_to_dict
 
 global_logger = logging.getLogger(__name__)
 
@@ -91,9 +92,9 @@ class EventLoggerAdapter:
 
         self.logger.info(
             json.dumps(
-                MessageToDict(
+                message_to_dict(
                     event,
-                    including_default_value_fields=True,
+                    always_print_fields_with_no_presence=True,
                     preserving_proto_field_name=True,
                     use_integers_for_enums=False,
                 )

--- a/python/ray/_private/protobuf_compat.py
+++ b/python/ray/_private/protobuf_compat.py
@@ -1,0 +1,41 @@
+from google.protobuf.json_format import MessageToDict
+import inspect
+
+"""
+This module provides a compatibility layer for different versions of the protobuf
+library.
+"""
+
+
+def rename_always_print_fields_with_no_presence(kwargs):
+    """
+    Protobuf version 5.26.0rc2 renamed argument for `MessageToDict`:
+    `including_default_value_fields` -> `always_print_fields_with_no_presence`.
+    See https://github.com/protocolbuffers/protobuf/commit/06e7caba58ede0220b110b89d08f329e5f8a7537#diff-8de817c14d6a087981503c9aea38730b1b3e98f4e306db5ff9d525c7c304f234L129  # noqa: E501
+
+    We choose to always use the new argument name. If user used the old arg, we raise an
+    error.
+
+    If protobuf does not have the new arg name but have the old arg name, we rename our
+    arg to the old one.
+    """
+    old_arg_name = "including_default_value_fields"
+    new_arg_name = "always_print_fields_with_no_presence"
+    if old_arg_name in kwargs:
+        raise ValueError(f"{old_arg_name} is deprecated, please use {new_arg_name}")
+    if new_arg_name not in kwargs:
+        return kwargs
+
+    params = inspect.signature(MessageToDict).parameters
+    if new_arg_name in params:
+        return kwargs
+    if old_arg_name in params:
+        kwargs[old_arg_name] = kwargs.pop(new_arg_name)
+        return kwargs
+    # Neither args are in the signature, do nothing.
+    return kwargs
+
+
+def message_to_dict(*args, **kwargs):
+    kwargs = rename_always_print_fields_with_no_presence(kwargs)
+    return MessageToDict(*args, **kwargs)

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -3,7 +3,7 @@ import logging
 from collections import defaultdict
 from typing import Set
 
-from google.protobuf.json_format import MessageToDict
+from ray._private.protobuf_compat import message_to_dict
 
 import ray
 from ray._private.client_mode_hook import client_mode_hook
@@ -346,7 +346,7 @@ class GlobalState:
             "bundles": {
                 # The value here is needs to be dictionarified
                 # otherwise, the payload becomes unserializable.
-                bundle.bundle_id.bundle_index: MessageToDict(bundle)["unitResources"]
+                bundle.bundle_id.bundle_index: message_to_dict(bundle)["unitResources"]
                 for bundle in placement_group_info.bundles
             },
             "bundles_to_node_id": {

--- a/python/ray/autoscaler/v2/scheduler.py
+++ b/python/ray/autoscaler/v2/scheduler.py
@@ -6,8 +6,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
-from google.protobuf.json_format import MessageToDict
-
+from ray._private.protobuf_compat import message_to_dict
 from ray.autoscaler._private.resource_demand_scheduler import UtilizationScore
 from ray.autoscaler.v2.schema import NodeType
 from ray.autoscaler.v2.utils import is_pending, resource_requests_by_count
@@ -245,7 +244,9 @@ class SchedulingNode:
             available_resources=self.available_resources,
             labels=self.labels,
             launch_reason=self.launch_reason,
-            sched_requests="|".join(str(MessageToDict(r)) for r in self.sched_requests),
+            sched_requests="|".join(
+                str(message_to_dict(r)) for r in self.sched_requests
+            ),
         )
 
 

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -2,10 +2,9 @@ import inspect
 import json
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
-from google.protobuf.json_format import MessageToDict
-
 from ray import cloudpickle
 from ray._private import ray_option_utils
+from ray._private.protobuf_compat import message_to_dict
 from ray._private.pydantic_compat import (
     BaseModel,
     Field,
@@ -199,9 +198,9 @@ class DeploymentConfig(BaseModel):
 
     @classmethod
     def from_proto(cls, proto: DeploymentConfigProto):
-        data = MessageToDict(
+        data = message_to_dict(
             proto,
-            including_default_value_fields=True,
+            always_print_fields_with_no_presence=True,
             preserving_proto_field_name=True,
             use_integers_for_enums=True,
         )

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1506,7 +1506,7 @@ def protobuf_message_to_dict(
     return dashboard_utils.message_to_dict(
         message,
         fields_to_decode,
-        including_default_value_fields=True,
+        always_print_fields_with_no_presence=True,
         preserving_proto_field_name=preserving_proto_field_name,
     )
 


### PR DESCRIPTION
Latest postmerge failure linux://python/ray/tests:test_output turns out to be from a recent protobuf pre-release change. It changed an argument name which breaks our event logger. This PR introduces a compatibility layer to support both args.

Also re-enabled core minimal tests in premerge.

This cherry pick is for the premerge failure due to the latest protobuf breaking change.