### PR TITLE
[ci] [release-automation] Add branch runner queue to pipeline

### DIFF
--- a/.buildkite/release-automation/config.yml
+++ b/.buildkite/release-automation/config.yml
@@ -13,6 +13,7 @@ runner_queues:
   macos: macos
   macos-arm64: macos-pr-arm64
   windows: windows_queue_pr
+  small_branch: runner_queue_small_branch
 builder_priority: 5
 runner_priority: 5
 buildkite_dirs:


### PR DESCRIPTION
## Changes
- Add `runner_queue_small_branch` as a runner queue option in `release-automation` pipeline