### PR TITLE
[Perf] Dependency first task dispatching

### DIFF
--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -133,7 +133,7 @@ void LocalTaskManager::DispatchScheduledTasksToWorkers() {
   // Try to dispatch the task with larger scheduling class 
   // to make tasks excute in a steaming way.
   std::sort(keys.begin(), keys.end());
-  for (auto it = keys.rbegin(); it != keys.rend();) {
+  for (auto it = keys.rbegin(); it != keys.rend(); it++) {
     const SchedulingClass& scheduling_class = *it;
     auto dispatch_queue_it = tasks_to_dispatch_.find(scheduling_class);
     if (dispatch_queue_it != tasks_to_dispatch_.end()) {
@@ -320,12 +320,8 @@ void LocalTaskManager::DispatchScheduledTasksToWorkers() {
         // TODO(scv119): fail the request.
         // Call CancelTask
         tasks_to_dispatch_.erase(dispatch_queue_it);
-        it++;
       } else if (dispatch_queue.empty()) {
         tasks_to_dispatch_.erase(dispatch_queue_it);
-        it++;
-      } else {
-        it++;
       }
     }
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
his PR proposes an optimization to task scheduling in Ray by prioritizing tasks with larger scheduling classes. The goal is to consume immediate results sooner, thereby reducing memory usage and potential data spilling. Currently, tasks are dispatched based primarily on their arrival order, which often leads to tasks with lower scheduling classes being executed first. This behavior can increase intermediate storage as data producers run before consumers, leading to inefficiency and higher memory demand.

### Problem Illustration

In the current implementation, tasks are stored in `tasks_to_dispatch_` within `src/ray/raylet/local_task_manager.cc` and dispatched in an order that does not prioritize the larger scheduling class. This results in data-producing tasks (with lower scheduling classes) executing before their corresponding data-consuming tasks (with higher scheduling classes), as shown in the following diagrams:

- Current Task Execution Flow:
  ![Current Task Execution Flow](https://github.com/ray-project/ray/assets/121425509/f4d3a72b-a932-4e95-92a2-e48e54e6c3f8)
  ![Further Illustration](https://github.com/ray-project/ray/assets/121425509/accae32e-698a-4d39-9124-c27bf1dd8511)

- Resulting Suboptimal Memory Utilization:
  ![Suboptimal Memory Utilization](https://github.com/ray-project/ray/assets/121425509/f31d56e0-a9aa-4cd3-80b4-39dcc36804eb)

### Proposed Solution

To address this issue, I propose altering the dispatch logic to prioritize tasks with larger scheduling classes. This approach will allow us to execute consumer tasks as soon as their dependencies are met, significantly reducing the time data resides in memory or spills to disk.

- Optimized Task Execution Proposal:
  ![Optimized Task Execution](https://github.com/ray-project/ray/assets/121425509/44c23863-ec60-47d1-8c06-eb9ac3dd0360)
  ![Optimization Benefits](https://github.com/ray-project/ray/assets/121425509/85927423-e339-4130-8ad9-4723efa0fd9f)

### Implementation Details

To implement this optimization, we will modify the dispatch strategy in `src/ray/raylet/local_task_manager.cc`. The new strategy involves maintaining a temporary list of scheduling classes from `tasks_to_dispatch_`, sorting them in descending order, and dispatching tasks based on this prioritization. This approach ensures that tasks with higher scheduling classes are considered for execution before those with lower ones, thereby optimizing memory usage and reducing potential data spilling.
```
std::vector<SchedulingClass> keys;
  for (const auto& entry : tasks_to_dispatch_) {
      keys.push_back(entry.first);
  }
  // Try to dispatch the task with larger scheduling class 
  // to make tasks excute in a steaming way.
  std::sort(keys.begin(), keys.end());
  for (auto it = keys.rbegin(); it != keys.rend(); it++) {
```
## Impact
This change is expected to improve the overall efficiency of Ray's task execution, particularly in scenarios where data producers and consumers are heavily interdependent. By optimizing the order of task execution, we can reduce memory footprint, minimize data spilling, and potentially improve the performance of Ray applications.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Close issue https://github.com/ray-project/ray/issues/43670

## Checks

- [√] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [√] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [√]I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [√] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
