### PR TITLE
[serve] Make `get_user_configured_option_names` private

### DIFF
--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -668,7 +668,7 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
         logging_config=s.logging_config,
     )
     deployment_config.user_configured_option_names = (
-        s.get_user_configured_option_names()
+        s._get_user_configured_option_names()
     )
 
     replica_config = ReplicaConfig.create(

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -466,7 +466,7 @@ class DeploymentSchema(BaseModel, allow_population_by_field_name=True):
         _route_prefix_format
     )
 
-    def get_user_configured_option_names(self) -> Set[str]:
+    def _get_user_configured_option_names(self) -> Set[str]:
         """Get set of names for all user-configured options.
 
         Any field not set to DEFAULT.VALUE is considered a user-configured option.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add underscore prefix so this doesn't show up in our API ref.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
