### PR TITLE
[tune] Increase the minimum number of allowed pending trials for faster auto-scaleup

### DIFF
--- a/doc/source/tune/api/env.rst
+++ b/doc/source/tune/api/env.rst
@@ -45,7 +45,7 @@ These are the environment variables Ray Tune currently considers:
 * **TUNE_MAX_LEN_IDENTIFIER**: Maximum length of trial subdirectory names (those
   with the parameter values in them)
 * **TUNE_MAX_PENDING_TRIALS_PG**: Maximum number of pending trials when placement groups are used. Defaults
-  to ``auto``, which will be updated to ``max(16, cluster_cpus * 1.1)`` for random/grid search and ``1``
+  to ``auto``, which will be updated to ``max(200, cluster_cpus * 1.1)`` for random/grid search and ``1``
   for any other search algorithms.
 * **TUNE_NODE_SYNCING_MIN_ITER_THRESHOLD**: When syncing trial data between nodes, only sync if this many
   iterations were recorded for the trial or the minimum time threshold was met. This will prevent unnecessary

--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -2172,14 +2172,15 @@ def _get_max_pending_trials(search_alg: SearchAlgorithm) -> int:
     if not isinstance(search_alg, BasicVariantGenerator):
         return 1
 
-    # Use a minimum of 16 to trigger fast autoscaling
-    # Scale up to at most the number of available cluster CPUs
-    cluster_cpus = ray.cluster_resources().get("CPU", 1.0)
-    max_pending_trials = min(
-        max(search_alg.total_samples, 16), max(16, int(cluster_cpus * 1.1))
-    )
+    # Allow up to at least 200 pending trials to trigger fast autoscaling
+    min_autoscaling_rate = 200
 
-    if max_pending_trials > 128:
+    # Allow more pending trials for larger clusters (based on number of CPUs)
+    cluster_cpus = ray.cluster_resources().get("CPU", 1.0)
+    max_pending_trials = min(search_alg.total_samples, int(cluster_cpus * 1.1))
+    max_pending_trials = max(min_autoscaling_rate, max_pending_trials)
+
+    if max_pending_trials > min_autoscaling_rate:
         logger.warning(
             f"The maximum number of pending trials has been "
             f"automatically set to the number of available "
@@ -2189,7 +2190,7 @@ def _get_max_pending_trials(search_alg: SearchAlgorithm) -> int:
             f"of trials, this could lead to scheduling overhead. "
             f"In this case, consider setting the "
             f"`TUNE_MAX_PENDING_TRIALS_PG` environment variable "
-            f"to the desired maximum number of concurrent trials."
+            f"to the desired maximum number of concurrent pending trials."
         )
 
     return max_pending_trials

--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -2177,8 +2177,7 @@ def _get_max_pending_trials(search_alg: SearchAlgorithm) -> int:
 
     # Allow more pending trials for larger clusters (based on number of CPUs)
     cluster_cpus = ray.cluster_resources().get("CPU", 1.0)
-    max_pending_trials = min(search_alg.total_samples, int(cluster_cpus * 1.1))
-    max_pending_trials = max(min_autoscaling_rate, max_pending_trials)
+    max_pending_trials = max(min_autoscaling_rate, int(cluster_cpus * 1.1))
 
     if max_pending_trials > min_autoscaling_rate:
         logger.warning(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR bumps up the minimum number of allowed pending trials from 16 to 200. This increases the speed of autoscaling for a Tune job that starts with a small cluster.

Ray Core benchmarks test submitting up to 600+ placement groups at a time. Having too many pending placement groups affects actor scheduling latency, so allowing up to 200 pending PGs is a middle ground.

## Related issue number

<!-- For example: "Closes #1234" -->
Mitigation for https://github.com/ray-project/ray/issues/43451

This does not fully fix the issue, since it may be better to adjust this value dynamically in response to cluster scale-ups. Currently, the value gets fixed to `max(16, int(initial_cluster_cpus * 1.1)`, where `initial_cluster_cpus` is just the number of CPUs at the beginning of the job.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
