### PR TITLE
[Doc,RLlib] Fix invalid doc syntax in LearnerGroup docstrings

### DIFF
--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -473,7 +473,7 @@ class LearnerGroup:
 
         Args:
             reduce_fn: See `update()` documentation for more details.
-            **kwargs: Keyword arguments to pass to each Learner.
+            \*\*kwargs: Keyword arguments to pass to each Learner.
 
         Returns:
             A list of dictionaries of results from the updates from each worker.
@@ -613,10 +613,10 @@ class LearnerGroup:
     def foreach_learner(
         self, func: Callable[[Learner, Optional[Any]], T], **kwargs
     ) -> List[T]:
-        """Calls the given function on each Learner L with the args: (L, **kwargs).
+        """Calls the given function on each Learner L with the args: (L, \*\*kwargs).
 
         Args:
-            func: The function to call on each Learner L with (L, **kwargs).
+            func: The function to call on each Learner L with (L, \*\*kwargs).
 
         Returns:
             A list of size len(Learners) with the return values of all calls to `func`.


### PR DESCRIPTION
## Why are these changes needed?

These docstrings are currently breaking the docs build.

## Related issue number

Closes https://github.com/ray-project/ray/issues/43437.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
