### PR TITLE
[Data] Update guidance on controlling number of written files

### DIFF
--- a/doc/source/data/saving-data.rst
+++ b/doc/source/data/saving-data.rst
@@ -131,8 +131,13 @@ To write data to formats other than Parquet, read the
 Changing the number of output files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you call a write method, Ray Data writes your data to one file per :term:`block`.
-To change the number of blocks, call :meth:`~ray.data.Dataset.repartition`.
+When you call a write method, Ray Data writes your data to several files. To control the
+number of output files, configure ``num_rows_per_file``.
+
+.. note::
+
+    ``num_rows_per_file`` is a hint, not a strict limit. Ray Data might write more or 
+    fewer rows to each file.
 
 .. testcode::
 
@@ -140,15 +145,14 @@ To change the number of blocks, call :meth:`~ray.data.Dataset.repartition`.
     import ray
 
     ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
-    ds.repartition(2).write_csv("/tmp/two_files/")
+    ds.write_csv("/tmp/few_files/", num_rows_per_file=75)
 
-    print(os.listdir("/tmp/two_files/"))
+    print(os.listdir("/tmp/few_files/"))
 
 .. testoutput::
     :options: +MOCK
 
-    ['26b07dba90824a03bb67f90a1360e104_000003.csv', '26b07dba90824a03bb67f90a1360e104_000002.csv']
-
+    ['0_000001_000000.csv', '0_000000_000000.csv', '0_000002_000000.csv']                                                          
 
 Converting Datasets to other Python libraries
 =============================================


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

https://github.com/ray-project/ray/pull/42694 introduced a `num_rows_per_file` parameter to write APIs. With the introduction of this API, users don't need to call `Dataset.repartition` to control the number of output files. This PR updates the documentation accordingly.

`num_rows_per_file` is preferable to `repartition` for a couple of reasons:
* It doesn't expose _blocks_ (an internal concept)
* It doesn't materialize all of the data in memory

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
