### PR TITLE
[Data] Increase timeout for `iter_tensor_batches_benchmark_multi_node` release test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5977,8 +5977,8 @@
     cluster_compute: multi_node_benchmark_compute.yaml
 
   run:
-    # Expect the benchmark to finish around 30 minutes.
-    timeout: 2400
+    # Expect the benchmark to finish around 60 minutes.
+    timeout: 3600
     script: python iter_tensor_batches_benchmark.py --data-size-gb=10
 
   variations:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5977,8 +5977,8 @@
     cluster_compute: multi_node_benchmark_compute.yaml
 
   run:
-    # Expect the benchmark to finish around 60 minutes.
-    timeout: 3600
+    # Expect the benchmark to finish within 90 minutes.
+    timeout: 5400
     script: python iter_tensor_batches_benchmark.py --data-size-gb=10
 
   variations:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
https://github.com/ray-project/ray/pull/42580 updated the `iter_tensor_batches_benchmark_multi_node` release test to correctly test the Ray Data functionality, but this results in the test taking longer to run (and rightfully so, since the test now correctly iterates over the dataset). We need to increase the timeout of the release test accordingly.

## Related issue number
Fixes #42646

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
