### PR TITLE
[KubeRay] add docs about KubeRay API compatibility

### DIFF
--- a/doc/source/cluster/kubernetes/references.md
+++ b/doc/source/cluster/kubernetes/references.md
@@ -7,4 +7,11 @@ the {ref}`configuration guide <kuberay-config>`.
 For comprehensive coverage of all supported RayCluster fields,
 refer to the [API reference][APIReference].
 
+## KubeRay API compatibility and guarantees
+
+v1 APIs in the KubeRay project are stable and suitable for production environments.
+While KubeRay maintainers strive to maintain backward compatibility, they reserve the right to deprecate API fields.
+They will clearly communicate the deprecation status, and may remove the APIs after a minimum of two minor releases.
+This policy allows for the necessary evolution of the API while providing a reasonable transition period for users.
+
 [APIReference]: https://ray-project.github.io/kuberay/reference/api/


### PR DESCRIPTION
## Why are these changes needed?

Now that KubeRay v1 APIs have been released for a while, it would be good to officially document the intended uses and guarentes for v1. 

Per discussion with @kevin85421 -- we want to let users know that these APIs can be used in production, but we don't necessarily want users thinking fields will never be removed. This PR adds some documentation to clarify the current guarentees.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
