### PR TITLE
[RLlib] Issue 42152: `__common__` in multi-agent env infos dict breaks env pre-checker.

### DIFF
--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -376,7 +376,7 @@ def check_multiagent_environments(env: "MultiAgentEnv") -> None:
     _check_if_element_multi_agent_dict(env, reward, "step, reward")
     _check_if_element_multi_agent_dict(env, done, "step, done")
     _check_if_element_multi_agent_dict(env, truncated, "step, truncated")
-    _check_if_element_multi_agent_dict(env, info, "step, info")
+    _check_if_element_multi_agent_dict(env, info, "step, info", allow_common=True)
     _check_reward(
         {"dummy_env_id": reward}, base_env=True, agent_ids=env.get_agent_ids()
     )
@@ -699,7 +699,11 @@ def _check_info(info, base_env=False, agent_ids=None):
                         "Your step function must return infos that are a dict. "
                         f"instead was a {type(inf)}: element: {inf}"
                     )
-                if not (agent_id in agent_ids or agent_id == "__all__"):
+                if not (
+                    agent_id in agent_ids
+                    or agent_id == "__all__"
+                    or agent_id == "__common__"
+                ):
                     error = (
                         f"Your dones dictionary must have agent ids that belong to "
                         f"the environment. Agent_ids recieved from "
@@ -745,7 +749,13 @@ def _check_if_multi_env_dict(env, element, function_string):
         )
 
 
-def _check_if_element_multi_agent_dict(env, element, function_string, base_env=False):
+def _check_if_element_multi_agent_dict(
+    env,
+    element,
+    function_string,
+    base_env=False,
+    allow_common=False,
+):
     if not isinstance(element, dict):
         if base_env:
             error = (
@@ -762,6 +772,8 @@ def _check_if_element_multi_agent_dict(env, element, function_string, base_env=F
         raise ValueError(error)
     agent_ids: Set = copy(env.get_agent_ids())
     agent_ids.add("__all__")
+    if allow_common:
+        agent_ids.add("__common__")
 
     if not all(k in agent_ids for k in element):
         if base_env:

--- a/rllib/utils/pre_checks/env.py
+++ b/rllib/utils/pre_checks/env.py
@@ -706,7 +706,7 @@ def _check_info(info, base_env=False, agent_ids=None):
                 ):
                     error = (
                         f"Your dones dictionary must have agent ids that belong to "
-                        f"the environment. Agent_ids recieved from "
+                        f"the environment. Agent_ids received from "
                         f"env.get_agent_ids() are: {agent_ids}"
                     )
                     raise ValueError(error)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Issue 42152: `__common__` in multi-agent env infos dict breaks env pre-checker.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Closes #42152 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
