### PR TITLE
[serve] Fix redundant `request_id` in log message

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1066,8 +1066,8 @@ class UserCallableWrapper:
         self._raise_if_not_initialized("call_user_method")
 
         logger.info(
-            f"Started executing request {request_metadata.request_id}",
-            extra={"log_to_stderr": False, "serve_access_log": True},
+            f"Started executing request to method '{request_metadata.call_method}'.",
+            extra={"log_to_stderr": True, "serve_access_log": True},
         )
 
         result = None

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1067,7 +1067,7 @@ class UserCallableWrapper:
 
         logger.info(
             f"Started executing request to method '{request_metadata.call_method}'.",
-            extra={"log_to_stderr": True, "serve_access_log": True},
+            extra={"log_to_stderr": False, "serve_access_log": True},
         )
 
         result = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Request ID is already in the metadata.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
