### PR TITLE
[serve] add `target_num_replicas` to rest api response

### DIFF
--- a/dashboard/modules/serve/tests/test_serve_dashboard.py
+++ b/dashboard/modules/serve/tests/test_serve_dashboard.py
@@ -447,6 +447,7 @@ def test_get_serve_instance_details(ray_start_stop, f_deployment_options, url):
                     len(deployment.replicas)
                     == deployment.deployment_config.num_replicas
                 )
+                assert len(deployment.replicas) == deployment.target_num_replicas
 
             for replica in deployment.replicas:
                 assert replica.state == ReplicaState.RUNNING

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2758,6 +2758,7 @@ class DeploymentStateManager:
             return None
         else:
             status_info = statuses[0]
+            deployment_state = self._deployment_states[id]
             return DeploymentDetails(
                 name=id.name,
                 status=status_info.status,
@@ -2766,7 +2767,8 @@ class DeploymentStateManager:
                 deployment_config=_deployment_info_to_schema(
                     id.name, self.get_deployment(id)
                 ),
-                replicas=self._deployment_states[id].list_replica_details(),
+                target_num_replicas=deployment_state._target_state.target_num_replicas,
+                replicas=deployment_state.list_replica_details(),
             )
 
     def get_deployment_statuses(

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -11,6 +11,7 @@ from ray._private.pydantic_compat import (
     BaseModel,
     Extra,
     Field,
+    NonNegativeInt,
     PositiveInt,
     StrictInt,
     root_validator,
@@ -954,6 +955,13 @@ class DeploymentDetails(BaseModel, extra=Extra.forbid, frozen=True):
             "The set of deployment config options that are currently applied to this "
             "deployment. These options may come from the user's code, config file "
             "options, or Serve default values."
+        )
+    )
+    target_num_replicas: NonNegativeInt = Field(
+        description=(
+            "The current target number of replicas for this deployment. This can "
+            "change over time for autoscaling deployments, but will remain a constant "
+            "number for other deployments."
         )
     )
     replicas: List[ReplicaDetails] = Field(

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -182,6 +182,7 @@ def test_get_serve_instance_details_json_serializable(serve_instance, policy):
                                     "num_cpus": 1.0,
                                 },
                             },
+                            "target_num_replicas": 1,
                             "replicas": [
                                 {
                                     "node_id": node_id,

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -849,6 +849,7 @@ def test_serve_instance_details_is_json_serializable():
                                 "_serialized_policy_def": serialized_policy_def
                             },
                         },
+                        "target_num_replicas": 0,
                         "replicas": [],
                     }
                 },
@@ -880,6 +881,7 @@ def test_serve_instance_details_is_json_serializable():
                                 "name": "deployment1",
                                 "autoscaling_config": {},
                             },
+                            "target_num_replicas": 0,
                             "replicas": [],
                         }
                     },


### PR DESCRIPTION
[serve] add `target_num_replicas` to rest api response

Add new field `target_num_replicas` to `DeploymentDetails` for Serve's GET Rest API.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
