### PR TITLE
[ray dashboard] Serve deployment page not loading UI bug fix 

### DIFF
--- a/dashboard/client/src/components/MetadataSection/MetadataSection.component.test.tsx
+++ b/dashboard/client/src/components/MetadataSection/MetadataSection.component.test.tsx
@@ -27,6 +27,24 @@ describe("MetadataContentField", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the content string if link is undefined", () => {
+    expect.assertions(4);
+
+    render(
+      <MetadataContentField
+        content={{ value: CONTENT_VALUE, link: undefined }}
+        label="test-label"
+      />,
+    );
+
+    expect(screen.getByText(CONTENT_VALUE)).toBeInTheDocument();
+    expect(screen.getByText(CONTENT_VALUE)).not.toHaveAttribute("href");
+    expect(screen.queryByLabelText(COPY_BUTTON_LABEL)).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("metadata-content-for-test-label"),
+    ).toBeInTheDocument();
+  });
+
   it("renders the content string with label", () => {
     expect.assertions(4);
 

--- a/dashboard/client/src/components/MetadataSection/MetadataSection.tsx
+++ b/dashboard/client/src/components/MetadataSection/MetadataSection.tsx
@@ -119,7 +119,9 @@ export const MetadataContentField: React.FC<{
   );
 
   if (content === undefined || "value" in content) {
-    return content === undefined || !("link" in content) || content.link === undefined ? (
+    return content === undefined ||
+      !("link" in content) ||
+      content.link === undefined ? (
       <div className={classes.contentContainer}>
         <Typography
           className={classes.content}

--- a/dashboard/client/src/components/MetadataSection/MetadataSection.tsx
+++ b/dashboard/client/src/components/MetadataSection/MetadataSection.tsx
@@ -119,7 +119,7 @@ export const MetadataContentField: React.FC<{
   );
 
   if (content === undefined || "value" in content) {
-    return content === undefined || !("link" in content) ? (
+    return content === undefined || !("link" in content) || content.link === undefined ? (
       <div className={classes.contentContainer}>
         <Typography
           className={classes.content}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Fixes bug where the serve deployment detail page fails to load if the deployment is in "Starting" state

**Manual Testing:**
- Create and run serve deployment with infeasible resources so the deployment remains in the "Starting" state
- Before this PR clicking an individual deployment from the "Serve" tab would not load. Fixed with this PR.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
