### PR TITLE
[serve] add support for compact strategy + max replicas per node

### DIFF
--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -149,7 +149,20 @@ class ReplicaSchedulingRequest:
                 Resources(),
             )
         else:
-            return Resources(self.actor_resources)
+            required = Resources(self.actor_resources)
+
+            # Using implicit resource (resources that every node
+            # implicitly has and total is 1)
+            # to limit the number of replicas on a single node.
+            if self.max_replicas_per_node is not None:
+                deployment_id = self.replica_id.deployment_id
+                implicit_resource = (
+                    f"{ray._raylet.IMPLICIT_RESOURCE_PREFIX}"
+                    f"{deployment_id.app_name}:{deployment_id.name}"
+                )
+                required[implicit_resource] = 1.0 / self.max_replicas_per_node
+
+            return required
 
 
 @dataclass
@@ -166,10 +179,12 @@ class DeploymentDownscaleRequest:
 
 @dataclass
 class DeploymentSchedulingInfo:
+    deployment_id: DeploymentID
     scheduling_policy: Any
     actor_resources: Optional[Resources] = None
     placement_group_bundles: Optional[List[Resources]] = None
     placement_group_strategy: Optional[str] = None
+    max_replicas_per_node: Optional[int] = None
 
     @property
     def required_resources(self) -> Resources:
@@ -186,7 +201,19 @@ class DeploymentSchedulingInfo:
         ):
             return sum(self.placement_group_bundles, Resources())
         else:
-            return self.actor_resources
+            required = self.actor_resources
+
+            # Using implicit resource (resources that every node
+            # implicitly has and total is 1)
+            # to limit the number of replicas on a single node.
+            if self.max_replicas_per_node:
+                implicit_resource = (
+                    f"{ray._raylet.IMPLICIT_RESOURCE_PREFIX}"
+                    f"{self.deployment_id.app_name}:{self.deployment_id.name}"
+                )
+                required[implicit_resource] = 1.0 / self.max_replicas_per_node
+
+            return required
 
     def is_non_strict_pack_pg(self) -> bool:
         return (
@@ -209,6 +236,18 @@ class LaunchingReplicaInfo:
 
     target_node_id: Optional[str] = None
     target_labels: Optional[Dict[str, Any]] = None
+
+
+def _flatten(
+    deployment_to_replicas: Dict[DeploymentID, Dict[ReplicaID, Any]]
+) -> Dict[ReplicaID, Any]:
+    """Flattens a dict of {deployment_id: {replica_id: val}} to {replica_id: val}."""
+
+    return {
+        replica_id: val
+        for replicas in deployment_to_replicas.values()
+        for replica_id, val in replicas.items()
+    }
 
 
 class DeploymentScheduler(ABC):
@@ -260,7 +299,7 @@ class DeploymentScheduler(ABC):
         assert deployment_id not in self._recovering_replicas
         assert deployment_id not in self._running_replicas
         self._deployments[deployment_id] = DeploymentSchedulingInfo(
-            scheduling_policy=scheduling_policy
+            deployment_id=deployment_id, scheduling_policy=scheduling_policy
         )
 
     def on_deployment_deployed(
@@ -270,20 +309,18 @@ class DeploymentScheduler(ABC):
     ) -> None:
         assert deployment_id in self._deployments
 
-        self._deployments[
-            deployment_id
-        ].actor_resources = Resources.from_ray_resource_dict(
+        info = self._deployments[deployment_id]
+        info.actor_resources = Resources.from_ray_resource_dict(
             replica_config.resource_dict
         )
+        info.max_replicas_per_node = replica_config.max_replicas_per_node
         if replica_config.placement_group_bundles:
-            self._deployments[deployment_id].placement_group_bundles = [
+            info.placement_group_bundles = [
                 Resources.from_ray_resource_dict(bundle)
                 for bundle in replica_config.placement_group_bundles
             ]
         if replica_config.placement_group_strategy:
-            self._deployments[
-                deployment_id
-            ].placement_group_strategy = replica_config.placement_group_strategy
+            info.placement_group_strategy = replica_config.placement_group_strategy
 
     def on_deployment_deleted(self, deployment_id: DeploymentID) -> None:
         """Called whenever a deployment is deleted."""
@@ -342,7 +379,7 @@ class DeploymentScheduler(ABC):
 
     def _get_node_to_running_replicas(
         self, deployment_id: Optional[DeploymentID] = None
-    ) -> Dict[str, Set[str]]:
+    ) -> Dict[str, Set[ReplicaID]]:
         res = defaultdict(set)
         if deployment_id:
             for replica_id, node_id in self._running_replicas[deployment_id].items():
@@ -389,16 +426,17 @@ class DeploymentScheduler(ABC):
             for node_id, resources in total_resources.items()
         }
         for deployment_id, replicas in self._launching_replicas.items():
+            deployment = self._deployments[deployment_id]
             for info in replicas.values():
-                if info.target_node_id:
-                    total_minus_replicas[info.target_node_id] -= self._deployments[
-                        deployment_id
-                    ].required_resources
+                target_node_id = info.target_node_id
+                if not target_node_id:
+                    continue
+                total_minus_replicas[target_node_id] -= deployment.required_resources
+
         for deployment_id, replicas in self._running_replicas.items():
+            deployment = self._deployments[deployment_id]
             for node_id in replicas.values():
-                total_minus_replicas[node_id] -= self._deployments[
-                    deployment_id
-                ].required_resources
+                total_minus_replicas[node_id] -= deployment.required_resources
 
         def custom_min(a: Resources, b: Resources):
             keys = set(a.keys()) | set(b.keys())
@@ -447,7 +485,7 @@ class DeploymentScheduler(ABC):
         self,
         upscales: Dict[DeploymentID, List[ReplicaSchedulingRequest]],
         downscales: Dict[DeploymentID, DeploymentDownscaleRequest],
-    ) -> Dict[DeploymentID, Set[str]]:
+    ) -> Dict[DeploymentID, Set[ReplicaID]]:
         """Called for each update cycle to do batch scheduling.
 
         Args:
@@ -547,7 +585,7 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
         self,
         upscales: Dict[DeploymentID, List[ReplicaSchedulingRequest]],
         downscales: Dict[DeploymentID, DeploymentDownscaleRequest],
-    ) -> Dict[DeploymentID, Set[str]]:
+    ) -> Dict[DeploymentID, Set[ReplicaID]]:
         """Called for each update cycle to do batch scheduling.
 
         Args:
@@ -571,11 +609,7 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
             # Flatten dict of deployment replicas into all replicas,
             # then sort by decreasing resource size
             all_scheduling_requests = sorted(
-                [
-                    scheduling_request
-                    for replicas in self._pending_replicas.values()
-                    for scheduling_request in replicas.values()
-                ],
+                _flatten(self._pending_replicas).values(),
                 key=lambda r: r.required_resources,
                 reverse=True,
             )
@@ -616,7 +650,7 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
 
     def _get_replicas_to_stop(
         self, deployment_id: DeploymentID, max_num_to_stop: int
-    ) -> Set[str]:
+    ) -> Set[ReplicaID]:
         """Prioritize replicas running on a node with fewest replicas of
             all deployments.
 

--- a/python/ray/serve/tests/test_max_replicas_per_node.py
+++ b/python/ray/serve/tests/test_max_replicas_per_node.py
@@ -6,10 +6,7 @@ import pytest
 import ray
 from ray import serve
 from ray._private.test_utils import wait_for_condition
-from ray.serve._private.constants import (
-    RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS,
-    RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY,
-)
+from ray.serve._private.constants import RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS
 from ray.util.state import list_actors
 
 
@@ -51,10 +48,6 @@ def check_alive_nodes(expected: int):
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="Flaky on Windows due to https://github.com/ray-project/ray/issues/36926.",
-)
-@pytest.mark.skipif(
-    RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY,
-    reason="Max replicas per node not supported for compact scheduling strategy yet.",
 )
 @pytest.mark.parametrize(
     "ray_autoscaling_cluster",
@@ -127,10 +120,6 @@ def test_basic(ray_autoscaling_cluster):
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="Flaky on Windows due to https://github.com/ray-project/ray/issues/36926.",
-)
-@pytest.mark.skipif(
-    RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY,
-    reason="Max replicas per node not supported for compact scheduling strategy yet.",
 )
 @pytest.mark.parametrize(
     "ray_autoscaling_cluster",

--- a/python/ray/serve/tests/unit/BUILD
+++ b/python/ray/serve/tests/unit/BUILD
@@ -25,3 +25,15 @@ py_test_module_list(
   tags = ["team:serve", "no_windows"],
   deps = ["//python/ray/serve:serve_lib", "//python/ray/serve/tests:common", ":conftest"],
 )
+
+py_test_module_list(
+  name_suffix="_with_compact_scheduling",
+  env={"RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY": "1"},
+  files = [
+    "test_deployment_scheduler.py",
+    "test_deployment_state.py",
+  ],
+  size = "medium",
+  tags = ["no_windows", "team:serve"],
+  deps = ["//python/ray/serve:serve_lib", "//python/ray/serve/tests:common", ":conftest"],
+)

--- a/python/ray/serve/tests/unit/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/unit/test_deployment_scheduler.py
@@ -1,5 +1,6 @@
 import random
 import sys
+from collections import defaultdict
 from typing import List
 from unittest.mock import Mock
 
@@ -182,6 +183,7 @@ class TestResources:
 
 def test_deployment_scheduling_info():
     info = DeploymentSchedulingInfo(
+        deployment_id=DeploymentID("a", "b"),
         scheduling_policy=SpreadDeploymentSchedulingPolicy,
         actor_resources=Resources.from_ray_resource_dict({"CPU": 2, "GPU": 1}),
     )
@@ -191,6 +193,7 @@ def test_deployment_scheduling_info():
     assert not info.is_non_strict_pack_pg()
 
     info = DeploymentSchedulingInfo(
+        deployment_id=DeploymentID("a", "b"),
         scheduling_policy=SpreadDeploymentSchedulingPolicy,
         actor_resources=Resources.from_ray_resource_dict({"CPU": 2, "GPU": 1}),
         placement_group_bundles=[
@@ -205,6 +208,7 @@ def test_deployment_scheduling_info():
     assert not info.is_non_strict_pack_pg()
 
     info = DeploymentSchedulingInfo(
+        deployment_id=DeploymentID("a", "b"),
         scheduling_policy=SpreadDeploymentSchedulingPolicy,
         actor_resources=Resources.from_ray_resource_dict({"CPU": 2, "GPU": 1}),
         placement_group_bundles=[
@@ -247,7 +251,12 @@ def test_get_available_resources_per_node():
         ReplicaID(unique_id="replica0", deployment_id=d_id), target_node_id="node1"
     )
     assert scheduler._get_available_resources_per_node().get("node1") == Resources(
-        **{"GPU": 9, "CPU": 29, "memory": 1024}
+        **{
+            "GPU": 9,
+            "CPU": 29,
+            "memory": 1024,
+            f"{ray._raylet.IMPLICIT_RESOURCE_PREFIX}b:a": 0.75,
+        }
     )
 
     # Similarly when a replica is marked as running, the resources it
@@ -256,7 +265,12 @@ def test_get_available_resources_per_node():
         ReplicaID(unique_id="replica1", deployment_id=d_id), node_id="node1"
     )
     assert scheduler._get_available_resources_per_node().get("node1") == Resources(
-        **{"GPU": 8, "CPU": 26, "memory": 1024}
+        **{
+            "GPU": 8,
+            "CPU": 26,
+            "memory": 1024,
+            f"{ray._raylet.IMPLICIT_RESOURCE_PREFIX}b:a": 0.5,
+        }
     )
 
     # Get updated info from GCS that available memory has dropped,
@@ -267,7 +281,12 @@ def test_get_available_resources_per_node():
         "node1", {"GPU": 10, "CPU": 32, "memory": 256}
     )
     assert scheduler._get_available_resources_per_node().get("node1") == Resources(
-        **{"GPU": 8, "CPU": 26, "memory": 256}
+        **{
+            "GPU": 8,
+            "CPU": 26,
+            "memory": 256,
+            f"{ray._raylet.IMPLICIT_RESOURCE_PREFIX}b:a": 0.5,
+        }
     )
 
 
@@ -752,6 +771,63 @@ class TestCompactScheduling:
             assert isinstance(scheduling_strategy, NodeAffinitySchedulingStrategy)
             assert scheduling_strategy.node_id == "node1"
             assert call.kwargs == {"placement_group": None}
+
+    def test_max_replicas_per_node(self):
+        """Test that at most `max_replicas_per_node` number of replicas
+        are scheduled onto a node even if that node has more resources.
+        """
+
+        d_id1 = DeploymentID(name="deployment1")
+        cluster_node_info_cache = MockClusterNodeInfoCache()
+        # Should try to schedule on node1 to minimize fragmentation
+        cluster_node_info_cache.add_node("node1", {"CPU": 20})
+        cluster_node_info_cache.add_node("node2", {"CPU": 21})
+
+        scheduler = default_impl.create_deployment_scheduler(
+            cluster_node_info_cache,
+            head_node_id_override="fake-head-node-id",
+            create_placement_group_fn_override=lambda *args, **kwargs: MockPlacementGroup(  # noqa
+                *args, **kwargs
+            ),
+        )
+        scheduler.on_deployment_created(d_id1, SpreadDeploymentSchedulingPolicy())
+        scheduler.on_deployment_deployed(
+            d_id1,
+            ReplicaConfig.create(
+                dummy, max_replicas_per_node=4, ray_actor_options={"num_cpus": 2}
+            ),
+        )
+
+        state = defaultdict(int)
+
+        def on_scheduled(actor_handle, placement_group):
+            scheduling_strategy = actor_handle._options["scheduling_strategy"]
+            if isinstance(scheduling_strategy, NodeAffinitySchedulingStrategy):
+                state[scheduling_strategy.node_id] += 1
+            elif isinstance(scheduling_strategy, PlacementGroupSchedulingStrategy):
+                state[placement_group._soft_target_node_id] += 1
+
+        scheduler.schedule(
+            upscales={
+                d_id1: [
+                    ReplicaSchedulingRequest(
+                        replica_id=ReplicaID(
+                            unique_id=f"replica{i}", deployment_id=d_id1
+                        ),
+                        actor_def=MockActorClass(),
+                        actor_resources={"CPU": 2},
+                        max_replicas_per_node=4,
+                        actor_options={"name": "random"},
+                        actor_init_args=(),
+                        on_scheduled=on_scheduled,
+                    )
+                    for i in range(5)
+                ]
+            },
+            downscales={},
+        )
+        assert state["node1"] == 4
+        assert state["node2"] == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[serve] add support for compact strategy + max replicas per node

Add support for compact scheduling strategy with `max_replicas_per_node`.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
