### PR TITLE
[train] Fix regression where large Trainer attributes get serialized along with actor class

### DIFF
--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import warnings
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
 
@@ -66,6 +67,40 @@ class TrainingFailedError(RuntimeError):
         "in the Trainer's `run_config` with `max_failures > 0`, or `max_failures = -1` "
         "for unlimited retries."
     )
+
+
+def train_coordinator_fn(
+    config: dict, trainer_cls: Type["BaseTrainer"], metadata: dict
+):
+    """This is the function that defines the logic of the Ray Train coordinator.
+    This is responsible for setting up a remote instance of the `trainer_cls`
+    (a different instance than the one calling `trainer.fit` on the driver!)
+    and running the training loop.
+    """
+    assert metadata is not None, metadata
+    # Propagate user metadata from the Trainer constructor.
+    _get_session().metadata = metadata
+
+    # config already contains merged values.
+    # Instantiate new Trainer in Trainable.
+    trainer = trainer_cls(**config)
+
+    # Get the checkpoint from Tune and pass it to workers later on.
+    checkpoint = ray.train.get_checkpoint()
+    if checkpoint:
+        # Set `starting_checkpoint` for auto-recovery fault-tolerance
+        # as well as manual restoration.
+        trainer.starting_checkpoint = checkpoint
+    # else: Train will restore from the user-provided
+    # `resume_from_checkpoint` == `starting_checkpoint`.
+
+    # Evaluate datasets if they are wrapped in a factory.
+    trainer.datasets = {
+        k: d() if callable(d) else d for k, d in trainer.datasets.items()
+    }
+
+    trainer.setup()
+    trainer.training_loop()
 
 
 @DeveloperAPI
@@ -656,38 +691,17 @@ class BaseTrainer(abc.ABC):
         scaling_config = self.scaling_config
         metadata = self.metadata
 
-        def train_func(config):
-            assert metadata is not None, metadata
-            # Propagate user metadata from the Trainer constructor.
-            _get_session().metadata = metadata
-
-            # config already contains merged values.
-            # Instantiate new Trainer in Trainable.
-            trainer = trainer_cls(**config)
-
-            # Get the checkpoint from Tune and pass it to workers later on.
-            checkpoint = ray.train.get_checkpoint()
-            if checkpoint:
-                # Set `starting_checkpoint` for auto-recovery fault-tolerance
-                # as well as manual restoration.
-                trainer.starting_checkpoint = checkpoint
-            # else: Train will restore from the user-provided
-            # `resume_from_checkpoint` == `starting_checkpoint`.
-
-            # Evaluate datasets if they are wrapped in a factory.
-            trainer.datasets = {
-                k: d() if callable(d) else d for k, d in self.datasets.items()
-            }
-
-            trainer.setup()
-            trainer.training_loop()
-
+        # Create a local copy of the training function to avoid modifying attributes
+        # of the globally accessible function.
+        _train_coordinator_fn = copy.copy(train_coordinator_fn)
         # Change the name of the training function to match the name of the Trainer
         # class. This will mean the Tune trial name will match the name of Trainer on
         # stdout messages and the results directory.
-        train_func.__name__ = trainer_cls.__name__
+        _train_coordinator_fn.__name__ = trainer_cls.__name__
 
-        trainable_cls = wrap_function(train_func)
+        trainable_cls = wrap_function(
+            partial(_train_coordinator_fn, trainer_cls=trainer_cls, metadata=metadata)
+        )
         has_base_dataset = bool(self.datasets)
         if has_base_dataset:
             from ray.data.context import DataContext
@@ -723,10 +737,10 @@ class BaseTrainer(abc.ABC):
                 merged_scaling_config = self._merged_config.get("scaling_config")
                 if isinstance(merged_scaling_config, dict):
                     merged_scaling_config = ScalingConfig(**merged_scaling_config)
-                self._merged_config[
-                    "scaling_config"
-                ] = self._reconcile_scaling_config_with_trial_resources(
-                    merged_scaling_config
+                self._merged_config["scaling_config"] = (
+                    self._reconcile_scaling_config_with_trial_resources(
+                        merged_scaling_config
+                    )
                 )
                 if self.has_base_dataset():
                     # Set the DataContext on the Trainer actor to the DataContext

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -737,10 +737,10 @@ class BaseTrainer(abc.ABC):
                 merged_scaling_config = self._merged_config.get("scaling_config")
                 if isinstance(merged_scaling_config, dict):
                     merged_scaling_config = ScalingConfig(**merged_scaling_config)
-                self._merged_config["scaling_config"] = (
-                    self._reconcile_scaling_config_with_trial_resources(
-                        merged_scaling_config
-                    )
+                self._merged_config[
+                    "scaling_config"
+                ] = self._reconcile_scaling_config_with_trial_resources(
+                    merged_scaling_config
                 )
                 if self.has_base_dataset():
                     # Set the DataContext on the Trainer actor to the DataContext

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -691,17 +691,15 @@ class BaseTrainer(abc.ABC):
         scaling_config = self.scaling_config
         metadata = self.metadata
 
-        # Create a local copy of the training function to avoid modifying attributes
-        # of the globally accessible function.
-        train_coordinator_fn = copy.copy(_train_coordinator_fn)
+        train_coordinator_fn = partial(
+            _train_coordinator_fn, trainer_cls=trainer_cls, metadata=metadata
+        )
         # Change the name of the training function to match the name of the Trainer
         # class. This will mean the Tune trial name will match the name of Trainer on
         # stdout messages and the results directory.
         train_coordinator_fn.__name__ = trainer_cls.__name__
 
-        trainable_cls = wrap_function(
-            partial(train_coordinator_fn, trainer_cls=trainer_cls, metadata=metadata)
-        )
+        trainable_cls = wrap_function(train_coordinator_fn)
         has_base_dataset = bool(self.datasets)
         if has_base_dataset:
             from ray.data.context import DataContext

--- a/python/ray/train/tests/test_base_trainer.py
+++ b/python/ray/train/tests/test_base_trainer.py
@@ -1,6 +1,7 @@
 import logging
 import tempfile
 
+import numpy as np
 import pytest
 
 import ray
@@ -184,6 +185,18 @@ def test_data_context_propagation(ray_start_4_cpus):
         train_loop=training_loop,
         datasets={"train": ray.data.range(10)},
     )
+    trainer.fit()
+
+
+def test_large_params(ray_start_4_cpus):
+    """Tests that large params are not serialized with the trainer actor
+    and are instead put into the object store separately."""
+    huge_array = np.zeros(shape=int(1e8))
+
+    def training_loop(self):
+        huge_array
+
+    trainer = DummyTrainer(training_loop)
     trainer.fit()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

https://github.com/ray-project/ray/pull/43146 re-introduced a problem that was originally fixed by https://github.com/ray-project/ray/pull/28826.

The problem:
* When there are large objects captured in the scope of a `Trainer`'s arguments, **the `Trainer` instance on the driver needs to be sure not to package itself (`self`) when registering the actor class** that will be run remotely.
* Otherwise, `self` gets packaged along with the actor class during serialization, and **so do these large objects.**
* Because Ray Train relies on creating a Ray Tune Trainable under the hood to schedule the remote `Trainer` instance (which serves as the dist. training coordinator), and because Ray Tune uses the Ray GCS redis key value store to save a shared copy of the serialized actor class, a huge actor class causes a gRPC error such as the one below:
```
E               ray.tune.error.TuneError: The Trainable/training function is too large for grpc resource limit. Check that its definition is not implicitly capturing a large array or other object in scope. Tip: use tune.with_parameters() to put large objects in the Ray object store. 
E               Original exception: Traceback (most recent call last):
E                 File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/experiment/experiment.py", line 149, in __init__
E                   self._run_identifier = Experiment.register_if_needed(run)
E                 File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/experiment/experiment.py", line 350, in register_if_needed
E                   register_trainable(name, run_object)
E                 File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/registry.py", line 112, in register_trainable
E                   _global_registry.register(TRAINABLE_CLASS, name, trainable)
E                 File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/registry.py", line 239, in register
E                   self.flush_values()
E                 File "/Users/justin/Developer/justinvyu-dev/python/ray/tune/registry.py", line 277, in flush_values
E                   _internal_kv_put(
E                 File "/Users/justin/Developer/justinvyu-dev/python/ray/_private/client_mode_hook.py", line 103, in wrapper
E                   return func(*args, **kwargs)
E                 File "/Users/justin/Developer/justinvyu-dev/python/ray/experimental/internal_kv.py", line 94, in _internal_kv_put
E                   return global_gcs_client.internal_kv_put(key, value, overwrite, namespace) == 0
E                 File "python/ray/_raylet.pyx", line 2614, in ray._raylet._auto_reconnect.wrapper
E                 File "python/ray/_raylet.pyx", line 2591, in ray._raylet._auto_reconnect.wrapper
E                 File "python/ray/_raylet.pyx", line 2728, in ray._raylet.GcsClient.internal_kv_put
E                 File "python/ray/_raylet.pyx", line 579, in ray._raylet.check_status
E               ray.exceptions.RpcError: Sent message larger than max (800008883 vs. 536870912)
```

The fix is to remove the reference to `self` in the train coordinator function trainable. This PR also restructures the code a bit to make it harder to make such a mistake in the future.

### Future considerations

* This redis key value store logic in Tune is probably not necessary and can be re-worked to remove this failure case.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/43191
Closes https://github.com/ray-project/ray/issues/43192
Closes https://github.com/ray-project/ray/issues/43193
Closes https://github.com/ray-project/ray/issues/43194
Closes https://github.com/ray-project/ray/issues/43195

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
