### PR TITLE
[Doc] Bump sphinx-click to avoid building protocol buffers for Ray CLI

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,10 +10,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  jobs:
-    pre_build:
-      - bash ./ci/env/install-bazel.sh
-      - ~/bin/bazel build //:install_py_proto
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -63,8 +63,6 @@ clean:
 	rm -rf ./source/rllib/package_ref/doc*
 
 html:
-    # Needed for rendering ray-core/api/cli.rst
-    bazel build //:install_py_proto
 	$(SPHINXBUILD) -W --keep-going -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -1,13 +1,11 @@
 # Production requirements. This is what readthedocs.com picks up
 
-watchfiles==0.19.0 # Required because sphinx-click doesn't support mocking
-
 # Syntax highlighting
 Pygments==2.16.1
 
 # Sphinx
 sphinx==7.1.2
-sphinx-click==5.0.1
+sphinx-click==5.1.0
 sphinx-copybutton==0.5.2
 sphinxemoji==0.2.0
 sphinx-jsonschema==1.19.1
@@ -21,9 +19,6 @@ pydata-sphinx-theme==0.14.1
 autodoc_pydantic==1.9.0
 
 pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3
-
-# Needed for rendering ray-core/api/cli.rst
-protobuf==4.23.2
 
 # MyST
 myst-parser==2.0.0 # Needed to parse markdown


### PR DESCRIPTION
## Why are these changes needed?

[A recent change](https://github.com/ray-project/ray/pull/43189) imported some objects from a protobuf-generated module into the Ray CLI. Previously we never needed to build the protobuf-generated module for doc builds, but this change necessitated doing so.

Normally we'd just mock out the generated module, but the sphinx plugin we are using to document the CLI (`sphinx-click`) didn't support mocking out modules as of `5.0.1`. However a [recent change](https://github.com/click-contrib/sphinx-click/pull/129) added support for mocking imports. With the release of `5.1.0`, we can take advantage of this to avoid the need to include external dependencies for building the CLI docs.

Happily, the recent update to `sphinx-click` reuses the `autodoc_mock_imports` configuration setting from `conf.py` to know what modules to mock out so no configuration change is needed :smiley: 

## Changes

- Avoid installing bazel and building the protocol buffers during the RTD build
- Remove `watchfiles` and `protobuf` from the list of doc build dependencies; neither is needed anymore
- Remove protobuf invocation in the `html` target of the docs Makefile. These lines were space-indented, which isn't valid `make` syntax. So removing these lines making local builds possible again.

## Related issue number

Closes https://github.com/ray-project/ray/issues/43404.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
