### PR TITLE
Fix resuming from checkpoint when using RayFSDPStrategy

### DIFF
--- a/python/ray/train/lightning/_lightning_utils.py
+++ b/python/ray/train/lightning/_lightning_utils.py
@@ -115,8 +115,16 @@ class RayFSDPStrategy(FSDPStrategy):  # noqa: F821
                 ),
             ):
                 state_dict = self.model.state_dict()
+                
+                ckpt_state_dict = {}
                 prefix_len = len("_forward_module.")
-                return {k[prefix_len:]: v for k, v in state_dict.items()}
+                for k, v in state_dict.items():
+                    if k.startswith("_forward_module."):
+                        non_prefixed_key = k[prefix_len:]
+                        ckpt_state_dict[non_prefixed_key] = v
+                    else:
+                        ckpt_state_dict[k] = v
+                return ckpt_state_dict
         else:
             # Otherwise Lightning uses Fairscale FSDP, no need to unshard by ourself.
             return super().lightning_module_state_dict()

--- a/python/ray/train/lightning/_lightning_utils.py
+++ b/python/ray/train/lightning/_lightning_utils.py
@@ -115,7 +115,7 @@ class RayFSDPStrategy(FSDPStrategy):  # noqa: F821
                 ),
             ):
                 state_dict = self.model.state_dict()
-                
+
                 ckpt_state_dict = {}
                 prefix_len = len("_forward_module.")
                 for k, v in state_dict.items():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Restoring from a checkpoint when using FSDP is currently flawed as the state_dict keys for each layer get modified and torch can not associate the weights to the layer name when loading. The current implementation always assumes that the layer keys in the state dict are prefixed with `_forward_module.` and then slices the key based on the length of the prefix.

The underlying reason why we remove the `_forward_module.` is unclear to me but we should check if it is prefixed before removing. This is implemented in this PR and fixes the loading of checkpoints when using `RayFSDPStrategy`

The following is an example of the wrong state_dict keys for a checkpoint:

```
# Keys in checkpoint["state_dict"]
der.embed_tokens.weight
der.embed_positions.weight
der.final_layer_norm.weight
...
```

Correct keys:
```
model.model.decoder.embed_tokens.weight
model.model.decoder.embed_positions.weight
model.model.decoder.final_layer_norm.weight
...
```