### PR TITLE
[ci] fix wheel upload for windows

### DIFF
--- a/ci/build/copy_build_artifacts.sh
+++ b/ci/build/copy_build_artifacts.sh
@@ -34,7 +34,7 @@ if [[ "$OSTYPE" == "msys" ]]; then
 fi
 
 export PATH=/opt/python/cp38-cp38/bin:$PATH
-pip install -q aws_requests_auth boto3
+pip install -q -c python/requirements_compiled.txt aws_requests_auth boto3 pyopenssl
 ./ci/env/env_info.sh
 
 # Sync the directory to buildkite artifacts


### PR DESCRIPTION
The wheel uploading script is failing on windows because it uses an old version of pyopenssl: https://buildkite.com/ray-project/postmerge/builds/3187#018df629-3d07-4ae4-a75f-090eb911104e/6-12137. Pin the version in the script.


Test:
- Can upload now: https://buildkite.com/ray-project/postmerge/builds/3192#018df661-9fc7-4ad3-a350-ce6f270d16e2