### PR TITLE
[Data] Soft deprecate `prefetch_blocks` parameter of `iter_rows`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3641,7 +3641,7 @@ class Dataset:
         Args:
             prefetch_batches: The number of batches to prefetch ahead of the current
                 batch during the scan.
-            prefetch_blocks: The number of blocks to prefetch ahead of the
+            prefetch_blocks: [Deprecated] The number of blocks to prefetch ahead of the
                 current block during the scan.
 
         Returns:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3641,8 +3641,8 @@ class Dataset:
         Args:
             prefetch_batches: The number of batches to prefetch ahead of the current
                 batch during the scan.
-            prefetch_blocks: [Deprecated] The number of blocks to prefetch ahead of the
-                current block during the scan.
+            prefetch_blocks: This argument is deprecated. Use ``prefetch_batches`` 
+                instead.
 
         Returns:
             An iterable over the rows in this dataset.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3623,7 +3623,9 @@ class Dataset:
         return DataIteratorImpl(self)
 
     @ConsumptionAPI
-    def iter_rows(self, *, prefetch_blocks: int = 0) -> Iterable[Dict[str, Any]]:
+    def iter_rows(
+        self, *, prefetch_batches: int = 0, prefetch_blocks: int = 0
+    ) -> Iterable[Dict[str, Any]]:
         """Return an iterable over the rows in this dataset.
 
         Examples:
@@ -3637,13 +3639,17 @@ class Dataset:
         Time complexity: O(1)
 
         Args:
+            prefetch_batches: The number of batches to prefetch ahead of the current
+                batch during the scan.
             prefetch_blocks: The number of blocks to prefetch ahead of the
                 current block during the scan.
 
         Returns:
             An iterable over the rows in this dataset.
         """
-        return self.iterator().iter_rows(prefetch_blocks=prefetch_blocks)
+        return self.iterator().iter_rows(
+            prefetch_batches=prefetch_batches, prefetch_blocks=prefetch_blocks
+        )
 
     @ConsumptionAPI
     def iter_batches(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3641,7 +3641,7 @@ class Dataset:
         Args:
             prefetch_batches: The number of batches to prefetch ahead of the current
                 batch during the scan.
-            prefetch_blocks: This argument is deprecated. Use ``prefetch_batches`` 
+            prefetch_blocks: This argument is deprecated. Use ``prefetch_batches``
                 instead.
 
         Returns:

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -234,7 +234,7 @@ class DataIterator(abc.ABC):
         iter_batch_args = {
             "batch_size": None,
             "batch_format": None,
-            "prefatch_batches": prefetch_batches,
+            "prefetch_blocks": prefetch_batches,
         }
 
         if prefetch_blocks > 0:

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -234,9 +234,8 @@ class DataIterator(abc.ABC):
         iter_batch_args = {
             "batch_size": None,
             "batch_format": None,
-            "prefetch_blocks": prefetch_batches,
+            "prefetch_batches": prefetch_batches,
         }
-
         if prefetch_blocks > 0:
             warnings.warn(
                 "`prefetch_blocks` is deprecated in Ray 2.10. Use "

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -225,8 +225,8 @@ class DataIterator(abc.ABC):
         Args:
             prefetch_batches: The number of batches to prefetch ahead of the current
                 batch during the scan.
-            prefetch_blocks: [Deprecated] The number of blocks to prefetch ahead of the
-                current block during the scan.
+            prefetch_blocks: This argument is deprecated. Use ``prefetch_batches``
+                instead.
 
         Returns:
             An iterable over rows of the dataset.

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -715,7 +715,7 @@ def test_iter_rows(ray_start_regular_shared):
         assert row == df_row.to_dict()
 
     # Prefetch.
-    for row, t_row in zip(ds.iter_rows(prefetch_blocks=1), to_pylist(t)):
+    for row, t_row in zip(ds.iter_rows(prefetch_batches=1), to_pylist(t)):
         assert isinstance(row, dict)
         assert row == t_row
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR deprecates the `prefetch_blocks` in favor of a new `prefetch_batches` parameter for consistency with other iteration APIs, which have used `prefetch_batches` since Ray 2.4 (see https://github.com/ray-project/ray/pull/43347)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
