### PR TITLE
[ci] fix release test repeated run

### DIFF
--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -155,8 +155,7 @@ def main(
         group_steps = []
         for test, smoke_test in tests:
             # run the tests as many time as the global or its local configuration allows
-            run_per_test = max(test.get("repeated_run", 1), run_per_test)
-            for run_id in range(run_per_test):
+            for run_id in range(max(test.get("repeated_run", 1), run_per_test)):
                 step = get_step(
                     test,
                     test_collection_file,


### PR DESCRIPTION
The existing code of computing repeated run overwriting the value of `run_per_test` which is an outter scope variable. This causes every tests that are declared after `microbenchmark.aws` to also be run 5 times currently.

Fix it by have an ephemeral value for repeated_run.

Test:
- CI