### PR TITLE
FIx: FIx calculation of lineage obj size

### DIFF
--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -526,6 +526,16 @@ int64_t ReferenceCounter::ReleaseLineageReferences(ReferenceTable::iterator ref)
   return lineage_bytes_evicted;
 }
 
+int64_t ReferenceCounter::GetLineageSize() const {
+  int64_t total_size = 0;
+  for (const auto &entry : object_id_refs_) {
+    if (entry.second.lineage_ref_count > 0) {
+      total_size += entry.second.object_size;
+    }
+  }
+  return total_size;
+}
+
 void ReferenceCounter::RemoveSubmittedTaskReferences(
     const std::vector<ObjectID> &argument_ids,
     bool release_lineage,

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -344,6 +344,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// Returns the total number of actors owned by this worker.
   size_t NumActorsOwnedByUs() const ABSL_LOCKS_EXCLUDED(mutex_);
 
+  /// Calculate the Current LineageObjectSize
+  int64_t GetLineageSize() const;
+
   /// Returns a set of all ObjectIDs currently in scope (i.e., nonzero reference count).
   std::unordered_set<ObjectID> GetAllInScopeObjectIDs() const ABSL_LOCKS_EXCLUDED(mutex_);
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -835,8 +835,7 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
     if (task_retryable) {
       // Pin the task spec if it may be retried again.
       release_lineage = false;
-      it->second.lineage_footprint_bytes = it->second.spec.GetMessage().ByteSizeLong();
-      total_lineage_footprint_bytes_ += it->second.lineage_footprint_bytes;
+      auto total_lineage_footprint_bytes_ = reference_counter_->GetLineageSize();
       if (total_lineage_footprint_bytes_ > max_lineage_bytes_) {
         RAY_LOG(INFO) << "Total lineage size is " << total_lineage_footprint_bytes_ / 1e6
                       << "MB, which exceeds the limit of " << max_lineage_bytes_ / 1e6


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
### Key problem
The current calculation for the lineage object size underestimates the size, especially for nested task calls (remote task calling another remote task).
### Consequences of this problem
This underestimation causes the Object Memory Store to continuously increase, leading to potential memory leaks. An example illustrating this issue is documented in https://github.com/ray-project/ray/issues/37912.

### The reason for this unexpected performance
task_manager wants to keep the task retryable based on the return(i.e. when return to plasma store). When retryable is true, task_manger will keep copy of the args of the task in case of retry. Ray will estimate the current lineage object size and when it keeps too much args(objects and current limit is 1GB), it will evict the old object.
The issue arises because Ray calculates the lineage object size to be much smaller than it actually is, failing to trigger the eviction of unused lineage objects. Although there's a 1GB limit for the lineage object size, Ray estimates the memory used to be less than 1GB, thereby never releasing lineage objects.And ray will continue to keep all input as lineage but never evict.
For instance, in the example provided in the issue, for a 400MB dataset, the lineage object size is erroneously calculated as 0.0006MB. 
![Picture1](https://github.com/ray-project/ray/assets/121425509/03277436-9e0a-4e20-985c-e37d42d992c2)
This leads to a continuous increase in memory usage.

![image](https://github.com/ray-project/ray/assets/121425509/b7faf39e-2cd6-45fe-b1de-c6dcf53c4248)


## Proposed Solution
Implement a function to accurately determine the real-time lineage object size.

### Expected Outcome after the Fix
The eviction mechanism will be triggered correctly when necessary, maintaining memory usage at a stable level.
![image](https://github.com/ray-project/ray/assets/121425509/a717ef2e-ac85-4ba8-932c-1b4a1d86d0a7)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/37912
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [√] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [√] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [√] Unit tests
   - [√] Release tests
   - [√] This PR is not tested :(
