### PR TITLE
[docker] update latest Docker Python dependencies

### DIFF
--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -446,14 +446,14 @@ Docker images for Python 3.9.
     .. tab-item:: ray (Python 3.9)
         :sync: ray (Python 3.9)
 
-        Ray version: nightly (`248521a <https://github.com/ray-project/ray/commit/248521af9ca0d68217365d3d3c9598a4142c912e>`_)
+        Ray version: nightly (`3ad5adb <https://github.com/ray-project/ray/commit/3ad5adb428bf4ce5db820d966928b8f6fbfc4d8e>`_)
 
         .. literalinclude:: ./pip_freeze_ray-py39-cpu.txt
 
     .. tab-item:: ray-ml (Python 3.9)
         :sync: ray-ml (Python 3.9)
 
-        Ray version: nightly (`248521a <https://github.com/ray-project/ray/commit/248521af9ca0d68217365d3d3c9598a4142c912e>`_)
+        Ray version: nightly (`3ad5adb <https://github.com/ray-project/ray/commit/3ad5adb428bf4ce5db820d966928b8f6fbfc4d8e>`_)
 
         .. literalinclude:: ./pip_freeze_ray-ml-py39-cpu.txt
 

--- a/doc/source/ray-overview/pip_freeze_ray-ml-py39-cpu.txt
+++ b/doc/source/ray-overview/pip_freeze_ray-ml-py39-cpu.txt
@@ -72,7 +72,7 @@ click==8.1.7
 cloudpickle==2.2.0
 cma==3.2.2
 cmaes==0.10.0
-cmake==3.28.1
+cmake==3.28.3
 colorama==0.4.6
 coloredlogs==15.0.1
 colorful==0.5.5
@@ -80,7 +80,7 @@ colorlog==6.7.0
 comet-ml==3.31.9
 comm==0.2.0
 commonmark==0.9.1
-conda @ file:///croot/conda_1706737954207/work
+conda @ file:///home/conda/feedstock_root/build_artifacts/conda_1707843821892/work
 conda-content-trust @ file:///croot/conda-content-trust_1693490622020/work
 conda-libmamba-solver @ file:///croot/conda-libmamba-solver_1706733287605/work/src
 conda-package-handling @ file:///croot/conda-package-handling_1690999929514/work
@@ -120,7 +120,7 @@ exceptiongroup==1.2.0
 executing==2.0.1
 fairscale==0.4.6
 Farama-Notifications==0.0.4
-fastapi==0.108.0
+fastapi==0.109.2
 fasteners==0.19
 fastjsonschema==2.19.0
 filelock==3.13.1
@@ -216,7 +216,7 @@ lazy_loader==0.3
 libclang==16.0.6
 libmambapy @ file:///croot/mamba-split_1704219408234/work/libmambapy
 lightgbm==3.3.5
-lightgbm-ray==0.1.9
+lightgbm-ray @ git+https://github.com/ray-project/lightgbm_ray.git@4c4d3413f86db769bddb6d08e2480a04bc75d712
 linear-operator==0.4.0
 lit==17.0.6
 locket==1.0.0
@@ -295,7 +295,7 @@ pettingzoo==1.23.1
 pexpect==4.8.0
 pickleshare==0.7.5
 Pillow==9.2.0
-pip-tools==7.3.0
+pip-tools==7.4.0
 pkginfo==1.9.6
 platformdirs==3.11.0
 plotly==5.18.0
@@ -353,13 +353,13 @@ PyWavelets==1.4.1
 PyYAML==6.0.1
 pyzmq==24.0.1
 querystring-parser==1.2.4
-ray @ file:///home/ray/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl#sha256=6a3c1815e5c35b33107c5143120c612d56c10c2f9772460ade68d5133165e8d3
+ray @ file:///home/ray/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl#sha256=89863b22d2324d7460cdb912125c3f6de9226535a9a6f14afcc7932839527bac
 raydp==1.7.0b20231020.dev0
 recsim==0.2.4
 redis==3.5.3
 referencing==0.33.0
 regex==2023.10.3
-requests @ file:///croot/requests_1690400202158/work
+requests @ file:///croot/requests_1707355572290/work
 requests-oauthlib==1.3.1
 requests-toolbelt==1.0.0
 responses==0.13.4
@@ -368,7 +368,7 @@ retry-decorator==1.1.1
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rich==12.6.0
-rpds-py==0.17.1
+rpds-py==0.18.0
 rsa==4.7.2
 ruamel.yaml @ file:///croot/ruamel.yaml_1666304550667/work
 ruamel.yaml.clib @ file:///croot/ruamel.yaml.clib_1666302247304/work
@@ -397,7 +397,7 @@ soupsieve==2.5
 SQLAlchemy==1.4.17
 sqlparse==0.4.4
 stack-data==0.6.3
-starlette==0.29.0
+starlette==0.36.3
 statsmodels==0.14.0
 SuperSuit==3.8.0
 sympy==1.12
@@ -448,10 +448,10 @@ typeguard==2.13.3
 typer==0.9.0
 types-python-dateutil==2.8.19.14
 typing_extensions==4.8.0
-tzdata==2023.4
+tzdata==2024.1
 uri-template==1.3.0
 uritemplate==3.0.1
-urllib3 @ file:///croot/urllib3_1698257533958/work
+urllib3==1.26.18
 uvicorn==0.22.0
 uvloop==0.19.0
 virtualenv==20.21.0
@@ -467,7 +467,7 @@ widgetsnbextension==3.6.6
 wrapt==1.16.0
 wurlitzer==3.0.3
 xgboost==1.7.6
-xgboost-ray==0.1.18
+xgboost-ray @ git+https://github.com/ray-project/xgboost_ray.git@5a840af05d487171883dadbfdd37b138b607bed8
 xmltodict==0.13.0
 xxhash==3.4.1
 y-py==0.6.2

--- a/doc/source/ray-overview/pip_freeze_ray-py39-cpu.txt
+++ b/doc/source/ray-overview/pip_freeze_ray-py39-cpu.txt
@@ -32,7 +32,7 @@ click==8.1.7
 cloudpickle==2.2.0
 colorful==0.5.5
 commonmark==0.9.1
-conda @ file:///croot/conda_1706737954207/work
+conda @ file:///home/conda/feedstock_root/build_artifacts/conda_1707843821892/work
 conda-content-trust @ file:///croot/conda-content-trust_1693490622020/work
 conda-libmamba-solver @ file:///croot/conda-libmamba-solver_1706733287605/work/src
 conda-package-handling @ file:///croot/conda-package-handling_1690999929514/work
@@ -44,7 +44,7 @@ distro @ file:///croot/distro_1701455004953/work
 dm-tree==0.1.8
 exceptiongroup==1.2.0
 Farama-Notifications==0.0.4
-fastapi==0.108.0
+fastapi==0.109.2
 filelock==3.13.1
 flatbuffers==23.5.26
 frozenlist==1.4.0
@@ -123,9 +123,9 @@ python-dotenv==1.0.1
 pytz==2022.7.1
 PyWavelets==1.4.1
 PyYAML==6.0.1
-ray @ file:///home/ray/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl#sha256=e9773e8ecf1d4d8eb60499205d32600a6b4124cb1e4dea4c01ca48e86cf3d568
+ray @ file:///home/ray/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl#sha256=c915d3a317600a021219d86f46109f941593e9f56b93db079fcb99ebb67c7265
 redis==3.5.3
-requests @ file:///croot/requests_1690400202158/work
+requests @ file:///croot/requests_1707355572290/work
 requests-oauthlib==1.3.1
 rich==12.6.0
 rsa==4.7.2
@@ -137,7 +137,7 @@ scipy==1.10.1
 six==1.16.0
 smart-open==6.2.0
 sniffio==1.3.0
-starlette==0.29.0
+starlette==0.36.3
 tabulate==0.9.0
 tensorboardX==2.6
 tifffile==2023.7.10
@@ -145,7 +145,7 @@ tqdm @ file:///croot/tqdm_1679561862951/work
 typer==0.9.0
 typing_extensions==4.8.0
 uritemplate==3.0.1
-urllib3 @ file:///croot/urllib3_1698257533958/work
+urllib3==1.26.18
 uvicorn==0.22.0
 uvloop==0.19.0
 virtualenv==20.21.0


### PR DESCRIPTION

## Why are these changes needed?

Update Docker Python dependencies to commit [3ad5adb](https://github.com/ray-project/ray/commit/3ad5adb428bf4ce5db820d966928b8f6fbfc4d8e)
Dependencies came from 
- [build: ray py3.9 docker (x86_64)](https://buildkite.com/ray-project/postmerge/builds/3067#018dd23a-ac89-4f3e-82da-6a5196b0a616)
- [build: ray-ml py3.9 docker (x86_64)](https://buildkite.com/ray-project/postmerge/builds/3067#018dd23a-ac8f-4d2f-b888-89533c02dd36)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://www.notion.so/anyscale-hq/How-to-release-Ray-go-release-ray-28e4a2347577471288bbd7d64001fa88?pvs=4#9cc39bb28f5742778b62dd1381601e03

