### PR TITLE
[data] optimize ray-data-resnet50-ingest-file-size-benchmark

### DIFF
--- a/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
@@ -561,12 +561,14 @@ if __name__ == "__main__":
         else:
             logger.info("Using Ray Datasets loader")
 
-            # Enable block splitting to support larger file sizes w/o OOM.
             ctx = ray.data.context.DataContext.get_current()
-
-            options.resource_limits.object_store_memory = 10e9
-            # Disable resource reservation for maximum throughput.
+            # Tweak the following configure options to maximize performance.
+            # Do not reserve resources for any op.
             ctx.op_resource_reservation_ratio = 0
+            # Set a larger `target_min_block_size` to avoid too many small blocks.
+            ctx.target_min_block_size = 20 * 1024**2
+            # Increase the streaming gen buffer size.
+            ctx._max_num_blocks_in_streaming_gen_buffer = 8
 
             datasets["train"] = build_dataset(
                 args.data_root,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

there is a perf regression for those 2 small-sized test cases in ray-data-resnet50-ingest-file-size-benchmark, due to the new backpressure change (#43171). 
Update some configs to fix the perf issue.  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
