### PR TITLE
[serve] compact scheduling preparation

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -135,6 +135,7 @@ from ray.includes.common cimport (
     kWorkerSetupHookKeyName,
     PythonCheckGcsHealth,
     PythonGetNodeLabels,
+    PythonGetResourcesTotal,
 )
 from ray.includes.unique_ids cimport (
     CActorID,
@@ -2793,10 +2794,12 @@ cdef class GcsClient:
 
         result = {}
         for node_info in node_infos:
+            c_resources = PythonGetResourcesTotal(node_info)
             result[node_info.node_id()] = {
                 "node_name": node_info.node_name(),
                 "state": node_info.state(),
-                "labels": PythonGetNodeLabels(node_info)
+                "labels": PythonGetNodeLabels(node_info),
+                "resources": {key.decode(): value for key, value in c_resources}
             }
         return result
 

--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -3,11 +3,13 @@ import sys
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Set, Tuple
+from functools import total_ordering
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 import ray
 from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
 from ray.serve._private.common import DeploymentID
+from ray.serve._private.config import ReplicaConfig
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 
@@ -15,6 +17,98 @@ class SpreadDeploymentSchedulingPolicy:
     """A scheduling policy that spreads replicas with best effort."""
 
     pass
+
+
+@total_ordering
+class Resources(dict):
+    def __init__(self, ray_resources: Dict = None):
+        if not ray_resources:
+            super().__init__()
+
+        else:
+            num_cpus = ray_resources.get("CPU", 0)
+            num_gpus = ray_resources.get("GPU", 0)
+            memory = ray_resources.get("memory", 0)
+            custom_resources = ray_resources.get("resources", dict())
+
+            super().__init__(
+                CPU=num_cpus, GPU=num_gpus, memory=memory, **custom_resources
+            )
+
+    def get(self, key: str):
+        val = super().get(key)
+        if val is not None:
+            return val
+
+        # Implicit resources by default have 1 total
+        if key.startswith(ray._raylet.IMPLICIT_RESOURCE_PREFIX):
+            return 1
+
+        # Otherwise by default there is 0 of this resource
+        return 0
+
+    def can_fit(self, other):
+        keys = set(self.keys()) | set(other.keys())
+        return all(self.get(k) >= other.get(k) for k in keys)
+
+    def __eq__(self, other):
+        keys = set(self.keys()) | set(other.keys())
+        return all([self.get(k) == other.get(k) for k in keys])
+
+    def __add__(self, other):
+        keys = set(self.keys()) | set(other.keys())
+
+        kwargs = dict()
+        for key in keys:
+            if key.startswith(ray._raylet.IMPLICIT_RESOURCE_PREFIX):
+                kwargs[key] = min(1.0, self.get(key) + other.get(key))
+            else:
+                kwargs[key] = self.get(key) + other.get(key)
+
+        return Resources(kwargs)
+
+    def __sub__(self, other):
+        keys = set(self.keys()) | set(other.keys())
+        kwargs = {key: self.get(key) - other.get(key) for key in keys}
+        return Resources(kwargs)
+
+    def __lt__(self, other):
+        """Determines priority when sorting a list of SoftResources.
+        1. GPU
+        2. CPU
+        3. memory
+        4. custom resources
+        This means a resource with a larger number of GPUs is always
+        sorted higher than a resource with a smaller number of GPUs,
+        regardless of the values of the other resource types. Similarly
+        for CPU next, memory next, etc.
+        """
+
+        keys = set(self.keys()) | set(other.keys())
+        keys = keys - {"GPU", "CPU", "memory"}
+
+        if self.get("GPU") < other.get("GPU"):
+            return True
+        elif self.get("GPU") > other.get("GPU"):
+            return False
+
+        if self.get("CPU") < other.get("CPU"):
+            return True
+        elif self.get("CPU") > other.get("CPU"):
+            return False
+
+        if self.get("memory") < other.get("memory"):
+            return True
+        elif self.get("memory") > other.get("memory"):
+            return False
+
+        for key in keys:
+            if self.get(key) < other.get(key):
+                return True
+            elif self.get(key) > other.get(key):
+                return False
+
+        return False
 
 
 @dataclass
@@ -51,73 +145,43 @@ class DeploymentDownscaleRequest:
     num_to_stop: int
 
 
+@dataclass
+class DeploymentSchedulingInfo:
+    scheduling_policy: Any
+    actor_resources: Optional[Resources] = None
+    placement_group_bundles: Optional[List[Resources]] = None
+    placement_group_strategy: Optional[str] = None
+
+    @property
+    def required_resources(self) -> Resources:
+        if (
+            self.placement_group_bundles is not None
+            and self.placement_group_strategy == "STRICT_PACK"
+        ):
+            return sum(self.placement_group_bundles, Resources())
+        else:
+            return self.actor_resources
+
+    def is_non_strict_pack_pg(self) -> bool:
+        return (
+            self.placement_group_bundles is not None
+            and self.placement_group_strategy != "STRICT_PACK"
+        )
+
+
 class DeploymentScheduler(ABC):
     """A centralized scheduler for all Serve deployments.
 
     It makes a batch of scheduling decisions in each update cycle.
     """
 
-    @abstractmethod
-    def on_deployment_created(
-        self,
-        deployment_id: DeploymentID,
-        scheduling_policy: SpreadDeploymentSchedulingPolicy,
-    ) -> None:
-        """Called whenever a new deployment is created."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def on_deployment_deleted(self, deployment_id: DeploymentID) -> None:
-        """Called whenever a deployment is deleted."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def on_replica_stopping(
-        self, deployment_id: DeploymentID, replica_name: str
-    ) -> None:
-        """Called whenever a deployment replica is being stopped."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def on_replica_running(
-        self, deployment_id: DeploymentID, replica_name: str, node_id: str
-    ) -> None:
-        """Called whenever a deployment replica is running with a known node id."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def on_replica_recovering(
-        self, deployment_id: DeploymentID, replica_name: str
-    ) -> None:
-        """Called whenever a deployment replica is recovering."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def schedule(
-        self,
-        upscales: Dict[DeploymentID, List[ReplicaSchedulingRequest]],
-        downscales: Dict[DeploymentID, DeploymentDownscaleRequest],
-    ) -> Dict[DeploymentID, Set[str]]:
-        """Called for each update cycle to do batch scheduling.
-
-        Args:
-            upscales: a dict of deployment name to a list of replicas to schedule.
-            downscales: a dict of deployment name to a downscale request.
-
-        Returns:
-            The name of replicas to stop for each deployment.
-        """
-        raise NotImplementedError
-
-
-class DefaultDeploymentScheduler(DeploymentScheduler):
     def __init__(
         self,
         cluster_node_info_cache: ClusterNodeInfoCache,
         head_node_id: str,
     ):
         # {deployment_id: scheduling_policy}
-        self._deployments = {}
+        self._deployments: Dict[DeploymentID, DeploymentSchedulingInfo] = {}
         # Replicas that are waiting to be scheduled.
         # {deployment_id: {replica_name: deployment_upscale_request}}
         self._pending_replicas = defaultdict(dict)
@@ -148,7 +212,28 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
         assert deployment_id not in self._launching_replicas
         assert deployment_id not in self._recovering_replicas
         assert deployment_id not in self._running_replicas
-        self._deployments[deployment_id] = scheduling_policy
+        self._deployments[deployment_id] = DeploymentSchedulingInfo(
+            scheduling_policy=scheduling_policy
+        )
+
+    def on_deployment_deployed(
+        self,
+        deployment_id: DeploymentID,
+        replica_config: ReplicaConfig,
+    ) -> None:
+        assert deployment_id in self._deployments
+
+        self._deployments[deployment_id].actor_resources = Resources(
+            replica_config.resource_dict
+        )
+        if replica_config.placement_group_bundles:
+            self._deployments[deployment_id].placement_group_bundles = [
+                Resources(bundle) for bundle in replica_config.placement_group_bundles
+            ]
+        if replica_config.placement_group_strategy:
+            self._deployments[
+                deployment_id
+            ].placement_group_strategy = replica_config.placement_group_strategy
 
     def on_deployment_deleted(self, deployment_id: DeploymentID) -> None:
         """Called whenever a deployment is deleted."""
@@ -197,6 +282,44 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
 
         self._recovering_replicas[deployment_id].add(replica_name)
 
+    def _get_node_to_running_replicas(
+        self, deployment_id: Optional[DeploymentID] = None
+    ) -> Dict[str, Set[str]]:
+        res = defaultdict(set)
+        if deployment_id:
+            for replica_id, node_id in self._running_replicas[deployment_id].items():
+                res[node_id].add(replica_id)
+        else:
+            for _, replicas in self._running_replicas.items():
+                for replica_id, node_id in replicas.items():
+                    res[node_id].add(replica_id)
+
+        return res
+
+    @abstractmethod
+    def schedule(
+        self,
+        upscales: Dict[DeploymentID, List[ReplicaSchedulingRequest]],
+        downscales: Dict[DeploymentID, DeploymentDownscaleRequest],
+    ) -> Dict[DeploymentID, Set[str]]:
+        """Called for each update cycle to do batch scheduling.
+
+        Args:
+            upscales: a dict of deployment name to a list of replicas to schedule.
+            downscales: a dict of deployment name to a downscale request.
+
+        Returns:
+            The name of replicas to stop for each deployment.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def detect_compact_opportunities(self) -> Tuple[str, float]:
+        """Returns a node ID to be compacted and a compaction deadlne."""
+        raise NotImplementedError
+
+
+class DefaultDeploymentScheduler(DeploymentScheduler):
     def schedule(
         self,
         upscales: Dict[DeploymentID, List[ReplicaSchedulingRequest]],
@@ -309,29 +432,25 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
             else:
                 replicas_to_stop.add(pending_launching_recovering_replica)
 
-        node_to_running_replicas_of_target_deployment = defaultdict(set)
-        for running_replica, node_id in self._running_replicas[deployment_id].items():
-            node_to_running_replicas_of_target_deployment[node_id].add(running_replica)
-
-        node_to_num_running_replicas_of_all_deployments = {}
-        for _, running_replicas in self._running_replicas.items():
-            for running_replica, node_id in running_replicas.items():
-                node_to_num_running_replicas_of_all_deployments[node_id] = (
-                    node_to_num_running_replicas_of_all_deployments.get(node_id, 0) + 1
-                )
+        node_to_running_replicas_of_target_deployment = (
+            self._get_node_to_running_replicas(deployment_id)
+        )
+        node_to_running_replicas_of_all_deployments = (
+            self._get_node_to_running_replicas()
+        )
 
         # Replicas on the head node has the lowest priority for downscaling
         # since we cannot relinquish the head node.
         def key(node_and_num_running_replicas_of_all_deployments):
             return (
-                node_and_num_running_replicas_of_all_deployments[1]
+                len(node_and_num_running_replicas_of_all_deployments[1])
                 if node_and_num_running_replicas_of_all_deployments[0]
                 != self._head_node_id
                 else sys.maxsize
             )
 
         for node_id, _ in sorted(
-            node_to_num_running_replicas_of_all_deployments.items(), key=key
+            node_to_running_replicas_of_all_deployments.items(), key=key
         ):
             if node_id not in node_to_running_replicas_of_target_deployment:
                 continue
@@ -344,3 +463,6 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
                     replicas_to_stop.add(running_replica)
 
         return replicas_to_stop
+
+    def detect_compact_opportunities(self) -> Tuple[str, float]:
+        return None, None

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1313,6 +1313,9 @@ class DeploymentState:
             f"application {self.app_name} from checkpoint."
         )
         self._target_state = target_state_checkpoint
+        self._deployment_scheduler.on_deployment_deployed(
+            self._id, self._target_state.info.replica_config
+        )
 
     def recover_current_state_from_replica_actor_names(
         self, replica_actor_names: List[str]
@@ -1589,6 +1592,9 @@ class DeploymentState:
 
         old_target_state = self._target_state
         self._set_target_state(deployment_info, target_num_replicas=target_num_replicas)
+        self._deployment_scheduler.on_deployment_deployed(
+            self._id, deployment_info.replica_config
+        )
 
         # Determine if the updated target state simply scales the current state.
         if self._target_state.is_scaled_copy_of(old_target_state):

--- a/python/ray/serve/tests/unit/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/unit/test_deployment_scheduler.py
@@ -1,0 +1,131 @@
+import random
+import sys
+from typing import List
+
+import pytest
+
+from ray.serve._private.deployment_scheduler import (
+    DeploymentSchedulingInfo,
+    Resources,
+    SpreadDeploymentSchedulingPolicy,
+)
+from ray.tests.conftest import *  # noqa
+
+
+def get_random_resources(n: int) -> List[Resources]:
+    """Gets n random resources."""
+
+    resources = {
+        "CPU": lambda: random.randint(0, 10),
+        "GPU": lambda: random.randint(0, 10),
+        "memory": lambda: random.randint(0, 10),
+        "resources": lambda: {"custom_A": random.randint(0, 10)},
+    }
+
+    res = list()
+    for _ in range(n):
+        resource_dict = dict()
+        for resource, callable in resources.items():
+            if random.randint(0, 1) == 0:
+                resource_dict[resource] = callable()
+
+        res.append(Resources(resource_dict))
+
+    return res
+
+
+class TestResources:
+    @pytest.mark.parametrize("resource_type", ["CPU", "GPU", "memory"])
+    def test_basic(self, resource_type: str):
+        # basic resources
+        a = Resources({resource_type: 1, "resources": {}})
+        b = Resources({resource_type: 0})
+        assert a.can_fit(b)
+        assert not b.can_fit(a)
+
+    def test_neither_bigger(self):
+        a = Resources({"CPU": 1, "GPU": 0})
+        b = Resources({"CPU": 0, "GPU": 1})
+        assert not a == b
+        assert not a.can_fit(b)
+        assert not b.can_fit(a)
+
+    combos = [tuple(get_random_resources(20)[i : i + 2]) for i in range(0, 20, 2)]
+
+    @pytest.mark.parametrize("resource_A,resource_B", combos)
+    def test_soft_resources_consistent_comparison(self, resource_A, resource_B):
+        """Resources should have consistent comparison. Either A==B, A<B, or A>B."""
+
+        assert (
+            resource_A == resource_B
+            or resource_A > resource_B
+            or resource_A < resource_B
+        )
+
+    def test_compare_resources(self):
+        # Prioritize GPU
+        a = Resources({"GPU": 1, "CPU": 10, "memory": 10, "resources": {"custom": 10}})
+        b = Resources({"GPU": 2, "CPU": 0, "memory": 0, "resources": {"custom": 0}})
+        assert b > a
+
+        # Then CPU
+        a = Resources({"GPU": 1, "CPU": 1, "memory": 10, "resources": {"custom": 10}})
+        b = Resources({"GPU": 1, "CPU": 2, "memory": 0, "resources": {"custom": 0}})
+        assert b > a
+
+        # Then memory
+        a = Resources({"GPU": 1, "CPU": 1, "memory": 1, "resources": {"custom": 10}})
+        b = Resources({"GPU": 1, "CPU": 1, "memory": 2, "resources": {"custom": 0}})
+        assert b > a
+
+        # Then custom resources
+        a = Resources({"GPU": 1, "CPU": 1, "memory": 1, "resources": {"custom": 1}})
+        b = Resources({"GPU": 1, "CPU": 1, "memory": 1, "resources": {"custom": 2}})
+        assert b > a
+
+    def test_sort_resources(self):
+        """Prioritize GPUs, CPUs, memory, then custom resources when sorting."""
+
+        a = Resources({"GPU": 0, "CPU": 4, "memory": 99, "resources": {"A": 10}})
+        b = Resources({"GPU": 0, "CPU": 2, "memory": 100})
+        c = Resources({"GPU": 1, "CPU": 1, "memory": 50})
+        d = Resources({"GPU": 2, "CPU": 0, "memory": 0})
+        e = Resources({"GPU": 3, "CPU": 8, "memory": 10000, "resources": {"A": 6}})
+        f = Resources({"GPU": 3, "CPU": 8, "memory": 10000, "resources": {"A": 2}})
+
+        for _ in range(10):
+            resources = [a, b, c, d, e, f]
+            random.shuffle(resources)
+            resources.sort(reverse=True)
+            assert resources == [e, f, d, c, a, b]
+
+
+def test_deployment_scheduling_info():
+    info = DeploymentSchedulingInfo(
+        scheduling_policy=SpreadDeploymentSchedulingPolicy,
+        actor_resources=Resources({"CPU": 2, "GPU": 1}),
+    )
+    assert info.required_resources == Resources({"CPU": 2, "GPU": 1})
+    assert not info.is_non_strict_pack_pg()
+
+    info = DeploymentSchedulingInfo(
+        scheduling_policy=SpreadDeploymentSchedulingPolicy,
+        actor_resources=Resources({"CPU": 2, "GPU": 1}),
+        placement_group_bundles=[Resources({"CPU": 100}), Resources({"GPU": 100})],
+        placement_group_strategy="STRICT_PACK",
+    )
+    assert info.required_resources == Resources({"CPU": 100, "GPU": 100})
+    assert not info.is_non_strict_pack_pg()
+
+    info = DeploymentSchedulingInfo(
+        scheduling_policy=SpreadDeploymentSchedulingPolicy,
+        actor_resources=Resources({"CPU": 2, "GPU": 1}),
+        placement_group_bundles=[Resources({"CPU": 100}), Resources({"GPU": 100})],
+        placement_group_strategy="PACK",
+    )
+    assert info.required_resources == Resources({"CPU": 2, "GPU": 1})
+    assert info.is_non_strict_pack_pg()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -27,6 +27,7 @@ from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.deployment_scheduler import (
     DefaultDeploymentScheduler,
     ReplicaSchedulingRequest,
+    SpreadDeploymentSchedulingPolicy,
 )
 from ray.serve._private.deployment_state import (
     ALL_REPLICA_STATES,
@@ -3375,6 +3376,9 @@ class TestTargetCapacity:
         deployment_state, _, _ = mock_deployment_state
 
         b_info_1, _ = deployment_info(num_replicas=2)
+        deployment_state._deployment_scheduler.on_deployment_created(
+            deployment_state._id, SpreadDeploymentSchedulingPolicy()
+        )
 
         self.update_target_capacity(
             deployment_state,
@@ -3419,6 +3423,9 @@ class TestTargetCapacity:
 
         code_version = "arbitrary_version"
         b_info_1, _ = deployment_info(num_replicas=2, version=code_version)
+        deployment_state._deployment_scheduler.on_deployment_created(
+            deployment_state._id, SpreadDeploymentSchedulingPolicy()
+        )
 
         # Initially deploy with no target_capacity set.
         self.update_target_capacity(
@@ -3489,6 +3496,9 @@ class TestTargetCapacity:
         ds, _, _ = mock_deployment_state
 
         b_info_1, _ = deployment_info(num_replicas=100)
+        ds._deployment_scheduler.on_deployment_created(
+            ds._id, SpreadDeploymentSchedulingPolicy()
+        )
 
         self.update_target_capacity(
             ds,
@@ -3514,6 +3524,9 @@ class TestTargetCapacity:
 
         code_version = "arbitrary_version"
         b_info_1, _ = deployment_info(num_replicas=10, version=code_version)
+        ds._deployment_scheduler.on_deployment_created(
+            ds._id, SpreadDeploymentSchedulingPolicy()
+        )
 
         # Start with target_capacity 100.
         self.update_target_capacity(
@@ -3645,6 +3658,9 @@ class TestTargetCapacity:
 
         code_version = "arbitrary_version"
         b_info_1, _ = deployment_info(num_replicas=10, version=code_version)
+        ds._deployment_scheduler.on_deployment_created(
+            ds._id, SpreadDeploymentSchedulingPolicy()
+        )
 
         # Start with target_capacity set to 0, should have no replicas start up.
         self.update_target_capacity(
@@ -3760,6 +3776,9 @@ class TestTargetCapacity:
 
         code_version = "arbitrary_version"
         b_info_1, _ = deployment_info(num_replicas=10, version=code_version)
+        ds._deployment_scheduler.on_deployment_created(
+            ds._id, SpreadDeploymentSchedulingPolicy()
+        )
 
         # Start with target_capacity set to 50, should have 5 replicas start up.
         self.update_target_capacity(
@@ -3829,6 +3848,9 @@ class TestTargetCapacity:
         # Set num_replicas to 0.
         code_version = "arbitrary_version"
         b_info_1, _ = deployment_info(num_replicas=0, version=code_version)
+        ds._deployment_scheduler.on_deployment_created(
+            ds._id, SpreadDeploymentSchedulingPolicy()
+        )
 
         # Start with target_capacity of 50.
         self.update_target_capacity(
@@ -3946,6 +3968,9 @@ class TestTargetCapacity:
 
         code_version = "arbitrary_version"
         b_info_1, _ = deployment_info(num_replicas=2, version=code_version)
+        ds._deployment_scheduler.on_deployment_created(
+            ds._id, SpreadDeploymentSchedulingPolicy()
+        )
 
         # Start with target_capacity set to 0, should have 0 replica start up
         # regardless of the autoscaling decision.


### PR DESCRIPTION
[serve] compact scheduling preparation

* Add API `get_available_resources_per_node` to cluster node info cache
* Add APIs `on_deployment_deployed` (to store pg and resource info for each deployment) and `detect_compact_opportunities` to deployment scheduler
* Add Resources class which is basically a wrapper around a resource dict that makes it easier to sort/compare them
* Add "resources" info to return value of `get_all_node_infos`.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/ray-project/ray/pull/43573).
* #43591
* #43577
* __->__ #43573