### PR TITLE
[serve] Remove ability to pass custom `_router_cls`

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -8,7 +8,6 @@ from functools import partial
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import ray
-from ray._private.utils import load_class
 from ray.actor import ActorHandle
 from ray.dag.py_obj_scanner import _PyObjScanner
 from ray.serve._private.common import DeploymentID, RequestMetadata, RunningReplicaInfo
@@ -26,6 +25,7 @@ from ray.serve._private.metrics_utils import InMemoryMetricsStore, MetricsPusher
 from ray.serve._private.replica_scheduler import (
     PendingRequest,
     PowerOfTwoChoicesReplicaScheduler,
+    ReplicaScheduler,
 )
 from ray.serve._private.utils import inside_ray_client_context
 from ray.serve.config import AutoscalingConfig
@@ -267,9 +267,10 @@ class Router:
         self_availability_zone: Optional[str],
         event_loop: asyncio.BaseEventLoop = None,
         _prefer_local_node_routing: bool = False,
-        _router_cls: Optional[str] = None,
         enable_queue_len_cache: bool = RAY_SERVE_ENABLE_QUEUE_LENGTH_CACHE,
         enable_strict_max_ongoing_requests: bool = RAY_SERVE_ENABLE_STRICT_MAX_ONGOING_REQUESTS,  # noqa: E501
+        *,
+        replica_scheduler: Optional[ReplicaScheduler] = None,
     ):
         """Used to assign requests to downstream replicas for a deployment.
 
@@ -291,12 +292,8 @@ class Router:
                 enable_strict_max_ongoing_requests
             )
 
-        if _router_cls:
-            self._replica_scheduler = load_class(_router_cls)(
-                event_loop=event_loop, deployment_id=deployment_id
-            )
-        else:
-            self._replica_scheduler = PowerOfTwoChoicesReplicaScheduler(
+        if replica_scheduler is None:
+            replica_scheduler = PowerOfTwoChoicesReplicaScheduler(
                 event_loop,
                 deployment_id,
                 _prefer_local_node_routing,
@@ -307,10 +304,7 @@ class Router:
                 use_replica_queue_len_cache=enable_queue_len_cache,
             )
 
-        logger.info(
-            f"Using router {self._replica_scheduler.__class__}.",
-            extra={"log_to_stderr": False},
-        )
+        self._replica_scheduler = replica_scheduler
 
         # The config for the deployment this router sends requests to will be broadcast
         # by the controller. That means it is not available until we get the first

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -61,7 +61,6 @@ class _HandleOptions:
     multiplexed_model_id: str = ""
     stream: bool = False
     _prefer_local_routing: bool = False
-    _router_cls: str = ""
     _request_protocol: str = RequestProtocol.UNDEFINED
 
     def copy_and_update(
@@ -70,7 +69,6 @@ class _HandleOptions:
         multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
         _prefer_local_routing: Union[bool, DEFAULT] = DEFAULT.VALUE,
-        _router_cls: Union[str, DEFAULT] = DEFAULT.VALUE,
         _request_protocol: Union[str, DEFAULT] = DEFAULT.VALUE,
     ) -> "_HandleOptions":
         return _HandleOptions(
@@ -86,9 +84,6 @@ class _HandleOptions:
             _prefer_local_routing=self._prefer_local_routing
             if _prefer_local_routing == DEFAULT.VALUE
             else _prefer_local_routing,
-            _router_cls=self._router_cls
-            if _router_cls == DEFAULT.VALUE
-            else _router_cls,
             _request_protocol=self._request_protocol
             if _request_protocol == DEFAULT.VALUE
             else _request_protocol,
@@ -155,7 +150,6 @@ class _DeploymentHandleBase:
                 availability_zone,
                 event_loop=_create_or_get_global_asyncio_event_loop_in_thread(),
                 _prefer_local_node_routing=self.handle_options._prefer_local_routing,
-                _router_cls=self.handle_options._router_cls,
             )
 
         return self._router, self._router._event_loop
@@ -203,7 +197,6 @@ class _DeploymentHandleBase:
         multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
         _prefer_local_routing: Union[bool, DEFAULT] = DEFAULT.VALUE,
-        _router_cls: Union[str, DEFAULT] = DEFAULT.VALUE,
     ):
         if stream is True and inside_ray_client_context():
             raise RuntimeError(
@@ -216,21 +209,15 @@ class _DeploymentHandleBase:
             multiplexed_model_id=multiplexed_model_id,
             stream=stream,
             _prefer_local_routing=_prefer_local_routing,
-            _router_cls=_router_cls,
         )
 
-        if (
-            self._router is None
-            and _router_cls == DEFAULT.VALUE
-            and _prefer_local_routing == DEFAULT.VALUE
-        ):
+        if self._router is None and _prefer_local_routing == DEFAULT.VALUE:
             self._get_or_create_router()
 
         return DeploymentHandle(
             self.deployment_name,
             self.app_name,
             handle_options=new_handle_options,
-            _router=None if _router_cls != DEFAULT.VALUE else self._router,
             _request_counter=self.request_counter,
             _recorded_telemetry=self._recorded_telemetry,
         )
@@ -711,7 +698,6 @@ class DeploymentHandle(_DeploymentHandleBase):
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
         use_new_handle_api: Union[bool, DEFAULT] = DEFAULT.VALUE,
         _prefer_local_routing: Union[bool, DEFAULT] = DEFAULT.VALUE,
-        _router_cls: Union[str, DEFAULT] = DEFAULT.VALUE,
     ) -> "DeploymentHandle":
         """Set options for this handle and return an updated copy of it.
 
@@ -735,7 +721,6 @@ class DeploymentHandle(_DeploymentHandleBase):
             multiplexed_model_id=multiplexed_model_id,
             stream=stream,
             _prefer_local_routing=_prefer_local_routing,
-            _router_cls=_router_cls,
         )
 
     def remote(

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -218,6 +218,7 @@ class _DeploymentHandleBase:
             self.deployment_name,
             self.app_name,
             handle_options=new_handle_options,
+            _router=self._router,
             _request_counter=self.request_counter,
             _recorded_telemetry=self._recorded_telemetry,
         )

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -9,7 +9,6 @@ import ray
 from ray import serve
 from ray.serve._private.common import RequestProtocol
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
-from ray.serve._private.router import PowerOfTwoChoicesReplicaScheduler
 from ray.serve.exceptions import RayServeException
 from ray.serve.handle import DeploymentHandle, _HandleOptions
 
@@ -357,28 +356,6 @@ def test_handle_options_with_same_router(serve_instance):
     handle2 = handle.options(multiplexed_model_id="model2")
     assert handle._router
     assert id(handle2._router) == id(handle._router)
-
-
-class MyRouter(PowerOfTwoChoicesReplicaScheduler):
-    pass
-
-
-def test_handle_options_custom_router(serve_instance):
-    @serve.deployment
-    def echo(name: str):
-        return f"Hi {name}"
-
-    handle = serve.run(echo.bind()).options(
-        _router_cls="ray.serve.tests.test_handle.MyRouter",
-    )
-
-    result = handle.remote("HI").result()
-    assert result == "Hi HI"
-
-    print("Router class used", handle._router._replica_scheduler)
-    assert (
-        "MyRouter" in handle._router._replica_scheduler.__class__.__name__
-    ), handle._router._replica_scheduler
 
 
 def test_set_request_protocol(serve_instance):

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -91,7 +91,7 @@ class FakeReplica(ReplicaWrapper):
 
 
 class FakeReplicaScheduler(ReplicaScheduler):
-    def __init__(self, **kwargs):
+    def __init__(self):
         self._block_requests = False
         self._blocked_requests: List[asyncio.Event] = []
         self._replica_to_return: Optional[FakeReplica] = None
@@ -157,6 +157,7 @@ def setup_router(request) -> Tuple[Router, FakeReplicaScheduler]:
     if not hasattr(request, "param"):
         request.param = {}
 
+    fake_replica_scheduler = FakeReplicaScheduler()
     router = Router(
         # TODO(edoakes): refactor to make a better fake controller or not depend on it.
         controller_handle=Mock(),
@@ -168,13 +169,13 @@ def setup_router(request) -> Tuple[Router, FakeReplicaScheduler]:
         event_loop=get_or_create_event_loop(),
         _prefer_local_node_routing=False,
         # TODO(edoakes): just pass a class instance here.
-        _router_cls="ray.serve.tests.unit.test_router.FakeReplicaScheduler",
         enable_queue_len_cache=request.param.get("enable_queue_len_cache", False),
         enable_strict_max_ongoing_requests=request.param.get(
             "enable_strict_max_ongoing_requests", False
         ),
+        replica_scheduler=fake_replica_scheduler,
     )
-    return router, router._replica_scheduler
+    return router, fake_replica_scheduler
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This was added as an experimental feature and never fully fleshed out. It's no longer being used.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
