### PR TITLE
[Data] Hard deprecate `num_blocks` parameter of `random_shuffle`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1044,11 +1044,10 @@ class Dataset:
         """  # noqa: E501
 
         if num_blocks is not None:
-            warnings.warn(
+            raise DeprecationWarning(
                 "`num_blocks` parameter is deprecated in Ray 2.9. random_shuffle() "
                 "does not support to change the number of output blocks. Use "
                 "repartition() instead.",  # noqa: E501
-                DeprecationWarning,
             )
         plan = self._plan.copy()
         op = RandomShuffle(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We soft deprecated the `num_blocks` parameter of `Dataset.random_shuffle` in Ray 2.9 in favor of `Dataset.repartition`. This PR hard deprecates the parameter for Ray 2.10.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
