### PR TITLE
[serve] Fix flaky `test_standalone_3.py`

### DIFF
--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -224,29 +224,30 @@ def test_handle_early_detect_failure(shutdown_ray):
     It should detect replica raises ActorError and take them out of the replicas set.
     """
 
-    @serve.deployment(num_replicas=2, max_concurrent_queries=1)
-    def f(do_crash: bool = False):
-        if do_crash:
-            os._exit(1)
-        return os.getpid()
+    try:
+        @serve.deployment(num_replicas=2, max_concurrent_queries=1)
+        def f(do_crash: bool = False):
+            if do_crash:
+                os._exit(1)
+            return os.getpid()
 
-    handle = serve.run(f.bind())
-    pids = ray.get([handle.remote()._to_object_ref_sync() for _ in range(2)])
-    assert len(set(pids)) == 2
+        handle = serve.run(f.bind())
+        responses = [handle.remote() for _ in range(10)]
+        assert len(set(r.result() for r in responses)) == 2
 
-    client = _get_global_client()
-    # Kill the controller so that the replicas membership won't be updated
-    # through controller health check + long polling.
-    ray.kill(client._controller, no_restart=True)
+        client = _get_global_client()
+        # Kill the controller so that the replicas membership won't be updated
+        # through controller health check + long polling.
+        ray.kill(client._controller, no_restart=True)
 
-    with pytest.raises(RayActorError):
-        handle.remote(do_crash=True).result()
+        with pytest.raises(RayActorError):
+            handle.remote(do_crash=True).result()
 
-    pids = ray.get([handle.remote()._to_object_ref_sync() for _ in range(10)])
-    assert len(set(pids)) == 1
-
-    # Restart the controller, and then clean up all the replicas
-    serve.shutdown()
+        responses = [handle.remote() for _ in range(10)]
+        assert len(set(r.result() for r in responses)) == 1
+    finally:
+        # Restart the controller, and then clean up all the replicas.
+        serve.shutdown()
 
 
 def test_autoscaler_shutdown_node_http_everynode(

--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -225,6 +225,7 @@ def test_handle_early_detect_failure(shutdown_ray):
     """
 
     try:
+
         @serve.deployment(num_replicas=2, max_concurrent_queries=1)
         def f(do_crash: bool = False):
             if do_crash:

--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -234,7 +234,7 @@ def test_handle_early_detect_failure(shutdown_ray):
 
         handle = serve.run(f.bind())
         responses = [handle.remote() for _ in range(10)]
-        assert len(set(r.result() for r in responses)) == 2
+        assert len({r.result() for r in responses}) == 2
 
         client = _get_global_client()
         # Kill the controller so that the replicas membership won't be updated
@@ -245,7 +245,7 @@ def test_handle_early_detect_failure(shutdown_ray):
             handle.remote(do_crash=True).result()
 
         responses = [handle.remote() for _ in range(10)]
-        assert len(set(r.result() for r in responses)) == 1
+        assert len({r.result() for r in responses}) == 1
     finally:
         # Restart the controller, and then clean up all the replicas.
         serve.shutdown()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Saw this flake on my PR. Adding more requests for higher likelihood both replicas are hit, and adding a `finally` block in case the test fails.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
