### PR TITLE
[Data] Avoid warning of compute argument in add/select/drop_columns()

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -646,12 +646,6 @@ class Dataset:
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """
-        compute = get_compute_strategy(
-            fn,
-            compute=compute,
-            concurrency=concurrency,
-        )
-
         def process_batch(batch: "pandas.DataFrame") -> "pandas.DataFrame":
             batch.loc[:, col] = fn(batch)
             return batch
@@ -663,6 +657,7 @@ class Dataset:
             process_batch,
             batch_format="pandas",  # TODO(ekl) we should make this configurable.
             compute=compute,
+            concurrency=concurrency,
             zero_copy_batch=False,
             **ray_remote_args,
         )
@@ -713,16 +708,12 @@ class Dataset:
         def fn(batch):
             return batch.drop(columns=cols)
 
-        compute = get_compute_strategy(
-            fn,
-            compute=compute,
-            concurrency=concurrency,
-        )
         return self.map_batches(
             fn,
             batch_format="pandas",
             zero_copy_batch=True,
             compute=compute,
+            concurrency=concurrency,
             **ray_remote_args,
         )
 
@@ -772,16 +763,12 @@ class Dataset:
         def fn(batch):
             return BlockAccessor.for_block(batch).select(columns=cols)
 
-        compute = get_compute_strategy(
-            fn,
-            compute=compute,
-            concurrency=concurrency,
-        )
         return self.map_batches(
             fn,
             batch_format="pandas",
             zero_copy_batch=True,
             compute=compute,
+            concurrency=concurrency,
             **ray_remote_args,
         )
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -646,6 +646,7 @@ class Dataset:
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
         """
+
         def process_batch(batch: "pandas.DataFrame") -> "pandas.DataFrame":
             batch.loc[:, col] = fn(batch)
             return batch


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to fix the bug when user uses `add/select/drop_columns` without `compute`/`concurrency` API. Before this PR, it prints out a deprecation warning by mistake. This PR is to avoid printing out the warning.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
