### PR TITLE
[serve] compact scheduling strategy

### DIFF
--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -60,7 +60,7 @@ class ClusterNodeInfoCache(ABC):
         """
         return self._cached_alive_nodes
 
-    def get_alive_node_resources(self) -> Dict[str, Dict]:
+    def get_total_resources_per_node(self) -> Dict[str, Dict]:
         """Get total resources for alive nodes."""
         return self._cached_total_resources_per_node
 

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -1,5 +1,6 @@
-from typing import Optional
+from typing import Callable, Optional
 
+import ray
 from ray._raylet import GcsClient
 from ray.serve._private.cluster_node_info_cache import (
     ClusterNodeInfoCache,
@@ -25,6 +26,12 @@ def create_cluster_node_info_cache(gcs_client: GcsClient) -> ClusterNodeInfoCach
 def create_deployment_scheduler(
     cluster_node_info_cache: ClusterNodeInfoCache,
     head_node_id_override: Optional[str] = None,
+    create_placement_group_fn_override: Optional[Callable] = None,
 ) -> DeploymentScheduler:
     head_node_id = head_node_id_override or get_head_node_id()
-    return DefaultDeploymentScheduler(cluster_node_info_cache, head_node_id)
+    return DefaultDeploymentScheduler(
+        cluster_node_info_cache,
+        head_node_id,
+        create_placement_group_fn=create_placement_group_fn_override
+        or ray.util.placement_group,
+    )

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -227,3 +227,45 @@ py_test_module_list(
   deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
   data = glob(["test_config_files/**/*"]),
 )
+
+# Test compact scheduling
+py_test_module_list(
+  name_suffix="_with_compact_scheduling",
+  env={"RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY": "1"},
+  files = [
+    "test_standalone.py",
+    "test_standalone_3.py",
+  ],
+  size = "large",
+  tags = ["exclusive", "team:serve"],
+  deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
+)
+
+py_test_module_list(
+  name_suffix="_with_compact_scheduling",
+  env={"RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY": "1"},
+  files = [
+    "test_standalone_2.py",
+  ],
+  size = "large",
+  tags = ["exclusive", "no_windows", "team:serve"],
+  deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
+  data = glob(["test_config_files/**/*"]),
+)
+
+py_test_module_list(
+  name_suffix="_with_compact_scheduling",
+  env={"RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY": "1"},
+  files = [
+    "test_deployment_scheduler.py",
+    "test_cluster.py",
+    "test_max_replicas_per_node.py",
+    "test_replica_placement_group.py",
+    "test_gcs_failure.py",
+    "test_controller_recovery.py",
+  ],
+  size = "medium",
+  tags = ["exclusive", "no_windows", "team:serve"],
+  deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
+  data = glob(["test_config_files/**/*"]),
+)

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import random
 import subprocess
 import tempfile
+from copy import deepcopy
 
 import pytest
 import requests
@@ -46,7 +47,10 @@ def ray_cluster():
 
 @pytest.fixture
 def ray_autoscaling_cluster(request):
-    cluster = AutoscalingCluster(**request.param)
+    # NOTE(zcin): We have to make a deepcopy here because AutoscalingCluster
+    # modifies the dictionary that's passed in.
+    params = deepcopy(request.param)
+    cluster = AutoscalingCluster(**params)
     cluster.start()
     yield
     serve.shutdown()

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -12,7 +12,10 @@ from ray._private.test_utils import SignalActor, wait_for_condition
 from ray.cluster_utils import Cluster
 from ray.exceptions import RayActorError
 from ray.serve._private.common import DeploymentID, ReplicaState
-from ray.serve._private.constants import SERVE_NAMESPACE
+from ray.serve._private.constants import (
+    RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY,
+    SERVE_NAMESPACE,
+)
 from ray.serve._private.deployment_state import ReplicaStartupStatus
 from ray.serve._private.utils import calculate_remaining_timeout, get_head_node_id
 from ray.serve.context import _get_global_client
@@ -249,6 +252,9 @@ def test_intelligent_scale_down(ray_cluster):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
+@pytest.mark.skipif(
+    RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY, reason="Needs spread strategy."
+)
 def test_replica_spread(ray_cluster):
     cluster = ray_cluster
 

--- a/python/ray/serve/tests/test_cluster_node_info_cache.py
+++ b/python/ray/serve/tests/test_cluster_node_info_cache.py
@@ -3,6 +3,7 @@ import pytest
 import ray
 from ray._raylet import GcsClient
 from ray.serve._private.default_impl import create_cluster_node_info_cache
+from ray.serve._private.test_utils import get_node_id
 from ray.tests.conftest import *  # noqa
 
 
@@ -12,10 +13,6 @@ def test_get_alive_nodes(ray_start_cluster):
     ray.init(address=cluster.address)
     worker_node = cluster.add_node(resources={"worker": 1})
     cluster.wait_for_nodes()
-
-    @ray.remote
-    def get_node_id():
-        return ray.get_runtime_context().get_node_id()
 
     head_node_id = ray.get(get_node_id.options(resources={"head": 1}).remote())
     worker_node_id = ray.get(get_node_id.options(resources={"worker": 1}).remote())

--- a/python/ray/serve/tests/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/test_deployment_scheduler.py
@@ -3,15 +3,20 @@ import sys
 import pytest
 
 import ray
+from ray import serve
+from ray._private.test_utils import wait_for_condition
 from ray._raylet import GcsClient
+from ray.serve._private import default_impl
 from ray.serve._private.common import DeploymentID, ReplicaID
-from ray.serve._private.default_impl import create_cluster_node_info_cache
+from ray.serve._private.constants import RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY
 from ray.serve._private.deployment_scheduler import (
-    DefaultDeploymentScheduler,
     ReplicaSchedulingRequest,
     SpreadDeploymentSchedulingPolicy,
 )
+from ray.serve._private.test_utils import check_apps_running, get_node_id
 from ray.serve._private.utils import get_head_node_id
+from ray.serve.context import _get_global_client
+from ray.serve.schema import ServeDeploySchema
 from ray.tests.conftest import *  # noqa
 
 
@@ -24,100 +29,229 @@ class Replica:
         return ray.util.get_current_placement_group()
 
 
-@pytest.mark.parametrize(
-    "placement_group_config",
-    [
-        {},
-        {"bundles": [{"CPU": 3}]},
-        {"bundles": [{"CPU": 1}, {"CPU": 1}, {"CPU": 1}], "strategy": "STRICT_PACK"},
-    ],
+@pytest.mark.skipif(
+    RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY, reason="Need to use spread strategy"
 )
-def test_spread_deployment_scheduling_policy_upscale(
-    ray_start_cluster, placement_group_config
-):
-    """Test to make sure replicas are spreaded."""
-    cluster = ray_start_cluster
-    cluster.add_node(num_cpus=3)
-    cluster.add_node(num_cpus=3)
-    cluster.wait_for_nodes()
-    ray.init(address=cluster.address)
-
-    cluster_node_info_cache = create_cluster_node_info_cache(
-        GcsClient(address=ray.get_runtime_context().gcs_address)
-    )
-    cluster_node_info_cache.update()
-
-    scheduler = DefaultDeploymentScheduler(cluster_node_info_cache, get_head_node_id())
-    dep_id = DeploymentID(name="deployment1")
-    r1_id = ReplicaID(unique_id="replica1", deployment_id=dep_id)
-    r2_id = ReplicaID(unique_id="replica2", deployment_id=dep_id)
-
-    scheduler.on_deployment_created(dep_id, SpreadDeploymentSchedulingPolicy())
-    replica_actor_handles = []
-    replica_placement_groups = []
-
-    def on_scheduled(actor_handle, placement_group):
-        replica_actor_handles.append(actor_handle)
-        replica_placement_groups.append(placement_group)
-
-    deployment_to_replicas_to_stop = scheduler.schedule(
-        upscales={
-            dep_id: [
-                ReplicaSchedulingRequest(
-                    replica_id=r1_id,
-                    actor_def=Replica,
-                    actor_resources={"CPU": 1},
-                    actor_options={"name": "deployment1_replica1"},
-                    actor_init_args=(),
-                    on_scheduled=on_scheduled,
-                    placement_group_bundles=placement_group_config.get("bundles", None),
-                    placement_group_strategy=placement_group_config.get(
-                        "strategy", None
-                    ),
-                ),
-                ReplicaSchedulingRequest(
-                    replica_id=r2_id,
-                    actor_def=Replica,
-                    actor_resources={"CPU": 1},
-                    actor_options={"name": "deployment1_replica2"},
-                    actor_init_args=(),
-                    on_scheduled=on_scheduled,
-                    placement_group_bundles=placement_group_config.get("bundles", None),
-                    placement_group_strategy=placement_group_config.get(
-                        "strategy", None
-                    ),
-                ),
-            ]
-        },
-        downscales={},
-    )
-    assert not deployment_to_replicas_to_stop
-    assert len(replica_actor_handles) == 2
-    assert len(replica_placement_groups) == 2
-    assert not scheduler._pending_replicas[dep_id]
-    assert len(scheduler._launching_replicas[dep_id]) == 2
-    assert (
-        len(
+class TestSpreadScheduling:
+    @pytest.mark.parametrize(
+        "placement_group_config",
+        [
+            {},
+            {"bundles": [{"CPU": 3}]},
             {
-                ray.get(replica_actor_handles[0].get_node_id.remote()),
-                ray.get(replica_actor_handles[1].get_node_id.remote()),
-            }
-        )
-        == 2
+                "bundles": [{"CPU": 1}, {"CPU": 1}, {"CPU": 1}],
+                "strategy": "STRICT_PACK",
+            },
+        ],
     )
-    if "bundles" in placement_group_config:
+    def test_spread_deployment_scheduling_policy_upscale(
+        self, ray_start_cluster, placement_group_config
+    ):
+        """Test to make sure replicas are spreaded."""
+        cluster = ray_start_cluster
+        cluster.add_node(num_cpus=3)
+        cluster.add_node(num_cpus=3)
+        cluster.wait_for_nodes()
+        ray.init(address=cluster.address)
+
+        cluster_node_info_cache = default_impl.create_cluster_node_info_cache(
+            GcsClient(address=ray.get_runtime_context().gcs_address)
+        )
+        cluster_node_info_cache.update()
+
+        scheduler = default_impl.create_deployment_scheduler(
+            cluster_node_info_cache, get_head_node_id(), ray.util.placement_group
+        )
+        dep_id = DeploymentID(name="deployment1")
+        r1_id = ReplicaID(unique_id="replica1", deployment_id=dep_id)
+        r2_id = ReplicaID(unique_id="replica2", deployment_id=dep_id)
+        scheduler.on_deployment_created(dep_id, SpreadDeploymentSchedulingPolicy())
+        replica_actor_handles = []
+        replica_placement_groups = []
+
+        def on_scheduled(actor_handle, placement_group):
+            replica_actor_handles.append(actor_handle)
+            replica_placement_groups.append(placement_group)
+
+        deployment_to_replicas_to_stop = scheduler.schedule(
+            upscales={
+                dep_id: [
+                    ReplicaSchedulingRequest(
+                        replica_id=r1_id,
+                        actor_def=Replica,
+                        actor_resources={"CPU": 1},
+                        actor_options={"name": "deployment1_replica1"},
+                        actor_init_args=(),
+                        on_scheduled=on_scheduled,
+                        placement_group_bundles=placement_group_config.get(
+                            "bundles", None
+                        ),
+                        placement_group_strategy=placement_group_config.get(
+                            "strategy", None
+                        ),
+                    ),
+                    ReplicaSchedulingRequest(
+                        replica_id=r2_id,
+                        actor_def=Replica,
+                        actor_resources={"CPU": 1},
+                        actor_options={"name": "deployment1_replica2"},
+                        actor_init_args=(),
+                        on_scheduled=on_scheduled,
+                        placement_group_bundles=placement_group_config.get(
+                            "bundles", None
+                        ),
+                        placement_group_strategy=placement_group_config.get(
+                            "strategy", None
+                        ),
+                    ),
+                ]
+            },
+            downscales={},
+        )
+        assert not deployment_to_replicas_to_stop
+        assert len(replica_actor_handles) == 2
+        assert len(replica_placement_groups) == 2
+        assert not scheduler._pending_replicas[dep_id]
+        assert len(scheduler._launching_replicas[dep_id]) == 2
         assert (
             len(
                 {
-                    ray.get(replica_actor_handles[0].get_placement_group.remote()),
-                    ray.get(replica_actor_handles[1].get_placement_group.remote()),
+                    ray.get(replica_actor_handles[0].get_node_id.remote()),
+                    ray.get(replica_actor_handles[1].get_node_id.remote()),
                 }
             )
             == 2
         )
-    scheduler.on_replica_stopping(r1_id)
-    scheduler.on_replica_stopping(r2_id)
-    scheduler.on_deployment_deleted(dep_id)
+        if "bundles" in placement_group_config:
+            assert (
+                len(
+                    {
+                        ray.get(replica_actor_handles[0].get_placement_group.remote()),
+                        ray.get(replica_actor_handles[1].get_placement_group.remote()),
+                    }
+                )
+                == 2
+            )
+        scheduler.on_replica_stopping(r1_id)
+        scheduler.on_replica_stopping(r2_id)
+        scheduler.on_deployment_deleted(dep_id)
+
+
+@serve.deployment
+def A():
+    return ray.get_runtime_context().get_node_id()
+
+
+app_A = A.bind()
+
+
+@pytest.mark.skipif(
+    not RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY, reason="Needs compact strategy."
+)
+class TestCompactScheduling:
+    @pytest.mark.parametrize("use_pg", [True, False])
+    def test_e2e_basic(self, ray_cluster, use_pg: bool):
+        cluster = ray_cluster
+        cluster.add_node(num_cpus=2, resources={"head": 1})
+        cluster.add_node(num_cpus=3, resources={"worker1": 1})
+        cluster.add_node(num_cpus=4, resources={"worker2": 1})
+        cluster.wait_for_nodes()
+        ray.init(address=cluster.address)
+
+        head_node_id = ray.get(get_node_id.options(resources={"head": 1}).remote())
+        worker1_node_id = ray.get(
+            get_node_id.options(resources={"worker1": 1}).remote()
+        )
+        worker2_node_id = ray.get(
+            get_node_id.options(resources={"worker2": 1}).remote()
+        )
+        print("head", head_node_id)
+        print("worker1", worker1_node_id)
+        print("worker2", worker2_node_id)
+
+        # Both f replicas should be scheduled on head node to minimize
+        # fragmentation
+        if use_pg:
+            app1 = A.options(
+                num_replicas=2,
+                ray_actor_options={"num_cpus": 0.1},
+                placement_group_bundles=[{"CPU": 0.5}, {"CPU": 0.5}],
+                placement_group_strategy="STRICT_PACK",
+            ).bind()
+        else:
+            app1 = A.options(num_replicas=2, ray_actor_options={"num_cpus": 1}).bind()
+
+        # Both app1 replicas should have been scheduled on head node
+        f_handle = serve.run(app1, name="app1", route_prefix="/app1")
+        refs = [f_handle.remote() for _ in range(20)]
+        assert {ref.result() for ref in refs} == {head_node_id}
+
+        if use_pg:
+            app2 = A.options(
+                num_replicas=1,
+                ray_actor_options={"num_cpus": 0.1},
+                placement_group_bundles=[{"CPU": 1}, {"CPU": 2}],
+                placement_group_strategy="STRICT_PACK",
+            ).bind()
+        else:
+            app2 = A.options(num_replicas=1, ray_actor_options={"num_cpus": 3}).bind()
+
+        # Then there should be enough space for the g replica
+        # The g replica should be scheduled on worker1, not worker2, to
+        # minimize fragmentation
+        g_handle = serve.run(app2, name="app2", route_prefix="/app2")
+        assert g_handle.remote().result() == worker1_node_id
+
+        serve.shutdown()
+
+    @pytest.mark.parametrize("use_pg", [True, False])
+    @pytest.mark.parametrize(
+        "app_resources,expected_worker_nodes",
+        [
+            # [2, 5, 3, 3, 7, 2, 6, 2] -> 3 nodes
+            ({5: 1, 3: 2, 7: 1, 2: 3, 6: 1}, 3),
+            # [1, 4, 7, 7, 3, 2] -> 2 nodes
+            ({1: 1, 7: 2, 3: 1, 2: 1}, 2),
+            # [7, 3, 2, 7, 7, 2] -> 3 nodes
+            ({7: 3, 3: 1, 2: 2}, 3),
+        ],
+    )
+    def test_e2e_fit_replicas(
+        self, ray_cluster, use_pg, app_resources, expected_worker_nodes
+    ):
+        for _ in range(expected_worker_nodes):
+            ray_cluster.add_node(num_cpus=10)
+        ray_cluster.wait_for_nodes()
+        ray.init(address=ray_cluster.address)
+
+        serve.start()
+        client = _get_global_client()
+
+        applications = []
+        for n, count in app_resources.items():
+            name = n
+            num_cpus = 0.1 * n
+            app = {
+                "name": f"app{name}",
+                "import_path": "ray.serve.tests.test_deployment_scheduler.app_A",
+                "route_prefix": f"/app{name}",
+                "deployments": [
+                    {
+                        "name": "A",
+                        "num_replicas": count,
+                        "ray_actor_options": {"num_cpus": 0 if use_pg else num_cpus},
+                    }
+                ],
+            }
+            if use_pg:
+                app["deployments"][0]["placement_group_bundles"] = [{"CPU": num_cpus}]
+                app["deployments"][0]["placement_group_strategy"] = "STRICT_PACK"
+
+            applications.append(app)
+
+        client.deploy_apps(ServeDeploySchema(**{"applications": applications}))
+        wait_for_condition(check_apps_running, apps=[f"app{n}" for n in app_resources])
+        print("Test passed!")
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_max_replicas_per_node.py
+++ b/python/ray/serve/tests/test_max_replicas_per_node.py
@@ -6,7 +6,10 @@ import pytest
 import ray
 from ray import serve
 from ray._private.test_utils import wait_for_condition
-from ray.serve._private.constants import RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS
+from ray.serve._private.constants import (
+    RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS,
+    RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY,
+)
 from ray.util.state import list_actors
 
 
@@ -48,6 +51,10 @@ def check_alive_nodes(expected: int):
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="Flaky on Windows due to https://github.com/ray-project/ray/issues/36926.",
+)
+@pytest.mark.skipif(
+    RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY,
+    reason="Max replicas per node not supported for compact scheduling strategy yet.",
 )
 @pytest.mark.parametrize(
     "ray_autoscaling_cluster",
@@ -120,6 +127,10 @@ def test_basic(ray_autoscaling_cluster):
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="Flaky on Windows due to https://github.com/ray-project/ray/issues/36926.",
+)
+@pytest.mark.skipif(
+    RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY,
+    reason="Max replicas per node not supported for compact scheduling strategy yet.",
 )
 @pytest.mark.parametrize(
     "ray_autoscaling_cluster",

--- a/python/ray/serve/tests/unit/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/unit/test_deployment_scheduler.py
@@ -1,15 +1,17 @@
 import random
 import sys
-from typing import List
+from copy import copy
+from typing import Dict, List, Optional
 from unittest.mock import Mock
 
 import pytest
 
 import ray
+from ray.serve._private import default_impl
 from ray.serve._private.common import DeploymentID, ReplicaID
 from ray.serve._private.config import ReplicaConfig
+from ray.serve._private.constants import RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY
 from ray.serve._private.deployment_scheduler import (
-    DefaultDeploymentScheduler,
     DeploymentDownscaleRequest,
     DeploymentSchedulingInfo,
     ReplicaSchedulingRequest,
@@ -18,6 +20,52 @@ from ray.serve._private.deployment_scheduler import (
 )
 from ray.serve._private.test_utils import MockClusterNodeInfoCache
 from ray.tests.conftest import *  # noqa
+from ray.util.scheduling_strategies import (
+    NodeAffinitySchedulingStrategy,
+    PlacementGroupSchedulingStrategy,
+)
+
+
+def dummy():
+    pass
+
+
+class MockActorHandle:
+    def __init__(self, **kwargs):
+        self._options = kwargs
+
+
+class MockActorClass:
+    def __init__(self):
+        self._init_args = ()
+        self._options = dict()
+
+    def options(self, **kwargs):
+        res = copy(self)
+
+        for k, v in kwargs.items():
+            res._options[k] = v
+
+        return res
+
+    def remote(self, *args) -> MockActorHandle:
+        return MockActorHandle(init_args=args, **self._options)
+
+
+class MockPlacementGroup:
+    def __init__(
+        self,
+        bundles: List[Dict[str, float]],
+        strategy: str = "PACK",
+        name: str = "",
+        lifetime: Optional[str] = None,
+        _soft_target_node_id: Optional[str] = None,
+    ):
+        self._bundles = bundles
+        self._strategy = strategy
+        self._name = name
+        self._lifetime = lifetime
+        self._soft_target_node_id = _soft_target_node_id
 
 
 def get_random_resources(n: int) -> List[Resources]:
@@ -206,14 +254,68 @@ def test_deployment_scheduling_info():
     assert info.is_non_strict_pack_pg()
 
 
+def test_get_available_resources_per_node():
+    d_id = DeploymentID("a", "b")
+
+    cluster_node_info_cache = MockClusterNodeInfoCache()
+    cluster_node_info_cache.add_node("node1", {"GPU": 10, "CPU": 32, "memory": 1024})
+
+    scheduler = default_impl.create_deployment_scheduler(
+        cluster_node_info_cache,
+        head_node_id_override="fake-head-node-id",
+        create_placement_group_fn_override=None,
+    )
+    scheduler.on_deployment_created(d_id, SpreadDeploymentSchedulingPolicy())
+    scheduler.on_deployment_deployed(
+        d_id,
+        ReplicaConfig.create(
+            dummy,
+            ray_actor_options={"num_gpus": 1, "num_cpus": 3},
+            max_replicas_per_node=4,
+        ),
+    )
+
+    # Without updating cluster node info cache, when a replica is marked
+    # as launching, the resources it uses should decrease the scheduler's
+    # view of current available resources per node in the cluster
+    scheduler._on_replica_launching(
+        ReplicaID(unique_id="replica0", deployment_id=d_id), target_node_id="node1"
+    )
+    assert scheduler._get_available_resources_per_node().get("node1") == Resources(
+        **{"GPU": 9, "CPU": 29, "memory": 1024}
+    )
+
+    # Similarly when a replica is marked as running, the resources it
+    # uses should decrease current available resources per node
+    scheduler.on_replica_running(
+        ReplicaID(unique_id="replica1", deployment_id=d_id), node_id="node1"
+    )
+    assert scheduler._get_available_resources_per_node().get("node1") == Resources(
+        **{"GPU": 8, "CPU": 26, "memory": 1024}
+    )
+
+    # Get updated info from GCS that available memory has dropped,
+    # the decreased memory should reflect in current available resources
+    # per node, while also keeping track of the CPU and GPU resources
+    # used by launching and running replicas
+    cluster_node_info_cache.set_available_resources_per_node(
+        "node1", {"GPU": 10, "CPU": 32, "memory": 256}
+    )
+    assert scheduler._get_available_resources_per_node().get("node1") == Resources(
+        **{"GPU": 8, "CPU": 26, "memory": 256}
+    )
+
+
 def test_downscale_multiple_deployments():
     """Test to make sure downscale prefers replicas without node id
     and then replicas on a node with fewest replicas of all deployments.
     """
 
     cluster_node_info_cache = MockClusterNodeInfoCache()
-    scheduler = DefaultDeploymentScheduler(
-        cluster_node_info_cache, head_node_id="fake-head-node-id"
+    scheduler = default_impl.create_deployment_scheduler(
+        cluster_node_info_cache,
+        head_node_id_override="fake-head-node-id",
+        create_placement_group_fn_override=None,
     )
 
     d1_id = DeploymentID(name="deployment1")
@@ -300,8 +402,10 @@ def test_downscale_head_node():
     head_node_id = "fake-head-node-id"
     dep_id = DeploymentID(name="deployment1")
     cluster_node_info_cache = MockClusterNodeInfoCache()
-    scheduler = DefaultDeploymentScheduler(
-        cluster_node_info_cache, head_node_id=head_node_id
+    scheduler = default_impl.create_deployment_scheduler(
+        cluster_node_info_cache,
+        head_node_id_override=head_node_id,
+        create_placement_group_fn_override=None,
     )
 
     r1_id = ReplicaID(
@@ -361,8 +465,10 @@ def test_downscale_single_deployment():
     cluster_node_info_cache = MockClusterNodeInfoCache()
     cluster_node_info_cache.add_node("node1")
     cluster_node_info_cache.add_node("node2")
-    scheduler = DefaultDeploymentScheduler(
-        cluster_node_info_cache, head_node_id="fake-head-node-id"
+    scheduler = default_impl.create_deployment_scheduler(
+        cluster_node_info_cache,
+        head_node_id_override="fake-head-node-id",
+        create_placement_group_fn_override=None,
     )
 
     scheduler.on_deployment_created(dep_id, SpreadDeploymentSchedulingPolicy())
@@ -453,6 +559,234 @@ def test_downscale_single_deployment():
     scheduler.on_replica_stopping(r1_id)
     scheduler.on_replica_stopping(r2_id)
     scheduler.on_deployment_deleted(dep_id)
+
+
+@pytest.mark.skipif(
+    not RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY, reason="Needs compact strategy."
+)
+class TestCompactScheduling:
+    def test_basic(self):
+        d_id1 = DeploymentID(name="deployment1")
+        d_id2 = DeploymentID(name="deployment2")
+
+        cluster_node_info_cache = MockClusterNodeInfoCache()
+        cluster_node_info_cache.add_node("node1", {"CPU": 3})
+        cluster_node_info_cache.add_node("node2", {"CPU": 2})
+        scheduler = default_impl.create_deployment_scheduler(
+            cluster_node_info_cache,
+            head_node_id_override="fake-head-node-id",
+            create_placement_group_fn_override=None,
+        )
+
+        scheduler.on_deployment_created(d_id1, SpreadDeploymentSchedulingPolicy())
+        scheduler.on_deployment_created(d_id2, SpreadDeploymentSchedulingPolicy())
+
+        scheduler.on_deployment_deployed(
+            d_id1,
+            ReplicaConfig.create(dummy, ray_actor_options={"num_cpus": 1}),
+        )
+        scheduler.on_deployment_deployed(
+            d_id2,
+            ReplicaConfig.create(dummy, ray_actor_options={"num_cpus": 3}),
+        )
+
+        on_scheduled_mock = Mock()
+        on_scheduled_mock2 = Mock()
+        scheduler.schedule(
+            upscales={
+                d_id1: [
+                    ReplicaSchedulingRequest(
+                        replica_id=ReplicaID(unique_id=f"r{i}", deployment_id=d_id1),
+                        actor_def=MockActorClass(),
+                        actor_resources={"CPU": 1},
+                        actor_options={},
+                        actor_init_args=(),
+                        on_scheduled=on_scheduled_mock,
+                    )
+                    for i in range(2)
+                ],
+                d_id2: [
+                    ReplicaSchedulingRequest(
+                        replica_id=ReplicaID(unique_id="r2", deployment_id=d_id2),
+                        actor_def=MockActorClass(),
+                        actor_resources={"CPU": 3},
+                        actor_options={},
+                        actor_init_args=(),
+                        on_scheduled=on_scheduled_mock2,
+                    )
+                ],
+            },
+            downscales={},
+        )
+
+        assert len(on_scheduled_mock.call_args_list) == 2
+        for call in on_scheduled_mock.call_args_list:
+            assert call.kwargs == {"placement_group": None}
+            assert len(call.args) == 1
+            scheduling_strategy = call.args[0]._options["scheduling_strategy"]
+            assert isinstance(scheduling_strategy, NodeAffinitySchedulingStrategy)
+            assert scheduling_strategy.node_id == "node2"
+
+        assert len(on_scheduled_mock2.call_args_list) == 1
+        call = on_scheduled_mock2.call_args_list[0]
+        assert call.kwargs == {"placement_group": None}
+        assert len(call.args) == 1
+        scheduling_strategy = call.args[0]._options["scheduling_strategy"]
+        assert isinstance(scheduling_strategy, NodeAffinitySchedulingStrategy)
+        assert scheduling_strategy.node_id == "node1"
+
+    def test_placement_groups(self):
+        d_id1 = DeploymentID(name="deployment1")
+        d_id2 = DeploymentID(name="deployment2")
+
+        cluster_node_info_cache = MockClusterNodeInfoCache()
+        cluster_node_info_cache.add_node("node1", {"CPU": 3})
+        cluster_node_info_cache.add_node("node2", {"CPU": 2})
+        scheduler = default_impl.create_deployment_scheduler(
+            cluster_node_info_cache,
+            head_node_id_override="fake-head-node-id",
+            create_placement_group_fn_override=lambda *args, **kwargs: MockPlacementGroup(  # noqa
+                *args, **kwargs
+            ),
+        )
+
+        ray.util.placement_group
+        scheduler.on_deployment_created(d_id1, SpreadDeploymentSchedulingPolicy())
+        scheduler.on_deployment_created(d_id2, SpreadDeploymentSchedulingPolicy())
+
+        scheduler.on_deployment_deployed(
+            d_id1,
+            ReplicaConfig.create(
+                dummy,
+                ray_actor_options={"num_cpus": 0},
+                placement_group_bundles=[{"CPU": 0.5}, {"CPU": 0.5}],
+                placement_group_strategy="STRICT_PACK",
+            ),
+        )
+        scheduler.on_deployment_deployed(
+            d_id2,
+            ReplicaConfig.create(
+                dummy,
+                ray_actor_options={"num_cpus": 0},
+                placement_group_bundles=[{"CPU": 0.5}, {"CPU": 2.5}],
+                placement_group_strategy="STRICT_PACK",
+            ),
+        )
+
+        on_scheduled_mock = Mock()
+        on_scheduled_mock2 = Mock()
+        scheduler.schedule(
+            upscales={
+                d_id1: [
+                    ReplicaSchedulingRequest(
+                        replica_id=ReplicaID(unique_id=f"r{i}", deployment_id=d_id1),
+                        actor_def=MockActorClass(),
+                        actor_resources={"CPU": 0},
+                        placement_group_bundles=[{"CPU": 0.5}, {"CPU": 0.5}],
+                        placement_group_strategy="STRICT_PACK",
+                        actor_options={"name": "random_replica"},
+                        actor_init_args=(),
+                        on_scheduled=on_scheduled_mock,
+                    )
+                    for i in range(2)
+                ],
+                d_id2: [
+                    ReplicaSchedulingRequest(
+                        replica_id=ReplicaID(unique_id="r2", deployment_id=d_id2),
+                        actor_def=MockActorClass(),
+                        actor_resources={"CPU": 0},
+                        placement_group_bundles=[{"CPU": 0.5}, {"CPU": 2.5}],
+                        placement_group_strategy="STRICT_PACK",
+                        actor_options={"name": "some_replica"},
+                        actor_init_args=(),
+                        on_scheduled=on_scheduled_mock2,
+                    )
+                ],
+            },
+            downscales={},
+        )
+
+        assert len(on_scheduled_mock.call_args_list) == 2
+        for call in on_scheduled_mock.call_args_list:
+            assert len(call.args) == 1
+            scheduling_strategy = call.args[0]._options["scheduling_strategy"]
+            assert isinstance(scheduling_strategy, PlacementGroupSchedulingStrategy)
+            assert call.kwargs.get("placement_group")._soft_target_node_id == "node2"
+
+        assert len(on_scheduled_mock2.call_args_list) == 1
+        call = on_scheduled_mock2.call_args_list[0]
+        assert len(call.args) == 1
+        scheduling_strategy = call.args[0]._options["scheduling_strategy"]
+        assert isinstance(scheduling_strategy, PlacementGroupSchedulingStrategy)
+        assert call.kwargs.get("placement_group")._soft_target_node_id == "node1"
+
+    def test_heterogeneous_resources(self):
+        d_id1 = DeploymentID(name="deployment1")
+        d_id2 = DeploymentID(name="deployment2")
+
+        cluster_node_info_cache = MockClusterNodeInfoCache()
+        cluster_node_info_cache.add_node("node1", {"GPU": 4, "CPU": 6})
+        cluster_node_info_cache.add_node("node2", {"GPU": 10, "CPU": 2})
+        scheduler = default_impl.create_deployment_scheduler(
+            cluster_node_info_cache,
+            head_node_id_override="fake-head-node-id",
+            create_placement_group_fn_override=None,
+        )
+
+        scheduler.on_deployment_created(d_id1, SpreadDeploymentSchedulingPolicy())
+        scheduler.on_deployment_created(d_id2, SpreadDeploymentSchedulingPolicy())
+        scheduler.on_deployment_deployed(
+            d_id1,
+            ReplicaConfig.create(
+                dummy, ray_actor_options={"num_gpus": 2, "num_cpus": 2}
+            ),
+        )
+        scheduler.on_deployment_deployed(
+            d_id2,
+            ReplicaConfig.create(
+                dummy, ray_actor_options={"num_gpus": 1, "num_cpus": 1}
+            ),
+        )
+
+        on_scheduled_mock = Mock()
+        scheduler.schedule(
+            upscales={
+                d_id1: [
+                    ReplicaSchedulingRequest(
+                        replica_id=ReplicaID(unique_id="r0", deployment_id=d_id1),
+                        actor_def=MockActorClass(),
+                        actor_resources={"GPU": 2, "CPU": 2},
+                        actor_options={},
+                        actor_init_args=(),
+                        on_scheduled=on_scheduled_mock,
+                    )
+                ],
+                d_id2: [
+                    ReplicaSchedulingRequest(
+                        replica_id=ReplicaID(unique_id=f"r{i+1}", deployment_id=d_id2),
+                        actor_def=MockActorClass(),
+                        actor_resources={"GPU": 1, "CPU": 1},
+                        actor_options={},
+                        actor_init_args=(),
+                        on_scheduled=on_scheduled_mock,
+                    )
+                    for i in range(2)
+                ],
+            },
+            downscales={},
+        )
+
+        # Even though scheduling on node 2 would minimize fragmentation
+        # of CPU resources, we should prioritize minimizing fragmentation
+        # of GPU resources first, so all 3 replicas should be scheduled
+        # to node 1
+        assert len(on_scheduled_mock.call_args_list) == 3
+        for call in on_scheduled_mock.call_args_list:
+            assert len(call.args) == 1
+            scheduling_strategy = call.args[0]._options["scheduling_strategy"]
+            assert isinstance(scheduling_strategy, NodeAffinitySchedulingStrategy)
+            assert scheduling_strategy.node_id == "node1"
+            assert call.kwargs == {"placement_group": None}
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -219,7 +219,7 @@ class MockReplicaActorWrapper:
         return ReplicaSchedulingRequest(
             replica_id=self._replica_id,
             actor_def=Mock(),
-            actor_resources=None,
+            actor_resources={},
             actor_options={},
             actor_init_args=(),
             on_scheduled=_on_scheduled_stub,
@@ -323,12 +323,15 @@ def mock_deployment_state() -> Tuple[DeploymentState, Mock, Mock]:
             pass
 
         cluster_node_info_cache = MockClusterNodeInfoCache()
+        cluster_node_info_cache.add_node("node-id")
 
         deployment_state = DeploymentState(
             DeploymentID(name="name", app_name="my_app"),
             mock_long_poll,
             DefaultDeploymentScheduler(
-                cluster_node_info_cache, head_node_id="fake-head-node-id"
+                cluster_node_info_cache,
+                head_node_id="fake-head-node-id",
+                create_placement_group_fn=None,
             ),
             cluster_node_info_cache,
             mock_save_checkpoint_fn,


### PR DESCRIPTION
[serve] compact scheduling strategy

Implement compact scheduling strategy when scheduling new pending replicas. This minimizes fragmentation.

This is feature flagged and can be turned on with `RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY = 1`.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/ray-project/ray/pull/43591).
* #43755
* __->__ #43591