### PR TITLE
[serve] `DeploymentID` cleanups

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -18,7 +18,7 @@ from ray.serve._private.common import (
     DeploymentStatusInfo,
     DeploymentStatusTrigger,
     EndpointInfo,
-    EndpointTag,
+    DeploymentID,
     TargetCapacityDirection,
 )
 from ray.serve._private.config import DeploymentConfig
@@ -271,7 +271,7 @@ class ApplicationState:
         self._set_target_state(None, None, target_config, None, None, False)
 
     def _delete_deployment(self, name):
-        id = EndpointTag(name, self._name)
+        id = DeploymentID(name=name, app_name=self._name)
         self._endpoint_state.delete_endpoint(id)
         self._deployment_state_manager.delete_deployment(id)
 
@@ -304,7 +304,7 @@ class ApplicationState:
                 f'Invalid route prefix "{route_prefix}", it must start with "/"'
             )
 
-        deployment_id = DeploymentID(deployment_name, self._name)
+        deployment_id = DeploymentID(name=deployment_name, app_name=self._name)
 
         self._deployment_state_manager.deploy(deployment_id, deployment_info)
 
@@ -685,7 +685,7 @@ class ApplicationState:
     def get_deployments_statuses(self) -> List[DeploymentStatusInfo]:
         """Return all deployment status information"""
         deployments = [
-            DeploymentID(deployment, self._name)
+            DeploymentID(name=deployment, app_name=self._name)
             for deployment in self.target_deployments
         ]
         return self._deployment_state_manager.get_deployment_statuses(deployments)
@@ -711,7 +711,7 @@ class ApplicationState:
         """
         details = {
             deployment_name: self._deployment_state_manager.get_deployment_details(
-                DeploymentID(deployment_name, self._name)
+                DeploymentID(name=deployment_name, app_name=self._name)
             )
             for deployment_name in self.target_deployments
         }

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -18,7 +18,6 @@ from ray.serve._private.common import (
     DeploymentStatusInfo,
     DeploymentStatusTrigger,
     EndpointInfo,
-    DeploymentID,
     TargetCapacityDirection,
 )
 from ray.serve._private.config import DeploymentConfig

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -491,7 +491,7 @@ class ServeControllerClient:
         all_deployments = ray.get(self._controller.list_deployment_ids.remote())
         if (
             not missing_ok
-            and DeploymentID(deployment_name, app_name) not in all_deployments
+            and DeploymentID(name=deployment_name, app_name=app_name) not in all_deployments
         ):
             raise KeyError(
                 f"Deployment '{deployment_name}' in application '{app_name}' does not "

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -491,7 +491,8 @@ class ServeControllerClient:
         all_deployments = ray.get(self._controller.list_deployment_ids.remote())
         if (
             not missing_ok
-            and DeploymentID(name=deployment_name, app_name=app_name) not in all_deployments
+            and DeploymentID(name=deployment_name, app_name=app_name)
+            not in all_deployments
         ):
             raise KeyError(
                 f"Deployment '{deployment_name}' in application '{app_name}' does not "

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -5,6 +5,7 @@ from typing import Awaitable, Callable, List, NamedTuple, Optional
 
 from ray.actor import ActorHandle
 from ray.serve.generated.serve_pb2 import ApplicationStatus as ApplicationStatusProto
+from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve.generated.serve_pb2 import (
     ApplicationStatusInfo as ApplicationStatusInfoProto,
 )
@@ -22,26 +23,20 @@ from ray.serve.generated.serve_pb2 import StatusOverview as StatusOverviewProto
 from ray.serve.grpc_util import RayServegRPCContext
 
 
-class DeploymentID(NamedTuple):
-    name: str
-    app: str
+@dataclass(frozen=True)
+class DeploymentID:
+    deployment_name: str
+    app_name: str = SERVE_DEFAULT_APP_NAME
 
     def __str__(self):
         # TODO(zcin): remove this once we no longer use the concatenated
         # string for metrics
-        if self.app:
-            return f"{self.app}_{self.name}"
-        else:
-            return self.name
+        return f"{self.app_name}_{self.deployment_name}"
 
     def to_replica_actor_class_name(self):
-        if self.app:
-            return f"ServeReplica:{self.app}:{self.name}"
-        else:
-            return f"ServeReplica:{self.name}"
+        return f"ServeReplica:{self.app_name}:{self.deployment_name}"
 
 
-EndpointTag = DeploymentID
 ReplicaTag = str
 NodeId = str
 Duration = float
@@ -522,7 +517,7 @@ class StatusOverview:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class ReplicaName:
     app_name: str
     deployment_name: str
@@ -544,7 +539,7 @@ class ReplicaName:
 
     @property
     def deployment_id(self):
-        return DeploymentID(self.deployment_name, self.app_name)
+        return DeploymentID(name=self.deployment_name, app_name=self.app_name)
 
     @staticmethod
     def is_replica_name(actor_name: str) -> bool:

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -523,7 +523,7 @@ class StatusOverview:
         )
 
 
-@dataclass(frozen=True)
+@dataclass
 class ReplicaName:
     app_name: str
     deployment_name: str

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -4,8 +4,8 @@ from enum import Enum
 from typing import Awaitable, Callable, List, NamedTuple, Optional
 
 from ray.actor import ActorHandle
-from ray.serve.generated.serve_pb2 import ApplicationStatus as ApplicationStatusProto
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
+from ray.serve.generated.serve_pb2 import ApplicationStatus as ApplicationStatusProto
 from ray.serve.generated.serve_pb2 import (
     ApplicationStatusInfo as ApplicationStatusInfoProto,
 )

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -25,16 +25,22 @@ from ray.serve.grpc_util import RayServegRPCContext
 
 @dataclass(frozen=True)
 class DeploymentID:
-    deployment_name: str
+    name: str
     app_name: str = SERVE_DEFAULT_APP_NAME
 
     def __str__(self):
         # TODO(zcin): remove this once we no longer use the concatenated
         # string for metrics
-        return f"{self.app_name}_{self.deployment_name}"
+        if self.app_name:
+            return f"{self.app_name}_{self.name}"
+        else:
+            return self.name
 
     def to_replica_actor_class_name(self):
-        return f"ServeReplica:{self.app_name}:{self.deployment_name}"
+        if self.app_name:
+            return f"ServeReplica:{self.app_name}:{self.name}"
+        else:
+            return f"ServeReplica:{self.name}"
 
 
 ReplicaTag = str

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Awaitable, Callable, List, NamedTuple, Optional
+from typing import Awaitable, Callable, List, Optional
 
 from ray.actor import ActorHandle
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -15,7 +15,7 @@ from ray.serve._private.application_state import ApplicationStateManager
 from ray.serve._private.common import (
     DeploymentID,
     EndpointInfo,
-    EndpointTag,
+    DeploymentID,
     MultiplexedReplicaInfo,
     NodeId,
     RunningReplicaInfo,
@@ -318,7 +318,7 @@ class ServeController:
             keys_to_snapshot_ids_bytes
         )
 
-    def get_all_endpoints(self) -> Dict[EndpointTag, Dict[str, Any]]:
+    def get_all_endpoints(self) -> Dict[DeploymentID, Dict[str, Any]]:
         """Returns a dictionary of deployment name to config."""
         return self.endpoint_state.get_endpoints()
 
@@ -734,7 +734,7 @@ class ServeController:
         # the only change was num_replicas, the start_time_ms is refreshed.
         # Is this the desired behaviour?
         updating = self.deployment_state_manager.deploy(
-            DeploymentID(name, ""), deployment_info
+            DeploymentID(name=name, app_name=""), deployment_info
         )
 
         if route_prefix is not None:
@@ -742,9 +742,9 @@ class ServeController:
                 route=route_prefix,
                 app_is_cross_language=not is_deployed_from_python,
             )
-            self.endpoint_state.update_endpoint(EndpointTag(name, ""), endpoint_info)
+            self.endpoint_state.update_endpoint(DeploymentID(name=name, app_name=""), endpoint_info)
         else:
-            self.endpoint_state.delete_endpoint(EndpointTag(name, ""))
+            self.endpoint_state.delete_endpoint(DeploymentID(name=name, app_name=""))
 
         return updating
 
@@ -861,7 +861,7 @@ class ServeController:
     def delete_deployment(self, name: str):
         """Should only be used for 1.x deployments."""
 
-        id = DeploymentID(name, "")
+        id = DeploymentID(name=name, app_name="")
         self.endpoint_state.delete_endpoint(id)
         return self.deployment_state_manager.delete_deployment(id)
 
@@ -883,7 +883,7 @@ class ServeController:
         Raises:
             KeyError if the deployment doesn't exist.
         """
-        id = DeploymentID(name, app_name)
+        id = DeploymentID(name=name, app_name=app_name)
         deployment_info = self.deployment_state_manager.get_deployment(id)
         if deployment_info is None:
             app_msg = f" in application '{app_name}'" if app_name else ""
@@ -1055,7 +1055,7 @@ class ServeController:
                 deployments go through this API.
         """
 
-        id = DeploymentID(name, app_name)
+        id = DeploymentID(name=name, app_name=app_name)
         status = self.deployment_state_manager.get_deployment_statuses([id])
         if not status:
             return None

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -922,7 +922,7 @@ class ServeController:
             route_prefix,
         ) in self.list_deployments_internal().items():
             # Only list 1.x deployments, which should have app=""
-            if deployment_id.app:
+            if deployment_id.app_name:
                 continue
 
             deployment_info_proto = deployment_info.to_proto()

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -15,7 +15,6 @@ from ray.serve._private.application_state import ApplicationStateManager
 from ray.serve._private.common import (
     DeploymentID,
     EndpointInfo,
-    DeploymentID,
     MultiplexedReplicaInfo,
     NodeId,
     RunningReplicaInfo,
@@ -742,7 +741,9 @@ class ServeController:
                 route=route_prefix,
                 app_is_cross_language=not is_deployed_from_python,
             )
-            self.endpoint_state.update_endpoint(DeploymentID(name=name, app_name=""), endpoint_info)
+            self.endpoint_state.update_endpoint(
+                DeploymentID(name=name, app_name=""), endpoint_info
+            )
         else:
             self.endpoint_state.delete_endpoint(DeploymentID(name=name, app_name=""))
 

--- a/python/ray/serve/_private/deploy_utils.py
+++ b/python/ray/serve/_private/deploy_utils.py
@@ -91,7 +91,7 @@ def deploy_args_to_deployment_info(
 
     return DeploymentInfo(
         actor_name=DeploymentID(
-            deployment_name, app_name
+            name=deployment_name, app_name=app_name
         ).to_replica_actor_class_name(),
         version=version,
         deployment_config=deployment_config,

--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -268,7 +268,7 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
                 # to limit the number of replicas on a single node.
                 actor_options["resources"][
                     f"{ray._raylet.IMPLICIT_RESOURCE_PREFIX}"
-                    f"{deployment_id.app}:{deployment_id.name}"
+                    f"{deployment_id.app_name}:{deployment_id.name}"
                 ] = (1.0 / replica_scheduling_request.max_replicas_per_node)
             actor_handle = replica_scheduling_request.actor_def.options(
                 scheduling_strategy=scheduling_strategy,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -281,7 +281,7 @@ class ActorReplicaWrapper:
 
     @property
     def app_name(self) -> str:
-        return self._deployment_id.app
+        return self._deployment_id.app_name
 
     @property
     def is_cross_language(self) -> bool:
@@ -943,7 +943,7 @@ class DeploymentReplica(VersionedReplica):
 
     @property
     def app_name(self) -> str:
-        return self._deployment_id.app
+        return self._deployment_id.app_name
 
     @property
     def version(self):
@@ -1372,7 +1372,7 @@ class DeploymentState:
 
     @property
     def app_name(self) -> str:
-        return self._id.app
+        return self._id.app_name
 
     def get_running_replica_infos(self) -> List[RunningReplicaInfo]:
         return [
@@ -2777,7 +2777,7 @@ class DeploymentStateManager:
 
         deployments = []
         for deployment_id in self._deployment_states:
-            if deployment_id.app == app_name:
+            if deployment_id.app_name == app_name:
                 deployments.append(deployment_id.name)
 
         return deployments
@@ -2861,7 +2861,7 @@ class DeploymentStateManager:
                 replica tag and model ids.
         """
         if info.deployment_id not in self._deployment_states:
-            app_msg = f" in application '{info.deployment_id.app}'"
+            app_msg = f" in application '{info.deployment_id.app_name}'"
             logger.error(
                 f"Deployment {info.deployment_id.name}{app_msg} not found in state "
                 "manager."

--- a/python/ray/serve/_private/endpoint_state.py
+++ b/python/ray/serve/_private/endpoint_state.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, Optional
 
 from ray import cloudpickle
-from ray.serve._private.common import EndpointInfo, EndpointTag
+from ray.serve._private.common import EndpointInfo, DeploymentID
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.long_poll import LongPollHost, LongPollNamespace
 from ray.serve._private.storage.kv_store import KVStoreBase
@@ -22,7 +22,7 @@ class EndpointState:
     def __init__(self, kv_store: KVStoreBase, long_poll_host: LongPollHost):
         self._kv_store = kv_store
         self._long_poll_host = long_poll_host
-        self._endpoints: Dict[EndpointTag, EndpointInfo] = dict()
+        self._endpoints: Dict[DeploymentID, EndpointInfo] = dict()
 
         checkpoint = self._kv_store.get(CHECKPOINT_KEY)
         if checkpoint is not None:
@@ -49,7 +49,7 @@ class EndpointState:
             LongPollNamespace.ROUTE_TABLE, self._endpoints
         )
 
-    def _get_endpoint_for_route(self, route: str) -> Optional[EndpointTag]:
+    def _get_endpoint_for_route(self, route: str) -> Optional[DeploymentID]:
         for endpoint, info in self._endpoints.items():
             if info.route == route:
                 return endpoint
@@ -57,7 +57,7 @@ class EndpointState:
         return None
 
     def update_endpoint(
-        self, endpoint: EndpointTag, endpoint_info: EndpointInfo
+        self, endpoint: DeploymentID, endpoint_info: EndpointInfo
     ) -> None:
         """Create or update the given endpoint.
 
@@ -84,12 +84,12 @@ class EndpointState:
         self._checkpoint()
         self._notify_route_table_changed()
 
-    def get_endpoint_route(self, endpoint: EndpointTag) -> Optional[str]:
+    def get_endpoint_route(self, endpoint: DeploymentID) -> Optional[str]:
         if endpoint in self._endpoints:
             return self._endpoints[endpoint].route
         return None
 
-    def get_endpoints(self) -> Dict[EndpointTag, Dict[str, Any]]:
+    def get_endpoints(self) -> Dict[DeploymentID, Dict[str, Any]]:
         endpoints = {}
         for endpoint, info in self._endpoints.items():
             endpoints[endpoint] = {
@@ -97,7 +97,7 @@ class EndpointState:
             }
         return endpoints
 
-    def delete_endpoint(self, endpoint: EndpointTag) -> None:
+    def delete_endpoint(self, endpoint: DeploymentID) -> None:
         # This method must be idempotent. We should validate that the
         # specified endpoint exists on the client.
         if endpoint not in self._endpoints:

--- a/python/ray/serve/_private/endpoint_state.py
+++ b/python/ray/serve/_private/endpoint_state.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, Optional
 
 from ray import cloudpickle
-from ray.serve._private.common import EndpointInfo, DeploymentID
+from ray.serve._private.common import DeploymentID, EndpointInfo
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.long_poll import LongPollHost, LongPollNamespace
 from ray.serve._private.storage.kv_store import KVStoreBase

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -358,7 +358,7 @@ class LongPollHost:
         self, key: KeyType, object_snapshot: Any
     ) -> bytes:
         if key == LongPollNamespace.ROUTE_TABLE:
-            # object_snapshot is Dict[EndpointTag, EndpointInfo]
+            # object_snapshot is Dict[DeploymentID, EndpointInfo]
             # NOTE(zcin): the endpoint dictionary broadcasted to Java
             # HTTP proxies should use string as key because Java does
             # not yet support 2.x or applications

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -396,7 +396,7 @@ class GenericProxy(ABC):
                     proxy_request.set_path(route_path.replace(route_prefix, "", 1))
 
             handle, request_id = self.setup_request_context_and_handle(
-                app_name=handle.deployment_id.app,
+                app_name=handle.deployment_id.app_name,
                 handle=handle,
                 route_path=route_path,
                 proxy_request=proxy_request,
@@ -412,7 +412,7 @@ class GenericProxy(ABC):
             return ResponseHandlerInfo(
                 response_generator=response_generator,
                 metadata=HandlerMetadata(
-                    application_name=handle.deployment_id.app,
+                    application_name=handle.deployment_id.app_name,
                     deployment_name=handle.deployment_id.name,
                     route=route_path,
                 ),

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -564,7 +564,9 @@ class gRPCProxy(GenericProxy):
         self, *, healthy: bool, message: str
     ) -> ResponseGenerator:
         yield ListApplicationsResponse(
-            application_names=[endpoint.app for endpoint in self.route_info.values()],
+            application_names=[
+                endpoint.app_name for endpoint in self.route_info.values()
+            ],
         ).SerializeToString()
 
         yield ResponseStatus(
@@ -787,8 +789,8 @@ class HTTPProxy(GenericProxy):
             response = dict()
             for route, endpoint in self.route_info.items():
                 # For 2.x deployments, return {route -> app name}
-                if endpoint.app:
-                    response[route] = endpoint.app
+                if endpoint.app_name:
+                    response[route] = endpoint.app_name
                 # Keep compatibility with 1.x deployments.
                 else:
                     response[route] = endpoint.name

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 from ray.serve._private.common import (
     ApplicationName,
     EndpointInfo,
-    EndpointTag,
+    DeploymentID,
     RequestProtocol,
 )
 from ray.serve._private.constants import (
@@ -21,7 +21,7 @@ class ProxyRouter(ABC):
     """Router interface for the proxy to use."""
 
     @abstractmethod
-    def update_routes(self, endpoints: Dict[EndpointTag, EndpointInfo]):
+    def update_routes(self, endpoints: Dict[DeploymentID, EndpointInfo]):
         raise NotImplementedError
 
 
@@ -40,13 +40,13 @@ class LongestPrefixRouter(ProxyRouter):
         # Routes sorted in order of decreasing length.
         self.sorted_routes: List[str] = list()
         # Endpoints associated with the routes.
-        self.route_info: Dict[str, EndpointTag] = dict()
+        self.route_info: Dict[str, DeploymentID] = dict()
         # Contains a ServeHandle for each endpoint.
-        self.handles: Dict[EndpointTag, DeploymentHandle] = dict()
+        self.handles: Dict[DeploymentID, DeploymentHandle] = dict()
         # Map of application name to is_cross_language.
         self.app_to_is_cross_language: Dict[ApplicationName, bool] = dict()
 
-    def update_routes(self, endpoints: Dict[EndpointTag, EndpointInfo]) -> None:
+    def update_routes(self, endpoints: Dict[DeploymentID, EndpointInfo]) -> None:
         logger.info(
             f"Got updated endpoints: {endpoints}.", extra={"log_to_stderr": False}
         )
@@ -131,11 +131,11 @@ class EndpointRouter(ProxyRouter):
         # Protocol to config handle
         self._protocol = protocol
         # Contains a ServeHandle for each endpoint.
-        self.handles: Dict[EndpointTag, DeploymentHandle] = dict()
+        self.handles: Dict[DeploymentID, DeploymentHandle] = dict()
         # Endpoints info associated with endpoints.
-        self.endpoints: Dict[EndpointTag, EndpointInfo] = dict()
+        self.endpoints: Dict[DeploymentID, EndpointInfo] = dict()
 
-    def update_routes(self, endpoints: Dict[EndpointTag, EndpointInfo]):
+    def update_routes(self, endpoints: Dict[DeploymentID, EndpointInfo]):
         logger.info(
             f"Got updated endpoints: {endpoints}.", extra={"log_to_stderr": False}
         )

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -58,7 +58,7 @@ class LongestPrefixRouter(ProxyRouter):
         for endpoint, info in endpoints.items():
             routes.append(info.route)
             route_info[info.route] = endpoint
-            app_to_is_cross_language[endpoint.app] = info.app_is_cross_language
+            app_to_is_cross_language[endpoint.app_name] = info.app_is_cross_language
             if endpoint in self.handles:
                 existing_handles.remove(endpoint)
             else:

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -176,7 +176,7 @@ class EndpointRouter(ProxyRouter):
         for endpoint_tag, handle in self.handles.items():
             # If the target_app_name matches with the endpoint or if
             # there is only one endpoint.
-            if target_app_name == endpoint_tag.app or len(self.handles) == 1:
+            if target_app_name == endpoint_tag.app_name or len(self.handles) == 1:
                 endpoint_info = self.endpoints[endpoint_tag]
                 return (
                     endpoint_info.route,

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -116,7 +116,7 @@ class LongestPrefixRouter(ProxyRouter):
                     return (
                         route,
                         self.handles[endpoint],
-                        self.app_to_is_cross_language[endpoint.app],
+                        self.app_to_is_cross_language[endpoint.app_name],
                     )
 
         return None

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -62,7 +62,7 @@ class LongestPrefixRouter(ProxyRouter):
             if endpoint in self.handles:
                 existing_handles.remove(endpoint)
             else:
-                handle = self._get_handle(endpoint.name, endpoint.app).options(
+                handle = self._get_handle(endpoint.name, endpoint.app_name).options(
                     # Streaming codepath isn't supported for Java.
                     stream=not info.app_is_cross_language,
                     _prefer_local_routing=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
@@ -145,7 +145,7 @@ class EndpointRouter(ProxyRouter):
             if endpoint in self.handles:
                 existing_handles.remove(endpoint)
             else:
-                handle = self._get_handle(endpoint.name, endpoint.app).options(
+                handle = self._get_handle(endpoint.name, endpoint.app_name).options(
                     # Streaming codepath isn't supported for Java.
                     stream=not info.app_is_cross_language,
                     _prefer_local_routing=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -4,8 +4,8 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from ray.serve._private.common import (
     ApplicationName,
-    EndpointInfo,
     DeploymentID,
+    EndpointInfo,
     RequestProtocol,
 )
 from ray.serve._private.constants import (

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -288,7 +288,7 @@ class ReplicaActor:
 
     def _set_internal_replica_context(self, *, servable_object: Callable = None):
         ray.serve.context._set_internal_replica_context(
-            app_name=self._deployment_id.app,
+            app_name=self._deployment_id.app_name,
             deployment=self._deployment_id.name,
             replica_tag=self._replica_tag,
             servable_object=servable_object,
@@ -346,7 +346,7 @@ class ReplicaActor:
             ray.serve.context._RequestContext(
                 request_metadata.route,
                 request_metadata.request_id,
-                self._deployment_id.app,
+                self._deployment_id.app_name,
                 request_metadata.multiplexed_model_id,
                 request_metadata.grpc_context,
             )

--- a/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
@@ -153,7 +153,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
             tag_keys=("app", "deployment", "actor_id"),
         ).set_default_tags(
             {
-                "app": self._deployment_id.app,
+                "app": self._deployment_id.app_name,
                 "deployment": self._deployment_id.name,
                 "actor_id": self_actor_id if self_actor_id else "",
             }
@@ -170,7 +170,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
             tag_keys=("app", "deployment", "actor_id"),
         ).set_default_tags(
             {
-                "app": self._deployment_id.app,
+                "app": self._deployment_id.app_name,
                 "deployment": self._deployment_id.name,
                 "actor_id": self_actor_id if self_actor_id else "",
             }
@@ -219,7 +219,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
 
     @property
     def app_name(self) -> str:
-        return self._deployment_id.app
+        return self._deployment_id.app_name
 
     @property
     def replica_queue_len_cache(self) -> ReplicaQueueLengthCache:

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -58,13 +58,13 @@ class RouterMetricsManager:
         # Exported metrics
         self.num_router_requests = router_requests_counter
         self.num_router_requests.set_default_tags(
-            {"deployment": deployment_id.name, "application": deployment_id.app}
+            {"deployment": deployment_id.name, "application": deployment_id.app_name}
         )
 
         self.num_queued_requests = 0
         self.num_queued_requests_gauge = queued_requests_gauge
         self.num_queued_requests_gauge.set_default_tags(
-            {"deployment": deployment_id.name, "application": deployment_id.app}
+            {"deployment": deployment_id.name, "application": deployment_id.app_name}
         )
 
         # Track queries sent to replicas for the autoscaling algorithm.

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -139,7 +139,7 @@ def get_num_running_replicas(
 ) -> int:
     """Get the replicas currently running for the given deployment."""
 
-    dep_id = DeploymentID(deployment_name, app_name)
+    dep_id = DeploymentID(name=deployment_name, app_name=app_name)
     actors = state_api.list_actors(
         filters=[
             ("class_name", "=", dep_id.to_replica_actor_class_name()),

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -106,7 +106,7 @@ class _DeploymentHandleBase:
         _request_counter: Optional[metrics.Counter] = None,
         _recorded_telemetry: bool = False,
     ):
-        self.deployment_id = DeploymentID(deployment_name, app_name)
+        self.deployment_id = DeploymentID(name=deployment_name, app_name=app_name)
         self.handle_options = handle_options or _HandleOptions()
         self._recorded_telemetry = _recorded_telemetry
 

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -194,7 +194,7 @@ class _DeploymentHandleBase:
 
     @property
     def app_name(self) -> str:
-        return self.deployment_id.app
+        return self.deployment_id.app_name
 
     def _options(
         self,

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -141,7 +141,9 @@ class _ModelMultiplexWrapper:
             if self._push_multiplexed_replica_info:
                 _get_global_client().record_multiplexed_replica_info(
                     MultiplexedReplicaInfo(
-                        DeploymentID(name=self._deployment_name, app_name=self._app_name),
+                        DeploymentID(
+                            name=self._deployment_name, app_name=self._app_name
+                        ),
                         self._replica_tag,
                         self._get_loading_and_loaded_model_ids(),
                     )

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -141,7 +141,7 @@ class _ModelMultiplexWrapper:
             if self._push_multiplexed_replica_info:
                 _get_global_client().record_multiplexed_replica_info(
                     MultiplexedReplicaInfo(
-                        DeploymentID(self._deployment_name, self._app_name),
+                        DeploymentID(name=self._deployment_name, app_name=self._app_name),
                         self._replica_tag,
                         self._get_loading_and_loaded_model_ids(),
                     )

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -458,7 +458,7 @@ def test_deployment_name_with_app_name(serve_instance):
 
     serve.run(g.bind())
     deployment_info = ray.get(controller._all_running_replicas.remote())
-    assert DeploymentID("g", SERVE_DEFAULT_APP_NAME) in deployment_info
+    assert DeploymentID(name="g") in deployment_info
 
     @serve.deployment
     def f():
@@ -466,7 +466,7 @@ def test_deployment_name_with_app_name(serve_instance):
 
     serve.run(f.bind(), route_prefix="/f", name="app1")
     deployment_info = ray.get(controller._all_running_replicas.remote())
-    assert DeploymentID("f", "app1") in deployment_info
+    assert DeploymentID(name="f", app_name="app1") in deployment_info
 
 
 def test_deploy_application_with_same_name(serve_instance):
@@ -483,7 +483,7 @@ def test_deploy_application_with_same_name(serve_instance):
     assert handle.remote().result() == "got model"
     assert requests.get("http://127.0.0.1:8000/").text == "got model"
     deployment_info = ray.get(controller._all_running_replicas.remote())
-    assert DeploymentID("Model", "app") in deployment_info
+    assert DeploymentID(name="Model", app_name="app") in deployment_info
 
     # After deploying a new app with the same name, no Model replicas should be running
     @serve.deployment
@@ -495,10 +495,10 @@ def test_deploy_application_with_same_name(serve_instance):
     assert handle.remote().result() == "got model1"
     assert requests.get("http://127.0.0.1:8000/").text == "got model1"
     deployment_info = ray.get(controller._all_running_replicas.remote())
-    assert DeploymentID("Model1", "app") in deployment_info
+    assert DeploymentID(name="Model1", app_name="app") in deployment_info
     assert (
-        DeploymentID("Model", "app") not in deployment_info
-        or deployment_info[DeploymentID("Model", "app")] == []
+        DeploymentID(name="Model", app_name="app") not in deployment_info
+        or deployment_info[DeploymentID(name="Model", app_name="app")] == []
     )
 
     # Redeploy with same app to update route prefix

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -42,9 +42,7 @@ from ray.serve.schema import ServeDeploySchema
 def get_running_replica_tags(name: str, controller: ServeController) -> List:
     """Get the replica tags of running replicas for given deployment"""
     replicas = ray.get(
-        controller._dump_replica_states_for_testing.remote(
-            DeploymentID(name=name)
-        )
+        controller._dump_replica_states_for_testing.remote(DeploymentID(name=name))
     )
     running_replicas = replicas.get([ReplicaState.RUNNING])
     return [replica.replica_tag for replica in running_replicas]

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -43,7 +43,7 @@ def get_running_replica_tags(name: str, controller: ServeController) -> List:
     """Get the replica tags of running replicas for given deployment"""
     replicas = ray.get(
         controller._dump_replica_states_for_testing.remote(
-            DeploymentID(name, SERVE_DEFAULT_APP_NAME)
+            DeploymentID(name=name)
         )
     )
     running_replicas = replicas.get([ReplicaState.RUNNING])
@@ -53,7 +53,7 @@ def get_running_replica_tags(name: str, controller: ServeController) -> List:
 def get_deployment_start_time(controller: ServeController, name: str):
     """Return start time for given deployment"""
     deployments = ray.get(controller.list_deployments_internal.remote())
-    deployment_info, _ = deployments[DeploymentID(name, SERVE_DEFAULT_APP_NAME)]
+    deployment_info, _ = deployments[DeploymentID(name=name)]
     return deployment_info.start_time_ms
 
 
@@ -117,7 +117,7 @@ def test_autoscaling_metrics(serve_instance):
             ray.get(signal.wait.remote())
 
     handle = serve.run(A.bind())
-    dep_id = DeploymentID("A", "default")
+    dep_id = DeploymentID(name="A")
     [handle.remote() for _ in range(50)]
 
     # Wait for metrics to propagate
@@ -713,7 +713,7 @@ def test_e2e_preserve_prev_replicas(serve_instance):
         return os.getpid()
 
     handle = serve.run(scaler.bind())
-    dep_id = DeploymentID("scaler", SERVE_DEFAULT_APP_NAME)
+    dep_id = DeploymentID(name="scaler")
     responses = [handle.remote() for _ in range(10)]
 
     wait_for_condition(

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -26,7 +26,7 @@ def assert_deployments_live(ids: List[DeploymentID]):
     running_actor_names = [actor["name"] for actor in list_actors()]
 
     for deployment_id in ids:
-        prefix = f"{deployment_id.app}#{deployment_id.name}"
+        prefix = f"{deployment_id.app_name}#{deployment_id.name}"
         msg = f"Deployment {deployment_id} is not live"
         assert any(prefix in actor_name for actor_name in running_actor_names), msg
 

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -83,9 +83,9 @@ def test_deploy_basic(ray_start_stop):
         print("Deployments are reachable over HTTP.")
 
         deployments = [
-            DeploymentID("Router", SERVE_DEFAULT_APP_NAME),
-            DeploymentID("Multiplier", SERVE_DEFAULT_APP_NAME),
-            DeploymentID("Adder", SERVE_DEFAULT_APP_NAME),
+            DeploymentID(name="Router"),
+            DeploymentID(name="Multiplier"),
+            DeploymentID(name="Adder"),
         ]
         assert_deployments_live(deployments)
         print("All deployments are live.\n")
@@ -112,9 +112,9 @@ def test_deploy_basic(ray_start_stop):
         print("Deployments are reachable over HTTP.")
 
         deployments = [
-            DeploymentID("Router", SERVE_DEFAULT_APP_NAME),
-            DeploymentID("Add", SERVE_DEFAULT_APP_NAME),
-            DeploymentID("Subtract", SERVE_DEFAULT_APP_NAME),
+            DeploymentID(name="Router"),
+            DeploymentID(name="Add"),
+            DeploymentID(name="Subtract"),
         ]
         assert_deployments_live(deployments)
         print("All deployments are live.\n")
@@ -202,12 +202,12 @@ def test_deploy_multi_app_basic(ray_start_stop):
         print('Application "app2" is reachable over HTTP.')
 
         deployment_names = [
-            DeploymentID("Router", "app1"),
-            DeploymentID("Multiplier", "app1"),
-            DeploymentID("Adder", "app1"),
-            DeploymentID("Router", "app2"),
-            DeploymentID("Multiplier", "app2"),
-            DeploymentID("Adder", "app2"),
+            DeploymentID(name="Router", app_name="app1"),
+            DeploymentID(name="Multiplier", app_name="app1"),
+            DeploymentID(name="Adder", app_name="app1"),
+            DeploymentID(name="Router", app_name="app2"),
+            DeploymentID(name="Multiplier", app_name="app2"),
+            DeploymentID(name="Adder", app_name="app2"),
         ]
         assert_deployments_live(deployment_names)
         print("All deployments are live.\n")
@@ -237,11 +237,11 @@ def test_deploy_multi_app_basic(ray_start_stop):
         print('Application "app2" is reachable over HTTP.')
 
         deployment_names = [
-            DeploymentID("BasicDriver", "app1"),
-            DeploymentID("f", "app1"),
-            DeploymentID("Router", "app2"),
-            DeploymentID("Multiplier", "app2"),
-            DeploymentID("Adder", "app2"),
+            DeploymentID(name="BasicDriver", app_name="app1"),
+            DeploymentID(name="f", app_name="app1"),
+            DeploymentID(name="Router", app_name="app2"),
+            DeploymentID(name="Multiplier", app_name="app2"),
+            DeploymentID(name="Adder", app_name="app2"),
         ]
         assert_deployments_live(deployment_names)
         print("All deployments are live.\n")

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -166,7 +166,7 @@ def test_replica_startup_status_transitions(ray_cluster):
         controller = client._controller
         replicas = ray.get(
             controller._dump_replica_states_for_testing.remote(
-                DeploymentID(E.name, "default")
+                DeploymentID(name=E.name)
             )
         )
         return replicas.get([replica_state])

--- a/python/ray/serve/tests/test_constructor_failure.py
+++ b/python/ray/serve/tests/test_constructor_failure.py
@@ -7,7 +7,6 @@ import pytest
 import ray
 from ray import serve
 from ray.serve._private.common import DeploymentID
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 
 
 def test_deploy_with_consistent_constructor_failure(serve_instance):
@@ -26,7 +25,7 @@ def test_deploy_with_consistent_constructor_failure(serve_instance):
     # Assert no replicas are running in deployment deployment after failed
     # deploy call
     deployment_id = DeploymentID(
-        "ConstructorFailureDeploymentOneReplica", SERVE_DEFAULT_APP_NAME
+        name="ConstructorFailureDeploymentOneReplica"
     )
     deployment_dict = ray.get(serve_instance._controller._all_running_replicas.remote())
     assert deployment_dict[deployment_id] == []
@@ -46,7 +45,7 @@ def test_deploy_with_consistent_constructor_failure(serve_instance):
     # Assert no replicas are running in deployment deployment after failed
     # deploy call
     deployment_id = DeploymentID(
-        "ConstructorFailureDeploymentTwoReplicas", SERVE_DEFAULT_APP_NAME
+        name="ConstructorFailureDeploymentTwoReplicas"
     )
     deployment_dict = ray.get(serve_instance._controller._all_running_replicas.remote())
     assert deployment_dict[deployment_id] == []
@@ -84,7 +83,7 @@ def test_deploy_with_partial_constructor_failure(serve_instance):
     # successful deploy call
     deployment_dict = ray.get(serve_instance._controller._all_running_replicas.remote())
     deployment_id = DeploymentID(
-        "PartialConstructorFailureDeployment", SERVE_DEFAULT_APP_NAME
+        name="PartialConstructorFailureDeployment"
     )
     assert len(deployment_dict[deployment_id]) == 2
 
@@ -113,7 +112,7 @@ def test_deploy_with_transient_constructor_failure(serve_instance):
     # successful deploy call with transient error
     deployment_dict = ray.get(serve_instance._controller._all_running_replicas.remote())
     deployment_id = DeploymentID(
-        "TransientConstructorFailureDeployment", SERVE_DEFAULT_APP_NAME
+        name="TransientConstructorFailureDeployment"
     )
     assert len(deployment_dict[deployment_id]) == 2
 

--- a/python/ray/serve/tests/test_constructor_failure.py
+++ b/python/ray/serve/tests/test_constructor_failure.py
@@ -24,9 +24,7 @@ def test_deploy_with_consistent_constructor_failure(serve_instance):
 
     # Assert no replicas are running in deployment deployment after failed
     # deploy call
-    deployment_id = DeploymentID(
-        name="ConstructorFailureDeploymentOneReplica"
-    )
+    deployment_id = DeploymentID(name="ConstructorFailureDeploymentOneReplica")
     deployment_dict = ray.get(serve_instance._controller._all_running_replicas.remote())
     assert deployment_dict[deployment_id] == []
 
@@ -44,9 +42,7 @@ def test_deploy_with_consistent_constructor_failure(serve_instance):
 
     # Assert no replicas are running in deployment deployment after failed
     # deploy call
-    deployment_id = DeploymentID(
-        name="ConstructorFailureDeploymentTwoReplicas"
-    )
+    deployment_id = DeploymentID(name="ConstructorFailureDeploymentTwoReplicas")
     deployment_dict = ray.get(serve_instance._controller._all_running_replicas.remote())
     assert deployment_dict[deployment_id] == []
 
@@ -82,9 +78,7 @@ def test_deploy_with_partial_constructor_failure(serve_instance):
     # Assert 2 replicas are running in deployment deployment after partially
     # successful deploy call
     deployment_dict = ray.get(serve_instance._controller._all_running_replicas.remote())
-    deployment_id = DeploymentID(
-        name="PartialConstructorFailureDeployment"
-    )
+    deployment_id = DeploymentID(name="PartialConstructorFailureDeployment")
     assert len(deployment_dict[deployment_id]) == 2
 
 
@@ -111,9 +105,7 @@ def test_deploy_with_transient_constructor_failure(serve_instance):
     # Assert 2 replicas are running in deployment deployment after partially
     # successful deploy call with transient error
     deployment_dict = ray.get(serve_instance._controller._all_running_replicas.remote())
-    deployment_id = DeploymentID(
-        name="TransientConstructorFailureDeployment"
-    )
+    deployment_id = DeploymentID(name="TransientConstructorFailureDeployment")
     assert len(deployment_dict[deployment_id]) == 2
 
 

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -50,7 +50,7 @@ def test_recover_start_from_replica_actor_names(serve_instance):
     # Assert 2 replicas are running in deployment deployment after partially
     # successful deploy() call with transient error
     deployment_dict = ray.get(serve_instance._controller._all_running_replicas.remote())
-    id = DeploymentID("recover_start_from_replica_actor_names", "app")
+    id = DeploymentID(name="recover_start_from_replica_actor_names", app_name="app")
     assert len(deployment_dict[id]) == 2
 
     replica_version_hash = None
@@ -163,7 +163,7 @@ def test_recover_rolling_update_from_replica_actor_names(serve_instance):
         wait_for_condition(
             check_replica_counts,
             controller=serve_instance._controller,
-            deployment_id=DeploymentID("test", "app"),
+            deployment_id=DeploymentID(name="test", app_name="app"),
             total=3,
             by_state=[
                 (ReplicaState.STOPPING, 1, lambda r: r._actor.pid in initial_pids),
@@ -202,7 +202,7 @@ def test_recover_rolling_update_from_replica_actor_names(serve_instance):
     serve_instance._wait_for_application_running("app")
     check_replica_counts(
         controller=serve_instance._controller,
-        deployment_id=DeploymentID("test", "app"),
+        deployment_id=DeploymentID(name="test", app_name="app"),
         total=2,
         by_state=(
             [(ReplicaState.RUNNING, 2, lambda r: r._actor.pid not in initial_pids)]
@@ -273,7 +273,7 @@ def test_replica_deletion_after_controller_recover(serve_instance):
     serve.delete("app", _blocking=False)
 
     def check_replica(replica_state=None):
-        id = DeploymentID("V1", "app")
+        id = DeploymentID(name="V1", app_name="app")
         try:
             replicas = ray.get(controller._dump_replica_states_for_testing.remote(id))
         except RayTaskError as ex:
@@ -315,7 +315,7 @@ def test_recover_deleting_application(serve_instance):
         async def __del__(self):
             await signal.wait.remote()
 
-    id = DeploymentID("A", SERVE_DEFAULT_APP_NAME)
+    id = DeploymentID(name="A")
     serve.run(A.bind())
 
     @ray.remote

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -500,9 +500,9 @@ def test_deploy_multi_app_deployments_removed(client: ServeControllerClient):
         for prefix in expected_actor_name_prefixes:
             assert any(name.startswith(prefix) for name in actor_names)
 
-        assert {DeploymentID(name=deployment, app_name="app1") for deployment in deployments} == set(
-            ray.get(client._controller._all_running_replicas.remote()).keys()
-        )
+        assert {
+            DeploymentID(name=deployment, app_name="app1") for deployment in deployments
+        } == set(ray.get(client._controller._all_running_replicas.remote()).keys())
         return True
 
     wait_for_condition(check_app, deployments=pizza_deployments)
@@ -680,9 +680,7 @@ def test_update_config_graceful_shutdown_timeout(client: ServeControllerClient):
     client.delete_apps([SERVE_DEFAULT_APP_NAME], blocking=False)
     # Replica should be dead within 10 second timeout, which means
     # graceful_shutdown_timeout_s was successfully updated lightweightly
-    wait_for_condition(
-        partial(check_deployments_dead, [DeploymentID(name="f")])
-    )
+    wait_for_condition(partial(check_deployments_dead, [DeploymentID(name="f")]))
 
 
 def test_update_config_max_concurrent_queries(client: ServeControllerClient):

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -500,7 +500,7 @@ def test_deploy_multi_app_deployments_removed(client: ServeControllerClient):
         for prefix in expected_actor_name_prefixes:
             assert any(name.startswith(prefix) for name in actor_names)
 
-        assert {DeploymentID(deployment, "app1") for deployment in deployments} == set(
+        assert {DeploymentID(name=deployment, app_name="app1") for deployment in deployments} == set(
             ray.get(client._controller._all_running_replicas.remote()).keys()
         )
         return True
@@ -681,7 +681,7 @@ def test_update_config_graceful_shutdown_timeout(client: ServeControllerClient):
     # Replica should be dead within 10 second timeout, which means
     # graceful_shutdown_timeout_s was successfully updated lightweightly
     wait_for_condition(
-        partial(check_deployments_dead, [DeploymentID("f", SERVE_DEFAULT_APP_NAME)])
+        partial(check_deployments_dead, [DeploymentID(name="f")])
     )
 
 

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -103,7 +103,7 @@ def check_endpoint(endpoint: str, json: Union[List, Dict], expected: str):
 
 
 def check_deployments_dead(deployment_ids: List[DeploymentID]):
-    prefixes = [f"{id.app}#{id.name}" for id in deployment_ids]
+    prefixes = [f"{id.app_name}#{id.name}" for id in deployment_ids]
     actor_names = [
         actor["name"] for actor in list_actors(filters=[("state", "=", "ALIVE")])
     ]

--- a/python/ray/serve/tests/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/test_deployment_scheduler.py
@@ -49,7 +49,7 @@ def test_spread_deployment_scheduling_policy_upscale(
     cluster_node_info_cache.update()
 
     scheduler = DefaultDeploymentScheduler(cluster_node_info_cache, get_head_node_id())
-    dep_id = DeploymentID("deployment1", "default")
+    dep_id = DeploymentID(name="deployment1")
     scheduler.on_deployment_created(dep_id, SpreadDeploymentSchedulingPolicy())
     replica_actor_handles = []
     replica_placement_groups = []
@@ -137,8 +137,8 @@ def test_spread_deployment_scheduling_policy_downscale_multiple_deployments(
     cluster_node_info_cache.update()
 
     scheduler = DefaultDeploymentScheduler(cluster_node_info_cache, get_head_node_id())
-    d1_id = DeploymentID("deployment1", "default")
-    d2_id = DeploymentID("deployment2", "default")
+    d1_id = DeploymentID(name="deployment1")
+    d2_id = DeploymentID(name="deployment2")
     scheduler.on_deployment_created(d1_id, SpreadDeploymentSchedulingPolicy())
     scheduler.on_deployment_created(d2_id, SpreadDeploymentSchedulingPolicy())
     scheduler.on_replica_running(d1_id, "replica1", "node1")
@@ -204,7 +204,7 @@ def test_spread_deployment_scheduling_policy_downscale_single_deployment(
     cluster_node_info_cache.update()
 
     scheduler = DefaultDeploymentScheduler(cluster_node_info_cache, get_head_node_id())
-    dep_id = DeploymentID("deployment1", "my_app")
+    dep_id = DeploymentID(name="deployment1")
     scheduler.on_deployment_created(dep_id, SpreadDeploymentSchedulingPolicy())
     scheduler.on_replica_running(dep_id, "replica1", "node1")
     scheduler.on_replica_running(dep_id, "replica2", "node1")
@@ -287,7 +287,7 @@ def test_spread_deployment_scheduling_policy_downscale_head_node(ray_start_clust
     cluster_node_info_cache.update()
 
     scheduler = DefaultDeploymentScheduler(cluster_node_info_cache, get_head_node_id())
-    dep_id = DeploymentID("deployment1", "my_app")
+    dep_id = DeploymentID(name="deployment1")
     scheduler.on_deployment_created(dep_id, SpreadDeploymentSchedulingPolicy())
     scheduler.on_replica_running(dep_id, "replica1", head_node_id)
     scheduler.on_replica_running(dep_id, "replica2", "node2")

--- a/python/ray/serve/tests/test_failure.py
+++ b/python/ray/serve/tests/test_failure.py
@@ -110,7 +110,7 @@ def test_http_proxy_failure(serve_instance):
 
 
 def _get_worker_handles(deployment_name: str, app_name: str = SERVE_DEFAULT_APP_NAME):
-    id = DeploymentID(deployment_name, app_name)
+    id = DeploymentID(name=deployment_name, app_name=app_name)
     controller = serve.context._global_client._controller
     deployment_dict = ray.get(controller._all_running_replicas.remote())
 

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -46,6 +46,7 @@ def test_serving_request_through_grpc_proxy(ray_cluster):
         "ray.serve.generated.serve_pb2_grpc.add_FruitServiceServicer_to_server",
     ]
 
+    app_name = "app"
     serve.start(
         grpc_options=gRPCOptions(
             port=grpc_port,
@@ -57,7 +58,7 @@ def test_serving_request_through_grpc_proxy(ray_cluster):
     # Ensures the not found is responding correctly.
     ping_grpc_call_method(channel, app_name, test_not_found=True)
 
-    serve.run(g)
+    serve.run(g, name=app_name)
 
     # Ensures ListApplications method succeeding.
     ping_grpc_list_applications(channel, [app_name])

--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -56,15 +56,10 @@ def test_serving_request_through_grpc_proxy(ray_cluster):
     channel = grpc.insecure_channel("localhost:9000")
 
     # Ensures the not found is responding correctly.
+    app_name = "default"
     ping_grpc_call_method(channel, app_name, test_not_found=True)
 
     serve.run(g)
-    replicas = ray.get(
-        serve.context._global_client._controller._all_running_replicas.remote()
-    )
-
-    # Ensures the app is deployed.
-    assert len(replicas[replica_name]) == 1
 
     # Ensures ListApplications method succeeding.
     ping_grpc_list_applications(channel, [app_name])

--- a/python/ray/serve/tests/test_long_poll.py
+++ b/python/ray/serve/tests/test_long_poll.py
@@ -9,7 +9,7 @@ import pytest
 import ray
 from ray._private.test_utils import async_wait_for_condition
 from ray._private.utils import get_or_create_event_loop
-from ray.serve._private.common import EndpointInfo, DeploymentID, RunningReplicaInfo
+from ray.serve._private.common import DeploymentID, EndpointInfo, RunningReplicaInfo
 from ray.serve._private.long_poll import (
     LongPollClient,
     LongPollHost,

--- a/python/ray/serve/tests/test_long_poll.py
+++ b/python/ray/serve/tests/test_long_poll.py
@@ -9,7 +9,7 @@ import pytest
 import ray
 from ray._private.test_utils import async_wait_for_condition
 from ray._private.utils import get_or_create_event_loop
-from ray.serve._private.common import EndpointInfo, EndpointTag, RunningReplicaInfo
+from ray.serve._private.common import EndpointInfo, DeploymentID, RunningReplicaInfo
 from ray.serve._private.long_poll import (
     LongPollClient,
     LongPollHost,
@@ -203,7 +203,7 @@ def test_listen_for_change_java(serve_instance):
     assert set(poll_result_1.updated_objects.keys()) == {"key_1"}
     assert poll_result_1.updated_objects["key_1"].object_snapshot.decode() == "999"
     request_2 = {"keys_to_snapshot_ids": {"ROUTE_TABLE": -1}}
-    endpoints: Dict[EndpointTag, EndpointInfo] = dict()
+    endpoints: Dict[DeploymentID, EndpointInfo] = dict()
     endpoints["deployment_name"] = EndpointInfo(route="/test/xlang/poll")
     endpoints["deployment_name1"] = EndpointInfo(route="/test/xlang/poll1")
     ray.get(host.notify_changed.remote(LongPollNamespace.ROUTE_TABLE, endpoints))

--- a/python/ray/serve/tests/test_proxy.py
+++ b/python/ray/serve/tests/test_proxy.py
@@ -10,7 +10,7 @@ import pytest
 import ray
 from ray import serve
 from ray.actor import ActorHandle
-from ray.serve._private.common import DeploymentID, EndpointInfo, EndpointTag
+from ray.serve._private.common import DeploymentID, EndpointInfo, DeploymentID
 from ray.serve._private.constants import (
     DEFAULT_UVICORN_KEEP_ALIVE_TIMEOUT_S,
     SERVE_NAMESPACE,
@@ -70,7 +70,7 @@ class FakeActorHandle:
 
 class FakeGrpcHandle:
     def __init__(self, streaming: bool, grpc_context: RayServegRPCContext):
-        self.deployment_id = DeploymentID("fak_deployment_name", "fake_app_name")
+        self.deployment_id = DeploymentID(name="fake_deployment_name", app_name="fake_app_name")
         self.streaming = streaming
         self.grpc_context = grpc_context
 
@@ -97,7 +97,7 @@ class FakeProxyRouter(ProxyRouter):
         self.handle = None
         self.app_is_cross_language = None
 
-    def update_routes(self, endpoints: Dict[EndpointTag, EndpointInfo]):
+    def update_routes(self, endpoints: Dict[DeploymentID, EndpointInfo]):
         pass
 
     def get_handle_for_endpoint(self, *args, **kwargs):
@@ -171,7 +171,7 @@ class FakeProxyRequest(ProxyRequest):
 
 class FakeHTTPHandle:
     def __init__(self, messages):
-        self.deployment_id = DeploymentID("fak_deployment_name", "fake_app_name")
+        self.deployment_id = DeploymentID(name="fake_deployment_name", app_name="fake_app_name")
         self.messages = messages
 
     async def remote(self, *args, **kwargs):
@@ -270,7 +270,7 @@ class TestgRPCProxy:
             grpc_proxy.update_draining(True)
         if routes_updated:
             grpc_proxy.update_routes(
-                {DeploymentID(app="app", name="deployment"): EndpointInfo("/route")},
+                {DeploymentID(name="deployment", app_name="app"): EndpointInfo("/route")},
             )
 
         status, [response_bytes] = await _consume_proxy_generator(
@@ -455,7 +455,7 @@ class TestHTTPProxy:
             http_proxy.update_draining(True)
         if routes_updated:
             http_proxy.update_routes(
-                {DeploymentID(app="app", name="deployment"): EndpointInfo("/route")},
+                {DeploymentID(name="deployment", app_name="app"): EndpointInfo("/route")},
             )
 
         status, messages = await _consume_proxy_generator(

--- a/python/ray/serve/tests/test_proxy.py
+++ b/python/ray/serve/tests/test_proxy.py
@@ -10,7 +10,7 @@ import pytest
 import ray
 from ray import serve
 from ray.actor import ActorHandle
-from ray.serve._private.common import DeploymentID, EndpointInfo, DeploymentID
+from ray.serve._private.common import DeploymentID, EndpointInfo
 from ray.serve._private.constants import (
     DEFAULT_UVICORN_KEEP_ALIVE_TIMEOUT_S,
     SERVE_NAMESPACE,
@@ -70,7 +70,9 @@ class FakeActorHandle:
 
 class FakeGrpcHandle:
     def __init__(self, streaming: bool, grpc_context: RayServegRPCContext):
-        self.deployment_id = DeploymentID(name="fake_deployment_name", app_name="fake_app_name")
+        self.deployment_id = DeploymentID(
+            name="fake_deployment_name", app_name="fake_app_name"
+        )
         self.streaming = streaming
         self.grpc_context = grpc_context
 
@@ -171,7 +173,9 @@ class FakeProxyRequest(ProxyRequest):
 
 class FakeHTTPHandle:
     def __init__(self, messages):
-        self.deployment_id = DeploymentID(name="fake_deployment_name", app_name="fake_app_name")
+        self.deployment_id = DeploymentID(
+            name="fake_deployment_name", app_name="fake_app_name"
+        )
         self.messages = messages
 
     async def remote(self, *args, **kwargs):
@@ -270,7 +274,11 @@ class TestgRPCProxy:
             grpc_proxy.update_draining(True)
         if routes_updated:
             grpc_proxy.update_routes(
-                {DeploymentID(name="deployment", app_name="app"): EndpointInfo("/route")},
+                {
+                    DeploymentID(name="deployment", app_name="app"): EndpointInfo(
+                        "/route"
+                    )
+                },
             )
 
         status, [response_bytes] = await _consume_proxy_generator(
@@ -455,7 +463,11 @@ class TestHTTPProxy:
             http_proxy.update_draining(True)
         if routes_updated:
             http_proxy.update_routes(
-                {DeploymentID(name="deployment", app_name="app"): EndpointInfo("/route")},
+                {
+                    DeploymentID(name="deployment", app_name="app"): EndpointInfo(
+                        "/route"
+                    )
+                },
             )
 
         status, messages = await _consume_proxy_generator(

--- a/python/ray/serve/tests/test_proxy_router.py
+++ b/python/ray/serve/tests/test_proxy_router.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 import pytest
 
-from ray.serve._private.common import EndpointInfo, DeploymentID, RequestProtocol
+from ray.serve._private.common import DeploymentID, EndpointInfo, RequestProtocol
 from ray.serve._private.proxy_router import (
     EndpointRouter,
     LongestPrefixRouter,
@@ -68,8 +68,12 @@ def test_no_match(mocked_router, request):
     router = request.getfixturevalue(mocked_router)
     router.update_routes(
         {
-            DeploymentID(name="endpoint", app_name="default"): EndpointInfo(route="/hello"),
-            DeploymentID(name="endpoint2", app_name="app2"): EndpointInfo(route="/hello2"),
+            DeploymentID(name="endpoint", app_name="default"): EndpointInfo(
+                route="/hello"
+            ),
+            DeploymentID(name="endpoint2", app_name="app2"): EndpointInfo(
+                route="/hello2"
+            ),
         }
     )
     assert get_handle_function(router)("/nonexistent") is None
@@ -86,8 +90,12 @@ def test_default_route(mocked_router, target_route, request):
     router = request.getfixturevalue(mocked_router)
     router.update_routes(
         {
-            DeploymentID(name="endpoint", app_name="default"): EndpointInfo(route="/endpoint"),
-            DeploymentID(name="endpoint2", app_name="app2"): EndpointInfo(route="/endpoint2"),
+            DeploymentID(name="endpoint", app_name="default"): EndpointInfo(
+                route="/endpoint"
+            ),
+            DeploymentID(name="endpoint2", app_name="app2"): EndpointInfo(
+                route="/endpoint2"
+            ),
         }
     )
 
@@ -107,7 +115,11 @@ def test_trailing_slash(mock_longest_prefix_router):
     assert route == "/test" and handle == "endpoint"
 
     router.update_routes(
-        {DeploymentID(name="endpoint", app_name="default"): EndpointInfo(route="/test/")}
+        {
+            DeploymentID(name="endpoint", app_name="default"): EndpointInfo(
+                route="/test/"
+            )
+        }
     )
 
     assert get_handle_function(router)("/test") is None
@@ -117,8 +129,12 @@ def test_prefix_match(mock_longest_prefix_router):
     router = mock_longest_prefix_router
     router.update_routes(
         {
-            DeploymentID(name="endpoint1", app_name="default"): EndpointInfo(route="/test/test2"),
-            DeploymentID(name="endpoint2", app_name="default"): EndpointInfo(route="/test"),
+            DeploymentID(name="endpoint1", app_name="default"): EndpointInfo(
+                route="/test/test2"
+            ),
+            DeploymentID(name="endpoint2", app_name="default"): EndpointInfo(
+                route="/test"
+            ),
             DeploymentID(name="endpoint3", app_name="default"): EndpointInfo(route="/"),
         }
     )
@@ -153,7 +169,11 @@ def test_prefix_match(mock_longest_prefix_router):
 def test_update_routes(mocked_router, target_route1, target_route2, request):
     router = request.getfixturevalue(mocked_router)
     router.update_routes(
-        {DeploymentID(name="endpoint", app_name="app1"): EndpointInfo(route="/endpoint")}
+        {
+            DeploymentID(name="endpoint", app_name="app1"): EndpointInfo(
+                route="/endpoint"
+            )
+        }
     )
 
     route, handle, app_is_cross_language = get_handle_function(router)(target_route1)

--- a/python/ray/serve/tests/test_proxy_router.py
+++ b/python/ray/serve/tests/test_proxy_router.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 import pytest
 
-from ray.serve._private.common import EndpointInfo, EndpointTag, RequestProtocol
+from ray.serve._private.common import EndpointInfo, DeploymentID, RequestProtocol
 from ray.serve._private.proxy_router import (
     EndpointRouter,
     LongestPrefixRouter,
@@ -68,8 +68,8 @@ def test_no_match(mocked_router, request):
     router = request.getfixturevalue(mocked_router)
     router.update_routes(
         {
-            EndpointTag("endpoint", "default"): EndpointInfo(route="/hello"),
-            EndpointTag("endpoint2", "default2"): EndpointInfo(route="/hello2"),
+            DeploymentID(name="endpoint", app_name="default"): EndpointInfo(route="/hello"),
+            DeploymentID(name="endpoint2", app_name="app2"): EndpointInfo(route="/hello2"),
         }
     )
     assert get_handle_function(router)("/nonexistent") is None
@@ -86,8 +86,8 @@ def test_default_route(mocked_router, target_route, request):
     router = request.getfixturevalue(mocked_router)
     router.update_routes(
         {
-            EndpointTag("endpoint", "default"): EndpointInfo(route="/endpoint"),
-            EndpointTag("endpoint2", "default2"): EndpointInfo(route="/endpoint2"),
+            DeploymentID(name="endpoint", app_name="default"): EndpointInfo(route="/endpoint"),
+            DeploymentID(name="endpoint2", app_name="app2"): EndpointInfo(route="/endpoint2"),
         }
     )
 
@@ -100,14 +100,14 @@ def test_default_route(mocked_router, target_route, request):
 def test_trailing_slash(mock_longest_prefix_router):
     router = mock_longest_prefix_router
     router.update_routes(
-        {EndpointTag("endpoint", "default"): EndpointInfo(route="/test")}
+        {DeploymentID(name="endpoint", app_name="default"): EndpointInfo(route="/test")}
     )
 
     route, handle, _ = get_handle_function(router)("/test/")
     assert route == "/test" and handle == "endpoint"
 
     router.update_routes(
-        {EndpointTag("endpoint", "default"): EndpointInfo(route="/test/")}
+        {DeploymentID(name="endpoint", app_name="default"): EndpointInfo(route="/test/")}
     )
 
     assert get_handle_function(router)("/test") is None
@@ -117,9 +117,9 @@ def test_prefix_match(mock_longest_prefix_router):
     router = mock_longest_prefix_router
     router.update_routes(
         {
-            EndpointTag("endpoint1", "default"): EndpointInfo(route="/test/test2"),
-            EndpointTag("endpoint2", "default"): EndpointInfo(route="/test"),
-            EndpointTag("endpoint3", "default"): EndpointInfo(route="/"),
+            DeploymentID(name="endpoint1", app_name="default"): EndpointInfo(route="/test/test2"),
+            DeploymentID(name="endpoint2", app_name="default"): EndpointInfo(route="/test"),
+            DeploymentID(name="endpoint3", app_name="default"): EndpointInfo(route="/"),
         }
     )
 
@@ -153,7 +153,7 @@ def test_prefix_match(mock_longest_prefix_router):
 def test_update_routes(mocked_router, target_route1, target_route2, request):
     router = request.getfixturevalue(mocked_router)
     router.update_routes(
-        {EndpointTag("endpoint", "app1"): EndpointInfo(route="/endpoint")}
+        {DeploymentID(name="endpoint", app_name="app1"): EndpointInfo(route="/endpoint")}
     )
 
     route, handle, app_is_cross_language = get_handle_function(router)(target_route1)
@@ -161,11 +161,11 @@ def test_update_routes(mocked_router, target_route1, target_route2, request):
 
     router.update_routes(
         {
-            EndpointTag("endpoint2", "app2"): EndpointInfo(
+            DeploymentID(name="endpoint2", app_name="app2"): EndpointInfo(
                 route="/endpoint2",
                 app_is_cross_language=True,
             ),
-            EndpointTag("endpoint3", "app3"): EndpointInfo(
+            DeploymentID(name="endpoint3", app_name="app3"): EndpointInfo(
                 route="/endpoint3",
                 app_is_cross_language=True,
             ),

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -501,7 +501,9 @@ def test_app_unhealthy(mocked_application_state):
     updated to unhealthy.
     """
     app_state, deployment_state_manager = mocked_application_state
-    id_a, id_b = DeploymentID(name="a", app_name="test_app"), DeploymentID(name="b", app_name="test_app")
+    id_a, id_b = DeploymentID(name="a", app_name="test_app"), DeploymentID(
+        name="b", app_name="test_app"
+    )
     app_state.deploy({"a": deployment_info("a"), "b": deployment_info("b")})
     assert app_state.status == ApplicationStatus.DEPLOYING
     app_state.update()
@@ -663,7 +665,9 @@ def test_deploy_with_renamed_app(mocked_application_state_manager):
     conflict with an old app running on the cluster.
     """
     app_state_manager, deployment_state_manager, _ = mocked_application_state_manager
-    a_id, b_id = DeploymentID(name="a", app_name="app1"), DeploymentID(name="b", app_name="app2")
+    a_id, b_id = DeploymentID(name="a", app_name="app1"), DeploymentID(
+        name="b", app_name="app2"
+    )
 
     # deploy app1
     app_state_manager.apply_deployment_args("app1", [deployment_params("a", "/url1")])

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -361,8 +361,8 @@ def test_deploy_and_delete_app(mocked_application_state):
     app_state, deployment_state_manager = mocked_application_state
 
     # DEPLOY application with deployments {d1, d2}
-    d1_id = DeploymentID("d1", "test_app")
-    d2_id = DeploymentID("d2", "test_app")
+    d1_id = DeploymentID(name="d1", app_name="test_app")
+    d2_id = DeploymentID(name="d2", app_name="test_app")
     app_state.deploy(
         {
             "d1": deployment_info("d1", "/hi", "/documentation"),
@@ -419,8 +419,8 @@ def test_deploy_and_delete_app(mocked_application_state):
 def test_app_deploy_failed_and_redeploy(mocked_application_state):
     """Test DEPLOYING -> DEPLOY_FAILED -> (redeploy) -> DEPLOYING -> RUNNING"""
     app_state, deployment_state_manager = mocked_application_state
-    d1_id = DeploymentID("d1", "test_app")
-    d2_id = DeploymentID("d2", "test_app")
+    d1_id = DeploymentID(name="d1", app_name="test_app")
+    d2_id = DeploymentID(name="d2", app_name="test_app")
     app_state.deploy({"d1": deployment_info("d1")})
     assert app_state.status == ApplicationStatus.DEPLOYING
 
@@ -471,7 +471,7 @@ def test_app_deploy_failed_and_recover(mocked_application_state):
     the application status should update to running.
     """
     app_state, deployment_state_manager = mocked_application_state
-    deployment_id = DeploymentID("d1", "test_app")
+    deployment_id = DeploymentID(name="d1", app_name="test_app")
     app_state.deploy({"d1": deployment_info("d1")})
     assert app_state.status == ApplicationStatus.DEPLOYING
 
@@ -501,7 +501,7 @@ def test_app_unhealthy(mocked_application_state):
     updated to unhealthy.
     """
     app_state, deployment_state_manager = mocked_application_state
-    id_a, id_b = DeploymentID("a", "test_app"), DeploymentID("b", "test_app")
+    id_a, id_b = DeploymentID(name="a", app_name="test_app"), DeploymentID(name="b", app_name="test_app")
     app_state.deploy({"a": deployment_info("a"), "b": deployment_info("b")})
     assert app_state.status == ApplicationStatus.DEPLOYING
     app_state.update()
@@ -535,7 +535,7 @@ def test_deploy_through_config_succeed(check_obj_ref_ready_nowait):
     Deploy obj ref finishes successfully, so status should transition to running.
     """
     kv_store = MockKVStore()
-    deployment_id = DeploymentID("a", "test_app")
+    deployment_id = DeploymentID(name="a", app_name="test_app")
     deployment_state_manager = MockDeploymentStateManager(kv_store)
     app_state_manager = ApplicationStateManager(
         deployment_state_manager, MockEndpointState(), kv_store
@@ -608,9 +608,9 @@ def test_deploy_through_config_fail(check_obj_ref_ready_nowait):
 def test_redeploy_same_app(mocked_application_state):
     """Test redeploying same application with updated deployments."""
     app_state, deployment_state_manager = mocked_application_state
-    a_id = DeploymentID("a", "test_app")
-    b_id = DeploymentID("b", "test_app")
-    c_id = DeploymentID("c", "test_app")
+    a_id = DeploymentID(name="a", app_name="test_app")
+    b_id = DeploymentID(name="b", app_name="test_app")
+    c_id = DeploymentID(name="c", app_name="test_app")
     app_state.deploy({"a": deployment_info("a"), "b": deployment_info("b")})
     assert app_state.status == ApplicationStatus.DEPLOYING
 
@@ -663,7 +663,7 @@ def test_deploy_with_renamed_app(mocked_application_state_manager):
     conflict with an old app running on the cluster.
     """
     app_state_manager, deployment_state_manager, _ = mocked_application_state_manager
-    a_id, b_id = DeploymentID("a", "app1"), DeploymentID("b", "app2")
+    a_id, b_id = DeploymentID(name="a", app_name="app1"), DeploymentID(name="b", app_name="app2")
 
     # deploy app1
     app_state_manager.apply_deployment_args("app1", [deployment_params("a", "/url1")])
@@ -710,7 +710,7 @@ def test_application_state_recovery(mocked_application_state_manager):
         deployment_state_manager,
         kv_store,
     ) = mocked_application_state_manager
-    deployment_id = DeploymentID("d1", "test_app")
+    deployment_id = DeploymentID(name="d1", app_name="test_app")
     app_name = "test_app"
 
     # DEPLOY application with deployments {d1, d2}
@@ -759,7 +759,7 @@ def test_recover_during_update(mocked_application_state_manager):
         deployment_state_manager,
         kv_store,
     ) = mocked_application_state_manager
-    deployment_id = DeploymentID("d1", "test_app")
+    deployment_id = DeploymentID(name="d1", app_name="test_app")
     app_name = "test_app"
 
     # DEPLOY application with deployment "d1"
@@ -824,7 +824,7 @@ def test_is_ready_for_shutdown(mocked_application_state_manager):
     ) = mocked_application_state_manager
     app_name = "test_app"
     deployment_name = "d1"
-    deployment_id = DeploymentID(deployment_name, app_name)
+    deployment_id = DeploymentID(name=deployment_name, app_name=app_name)
 
     # DEPLOY application with deployment "d1"
     params = deployment_params(deployment_name)

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -106,7 +106,7 @@ class MockDeploymentStateManager:
     def get_deployments_in_application(self, app_name: str):
         deployments = []
         for deployment_id in self.deployment_infos:
-            if deployment_id.app == app_name:
+            if deployment_id.app_name == app_name:
                 deployments.append(deployment_id.name)
 
         return deployments

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -54,7 +54,7 @@ from ray.serve._private.utils import (
 # loop, so we can't "mark" a replica dead through a method. This global
 # state is cleared after each test that uses the fixtures in this file.
 dead_replicas_context = set()
-TEST_DEPLOYMENT_ID = DeploymentID("test_deployment", "test_app")
+TEST_DEPLOYMENT_ID = DeploymentID(name="test_deployment", app_name="test_app")
 
 
 class FakeRemoteFunction:
@@ -344,7 +344,7 @@ def mock_deployment_state() -> Tuple[DeploymentState, Mock, Mock]:
         cluster_node_info_cache = MockClusterNodeInfoCache()
 
         deployment_state = DeploymentState(
-            DeploymentID("name", "my_app"),
+            DeploymentID(name="name", app_name="my_app"),
             mock_long_poll,
             DefaultDeploymentScheduler(
                 cluster_node_info_cache, head_node_id="fake-head-node-id"
@@ -3210,7 +3210,7 @@ class TestActorReplicaWrapper:
             version=deployment_version("1"),
             actor_name="test",
             replica_tag="test_tag",
-            deployment_id=DeploymentID("test_deployment", "test_app"),
+            deployment_id=DeploymentID(name="test_deployment", app_name="test_app"),
         )
         assert (
             actor_replica.graceful_shutdown_timeout_s

--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -119,7 +119,7 @@ def pow_2_scheduler(request) -> PowerOfTwoChoicesReplicaScheduler:
     async def construct_scheduler(loop: asyncio.AbstractEventLoop):
         return PowerOfTwoChoicesReplicaScheduler(
             loop,
-            DeploymentID("TEST_DEPLOYMENT", "TEST_APP"),
+            DeploymentID(name="TEST_DEPLOYMENT"),
             prefer_local_node_routing=request.param.get("prefer_local_node", False),
             prefer_local_az_routing=request.param.get("prefer_local_az", False),
             self_node_id=SCHEDULER_NODE_ID,

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -160,7 +160,7 @@ def setup_router(request) -> Tuple[Router, FakeReplicaScheduler]:
     router = Router(
         # TODO(edoakes): refactor to make a better fake controller or not depend on it.
         controller_handle=Mock(),
-        deployment_id=DeploymentID("test-deployment", "test-app"),
+        deployment_id=DeploymentID(name="test-deployment"),
         handle_id="test-handle-id",
         self_node_id="test-node-id",
         self_actor_id="test-node-id",
@@ -509,7 +509,7 @@ def running_replica_info(replica_tag: str) -> RunningReplicaInfo:
 class TestRouterMetricsManager:
     def test_num_router_requests(self):
         metrics_manager = RouterMetricsManager(
-            DeploymentID("a", "b"),
+            DeploymentID(name="a", app_name="b"),
             "random",
             get_or_create_event_loop(),
             Mock(),
@@ -530,7 +530,7 @@ class TestRouterMetricsManager:
 
     def test_num_queued_requests_gauge(self):
         metrics_manager = RouterMetricsManager(
-            DeploymentID("a", "b"),
+            DeploymentID(name="a", app_name="b"),
             "random",
             get_or_create_event_loop(),
             Mock(),
@@ -553,7 +553,7 @@ class TestRouterMetricsManager:
 
     def test_track_requests_sent_to_replicas(self):
         metrics_manager = RouterMetricsManager(
-            DeploymentID("a", "b"),
+            DeploymentID(name="a", app_name="b"),
             "random",
             get_or_create_event_loop(),
             Mock(),
@@ -601,7 +601,7 @@ class TestRouterMetricsManager:
 
     def test_should_send_scaled_to_zero_optimized_push(self):
         metrics_manager = RouterMetricsManager(
-            DeploymentID("a", "b"),
+            DeploymentID(name="a", app_name="b"),
             "random",
             get_or_create_event_loop(),
             Mock(),
@@ -632,7 +632,7 @@ class TestRouterMetricsManager:
         timer = MockTimer()
         start = random.randint(50, 100)
         timer.reset(start)
-        deployment_id = DeploymentID("a", "b")
+        deployment_id = DeploymentID(name="a", app_name="b")
         handle_id = "random"
         mock_controller_handle = Mock()
 
@@ -676,7 +676,7 @@ class TestRouterMetricsManager:
     @patch("ray.serve._private.router.MetricsPusher")
     def test_update_deployment_config(self, metrics_pusher_mock):
         metrics_manager = RouterMetricsManager(
-            DeploymentID("a", "b"),
+            DeploymentID(name="a", app_name="b"),
             "random",
             get_or_create_event_loop(),
             Mock(),

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -96,7 +96,7 @@ def _make_user_callable_wrapper(
         callable if callable is not None else BasicClass,
         init_args,
         init_kwargs,
-        deployment_id=DeploymentID(app="test_app", name="test_name"),
+        deployment_id=DeploymentID(name="test_name"),
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Removes confusing aliasing of `EndpointTag` -> `DeploymentID`.
- Makes `DeploymentID` a `dataclass` to match `ReplicaName`
- Uses kwargs instead of positionals when constructing `DeploymentID`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
