### PR TITLE
[Data] Refine estimate of object store memory usage from pending task outputs

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -178,18 +178,27 @@ class OpRuntimeMetrics:
 
         If an estimate isn't available, this property returns ``None``.
         """
+        per_task_output = self.obj_store_mem_max_pending_output_per_task
+        if per_task_output is None:
+            return None
+        return self.num_tasks_running * per_task_output
+
+    def obj_store_mem_max_pending_output_per_task(self) -> Optional[float]:
+        """Estimated size in bytes of output blocks in a task's generator buffer."""
         context = ray.data.DataContext.get_current()
         if context._max_num_blocks_in_streaming_gen_buffer is None:
             return None
 
-        estimated_bytes_per_output = (
+        bytes_per_output = (
             self.average_bytes_per_output or context.target_max_block_size
         )
-        return (
-            self.num_tasks_running
-            * estimated_bytes_per_output
-            * context._max_num_blocks_in_streaming_gen_buffer
-        )
+
+        num_pending_outputs = context._max_num_blocks_in_streaming_gen_buffer
+        if self.average_num_outputs_per_task is not None:
+            num_pending_outputs = min(
+                num_pending_outputs, self.average_num_outputs_per_task
+            )
+        return bytes_per_output * num_pending_outputs
 
     @property
     def average_bytes_inputs_per_task(self) -> Optional[float]:

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -3,9 +3,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import ray
 from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
-from ray.data._internal.execution.operators.actor_pool_map_operator import (
-    ActorPoolMapOperator,
-)
 from ray.data._internal.memory_tracing import trace_allocation
 
 if TYPE_CHECKING:
@@ -188,6 +185,10 @@ class OpRuntimeMetrics:
         # Ray Data launches multiple tasks per actor, but only one task runs at a
         # time per actor. So, the number of actually running tasks is capped by the
         # number of active actors.
+        from ray.data._internal.execution.operators.actor_pool_map_operator import (
+            ActorPoolMapOperator,
+        )
+
         num_tasks_running = self.num_tasks_running
         if isinstance(self._op, ActorPoolMapOperator):
             num_tasks_running = min(

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -197,6 +197,7 @@ class OpRuntimeMetrics:
 
         return num_tasks_running * per_task_output
 
+    @property
     def obj_store_mem_max_pending_output_per_task(self) -> Optional[float]:
         """Estimated size in bytes of output blocks in a task's generator buffer."""
         context = ray.data.DataContext.get_current()

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -198,7 +198,9 @@ def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_co
         _mul2_map_data_prcessor,
         input_op=input_op,
         name="TestMapper",
-        compute_strategy=ActorPoolStrategy(min_size=2, max_size=10),
+        compute_strategy=ActorPoolStrategy(
+            min_size=2, max_size=10, max_tasks_in_flight_per_actor=2
+        ),
     )
     op.start(ExecutionOptions())
 
@@ -241,7 +243,7 @@ def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_co
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(3200, rel=0.5)
     assert op.metrics.obj_store_mem_pending_task_outputs == pytest.approx(
-        4  # Number of active tasks (with two tasks in flight per actor)
+        2  # We launched 4 tasks across 2 actor, but only 2 tasks run at a time
         * ctx._max_num_blocks_in_streaming_gen_buffer
         * ctx.target_max_block_size,
         rel=0.5,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ray Core buffers blocks produced by running tasks. To estimate the amount of object store usage from buffered blocks, we use the following formula:
https://github.com/ray-project/ray/blob/de439b4114f1a12e78e084ea09b05eff217d32bc/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py#L189-L191

This expression is an overestimation because of the following reasons:
1. `num_tasks_running` represents the number of _launched_ tasks, not the number of actually running tasks. This is especially an issue with `ActorPoolMapOperator`, because we launch multiple tasks per actor, but only one task runs at at time per actor.
2. `context._max_num_blocks_in_streaming_gen_buffer` the _maximum_ number of buffered blocks, not the typical number of buffered blocks. Often, tasks only produce one output, so the number of buffered outputs is at most one.

This PR addresses the two issues described above.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
