### PR TITLE
[Doc] Add missing typer mock to fix RTD build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -494,6 +494,7 @@ autodoc_mock_imports = [
     "torchvision",
     "transformers",
     "tree",
+    "typer",
     "uvicorn",
     "wandb",
     "watchfiles",


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes the RTD build, which is currently broken. I'm not exactly sure when `typer` got added to RLlib, but we weren't mocking it out before and it's not in the `requirements-doc.txt` so the RTD build has been broken.

This PR adds `typer` as a module to be mocked for doc builds.

## Related issue number

Originally reported in connection with https://github.com/ray-project/ray/pull/43667.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
