### PR TITLE
[Serve] add blocking to serve.run()

### DIFF
--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -2,6 +2,7 @@ import ray._private.worker
 
 try:
     from ray.serve.api import (
+        _run,
         Application,
         Deployment,
         delete,
@@ -35,6 +36,7 @@ except ModuleNotFoundError as e:
 ray._private.worker.blocking_get_inside_async_warned = True
 
 __all__ = [
+    "_run",
     "batch",
     "start",
     "HTTPOptions",

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -2,9 +2,9 @@ import ray._private.worker
 
 try:
     from ray.serve.api import (
-        _run,
         Application,
         Deployment,
+        _run,
         delete,
         deployment,
         get_app_handle,

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -5,6 +5,7 @@ import time
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Union
 
+import watchfiles
 from fastapi import APIRouter, FastAPI
 
 import ray
@@ -519,6 +520,8 @@ def run(
     name: str = SERVE_DEFAULT_APP_NAME,
     route_prefix: str = DEFAULT.VALUE,
     logging_config: Optional[Union[Dict, LoggingConfig]] = None,
+    watch_dir: Optional[str] = None,
+    reload_app_func: Optional[Callable] = None,
 ) -> DeploymentHandle:
     """Run an application and return a handle to its ingress deployment.
 
@@ -541,16 +544,54 @@ def run(
             nor in the ingress deployment, the route prefix will default to '/'.
         logging_config: Application logging config. If provided, the config will
             be applied to all deployments which doesn't have logging config.
-
+        watch_dir: Directory to watch file changes and automatically redeploys the
+            application. Should only be set if blocking is True
+        reload_app_func: Function used to reload app when watched file changes. Should
+            only be set if blocking is True
     Returns:
         DeploymentHandle: A handle that can be used to call the application.
     """
-    handle = _run(
-        target=target,
-        name=name,
-        route_prefix=route_prefix,
-        logging_config=logging_config,
-    )
+    if watch_dir is not None or reload_app_func is not None:
+        if not blocking:
+            raise RayServeException(
+                "Please specify blocking=True when passing watch_dir or "
+                "reload_app_func."
+            )
+
+        if watch_dir is None:
+            raise RayServeException(
+                "Please specify watch_dir when passing reload_app_func."
+            )
+
+        if reload_app_func is None:
+            raise RayServeException(
+                "Please specify watch_dir when passing watch_dir."
+            )
+
+        for changes in watchfiles.watch(
+            watch_dir,
+            rust_timeout=10000,
+            yield_on_timeout=True,
+        ):
+            if changes:
+                logger.info(
+                    f"Detected file change in path {watch_dir}. Redeploying app."
+                )
+                handle = _run(
+                    target=reload_app_func(),
+                    name=name,
+                    route_prefix=route_prefix,
+                    logging_config=logging_config,
+                )
+                logger.info("Redeployed app successfully.")
+    else:
+        handle = _run(
+            target=target,
+            name=name,
+            route_prefix=route_prefix,
+            logging_config=logging_config,
+        )
+        logger.info("Deployed app successfully.")
 
     if blocking:
         try:

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -9,7 +9,6 @@ from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Tuple
 
 import click
-import watchfiles
 import yaml
 
 import ray
@@ -590,9 +589,17 @@ def run(
         if is_config:
             client.deploy_apps(config, _blocking=False)
             cli_logger.success("Submitted deploy config successfully.")
+            if blocking:
+                while True:
+                    # Block, letting Ray print logs to the terminal.
+                    time.sleep(10)
         else:
-            serve.run(app, name=name, route_prefix=route_prefix)
-            cli_logger.success("Deployed app successfully.")
+            serve.run(
+                target=app,
+                blocking=blocking,
+                name=name,
+                route_prefix=route_prefix,
+            )
 
         if reload:
             if not blocking:
@@ -604,27 +611,19 @@ def run(
             else:
                 watch_dir = app_dir
 
-            for changes in watchfiles.watch(
-                watch_dir,
-                rust_timeout=10000,
-                yield_on_timeout=True,
-            ):
-                if changes:
-                    cli_logger.info(
-                        f"Detected file change in path {watch_dir}. Redeploying app."
-                    )
-                    # The module needs to be reloaded with `importlib` in order to pick
-                    # up any changes.
-                    app = _private_api.call_app_builder_with_args_if_necessary(
-                        import_attr(import_path, reload_module=True), args_dict
-                    )
-                    serve.run(app, name=name, route_prefix=route_prefix)
-                    cli_logger.success("Redeployed app successfully.")
+            def reload_app_func() -> Application:
+                return _private_api.call_app_builder_with_args_if_necessary(
+                    import_attr(import_path, reload_module=True), args_dict
+                )
 
-        if blocking:
-            while True:
-                # Block, letting Ray print logs to the terminal.
-                time.sleep(10)
+            serve.run(
+                target=app,
+                blocking=blocking,
+                name=name,
+                route_prefix=route_prefix,
+                watch_dir=watch_dir,
+                reload_app_func=reload_app_func,
+            )
 
     except KeyboardInterrupt:
         cli_logger.info("Got KeyboardInterrupt, shutting down...")

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import re
 import sys
+import time
 import traceback
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Tuple
@@ -589,6 +590,10 @@ def run(
         if is_config:
             client.deploy_apps(config, _blocking=False)
             cli_logger.success("Submitted deploy config successfully.")
+            if blocking:
+                while True:
+                    # Block, letting Ray print logs to the terminal.
+                    time.sleep(10)
         else:
             # This should not block if reload is true so the watchfiles can be triggered
             should_block = blocking and not reload

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -3,7 +3,6 @@ import os
 import pathlib
 import re
 import sys
-import time
 import traceback
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Tuple
@@ -591,7 +590,9 @@ def run(
             client.deploy_apps(config, _blocking=False)
             cli_logger.success("Submitted deploy config successfully.")
         else:
-            serve.run(app, name=name, route_prefix=route_prefix)
+            # This should not block if reload is true so the watchfiles can be triggered
+            should_block = blocking and not reload
+            serve.run(app, blocking=should_block, name=name, route_prefix=route_prefix)
             cli_logger.success("Deployed app successfully.")
 
         if reload:
@@ -618,13 +619,10 @@ def run(
                     app = _private_api.call_app_builder_with_args_if_necessary(
                         import_attr(import_path, reload_module=True), args_dict
                     )
-                    serve.run(app, name=name, route_prefix=route_prefix)
+                    serve.run(
+                        target=app, blocking=True, name=name, route_prefix=route_prefix
+                    )
                     cli_logger.success("Redeployed app successfully.")
-
-        if blocking:
-            while True:
-                # Block, letting Ray print logs to the terminal.
-                time.sleep(10)
 
     except KeyboardInterrupt:
         cli_logger.info("Got KeyboardInterrupt, shutting down...")

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -2,6 +2,8 @@ import asyncio
 import os
 import sys
 from typing import Dict, Optional
+import subprocess
+import signal
 
 import pytest
 import requests
@@ -848,7 +850,7 @@ def test_status_constructor_error(serve_instance):
         def __init__(self):
             1 / 0
 
-    serve.run(A.bind(), _blocking=False)
+    serve._run(A.bind(), _blocking=False)
 
     def check_for_failed_deployment():
         default_app = serve.status().applications[SERVE_DEFAULT_APP_NAME]
@@ -880,7 +882,7 @@ def test_status_package_unavailable_in_controller(serve_instance):
             create_engine("mysql://some_wrong_url:3306").connect()
 
     ray_actor_options = {"runtime_env": {"pip": ["PyMySQL", "sqlalchemy==1.3.19"]}}
-    serve.run(
+    serve._run(
         MyDeployment.options(ray_actor_options=ray_actor_options).bind(),
         _blocking=False,
     )

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -2,8 +2,6 @@ import asyncio
 import os
 import sys
 from typing import Dict, Optional
-import subprocess
-import signal
 
 import pytest
 import requests

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -1081,7 +1081,7 @@ def test_autoscaling_status_changes(serve_instance):
     app = AutoscalingDeployment.bind()
 
     # Start the AutoscalingDeployment.
-    serve.run(app, name=app_name, _blocking=False)
+    serve._run(app, name=app_name, _blocking=False)
 
     # Active replicas are replicas that are waiting or running.
     expected_num_active_replicas: int = min_replicas
@@ -1165,7 +1165,7 @@ def test_autoscaling_status_changes(serve_instance):
             max_replicas=max_replicas,
         )
     ).bind()
-    serve.run(app, name=app_name, _blocking=False)
+    serve._run(app, name=app_name, _blocking=False)
     expected_num_active_replicas = min_replicas
 
     wait_for_condition(check_num_active_replicas, expected=expected_num_active_replicas)
@@ -1221,7 +1221,7 @@ def test_autoscaling_status_changes(serve_instance):
             max_replicas=max_replicas,
         )
     ).bind()
-    serve.run(app, name=app_name, _blocking=False)
+    serve._run(app, name=app_name, _blocking=False)
     expected_num_active_replicas = min_replicas
 
     wait_for_condition(check_num_active_replicas, expected=expected_num_active_replicas)

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -156,7 +156,7 @@ def test_replica_startup_status_transitions(ray_cluster):
         async def __init__(self):
             await signal.wait.remote()
 
-    serve.run(E.bind(), _blocking=False)
+    serve._run(E.bind(), _blocking=False)
 
     def get_replicas(replica_state):
         controller = client._controller

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -191,7 +191,7 @@ def test_recover_rolling_update_from_replica_actor_names(serve_instance):
     # Redeploy new version. Since there is one replica blocking, only one new
     # replica should be started up.
     V2 = V1.options(func_or_class=V2, version="2")
-    serve.run(V2.bind(), _blocking=False, name="app")
+    serve._run(V2.bind(), _blocking=False, name="app")
     with pytest.raises(TimeoutError):
         client._wait_for_application_running("app", timeout_s=0.1)
     responses3, blocking3 = make_nonblocking_calls({"1": 1}, expect_blocking=True)
@@ -231,7 +231,7 @@ def test_controller_recover_initializing_actor(serve_instance):
         def __call__(self, request):
             return f"1|{os.getpid()}"
 
-    serve.run(V1.bind(), _blocking=False, name="app")
+    serve._run(V1.bind(), _blocking=False, name="app")
     ray.get(pending_init_indicator.remote())
 
     def get_actor_info(name: str):

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -351,7 +351,9 @@ def test_reconfigure_multiple_replicas(serve_instance, use_handle):
 
     # Reconfigure should block one replica until the signal is sent. Check that
     # some requests are now blocking.
-    serve._run(V1.options(user_config={"test": "2"}).bind(), name="app", _blocking=False)
+    serve._run(
+        V1.options(user_config={"test": "2"}).bind(), name="app", _blocking=False
+    )
     responses2, blocking2 = make_nonblocking_calls({"1": 1}, expect_blocking=True)
     assert list(responses2["1"])[0] in pids1
 

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -149,7 +149,7 @@ def test_redeploy_single_replica(serve_instance, use_handle):
     # Redeploy new version. This should not go through until the old version
     # replica completely stops.
     V2 = V1.options(func_or_class=V2, version="2")
-    serve.run(V2.bind(), _blocking=False, name="app")
+    serve._run(V2.bind(), _blocking=False, name="app")
     with pytest.raises(TimeoutError):
         client._wait_for_application_running("app", timeout_s=0.1)
 
@@ -264,7 +264,7 @@ def test_redeploy_multiple_replicas(serve_instance, use_handle):
     # Redeploy new version. Since there is one replica blocking, only one new
     # replica should be started up.
     V2 = V1.options(func_or_class=V2, version="2")
-    serve.run(V2.bind(), _blocking=False, name="app")
+    serve._run(V2.bind(), _blocking=False, name="app")
     with pytest.raises(TimeoutError):
         client._wait_for_application_running("app", timeout_s=0.1)
     responses3, blocking3 = make_nonblocking_calls({"1": 1}, expect_blocking=True)
@@ -351,7 +351,7 @@ def test_reconfigure_multiple_replicas(serve_instance, use_handle):
 
     # Reconfigure should block one replica until the signal is sent. Check that
     # some requests are now blocking.
-    serve.run(V1.options(user_config={"test": "2"}).bind(), name="app", _blocking=False)
+    serve._run(V1.options(user_config={"test": "2"}).bind(), name="app", _blocking=False)
     responses2, blocking2 = make_nonblocking_calls({"1": 1}, expect_blocking=True)
     assert list(responses2["1"])[0] in pids1
 

--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -256,7 +256,7 @@ def test_deploy_bad_pip_package_deployment(serve_instance):
         def __call__(self):
             return "hello world"
 
-    serve.run(Model.bind(), _blocking=False)
+    serve._run(Model.bind(), _blocking=False)
 
     def check_fail():
         app_status = serve.status().applications["default"]

--- a/python/ray/serve/tests/test_failure.py
+++ b/python/ray/serve/tests/test_failure.py
@@ -233,7 +233,7 @@ def test_no_available_replicas_does_not_block_proxy(serve_instance):
     for _ in range(2):
         starting_actor = SignalActor.remote()
         finish_starting_actor = SignalActor.remote()
-        serve.run(
+        serve._run(
             SlowStarter.bind(starting_actor, finish_starting_actor), _blocking=False
         )
 

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -670,7 +670,7 @@ def test_updating_status_message(lower_slow_startup_threshold_and_reset):
     def f(*args):
         pass
 
-    serve.run(f.bind(), _blocking=False)
+    serve._run(f.bind(), _blocking=False)
 
     def updating_message():
         deployment_status = (
@@ -699,7 +699,7 @@ def test_unhealthy_override_updating_status(lower_slow_startup_threshold_and_res
         def __call__(self, request):
             pass
 
-    serve.run(f.bind(), _blocking=False)
+    serve._run(f.bind(), _blocking=False)
 
     wait_for_condition(
         lambda: serve.status()

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -140,7 +140,7 @@ class RandomTest:
 
         if blocking:
             ray.get(self.random_killer.spare.remote(new_name))
-            serve.run(
+            serve._run(
                 handler.bind(),
                 name=new_name,
                 route_prefix=f"/{new_name}",
@@ -149,7 +149,7 @@ class RandomTest:
             self.applications.append(new_name)
             ray.get(self.random_killer.stop_spare.remote(new_name))
         else:
-            serve.run(
+            serve._run(
                 handler.bind(),
                 name=new_name,
                 route_prefix=f"/{new_name}",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Rename the existing `serve.run` to `serve._run` and added `blocking` option to the new `serve.run`

## Related issue number

Closes https://github.com/ray-project/ray/issues/43211

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Manually tested and seeing it behaves correctly  
```
from ray import serve

@serve.deployment
def foo() -> str:
    return "bar"

handle = serve.run(foo.bind(), blocking=True)
xxx = "xxx"

```
<img width="1546" alt="image" src="https://github.com/ray-project/ray/assets/7553988/72da2fba-59d7-40de-b415-0113157a7e1c">
