### PR TITLE
[ci] run windows tests on postmerge only

### DIFF
--- a/.buildkite/base.rayci.yml
+++ b/.buildkite/base.rayci.yml
@@ -70,7 +70,3 @@ steps:
   - name: docgpubuild
     wanda: ci/docker/docgpu.build.wanda.yaml
     depends_on: oss-ci-base_gpu
-
-  - name: windowsbuild
-    wanda: ci/docker/windows.build.wanda.yaml
-    instance_type: builder-windows

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -44,25 +44,6 @@ steps:
       - manylinux
       - forge
 
-  - label: ":windows: wheel {{matrix}}"
-    # we have linux/mac wheels tag, but do not have a windows wheels tag..
-    # so using python and core_cpp here, to make sure at least it builds
-    tags:
-      - oss
-      - python
-      - core_cpp
-    job_env: WINDOWS
-    mount_windows_artifacts: true
-    instance_type: windows
-    commands:
-      - bash ci/ray_ci/windows/install_tools.sh
-      - bazel run //ci/ray_ci:build_in_docker_windows -- wheel --python-version {{matrix}} --operating-system windows --upload
-    matrix:
-      - "3.8"
-      - "3.9"
-      - "3.10"
-      - "3.11"
-
   - label: ":tapioca: build: jar"
     tags:
       - java

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -72,25 +72,6 @@ steps:
         --test-env=TEST_EXTERNAL_REDIS=1
         --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual
 
-  - label: ":ray: core: :windows: python tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
-    tags: python
-    job_env: WINDOWS
-    mount_windows_artifacts: true
-    instance_type: windows
-    parallelism: 5
-    commands:
-      - bash ci/ray_ci/windows/install_tools.sh
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
-        --build-name windowsbuild
-        --operating-system windows
-        --except-tags no_windows
-        --test-env=CI="1"
-        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
-        --test-env=USERPROFILE
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 2
-    depends_on: windowsbuild
-
   - label: ":ray: core: memory pressure tests"
     tags:
       - python
@@ -310,24 +291,6 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type tsan-clang
         --except-tags no_tsan
         --parallelism-per-worker 2
-
-  - label: ":ray: core: :windows: cpp tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
-    tags: core_cpp
-    job_env: WINDOWS
-    mount_windows_artifacts: true
-    instance_type: windows
-    commands:
-      - bash ci/ray_ci/windows/install_tools.sh
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
-        --build-name windowsbuild
-        --operating-system windows
-        --except-tags no_windows
-        --test-env=CI="1"
-        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
-        --test-env=USERPROFILE
-        --parallelism-per-worker 2
-    depends_on: windowsbuild
 
   - label: ":ray: core: flaky tests"
     tags:

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -294,23 +294,6 @@ steps:
         --only-tags ptl_v2
     depends_on: [ "mllightning2gpubuild", "forge" ]
 
-  - label: ":train: ml: :windows: tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
-    tags:
-      - train
-    job_env: WINDOWS
-    mount_windows_artifacts: true
-    instance_type: windows
-    commands:
-      - bash ci/ray_ci/windows/install_tools.sh
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train:test_windows ml
-        --build-name windowsbuild
-        --operating-system windows
-        --test-env=CI="1"
-        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
-        --test-env=USERPROFILE
-    depends_on: windowsbuild
-
   - label: ":train: ml: flaky tests"
     tags: 
       - train

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -50,42 +50,6 @@ steps:
         "./java/test.sh"
     depends_on: [ "corebuild", "forge" ]
 
-  - label: "flaky :windows: tests"
-    tags: skip-on-premerge
-    job_env: WINDOWS
-    mount_windows_artifacts: true
-    instance_type: windows
-    commands:
-      - bash ci/ray_ci/windows/install_tools.sh
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... //python/ray/tests/... core
-        --run-flaky-tests
-        --except-tags no_windows
-        --build-name windowsbuild
-        --operating-system windows
-        --test-env=CI="1"
-        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
-        --test-env=USERPROFILE
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless
-        --skip-ray-installation
-        --except-tags no_windows
-        --run-flaky-tests
-        --build-name windowsbuild
-        --operating-system windows
-        --test-env=CI="1"
-        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
-        --test-env=USERPROFILE
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
-        --skip-ray-installation
-        --except-tags no_windows
-        --run-flaky-tests
-        --build-name windowsbuild
-        --operating-system windows
-        --test-env=CI="1"
-        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
-        --test-env=USERPROFILE
-    depends_on: windowsbuild
-    soft_fail: true
-
   # bot
   - label: ":robot_face: CI state machine bot"
     tags: skip-on-premerge

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -76,25 +76,6 @@ steps:
         python: ["3.8", "3.11"]
         worker_id: ["0", "1"]
 
-  - label: ":ray-serve: serve: :windows: tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
-    tags: serve
-    job_env: WINDOWS
-    mount_windows_artifacts: true
-    instance_type: windows
-    parallelism: 2
-    commands:
-      - bash ci/ray_ci/windows/install_tools.sh
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
-        --build-name windowsbuild
-        --operating-system windows
-        --except-tags no_windows
-        --test-env=CI="1"
-        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
-        --test-env=USERPROFILE
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-    depends_on: windowsbuild
-
   - label: ":ray-serve: serve: release tests"
     tags:
       - serve

--- a/.buildkite/serverless.rayci.yml
+++ b/.buildkite/serverless.rayci.yml
@@ -19,23 +19,6 @@ steps:
         --parallelism-per-worker 3
         --except-tags manual,spark_plugin_tests
 
-  - label: ":serverless: serverless: :windows: tests"
-    tags: python
-    job_env: WINDOWS
-    mount_windows_artifacts: true
-    instance_type: windows
-    commands:
-      - bash ci/ray_ci/windows/install_tools.sh
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless
-        --build-name windowsbuild
-        --operating-system windows
-        --except-tags no_windows
-        --test-env=CI="1"
-        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
-        --test-env=USERPROFILE
-        --parallelism-per-worker 3
-    depends_on: windowsbuild
-
   - label: ":serverless: serverless: spark tests"
     tags: python
     instance_type: medium

--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -1,0 +1,155 @@
+group: windows tests
+sort_key: "~windows"
+steps:
+  # block on premerge
+  - block: "run windows tests"
+    if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b"
+
+  - name: windowsbuild
+    wanda: ci/docker/windows.build.wanda.yaml
+    instance_type: builder-windows
+
+  - label: ":windows: wheel {{matrix}}"
+    # we have linux/mac wheels tag, but do not have a windows wheels tag..
+    # so using python and core_cpp here, to make sure at least it builds
+    tags:
+      - oss
+      - python
+      - core_cpp
+    job_env: WINDOWS
+    mount_windows_artifacts: true
+    instance_type: windows
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - bazel run //ci/ray_ci:build_in_docker_windows -- wheel --python-version {{matrix}} --operating-system windows --upload
+    matrix:
+      - "3.8"
+      - "3.9"
+      - "3.10"
+      - "3.11"
+
+  - label: ":ray: core: :windows: cpp tests"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    tags: core_cpp
+    job_env: WINDOWS
+    mount_windows_artifacts: true
+    instance_type: windows
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
+        --build-name windowsbuild
+        --operating-system windows
+        --except-tags no_windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+        --parallelism-per-worker 2
+    depends_on: windowsbuild
+
+  - label: ":ray: core: :windows: python tests"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    tags: python
+    job_env: WINDOWS
+    mount_windows_artifacts: true
+    instance_type: windows
+    parallelism: 5
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core
+        --build-name windowsbuild
+        --operating-system windows
+        --except-tags no_windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 2
+    depends_on: windowsbuild
+
+  - label: ":serverless: serverless: :windows: tests"
+    tags: python
+    job_env: WINDOWS
+    mount_windows_artifacts: true
+    instance_type: windows
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless
+        --build-name windowsbuild
+        --operating-system windows
+        --except-tags no_windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+        --parallelism-per-worker 3
+    depends_on: windowsbuild
+
+  - label: ":ray-serve: serve: :windows: tests"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    tags: serve
+    job_env: WINDOWS
+    mount_windows_artifacts: true
+    instance_type: windows
+    parallelism: 2
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
+        --build-name windowsbuild
+        --operating-system windows
+        --except-tags no_windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+    depends_on: windowsbuild
+
+  - label: ":train: ml: :windows: tests"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    tags:
+      - train
+    job_env: WINDOWS
+    mount_windows_artifacts: true
+    instance_type: windows
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train:test_windows ml
+        --build-name windowsbuild
+        --operating-system windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+    depends_on: windowsbuild
+
+  - label: "flaky :windows: tests"
+    tags: skip-on-premerge
+    job_env: WINDOWS
+    mount_windows_artifacts: true
+    instance_type: windows
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... //python/ray/tests/... core
+        --run-flaky-tests
+        --except-tags no_windows
+        --build-name windowsbuild
+        --operating-system windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless
+        --skip-ray-installation
+        --except-tags no_windows
+        --run-flaky-tests
+        --build-name windowsbuild
+        --operating-system windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
+        --skip-ray-installation
+        --except-tags no_windows
+        --run-flaky-tests
+        --build-name windowsbuild
+        --operating-system windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+    depends_on: windowsbuild
+    soft_fail: true


### PR DESCRIPTION
We need to cut infrastructure cost further, and we are doubling down on cutting down tests that are lower on the value side. This PR move all windows test on run only on-demand on premerge (they still on postmerge as usual).

Test:
- CI 