### PR TITLE
[Data] Fix `FutureWarning` with `pyarrow.concat_tables`

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -256,13 +256,13 @@ def concat(blocks: List["pyarrow.Table"]) -> "pyarrow.Table":
         table.validate()
     else:
         # No extension array columns, so use built-in pyarrow.concat_tables.
-        if parse_version(_get_pyarrow_version()) < parse_version("14.0.0"):
+        if parse_version(_get_pyarrow_version()) >= parse_version("14.0.0"):
             # `promote` was superseded by `promote_options='default'` in Arrow 14. To
             # prevent `FutureWarning`s, we manually check the Arrow version and use the
             # appropriate parameter.
-            table = pyarrow.concat_tables(blocks, promote=True)
-        else:
             table = pyarrow.concat_tables(blocks, promote_options="default")
+        else:
+            table = pyarrow.concat_tables(blocks, promote=True)
     return table
 
 

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -1,9 +1,14 @@
 from typing import TYPE_CHECKING, List, Union
 
+from packaging.version import parse as parse_version
+
+from ray._private.utils import _get_pyarrow_version
+
 try:
     import pyarrow
 except ImportError:
     pyarrow = None
+
 
 if TYPE_CHECKING:
     from ray.data._internal.planner.exchange.sort_task_spec import SortKey
@@ -251,7 +256,13 @@ def concat(blocks: List["pyarrow.Table"]) -> "pyarrow.Table":
         table.validate()
     else:
         # No extension array columns, so use built-in pyarrow.concat_tables.
-        table = pyarrow.concat_tables(blocks, promote=True)
+        if parse_version(_get_pyarrow_version()) < parse_version("14.0.0"):
+            # `promote` was superseded by `promote_options='default'` in Arrow 14. To
+            # prevent `FutureWarning`s, we manually check the Arrow version and use the
+            # appropriate parameter.
+            table = pyarrow.concat_tables(blocks, promote=True)
+        else:
+            table = pyarrow.concat_tables(blocks, promote_options="default")
     return table
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `promote` parameter of `pyarrow.concat_tables` was superseded by `promote_options='default'` in Arrow 14. To
prevent `FutureWarning`s like the one below, this PR updates the code to use the appropriate parameter.

> (MapBatches(pyarrow_batch_mapper)->MapBatches(my_fn_name) pid=675, ip=x.x.x.x)   return transform_pyarrow.concat(tables)
(MapBatches(pyarrow_batch_mapper)->MapBatches(my_fn_name) pid=294, ip=x.x.x.x) /home/ray/.pyenv/versions/3.11.7/lib/python3.11/site-packages/ray/data/_internal/arrow_block.py:148: FutureWarning: promote has been superseded by promote_options='default'.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
