### PR TITLE
[Core] Release PG CPU resources for blocked worker

### DIFF
--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -973,7 +973,7 @@ void LocalTaskManager::ReleaseWorkerResources(std::shared_ptr<WorkerInterface> w
 
     // For PG, there may be two cpu resources: wildcard and indexed.
     std::vector<ResourceID> cpu_resource_ids;
-    for (const auto resource_id : allocated_instances->ResourceIds()) {
+    for (const auto &resource_id : allocated_instances->ResourceIds()) {
       if (IsCPUOrPlacementGroupCPUResource(resource_id)) {
         cpu_resource_ids.emplace_back(resource_id);
       }

--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -943,30 +943,39 @@ int64_t LocalTaskManager::TotalBacklogSize(SchedulingClass scheduling_class) {
 
 void LocalTaskManager::ReleaseWorkerResources(std::shared_ptr<WorkerInterface> worker) {
   RAY_CHECK(worker != nullptr);
-  auto allocated_instances = worker->GetAllocatedInstances();
-  if (allocated_instances != nullptr) {
-    if (worker->IsBlocked()) {
-      // If the worker is blocked, its CPU instances have already been released. We clear
-      // the CPU instances to avoid double freeing.
-      allocated_instances->Remove(ResourceID::CPU());
-    }
-    cluster_resource_scheduler_->GetLocalResourceManager().ReleaseWorkerResources(
-        worker->GetAllocatedInstances());
-    worker->ClearAllocatedInstances();
+  auto allocated_instances = worker->GetAllocatedInstances()
+                                 ? worker->GetAllocatedInstances()
+                                 : worker->GetLifetimeAllocatedInstances();
+  if (allocated_instances == nullptr) {
     return;
   }
 
-  auto lifetime_allocated_instances = worker->GetLifetimeAllocatedInstances();
-  if (lifetime_allocated_instances != nullptr) {
-    if (worker->IsBlocked()) {
-      // If the worker is blocked, its CPU instances have already been released. We clear
-      // the CPU instances to avoid double freeing.
-      lifetime_allocated_instances->Remove(ResourceID::CPU());
+  if (worker->IsBlocked()) {
+    // If the worker is blocked, its CPU instances have already been released. We clear
+    // the CPU instances to avoid double freeing.
+
+    // For PG, there may be two cpu resources: wildcard and indexed.
+    std::vector<ResourceID> cpu_resource_ids;
+    for (const auto resource_id : allocated_instances->ResourceIds()) {
+      auto possible_pg_resource = ParsePgFormattedResource(resource_id.Binary(),
+                                                           /*for_wildcard_resource*/ true,
+                                                           /*for_indexed_resource*/ true);
+      if ((resource_id == ResourceID::CPU()) ||
+          (possible_pg_resource.has_value() &&
+           possible_pg_resource->original_resource == ResourceID::CPU().Binary())) {
+        cpu_resource_ids.emplace_back(resource_id);
+      }
     }
-    cluster_resource_scheduler_->GetLocalResourceManager().ReleaseWorkerResources(
-        worker->GetLifetimeAllocatedInstances());
-    worker->ClearLifetimeAllocatedInstances();
+
+    for (const auto cpu_resource_id : cpu_resource_ids) {
+      allocated_instances->Remove(cpu_resource_id);
+    }
   }
+
+  cluster_resource_scheduler_->GetLocalResourceManager().ReleaseWorkerResources(
+      allocated_instances);
+  worker->ClearAllocatedInstances();
+  worker->ClearLifetimeAllocatedInstances();
 }
 
 bool LocalTaskManager::ReleaseCpuResourcesFromBlockedWorker(
@@ -975,17 +984,36 @@ bool LocalTaskManager::ReleaseCpuResourcesFromBlockedWorker(
     return false;
   }
 
+  bool cpu_resources_released = false;
   if (worker->GetAllocatedInstances() != nullptr) {
-    if (worker->GetAllocatedInstances()->Has(ResourceID::CPU())) {
-      auto cpu_instances = worker->GetAllocatedInstances()->GetDouble(ResourceID::CPU());
-      cluster_resource_scheduler_->GetLocalResourceManager().AddResourceInstances(
-          ResourceID::CPU(), cpu_instances);
-      worker->MarkBlocked();
-      return true;
+    for (const auto resource_id : worker->GetAllocatedInstances()->ResourceIds()) {
+      auto possible_pg_resource = ParsePgFormattedResource(resource_id.Binary(),
+                                                           /*for_wildcard_resource*/ true,
+                                                           /*for_indexed_resource*/ true);
+      if ((resource_id == ResourceID::CPU()) ||
+          (possible_pg_resource.has_value() &&
+           possible_pg_resource->original_resource == ResourceID::CPU().Binary())) {
+        auto cpu_instances = worker->GetAllocatedInstances()->GetDouble(resource_id);
+        cluster_resource_scheduler_->GetLocalResourceManager().AddResourceInstances(
+            resource_id, cpu_instances);
+        cpu_resources_released = true;
+
+        if (resource_id == ResourceID::CPU()) {
+          break;
+        } else {
+          // Cannot break since we need to release
+          // both PG wildcard and indexed CPU resources.
+        }
+      }
     }
   }
 
-  return false;
+  if (cpu_resources_released) {
+    worker->MarkBlocked();
+    return true;
+  } else {
+    return false;
+  }
 }
 
 bool LocalTaskManager::ReturnCpuResourcesToUnblockedWorker(
@@ -993,19 +1021,40 @@ bool LocalTaskManager::ReturnCpuResourcesToUnblockedWorker(
   if (!worker || !worker->IsBlocked()) {
     return false;
   }
+
+  bool cpu_resources_returned = false;
   if (worker->GetAllocatedInstances() != nullptr) {
-    if (worker->GetAllocatedInstances()->Has(ResourceID::CPU())) {
-      auto cpu_instances = worker->GetAllocatedInstances()->GetDouble(ResourceID::CPU());
-      // Important: we allow going negative here, since otherwise you can use infinite
-      // CPU resources by repeatedly blocking / unblocking a task. By allowing it to go
-      // negative, at most one task can "borrow" this worker's resources.
-      cluster_resource_scheduler_->GetLocalResourceManager().SubtractResourceInstances(
-          ResourceID::CPU(), cpu_instances, /*allow_going_negative=*/true);
-      worker->MarkUnblocked();
-      return true;
+    for (const auto resource_id : worker->GetAllocatedInstances()->ResourceIds()) {
+      auto possible_pg_resource = ParsePgFormattedResource(resource_id.Binary(),
+                                                           /*for_wildcard_resource*/ true,
+                                                           /*for_indexed_resource*/ true);
+      if ((resource_id == ResourceID::CPU()) ||
+          (possible_pg_resource.has_value() &&
+           possible_pg_resource->original_resource == ResourceID::CPU().Binary())) {
+        auto cpu_instances = worker->GetAllocatedInstances()->GetDouble(resource_id);
+        // Important: we allow going negative here, since otherwise you can use infinite
+        // CPU resources by repeatedly blocking / unblocking a task. By allowing it to go
+        // negative, at most one task can "borrow" this worker's resources.
+        cluster_resource_scheduler_->GetLocalResourceManager().SubtractResourceInstances(
+            resource_id, cpu_instances, /*allow_going_negative=*/true);
+        cpu_resources_returned = true;
+
+        if (resource_id == ResourceID::CPU()) {
+          break;
+        } else {
+          // Cannot break since we need to return
+          // both PG wildcard and indexed CPU resources.
+        }
+      }
     }
   }
-  return false;
+
+  if (cpu_resources_returned) {
+    worker->MarkUnblocked();
+    return true;
+  } else {
+    return false;
+  }
 }
 
 ResourceSet LocalTaskManager::CalcNormalTaskResources() const {
@@ -1028,7 +1077,17 @@ ResourceSet LocalTaskManager::CalcNormalTaskResources() const {
       auto resource_set = allocated_instances->ToResourceSet();
       // Blocked normal task workers have temporarily released its allocated CPU.
       if (worker->IsBlocked()) {
-        resource_set.Set(ResourceID::CPU(), 0);
+        for (const auto resource_id : allocated_instances->ResourceIds()) {
+          auto possible_pg_resource =
+              ParsePgFormattedResource(resource_id.Binary(),
+                                       /*for_wildcard_resource*/ true,
+                                       /*for_indexed_resource*/ true);
+          if ((resource_id == ResourceID::CPU()) ||
+              (possible_pg_resource.has_value() &&
+               possible_pg_resource->original_resource == ResourceID::CPU().Binary())) {
+            resource_set.Set(resource_id, 0);
+          }
+        }
       }
       total_normal_task_resources += resource_set;
     }

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -570,8 +570,18 @@ TEST_F(ClusterTaskManagerTest, BlockedWorkerDiesTest) {
    Tests the edge case in which a worker crashes while it's blocked. In this case, its CPU
    resources should not be double freed.
    */
-  RayTask task = CreateTask({{ray::kCPU_ResourceLabel, 4}});
-  rpc::RequestWorkerLeaseReply reply;
+
+  // Add PG CPU and GPU resources.
+  scheduler_->GetLocalResourceManager().AddLocalResourceInstances(
+      scheduling::ResourceID("CPU_group_aaa"), std::vector<FixedPoint>{FixedPoint(1)});
+  scheduler_->GetLocalResourceManager().AddLocalResourceInstances(
+      scheduling::ResourceID("CPU_group_0_aaa"), std::vector<FixedPoint>{FixedPoint(1)});
+
+  RayTask task1 = CreateTask({{ray::kCPU_ResourceLabel, 4}});
+  rpc::RequestWorkerLeaseReply reply1;
+  RayTask task2 = CreateTask({{"CPU_group_aaa", 1}, {"CPU_group_0_aaa", 1}});
+  rpc::RequestWorkerLeaseReply reply2;
+
   bool callback_occurred = false;
   bool *callback_occurred_ptr = &callback_occurred;
   auto callback = [callback_occurred_ptr](
@@ -579,33 +589,47 @@ TEST_F(ClusterTaskManagerTest, BlockedWorkerDiesTest) {
     *callback_occurred_ptr = true;
   };
 
-  task_manager_.QueueAndScheduleTask(task, false, false, &reply, callback);
+  task_manager_.QueueAndScheduleTask(task1, false, false, &reply1, callback);
   pool_.TriggerCallbacks();
 
   ASSERT_FALSE(callback_occurred);
   ASSERT_EQ(leased_workers_.size(), 0);
   ASSERT_EQ(pool_.workers.size(), 0);
 
-  std::shared_ptr<MockWorker> worker =
+  std::shared_ptr<MockWorker> worker1 =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
-  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker));
+  std::shared_ptr<MockWorker> worker2 =
+      std::make_shared<MockWorker>(WorkerID::FromRandom(), 5678);
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker1));
 
   task_manager_.ScheduleAndDispatchTasks();
   pool_.TriggerCallbacks();
 
+  task_manager_.QueueAndScheduleTask(task2, false, false, &reply2, callback);
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker2));
+  task_manager_.ScheduleAndDispatchTasks();
+  pool_.TriggerCallbacks();
+
   ASSERT_TRUE(callback_occurred);
-  ASSERT_EQ(leased_workers_.size(), 1);
+  ASSERT_EQ(leased_workers_.size(), 2);
   ASSERT_EQ(pool_.workers.size(), 0);
   ASSERT_EQ(node_info_calls_, 0);
 
   // Block the worker. Which releases only the CPU resource.
-  local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker);
+  local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker1);
+  local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker2);
 
-  RayTask finished_task;
+  RayTask finished_task1;
+  RayTask finished_task2;
   // If a resource was double-freed, we will crash in this call.
-  local_task_manager_->TaskFinished(leased_workers_.begin()->second, &finished_task);
-  ASSERT_EQ(finished_task.GetTaskSpecification().TaskId(),
-            task.GetTaskSpecification().TaskId());
+  local_task_manager_->TaskFinished(leased_workers_[worker1->WorkerId()],
+                                    &finished_task1);
+  local_task_manager_->TaskFinished(leased_workers_[worker2->WorkerId()],
+                                    &finished_task2);
+  ASSERT_EQ(finished_task1.GetTaskSpecification().TaskId(),
+            task1.GetTaskSpecification().TaskId());
+  ASSERT_EQ(finished_task2.GetTaskSpecification().TaskId(),
+            task2.GetTaskSpecification().TaskId());
 
   AssertNoLeaks();
 }
@@ -1768,16 +1792,28 @@ TEST_F(ClusterTaskManagerTest, FeasibleToNonFeasible) {
 }
 
 TEST_F(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources) {
+  // Add PG CPU and GPU resources.
+  scheduler_->GetLocalResourceManager().AddLocalResourceInstances(
+      scheduling::ResourceID("CPU_group_aaa"), std::vector<FixedPoint>{FixedPoint(1)});
+  scheduler_->GetLocalResourceManager().AddLocalResourceInstances(
+      scheduling::ResourceID("CPU_group_0_aaa"), std::vector<FixedPoint>{FixedPoint(1)});
+  scheduler_->GetLocalResourceManager().AddLocalResourceInstances(
+      scheduling::ResourceID("GPU_group_aaa"), std::vector<FixedPoint>{FixedPoint(1)});
+  scheduler_->GetLocalResourceManager().AddLocalResourceInstances(
+      scheduling::ResourceID("GPU_group_0_aaa"), std::vector<FixedPoint>{FixedPoint(1)});
+
   const NodeResources &node_resources =
       scheduler_->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(id_.Binary()));
   ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
   ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 4);
 
-  auto worker = std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
+  auto worker1 = std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
+  auto worker2 = std::make_shared<MockWorker>(WorkerID::FromRandom(), 5678);
 
   // Check failed as the worker has no allocated resource instances.
-  ASSERT_FALSE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker));
+  ASSERT_FALSE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker1));
+  ASSERT_FALSE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker2));
 
   auto node_resource_instances =
       scheduler_->GetLocalResourceManager().GetLocalResources();
@@ -1785,43 +1821,78 @@ TEST_F(ClusterTaskManagerTestWithGPUsAtHead, RleaseAndReturnWorkerCpuResources) 
       node_resource_instances.GetAvailableResourceInstances();
 
   auto allocated_instances = std::make_shared<TaskResourceInstances>();
-  const absl::flat_hash_map<std::string, double> task_spec = {{"CPU", 1.}, {"GPU", 1.}};
+  absl::flat_hash_map<std::string, double> task_spec = {{"CPU", 1.}, {"GPU", 1.}};
   ASSERT_TRUE(scheduler_->GetLocalResourceManager().AllocateLocalTaskResources(
       task_spec, allocated_instances));
-  worker->SetAllocatedInstances(allocated_instances);
+  worker1->SetAllocatedInstances(allocated_instances);
+
+  allocated_instances = std::make_shared<TaskResourceInstances>();
+  task_spec = {{"CPU_group_aaa", 1.},
+               {"CPU_group_0_aaa", 1.},
+               {"GPU_group_aaa", 1.},
+               {"GPU_group_0_aaa", 1.}};
+  ASSERT_TRUE(scheduler_->GetLocalResourceManager().AllocateLocalTaskResources(
+      task_spec, allocated_instances));
+  worker2->SetAllocatedInstances(allocated_instances);
 
   // Check that the resoruces are allocated successfully.
   ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
   ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Check that the cpu resources are released successfully.
-  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker));
+  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker1));
+  ASSERT_TRUE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker2));
 
   // Check that only cpu resources are released.
   ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
   ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 1);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 1);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Mark worker as blocked.
-  worker->MarkBlocked();
+  worker1->MarkBlocked();
+  worker2->MarkBlocked();
   // Check failed as the worker is blocked.
-  ASSERT_FALSE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker));
+  ASSERT_FALSE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker1));
+  ASSERT_FALSE(local_task_manager_->ReleaseCpuResourcesFromBlockedWorker(worker2));
   // Check nothing will be changed.
   ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
   ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 1);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 1);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Check that the cpu resources are returned back to worker successfully.
-  ASSERT_TRUE(local_task_manager_->ReturnCpuResourcesToUnblockedWorker(worker));
+  ASSERT_TRUE(local_task_manager_->ReturnCpuResourcesToUnblockedWorker(worker1));
+  ASSERT_TRUE(local_task_manager_->ReturnCpuResourcesToUnblockedWorker(worker2));
 
   // Check that only cpu resources are returned back to the worker.
   ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
   ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Mark worker as unblocked.
-  worker->MarkUnblocked();
-  ASSERT_FALSE(local_task_manager_->ReturnCpuResourcesToUnblockedWorker(worker));
+  worker1->MarkUnblocked();
+  worker2->MarkUnblocked();
+  ASSERT_FALSE(local_task_manager_->ReturnCpuResourcesToUnblockedWorker(worker1));
+  ASSERT_FALSE(local_task_manager_->ReturnCpuResourcesToUnblockedWorker(worker2));
   // Check nothing will be changed.
   ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
   ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 }
 
 TEST_F(ClusterTaskManagerTest, TestSpillWaitingTasks) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently we release CPU resource when a worker process is blocked on `ray.get()`, however this doesn't work if the CPU resource is inside a PG and this PR fixes it.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #40925
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
