### PR TITLE
[State CLI] Improve the error message when an ID is missing for the `ray get` command

### DIFF
--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -353,6 +353,7 @@ address_option = click.option(
 @click.argument(
     "id",
     type=str,
+    required=False,
 )
 @address_option
 @timeout_option
@@ -398,6 +399,9 @@ def ray_get(
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
             if the CLI is failed to query the data.
     """  # noqa: E501
+    if not id:
+        raise click.UsageError(f"Missing argument 'ID'. Do you mean 'ray list {resource}'?")
+
     # All resource names use '_' rather than '-'. But users options have '-'
     resource = StateResource(resource.replace("-", "_"))
 

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -400,7 +400,9 @@ def ray_get(
             if the CLI is failed to query the data.
     """  # noqa: E501
     if not id:
-        raise click.UsageError(f"Missing argument 'ID'. Do you mean 'ray list {resource}'?")
+        raise click.UsageError(
+            f"Missing argument 'ID'. Do you mean 'ray list {resource}'?"
+        )
 
     # All resource names use '_' rather than '-'. But users options have '-'
     resource = StateResource(resource.replace("-", "_"))

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -400,7 +400,7 @@ def ray_get(
             if the CLI is failed to query the data.
     """  # noqa: E501
     if not id:
-        raise click.UsageError(
+        raise click.BadParameter(
             f"Missing argument 'ID'. Do you mean 'ray list {resource}'?"
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Instead of falling back to `ray list`, I prefer to update the error message. We should not have two APIs that have the same behavior (e.g. `ray get nodes` and `ray list nodes`).

<!-- Please give a short summary of the change and the problem this solves. -->
* Without this PR
  <img width="574" alt="Screen Shot 2024-03-02 at 6 29 12 PM" src="https://github.com/ray-project/ray/assets/20109646/7024e9a9-c89e-4498-9c46-fccb5098486a">

* With this PR
  <img width="607" alt="Screen Shot 2024-03-02 at 6 27 53 PM" src="https://github.com/ray-project/ray/assets/20109646/3fee58fd-478f-46a0-93fd-da95f957f945">

```sh
# Step 1: Launch a Ray cluster with Ray dashboard
ray start --head --dashboard-host=0.0.0.0 --include-dashboard=True

# Step 2: Missing argument 'ID'
ray get nodes
# Usage: ray get [OPTIONS] {actors|placement-
#               groups|nodes|workers|tasks|objects|cluster-events} [ID]
# Try 'ray get --help' for help.
#
# Error: Missing argument 'ID'. Do you mean 'ray list nodes'?

# Step 3: With ID
ray get nodes 50ee75c43b3918925265421c32873385f962aaa2cc80bec29d5f3903

# ---
# -   node_id: 50ee75c43b3918925265421c32873385f962aaa2cc80bec29d5f3903
#     node_ip: 172.31.13.10
#     is_head_node: true
#     state: ALIVE
#     node_name: 172.31.13.10
#     resources_total:
#         CPU: 32.0
#         object_store_memory: 15.433 GiB
#         node:172.31.13.10: 1.0
#         node:__internal_head__: 1.0
#         memory: 30.866 GiB
#     labels:
#         ray.io/node_id: 50ee75c43b3918925265421c32873385f962aaa2cc80bec29d5f3903
#     start_time_ms: '2024-03-03 02:31:36.606000'
#     end_time_ms: '1970-01-01 00:00:00'
# ...
```
## Related issue number

Closes #36777 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
