### PR TITLE
[Core] Avoid double reading env in RayConfig initialzation

### DIFF
--- a/src/ray/common/ray_config.h
+++ b/src/ray/common/ray_config.h
@@ -71,7 +71,7 @@ class RayConfig {
 /// \param default_value Default value of the config item.
 #define RAY_CONFIG(type, name, default_value)                       \
  private:                                                           \
-  type name##_ = ReadEnv<type>("RAY_" #name, #type, default_value); \
+  type name##_ = default_value; \
                                                                     \
  public:                                                            \
   inline type &name() { return name##_; }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

By default, the constructor will read values from env. No need to read it again for in-class initializers.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
