### PR TITLE
If PG 2pc commit fails, don't call CommitBundleResources.

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -324,8 +324,13 @@ void GcsPlacementGroupScheduler::CommitAllBundles(
         lease_status_tracker->MarkCommitRequestReturned(node_id, bundle, status);
         (*commited_bundle_locations)[bundle->BundleId()] = {node_id, bundle};
       }
-      // Commit the bundle resources on the remote node to the cluster resources.
-      CommitBundleResources(commited_bundle_locations);
+
+      if (status.ok()) {
+        // Commit the bundle resources on the remote node to the cluster resources.
+        // If status is not OK, no need to call ReturnBundleResources because the
+        // OnAllBundleCommitRequestReturned function calls it.
+        CommitBundleResources(commited_bundle_locations);
+      }
 
       if (lease_status_tracker->AllCommitRequestReturned()) {
         OnAllBundleCommitRequestReturned(

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -236,8 +236,7 @@ struct GcsServerMocker {
     }
 
     // Trigger reply to CommitBundleResources.
-    bool GrantCommitBundleResources(bool success = true,
-                                    const Status &status = Status::OK()) {
+    bool GrantCommitBundleResources(const Status &status = Status::OK()) {
       rpc::CommitBundleResourcesReply reply;
       if (commit_callbacks.size() == 0) {
         return false;


### PR DESCRIPTION
Placement group manager crashes in this time order:

1. sent PREPARE to all nodes;
2. received PREPARE reply from all nodes;
3. one node dead
4. send COMMIT to all nodes
5. for the dead node, the manager knows it's dead, but still called CommitBundleResources
6. CommitBundleResources asserts the node always exist and check failed.

This PR removed the call to CommitBundleResources in step 5.

Also, it fixed some unit tests that never worked (always pass). Added a test case specifically for this code path.

Fixes #43371.