### PR TITLE
[ci] fix get release blockers

### DIFF
--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -38,7 +38,6 @@ class TestStateMachine(abc.ABC):
     ...
     """
 
-    ray_user = None
     ray_repo = None
     ray_buildkite = None
 
@@ -61,12 +60,6 @@ class TestStateMachine(abc.ABC):
         return Github(get_secret_token(AWS_SECRET_GITHUB))
 
     @classmethod
-    def get_ray_user(cls):
-        if not cls.ray_user:
-            cls.ray_user = cls.get_github().get_user()
-        return cls.ray_user
-
-    @classmethod
     def get_ray_repo(cls):
         cls._init_ray_repo()
         return cls.ray_repo
@@ -80,10 +73,10 @@ class TestStateMachine(abc.ABC):
 
     @classmethod
     def get_release_blockers(cls) -> List[github.Issue.Issue]:
-        user = cls.get_ray_user()
-        blocker_label = cls.get_ray_repo().get_label(WEEKLY_RELEASE_BLOCKER_TAG)
+        repo = cls.get_ray_repo()
+        blocker_label = repo.get_label(WEEKLY_RELEASE_BLOCKER_TAG)
 
-        return user.get_issues(state="open", labels=[blocker_label])
+        return repo.get_issues(state="open", labels=[blocker_label])
 
     @classmethod
     def get_issue_owner(cls, issue: github.Issue.Issue) -> str:

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -65,19 +65,6 @@ class MockIssueDB:
     issue_db = {}
 
 
-class MockUser:
-    def get_issues(self, state: str, labels: List[MockLabel]) -> List[MockIssue]:
-        issues = []
-        for issue in MockIssueDB.issue_db.values():
-            if issue.state != state:
-                continue
-            issue_labels = [label.name for label in issue.labels]
-            if all(label.name in issue_labels for label in labels):
-                issues.append(issue)
-
-        return issues
-
-
 class MockRepo:
     def create_issue(self, labels: List[str], title: str, *args, **kwargs):
         label_objs = [MockLabel(label) for label in labels]
@@ -88,6 +75,17 @@ class MockRepo:
 
     def get_issue(self, number: int):
         return MockIssueDB.issue_db[number]
+
+    def get_issues(self, state: str, labels: List[MockLabel]) -> List[MockIssue]:
+        issues = []
+        for issue in MockIssueDB.issue_db.values():
+            if issue.state != state:
+                continue
+            issue_labels = [label.name for label in issue.labels]
+            if all(label.name in issue_labels for label in labels):
+                issues.append(issue)
+
+        return issues
 
     def get_label(self, name: str):
         return MockLabel(name)
@@ -117,7 +115,6 @@ class MockBuildkite:
         return MockBuildkiteJob()
 
 
-TestStateMachine.ray_user = MockUser()
 TestStateMachine.ray_repo = MockRepo()
 TestStateMachine.ray_buildkite = MockBuildkite()
 


### PR DESCRIPTION
Fix the logic to get release blockers. The current logic only get release blockers assigned to a specific user. Get all release blockers instead.

Test:
- CI
- bazel run //ci/ray_ci/automation:weekly_green_metric