### PR TITLE
[RLlib] Uniform random n-step sampling in `PrioritizedEpisodeReplayBuffer`.

### DIFF
--- a/rllib/algorithms/sac/sac.py
+++ b/rllib/algorithms/sac/sac.py
@@ -190,9 +190,7 @@ class SACConfig(AlgorithmConfig):
                 postprocessed to become sa[discounted sum of R][s t+n] tuples. An
                 integer will be interpreted as a fixed n-step value. In case of a tuple
                 the n-step value will be drawn for each sample in the train batch from
-                a uniform distribution over the  interval defined by the 'n-step'-tuple
-                . if `n-step' is `None` it is drawn for each sample in the training
-                batch from a uniform distributioon over the interval [1, 5].
+                a uniform distribution over the  interval defined by the 'n-step'-tuple.
             store_buffer_in_checkpoints: Set this to True, if you want the contents of
                 your buffer(s) to be stored in any saved checkpoints as well.
                 Warnings will be created if:
@@ -332,9 +330,7 @@ class SACConfig(AlgorithmConfig):
         super().validate()
 
         # Check rollout_fragment_length to be compatible with n_step.
-        if self.n_step is None:
-            min_rollout_fragment_length = 5
-        elif isinstance(self.n_step, tuple):
+        if isinstance(self.n_step, tuple):
             min_rollout_fragment_length = self.n_step[1]
         else:
             min_rollout_fragment_length = self.n_step
@@ -350,9 +346,7 @@ class SACConfig(AlgorithmConfig):
                 f"smaller than needed for `n_step` ({self.n_step})! If `n_step` is "
                 f"an integer try setting `rollout_fragment_length={self.n_step}`. If "
                 "`n_step` is a tuple, try setting "
-                f"`rollout_fragment_length={self.n_step[1]}`. If, however, `n_step` "
-                "is `None` set `rollout_fragment_length=5`, i.e. the upper bound of "
-                "the `n_step` sampling interval the replay buffer will use."
+                f"`rollout_fragment_length={self.n_step[1]}`."
             )
 
         if self.use_state_preprocessor != DEPRECATED_VALUE:
@@ -388,9 +382,7 @@ class SACConfig(AlgorithmConfig):
     @override(AlgorithmConfig)
     def get_rollout_fragment_length(self, worker_index: int = 0) -> int:
         if self.rollout_fragment_length == "auto":
-            return (
-                self.n_step[1] if isinstance(self.n_step, tuple) else self.n_step
-            ) or 5
+            return self.n_step[1] if isinstance(self.n_step, tuple) else self.n_step
         else:
             return self.rollout_fragment_length
 

--- a/rllib/algorithms/sac/torch/sac_torch_learner.py
+++ b/rllib/algorithms/sac/torch/sac_torch_learner.py
@@ -231,7 +231,7 @@ class SACTorchLearner(SACLearner, TorchLearner):
         # backpropagate through the target network when optimizing the Q loss.
         q_selected_target = (
             batch[SampleBatch.REWARDS]
-            + (self.config.gamma**self.config.n_step) * q_next_masked
+            + (self.config.gamma ** batch["n_steps"]) * q_next_masked
         ).detach()
 
         # Calculate the TD-error. Note, this is needed for the priority weights in

--- a/rllib/core/learner/torch/torch_learner.py
+++ b/rllib/core/learner/torch/torch_learner.py
@@ -43,7 +43,7 @@ from ray.rllib.utils.typing import ModuleID, Optimizer, Param, ParamDict, Tensor
 torch, nn = try_import_torch()
 
 if torch:
-    from ray.air._internal.torch_utils import get_device
+    from ray.air._internal.torch_utils import get_devices
 
 
 logger = logging.getLogger(__name__)
@@ -303,7 +303,7 @@ class TorchLearner(Learner):
             # the user the option to run on the gpu of their choice, so we enable that
             # option here via the local gpu id scaling config parameter.
             if self._distributed:
-                devices = get_device()
+                devices = get_devices()
                 assert len(devices) == 1, (
                     "`get_devices()` should only return one cuda device, "
                     f"but {devices} was returned instead."

--- a/rllib/core/learner/torch/torch_learner.py
+++ b/rllib/core/learner/torch/torch_learner.py
@@ -43,7 +43,7 @@ from ray.rllib.utils.typing import ModuleID, Optimizer, Param, ParamDict, Tensor
 torch, nn = try_import_torch()
 
 if torch:
-    from ray.air._internal.torch_utils import get_devices
+    from ray.air._internal.torch_utils import get_device
 
 
 logger = logging.getLogger(__name__)
@@ -303,7 +303,7 @@ class TorchLearner(Learner):
             # the user the option to run on the gpu of their choice, so we enable that
             # option here via the local gpu id scaling config parameter.
             if self._distributed:
-                devices = get_devices()
+                devices = get_device()
                 assert len(devices) == 1, (
                     "`get_devices()` should only return one cuda device, "
                     f"but {devices} was returned instead."

--- a/rllib/utils/replay_buffers/prioritized_episode_replay_buffer.py
+++ b/rllib/utils/replay_buffers/prioritized_episode_replay_buffer.py
@@ -28,7 +28,8 @@ class PrioritizedEpisodeReplayBuffer(EpisodeReplayBuffer):
             capacity=capacity, batch_size_B=batch_size_B, batch_length_T=batch_length_T
         )
 
-        assert alpha > 0
+        # `alpha` should be non-negative.
+        assert alpha >= 0
         self._alpha = alpha
 
         # Initialize segment trees for the priority weights. Note, b/c the trees
@@ -215,7 +216,8 @@ class PrioritizedEpisodeReplayBuffer(EpisodeReplayBuffer):
                 be the one executed n steps before such that we always have the
                 state-action pair that triggered the rewards.
                 If `n_step` is a tuple, it is considered as a range to sample
-                from. If `None`, we sample from the range (1, 5).
+                from. If `None`, we sample from the range (1, 5). note, sampling
+                is repeated for each item in 'num_items´.
             beta: The exponent of the importance sampling weight (see Schaul et
                 al. (2016)). A `beta=0.0` does not correct for the bias introduced
                 by prioritized replay and `beta=1.0` fully corrects for it.
@@ -246,12 +248,13 @@ class PrioritizedEpisodeReplayBuffer(EpisodeReplayBuffer):
         batch_length_T = batch_length_T or self.batch_length_T
 
         # Sample the n-step if necessary.
-        if n_step is None:
-            # If ' None' we sample from the closed interval (1, 5).
-            n_step = self.rng.integers(1, 5)
-        elif isinstance(n_step, tuple):
-            # Otherwise sample from the user-defined interval.
-            n_step = self.rng.integers(n_step[0], n_step[1])
+        _random_n_step = False
+        # If `n_step` is `None` we sample from the interval (1, 5).
+        n_step = n_step or (1, 5)
+        if isinstance(n_step, tuple):
+            # Use random n-step sampling.
+            _random_n_step = True
+            _n_steps = n_step
 
         # Rows to return.
         observations = [[] for _ in range(batch_size_B)]
@@ -261,6 +264,7 @@ class PrioritizedEpisodeReplayBuffer(EpisodeReplayBuffer):
         is_terminated = [[False] * batch_length_T for _ in range(batch_size_B)]
         is_truncated = [[False] * batch_length_T for _ in range(batch_size_B)]
         weights = [[] for _ in range(batch_size_B)]
+        n_steps = [[] for _ in range(batch_size_B)]
         # If `info` should be included, construct also a container for them.
         # TODO (simon): Add also `extra_model_outs`.
         if include_infos:
@@ -300,6 +304,10 @@ class PrioritizedEpisodeReplayBuffer(EpisodeReplayBuffer):
                 index_triple[1],
             )
             episode = self.episodes[episode_idx]
+
+            # If we use random n-step sampling, draw the n-step for this item.
+            if _random_n_step:
+                n_step = int(self.rng.integers(_n_steps[0], _n_steps[1]))
             # If we are at the end of an episode, continue.
             # Note, priority sampling got us `o_(t+n)` and we need for the loss
             # calculation in addition `o_t`.
@@ -308,6 +316,8 @@ class PrioritizedEpisodeReplayBuffer(EpisodeReplayBuffer):
             # to make n-step possible.
             if episode_ts - n_step < 0:
                 continue
+            else:
+                n_steps[B].append(n_step)
 
             # Starting a new chunk.
             # Ensure that each row contains a tuple of the form:
@@ -364,6 +374,7 @@ class PrioritizedEpisodeReplayBuffer(EpisodeReplayBuffer):
             SampleBatch.TERMINATEDS: np.array(is_terminated),
             SampleBatch.TRUNCATEDS: np.array(is_truncated),
             "weights": np.array(weights),
+            "n_steps": np.array(n_steps),
         }
         if include_infos:
             ret.update(
@@ -430,7 +441,7 @@ class PrioritizedEpisodeReplayBuffer(EpisodeReplayBuffer):
             # Note, TD-errors come in as absolute values or results from
             # cross-entropy loss calculations.
             assert priority > 0
-            assert 0 <= idx < self.get_num_timesteps()
+            assert 0 <= idx < self._sum_segment.capacity
             # TODO (simon): Create metrics.
             # delta = priority**self._alpha - self._sum_segment[idx]
             # Update the priorities in the segment trees.


### PR DESCRIPTION
## Why are these changes needed?

Random n-step sampling introduces an additional source of variablity into experience replay and should therefore increase robustness.

## Related issue number

Closes #43299

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
