### PR TITLE
[serve] Disable task events by default for Serve actors

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -23,6 +23,7 @@ from ray.serve._private.common import (
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
     NEW_DEFAULT_MAX_ONGOING_REQUESTS,
+    RAY_SERVE_ENABLE_TASK_EVENTS,
     SERVE_LOGGER_NAME,
 )
 from ray.serve._private.deploy_utils import (
@@ -416,7 +417,8 @@ class ApplicationState:
             # Kick off new build app task
             logger.info(f"Building application '{self._name}'.")
             build_app_obj_ref = build_serve_application.options(
-                runtime_env=config.runtime_env
+                runtime_env=config.runtime_env,
+                enable_task_events=RAY_SERVE_ENABLE_TASK_EVENTS,
             ).remote(
                 config.import_path,
                 config.deployment_names,

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -315,3 +315,8 @@ RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS = (
 
 # Timeout for gracefully shutting down metrics pusher, e.g. in routers or replicas
 METRICS_PUSHER_GRACEFUL_SHUTDOWN_TIMEOUT_S = 10
+
+# Feature flag to set `enable_task_events=True` on Serve-managed actors.
+RAY_SERVE_ENABLE_TASK_EVENTS = (
+    os.environ.get("RAY_SERVE_ENABLE_TASK_EVENTS", "0") == "1"
+)

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -24,6 +24,7 @@ from ray.serve._private.constants import (
     CONTROL_LOOP_PERIOD_S,
     CONTROLLER_MAX_CONCURRENCY,
     RAY_SERVE_CONTROLLER_CALLBACK_IMPORT_PATH,
+    RAY_SERVE_ENABLE_TASK_EVENTS,
     RECOVERING_LONG_POLL_BROADCAST_TIMEOUT_S,
     SERVE_CONTROLLER_NAME,
     SERVE_DEFAULT_APP_NAME,
@@ -1147,6 +1148,7 @@ class ServeControllerAvatar:
                 resources={HEAD_NODE_RESOURCE_NAME: 0.001},
                 namespace=SERVE_NAMESPACE,
                 max_concurrency=CONTROLLER_MAX_CONCURRENCY,
+                enable_task_events=RAY_SERVE_ENABLE_TASK_EVENTS,
             ).remote(
                 http_config=http_config,
                 global_logging_config=logging_config,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -37,6 +37,7 @@ from ray.serve._private.constants import (
     MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT,
     RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
     RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS,
+    RAY_SERVE_ENABLE_TASK_EVENTS,
     RAY_SERVE_FORCE_STOP_UNHEALTHY_REPLICAS,
     REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
     SERVE_LOGGER_NAME,
@@ -468,6 +469,7 @@ class ActorReplicaWrapper:
             "name": self._actor_name,
             "namespace": SERVE_NAMESPACE,
             "lifetime": "detached",
+            "enable_task_events": RAY_SERVE_ENABLE_TASK_EVENTS,
         }
         actor_options.update(deployment_info.replica_config.ray_actor_options)
 

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -19,6 +19,7 @@ from ray.serve._private.constants import (
     PROXY_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
     PROXY_READY_CHECK_TIMEOUT_S,
     RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE,
+    RAY_SERVE_ENABLE_TASK_EVENTS,
     SERVE_LOGGER_NAME,
     SERVE_NAMESPACE,
     SERVE_PROXY_NAME,
@@ -161,6 +162,7 @@ class ActorProxyWrapper(ProxyWrapper):
             max_concurrency=ASYNC_CONCURRENCY,
             max_restarts=0,
             scheduling_strategy=NodeAffinitySchedulingStrategy(node_id, soft=False),
+            enable_task_events=RAY_SERVE_ENABLE_TASK_EVENTS,
         ).remote(
             config.host,
             port,

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -37,6 +37,7 @@ py_test_module_list(
     "test_expected_versions.py",
     "test_actor_replica_wrapper.py",
     "test_max_queued_requests.py",
+    "test_enable_task_events.py",
   ],
   size = "small",
   tags = ["exclusive", "team:serve"],
@@ -208,6 +209,19 @@ py_test_module_list(
     "test_max_replicas_per_node.py",
   ],
   size = "medium",
+  tags = ["exclusive", "no_windows", "team:serve"],
+  deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
+  data = glob(["test_config_files/**/*"]),
+)
+
+# Test feature flag for task events.
+py_test_module_list(
+  name_suffix="_with_task_events_enabled",
+  env={"RAY_SERVE_ENABLE_TASK_EVENTS": "1"},
+  files = [
+    "test_enable_task_events.py",
+  ],
+  size = "small",
   tags = ["exclusive", "no_windows", "team:serve"],
   deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
   data = glob(["test_config_files/**/*"]),

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -1,4 +1,3 @@
-import importlib
 import os
 import random
 import subprocess

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import random
 import subprocess
@@ -164,7 +165,6 @@ def ray_instance(request):
         requested_env_vars = {}
 
     os.environ.update(requested_env_vars)
-
     yield ray.init(
         _metrics_export_port=9999,
         _system_config={

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -537,14 +537,8 @@ def test_controller_recover_and_deploy(client: ServeControllerClient):
     config = ServeDeploySchema.parse_obj(config_json)
     client.deploy_apps(config)
 
-    # Wait for deploy_serve_application task to start->config has been checkpointed
     wait_for_condition(
-        lambda: len(
-            list_tasks(
-                filters=[("func_or_class_name", "=", "build_serve_application")],
-            )
-        )
-        > 0
+        lambda: serve.status().applications["default"].status == "DEPLOYING"
     )
     ray.kill(client._controller, no_restart=False)
 

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -36,7 +36,7 @@ from ray.serve.tests.common.remote_uris import (
     TEST_RUNTIME_ENV_PINNED_URI,
 )
 from ray.tests.conftest import call_ray_stop_only  # noqa: F401
-from ray.util.state import list_actors, list_tasks
+from ray.util.state import list_actors
 
 
 @pytest.fixture

--- a/python/ray/serve/tests/test_enable_task_events.py
+++ b/python/ray/serve/tests/test_enable_task_events.py
@@ -1,13 +1,13 @@
-import requests
 import sys
 
 import pytest
+import requests
 from starlette.requests import Request
 
 import ray
 from ray import serve
-from ray.serve._private.constants import RAY_SERVE_ENABLE_TASK_EVENTS
 from ray._private.test_utils import wait_for_condition
+from ray.serve._private.constants import RAY_SERVE_ENABLE_TASK_EVENTS
 from ray.util.state import list_tasks
 
 
@@ -33,13 +33,19 @@ def test_task_events_disabled_by_default(serve_instance):
     # Check that none of the Serve-managed actors or tasks generate events.
     serve.run(Deployment.bind())
 
-    assert requests.get("http://localhost:8000", json={"call_task": False}).text == "hi from deployment"
+    assert (
+        requests.get("http://localhost:8000", json={"call_task": False}).text
+        == "hi from deployment"
+    )
     for _ in range(100):
         assert len(list_tasks()) == 0
 
     # Now call a Ray task from within the deployment.
     # A task event should be generated.
-    assert requests.get("http://localhost:8000", json={"call_task": True}).text == "hi from task"
+    assert (
+        requests.get("http://localhost:8000", json={"call_task": True}).text
+        == "hi from task"
+    )
     wait_for_condition(lambda: len(list_tasks()) == 1)
     [task_state] = list_tasks()
     assert task_state.name == "some_task"
@@ -52,7 +58,10 @@ def test_enable_task_events(serve_instance):
     # Check that the Serve-managed actors generate events.
     serve.run(Deployment.bind())
 
-    assert requests.get("http://localhost:8000", json={"call_task": False}).text == "hi from deployment"
+    assert (
+        requests.get("http://localhost:8000", json={"call_task": False}).text
+        == "hi from deployment"
+    )
 
     def check_for_expected_actor_tasks():
         found_proxy = False
@@ -72,6 +81,7 @@ def test_enable_task_events(serve_instance):
         return True
 
     wait_for_condition(check_for_expected_actor_tasks, timeout=5)
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_enable_task_events.py
+++ b/python/ray/serve/tests/test_enable_task_events.py
@@ -1,0 +1,77 @@
+import requests
+import sys
+
+import pytest
+from starlette.requests import Request
+
+import ray
+from ray import serve
+from ray.serve._private.constants import RAY_SERVE_ENABLE_TASK_EVENTS
+from ray._private.test_utils import wait_for_condition
+from ray.util.state import list_tasks
+
+
+@ray.remote
+def some_task():
+    return "hi from task"
+
+
+@serve.deployment
+class Deployment:
+    async def __call__(self, request: Request) -> str:
+        if (await request.json())["call_task"] is True:
+            msg = await some_task.remote()
+        else:
+            msg = "hi from deployment"
+
+        return msg
+
+
+@pytest.mark.skipif(RAY_SERVE_ENABLE_TASK_EVENTS, reason="Task events enabled.")
+def test_task_events_disabled_by_default(serve_instance):
+    # Deploy simple Serve app and call it over HTTP.
+    # Check that none of the Serve-managed actors or tasks generate events.
+    serve.run(Deployment.bind())
+
+    assert requests.get("http://localhost:8000", json={"call_task": False}).text == "hi from deployment"
+    for _ in range(100):
+        assert len(list_tasks()) == 0
+
+    # Now call a Ray task from within the deployment.
+    # A task event should be generated.
+    assert requests.get("http://localhost:8000", json={"call_task": True}).text == "hi from task"
+    wait_for_condition(lambda: len(list_tasks()) == 1)
+    [task_state] = list_tasks()
+    assert task_state.name == "some_task"
+    assert task_state.type == "NORMAL_TASK"
+
+
+@pytest.mark.skipif(not RAY_SERVE_ENABLE_TASK_EVENTS, reason="Task events disabled.")
+def test_enable_task_events(serve_instance):
+    # Deploy simple Serve app and call it over HTTP.
+    # Check that the Serve-managed actors generate events.
+    serve.run(Deployment.bind())
+
+    assert requests.get("http://localhost:8000", json={"call_task": False}).text == "hi from deployment"
+
+    def check_for_expected_actor_tasks():
+        found_proxy = False
+        found_replica = False
+        found_controller = False
+        for task_state in list_tasks():
+            if "ProxyActor" in task_state.name:
+                found_proxy = True
+            if "ServeReplica" in task_state.name:
+                found_replica = True
+            if "ServeController" in task_state.name:
+                found_controller = True
+
+        assert found_proxy, "No proxy tasks found."
+        assert found_replica, "No replica tasks found."
+        assert found_controller, "No controller tasks found."
+        return True
+
+    wait_for_condition(check_for_expected_actor_tasks, timeout=5)
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -240,6 +240,7 @@ def test_streaming_request_already_sent_and_timed_out(ray_instance, shutdown_ser
     "ray_instance",
     [
         {"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5"},
+        {"RAY_SERVE_ENABLE_TASK_EVENTS": "1"},
     ],
     indirect=True,
 )

--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -239,8 +239,10 @@ def test_streaming_request_already_sent_and_timed_out(ray_instance, shutdown_ser
 @pytest.mark.parametrize(
     "ray_instance",
     [
-        {"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5"},
-        {"RAY_SERVE_ENABLE_TASK_EVENTS": "1"},
+        {
+            "RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5",
+            "RAY_SERVE_ENABLE_TASK_EVENTS": "1",
+        },
     ],
     indirect=True,
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Disables task events by default because they aren't useful and add "junk traffic" to the cluster.

Adds a feature flag to re-enable as an escape hatch.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
