### PR TITLE
[Data] Fix `RowBasedFileDatasink` example

### DIFF
--- a/python/ray/data/datasource/file_datasink.py
+++ b/python/ray/data/datasource/file_datasink.py
@@ -156,7 +156,6 @@ class RowBasedFileDatasink(_FileDatasink):
 
             from ray.data.datasource import RowBasedFileDatasink
 
-
             class ImageDatasink(RowBasedFileDatasink):
                 def __init__(self, path: str, *, column: str, file_format: str = "png"):
                     super().__init__(path, file_format=file_format)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `RowBasedFileDatasink` erroneously illustrates how to extend `FileBasedDatasource` rather than `RowBasedFileDatasink`. This PR updates the docstring with an appropriate example.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
