### PR TITLE
[core] fix worker launch time formatting

### DIFF
--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -89,14 +89,8 @@ class Humanify:
     """A class containing default methods to
     convert units into a human readable string."""
 
-    def timestamp(x):
-        """
-        Converts milliseconds to a datetime object.
-        If the input is -1, return an empty string.
-        If the input is not an int or float, raise a ValueError.
-        """
-        if x == -1:
-            return ""
+    def timestamp(x: float):
+        """Converts milliseconds to a datetime object."""
         return str(datetime.datetime.fromtimestamp(x / 1000))
 
     def memory(x: int):
@@ -636,12 +630,16 @@ class WorkerState(StateSchema):
     #: -> start_time_ms (worker is ready to be used).
     #: -> end_time_ms (worker is destroyed).
     worker_launch_time_ms: Optional[int] = state_column(
-        filterable=False, detail=True, format_fn=Humanify.timestamp
+        filterable=False,
+        detail=True,
+        format_fn=lambda x: "" if x == -1 else Humanify.timestamp(x),
     )
     #: The time worker is succesfully launched
     #: -1 if the value doesn't exist.
     worker_launched_time_ms: Optional[int] = state_column(
-        filterable=False, detail=True, format_fn=Humanify.timestamp
+        filterable=False,
+        detail=True,
+        format_fn=lambda x: "" if x == -1 else Humanify.timestamp(x),
     )
     #: The time when the worker is started and initialized.
     #: 0 if the value doesn't exist.

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -89,8 +89,14 @@ class Humanify:
     """A class containing default methods to
     convert units into a human readable string."""
 
-    def timestamp(x: float):
-        """Converts miliseconds to a datetime object."""
+    def timestamp(x):
+        """
+        Converts milliseconds to a datetime object.
+        If the input is -1, return an empty string.
+        If the input is not an int or float, raise a ValueError.
+        """
+        if x == -1:
+            return ""
         return str(datetime.datetime.fromtimestamp(x / 1000))
 
     def memory(x: int):
@@ -104,7 +110,7 @@ class Humanify:
         return str(format(x, ".3f")) + " B"
 
     def duration(x: int):
-        """Converts miliseconds to a human readable duration."""
+        """Converts milliseconds to a human readable duration."""
         return str(datetime.timedelta(milliseconds=x))
 
     def events(events: List[dict]):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Timestamp was not set for when triggering the launcher, resulting in default timestamp being set as (int) -1 == (unsigned) 18446744073709551615 (2^64-1)

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/35130

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
