### PR TITLE
[Data] Remove dead `batch_block_refs` function

### DIFF
--- a/python/ray/data/_internal/block_batching/__init__.py
+++ b/python/ray/data/_internal/block_batching/__init__.py
@@ -1,6 +1,3 @@
-from ray.data._internal.block_batching.block_batching import (
-    batch_block_refs,
-    batch_blocks,
-)
+from ray.data._internal.block_batching.block_batching import batch_blocks
 
-__all__ = ["batch_blocks", "batch_block_refs"]
+__all__ = ["batch_blocks"

--- a/python/ray/data/_internal/block_batching/__init__.py
+++ b/python/ray/data/_internal/block_batching/__init__.py
@@ -1,3 +1,3 @@
 from ray.data._internal.block_batching.block_batching import batch_blocks
 
-__all__ = ["batch_blocks"
+__all__ = ["batch_blocks"]

--- a/python/ray/data/_internal/block_batching/block_batching.py
+++ b/python/ray/data/_internal/block_batching/block_batching.py
@@ -1,23 +1,18 @@
 import collections
 import itertools
 from contextlib import nullcontext
-from typing import Any, Callable, Iterator, Optional, TypeVar
+from typing import Callable, Iterator, Optional, TypeVar
 
-import ray
 from ray.data._internal.block_batching.interfaces import BlockPrefetcher
 from ray.data._internal.block_batching.util import (
-    ActorBlockPrefetcher,
-    WaitBlockPrefetcher,
     blocks_to_batches,
     collate,
     extract_data_from_batch,
     format_batches,
-    resolve_block_refs,
 )
 from ray.data._internal.memory_tracing import trace_deallocation
 from ray.data._internal.stats import DatasetStats
 from ray.data.block import Block, DataBatch
-from ray.data.context import DataContext
 from ray.types import ObjectRef
 
 T = TypeVar("T")

--- a/python/ray/data/_internal/block_batching/block_batching.py
+++ b/python/ray/data/_internal/block_batching/block_batching.py
@@ -23,91 +23,6 @@ from ray.types import ObjectRef
 T = TypeVar("T")
 
 
-def batch_block_refs(
-    block_refs: Iterator[ObjectRef[Block]],
-    *,
-    stats: Optional[DatasetStats] = None,
-    prefetch_blocks: int = 0,
-    clear_block_after_read: bool = False,
-    batch_size: Optional[int] = None,
-    batch_format: str = "default",
-    drop_last: bool = False,
-    collate_fn: Optional[Callable[[DataBatch], Any]] = None,
-    shuffle_buffer_min_size: Optional[int] = None,
-    shuffle_seed: Optional[int] = None,
-    ensure_copy: bool = False,
-) -> Iterator[DataBatch]:
-    """Create formatted batches of data from 1 or more block object references.
-
-    This takes a block iterator and creates batch_size batches, slicing,
-    unioning, shuffling, prefetching, and formatting blocks as needed.
-
-    This is used by both Dataset.iter_batches() and Dataset.map_batches().
-
-    Args:
-        block_refs: An iterator over block object references.
-        prefetch_blocks: The number of blocks to prefetch ahead of the
-            current block during the scan.
-        clear_block_after_read: Whether to clear the block from object store
-            manually (i.e. without waiting for Python's automatic GC) after it
-            is read. Doing so will reclaim memory faster and hence reduce the
-            memory footprint. However, the caller has to ensure the safety, i.e.
-            the block will never be accessed again.
-        batch_size: Record batch size, or None to let the system pick.
-        batch_format: The format in which to return each batch.
-            Specify "default" to use the current block format (promoting
-            Arrow to pandas automatically), "pandas" to
-            select ``pandas.DataFrame`` or "pyarrow" to select
-            ``pyarrow.Table``. Default is "default".
-        drop_last: Whether to drop the last batch if it's incomplete.
-        collate_fn: A function to apply to each data batch before returning it.
-        shuffle_buffer_min_size: If non-None, the data will be randomly shuffled using a
-            local in-memory shuffle buffer, and this value will serve as the minimum
-            number of rows that must be in the local in-memory shuffle buffer in order
-            to yield a batch.
-        shuffle_seed: The seed to use for the local random shuffle.
-        ensure_copy: Whether batches are always copied from the underlying base
-            blocks (not zero-copy views).
-
-    Returns:
-        An iterator over record batches.
-    """
-    context = DataContext.get_current()
-
-    if (
-        prefetch_blocks > 0
-        and context.actor_prefetcher_enabled
-        and not ray.util.client.ray.is_connected()
-    ):
-        prefetcher = ActorBlockPrefetcher()
-    else:
-        prefetcher = WaitBlockPrefetcher()
-
-    eager_free = clear_block_after_read and DataContext.get_current().eager_free
-
-    block_iter = resolve_block_refs(
-        _prefetch_blocks(
-            block_ref_iter=block_refs,
-            prefetcher=prefetcher,
-            num_blocks_to_prefetch=prefetch_blocks,
-            eager_free=eager_free,
-        ),
-        stats=stats,
-    )
-
-    yield from batch_blocks(
-        block_iter,
-        stats=stats,
-        batch_size=batch_size,
-        batch_format=batch_format,
-        drop_last=drop_last,
-        collate_fn=collate_fn,
-        shuffle_buffer_min_size=shuffle_buffer_min_size,
-        shuffle_seed=shuffle_seed,
-        ensure_copy=ensure_copy,
-    )
-
-
 def batch_blocks(
     blocks: Iterator[Block],
     *,
@@ -122,9 +37,8 @@ def batch_blocks(
 ) -> Iterator[DataBatch]:
     """Create formatted batches of data from 1 or more blocks.
 
-    This is equivalent to batch_block_refs, except
-    it takes in an iterator consisting of already fetched blocks.
-    This means that this function does not support block prefetching.
+    This function takes in an iterator of already fetched blocks. Consequently, this
+    function doesn't support block prefetching.
     """
 
     def _iterator_fn(base_iterator: Iterator[Block]) -> Iterator[DataBatch]:

--- a/python/ray/data/tests/block_batching/test_block_batching.py
+++ b/python/ray/data/tests/block_batching/test_block_batching.py
@@ -7,7 +7,6 @@ import pytest
 from ray.data._internal.block_batching.block_batching import (
     BlockPrefetcher,
     _prefetch_blocks,
-    batch_block_refs,
     batch_blocks,
 )
 from ray.data.block import Block
@@ -16,20 +15,6 @@ from ray.data.block import Block
 def block_generator(num_rows: int, num_blocks: int):
     for _ in range(num_blocks):
         yield pa.table({"foo": [1] * num_rows})
-
-
-def test_batch_block_refs():
-    with mock.patch(
-        "ray.data._internal.block_batching.block_batching._prefetch_blocks"
-    ) as mock_prefetch, mock.patch(
-        "ray.data._internal.block_batching.block_batching.batch_blocks"
-    ) as mock_batch_blocks:
-        block_iter = block_generator(2, 2)
-        batch_iter = batch_block_refs(block_iter)
-        for _ in batch_iter:
-            pass
-        assert mock_prefetch.call_count == 1
-        assert mock_batch_blocks.call_count == 1
 
 
 def test_batch_blocks():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`batch_block_refs` isn't used anywhere in the code, and it's not a user-facing API. So, this PR removes it.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
