### PR TITLE
[ci][release] repeated run for release tests

### DIFF
--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -38,6 +38,9 @@
 						"weekly"
 					]
 				},
+				"repeated_run": {
+					"type": "integer"
+				},
 				"team": {
 					"type": "string"
 				},

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -56,7 +56,10 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
     "--run-per-test",
     default=1,
     type=int,
-    help=("The number of time we run test on the same commit"),
+    help=(
+        "The number of time we run test on the same commit. This number might be "
+        "overridden by the local test config (whichever is higher)."
+    ),
 )
 def main(
     test_collection_file: Tuple[str],
@@ -151,6 +154,8 @@ def main(
         tests = grouped_tests[group]
         group_steps = []
         for test, smoke_test in tests:
+            # run the tests as many time as the global or its local configuration allows
+            run_per_test = max(test.get("repeated_run", 1), run_per_test)
             for run_id in range(run_per_test):
                 step = get_step(
                     test,

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -9,6 +9,10 @@
 #  # Provide the working directory which will be uploaded to the cluster
 #  working_dir: example_dir
 #
+#  The number of time we run test on the same commit. This number might be 
+#  overritten by the global pipeline config (whichever is higher)
+#  repeated_run: 5
+#
 #  # How often to run the tests.
 #  # One of [manual, any, multi, nightly, nightly-3x, weekly].
 #  # Descriptions of each frequency (that's not immediately obvious):
@@ -4592,6 +4596,7 @@
   group: core-daily-test
   team: core
   frequency: nightly
+  repeated_run: 5
   working_dir: microbenchmark
 
   cluster:


### PR DESCRIPTION
We talked in today core-devprod meeting that in addition to running release tests more regularly (for easier bisecting performance regression), we will also run them repeatedly to denoise the metrics.

Add a feature to run a release tests multiple times:

Test:
- CI
- Release tests: https://buildkite.com/ray-project/release/builds/9568#_