### PR TITLE
[serve] Fix passing deprecated `loop` param to `asyncio.Event`

### DIFF
--- a/python/ray/serve/_private/metrics_utils.py
+++ b/python/ray/serve/_private/metrics_utils.py
@@ -30,10 +30,20 @@ class MetricsPusher:
         self._async_sleep = async_sleep or asyncio.sleep
         self._tasks: Dict[str, _MetricsTask] = dict()
         self._async_tasks: Dict[str, asyncio.Task] = dict()
-        self._stop_event = asyncio.Event()
+
+        # The event needs to be lazily initialized because this class may be constructed
+        # on the main thread but its methods called on a separate asyncio loop.
+        self._stop_event: Optional[asyncio.Event] = None
+
+    @property
+    def stop_event(self) -> asyncio.Event:
+        if self._stop_event is None:
+            self._stop_event = asyncio.Event()
+
+        return self._stop_event
 
     def start(self):
-        self._stop_event.clear()
+        self.stop_event.clear()
 
     async def metrics_task(self, name: str):
         """Periodically runs `task_func` every `interval_s` until `stop_event` is set.
@@ -41,7 +51,7 @@ class MetricsPusher:
         If `task_func` raises an error, an exception will be logged.
         """
 
-        wait_for_stop_event = asyncio.create_task(self._stop_event.wait())
+        wait_for_stop_event = asyncio.create_task(self.stop_event.wait())
         while True:
             if wait_for_stop_event.done():
                 return
@@ -76,7 +86,7 @@ class MetricsPusher:
             self._async_tasks[name] = asyncio.create_task(self.metrics_task(name))
 
     def stop_tasks(self):
-        self._stop_event.set()
+        self.stop_event.set()
         self._tasks.clear()
         self._async_tasks.clear()
 
@@ -86,7 +96,7 @@ class MetricsPusher:
         This method will ensure idempotency of shutdown call.
         """
 
-        self._stop_event.set()
+        self.stop_event.set()
         if self._async_tasks:
             await asyncio.wait(
                 list(self._async_tasks.values()),

--- a/python/ray/serve/_private/metrics_utils.py
+++ b/python/ray/serve/_private/metrics_utils.py
@@ -24,14 +24,13 @@ class MetricsPusher:
 
     def __init__(
         self,
-        event_loop: asyncio.AbstractEventLoop,
+        *,
         async_sleep: Optional[Callable[[int], None]] = None,
     ):
-        self._event_loop = event_loop
         self._async_sleep = async_sleep or asyncio.sleep
         self._tasks: Dict[str, _MetricsTask] = dict()
         self._async_tasks: Dict[str, asyncio.Task] = dict()
-        self._stop_event = asyncio.Event(loop=event_loop)
+        self._stop_event = asyncio.Event()
 
     def start(self):
         self._stop_event.clear()
@@ -74,9 +73,7 @@ class MetricsPusher:
 
         self._tasks[name] = _MetricsTask(task_func, interval_s)
         if name not in self._async_tasks or self._async_tasks[name].done():
-            self._async_tasks[name] = self._event_loop.create_task(
-                self.metrics_task(name)
-            )
+            self._async_tasks[name] = asyncio.create_task(self.metrics_task(name))
 
     def stop_tasks(self):
         self._stop_event.set()

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -109,8 +109,7 @@ class ReplicaMetricsManager:
     ):
         self._replica_tag = replica_tag
         self._deployment_id = deployment_id
-        self._event_loop = event_loop
-        self._metrics_pusher = MetricsPusher(event_loop)
+        self._metrics_pusher = MetricsPusher()
         self._metrics_store = InMemoryMetricsStore()
         self._autoscaling_config = autoscaling_config
         self._controller_handle = ray.get_actor(

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -5,7 +5,6 @@ import time
 from collections import OrderedDict
 from typing import Any, Callable, List, Set
 
-from ray._private.utils import get_or_create_event_loop
 from ray.serve import metrics
 from ray.serve._private.common import DeploymentID, MultiplexedReplicaInfo
 from ray.serve._private.constants import (
@@ -113,7 +112,7 @@ class _ModelMultiplexWrapper:
         # failed to load.
         self._model_load_tasks: Set[str] = set()
 
-        self.metrics_pusher = MetricsPusher(get_or_create_event_loop())
+        self.metrics_pusher = MetricsPusher()
         self.metrics_pusher.register_or_update_task(
             self._PUSH_MULTIPLEXED_MODEL_IDS_TASK_NAME,
             self._push_model_ids_info,

--- a/python/ray/serve/tests/test_multiplex.py
+++ b/python/ray/serve/tests/test_multiplex.py
@@ -30,8 +30,9 @@ def start_serve_with_context():
     ray.shutdown()
 
 
+@pytest.mark.asyncio
 class TestMultiplexWrapper:
-    def test_failed_to_get_replica_context(self):
+    async def test_failed_to_get_replica_context(self):
         async def model_load_func(model_id: str):
             return model_id
 
@@ -40,7 +41,6 @@ class TestMultiplexWrapper:
         ):
             _ModelMultiplexWrapper(model_load_func, None, max_num_models_per_replica=2)
 
-    @pytest.mark.asyncio
     async def test_push_model_ids_info(self, start_serve_with_context):
         async def model_load_func(model_id: str):
             return model_id
@@ -54,7 +54,7 @@ class TestMultiplexWrapper:
         multiplexer._push_model_ids_info()
         assert multiplexer._push_multiplexed_replica_info is False
 
-    def test_collect_model_ids(self):
+    async def test_collect_model_ids(self):
         multiplexer = _ModelMultiplexWrapper(None, None, max_num_models_per_replica=1)
         multiplexer.models = {"1": "1", "2": "2"}
         assert sorted(multiplexer._get_loading_and_loaded_model_ids()) == ["1", "2"]
@@ -65,7 +65,6 @@ class TestMultiplexWrapper:
             "3",
         ]
 
-    @pytest.mark.asyncio
     async def test_multiplex_wrapper(self, start_serve_with_context):
         """Test multiplex wrapper with LRU caching."""
 
@@ -106,7 +105,6 @@ class TestMultiplexWrapper:
         assert multiplexer._push_multiplexed_replica_info
         assert multiplexer.models == {"2": "2", "4": "4"}
 
-    @pytest.mark.asyncio
     async def test_bad_call_multiplexed_func(self, start_serve_with_context):
         """Test bad call to multiplexed function"""
 
@@ -121,7 +119,6 @@ class TestMultiplexWrapper:
         with pytest.raises(TypeError):
             await multiplexer.load_model()
 
-    @pytest.mark.asyncio
     async def test_unload_model_call_del(self, start_serve_with_context):
         class MyModel:
             def __init__(self, model_id):
@@ -145,7 +142,6 @@ class TestMultiplexWrapper:
         with pytest.raises(Exception, match="1 is dead"):
             await multiplexer.load_model("2")
 
-    @pytest.mark.asyncio
     async def test_push_model_ids_info_after_unload_model(self):
         """
         Push the model ids info right after the model is unloaded, even though
@@ -177,7 +173,6 @@ class TestMultiplexWrapper:
         assert multiplexer._push_multiplexed_replica_info
         signal.send.remote()
 
-    @pytest.mark.asyncio
     async def test_load_models_concurrently(self, start_serve_with_context):
         """
         Test load models concurrently. models info should include loading models and

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -4,7 +4,6 @@ import sys
 import pytest
 
 from ray._private.test_utils import async_wait_for_condition
-from ray._private.utils import get_or_create_event_loop
 from ray.serve._private.metrics_utils import InMemoryMetricsStore, MetricsPusher
 from ray.serve._private.test_utils import MockAsyncTimer
 
@@ -22,7 +21,7 @@ class TestMetricsPusher:
             nonlocal val
             val += 1
 
-        metrics_pusher = MetricsPusher(get_or_create_event_loop())
+        metrics_pusher = MetricsPusher()
         metrics_pusher.start()
         assert len(metrics_pusher._tasks) == 0
 
@@ -38,7 +37,7 @@ class TestMetricsPusher:
         def task(s):
             s["val"] += 1
 
-        metrics_pusher = MetricsPusher(get_or_create_event_loop(), timer.sleep)
+        metrics_pusher = MetricsPusher(async_sleep=timer.sleep)
         metrics_pusher.start()
 
         metrics_pusher.register_or_update_task("basic", lambda: task(state), 0.5)
@@ -61,7 +60,7 @@ class TestMetricsPusher:
         def task(key, s):
             s[key] += 1
 
-        metrics_pusher = MetricsPusher(get_or_create_event_loop(), timer.sleep)
+        metrics_pusher = MetricsPusher(async_sleep=timer.sleep)
         metrics_pusher.start()
 
         # Each task interval is different, and they don't divide each other.
@@ -104,7 +103,7 @@ class TestMetricsPusher:
 
         # Start metrics pusher and register task() with interval 1s.
         # After (fake) 10s, the task should have executed 10 times
-        metrics_pusher = MetricsPusher(get_or_create_event_loop(), timer.sleep)
+        metrics_pusher = MetricsPusher(async_sleep=timer.sleep)
         metrics_pusher.start()
 
         # Give the metrics pusher thread opportunity to execute task

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -509,7 +509,6 @@ class TestRouterMetricsManager:
         metrics_manager = RouterMetricsManager(
             DeploymentID(name="a", app_name="b"),
             "random",
-            get_or_create_event_loop(),
             Mock(),
             FakeCounter(tag_keys=("deployment", "route", "application")),
             FakeGauge(tag_keys=("deployment", "application")),
@@ -530,7 +529,6 @@ class TestRouterMetricsManager:
         metrics_manager = RouterMetricsManager(
             DeploymentID(name="a", app_name="b"),
             "random",
-            get_or_create_event_loop(),
             Mock(),
             FakeCounter(tag_keys=("deployment", "route", "application")),
             FakeGauge(tag_keys=("deployment", "application")),
@@ -553,7 +551,6 @@ class TestRouterMetricsManager:
         metrics_manager = RouterMetricsManager(
             DeploymentID(name="a", app_name="b"),
             "random",
-            get_or_create_event_loop(),
             Mock(),
             FakeCounter(tag_keys=("deployment", "route", "application")),
             FakeGauge(tag_keys=("deployment", "application")),
@@ -601,7 +598,6 @@ class TestRouterMetricsManager:
         metrics_manager = RouterMetricsManager(
             DeploymentID(name="a", app_name="b"),
             "random",
-            get_or_create_event_loop(),
             Mock(),
             FakeCounter(tag_keys=("deployment", "route", "application")),
             FakeGauge(tag_keys=("deployment", "application")),
@@ -638,7 +634,6 @@ class TestRouterMetricsManager:
             metrics_manager = RouterMetricsManager(
                 deployment_id,
                 handle_id,
-                get_or_create_event_loop(),
                 mock_controller_handle,
                 FakeCounter(tag_keys=("deployment", "route", "application")),
                 FakeGauge(tag_keys=("deployment", "application")),
@@ -676,7 +671,6 @@ class TestRouterMetricsManager:
         metrics_manager = RouterMetricsManager(
             DeploymentID(name="a", app_name="b"),
             "random",
-            get_or_create_event_loop(),
             Mock(),
             FakeCounter(tag_keys=("deployment", "route", "application")),
             FakeGauge(tag_keys=("deployment", "application")),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Deprecated in Python 3.11, so those tests are failing. I've refactored a bit to not pass the loop around unnecessarily too.

## Related issue number

Closes https://github.com/ray-project/ray/issues/43597

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
