### PR TITLE
[data] Fix bug in memory reservation

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -548,7 +548,7 @@ py_test(
 
 py_test(
     name = "test_backpressure_e2e",
-    size = "medium",
+    size = "large",
     srcs = ["tests/test_backpressure_e2e.py"],
     tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -58,7 +58,9 @@ class LimitOperator(OneToOneOperator):
                     metadata.size_bytes = BlockAccessor.for_block(block).size_bytes()
                     return block, metadata
 
-                block, metadata_ref = cached_remote_fn(slice_fn, num_returns=2).remote(
+                block, metadata_ref = cached_remote_fn(
+                    slice_fn, num_cpus=0, num_returns=2
+                ).remote(
                     block,
                     metadata,
                     self._limit - self._consumed_rows,

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -287,7 +287,9 @@ def _split_block(
     b: ObjectRef[Block], left_size: int
 ) -> (ObjectRef[Block], ObjectRef[Block]):
     split_single_block = cached_remote_fn(_split_single_block)
-    left, right = split_single_block.options(num_returns=2).remote(b, left_size)
+    left, right = split_single_block.options(num_cpus=0, num_returns=2).remote(
+        b, left_size
+    )
     return left, right
 
 

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -505,7 +505,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
         E.g.,
           - "cur_map->downstream_map" will return an empty list.
-          - "cur_map->limit1->limi2->downstream_map" will return [limit1, limit2].
+          - "cur_map->limit1->limit2->downstream_map" will return [limit1, limit2].
         """
         for next_op in op.output_dependencies:
             if not isinstance(next_op, MapOperator):
@@ -518,7 +518,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
         E.g.,
           - "cur_map->downstream_map" will return [downstream_map].
-          - "cur_map->limit1->limi2->downstream_map" will return [downstream_map].
+          - "cur_map->limit1->limit2->downstream_map" will return [downstream_map].
         """
         for next_op in op.output_dependencies:
             if isinstance(next_op, MapOperator):

--- a/python/ray/data/tests/test_backpressure_e2e.py
+++ b/python/ray/data/tests/test_backpressure_e2e.py
@@ -107,6 +107,9 @@ def _build_dataset(
 
     ds = ray.data.range(1, parallelism=1).materialize()
     ds = ds.map_batches(producer, batch_size=None, num_cpus=producer_num_cpus)
+    # Add a limit op in the middle, to test that ReservationOpResourceAllocator
+    # will account limit op's resource usage to the previous producer map op.
+    ds = ds.limit(num_blocks)
     ds = ds.map_batches(consumer, batch_size=None, num_cpus=consumer_num_cpus)
     return ds
 

--- a/python/ray/data/tests/test_backpressure_e2e.py
+++ b/python/ray/data/tests/test_backpressure_e2e.py
@@ -186,7 +186,9 @@ def test_no_deadlock_on_resource_contention(
     assert len(ds.take_all()) == num_blocks
 
 
-def test_no_deadlock_with_preserve_order(restore_data_context, shutdown_only):  # noqa: F811
+def test_no_deadlock_with_preserve_order(
+    restore_data_context, shutdown_only  # noqa: F811
+):
     """Test backpressure won't cause deadlocks when `preserve_order=True`."""
     num_blocks = 20
     block_size = 10 * 1024 * 1024

--- a/python/ray/data/tests/test_backpressure_e2e.py
+++ b/python/ray/data/tests/test_backpressure_e2e.py
@@ -119,16 +119,14 @@ def _build_dataset(
 
 
 @pytest.mark.parametrize(
-    "cluster_cpus, cluster_obj_store_mem_mb, insert_limit_op",
+    "cluster_cpus, cluster_obj_store_mem_mb",
     [
-        (3, 500, False),  # CPU not enough
-        (3, 500, True),  # CPU not enough
-        (4, 100, False),  # Object store memory not enough
-        (4, 100, True),  # Object store memory not enough
-        (3, 100, False),  # Both not enough
-        (3, 100, True),  # Both not enough
+        (3, 500),  # CPU not enough
+        (4, 100),  # Object store memory not enough
+        (3, 100),  # Both not enough
     ],
 )
+@pytest.mark.parametrize("insert_limit_op", [False, True])
 def test_no_deadlock_on_small_cluster_resources(
     cluster_cpus,
     cluster_obj_store_mem_mb,

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -480,6 +480,10 @@ def test_e2e_liveness_with_output_backpressure_edge_case(
 
 
 def test_e2e_autoscaling_up(ray_start_10_cpus_shared, restore_data_context):
+    ctx = ray.data.DataContext.get_current()
+    ctx.execution_options.resource_limits.object_store_memory = 100 * 1024**2
+    ctx.target_max_block_size = 1 * 1024**2
+
     @ray.remote(max_concurrency=10)
     class Barrier:
         def __init__(self, n, delay=0):

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -4,6 +4,7 @@ import threading
 import time
 from typing import Any, List
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -420,7 +421,7 @@ def test_scheduling_progress_when_output_blocked(
 def test_backpressure_from_output(ray_start_10_cpus_shared, restore_data_context):
     # Here we set the memory limit low enough so the output getting blocked will
     # actually stall execution.
-    block_size = 10 * 1024*1024
+    block_size = 10 * 1024 * 1024
 
     @ray.remote
     class Counter:

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -451,7 +451,6 @@ def test_backpressure_from_output(ray_start_10_cpus_shared, restore_data_context
     next(it)
     time.sleep(3)  # Pause a little so anything that would be executed runs.
     num_finished = ray.get(counter.get.remote())
-    print(num_finished)
     assert num_finished < 20, num_finished
     # Check intermediate stats reporting.
     stats = ds.stats()

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -420,6 +420,7 @@ def test_scheduling_progress_when_output_blocked(
 def test_backpressure_from_output(ray_start_10_cpus_shared, restore_data_context):
     # Here we set the memory limit low enough so the output getting blocked will
     # actually stall execution.
+    block_size = 10 * 1024*1024
 
     @ray.remote
     class Counter:
@@ -436,17 +437,21 @@ def test_backpressure_from_output(ray_start_10_cpus_shared, restore_data_context
 
     def func(x):
         ray.get(counter.inc.remote())
-        return x
+        return {
+            "data": [np.ones(block_size, dtype=np.uint8)],
+        }
 
     ctx = DataContext.get_current()
-    ctx.execution_options.resource_limits.object_store_memory = 10000
+    ctx.target_max_block_size = block_size
+    ctx.execution_options.resource_limits.object_store_memory = block_size
 
     # Only take the first item from the iterator.
-    ds = ray.data.range(100000, parallelism=100).map_batches(func, batch_size=None)
-    it = iter(ds.iter_batches(batch_size=None))
+    ds = ray.data.range(100, parallelism=100).map_batches(func, batch_size=None)
+    it = iter(ds.iter_batches(batch_size=None, prefetch_batches=0))
     next(it)
     time.sleep(3)  # Pause a little so anything that would be executed runs.
     num_finished = ray.get(counter.get.remote())
+    print(num_finished)
     assert num_finished < 20, num_finished
     # Check intermediate stats reporting.
     stats = ds.stats()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix bugs in ReservationOpResourceAllocator (introduced by https://github.com/ray-project/ray/pull/43171)
* We treat a map op and its following non-map ops as the same group. `update_resources` already handles this properly . But `_should_unblock_streaming_output_backpressure` and ` _op_outputs_reserved_remaining` didn't consider this.
* Since we don't reserve any resources for `limit` and `streaming_split`, should set `num_cpus=0` for their tasks. 
* `_reserved_for_op_outputs` currently also includes op's internal output buffers. This is incorrect, because when `preserve_order=True`, task outputs will accumulate in op's internal output buffer, and use all the memory budget from `_reserved_for_op_outputs`. Then we still don't have memory budget to pull the blocks from the internal output buffer. Excluding the internal output buffer from `_reserved_for_op_outputs` fixes this issue.

Also deflake `test_backpressure_from_output` and `test_e2e_autoscaling_up`, as they depend on physical memory size of the node. 

## Related issue number

closes #43493
closes #43490

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
