### PR TITLE
[ci] remove test_xgboost_sweep from doc

### DIFF
--- a/doc/source/tune/tutorials/tune-scalability.rst
+++ b/doc/source/tune/tutorials/tune-scalability.rst
@@ -63,13 +63,6 @@ description.
      - 16
      - 86,400
      - 88687.41
-   * - `XGBoost parameter sweep <https://github.com/ray-project/ray/blob/master/release/tune_tests/scalability_tests/workloads/test_xgboost_sweep.py>`_
-     - 16
-     - ?
-     - 16
-     - 64
-     - ?
-     - 3903
    * - `Durable trainable <https://github.com/ray-project/ray/blob/master/release/tune_tests/scalability_tests/workloads/test_durable_trainable.py>`_
      - 16
      - | 10/60


### PR DESCRIPTION
Remove test_xgboost_sweep from doc, the test has been deleted I think. This also fix the lint that is broken in master

Test:
- CI