### PR TITLE
[core] Release streaming generator task metadata based on ref counter

### DIFF
--- a/doc/source/ray-core/ray-generator.rst
+++ b/doc/source/ray-core/ray-generator.rst
@@ -127,8 +127,8 @@ use ``__anext__`` or ``async for`` loops.
 
 Garbage collection of object references
 ---------------------------------------
-The returned ref from ``next(generator)`` is just a regular Ray object reference and is distributed ref counted in the same way.
-If references are not consumed from a generator by the ``next`` API, references are garbage collected (GC’ed) when the generator is GC’ed.
+The returned ``ObjectRef`` from ``next(generator)`` is just a regular Ray object reference and is ref-counted in the same way.
+If references are not consumed from a generator by the ``next`` API, references are garbage-collected when the ``generator`` object goes out of scope.
 
 .. literalinclude:: doc_code/streaming_generator.py
     :language: python
@@ -136,7 +136,7 @@ If references are not consumed from a generator by the ``next`` API, references 
     :end-before: __streaming_generator_gc_end__
 
 In the following example, Ray counts ``ref1`` as a normal Ray object reference after Ray returns it. Other references
-that aren't consumed with ``next(gen)`` are removed when the generator is GC'ed. In this example, garbage collection happens when you call ``del gen``.
+that aren't consumed with ``next(gen)`` are removed when the generator is garbage-collected. In this example, garbage collection happens when you call ``del gen``.
 
 Fault tolerance
 ---------------
@@ -202,11 +202,11 @@ Thread safety
 -------------
 ``ObjectRefGenerator`` object is not thread-safe.
 
-Limitation
-----------
+Limitations
+-----------
 Ray generators don't support these features:
 
 - ``throw``, ``send``, and ``close`` APIs.
 - ``return`` statements from generators.
-- Passing ``ObjectRefGenerator`` to another task or actor.
+- Passing an ``ObjectRefGenerator`` to another task or actor.
 - :ref:`Ray Client <ray-client-ref>`

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -162,7 +162,6 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             const CObjectID& return_id,
             shared_ptr[CRayObject] *return_object,
             const CObjectID& generator_id)
-        void DelObjectRefStream(const CObjectID &generator_id)
         CRayStatus TryReadObjectRefStream(
             const CObjectID &generator_id,
             CObjectReference *object_ref_out)

--- a/python/ray/tests/test_streaming_generator.py
+++ b/python/ray/tests/test_streaming_generator.py
@@ -34,7 +34,6 @@ class MockedWorker:
 def mocked_worker():
     mocked_core_worker = Mock()
     mocked_core_worker.try_read_next_object_ref_stream.return_value = None
-    mocked_core_worker.delete_object_ref_stream.return_value = None
     mocked_core_worker.create_object_ref_stream.return_value = None
     mocked_core_worker.peek_object_ref_stream.return_value = [], []
     worker = MockedWorker(mocked_core_worker)
@@ -94,7 +93,6 @@ def test_streaming_object_ref_generator_basic_unit(mocked_worker):
                 dumps(generator)
 
             del generator
-            c.delete_object_ref_stream.assert_called()
 
 
 def test_streaming_object_ref_generator_task_failed_unit(mocked_worker):

--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -422,7 +422,9 @@ def test_python_object_leak(shutdown_only):
 
 @pytest.mark.parametrize("delay", [True, False])
 @pytest.mark.parametrize("actor_task", [True, False])
-def test_reconstruction_generator_out_of_scope(monkeypatch, ray_start_cluster, delay, actor_task):
+def test_reconstruction_generator_out_of_scope(
+    monkeypatch, ray_start_cluster, delay, actor_task
+):
     with monkeypatch.context() as m:
         if delay:
             m.setenv(
@@ -483,25 +485,13 @@ def test_reconstruction_generator_out_of_scope(monkeypatch, ray_start_cluster, d
     del gen
 
     for i, ref in enumerate(refs):
-        print("first trial.")
-        print("fetching ", i)
         assert ray.get(fetch.remote(ref)) == i
 
     cluster.remove_node(node_to_kill, allow_graceful=False)
     node_to_kill = cluster.add_node(num_cpus=1, num_gpus=1, object_store_memory=10**8)
 
     for i, ref in enumerate(refs):
-        print("second trial.")
-        print("fetching ", i)
         assert ray.get(fetch.remote(ref)) == i
-
-    #cluster.remove_node(node_to_kill, allow_graceful=False)
-    #node_to_kill = cluster.add_node(num_cpus=1, num_gpus=1, object_store_memory=10**8)
-
-    #for i, ref in enumerate(refs):
-    #    print("first trial.")
-    #    print("fetching ", i)
-    #    assert ray.get(fetch.remote(ref)) == i
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -420,6 +420,90 @@ def test_python_object_leak(shutdown_only):
     assert len(list_actors()) == 12
 
 
+@pytest.mark.parametrize("delay", [True, False])
+@pytest.mark.parametrize("actor_task", [True, False])
+def test_reconstruction_generator_out_of_scope(monkeypatch, ray_start_cluster, delay, actor_task):
+    with monkeypatch.context() as m:
+        if delay:
+            m.setenv(
+                "RAY_testing_asio_delay_us",
+                "CoreWorkerService.grpc_server."
+                "ReportGeneratorItemReturns=10000:1000000",
+            )
+        cluster = ray_start_cluster
+        # Head node with no resources.
+        cluster.add_node(
+            num_cpus=0,
+            _system_config=RECONSTRUCTION_CONFIG,
+            enable_object_reconstruction=True,
+        )
+        ray.init(address=cluster.address)
+        # Node to place the initial object.
+        node_to_kill = cluster.add_node(
+            num_cpus=1, num_gpus=1, object_store_memory=10**8
+        )
+        cluster.wait_for_nodes()
+
+    @ray.remote(num_cpus=0, num_gpus=1, max_restarts=-1, max_task_retries=2)
+    class Actor:
+        def dynamic_generator(self, num_returns):
+            for i in range(num_returns):
+                print("YIELD", i)
+                yield np.ones(1_000_000, dtype=np.int8) * i
+
+    @ray.remote(num_returns="streaming", max_retries=2)
+    def dynamic_generator(num_returns):
+        for i in range(num_returns):
+            print("YIELD", i)
+            yield np.ones(1_000_000, dtype=np.int8) * i
+
+    @ray.remote
+    def dependent_task(x):
+        return x
+
+    @ray.remote
+    def fetch(x):
+        return x[0]
+
+    # Test recovery of all dynamic objects through re-execution.
+    if actor_task:
+        actor = Actor.remote()
+        gen = actor.dynamic_generator.options(num_returns="streaming").remote(1)
+    else:
+        gen = ray.get(dynamic_generator.remote(1))
+    refs = []
+
+    print("generator", gen)
+    for i in range(1):
+        ref = next(gen)
+        print("generator return", ref)
+        ref = dependent_task.remote(ref)
+        print("dependent ref", ref)
+        refs.append(ref)
+    del gen
+
+    for i, ref in enumerate(refs):
+        print("first trial.")
+        print("fetching ", i)
+        assert ray.get(fetch.remote(ref)) == i
+
+    cluster.remove_node(node_to_kill, allow_graceful=False)
+    node_to_kill = cluster.add_node(num_cpus=1, num_gpus=1, object_store_memory=10**8)
+
+    for i, ref in enumerate(refs):
+        print("second trial.")
+        print("fetching ", i)
+        assert ray.get(fetch.remote(ref)) == i
+
+    #cluster.remove_node(node_to_kill, allow_graceful=False)
+    #node_to_kill = cluster.add_node(num_cpus=1, num_gpus=1, object_store_memory=10**8)
+
+    #for i, ref in enumerate(refs):
+    #    print("first trial.")
+    #    print("fetching ", i)
+    #    assert ray.get(fetch.remote(ref)) == i
+
+
 if __name__ == "__main__":
     import os
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3142,6 +3142,7 @@ void CoreWorker::HandleReportGeneratorItemReturns(
                        << generator_id << ". Worker ID: " << worker_id
                        << ". Total consumed: " << total_num_object_consumed;
         if (!status.ok()) {
+          RAY_LOG(DEBUG) << "HandleReportGeneratorItemReturns error: " << status.message();
           RAY_CHECK_EQ(total_num_object_consumed, -1);
         }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3524,7 +3524,8 @@ void CoreWorker::ProcessSubscribeForObjectEviction(
       // "streaming".
       task_manager_->TemporarilyOwnGeneratorReturnRefIfNeeded(object_id, generator_id);
     } else {
-      reference_counter_->AddDynamicReturn(object_id, generator_id);
+      reference_counter_->AddDynamicReturnAndReleaseLineageIfOutOfScope(object_id,
+                                                                        generator_id);
     }
   }
 
@@ -3663,7 +3664,8 @@ void CoreWorker::AddSpilledObjectLocationOwner(
       // "streaming".
       task_manager_->TemporarilyOwnGeneratorReturnRefIfNeeded(object_id, *generator_id);
     } else {
-      reference_counter_->AddDynamicReturn(object_id, *generator_id);
+      reference_counter_->AddDynamicReturnAndReleaseLineageIfOutOfScope(object_id,
+                                                                        *generator_id);
     }
   }
 
@@ -3700,7 +3702,8 @@ void CoreWorker::AddObjectLocationOwner(const ObjectID &object_id,
     } else {
       // The task is a generator and may not have finished yet. Add the internal
       // ObjectID so that we can update its location.
-      reference_counter_->AddDynamicReturn(object_id, maybe_generator_id);
+      reference_counter_->AddDynamicReturnAndReleaseLineageIfOutOfScope(
+          object_id, maybe_generator_id);
     }
     RAY_UNUSED(reference_counter_->AddObjectLocation(object_id, node_id));
   }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2955,10 +2955,6 @@ Status CoreWorker::SealReturnObject(const ObjectID &return_id,
   return status;
 }
 
-void CoreWorker::DelObjectRefStream(const ObjectID &generator_id) {
-  task_manager_->DelObjectRefStream(generator_id);
-}
-
 Status CoreWorker::TryReadObjectRefStream(const ObjectID &generator_id,
                                           rpc::ObjectReference *object_ref_out) {
   ObjectID object_id;
@@ -3142,7 +3138,8 @@ void CoreWorker::HandleReportGeneratorItemReturns(
                        << generator_id << ". Worker ID: " << worker_id
                        << ". Total consumed: " << total_num_object_consumed;
         if (!status.ok()) {
-          RAY_LOG(DEBUG) << "HandleReportGeneratorItemReturns error: " << status.message();
+          RAY_LOG(DEBUG) << "HandleReportGeneratorItemReturns error: "
+                         << status.message();
           RAY_CHECK_EQ(total_num_object_consumed, -1);
         }
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -400,17 +400,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// It should not be nil.
   std::pair<rpc::ObjectReference, bool> PeekObjectRefStream(const ObjectID &generator_id);
 
-  /// Delete the ObjectRefStream that was
-  /// created upon the initial task
-  /// submission.
-  ///
-  /// It is a pass-through method. See TaskManager::DelObjectRefStream
-  /// for details.
-  ///
-  /// \param[in] generator_id The object ref id of the streaming
-  /// generator task.
-  void DelObjectRefStream(const ObjectID &generator_id);
-
   const PlacementGroupID &GetCurrentPlacementGroupId() const {
     return worker_context_.GetCurrentPlacementGroupId();
   }

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -190,8 +190,18 @@ class ReferenceCounter : public ReferenceCounterInterface,
                       const absl::optional<NodeID> &pinned_at_raylet_id =
                           absl::optional<NodeID>()) ABSL_LOCKS_EXCLUDED(mutex_);
 
-  /// Add an owned object that was dynamically created. These are objects that
-  /// were created by a task that we called, but that we own.
+  /// Add an owned object that was dynamically created by a task as the task
+  /// executes. These are objects that were created by a (streaming generator)
+  /// task that we called.
+  ///
+  /// Initially, the object will get added with no local references because the
+  /// caller has not yet consumed it from the generator. Intially, the object
+  /// will stay in scope because we register it as contained in the generator
+  /// object. Once the caller consumes the ObjectRef from the generator, a
+  /// local reference is added through the normal ref counting protocol. Thus,
+  /// the object will go out of scope once the generator object ref has gone
+  /// out of scope AND, if the object's ref was consumed by the caller, once
+  /// the object's ref has gone out of scope.
   ///
   /// \param[in] object_id The ID of the object that we now own.
   /// \param[in] generator_id The ID of the object that wraps the dynamically

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -201,28 +201,6 @@ class ReferenceCounter : public ReferenceCounterInterface,
   void AddDynamicReturn(const ObjectID &object_id, const ObjectID &generator_id)
       ABSL_LOCKS_EXCLUDED(mutex_);
 
-  /// Own an object that the current owner (current process) dynamically created.
-  ///
-  /// The API is idempotent.
-  ///
-  /// TODO(sang): This API should be merged with AddDynamicReturn when
-  /// we turn on streaming generator by default.
-  ///
-  /// For normal task return, the owner creates and owns the references before
-  /// the object values are created. However, when you dynamically create objects,
-  /// the owner doesn't know (i.e., own) the references until it is reported from
-  /// the executor side.
-  ///
-  /// This API is used to own this type of dynamically generated references.
-  /// The executor should ensure the objects are not GC'ed until the owner
-  /// registers the dynamically created references by this API.
-  ///
-  /// \param[in] object_id The ID of the object that we now own.
-  /// \param[in] generator_id The Object ID of the streaming generator task.
-  void OwnDynamicStreamingTaskReturnRef(const ObjectID &object_id,
-                                        const ObjectID &generator_id)
-      ABSL_LOCKS_EXCLUDED(mutex_);
-
   /// Update the size of the object.
   ///
   /// \param[in] object_id The ID of the object.

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1190,7 +1190,8 @@ int64_t TaskManager::RemoveLineageReference(const ObjectID &object_id,
     it->second.reconstructable_return_ids.erase(object_id);
     RAY_LOG(DEBUG) << "Task " << task_id << " now has "
                    << it->second.reconstructable_return_ids.size()
-                   << " plasma returns in scope";
+                   << " plasma returns in scope"
+                   << ", task status: " << it->second.GetStatus();
 
     if (it->second.reconstructable_return_ids.empty() && !it->second.IsPending()) {
       // If the task can no longer be retried, decrement the lineage ref count

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -639,7 +639,10 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
     // Set the NodeID where the task is executed.
     void SetNodeId(const NodeID &node_id) { node_id_ = node_id; }
 
-    bool IsPending() const { return GetStatus() != rpc::TaskStatus::FINISHED; }
+    bool IsPending() const {
+      return GetStatus() != rpc::TaskStatus::FINISHED &&
+             GetStatus() != rpc::TaskStatus::FAILED;
+    }
 
     bool IsWaitingForExecution() const {
       return GetStatus() == rpc::TaskStatus::SUBMITTED_TO_WORKER;

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -804,7 +804,7 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// \param[in] generator_id The object ref id of the streaming
   /// generator task.
   void DelObjectRefStream(const ObjectID &generator_id)
-      ABSL_GUARDED_BY(object_ref_stream_ops_mu_);
+      ABSL_LOCKS_EXCLUDED(object_ref_stream_ops_mu_);
 
   /// Used to store task results.
   std::shared_ptr<CoreWorkerMemoryStore> in_memory_store_;
@@ -843,6 +843,10 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
 
   /// The lock to protect concurrency problems when
   /// using object ref stream APIs
+  /// TODO(swang): Merge this with the global TaskManager::mu_ and make
+  /// ObjectRefStream a member of submissible_tasks_ to avoid bugs where we
+  /// delete from submissible_tasks_ but not object_ref_streams_, and vice
+  /// versa.
   mutable absl::Mutex object_ref_stream_ops_mu_;
 
   /// Tracks per-task-state counters for metric purposes.

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -160,6 +160,7 @@ class TaskManagerTest : public ::testing::Test {
   ObjectID ReportGeneratorItemReturns(const ObjectID &generator_id,
                                       int64_t stream_index,
                                       bool set_in_plasma = false,
+                                      bool *item_inserted = nullptr,
                                       ExecutionSignalCallback callback = nullptr) {
     auto dynamic_return_id = ObjectID::FromIndex(generator_id.TaskId(), stream_index + 2);
     auto data = GenerateRandomBuffer();
@@ -172,7 +173,10 @@ class TaskManagerTest : public ::testing::Test {
     if (callback == nullptr) {
       callback = [](Status status, int64_t num_objects_consumed) {};
     }
-    manager_.HandleReportGeneratorItemReturns(req, callback);
+    bool success = manager_.HandleReportGeneratorItemReturns(req, callback);
+    if (item_inserted) {
+      *item_inserted = success;
+    }
     return dynamic_return_id;
   }
 
@@ -1392,7 +1396,8 @@ TEST_F(TaskManagerLineageTest, TestObjectRefStreamDynamicReturnGC) {
   ASSERT_TRUE(manager_.ObjectRefStreamExists(generator_id));
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
   // Dynamic return ref created and returned to caller.
-  dynamic_return_id = ReportGeneratorItemReturns(generator_id, 0, /*set_in_plasma=*/false);
+  dynamic_return_id =
+      ReportGeneratorItemReturns(generator_id, 0, /*set_in_plasma=*/false);
   reference_counter_->AddLocalReference(dynamic_return_id, "");
   // Two refs in scope: generator ref and one dynamic return.
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 2);
@@ -1408,7 +1413,8 @@ TEST_F(TaskManagerLineageTest, TestObjectRefStreamDynamicReturnGC) {
   CompletePendingStreamingTask(spec, addr_, 1, /*set_in_plasma=*/true);
   // Task metadata deleted.
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 0);
-  ASSERT_FALSE(manager_.ObjectRefStreamExists(generator_id)); }
+  ASSERT_FALSE(manager_.ObjectRefStreamExists(generator_id));
+}
 
 TEST_F(TaskManagerTest, TestObjectRefStreamDeletedStreamIgnored) {
   /**
@@ -1451,9 +1457,10 @@ TEST_F(TaskManagerTest, TestObjectRefStreamBasic) {
    * Test the basic cases (write -> read).
    * CREATE WRITE, WRITE, WRITEEoF, READ, READ, KeyERROR DELETE
    */
-  auto spec =
-      CreateTaskHelper(1, {}, /*dynamic_returns=*/true,
-      /*is_streaming_generator=*/true);
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true);
   auto generator_id = spec.ReturnId(0);
   rpc::Address caller_address;
   manager_.AddPendingTask(caller_address, spec, "", 0);
@@ -1462,7 +1469,8 @@ TEST_F(TaskManagerTest, TestObjectRefStreamBasic) {
   std::vector<ObjectID> dynamic_return_ids;
   std::vector<std::shared_ptr<Buffer>> datas;
   for (auto i = 0; i < last_idx; i++) {
-    auto dynamic_return_id = ReportGeneratorItemReturns(generator_id, i, /*set_in_plasma=*/false);
+    auto dynamic_return_id =
+        ReportGeneratorItemReturns(generator_id, i, /*set_in_plasma=*/false);
     dynamic_return_ids.push_back(dynamic_return_id);
   }
 
@@ -1490,9 +1498,10 @@ TEST_F(TaskManagerTest, TestObjectRefStreamBasic) {
 }
 
 TEST_F(TaskManagerTest, TestPeekObjectReady) {
-  auto spec =
-      CreateTaskHelper(1, {}, /*dynamic_returns=*/true,
-      /*is_streaming_generator=*/true);
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true);
   auto generator_id = spec.ReturnId(0);
   rpc::Address caller_address;
   manager_.AddPendingTask(caller_address, spec, "", 0);
@@ -1503,7 +1512,8 @@ TEST_F(TaskManagerTest, TestPeekObjectReady) {
     ASSERT_FALSE(ready);
   }
 
-  auto dynamic_return_id = ReportGeneratorItemReturns(generator_id, 0, /*set_in_plasma=*/false);
+  auto dynamic_return_id =
+      ReportGeneratorItemReturns(generator_id, 0, /*set_in_plasma=*/false);
 
   {
     auto [obj_id, ready] = manager_.PeekObjectRefStream(generator_id);
@@ -1515,744 +1525,567 @@ TEST_F(TaskManagerTest, TestPeekObjectReady) {
   // DELETE
   reference_counter_->RemoveLocalReference(generator_id, nullptr);
 }
-//
-// TEST_F(TaskManagerTest, TestObjectRefStreamMixture) {
-//  /**
-//   * Test the basic cases, but write and read are mixed up.
-//   * CREATE WRITE READ WRITE READ WRITEEoF KeyError DELETE
-//   */
-//  auto spec =
-//      CreateTaskHelper(1, {}, /*dynamic_returns=*/true,
-//      /*is_streaming_generator=*/true);
-//  auto generator_id = spec.ReturnId(0);
-//  rpc::Address caller_address;
-//  manager_.AddPendingTask(caller_address, spec, "", 0);
-//
-//  auto last_idx = 2;
-//  std::vector<ObjectID> dynamic_return_ids;
-//  std::vector<std::shared_ptr<Buffer>> datas;
-//  for (auto i = 0; i < last_idx; i++) {
-//    auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), i + 2);
-//    dynamic_return_ids.push_back(dynamic_return_id);
-//    auto data = GenerateRandomBuffer();
-//    datas.push_back(data);
-//
-//    auto req = GetIntermediateTaskReturn(
-//        /*idx*/ i,
-//        generator_id,
-//        /*dynamic_return_id*/ dynamic_return_id,
-//        /*data*/ data,
-//        /*set_in_plasma*/ false);
-//    // WRITE
-//    ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//        req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//    // READ
-//    ObjectID obj_id;
-//    auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//    ASSERT_TRUE(status.ok());
-//    ASSERT_EQ(obj_id, dynamic_return_ids[i]);
-//  }
-//  // WRITEEoF
-//  CompletePendingStreamingTask(spec, caller_address, 2);
-//
-//  ObjectID obj_id;
-//  // READ (EoF)
-//  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.IsObjectRefEndOfStream());
-//  // DELETE
-//  manager_.DelObjectRefStream(generator_id);
-//}
-//
-// TEST_F(TaskManagerTest, TestObjectRefEndOfStream) {
-//  /**
-//   * Test that after writing EoF, write/read doesn't work.
-//   * CREATE WRITE WRITEEoF, WRITE(verify no op) DELETE
-//   */
-//  auto spec =
-//      CreateTaskHelper(1, {}, /*dynamic_returns=*/true,
-//      /*is_streaming_generator=*/true);
-//  auto generator_id = spec.ReturnId(0);
-//  rpc::Address caller_address;
-//  manager_.AddPendingTask(caller_address, spec, "", 0);
-//
-//  // WRITE
-//  auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 2);
-//  auto data = GenerateRandomBuffer();
-//  auto req = GetIntermediateTaskReturn(
-//      /*idx*/ 0,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//  CompletePendingStreamingTask(spec, caller_address, 1);
-//  // READ (works)
-//  ObjectID obj_id;
-//  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.ok());
-//  ASSERT_EQ(obj_id, dynamic_return_id);
-//
-//  // WRITE
-//  dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 3);
-//  data = GenerateRandomBuffer();
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 1,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_FALSE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//  // READ (doesn't works because EoF is already written)
-//  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.IsObjectRefEndOfStream());
-//}
-//
-// TEST_F(TaskManagerTest, TestObjectRefStreamIndexDiscarded) {
-//  /**
-//   * Test that when the ObjectRefStream is already written
-//   * the WRITE will be ignored.
-//   */
-//  auto spec =
-//      CreateTaskHelper(1, {}, /*dynamic_returns=*/true,
-//      /*is_streaming_generator=*/true);
-//  auto generator_id = spec.ReturnId(0);
-//  rpc::Address caller_address;
-//  manager_.AddPendingTask(caller_address, spec, "", 0);
-//
-//  // WRITE
-//  auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 2);
-//  auto data = GenerateRandomBuffer();
-//  auto req = GetIntermediateTaskReturn(
-//      /*idx*/ 0,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//  // READ
-//  ObjectID obj_id;
-//  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.ok());
-//  ASSERT_EQ(obj_id, dynamic_return_id);
-//
-//  // WRITE to the first index again.
-//  dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 2);
-//  data = GenerateRandomBuffer();
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 0,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_FALSE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//  // READ (New write will be ignored).
-//  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.ok());
-//  ASSERT_EQ(obj_id, ObjectID::Nil());
-//  CompletePendingStreamingTask(spec, caller_address, 1);
-//}
-//
-// TEST_F(TaskManagerTest, TestObjectRefStreamReadIgnoredWhenNothingWritten) {
-//  /**
-//   * Test read will return Nil if nothing was written.
-//   * CREATE READ (no op) WRITE READ (working) READ (no op)
-//   */
-//  auto spec =
-//      CreateTaskHelper(1, {}, /*dynamic_returns=*/true,
-//      /*is_streaming_generator=*/true);
-//  auto generator_id = spec.ReturnId(0);
-//  rpc::Address caller_address;
-//  manager_.AddPendingTask(caller_address, spec, "", 0);
-//
-//  // READ (no-op)
-//  ObjectID obj_id;
-//  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.ok());
-//  ASSERT_EQ(obj_id, ObjectID::Nil());
-//
-//  // WRITE
-//  auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 2);
-//  auto data = GenerateRandomBuffer();
-//  auto req = GetIntermediateTaskReturn(
-//      /*idx*/ 0,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//  // READ (works this time)
-//  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.ok());
-//  ASSERT_EQ(obj_id, dynamic_return_id);
-//
-//  // READ (nothing should return)
-//  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.ok());
-//  ASSERT_EQ(obj_id, ObjectID::Nil());
-//  CompletePendingStreamingTask(spec, caller_address, 1);
-//}
-//
-// TEST_F(TaskManagerTest, TestObjectRefStreamEndtoEnd) {
-//  /**
-//   * Test e2e
-//   * (task submitted -> report intermediate task return -> task finished)
-//   * This also tests if we can read / write stream before / after task finishes.
-//   */
-//  // Submit a task.
-//  rpc::Address caller_address;
-//  auto spec =
-//      CreateTaskHelper(1, {}, /*dynamic_returns=*/true,
-//      /*is_streaming_generator=*/true);
-//  auto generator_id = spec.ReturnId(0);
-//  manager_.AddPendingTask(caller_address, spec, "", /*num_retries=*/0);
-//  manager_.MarkDependenciesResolved(spec.TaskId());
-//  manager_.MarkTaskWaitingForExecution(
-//      spec.TaskId(), NodeID::FromRandom(), WorkerID::FromRandom());
-//
-//  // The results are reported before the task is finished.
-//  auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 2);
-//  auto data = GenerateRandomBuffer();
-//  auto req = GetIntermediateTaskReturn(
-//      /*idx*/ 0,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//
-//  // NumObjectIDsInScope == Generator + intermediate result.
-//  ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 2);
-//  std::vector<std::shared_ptr<RayObject>> results;
-//  WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-//  RAY_CHECK_OK(store_->Get({dynamic_return_id}, 1, 1, ctx, false, &results));
-//  ASSERT_EQ(results.size(), 1);
-//
-//  // Make sure you can read.
-//  ObjectID obj_id;
-//  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.ok());
-//  ASSERT_EQ(obj_id, dynamic_return_id);
-//
-//  // Finish the task.
-//  CompletePendingStreamingTask(spec, caller_address, 2);
-//
-//  // Test you can write to the stream after task finishes.
-//  // TODO(sang): Make sure this doesn't happen by ensuring the ordering
-//  // from the executor side.
-//  auto dynamic_return_id2 = ObjectID::FromIndex(spec.TaskId(), 3);
-//  data = GenerateRandomBuffer();
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 1,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id2,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//
-//  // NumObjectIDsInScope == Generator + 2 intermediate result.
-//  results.clear();
-//  RAY_CHECK_OK(store_->Get({dynamic_return_id2}, 1, 1, ctx, false, &results));
-//  ASSERT_EQ(results.size(), 1);
-//
-//  // Make sure you can read.
-//  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.ok());
-//  ASSERT_EQ(obj_id, dynamic_return_id2);
-//
-//  // Nothing more to read.
-//  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.IsObjectRefEndOfStream());
-//
-//  manager_.DelObjectRefStream(generator_id);
-//}
-//
-// TEST_F(TaskManagerTest, TestObjectRefStreamDelCleanReferences) {
-//  /**
-//   * Verify DEL cleans all references/objects and ignore all future WRITE.
-//   *
-//   * CREATE WRITE WRITE DEL (make sure no refs are leaked)
-//   */
-//  // Submit a task so that generator ID will be available
-//  // to the reference counter.
-//  rpc::Address caller_address;
-//  auto spec =
-//      CreateTaskHelper(1, {}, /*dynamic_returns=*/true,
-//      /*is_streaming_generator=*/true);
-//  auto generator_id = spec.ReturnId(0);
-//  manager_.AddPendingTask(caller_address, spec, "", /*num_retries=*/0);
-//  manager_.MarkDependenciesResolved(spec.TaskId());
-//  manager_.MarkTaskWaitingForExecution(
-//      spec.TaskId(), NodeID::FromRandom(), WorkerID::FromRandom());
-//
-//  // WRITE
-//  auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 2);
-//  auto data = GenerateRandomBuffer();
-//  auto req = GetIntermediateTaskReturn(
-//      /*idx*/ 0,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//  // WRITE 2
-//  auto dynamic_return_id2 = ObjectID::FromIndex(spec.TaskId(), 3);
-//  data = GenerateRandomBuffer();
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 1,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id2,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//
-//  // NumObjectIDsInScope == Generator + 2 WRITE
-//  ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 3);
-//  // 2 in memory objects.
-//  ASSERT_EQ(store_->Size(), 2);
-//  std::vector<std::shared_ptr<RayObject>> results;
-//  WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
-//  RAY_CHECK_OK(store_->Get({dynamic_return_id}, 1, 1, ctx, false, &results));
-//  ASSERT_EQ(results.size(), 1);
-//  results.clear();
-//  RAY_CHECK_OK(store_->Get({dynamic_return_id2}, 1, 1, ctx, false, &results));
-//  ASSERT_EQ(results.size(), 1);
-//  results.clear();
-//
-//  // DELETE. This should clean all references except generator id.
-//  manager_.DelObjectRefStream(generator_id);
-//  ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
-//  // All the in memory objects should be cleaned up.
-//  ASSERT_EQ(store_->Size(), 0);
-//  ASSERT_TRUE(store_->Get({dynamic_return_id}, 1, 1, ctx, false,
-//  &results).IsTimedOut()); results.clear();
-//  ASSERT_TRUE(store_->Get({dynamic_return_id2}, 1, 1, ctx, false,
-//  &results).IsTimedOut()); results.clear();
-//
-//  // NOTE: We panic if READ is called after DELETE. The
-//  // API caller should guarantee this doesn't happen.
-//  // So we don't test it.
-//  // WRITE 3. Should be ignored.
-//  auto dynamic_return_id3 = ObjectID::FromIndex(spec.TaskId(), 4);
-//  data = GenerateRandomBuffer();
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 2,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id3,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_FALSE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//  // The write should have been no op. No refs and no obj values except the generator
-//  id. ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
-//  // All the in memory objects should be cleaned up.
-//  ASSERT_EQ(store_->Size(), 0);
-//  ASSERT_TRUE(store_->Get({dynamic_return_id3}, 1, 1, ctx, false,
-//  &results).IsTimedOut()); results.clear();
-//
-//  CompletePendingStreamingTask(spec, caller_address, 2);
-//}
-//
-// TEST_F(TaskManagerTest, TestObjectRefStreamOutofOrder) {
-//  /**
-//   * Test the case where the task return RPC is received out of order
-//   */
-//  auto spec =
-//      CreateTaskHelper(1, {}, /*dynamic_returns=*/true,
-//      /*is_streaming_generator=*/true);
-//  auto generator_id = spec.ReturnId(0);
-//  rpc::Address caller_address;
-//  manager_.AddPendingTask(caller_address, spec, "", /*num_retries=*/0);
-//
-//  auto last_idx = 2;
-//  std::vector<ObjectID> dynamic_return_ids;
-//  // EoF reported first.
-//  CompletePendingStreamingTask(spec, caller_address, 2);
-//
-//  // Write index 1 -> 0
-//  for (auto i = last_idx - 1; i > -1; i--) {
-//    auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), i + 2);
-//    dynamic_return_ids.insert(dynamic_return_ids.begin(), dynamic_return_id);
-//    auto data = GenerateRandomBuffer();
-//
-//    auto req = GetIntermediateTaskReturn(
-//        /*idx*/ i,
-//        generator_id,
-//        /*dynamic_return_id*/ dynamic_return_id,
-//        /*data*/ data,
-//        /*set_in_plasma*/ false);
-//    // WRITE * 2
-//    ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//        req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//  }
-//
-//  // Verify read works.
-//  ObjectID obj_id;
-//  for (auto i = 0; i < last_idx; i++) {
-//    auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//    ASSERT_TRUE(status.ok());
-//    ASSERT_EQ(obj_id, dynamic_return_ids[i]);
-//  }
-//
-//  // READ (EoF)
-//  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(status.IsObjectRefEndOfStream());
-//  manager_.DelObjectRefStream(generator_id);
-//}
-//
-// TEST_F(TaskManagerTest, TestObjectRefStreamDelOutOfOrder) {
-//  /**
-//   * Verify there's no leak when we delete a ObjectRefStream
-//   * that has out of order WRITEs.
-//   * WRITE index 1 -> Del -> Write index 0. Both 0 and 1 have to be
-//   * deleted.
-//   */
-//  // Submit a generator task.
-//  rpc::Address caller_address;
-//  auto spec =
-//      CreateTaskHelper(1, {}, /*dynamic_returns=*/true,
-//      /*is_streaming_generator=*/true);
-//  auto generator_id = spec.ReturnId(0);
-//  manager_.AddPendingTask(caller_address, spec, "", /*num_retries=*/0);
-//  manager_.MarkDependenciesResolved(spec.TaskId());
-//  manager_.MarkTaskWaitingForExecution(
-//      spec.TaskId(), NodeID::FromRandom(), WorkerID::FromRandom());
-//
-//  // WRITE to index 1
-//  auto dynamic_return_id_index_1 = ObjectID::FromIndex(spec.TaskId(), 3);
-//  auto data = GenerateRandomBuffer();
-//  auto req = GetIntermediateTaskReturn(
-//      /*idx*/ 1,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id_index_1,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//  ASSERT_TRUE(reference_counter_->HasReference(dynamic_return_id_index_1));
-//
-//  // Delete the stream. This should remove references from ^.
-//  manager_.DelObjectRefStream(generator_id);
-//  ASSERT_FALSE(reference_counter_->HasReference(dynamic_return_id_index_1));
-//
-//  // WRITE to index 0. It should fail cuz the stream has been removed.
-//  auto dynamic_return_id_index_0 = ObjectID::FromIndex(spec.TaskId(), 2);
-//  data = GenerateRandomBuffer();
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 0,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id_index_0,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_FALSE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//  ASSERT_FALSE(reference_counter_->HasReference(dynamic_return_id_index_0));
-//
-//  // There must be only a generator ID.
-//  ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);
-//  // All the objects should be cleaned up.
-//  ASSERT_EQ(store_->Size(), 0);
-//  CompletePendingStreamingTask(spec, caller_address, 0);
-//}
-//
-// TEST_F(TaskManagerTest, TestObjectRefStreamTemporarilyOwnGeneratorReturnRefIfNeeded) {
-//  /**
-//   * Test TemporarilyOwnGeneratorReturnRefIfNeeded
-//   */
-//  rpc::Address caller_address;
-//  auto spec =
-//      CreateTaskHelper(1, {}, /*dynamic_returns=*/true,
-//      /*is_streaming_generator=*/true);
-//  auto generator_id = spec.ReturnId(0);
-//
-//  /**
-//   * Test TemporarilyOwnGeneratorReturnRefIfNeeded is no-op when the stream is
-//   * not created yet.
-//   */
-//  auto dynamic_return_id_index_0 = ObjectID::FromIndex(spec.TaskId(), 2);
-//  manager_.TemporarilyOwnGeneratorReturnRefIfNeeded(dynamic_return_id_index_0,
-//                                                    generator_id);
-//  // It is no-op if the object ref stream is not created.
-//  ASSERT_FALSE(reference_counter_->HasReference(dynamic_return_id_index_0));
-//
-//  /**
-//   * Submit a generator task.
-//   */
-//  manager_.AddPendingTask(caller_address, spec, "", /*num_retries=*/0);
-//  manager_.MarkDependenciesResolved(spec.TaskId());
-//  manager_.MarkTaskWaitingForExecution(
-//      spec.TaskId(), NodeID::FromRandom(), WorkerID::FromRandom());
-//
-//  /**
-//   * Test TemporarilyOwnGeneratorReturnRefIfNeeded called before any
-//   * HandleReportGeneratorItemReturns adds a refernece.
-//   */
-//  manager_.TemporarilyOwnGeneratorReturnRefIfNeeded(dynamic_return_id_index_0,
-//                                                    generator_id);
-//  // We has a reference to this object before the ref is
-//  // reported via HandleReportGeneratorItemReturns.
-//  ASSERT_TRUE(reference_counter_->HasReference(dynamic_return_id_index_0));
-//
-//  /**
-//   * Test TemporarilyOwnGeneratorReturnRefIfNeeded called after the
-//   * ref consumed / removed will be no-op.
-//   */
-//  // WRITE 0 -> WRITE 1
-//  auto data = GenerateRandomBuffer();
-//  auto req = GetIntermediateTaskReturn(
-//      /*idx*/ 0,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id_index_0,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//  auto dynamic_return_id_index_1 = ObjectID::FromIndex(spec.TaskId(), 3);
-//  data = GenerateRandomBuffer();
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 1,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id_index_1,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
-//
-//  // READ 0 -> READ 1
-//  for (auto i = 0; i < 2; i++) {
-//    ObjectID object_id;
-//    auto status = manager_.TryReadObjectRefStream(generator_id, &object_id);
-//    ASSERT_TRUE(status.ok());
-//  }
-//
-//  std::vector<ObjectID> removed;
-//  reference_counter_->RemoveLocalReference(dynamic_return_id_index_1, &removed);
-//  ASSERT_EQ(removed.size(), 1UL);
-//  ASSERT_FALSE(reference_counter_->HasReference(dynamic_return_id_index_1));
-//  // If the ref has been already consumed and deleted,
-//  // this shouldn't add a reference.
-//  manager_.TemporarilyOwnGeneratorReturnRefIfNeeded(dynamic_return_id_index_1,
-//                                                    generator_id);
-//  ASSERT_FALSE(reference_counter_->HasReference(dynamic_return_id_index_1));
-//
-//  /**
-//   * Test TemporarilyOwnGeneratorReturnRefIfNeeded called but
-//   * HandleReportGeneratorItemReturns is never called. In this case, when
-//   * the stream is deleted these refs should be cleaned up.
-//   */
-//  auto dynamic_return_id_index_2 = ObjectID::FromIndex(spec.TaskId(), 4);
-//  manager_.TemporarilyOwnGeneratorReturnRefIfNeeded(dynamic_return_id_index_2,
-//                                                    generator_id);
-//  ASSERT_TRUE(reference_counter_->HasReference(dynamic_return_id_index_2));
-//  manager_.DelObjectRefStream(generator_id);
-//  ASSERT_FALSE(reference_counter_->HasReference(dynamic_return_id_index_2));
-//
-//  CompletePendingStreamingTask(spec, caller_address, 2);
-//}
-//
-// TEST_F(TaskManagerTest, TestObjectRefStreamBackpressure) {
-//  /**
-//   * Test the RPC is not replied when backpressured.
-//   * Test the RPC is replied when the stream is deleted.
-//   * Test the RPC is replied when the data is consumed.
-//   */
-//  auto spec = CreateTaskHelper(1,
-//                               {},
-//                               /*dynamic_returns=*/true,
-//                               /*is_streaming_generator=*/true,
-//                               /*generator_backpressure_num_objects*/ 2);
-//  auto generator_id = spec.ReturnId(0);
-//  rpc::Address caller_address;
-//  manager_.AddPendingTask(caller_address, spec, "", 0);
-//
-//  /// 1 generate, 0 consumed, 2 threshold -> should signal immediately.
-//  auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 2);
-//  auto data = GenerateRandomBuffer();
-//  auto req = GetIntermediateTaskReturn(
-//      /*idx*/ 0,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  bool signal_called = false;
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req,
-//      /*execution_signal_callback*/ [&signal_called](Status status,
-//                                                     int64_t num_objects_consumed) {
-//        signal_called = true;
-//        ASSERT_TRUE(status.ok());
-//        ASSERT_EQ(num_objects_consumed, 0);
-//      }));
-//  ASSERT_TRUE(signal_called);
-//
-//  /// 2 generate, 0 consumed, 2 threshold -> backpressured
-//  dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 3);
-//  data = GenerateRandomBuffer();
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 1,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  signal_called = false;
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req,
-//      /*execution_signal_callback*/ [&signal_called](Status status,
-//                                                     int64_t num_objects_consumed) {
-//        signal_called = true;
-//        ASSERT_TRUE(status.ok());
-//        ASSERT_EQ(num_objects_consumed, 1);
-//      }));
-//  ASSERT_FALSE(signal_called);
-//
-//  ObjectID obj_id;
-//  // Read should signal the executor.
-//  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(signal_called);
-//
-//  /// 3 generate, 1 consumed, 2 threshold -> backpressured
-//  dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 4);
-//  data = GenerateRandomBuffer();
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 2,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  signal_called = false;
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req,
-//      /*execution_signal_callback*/ [&signal_called](Status status,
-//                                                     int64_t num_objects_consumed) {
-//        signal_called = true;
-//        ASSERT_TRUE(status.IsNotFound());
-//        ASSERT_EQ(num_objects_consumed, -1);
-//      }));
-//  ASSERT_FALSE(signal_called);
-//
-//  // Deleting the stream should send a signal.
-//  manager_.DelObjectRefStream(generator_id);
-//  ASSERT_TRUE(signal_called);
-//  CompletePendingStreamingTask(spec, caller_address, 2);
-//
-//  /// No need to test out of order case. It won't be different.
-//}
-//
-// TEST_F(TaskManagerTest, TestBackpressureAfterReconstruction) {
-//  // Consumed objects should be signaled immediately.
-//  // Unconsumed objects should not be.
-//  auto spec = CreateTaskHelper(1,
-//                               {},
-//                               /*dynamic_returns=*/true,
-//                               /*is_streaming_generator=*/true,
-//                               /*generator_backpressure_num_objects*/ 2);
-//  auto generator_id = spec.ReturnId(0);
-//  rpc::Address caller_address;
-//  manager_.AddPendingTask(caller_address, spec, "", 1);
-//
-//  /// 1 generate, 0 consumed, 2 threshold -> should signal immediately.
-//  auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 2);
-//  auto data = GenerateRandomBuffer();
-//  auto req = GetIntermediateTaskReturn(
-//      /*idx*/ 0,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  bool signal_called = false;
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req,
-//      /*execution_signal_callback*/ [&signal_called](Status status,
-//                                                     int64_t num_objects_consumed) {
-//        signal_called = true;
-//        ASSERT_TRUE(status.ok());
-//        ASSERT_EQ(num_objects_consumed, 0);
-//      }));
-//  ASSERT_TRUE(signal_called);
-//
-//  /// 2 generate, 0 consumed, 2 threshold -> backpressured
-//  dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 3);
-//  data = GenerateRandomBuffer();
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 1,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  signal_called = false;
-//  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
-//      req,
-//      /*execution_signal_callback*/ [&signal_called](Status status,
-//                                                     int64_t num_objects_consumed) {
-//        signal_called = true;
-//        ASSERT_TRUE(status.ok());
-//        ASSERT_EQ(num_objects_consumed, 1);
-//      }));
-//  ASSERT_FALSE(signal_called);
-//
-//  // Worker failure. New worker should start reporting the task.
-//  auto error = rpc::ErrorType::WORKER_DIED;
-//  ASSERT_TRUE(manager_.FailOrRetryPendingTask(spec.TaskId(), error));
-//
-//  // Two report will come again. The first one should reply immediately (because)
-//  // it is already replied and the second one should be backpressured.
-//  /// 1 generate, 0 consumed, 2 threshold -> should signal immediately.
-//  dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 2);
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 0,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  bool retry_signal_called = false;
-//  ASSERT_FALSE(manager_.HandleReportGeneratorItemReturns(
-//      req,
-//      /*execution_signal_callback*/ [&retry_signal_called](Status status,
-//                                                           int64_t num_objects_consumed)
-//                                                           {
-//        retry_signal_called = true;
-//        ASSERT_TRUE(status.ok());
-//        ASSERT_EQ(num_objects_consumed, 0);
-//      }));
-//  ASSERT_TRUE(retry_signal_called);
-//
-//  /// 2 generate, 0 consumed, 2 threshold -> backpressured
-//  dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 3);
-//  data = GenerateRandomBuffer();
-//  req = GetIntermediateTaskReturn(
-//      /*idx*/ 1,
-//      generator_id,
-//      /*dynamic_return_id*/ dynamic_return_id,
-//      /*data*/ data,
-//      /*set_in_plasma*/ false);
-//  retry_signal_called = false;
-//  ASSERT_FALSE(manager_.HandleReportGeneratorItemReturns(
-//      req,
-//      /*execution_signal_callback*/ [&retry_signal_called](Status status,
-//                                                           int64_t num_objects_consumed)
-//                                                           {
-//        retry_signal_called = true;
-//        ASSERT_TRUE(status.ok());
-//        ASSERT_EQ(num_objects_consumed, 1);
-//      }));
-//  // Backpressured.
-//  ASSERT_FALSE(retry_signal_called);
-//
-//  ObjectID obj_id;
-//  // Read should signal both executor.
-//  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
-//  ASSERT_TRUE(signal_called);
-//  ASSERT_TRUE(retry_signal_called);
-//  CompletePendingStreamingTask(spec, caller_address, 2);
-//}
+
+TEST_F(TaskManagerTest, TestObjectRefStreamMixture) {
+  /**
+   * Test the basic cases, but write and read are mixed up.
+   * CREATE WRITE READ WRITE READ WRITEEoF KeyError DELETE
+   */
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+  rpc::Address caller_address;
+  manager_.AddPendingTask(caller_address, spec, "", 0);
+
+  auto last_idx = 2;
+  std::vector<ObjectID> dynamic_return_ids;
+  std::vector<std::shared_ptr<Buffer>> datas;
+  for (auto i = 0; i < last_idx; i++) {
+    // WRITE
+    auto dynamic_return_id =
+        ReportGeneratorItemReturns(generator_id, i, /*set_in_plasma=*/false);
+    dynamic_return_ids.push_back(dynamic_return_id);
+
+    // READ
+    ObjectID obj_id;
+    auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+    ASSERT_TRUE(status.ok());
+    ASSERT_EQ(obj_id, dynamic_return_ids[i]);
+  }
+
+  // WRITEEoF
+  CompletePendingStreamingTask(spec, addr_, 2, /*set_in_plasma=*/false);
+
+  ObjectID obj_id;
+  // READ (EoF)
+  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.IsObjectRefEndOfStream());
+  // DELETE
+  reference_counter_->RemoveLocalReference(generator_id, nullptr);
+}
+
+TEST_F(TaskManagerTest, TestObjectRefEndOfStream) {
+  /**
+   * Test that after writing EoF, write/read doesn't work.
+   * CREATE WRITE WRITEEoF, WRITE(verify no op) DELETE
+   */
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+  rpc::Address caller_address;
+  manager_.AddPendingTask(caller_address, spec, "", 0);
+
+  // WRITE
+  auto dynamic_return_id =
+      ReportGeneratorItemReturns(generator_id, 0, /*set_in_plasma=*/false);
+  CompletePendingStreamingTask(spec, caller_address, 1);
+  // READ (works)
+  ObjectID obj_id;
+  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(obj_id, dynamic_return_id);
+
+  // WRITE
+  bool item_inserted = false;
+  dynamic_return_id = ReportGeneratorItemReturns(
+      generator_id, 1, /*set_in_plasma=*/false, &item_inserted);
+  ASSERT_FALSE(item_inserted);
+  // READ (doesn't works because EoF is already written)
+  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.IsObjectRefEndOfStream());
+  // DELETE
+  reference_counter_->RemoveLocalReference(generator_id, nullptr);
+}
+
+TEST_F(TaskManagerTest, TestObjectRefStreamIndexDiscarded) {
+  /**
+   * Test that when the ObjectRefStream is already written
+   * the WRITE will be ignored.
+   */
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+  rpc::Address caller_address;
+  manager_.AddPendingTask(caller_address, spec, "", 0);
+
+  // WRITE
+  auto dynamic_return_id =
+      ReportGeneratorItemReturns(generator_id, 0, /*set_in_plasma=*/false);
+  // READ (works)
+  ObjectID obj_id;
+  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(obj_id, dynamic_return_id);
+
+  // WRITE
+  bool item_inserted = false;
+  dynamic_return_id = ReportGeneratorItemReturns(
+      generator_id, 0, /*set_in_plasma=*/false, &item_inserted);
+  ASSERT_FALSE(item_inserted);
+  // READ (doesn't works because EoF is already written)
+  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(obj_id, ObjectID::Nil());
+
+  // DELETE
+  CompletePendingStreamingTask(spec, caller_address, 1);
+  reference_counter_->RemoveLocalReference(generator_id, nullptr);
+}
+
+TEST_F(TaskManagerTest, TestObjectRefStreamReadIgnoredWhenNothingWritten) {
+  /**
+   * Test read will return Nil if nothing was written.
+   * CREATE READ (no op) WRITE READ (working) READ (no op)
+   */
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+  rpc::Address caller_address;
+  manager_.AddPendingTask(caller_address, spec, "", 0);
+
+  // READ (no-op)
+  ObjectID obj_id;
+  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(obj_id, ObjectID::Nil());
+
+  // WRITE
+  auto dynamic_return_id =
+      ReportGeneratorItemReturns(generator_id, 0, /*set_in_plasma=*/false);
+  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(obj_id, dynamic_return_id);
+
+  // READ (nothing should return)
+  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(obj_id, ObjectID::Nil());
+
+  CompletePendingStreamingTask(spec, caller_address, 1);
+  reference_counter_->RemoveLocalReference(generator_id, nullptr);
+}
+
+TEST_F(TaskManagerTest, TestObjectRefStreamEndtoEnd) {
+  /**
+   * Test e2e
+   * (task submitted -> report intermediate task return -> task finished)
+   * This also tests if we can read / write stream before / after task finishes.
+   */
+  // Submit a task.
+  rpc::Address caller_address;
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+  manager_.AddPendingTask(caller_address, spec, "", /*num_retries=*/0);
+  manager_.MarkDependenciesResolved(spec.TaskId());
+  manager_.MarkTaskWaitingForExecution(
+      spec.TaskId(), NodeID::FromRandom(), WorkerID::FromRandom());
+
+  // The results are reported before the task is finished.
+  auto dynamic_return_id =
+      ReportGeneratorItemReturns(generator_id, 0, /*set_in_plasma=*/false);
+
+  // NumObjectIDsInScope == Generator + intermediate result.
+  ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 2);
+  std::vector<std::shared_ptr<RayObject>> results;
+  WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
+  RAY_CHECK_OK(store_->Get({dynamic_return_id}, 1, 1, ctx, false, &results));
+  ASSERT_EQ(results.size(), 1);
+
+  // Make sure you can read.
+  ObjectID obj_id;
+  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(obj_id, dynamic_return_id);
+
+  // Finish the task.
+  CompletePendingStreamingTask(spec, caller_address, 2);
+
+  // Test you can write to the stream after task finishes.
+  // TODO(sang): Make sure this doesn't happen by ensuring the ordering
+  // from the executor side.
+  auto dynamic_return_id2 =
+      ReportGeneratorItemReturns(generator_id, 1, /*set_in_plasma=*/false);
+  // NumObjectIDsInScope == Generator + 2 intermediate result.
+  results.clear();
+  RAY_CHECK_OK(store_->Get({dynamic_return_id2}, 1, 1, ctx, false, &results));
+  ASSERT_EQ(results.size(), 1);
+
+  // Make sure you can read.
+  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(obj_id, dynamic_return_id2);
+
+  // Nothing more to read.
+  status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.IsObjectRefEndOfStream());
+
+  reference_counter_->RemoveLocalReference(generator_id, nullptr);
+}
+
+TEST_F(TaskManagerTest, TestObjectRefStreamDelCleanReferences) {
+  /**
+   * Verify DEL cleans all references/objects and ignore all future WRITE.
+   *
+   * CREATE WRITE WRITE DEL (make sure no refs are leaked)
+   */
+  // Submit a task so that generator ID will be available
+  // to the reference counter.
+  rpc::Address caller_address;
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+  manager_.AddPendingTask(caller_address, spec, "", /*num_retries=*/0);
+  manager_.MarkDependenciesResolved(spec.TaskId());
+  manager_.MarkTaskWaitingForExecution(
+      spec.TaskId(), NodeID::FromRandom(), WorkerID::FromRandom());
+
+  // WRITE
+  auto dynamic_return_id =
+      ReportGeneratorItemReturns(generator_id, 0, /*set_in_plasma=*/false);
+  // WRITE 2
+  auto dynamic_return_id2 =
+      ReportGeneratorItemReturns(generator_id, 1, /*set_in_plasma=*/false);
+
+  // NumObjectIDsInScope == Generator + 2 WRITE
+  ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 3);
+  // 2 in memory objects.
+  ASSERT_EQ(store_->Size(), 2);
+  std::vector<std::shared_ptr<RayObject>> results;
+  WorkerContext ctx(WorkerType::WORKER, WorkerID::FromRandom(), JobID::FromInt(0));
+  RAY_CHECK_OK(store_->Get({dynamic_return_id}, 1, 1, ctx, false, &results));
+  ASSERT_EQ(results.size(), 1);
+  results.clear();
+  RAY_CHECK_OK(store_->Get({dynamic_return_id2}, 1, 1, ctx, false, &results));
+  ASSERT_EQ(results.size(), 1);
+  results.clear();
+
+  // DELETE. This should clean all references except generator id.
+  CompletePendingStreamingTask(spec, caller_address, 2);
+  reference_counter_->RemoveLocalReference(generator_id, nullptr);
+  ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 0);
+
+  // NOTE: We panic if READ is called after DELETE. The
+  // API caller should guarantee this doesn't happen.
+  // So we don't test it.
+  // WRITE 3. Should be ignored.
+  bool item_inserted = false;
+  ReportGeneratorItemReturns(generator_id, 2, /*set_in_plasma=*/false, &item_inserted);
+  ASSERT_FALSE(item_inserted);
+}
+
+TEST_F(TaskManagerTest, TestObjectRefStreamOutofOrder) {
+  /**
+   * Test the case where the task return RPC is received out of order
+   */
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+  rpc::Address caller_address;
+  manager_.AddPendingTask(caller_address, spec, "", /*num_retries=*/0);
+
+  auto last_idx = 2;
+  std::vector<ObjectID> dynamic_return_ids;
+  // EoF reported first.
+  CompletePendingStreamingTask(spec, caller_address, 2);
+
+  // Write index 1 -> 0
+  for (auto i = last_idx - 1; i > -1; i--) {
+    auto dynamic_return_id =
+        ReportGeneratorItemReturns(generator_id, i, /*set_in_plasma=*/false);
+    dynamic_return_ids.insert(dynamic_return_ids.begin(), dynamic_return_id);
+  }
+
+  // Verify read works.
+  ObjectID obj_id;
+  for (auto i = 0; i < last_idx; i++) {
+    auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+    ASSERT_TRUE(status.ok());
+    ASSERT_EQ(obj_id, dynamic_return_ids[i]);
+  }
+
+  // READ (EoF)
+  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.IsObjectRefEndOfStream());
+
+  reference_counter_->RemoveLocalReference(generator_id, nullptr);
+}
+
+TEST_F(TaskManagerTest, TestObjectRefStreamTemporarilyOwnGeneratorReturnRefIfNeeded) {
+  /**
+   * Test TemporarilyOwnGeneratorReturnRefIfNeeded
+   */
+  rpc::Address caller_address;
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+
+  /**
+   * Test TemporarilyOwnGeneratorReturnRefIfNeeded is no-op when the stream is
+   * not created yet.
+   */
+  auto dynamic_return_id_index_0 = ObjectID::FromIndex(spec.TaskId(), 2);
+  manager_.TemporarilyOwnGeneratorReturnRefIfNeeded(dynamic_return_id_index_0,
+                                                    generator_id);
+  // It is no-op if the object ref stream is not created.
+  ASSERT_FALSE(reference_counter_->HasReference(dynamic_return_id_index_0));
+
+  /**
+   * Submit a generator task.
+   */
+  manager_.AddPendingTask(caller_address, spec, "", /*num_retries=*/0);
+  manager_.MarkDependenciesResolved(spec.TaskId());
+  manager_.MarkTaskWaitingForExecution(
+      spec.TaskId(), NodeID::FromRandom(), WorkerID::FromRandom());
+
+  /**
+   * Test TemporarilyOwnGeneratorReturnRefIfNeeded called before any
+   * HandleReportGeneratorItemReturns adds a refernece.
+   */
+  manager_.TemporarilyOwnGeneratorReturnRefIfNeeded(dynamic_return_id_index_0,
+                                                    generator_id);
+  // We has a reference to this object before the ref is
+  // reported via HandleReportGeneratorItemReturns.
+  ASSERT_TRUE(reference_counter_->HasReference(dynamic_return_id_index_0));
+
+  /**
+   * Test TemporarilyOwnGeneratorReturnRefIfNeeded called after the
+   * ref consumed / removed will be no-op.
+   */
+  // WRITE 0 -> WRITE 1
+  auto dynamic_return_id =
+      ReportGeneratorItemReturns(generator_id, 0, /*set_in_plasma=*/false);
+  auto dynamic_return_id_index_1 =
+      ReportGeneratorItemReturns(generator_id, 1, /*set_in_plasma=*/false);
+
+  // READ 0 -> READ 1
+  for (auto i = 0; i < 2; i++) {
+    ObjectID object_id;
+    auto status = manager_.TryReadObjectRefStream(generator_id, &object_id);
+    ASSERT_TRUE(status.ok());
+  }
+
+  ASSERT_TRUE(reference_counter_->HasReference(dynamic_return_id));
+  ASSERT_TRUE(reference_counter_->HasReference(dynamic_return_id_index_1));
+
+  /**
+   * Test TemporarilyOwnGeneratorReturnRefIfNeeded called but
+   * HandleReportGeneratorItemReturns is never called. In this case, when
+   * the stream is deleted these refs should be cleaned up.
+   */
+  auto dynamic_return_id_index_2 = ObjectID::FromIndex(spec.TaskId(), 4);
+  manager_.TemporarilyOwnGeneratorReturnRefIfNeeded(dynamic_return_id_index_2,
+                                                    generator_id);
+  ASSERT_TRUE(reference_counter_->HasReference(dynamic_return_id_index_2));
+  reference_counter_->RemoveLocalReference(generator_id, nullptr);
+  ASSERT_FALSE(reference_counter_->HasReference(dynamic_return_id_index_2));
+
+  CompletePendingStreamingTask(spec, caller_address, 2);
+}
+
+TEST_F(TaskManagerTest, TestObjectRefStreamBackpressure) {
+  /**
+   * Test the RPC is not replied when backpressured.
+   * Test the RPC is replied when the stream is deleted.
+   * Test the RPC is replied when the data is consumed.
+   */
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true,
+                               /*generator_backpressure_num_objects*/ 2);
+  auto generator_id = spec.ReturnId(0);
+  rpc::Address caller_address;
+  manager_.AddPendingTask(caller_address, spec, "", 0);
+
+  /// 1 generate, 0 consumed, 2 threshold -> should signal immediately.
+  {
+    bool signal_called = false;
+    auto execution_signal_callback = [&signal_called](Status status,
+                                                      int64_t num_objects_consumed) {
+      signal_called = true;
+      ASSERT_TRUE(status.ok());
+      ASSERT_EQ(num_objects_consumed, 0);
+    };
+    bool item_inserted = false;
+    ReportGeneratorItemReturns(generator_id,
+                               0,
+                               /*set_in_plasma=*/false,
+                               &item_inserted,
+                               execution_signal_callback);
+    ASSERT_TRUE(item_inserted);
+    ASSERT_TRUE(signal_called);
+  }
+
+  /// 2 generate, 0 consumed, 2 threshold -> backpressured
+  {
+    bool signal_called = false;
+    auto execution_signal_callback = [&signal_called](Status status,
+                                                      int64_t num_objects_consumed) {
+      signal_called = true;
+      ASSERT_TRUE(status.ok());
+      ASSERT_EQ(num_objects_consumed, 1);
+    };
+    bool item_inserted = false;
+    ReportGeneratorItemReturns(generator_id,
+                               1,
+                               /*set_in_plasma=*/false,
+                               &item_inserted,
+                               execution_signal_callback);
+    ASSERT_TRUE(item_inserted);
+    ASSERT_FALSE(signal_called);
+
+    // Read should signal the executor.
+    ObjectID obj_id;
+    auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+    ASSERT_TRUE(signal_called);
+  }
+
+  /// 3 generate, 1 consumed, 2 threshold -> backpressured
+  {
+    bool signal_called = false;
+    auto execution_signal_callback = [&signal_called](Status status,
+                                                      int64_t num_objects_consumed) {
+      signal_called = true;
+      ASSERT_TRUE(status.IsNotFound());
+      ASSERT_EQ(num_objects_consumed, -1);
+    };
+    bool item_inserted = false;
+    ReportGeneratorItemReturns(generator_id,
+                               2,
+                               /*set_in_plasma=*/false,
+                               &item_inserted,
+                               execution_signal_callback);
+    ASSERT_TRUE(item_inserted);
+    ASSERT_FALSE(signal_called);
+
+    // Deleting the stream should send a signal.
+    reference_counter_->RemoveLocalReference(generator_id, nullptr);
+    CompletePendingStreamingTask(spec, caller_address, 2);
+    ASSERT_TRUE(signal_called);
+  }
+
+  /// No need to test out of order case. It won't be different.
+}
+
+TEST_F(TaskManagerTest, TestBackpressureAfterReconstruction) {
+  // Consumed objects should be signaled immediately.
+  // Unconsumed objects should not be.
+  auto spec = CreateTaskHelper(1,
+                               {},
+                               /*dynamic_returns=*/true,
+                               /*is_streaming_generator=*/true,
+                               /*generator_backpressure_num_objects*/ 2);
+  auto generator_id = spec.ReturnId(0);
+  rpc::Address caller_address;
+  manager_.AddPendingTask(caller_address, spec, "", 1);
+
+  /// 1 generate, 0 consumed, 2 threshold -> should signal immediately.
+  {
+    bool signal_called = false;
+    auto execution_signal_callback = [&signal_called](Status status,
+                                                      int64_t num_objects_consumed) {
+      signal_called = true;
+      ASSERT_TRUE(status.ok());
+      ASSERT_EQ(num_objects_consumed, 0);
+    };
+    bool item_inserted = false;
+    ReportGeneratorItemReturns(generator_id,
+                               0,
+                               /*set_in_plasma=*/false,
+                               &item_inserted,
+                               execution_signal_callback);
+    ASSERT_TRUE(item_inserted);
+    ASSERT_TRUE(signal_called);
+  }
+
+  /// 2 generate, 0 consumed, 2 threshold -> backpressured
+  bool signal_called = false;
+  {
+    auto execution_signal_callback = [&signal_called](Status status,
+                                                      int64_t num_objects_consumed) {
+      signal_called = true;
+      ASSERT_TRUE(status.ok());
+      ASSERT_EQ(num_objects_consumed, 1);
+    };
+    bool item_inserted = false;
+    ReportGeneratorItemReturns(generator_id,
+                               1,
+                               /*set_in_plasma=*/false,
+                               &item_inserted,
+                               execution_signal_callback);
+    ASSERT_TRUE(item_inserted);
+    ASSERT_FALSE(signal_called);
+  }
+
+  // Worker failure. New worker should start reporting the task.
+  auto error = rpc::ErrorType::WORKER_DIED;
+  ASSERT_TRUE(manager_.FailOrRetryPendingTask(spec.TaskId(), error));
+
+  // Two report will come again. The first one should reply immediately (because)
+  // it is already replied and the second one should be backpressured.
+  /// 1 generate, 0 consumed, 2 threshold -> should signal immediately.
+  {
+    bool retry_signal_called = false;
+    bool item_inserted = false;
+    auto execution_signal_callback = [&retry_signal_called](
+                                         Status status, int64_t num_objects_consumed) {
+      retry_signal_called = true;
+      ASSERT_TRUE(status.ok());
+      ASSERT_EQ(num_objects_consumed, 0);
+    };
+    ReportGeneratorItemReturns(generator_id,
+                               0,
+                               /*set_in_plasma=*/false,
+                               &item_inserted,
+                               execution_signal_callback);
+    ASSERT_FALSE(item_inserted);
+    ASSERT_TRUE(retry_signal_called);
+  }
+
+  /// 2 generate, 0 consumed, 2 threshold -> backpressured
+  bool retry_signal_called = false;
+  auto execution_signal_callback = [&retry_signal_called](Status status,
+                                                          int64_t num_objects_consumed) {
+    retry_signal_called = true;
+    ASSERT_TRUE(status.ok());
+    ASSERT_EQ(num_objects_consumed, 1);
+  };
+  // Backpressured.
+  bool item_inserted = false;
+  ReportGeneratorItemReturns(generator_id,
+                             1,
+                             /*set_in_plasma=*/false,
+                             &item_inserted,
+                             execution_signal_callback);
+  ASSERT_FALSE(item_inserted);
+  ASSERT_FALSE(retry_signal_called);
+
+  ObjectID obj_id;
+  // Read should signal both executor.
+  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(signal_called);
+  ASSERT_TRUE(retry_signal_called);
+
+  reference_counter_->RemoveLocalReference(generator_id, nullptr);
+  CompletePendingStreamingTask(spec, caller_address, 2);
+}
 
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -25,6 +25,9 @@
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker/task_event_buffer.h"
 
+using ::testing::_;
+using ::testing::Return;
+
 namespace ray {
 namespace core {
 
@@ -101,7 +104,9 @@ class MockTaskEventBuffer : public worker::TaskEventBuffer {
 
   MOCK_METHOD(void, Stop, (), (override));
 
-  MOCK_METHOD(bool, Enabled, (), (const, override));
+  bool Enabled() const override {
+    return false;
+  }
 
   MOCK_METHOD(const std::string, DebugString, (), (override));
 };
@@ -150,6 +155,7 @@ class TaskManagerTest : public ::testing::Test {
   void AssertNoLeaks() {
     absl::MutexLock lock(&manager_.mu_);
     ASSERT_EQ(manager_.submissible_tasks_.size(), 0);
+    ASSERT_EQ(manager_.object_ref_streams_.size(), 0);
     ASSERT_EQ(manager_.num_pending_tasks_, 0);
     ASSERT_EQ(manager_.total_lineage_footprint_bytes_, 0);
   }

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -416,8 +416,10 @@ message ReportGeneratorItemReturnsReply {
   // The total number objects consumed from the generator.
   // -1 means it is not known. The executor side should just
   // assume everything is consumed if it is -1.
+  // This is total for the generator task.
   int64 total_num_object_consumed = 1;
 }
+
 
 service CoreWorkerService {
   // Notify core worker GCS has restarted.
@@ -439,7 +441,10 @@ service CoreWorkerService {
   /// It is replied once there are batch of objects that need to be published to
   /// the caller (subscriber).
   rpc PubsubLongPolling(PubsubLongPollingRequest) returns (PubsubLongPollingReply);
-  // The RPC to report the intermediate task return to the caller.
+  // Called by the executor of the generator task. The RPC to report the intermediate task return to the caller.
+  // PushTask begin
+  // [ReportGeneratorItemReturn]
+  // PushTask reply
   rpc ReportGeneratorItemReturns(ReportGeneratorItemReturnsRequest)
       returns (ReportGeneratorItemReturnsReply);
   /// The pubsub command batch request used by the subscriber.

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -413,10 +413,11 @@ message ReportGeneratorItemReturnsRequest {
 }
 
 message ReportGeneratorItemReturnsReply {
-  // The total number objects consumed from the generator.
-  // -1 means it is not known. The executor side should just
-  // assume everything is consumed if it is -1.
-  // This is total for the generator task.
+  // The total number of objects that have been consumed from the generator,
+  // i.e. a ref was returned to the caller of the generator task.  -1 means
+  // unknown and may be returned if an error occurred when requesting from the
+  // caller. The executor side should just assume everything is consumed if it
+  // is -1.
   int64 total_num_object_consumed = 1;
 }
 
@@ -441,10 +442,10 @@ service CoreWorkerService {
   /// It is replied once there are batch of objects that need to be published to
   /// the caller (subscriber).
   rpc PubsubLongPolling(PubsubLongPollingRequest) returns (PubsubLongPollingReply);
-  // Called by the executor of the generator task. The RPC to report the intermediate task return to the caller.
-  // PushTask begin
-  // [ReportGeneratorItemReturn]
-  // PushTask reply
+  // Called by the executor of the generator task to the task's caller. The RPC
+  // is used to report the intermediate task returns to the caller. The reply
+  // is used for streaming generator backpressure; the caller signals how many
+  // ObjectRefs it has consumed from the generator in the reply.
   rpc ReportGeneratorItemReturns(ReportGeneratorItemReturnsRequest)
       returns (ReportGeneratorItemReturnsReply);
   /// The pubsub command batch request used by the subscriber.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Update streaming generator metadata management to use the standard ref counting path. Changes:
- Task metadata is removed once all refs returned by the generator can no longer be reconstructed, instead of through an explicit delete call when the generator ref is deleted. The latter is incorrect because even if the generator ref has been deleted, the task may still get re-executed if the refs returned by the generator are reconstructed. Now we instead delete the stream metadata when the corresponding task metadata is GCed, so we can rely on the normal ref counting protocol to GC streams.
- Refs returned by the generator are initially added with local ref count=0, and contained in the generator ref. The local ref count is incremented when the ref is returned to the caller.
- Do not hold the TaskManager lock when calling ReferenceCounter methods. This can cause deadlock.
- Fixes some typos

## Related issue number

Closes #39151.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
