### PR TITLE
[Doc] Remove a broken ref in tune scalability benchmarks

### DIFF
--- a/doc/source/tune/tutorials/tune-scalability.rst
+++ b/doc/source/tune/tutorials/tune-scalability.rst
@@ -63,14 +63,6 @@ description.
      - 16
      - 86,400
      - 88687.41
-   * - `Durable trainable <https://github.com/ray-project/ray/blob/master/release/tune_tests/scalability_tests/workloads/test_durable_trainable.py>`_
-     - 16
-     - | 10/60
-       | with 10MB CP
-     - 16
-     - 2
-     - 300
-     - 392.42
 
 
 Below we discuss some insights on results where we observed much overhead.


### PR DESCRIPTION
## Why are these changes needed?

This PR removes a broken reference in the tune scalability benchmarks.

## Related issue number

No issue for this has been made, but this is currently blocking merge of #42862.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
