### PR TITLE
[data] auto-resize progress bars when terminal window resizes

### DIFF
--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -58,7 +58,11 @@ class ProgressBar:
             if ctx.use_ray_tqdm:
                 self._bar = tqdm_ray.tqdm(total=total, position=position)
             else:
-                self._bar = tqdm.tqdm(total=total, position=position)
+                self._bar = tqdm.tqdm(
+                    total=total,
+                    position=position,
+                    dynamic_ncols=True,
+                )
             self._bar.set_description(self._desc)
         else:
             global needs_warning

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -178,6 +178,7 @@ class _Bar:
             total=state["total"],
             position=pos_offset + state["pos"],
             leave=False,
+            dynamic_ncols=True,
         )
         if state["x"]:
             self.bar.update(state["x"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

right now, when terminal window resizes, progress bar will keep printing new lines and spam the log. add this `dynamic_ncols=True` parameter to make progress bars auto-resize. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
