### PR TITLE
[release] support repeated run for release test

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -56,17 +56,22 @@ DEFAULT_STEP_TEMPLATE: Dict[str, Any] = {
     },
 }
 
+
 def get_step_for_test_group(
     grouped_tests: Dict[str, List[Tuple[Test, bool]]],
+    minimum_run_per_test: int = 1,
+    test_collection_file: List[str] = None,
+    env: Optional[Dict] = None,
+    priority: int = 0,
+    global_config: Optional[str] = None,
+    is_concurrency_limit: bool = True,
 ):
     steps = []
     for group in sorted(grouped_tests):
         tests = grouped_tests[group]
         group_steps = []
         for test, smoke_test in tests:
-            # run the tests as many time as the global or its local configuration allows
-            run_per_test = max(test.get("repeated_run", 1), run_per_test)
-            for run_id in range(max(test.get(""))):
+            for run_id in range(max(test.get("repeated_run", 1), minimum_run_per_test)):
                 step = get_step(
                     test,
                     test_collection_file,
@@ -76,11 +81,11 @@ def get_step_for_test_group(
                     report=True,
                     smoke_test=smoke_test,
                     env=env,
-                    priority_val=priority.value,
+                    priority_val=priority,
                     global_config=global_config,
                 )
 
-                if no_concurrency_limit:
+                if not is_concurrency_limit:
                     step.pop("concurrency", None)
                     step.pop("concurrency_group", None)
 
@@ -88,6 +93,8 @@ def get_step_for_test_group(
 
         group_step = {"group": group, "steps": group_steps}
         steps.append(group_step)
+
+    return steps
 
 
 def get_step(

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -15,6 +15,9 @@
 				"working_dir": {
 					"type": "string"
 				},
+				"repeated_run": {
+					"type": "integer"
+				},
 				"env": {
 					"type": "string"
 				},

--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -9,7 +9,7 @@ import click
 
 from ray_release.buildkite.filter import filter_tests, group_tests
 from ray_release.buildkite.settings import get_pipeline_settings
-from ray_release.buildkite.step import get_step
+from ray_release.buildkite.step import get_step_for_test_group
 from ray_release.byod.build import (
     build_anyscale_base_byod_images,
     build_anyscale_custom_byod_image,
@@ -146,33 +146,15 @@ def main(
     if os.environ.get("REPORT_TO_RAY_TEST_DB", False):
         env["REPORT_TO_RAY_TEST_DB"] = "1"
 
-    steps = []
-    for group in sorted(grouped_tests):
-        tests = grouped_tests[group]
-        group_steps = []
-        for test, smoke_test in tests:
-            for run_id in range(run_per_test):
-                step = get_step(
-                    test,
-                    test_collection_file,
-                    run_id=run_id,
-                    # Always report performance data to databrick. Since the data is
-                    # indexed by branch and commit hash, we can always filter data later
-                    report=True,
-                    smoke_test=smoke_test,
-                    env=env,
-                    priority_val=priority.value,
-                    global_config=global_config,
-                )
-
-                if no_concurrency_limit:
-                    step.pop("concurrency", None)
-                    step.pop("concurrency_group", None)
-
-                group_steps.append(step)
-
-        group_step = {"group": group, "steps": group_steps}
-        steps.append(group_step)
+    steps = get_step_for_test_group(
+        grouped_tests,
+        minimum_run_per_test=run_per_test,
+        test_collection_file=test_collection_file,
+        env=env,
+        priority=priority.value,
+        global_config=global_config,
+        is_concurrency_limit=not no_concurrency_limit,
+    )
 
     if "BUILDKITE" in os.environ:
         if os.path.exists(PIPELINE_ARTIFACT_PATH):

--- a/release/ray_release/tests/test_step.py
+++ b/release/ray_release/tests/test_step.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 from ray_release.bazel import bazel_runfile
-from ray_release.buildkite.step import get_step
+from ray_release.buildkite.step import get_step, get_step_for_test_group
 from ray_release.configs.global_config import init_global_config
 from ray_release.test import Test
 
@@ -27,6 +27,25 @@ def _stub_test(val: dict) -> Test:
 def test_get_step():
     step = get_step(_stub_test({}), run_id=2)
     assert step["label"] == "test (None) (2)"
+
+
+def test_get_step_for_test_group():
+    grouped_tests = {
+        "group1": [
+            (_stub_test({"name": "test1", "repeated_run": 3}), False),
+            (_stub_test({"name": "test2"}), False),
+        ],
+        "group2": [(_stub_test({"name": "test3"}), False)],
+    }
+    steps = get_step_for_test_group(grouped_tests)
+    assert len(steps) == 2
+    assert steps[0]["group"] == "group1"
+    assert [step["label"] for step in steps[0]["steps"]] == [
+        "test1 (None) (0)",
+        "test1 (None) (1)",
+        "test1 (None) (2)",
+        "test2 (None) (0)",
+    ]
 
 
 if __name__ == "__main__":

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4080,6 +4080,7 @@
 
   variations:
     - __suffix__: aws
+      repeated_run: 5
     - __suffix__: gce
       env: gce
       frequency: manual


### PR DESCRIPTION
We talked in today core-devprod meeting that in addition to running release tests more regularly (for easier bisecting performance regression), we will also run them repeatedly to denoise the metrics.

Add a feature to run a release tests multiple times:

Test:
- CI