### PR TITLE
[ci] stop assign test failure tickets to can

### DIFF
--- a/release/ray_release/test_automation/ci_state_machine.py
+++ b/release/ray_release/test_automation/ci_state_machine.py
@@ -1,6 +1,5 @@
 from ray_release.test_automation.state_machine import (
     TestStateMachine,
-    DEFAULT_ISSUE_OWNER,
     WEEKLY_RELEASE_BLOCKER_TAG,
 )
 
@@ -82,7 +81,6 @@ class CITestStateMachine(TestStateMachine):
             title=f"CI test {self.test.get_name()} is {self.test.get_state().value}",
             body=body,
             labels=labels,
-            assignee=DEFAULT_ISSUE_OWNER,
         ).number
         self.test[Test.KEY_GITHUB_ISSUE_NUMBER] = issue_number
 

--- a/release/ray_release/test_automation/release_state_machine.py
+++ b/release/ray_release/test_automation/release_state_machine.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 from ray_release.test_automation.state_machine import (
     TestStateMachine,
-    DEFAULT_ISSUE_OWNER,
     WEEKLY_RELEASE_BLOCKER_TAG,
 )
 from ray_release.test import Test, TestState
@@ -86,7 +85,6 @@ class ReleaseTestStateMachine(TestStateMachine):
                 f"Managed by OSS Test Policy"
             ),
             labels=labels,
-            assignee=DEFAULT_ISSUE_OWNER,
         ).number
         self.test[Test.KEY_GITHUB_ISSUE_NUMBER] = issue_number
 

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -14,7 +14,6 @@ from ray_release.aws import get_secret_token
 RAY_REPO = "ray-project/ray"
 AWS_SECRET_GITHUB = "ray_ci_github_token"
 AWS_SECRET_BUILDKITE = "ray_ci_buildkite_token"
-DEFAULT_ISSUE_OWNER = "can-anyscale"
 WEEKLY_RELEASE_BLOCKER_TAG = "weekly-release-blocker"
 NO_TEAM = "none"
 TEAM = [


### PR DESCRIPTION
Keep the automated test failure tickets ownerless so it's easier for Sam to track

Test:
- CI