### PR TITLE
[Data] Restructure stdout logging

### DIFF
--- a/python/ray/data/_internal/dataset_logger.py
+++ b/python/ray/data/_internal/dataset_logger.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Optional
 
 import ray
 from ray._private.ray_constants import LOGGER_FORMAT, LOGGER_LEVEL
@@ -37,6 +38,8 @@ class DatasetLogger:
         self.log_name = log_name
         # Lazily initialized in self._initialize_logger()
         self._logger = None
+        # Lazily initialized in self._initialize_logger()
+        self._datasets_log_path = None
 
     def _initialize_logger(self) -> logging.Logger:
         """Internal method to initialize the logger and the extra file handler
@@ -79,6 +82,7 @@ class DatasetLogger:
             file_log_handler.setLevel(LOGGER_LEVEL.upper())
             file_log_handler.setFormatter(file_log_formatter)
             logger.addHandler(file_log_handler)
+            self._datasets_log_path = datasets_log_path
         return logger
 
     def get_logger(self, log_to_stdout: bool = True) -> logging.Logger:
@@ -99,3 +103,9 @@ class DatasetLogger:
             self._logger = self._initialize_logger()
         self._logger.propagate = log_to_stdout
         return self._logger
+
+    def get_datasets_log_path(self) -> Optional[str]:
+        """
+        Returns the Datasets log file path if it exists.
+        """
+        return self._datasets_log_path

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -157,7 +157,7 @@ class ExecutionOptions:
             streaming_split operations.
         verbose_progress: Whether to report progress individually per operator. By
             default, only AllToAll operators and global progress is reported. This
-            option is useful for performance debugging. Off by default.
+            option is useful for performance debugging. On by default.
     """
 
     resource_limits: ExecutionResources = field(default_factory=ExecutionResources)
@@ -172,7 +172,7 @@ class ExecutionOptions:
 
     actor_locality_enabled: bool = True
 
-    verbose_progress: bool = bool(int(os.environ.get("RAY_DATA_VERBOSE_PROGRESS", "0")))
+    verbose_progress: bool = bool(int(os.environ.get("RAY_DATA_VERBOSE_PROGRESS", "1")))
 
     def validate(self) -> None:
         """Validate the options."""

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -123,7 +123,7 @@ class ActorPoolMapOperator(MapOperator):
         # situations where the scheduler is unable to schedule downstream operators
         # due to lack of available actors, causing an initial "pileup" of objects on
         # upstream operators, leading to a spike in memory usage prior to steady state.
-        logger.get_logger().info(
+        logger.get_logger(log_to_stdout=False).info(
             f"{self._name}: Waiting for {len(refs)} pool actors to start..."
         )
         try:

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -109,16 +109,14 @@ class StreamingExecutor(Executor, threading.Thread):
         if not isinstance(dag, InputDataBuffer):
             stdout_logger = logger.get_logger()
             log_path = logger.get_datasets_log_path()
-            message = (
-                "Starting execution of Dataset. Monitor progress on Ray "
-                "Dashboard."
-            )
+            message = "Starting execution of Dataset."
             if log_path is not None:
                 message += f" Full log is in {log_path}"
             stdout_logger.info(message)
             stdout_logger.info("Execution plan of Dataset: %s\n", dag)
             logger.get_logger(log_to_stdout=False).info(
-                "Execution config: %s", self._options)
+                "Execution config: %s", self._options
+            )
             if not self._options.verbose_progress:
                 logger.get_logger(log_to_stdout=False).info(
                     "Tip: For detailed progress reporting, run "

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -259,7 +259,7 @@ class StreamingExecutor(Executor, threading.Thread):
         """
 
         if DEBUG_TRACE_SCHEDULING:
-            logger.get_logger(log_to_stdout=False).info("Scheduling loop step...")
+            logger.get_logger().info("Scheduling loop step...")
 
         # Note: calling process_completed_tasks() is expensive since it incurs
         # ray.wait() overhead, so make sure to allow multiple dispatch per call for

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -107,10 +107,20 @@ class StreamingExecutor(Executor, threading.Thread):
         self._start_time = time.perf_counter()
 
         if not isinstance(dag, InputDataBuffer):
-            logger.get_logger().info("Executing DAG %s", dag)
-            logger.get_logger().info("Execution config: %s", self._options)
+            stdout_logger = logger.get_logger()
+            log_path = logger.get_datasets_log_path()
+            message = (
+                "Starting execution of Dataset. Monitor progress on Ray "
+                "Dashboard."
+            )
+            if log_path is not None:
+                message += f" Full log is in {log_path}"
+            stdout_logger.info(message)
+            stdout_logger.info("Execution plan of Dataset: %s\n", dag)
+            logger.get_logger(log_to_stdout=False).info(
+                "Execution config: %s", self._options)
             if not self._options.verbose_progress:
-                logger.get_logger().info(
+                logger.get_logger(log_to_stdout=False).info(
                     "Tip: For detailed progress reporting, run "
                     "`ray.data.DataContext.get_current()."
                     "execution_options.verbose_progress = True`"
@@ -168,7 +178,7 @@ class StreamingExecutor(Executor, threading.Thread):
         with self._shutdown_lock:
             if not self._execution_started or self._shutdown:
                 return
-            logger.get_logger().debug(f"Shutting down {self}.")
+            logger.get_logger(log_to_stdout=False).debug(f"Shutting down {self}.")
             _num_shutdown += 1
             self._shutdown = True
             # Give the scheduling loop some time to finish processing.
@@ -251,7 +261,7 @@ class StreamingExecutor(Executor, threading.Thread):
         """
 
         if DEBUG_TRACE_SCHEDULING:
-            logger.get_logger().info("Scheduling loop step...")
+            logger.get_logger(log_to_stdout=False).info("Scheduling loop step...")
 
         # Note: calling process_completed_tasks() is expensive since it incurs
         # ray.wait() overhead, so make sure to allow multiple dispatch per call for

--- a/python/ray/data/_internal/logical/rules/set_read_parallelism.py
+++ b/python/ray/data/_internal/logical/rules/set_read_parallelism.py
@@ -38,10 +38,12 @@ def compute_additional_split_factor(
     if cur_additional_split_factor:
         size_based_splits *= cur_additional_split_factor
     logger.get_logger(log_to_stdout=False).debug(
-        f"Size based split factor {size_based_splits}")
+        f"Size based split factor {size_based_splits}"
+    )
     estimated_num_blocks = num_read_tasks * size_based_splits
     logger.get_logger(log_to_stdout=False).debug(
-        f"Blocks after size splits {estimated_num_blocks}")
+        f"Blocks after size splits {estimated_num_blocks}"
+    )
 
     available_cpu_slots = ray_available_resources().get("CPU", 1)
     if (
@@ -130,4 +132,5 @@ class SetReadParallelismRule(Rule):
             op.set_additional_split_factor(k)
 
         logger.get_logger(log_to_stdout=False).debug(
-            f"Estimated num output blocks {estimated_num_blocks}")
+            f"Estimated num output blocks {estimated_num_blocks}"
+        )

--- a/python/ray/data/_internal/logical/rules/set_read_parallelism.py
+++ b/python/ray/data/_internal/logical/rules/set_read_parallelism.py
@@ -29,7 +29,7 @@ def compute_additional_split_factor(
     expected_block_size = None
     if mem_size:
         expected_block_size = mem_size / num_read_tasks
-        logger.get_logger().debug(
+        logger.get_logger(log_to_stdout=False).debug(
             f"Expected in-memory size {mem_size}," f" block size {expected_block_size}"
         )
         size_based_splits = round(max(1, expected_block_size / target_max_block_size))
@@ -37,9 +37,11 @@ def compute_additional_split_factor(
         size_based_splits = 1
     if cur_additional_split_factor:
         size_based_splits *= cur_additional_split_factor
-    logger.get_logger().debug(f"Size based split factor {size_based_splits}")
+    logger.get_logger(log_to_stdout=False).debug(
+        f"Size based split factor {size_based_splits}")
     estimated_num_blocks = num_read_tasks * size_based_splits
-    logger.get_logger().debug(f"Blocks after size splits {estimated_num_blocks}")
+    logger.get_logger(log_to_stdout=False).debug(
+        f"Blocks after size splits {estimated_num_blocks}")
 
     available_cpu_slots = ray_available_resources().get("CPU", 1)
     if (
@@ -112,14 +114,14 @@ class SetReadParallelismRule(Rule):
 
         if logical_op._parallelism == -1:
             assert reason != ""
-            logger.get_logger().info(
+            logger.get_logger(log_to_stdout=False).info(
                 f"Using autodetected parallelism={detected_parallelism} "
                 f"for operator {logical_op.name} to satisfy {reason}."
             )
         logical_op.set_detected_parallelism(detected_parallelism)
 
         if k is not None:
-            logger.get_logger().info(
+            logger.get_logger(log_to_stdout=False).info(
                 f"To satisfy the requested parallelism of {detected_parallelism}, "
                 f"each read task output is split into {k} smaller blocks."
             )
@@ -127,4 +129,5 @@ class SetReadParallelismRule(Rule):
         if k is not None:
             op.set_additional_split_factor(k)
 
-        logger.get_logger().debug(f"Estimated num output blocks {estimated_num_blocks}")
+        logger.get_logger(log_to_stdout=False).debug(
+            f"Estimated num output blocks {estimated_num_blocks}")

--- a/python/ray/data/_internal/planner/exchange/pull_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/pull_based_shuffle_task_scheduler.py
@@ -80,7 +80,7 @@ class PullBasedShuffleTaskScheduler(ExchangeTaskScheduler):
 
         if _debug_limit_execution_to_num_blocks is not None:
             input_blocks_list = input_blocks_list[:_debug_limit_execution_to_num_blocks]
-            logger.get_logger().info(
+            logger.get_logger(log_to_stdout=False).info(
                 f"Limiting execution to {len(input_blocks_list)} map tasks"
             )
         shuffle_map_out = [
@@ -112,7 +112,7 @@ class PullBasedShuffleTaskScheduler(ExchangeTaskScheduler):
 
         if _debug_limit_execution_to_num_blocks is not None:
             output_num_blocks = _debug_limit_execution_to_num_blocks
-            logger.get_logger().info(
+            logger.get_logger(log_to_stdout=False).info(
                 f"Limiting execution to {output_num_blocks} reduce tasks"
             )
         shuffle_reduce_out = [

--- a/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
@@ -443,7 +443,8 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
         _debug_limit_execution_to_num_blocks: int = None,
     ) -> Tuple[List[RefBundle], StatsDict]:
         logger.get_logger(log_to_stdout=False).info(
-            "Using experimental push-based shuffle.")
+            "Using experimental push-based shuffle."
+        )
         # TODO: Preemptively clear the blocks list since we will incrementally delete
         # the last remaining references as we submit the dependent map tasks during the
         # map-merge stage.
@@ -497,7 +498,8 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
         # verbosely for now.
         # See https://github.com/ray-project/ray/issues/42002.
         logger.get_logger(log_to_stdout=False).info(
-            f"Push-based shuffle schedule:\n{stage}")
+            f"Push-based shuffle schedule:\n{stage}"
+        )
 
         map_fn = self._map_partition
         merge_fn = self._merge

--- a/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
@@ -358,7 +358,7 @@ class _ReduceStageIterator:
             self._reduce_arg_blocks = self._reduce_arg_blocks[
                 :_debug_limit_execution_to_num_blocks
             ]
-            logger.get_logger().info(
+            logger.get_logger(log_to_stdout=False).info(
                 f"Limiting execution to {len(self._reduce_arg_blocks)} reduce tasks"
             )
 
@@ -442,7 +442,8 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
         merge_factor: float = 2,
         _debug_limit_execution_to_num_blocks: int = None,
     ) -> Tuple[List[RefBundle], StatsDict]:
-        logger.get_logger().info("Using experimental push-based shuffle.")
+        logger.get_logger(log_to_stdout=False).info(
+            "Using experimental push-based shuffle.")
         # TODO: Preemptively clear the blocks list since we will incrementally delete
         # the last remaining references as we submit the dependent map tasks during the
         # map-merge stage.
@@ -495,7 +496,8 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
         # the logging level to DEBUG from a driver script, so just print
         # verbosely for now.
         # See https://github.com/ray-project/ray/issues/42002.
-        logger.get_logger().info(f"Push-based shuffle schedule:\n{stage}")
+        logger.get_logger(log_to_stdout=False).info(
+            f"Push-based shuffle schedule:\n{stage}")
 
         map_fn = self._map_partition
         merge_fn = self._merge
@@ -514,7 +516,7 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
 
         if _debug_limit_execution_to_num_blocks is not None:
             input_blocks_list = input_blocks_list[:_debug_limit_execution_to_num_blocks]
-            logger.get_logger().info(
+            logger.get_logger(log_to_stdout=False).info(
                 f"Limiting execution to {len(input_blocks_list)} map tasks"
             )
         map_stage_iter = _MapStageIterator(
@@ -739,7 +741,7 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
         num_output_blocks: int,
     ) -> _PushBasedShuffleStage:
         num_cpus_total = sum(v for v in num_cpus_per_node_map.values())
-        logger.get_logger().info(
+        logger.get_logger(log_to_stdout=False).info(
             f"Found {num_cpus_total} CPUs available CPUs for push-based shuffle."
         )
         num_tasks_per_map_merge_group = merge_factor + 1

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -251,7 +251,7 @@ class FileBasedDatasource(Datasource):
                     if len(read_paths) < num_threads:
                         num_threads = len(read_paths)
 
-                    logger.get_logger().debug(
+                    logger.get_logger(log_to_stdout=False).debug(
                         f"Reading {len(read_paths)} files with {num_threads} threads."
                     )
 
@@ -261,7 +261,8 @@ class FileBasedDatasource(Datasource):
                         num_workers=num_threads,
                     )
                 else:
-                    logger.get_logger().debug(f"Reading {len(read_paths)} files.")
+                    logger.get_logger(log_to_stdout=False).debug(
+                        f"Reading {len(read_paths)} files.")
                     yield from read_files(read_paths)
 
             return read_task_fn

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -262,7 +262,8 @@ class FileBasedDatasource(Datasource):
                     )
                 else:
                     logger.get_logger(log_to_stdout=False).debug(
-                        f"Reading {len(read_paths)} files.")
+                        f"Reading {len(read_paths)} files."
+                    )
                     yield from read_files(read_paths)
 
             return read_task_fn

--- a/python/ray/data/datasource/file_datasink.py
+++ b/python/ray/data/datasource/file_datasink.py
@@ -196,7 +196,7 @@ class RowBasedFileDatasink(_FileDatasink):
                 with self.open_output_stream(write_path) as file:
                     self.write_row_to_file(row, file)
 
-            logger.get_logger().debug(f"Writing {write_path} file.")
+            logger.get_logger(log_to_stdout=False).debug(f"Writing {write_path} file.")
             call_with_retry(
                 write_row_to_path,
                 description=f"write '{write_path}'",
@@ -262,7 +262,7 @@ class BlockBasedFileDatasink(_FileDatasink):
             with self.open_output_stream(write_path) as file:
                 self.write_block_to_file(block, file)
 
-        logger.get_logger().debug(f"Writing {write_path} file.")
+        logger.get_logger(log_to_stdout=False).debug(f"Writing {write_path} file.")
         call_with_retry(
             write_block_to_path,
             description=f"write '{write_path}'",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to restructure the standard output logging of Ray Data w/ motivation to provide useful information for users, because we heard from multiple users that the logging on standard output is spammy and not that useful.

The change includes:
* Don't print any `info`/`debug`-level log on stdout. The `warn`/`error`-level log is still on stdout. All logs are persisted in `ray-data.log` file.
* Only print out the file path of `ray-data.log` file and physical execution plan.
* Enable verbose progress bar by default, because we find it's generally useful for users and developers to monitor.

The stdout after this PR:

```
2024-02-22 11:29:41,506	INFO streaming_executor.py:118 -- Starting execution of Dataset. Full log is in /tmp/ray/session_2024-02-22_11-29-22_201527_7239/logs/ray-data.log
2024-02-22 11:29:41,506	INFO streaming_executor.py:119 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[ReadRange] -> TaskPoolMapOperator[Map(foo)->Map(<lambda>)]

Running: 1.0/10.0 CPU, 0.0/0.0 GPU, 0.0 MiB/512.0 MiB object_store_memory:   0%|                   | 0/10 [00:01<?, ?it/s]
- ReadRange->SplitBlocks(2): 9 active, 0 queued, 0.0 MiB objects:  15%|███                 | 3/20 [00:01<00:08,  2.11it/s]
- Map(foo)->Map(<lambda>): 10 active, 10 queued, 0.0 MiB objects:   0%|                            | 0/10 [00:01<?, ?it/s]
```

The stdout before this PR:

```
2024-02-22 11:44:25,607	INFO set_read_parallelism.py:115 -- Using autodetected parallelism=20 for stage ReadRange to satisfy parallelism at least twice the available number of CPUs (10).
2024-02-22 11:44:25,608	INFO set_read_parallelism.py:122 -- To satisfy the requested parallelism of 20, each read task output is split into 2 smaller blocks.
2024-02-22 11:44:25,608	INFO streaming_executor.py:112 -- Executing DAG InputDataBuffer[Input] -> TaskPoolMapOperator[ReadRange] -> TaskPoolMapOperator[Map(foo)->Map(<lambda>)]
2024-02-22 11:44:25,608	INFO streaming_executor.py:113 -- Execution config: ExecutionOptions(resource_limits=ExecutionResources(cpu=None, gpu=None, object_store_memory=None), exclude_resources=ExecutionResources(cpu=0, gpu=0, object_store_memory=0), locality_with_output=False, preserve_order=False, actor_locality_enabled=True, verbose_progress=False)
2024-02-22 11:44:25,608	INFO streaming_executor.py:115 -- Tip: For detailed progress reporting, run `ray.data.DataContext.get_current().execution_options.verbose_progress = True`
Running: 10.0/10.0 CPU, 0.0/0.0 GPU, 0.0 MiB/512.0 MiB object_store_memory:  45%|████▌     | 9/20 [00:02<00:01,  5.56it/s]
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
