### PR TITLE
[release] use bigger machine for build

### DIFF
--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -27,7 +27,7 @@ steps:
   - label: ":tapioca: build: anyscale-ml py{{matrix}}-cu11.8.0 docker"
     tags: skip-on-premerge
     key: anyscalemlbuild
-    instance_type: release
+    instance_type: medium
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- anyscale --python-version {{matrix}}
         --platform cu11.8.0 --image-type ray-ml --upload

--- a/.buildkite/release/config.yml
+++ b/.buildkite/release/config.yml
@@ -7,6 +7,7 @@ builder_queues:
   builder: builder_queue_branch
 runner_queues:
   release: release_queue_small
+  medium: runner_queue_medium_branch
 buildkite_dirs:
   - .buildkite/release
 env:


### PR DESCRIPTION
In https://buildkite.com/ray-project/release/builds/9440#018de73a-f942-432a-bb02-a36d125352bd, we're seeing that the build is OOMing on a smaller machine. Use bigger machine for release build job.

Test:
- Release test