### PR TITLE
[Core] Remove deprecated Metric methods

### DIFF
--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -719,7 +719,7 @@ def test_basic_custom_metrics(metric_mock):
     # -- Gauge --
     gauge = Gauge("gauge", description="gauge")
     gauge._metric = metric_mock
-    gauge.record(4)
+    gauge.set(4)
     metric_mock.record.assert_called_with(4, tags={})
 
     # -- Histogram
@@ -758,12 +758,12 @@ def test_custom_metrics_with_extra_tags(metric_mock):
     gauge._metric = metric_mock
 
     # Record with base tags
-    gauge.record(4, tags=base_tags)
+    gauge.set(4, tags=base_tags)
     metric_mock.record.assert_called_with(4, tags=base_tags)
     metric_mock.reset_mock()
 
     # Record with extra tags
-    gauge.record(4, tags=extra_tags)
+    gauge.set(4, tags=extra_tags)
     metric_mock.record.assert_called_with(4, tags=extra_tags)
     metric_mock.reset_mock()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Those methods have been deprecated for 3 years and they are DeveloperAPI so it's safe to remove them.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
