### PR TITLE
[Data] Remove Ray Data read parallelism from all libraries and tests

### DIFF
--- a/dashboard/modules/data/tests/test_data_head.py
+++ b/dashboard/modules/data/tests/test_data_head.py
@@ -37,7 +37,7 @@ OPERATOR_SCHEMA = [
 )
 def test_get_datasets():
     ray.init()
-    ds = ray.data.range(100, parallelism=20).map_batches(lambda x: x)
+    ds = ray.data.range(100, override_num_blocks=20).map_batches(lambda x: x)
     ds._set_name("data_head_test")
     ds.materialize()
 

--- a/python/ray/air/tests/test_new_dataset_config.py
+++ b/python/ray/air/tests/test_new_dataset_config.py
@@ -239,15 +239,15 @@ class TestRandom(DataParallelTrainer):
 
 
 def test_per_epoch_preprocessing(ray_start_4_cpus):
-    ds = ray.data.range(100, parallelism=100).randomize_block_order()
+    ds = ray.data.range(100, override_num_blocks=100).randomize_block_order()
     test = TestRandom(2, True, datasets={"train": ds})
     test.fit()
 
-    ds = ray.data.range(100, parallelism=100).random_shuffle()
+    ds = ray.data.range(100, override_num_blocks=100).random_shuffle()
     test = TestRandom(2, True, datasets={"train": ds})
     test.fit()
 
-    ds = ray.data.range(100, parallelism=100).map(
+    ds = ray.data.range(100, override_num_blocks=100).map(
         lambda x: {"id": x["id"] * random.random()}
     )
     test = TestRandom(2, True, datasets={"train": ds})
@@ -257,7 +257,7 @@ def test_per_epoch_preprocessing(ray_start_4_cpus):
 def test_materialized_preprocessing(ray_start_4_cpus):
     # TODO(ekl) we should test all these configs with splitting enabled, but this
     # requires implementing deterministic streaming split.
-    ds = ray.data.range(100, parallelism=100).randomize_block_order()
+    ds = ray.data.range(100, override_num_blocks=100).randomize_block_order()
     ds = ds.materialize()
     test = TestRandom(
         2,
@@ -267,7 +267,7 @@ def test_materialized_preprocessing(ray_start_4_cpus):
     )
     test.fit()
 
-    ds = ray.data.range(100, parallelism=100).random_shuffle()
+    ds = ray.data.range(100, override_num_blocks=100).random_shuffle()
     ds = ds.materialize()
     test = TestRandom(
         2,
@@ -277,7 +277,7 @@ def test_materialized_preprocessing(ray_start_4_cpus):
     )
     test.fit()
 
-    ds = ray.data.range(100, parallelism=100).map(
+    ds = ray.data.range(100, override_num_blocks=100).map(
         lambda x: {"id": x["id"] * random.random()}
     )
     ds = ds.materialize()

--- a/python/ray/air/util/check_ingest.py
+++ b/python/ray/air/util/check_ingest.py
@@ -169,8 +169,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Generate a synthetic dataset of ~10GiB of float64 data. The dataset is sharded
-    # into 100 blocks (parallelism=100).
-    ds = ray.data.range_tensor(50000, shape=(80, 80, 4), parallelism=100)
+    # into 100 blocks (override_num_blocks=100).
+    ds = ray.data.range_tensor(50000, shape=(80, 80, 4), override_num_blocks=100)
 
     # An example preprocessing chain that just scales all values by 4.0 in two stages.
     ds = ds.map_batches(lambda df: df * 2, batch_format="pandas")

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4398,7 +4398,7 @@ class Dataset:
 
         Examples:
             >>> import ray
-            >>> ds = ray.data.range(10, parallelism=2)
+            >>> ds = ray.data.range(10, override_num_blocks=2)
             >>> refs = ds.to_pandas_refs()
             >>> len(refs)
             2
@@ -4426,7 +4426,7 @@ class Dataset:
 
         Examples:
             >>> import ray
-            >>> ds = ray.data.range(10, parallelism=2)
+            >>> ds = ray.data.range(10, override_num_blocks=2)
             >>> refs = ds.to_numpy_refs()
             >>> len(refs)
             2
@@ -4461,7 +4461,7 @@ class Dataset:
 
         Examples:
             >>> import ray
-            >>> ds = ray.data.range(10, parallelism=2)
+            >>> ds = ray.data.range(10, override_num_blocks=2)
             >>> refs = ds.to_arrow_refs()
             >>> len(refs)
             2

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -468,7 +468,7 @@ def read_mongo(
         ...     collection="my_collection",
         ...     pipeline=[{"$match": {"col2": {"$gte": 0, "$lt": 100}}}, {"$sort": "sort_field"}], # noqa: E501
         ...     schema=Schema({"col1": pa.string(), "col2": pa.int64()}),
-        ...     parallelism=10,
+        ...     override_num_blocks=10,
         ... )
 
     Args:
@@ -1955,10 +1955,10 @@ def read_sql(
         ``LIMIT`` and ``OFFSET`` to fetch a subset of the rows. However, for many
         databases, ``OFFSET`` is slow.
 
-        As a workaround, set ``parallelism=1`` to directly fetch all rows in a single
-        task. Note that this approach requires all result rows to fit in the memory of
-        single task. If the rows don't fit, your program may raise an out of memory
-        error.
+        As a workaround, set ``override_num_blocks=1`` to directly fetch all rows in a
+        single task. Note that this approach requires all result rows to fit in the
+        memory of single task. If the rows don't fit, your program may raise an out of
+        memory error.
 
     Examples:
 

--- a/python/ray/data/tests/test_auto_parallelism.py
+++ b/python/ray/data/tests/test_auto_parallelism.py
@@ -128,14 +128,14 @@ def test_auto_parallelism_basic(shutdown_only):
     context = DataContext.get_current()
     context.min_parallelism = 1
     # Datasource bound.
-    ds = ray.data.range_tensor(5, shape=(100,), parallelism=-1)
+    ds = ray.data.range_tensor(5, shape=(100,), override_num_blocks=-1)
     assert ds._plan.initial_num_blocks() == 5, ds
     # CPU bound. TODO(ekl) we should fix range datasource to respect parallelism more
     # properly, currently it can go a little over.
-    ds = ray.data.range_tensor(10000, shape=(100,), parallelism=-1)
+    ds = ray.data.range_tensor(10000, shape=(100,), override_num_blocks=-1)
     assert ds._plan.initial_num_blocks() == 16, ds
     # Block size bound.
-    ds = ray.data.range_tensor(100000000, shape=(100,), parallelism=-1)
+    ds = ray.data.range_tensor(100000000, shape=(100,), override_num_blocks=-1)
     assert ds._plan.initial_num_blocks() >= 590, ds
     assert ds._plan.initial_num_blocks() <= 600, ds
 
@@ -147,7 +147,7 @@ def test_auto_parallelism_placement_group(shutdown_only):
     def run():
         context = DataContext.get_current()
         context.min_parallelism = 1
-        ds = ray.data.range_tensor(2000, shape=(100,), parallelism=-1)
+        ds = ray.data.range_tensor(2000, shape=(100,), override_num_blocks=-1)
         return ds._plan.initial_num_blocks()
 
     # 1/16 * 4 * 16 = 4

--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -114,7 +114,7 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
         # Create a dataset with 2 map ops. Each map op has N tasks, where N is
         # the number of cluster CPUs.
         N = self.__class__._cluster_cpus
-        ds = ray.data.range(N, parallelism=N)
+        ds = ray.data.range(N, override_num_blocks=N)
         # Use different `num_cpus` to make sure they don't fuse.
         ds = ds.map_batches(map_func1, batch_size=None, num_cpus=1, concurrency=1)
         ds = ds.map_batches(map_func2, batch_size=None, num_cpus=1.1, concurrency=1)
@@ -150,7 +150,7 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
             # Create a dataset with 2 map ops. Each map op has N tasks, where N is
             # the number of cluster CPUs.
             N = self.__class__._cluster_cpus
-            ds = ray.data.range(N, parallelism=N)
+            ds = ray.data.range(N, override_num_blocks=N)
             # Use different `num_cpus` to make sure they don't fuse.
             ds = ds.map_batches(map_func1, batch_size=None, num_cpus=1, concurrency=1)
             ds = ds.map_batches(map_func2, batch_size=None, num_cpus=1.1, concurrency=1)

--- a/python/ray/data/tests/test_binary.py
+++ b/python/ray/data/tests/test_binary.py
@@ -41,7 +41,7 @@ def test_read_binary_files_partitioning(ray_start_regular_shared, tmp_path):
 
 def test_read_binary_files(ray_start_regular_shared):
     with gen_bin_files(10) as (_, paths):
-        ds = ray.data.read_binary_files(paths, parallelism=10)
+        ds = ray.data.read_binary_files(paths, override_num_blocks=10)
         for i, item in enumerate(ds.iter_rows()):
             expected = open(paths[i], "rb").read()
             assert expected == item["bytes"]
@@ -73,7 +73,7 @@ def test_read_binary_files_with_fs(ray_start_regular_shared):
     with gen_bin_files(10) as (tempdir, paths):
         # All the paths are absolute, so we want the root file system.
         fs, _ = pa.fs.FileSystem.from_uri("/")
-        ds = ray.data.read_binary_files(paths, filesystem=fs, parallelism=10)
+        ds = ray.data.read_binary_files(paths, filesystem=fs, override_num_blocks=10)
         for i, item in enumerate(ds.iter_rows()):
             expected = open(paths[i], "rb").read()
             assert expected == item["bytes"]

--- a/python/ray/data/tests/test_block_sizing.py
+++ b/python/ray/data/tests/test_block_sizing.py
@@ -27,7 +27,7 @@ def test_map(shutdown_only, restore_data_context):
     last_snapshot = get_initial_core_execution_metrics_snapshot()
 
     # Test read.
-    ds = ray.data.range(100_000, parallelism=1).materialize()
+    ds = ray.data.range(100_000, override_num_blocks=1).materialize()
     assert (
         num_blocks_expected <= ds._plan.initial_num_blocks() <= num_blocks_expected + 1
     )
@@ -40,7 +40,11 @@ def test_map(shutdown_only, restore_data_context):
     # Test read -> map.
     # NOTE(swang): For some reason BlockBuilder's estimated memory usage when a
     # map fn is used is 2x the actual memory usage.
-    ds = ray.data.range(100_000, parallelism=1).map(lambda row: row).materialize()
+    ds = (
+        ray.data.range(100_000, override_num_blocks=1)
+        .map(lambda row: row)
+        .materialize()
+    )
     assert (
         num_blocks_expected * 2
         <= ds._plan.initial_num_blocks()
@@ -57,7 +61,7 @@ def test_map(shutdown_only, restore_data_context):
     num_blocks_expected //= 2
 
     # Test read.
-    ds = ray.data.range(100_000, parallelism=1).materialize()
+    ds = ray.data.range(100_000, override_num_blocks=1).materialize()
     assert (
         num_blocks_expected <= ds._plan.initial_num_blocks() <= num_blocks_expected + 1
     )
@@ -68,7 +72,11 @@ def test_map(shutdown_only, restore_data_context):
     )
 
     # Test read -> map.
-    ds = ray.data.range(100_000, parallelism=1).map(lambda row: row).materialize()
+    ds = (
+        ray.data.range(100_000, override_num_blocks=1)
+        .map(lambda row: row)
+        .materialize()
+    )
     assert (
         num_blocks_expected * 2
         <= ds._plan.initial_num_blocks()
@@ -85,7 +93,7 @@ def test_map(shutdown_only, restore_data_context):
     ctx.target_shuffle_max_block_size = ctx.target_max_block_size / 2
 
     # Test read.
-    ds = ray.data.range(100_000, parallelism=1).materialize()
+    ds = ray.data.range(100_000, override_num_blocks=1).materialize()
     assert (
         num_blocks_expected <= ds._plan.initial_num_blocks() <= num_blocks_expected + 1
     )
@@ -96,7 +104,11 @@ def test_map(shutdown_only, restore_data_context):
     )
 
     # Test read -> map.
-    ds = ray.data.range(100_000, parallelism=1).map(lambda row: row).materialize()
+    ds = (
+        ray.data.range(100_000, override_num_blocks=1)
+        .map(lambda row: row)
+        .materialize()
+    )
     assert (
         num_blocks_expected * 2
         <= ds._plan.initial_num_blocks()

--- a/python/ray/data/tests/test_context_propagation.py
+++ b/python/ray/data/tests/test_context_propagation.py
@@ -126,7 +126,9 @@ def test_streaming_split(
         return x
 
     num_splits = 2
-    splits = ray.data.range(10, parallelism=10).map(f).streaming_split(num_splits)
+    splits = (
+        ray.data.range(10, override_num_blocks=10).map(f).streaming_split(num_splits)
+    )
 
     @ray.remote(num_cpus=0)
     def consume(split):
@@ -156,7 +158,7 @@ placement_group = ray.util.placement_group(
 )
 ray.get(placement_group.ready())
 context.scheduling_strategy = PlacementGroupSchedulingStrategy(placement_group)
-ds = ray.data.range(100, parallelism=2).map(lambda x: {"id": x["id"] + 1})
+ds = ray.data.range(100, override_num_blocks=2).map(lambda x: {"id": x["id"] + 1})
 assert ds.take_all() == [{"id": x} for x in range(1, 101)]
 placement_group_assert_no_leak([placement_group])
 ray.shutdown()

--- a/python/ray/data/tests/test_csv.py
+++ b/python/ray/data/tests/test_csv.py
@@ -83,12 +83,12 @@ def test_csv_read(ray_start_regular_shared, fs, data_path, endpoint_url):
     assert ds.input_files() == [_unwrap_protocol(path1)]
     assert "{one: int64, two: string}" in str(ds), ds
 
-    # Two files, parallelism=2.
+    # Two files, override_num_blocks=2.
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
     path2 = os.path.join(data_path, "test2.csv")
     df2.to_csv(path2, index=False, storage_options=storage_options)
     ds = ray.data.read_csv(
-        [path1, path2], parallelism=2, filesystem=fs, partitioning=None
+        [path1, path2], override_num_blocks=2, filesystem=fs, partitioning=None
     )
     dsdf = ds.to_pandas()
     df = pd.concat([df1, df2], ignore_index=True)
@@ -97,12 +97,12 @@ def test_csv_read(ray_start_regular_shared, fs, data_path, endpoint_url):
     for block, meta in ds._plan.execute().get_blocks_with_metadata():
         BlockAccessor.for_block(ray.get(block)).size_bytes() == meta.size_bytes
 
-    # Three files, parallelism=2.
+    # Three files, override_num_blocks=2.
     df3 = pd.DataFrame({"one": [7, 8, 9], "two": ["h", "i", "j"]})
     path3 = os.path.join(data_path, "test3.csv")
     df3.to_csv(path3, index=False, storage_options=storage_options)
     ds = ray.data.read_csv(
-        [path1, path2, path3], parallelism=2, filesystem=fs, partitioning=None
+        [path1, path2, path3], override_num_blocks=2, filesystem=fs, partitioning=None
     )
     df = pd.concat([df1, df2, df3], ignore_index=True)
     dsdf = ds.to_pandas()
@@ -367,7 +367,7 @@ def test_csv_read_many_files_partitioned(
         paths,
         filesystem=fs,
         partitioning=partition_path_encoder.scheme,
-        parallelism=num_files,
+        override_num_blocks=num_files,
     )
 
     assert_base_partitioned_ds(
@@ -659,7 +659,7 @@ def test_csv_read_partitioned_with_filter_multikey(
             data_path,
             partition_filter=partition_path_filter,
             filesystem=fs,
-            parallelism=6,
+            override_num_blocks=6,
         )
         assert_base_partitioned_ds(ds, num_input_files=6, num_computed=6)
         assert ray.get(kept_file_counter.get.remote()) == 6
@@ -738,7 +738,7 @@ def test_csv_roundtrip(ray_start_regular_shared, fs, data_path):
     ds = ray.data.from_pandas([df, df2])
     ds._set_uuid("data")
     ds.write_csv(data_path, filesystem=fs)
-    ds2 = ray.data.read_csv(data_path, parallelism=2, filesystem=fs)
+    ds2 = ray.data.read_csv(data_path, override_num_blocks=2, filesystem=fs)
     ds2df = ds2.to_pandas()
     assert pd.concat([df, df2], ignore_index=True).equals(ds2df)
     # Test metadata ops.
@@ -863,7 +863,7 @@ def test_csv_invalid_file_handler(shutdown_only, tmp_path):
 
 @pytest.mark.parametrize("num_rows_per_file", [5, 10, 50])
 def test_write_num_rows_per_file(tmp_path, ray_start_regular_shared, num_rows_per_file):
-    ray.data.range(100, parallelism=20).write_csv(
+    ray.data.range(100, override_num_blocks=20).write_csv(
         tmp_path, num_rows_per_file=num_rows_per_file
     )
 

--- a/python/ray/data/tests/test_datasink.py
+++ b/python/ray/data/tests/test_datasink.py
@@ -21,7 +21,9 @@ def test_num_rows_per_write(tmp_path, ray_start_regular_shared, num_rows_per_wri
         def num_rows_per_write(self):
             return self._num_rows_per_write
 
-    ray.data.range(100, parallelism=20).write_datasink(MockDatasink(num_rows_per_write))
+    ray.data.range(100, override_num_blocks=20).write_datasink(
+        MockDatasink(num_rows_per_write)
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_file_datasink.py
+++ b/python/ray/data/tests/test_file_datasink.py
@@ -154,7 +154,7 @@ def test_write_num_rows_per_file(tmp_path, ray_start_regular_shared, num_rows_pe
             for _ in range(block.num_rows()):
                 file.write(b"row\n")
 
-    ds = ray.data.range(100, parallelism=20)
+    ds = ray.data.range(100, override_num_blocks=20)
 
     ds.write_datasink(
         MockFileDatasink(path=tmp_path, num_rows_per_file=num_rows_per_file)

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -76,7 +76,7 @@ def test_to_arrow_refs(ray_start_regular_shared):
 
 
 def test_get_internal_block_refs(ray_start_regular_shared):
-    blocks = ray.data.range(10, parallelism=10).get_internal_block_refs()
+    blocks = ray.data.range(10, override_num_blocks=10).get_internal_block_refs()
     assert len(blocks) == 10
     out = []
     for b in ray.get(blocks):
@@ -146,14 +146,14 @@ def test_read_example_data(ray_start_regular_shared, tmp_path):
 
 def test_write_datasink(ray_start_regular_shared):
     output = DummyOutputDatasink()
-    ds = ray.data.range(10, parallelism=2)
+    ds = ray.data.range(10, override_num_blocks=2)
     ds.write_datasink(output)
     assert output.num_ok == 1
     assert output.num_failed == 0
     assert ray.get(output.data_sink.get_rows_written.remote()) == 10
 
     output.enabled = False
-    ds = ray.data.range(10, parallelism=2)
+    ds = ray.data.range(10, override_num_blocks=2)
     with pytest.raises(ValueError):
         ds.write_datasink(output, ray_remote_args={"max_retries": 0})
     assert output.num_ok == 1
@@ -274,7 +274,7 @@ def test_write_datasink_ray_remote_args(ray_start_cluster):
     bar_node_id = ray.get(get_node_id.options(resources={"bar": 1}).remote())
 
     output = NodeLoggerOutputDatasink()
-    ds = ray.data.range(100, parallelism=10)
+    ds = ray.data.range(100, override_num_blocks=10)
     # Pin write tasks to node with "bar" resource.
     ds.write_datasink(output, ray_remote_args={"resources": {"bar": 1}})
     assert output.num_ok == 1

--- a/python/ray/data/tests/test_huggingface.py
+++ b/python/ray/data/tests/test_huggingface.py
@@ -46,7 +46,9 @@ def test_from_huggingface(hf_dataset, ray_start_regular_shared, num_par):
         ray.data.from_huggingface(hf_dataset)
 
     ray_datasets = {
-        "train": ray.data.from_huggingface(hf_dataset["train"], parallelism=num_par),
+        "train": ray.data.from_huggingface(
+            hf_dataset["train"], override_num_blocks=num_par
+        ),
     }
 
     assert isinstance(ray_datasets["train"], ray.data.Dataset)

--- a/python/ray/data/tests/test_image.py
+++ b/python/ray/data/tests/test_image.py
@@ -39,7 +39,7 @@ class TestReadImages:
         )
         ds = ray.data.read_images(
             "example://image-datasets/simple",
-            parallelism=1,
+            override_num_blocks=1,
             include_paths=True,
         )
         paths = [item["path"][-len("image1.jpg") :] for item in ds.take_all()]
@@ -227,7 +227,7 @@ class TestReadImages:
     ):
         root = "example://image-datasets/different-sizes"
         ds = ray.data.read_images(
-            root, size=(image_size, image_size), mode=image_mode, parallelism=1
+            root, size=(image_size, image_size), mode=image_mode, override_num_blocks=1
         )
 
         data_size = ds.size_bytes()
@@ -258,7 +258,7 @@ class TestReadImages:
         ctx.target_max_block_size = 1
         try:
             root = "example://image-datasets/simple"
-            ds = ray.data.read_images(root, parallelism=1)
+            ds = ray.data.read_images(root, override_num_blocks=1)
             assert ds._plan.initial_num_blocks() == 1
             ds = ds.materialize()
             # Verify dynamic block splitting taking effect to generate more blocks.

--- a/python/ray/data/tests/test_mongo.py
+++ b/python/ray/data/tests/test_mongo.py
@@ -76,7 +76,7 @@ def test_read_write_mongo(ray_start_regular_shared, start_mongo):
         database=foo_db,
         collection=foo_collection,
         schema=schema,
-        parallelism=2,
+        override_num_blocks=2,
     )
     assert ds._block_num_rows() == [3, 2]
     assert str(ds) == (
@@ -90,7 +90,7 @@ def test_read_write_mongo(ray_start_regular_shared, start_mongo):
         uri=mongo_url,
         database=foo_db,
         collection=foo_collection,
-        parallelism=2,
+        override_num_blocks=2,
     )
     assert ds._block_num_rows() == [3, 2]
     assert str(ds) == (
@@ -108,7 +108,7 @@ def test_read_write_mongo(ray_start_regular_shared, start_mongo):
         database=foo_db,
         collection=foo_collection,
         pipeline=[{"$match": {"int_field": {"$gte": 0, "$lt": 3}}}],
-        parallelism=2,
+        override_num_blocks=2,
     )
     assert ds._block_num_rows() == [2, 1]
     assert str(ds) == (
@@ -140,7 +140,7 @@ def test_read_write_mongo(ray_start_regular_shared, start_mongo):
         uri=mongo_url,
         database=foo_db,
         collection=foo_collection,
-        parallelism=1000,
+        override_num_blocks=1000,
     )
     assert str(ds) == (
         "Dataset(\n"
@@ -200,7 +200,7 @@ def test_mongo_datasource(ray_start_regular_shared, start_mongo):
         database=foo_db,
         collection=foo_collection,
         schema=schema,
-        parallelism=2,
+        override_num_blocks=2,
     ).materialize()
     assert ds._block_num_rows() == [3, 2]
     assert str(ds) == (
@@ -218,7 +218,7 @@ def test_mongo_datasource(ray_start_regular_shared, start_mongo):
         uri=mongo_url,
         database=foo_db,
         collection=foo_collection,
-        parallelism=2,
+        override_num_blocks=2,
     ).materialize()
     assert ds._block_num_rows() == [3, 2]
     assert str(ds) == (
@@ -252,7 +252,7 @@ def test_mongo_datasource(ray_start_regular_shared, start_mongo):
         uri=mongo_url,
         database=foo_db,
         collection=foo_collection,
-        parallelism=1000,
+        override_num_blocks=1000,
     )
     assert str(ds) == (
         "Dataset(\n"
@@ -269,7 +269,7 @@ def test_mongo_datasource(ray_start_regular_shared, start_mongo):
         database=foo_db,
         collection=foo_collection,
         pipeline=[{"$match": {"int_field": {"$gte": 0, "$lt": 3}}}],
-        parallelism=2,
+        override_num_blocks=2,
     )
     assert ds._block_num_rows() == [2, 1]
     assert str(ds) == (

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -96,7 +96,7 @@ def test_scalar_lists_not_converted(ray_start_regular_shared):
 
 def test_scalar_numpy(ray_start_regular_shared):
     data = np.int64(1)
-    ds = ray.data.range(2, parallelism=1)
+    ds = ray.data.range(2, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data})
     output = ds.take_batch()["output"]
     assert_structure_equals(output, np.array([1, 1], dtype=np.int64))
@@ -104,7 +104,7 @@ def test_scalar_numpy(ray_start_regular_shared):
 
 def test_scalar_arrays(ray_start_regular_shared):
     data = np.array([1, 2, 3])
-    ds = ray.data.range(2, parallelism=1)
+    ds = ray.data.range(2, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data})
     output = ds.take_batch()["output"]
     assert_structure_equals(output, np.array([[1, 2, 3], [1, 2, 3]], dtype=np.int64))
@@ -113,7 +113,7 @@ def test_scalar_arrays(ray_start_regular_shared):
 def test_bytes(ray_start_regular_shared):
     """Tests that bytes are converted to object dtype instead of zero-terminated."""
     data = b"\x1a\n\x00\n\x1a"
-    ds = ray.data.range(1, parallelism=1)
+    ds = ray.data.range(1, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data})
     output = ds.take_batch()["output"]
     assert_structure_equals(output, np.array([b"\x1a\n\x00\n\x1a"], dtype=object))
@@ -121,7 +121,7 @@ def test_bytes(ray_start_regular_shared):
 
 def test_scalar_array_like(ray_start_regular_shared):
     data = torch.Tensor([1, 2, 3])
-    ds = ray.data.range(2, parallelism=1)
+    ds = ray.data.range(2, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data})
     output = ds.take_batch()["output"]
     assert_structure_equals(output, np.array([[1, 2, 3], [1, 2, 3]], dtype=np.float32))
@@ -129,7 +129,7 @@ def test_scalar_array_like(ray_start_regular_shared):
 
 def test_scalar_ragged_arrays(ray_start_regular_shared):
     data = [np.array([1, 2, 3]), np.array([1, 2])]
-    ds = ray.data.range(2, parallelism=1)
+    ds = ray.data.range(2, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data[x["id"]]})
     output = ds.take_batch()["output"]
     assert_structure_equals(
@@ -139,7 +139,7 @@ def test_scalar_ragged_arrays(ray_start_regular_shared):
 
 def test_scalar_ragged_array_like(ray_start_regular_shared):
     data = [torch.Tensor([1, 2, 3]), torch.Tensor([1, 2])]
-    ds = ray.data.range(2, parallelism=1)
+    ds = ray.data.range(2, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data[x["id"]]})
     output = ds.take_batch()["output"]
     assert_structure_equals(
@@ -147,7 +147,7 @@ def test_scalar_ragged_array_like(ray_start_regular_shared):
     )
 
     data = [torch.zeros((3, 5, 10)), torch.zeros((3, 8, 8))]
-    ds = ray.data.range(2, parallelism=1)
+    ds = ray.data.range(2, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data[x["id"]]})
     output = ds.take_batch()["output"]
     assert_structure_equals(

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -149,7 +149,7 @@ def test_lazy_fanout(shutdown_only, local_path):
 
     # Test that fan-out of a lazy dataset results in re-execution up to the datasource,
     # due to block move semantics.
-    ds = ray.data.read_datasource(source, parallelism=1)
+    ds = ray.data.read_datasource(source, override_num_blocks=1)
     ds1 = ds.map(inc)
     ds2 = ds1.map(inc)
     ds3 = ds1.map(inc)
@@ -282,7 +282,7 @@ def test_optimize_lazy_reuse_base_data(
         df.to_csv(path, index=False)
     counter = Counter.remote()
     source = MySource(paths, counter)
-    ds = ray.data.read_datasource(source, parallelism=4)
+    ds = ray.data.read_datasource(source, override_num_blocks=4)
     num_reads = ray.get(counter.get.remote())
     assert num_reads == 1, num_reads
     ds = ds.map(column_udf("id", lambda x: x))

--- a/python/ray/data/tests/test_random_access.py
+++ b/python/ray/data/tests/test_random_access.py
@@ -7,7 +7,7 @@ from ray.tests.conftest import *  # noqa
 
 @pytest.mark.parametrize("pandas", [False, True])
 def test_basic(ray_start_regular_shared, pandas):
-    ds = ray.data.range(100, parallelism=10)
+    ds = ray.data.range(100, override_num_blocks=10)
     ds = ds.add_column("embedding", lambda b: b["id"] ** 2)
     if not pandas:
         ds = ds.map_batches(
@@ -45,7 +45,7 @@ def test_errors(ray_start_regular_shared):
 
 
 def test_stats(ray_start_regular_shared):
-    ds = ray.data.range(100, parallelism=10)
+    ds = ray.data.range(100, override_num_blocks=10)
     rad = ds.to_random_access_dataset("id", num_workers=1)
     stats = rad.stats()
     assert "Accesses per worker: 0 min, 0 max, 0 mean" in stats, stats

--- a/python/ray/data/tests/test_randomize_block_order.py
+++ b/python/ray/data/tests/test_randomize_block_order.py
@@ -113,7 +113,7 @@ def test_randomize_block_order_after_repartition():
 
 
 def test_randomize_blocks_e2e(ray_start_regular_shared):
-    ds = ray.data.range(12, parallelism=4)
+    ds = ray.data.range(12, override_num_blocks=4)
     ds = ds.randomize_block_order(seed=0)
     assert extract_values("id", ds.take_all()) == [
         6,

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -56,7 +56,7 @@ def test_sort_simple(ray_start_regular, use_push_based_shuffle):
     parallelism = 4
     xs = list(range(num_items))
     random.shuffle(xs)
-    ds = ray.data.from_items(xs, parallelism=parallelism)
+    ds = ray.data.from_items(xs, override_num_blocks=parallelism)
     assert extract_values("item", ds.sort("item").take(num_items)) == list(
         range(num_items)
     )
@@ -171,7 +171,7 @@ def test_sort_arrow_with_empty_blocks(
         )
 
         ds = ray.data.from_items(
-            [{"A": (x % 3), "B": x} for x in range(3)], parallelism=3
+            [{"A": (x % 3), "B": x} for x in range(3)], override_num_blocks=3
         )
         ds = ds.filter(lambda r: r["A"] == 0)
         assert list(ds.sort("A").iter_rows()) == [{"A": 0, "B": 0}]
@@ -271,7 +271,9 @@ def test_sort_pandas_with_empty_blocks(ray_start_regular, use_push_based_shuffle
         == 0
     )
 
-    ds = ray.data.from_items([{"A": (x % 3), "B": x} for x in range(3)], parallelism=3)
+    ds = ray.data.from_items(
+        [{"A": (x % 3), "B": x} for x in range(3)], override_num_blocks=3
+    )
     ds = ds.filter(lambda r: r["A"] == 0)
     assert list(ds.sort("A").iter_rows()) == [{"A": 0, "B": 0}]
 
@@ -435,7 +437,7 @@ def test_push_based_shuffle_stats(ray_start_cluster):
         ray.init(cluster.address)
 
         parallelism = 100
-        ds = ray.data.range(1000, parallelism=parallelism).random_shuffle()
+        ds = ray.data.range(1000, override_num_blocks=parallelism).random_shuffle()
         ds = ds.materialize()
         assert "RandomShuffleMerge" in ds.stats()
         # Check all nodes used.
@@ -470,7 +472,11 @@ def test_sort_multinode(ray_start_cluster, use_push_based_shuffle):
     ray.init(cluster.address)
 
     parallelism = 100
-    ds = ray.data.range(1000, parallelism=parallelism).random_shuffle().sort("id")
+    ds = (
+        ray.data.range(1000, override_num_blocks=parallelism)
+        .random_shuffle()
+        .sort("id")
+    )
     for i, row in enumerate(ds.iter_rows()):
         assert row["id"] == i
 
@@ -576,7 +582,9 @@ def test_push_based_shuffle_reduce_stage_scheduling(ray_start_cluster, pipeline)
 
         ray.init(cluster.address)
 
-        ds = ray.data.range(1000, parallelism=num_output_blocks).random_shuffle()
+        ds = ray.data.range(
+            1000, override_num_blocks=num_output_blocks
+        ).random_shuffle()
         # Only the last round should have fewer tasks in flight.
         assert task_context["num_instances_below_parallelism"] <= 1
         task_context["num_instances_below_parallelism"] = 0
@@ -613,7 +621,7 @@ def test_debug_limit_shuffle_execution_to_num_blocks(
     shuffle_fn = shuffle_op
 
     parallelism = 100
-    ds = ray.data.range(1000, parallelism=parallelism)
+    ds = ray.data.range(1000, override_num_blocks=parallelism)
     shuffled_ds = shuffle_fn(ds).materialize()
     shuffled_ds = shuffled_ds.materialize()
     assert shuffled_ds._plan.initial_num_blocks() == parallelism
@@ -631,7 +639,7 @@ def test_memory_usage(ray_start_regular, restore_data_context, use_push_based_sh
     DataContext.get_current().use_push_based_shuffle = use_push_based_shuffle
 
     parallelism = 2
-    ds = ray.data.range(int(1e8), parallelism=parallelism)
+    ds = ray.data.range(int(1e8), override_num_blocks=parallelism)
     ds = ds.random_shuffle().materialize()
 
     stats = ds._get_stats_summary()
@@ -664,7 +672,7 @@ def test_sort_object_ref_warnings(
     if not under_threshold:
         DataContext.get_current().warn_on_driver_memory_usage_bytes = 10_000
 
-    ds = ray.data.range(int(1e8), parallelism=10)
+    ds = ray.data.range(int(1e8), override_num_blocks=10)
     with caplog.at_level(logging.WARNING, logger="ray.data.dataset"):
         ds = ds.random_shuffle().materialize()
 
@@ -703,7 +711,7 @@ def test_sort_inlined_objects_warnings(
     if not under_threshold:
         DataContext.get_current().warn_on_driver_memory_usage_bytes = 3_000_000
 
-    ds = ray.data.range(int(1e6), parallelism=10)
+    ds = ray.data.range(int(1e6), override_num_blocks=10)
     with caplog.at_level(logging.WARNING, logger="ray.data.dataset"):
         ds = ds.random_shuffle().materialize()
 

--- a/python/ray/data/tests/test_sql.py
+++ b/python/ray/data/tests/test_sql.py
@@ -37,7 +37,7 @@ def test_read_sql(temp_database: str, parallelism: int):
     dataset = ray.data.read_sql(
         "SELECT * FROM movie",
         lambda: sqlite3.connect(temp_database),
-        parallelism=parallelism,
+        override_num_blocks=parallelism,
     )
     actual_values = [tuple(record.values()) for record in dataset.take_all()]
 
@@ -267,7 +267,7 @@ def test_databricks_uc_datasource():
             table="table1",
             catalog="catalog1",
             schema="db1",
-            parallelism=5,
+            override_num_blocks=5,
         ).to_pandas()
 
         pd.testing.assert_frame_equal(result, expected_result_df)
@@ -278,7 +278,7 @@ def test_databricks_uc_datasource():
             query="select * from table1",
             catalog="catalog1",
             schema="db1",
-            parallelism=5,
+            override_num_blocks=5,
         ).to_pandas()
 
         pd.testing.assert_frame_equal(result, expected_result_df)
@@ -289,7 +289,7 @@ def test_databricks_uc_datasource():
             query="select * from table1",
             catalog="catalog1",
             schema="db1",
-            parallelism=100,
+            override_num_blocks=100,
         ).to_pandas()
 
         pd.testing.assert_frame_equal(result, expected_result_df)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -174,7 +174,7 @@ def patch_update_stats_actor_iter():
 def test_streaming_split_stats(ray_start_regular_shared, restore_data_context):
     context = DataContext.get_current()
     context.verbose_stats_logs = True
-    ds = ray.data.range(1000, parallelism=10)
+    ds = ray.data.range(1000, override_num_blocks=10)
     it = ds.map_batches(dummy_map_batches).streaming_split(1)[0]
     list(it.iter_batches())
     stats = it.stats()
@@ -220,7 +220,7 @@ def test_large_args_scheduling_strategy(
 ):
     context = DataContext.get_current()
     context.verbose_stats_logs = verbose_stats_logs
-    ds = ray.data.range_tensor(100, shape=(100000,), parallelism=1)
+    ds = ray.data.range_tensor(100, shape=(100000,), override_num_blocks=1)
     ds = ds.map_batches(dummy_map_batches, num_cpus=0.9).materialize()
     stats = ds.stats()
     expected_stats = (
@@ -264,7 +264,7 @@ def test_dataset_stats_basic(
     )
 
     with patch.object(logger, "info") as mock_logger:
-        ds = ray.data.range(1000, parallelism=10)
+        ds = ray.data.range(1000, override_num_blocks=10)
         ds = ds.map_batches(dummy_map_batches).materialize()
 
         if enable_auto_log_stats:
@@ -341,7 +341,7 @@ def test_dataset_stats_basic(
 def test_block_location_nums(ray_start_regular_shared, restore_data_context):
     context = DataContext.get_current()
     context.enable_get_object_locations_for_metrics = True
-    ds = ray.data.range(1000, parallelism=10)
+    ds = ray.data.range(1000, override_num_blocks=10)
     ds = ds.map_batches(dummy_map_batches).materialize()
 
     for batch in ds.iter_batches():
@@ -553,7 +553,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
 
 
 def test_dataset_stats_shuffle(ray_start_regular_shared):
-    ds = ray.data.range(1000, parallelism=10)
+    ds = ray.data.range(1000, override_num_blocks=10)
     ds = ds.random_shuffle().repartition(1, shuffle=True)
     stats = canonicalize(ds.materialize().stats())
     assert (
@@ -606,28 +606,28 @@ Operator N Repartition: executed in T
 
 
 def test_dataset_stats_repartition(ray_start_regular_shared):
-    ds = ray.data.range(1000, parallelism=10)
+    ds = ray.data.range(1000, override_num_blocks=10)
     ds = ds.repartition(1, shuffle=False)
     stats = ds.materialize().stats()
     assert "Repartition" in stats, stats
 
 
 def test_dataset_stats_union(ray_start_regular_shared):
-    ds = ray.data.range(1000, parallelism=10)
+    ds = ray.data.range(1000, override_num_blocks=10)
     ds = ds.union(ds)
     stats = ds.materialize().stats()
     assert "Union" in stats, stats
 
 
 def test_dataset_stats_zip(ray_start_regular_shared):
-    ds = ray.data.range(1000, parallelism=10)
+    ds = ray.data.range(1000, override_num_blocks=10)
     ds = ds.zip(ds)
     stats = ds.materialize().stats()
     assert "Zip" in stats, stats
 
 
 def test_dataset_stats_sort(ray_start_regular_shared):
-    ds = ray.data.range(1000, parallelism=10)
+    ds = ray.data.range(1000, override_num_blocks=10)
     ds = ds.sort("id")
     stats = ds.materialize().stats()
     assert "SortMap" in stats, stats
@@ -641,7 +641,7 @@ def test_dataset_stats_from_items(ray_start_regular_shared):
 
 
 def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
-    ds = ray.data.range(1000, parallelism=10)
+    ds = ray.data.range(1000, override_num_blocks=10)
     ds.write_parquet(str(tmp_path))
     ds = ray.data.read_parquet(str(tmp_path)).map(lambda x: x)
     stats = canonicalize(ds.materialize().stats())
@@ -659,7 +659,9 @@ def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
 
 
 def test_dataset_split_stats(ray_start_regular_shared, tmp_path):
-    ds = ray.data.range(100, parallelism=10).map(column_udf("id", lambda x: x + 1))
+    ds = ray.data.range(100, override_num_blocks=10).map(
+        column_udf("id", lambda x: x + 1)
+    )
     dses = ds.split_at_indices([49])
     dses = [ds.map(column_udf("id", lambda x: x + 1)) for ds in dses]
     for ds_ in dses:
@@ -864,7 +866,7 @@ def test_get_total_stats(ray_start_regular_shared, op_two_block):
     "See: https://github.com/ray-project/ray/pull/40173"
 )
 def test_streaming_stats_full(ray_start_regular_shared, restore_data_context):
-    ds = ray.data.range(5, parallelism=5).map(column_udf("id", lambda x: x + 1))
+    ds = ray.data.range(5, override_num_blocks=5).map(column_udf("id", lambda x: x + 1))
     ds.take_all()
     stats = canonicalize(ds.stats())
     assert (
@@ -893,7 +895,7 @@ Dataset iterator time breakdown:
 
 
 def test_write_ds_stats(ray_start_regular_shared, tmp_path):
-    ds = ray.data.range(100, parallelism=100)
+    ds = ray.data.range(100, override_num_blocks=100)
     ds.write_parquet(str(tmp_path))
     stats = ds.stats()
 
@@ -913,7 +915,11 @@ def test_write_ds_stats(ray_start_regular_shared, tmp_path):
 
     assert stats == ds._write_ds.stats()
 
-    ds = ray.data.range(100, parallelism=100).map_batches(lambda x: x).materialize()
+    ds = (
+        ray.data.range(100, override_num_blocks=100)
+        .map_batches(lambda x: x)
+        .materialize()
+    )
     ds.write_parquet(str(tmp_path))
     stats = ds.stats()
 
@@ -1030,7 +1036,7 @@ def test_spilled_stats(shutdown_only, verbose_stats_logs, restore_data_context):
 
     # The size of dataset is around 50MB, there should be no spillage
     ds = (
-        ray.data.range(250 * 80 * 80 * 4, parallelism=1)
+        ray.data.range(250 * 80 * 80 * 4, override_num_blocks=1)
         .map_batches(lambda x: x)
         .materialize()
     )
@@ -1088,7 +1094,7 @@ def test_stats_actor_iter_metrics():
 
 
 def test_dataset_name():
-    ds = ray.data.range(100, parallelism=20).map_batches(lambda x: x)
+    ds = ray.data.range(100, override_num_blocks=20).map_batches(lambda x: x)
     ds._set_name("test_ds")
     assert ds._name == "test_ds"
     assert str(ds) == (
@@ -1124,7 +1130,7 @@ def test_dataset_name():
 
     assert update_fn.call_args_list[-1].args[0] == f"dataset_{mds._uuid}"
 
-    ds = ray.data.range(100, parallelism=20)
+    ds = ray.data.range(100, override_num_blocks=20)
     ds._set_name("very_loooooooong_name")
     assert (
         str(ds)
@@ -1172,7 +1178,7 @@ def test_op_state_logging():
 
 
 def test_stats_actor_datasets(ray_start_cluster):
-    ds = ray.data.range(100, parallelism=20).map_batches(lambda x: x)
+    ds = ray.data.range(100, override_num_blocks=20).map_batches(lambda x: x)
     ds._set_name("test_stats_actor_datasets")
     ds.materialize()
     stats_actor = _get_or_create_stats_actor()

--- a/python/ray/data/tests/test_streaming_executor_errored_blocks.py
+++ b/python/ray/data/tests/test_streaming_executor_errored_blocks.py
@@ -40,7 +40,7 @@ def test_max_errored_blocks(
             raise RuntimeError(f"Task failed: {id}")
         return row
 
-    ds = ray.data.range(num_tasks, parallelism=num_tasks).map(map_func)
+    ds = ray.data.range(num_tasks, override_num_blocks=num_tasks).map(map_func)
     should_fail = 0 <= max_errored_blocks < num_errored_blocks
     if should_fail:
         with pytest.raises(Exception, match="Task failed"):

--- a/python/ray/data/tests/test_text.py
+++ b/python/ray/data/tests/test_text.py
@@ -192,7 +192,7 @@ def test_read_text_remote_args(ray_start_cluster, tmp_path):
         f.write("goodbye")
 
     ds = ray.data.read_text(
-        path, parallelism=2, ray_remote_args={"resources": {"bar": 1}}
+        path, override_num_blocks=2, ray_remote_args={"resources": {"bar": 1}}
     )
 
     blocks = ds.get_internal_block_refs()

--- a/python/ray/data/tests/test_tfrecords.py
+++ b/python/ray/data/tests/test_tfrecords.py
@@ -499,10 +499,10 @@ def test_write_tfrecords(
     # The dataset we will write to a .tfrecords file.
     ds = ray.data.from_items(
         data_partial(with_tf_schema),
-        # Here, we specify `parallelism=1` to ensure that all rows end up in the same
+        # Here, we specify `override_num_blocks=1` to ensure that all rows end up in the same
         # block, which is required for type inference involving
         # partially missing columns.
-        parallelism=1,
+        override_num_blocks=1,
     )
 
     # The corresponding tf.train.Example that we would expect to read
@@ -602,10 +602,10 @@ def test_readback_tfrecords(
     """
 
     # The dataset we will write to a .tfrecords file.
-    # Here and in the read_tfrecords call below, we specify `parallelism=1`
+    # Here and in the read_tfrecords call below, we specify `override_num_blocks=1`
     # to ensure that all rows end up in the same block, which is required
     # for type inference involving partially missing columns.
-    ds = ray.data.from_items(data_partial(with_tf_schema), parallelism=1)
+    ds = ray.data.from_items(data_partial(with_tf_schema), override_num_blocks=1)
     expected_records = tf_records_partial()
 
     tf_schema = None
@@ -617,7 +617,7 @@ def test_readback_tfrecords(
     ds.write_tfrecords(tmp_path, tf_schema=tf_schema)
     # Read the TFRecords.
     readback_ds = read_tfrecords_with_tfx_read_override(
-        tmp_path, tf_schema=tf_schema, parallelism=1
+        tmp_path, tf_schema=tf_schema, override_num_blocks=1
     )
     _ds_eq_streaming(ds, readback_ds)
 
@@ -641,7 +641,7 @@ def test_readback_tfrecords_empty_features(
             # type inference on completely empty columns is ambiguous.
             ds.write_tfrecords(tmp_path)
     else:
-        ds = ray.data.from_items(data_empty(with_tf_schema), parallelism=1)
+        ds = ray.data.from_items(data_empty(with_tf_schema), override_num_blocks=1)
         expected_records = tf_records_empty()
 
         features = expected_records[0].features
@@ -654,7 +654,7 @@ def test_readback_tfrecords_empty_features(
         readback_ds = read_tfrecords_with_tfx_read_override(
             tmp_path,
             tf_schema=tf_schema,
-            parallelism=1,
+            override_num_blocks=1,
         )
         _ds_eq_streaming(ds, readback_ds)
 
@@ -691,7 +691,7 @@ def test_read_with_invalid_schema(
     from tensorflow_metadata.proto.v0 import schema_pb2
 
     # The dataset we will write to a .tfrecords file.
-    ds = ray.data.from_items(data_partial(True), parallelism=1)
+    ds = ray.data.from_items(data_partial(True), override_num_blocks=1)
     expected_records = tf_records_partial()
 
     # Build fake schema proto with missing/incorrect field name
@@ -740,7 +740,7 @@ def test_read_with_invalid_schema(
 
 @pytest.mark.parametrize("num_rows_per_file", [5, 10, 50])
 def test_write_num_rows_per_file(tmp_path, ray_start_regular_shared, num_rows_per_file):
-    ray.data.range(100, parallelism=20).write_tfrecords(
+    ray.data.range(100, override_num_blocks=20).write_tfrecords(
         tmp_path, num_rows_per_file=num_rows_per_file
     )
 

--- a/python/ray/data/tests/test_tfrecords.py
+++ b/python/ray/data/tests/test_tfrecords.py
@@ -499,9 +499,9 @@ def test_write_tfrecords(
     # The dataset we will write to a .tfrecords file.
     ds = ray.data.from_items(
         data_partial(with_tf_schema),
-        # Here, we specify `override_num_blocks=1` to ensure that all rows end up in the same
-        # block, which is required for type inference involving
-        # partially missing columns.
+        # Here, we specify `override_num_blocks=1` to ensure that all rows end up in
+        # the same block, which is required for type inference involving partially
+        # missing columns.
         override_num_blocks=1,
     )
 

--- a/python/ray/data/tests/test_webdataset.py
+++ b/python/ray/data/tests/test_webdataset.py
@@ -39,7 +39,7 @@ def test_webdataset_read(ray_start_2_cpus, tmp_path):
             tf.write(f"{i}.b", str(i**2).encode("utf-8"))
     assert os.path.exists(path)
     assert len(glob.glob(f"{tmp_path}/*.tar")) == 1
-    ds = ray.data.read_webdataset(paths=[str(tmp_path)], parallelism=1)
+    ds = ray.data.read_webdataset(paths=[str(tmp_path)], override_num_blocks=1)
     samples = ds.take(100)
     assert len(samples) == 100
     for i, sample in enumerate(samples):
@@ -62,7 +62,7 @@ def test_webdataset_suffixes(ray_start_2_cpus, tmp_path):
 
     # test simple suffixes
     ds = ray.data.read_webdataset(
-        paths=[str(tmp_path)], parallelism=1, suffixes=["txt", "cls"]
+        paths=[str(tmp_path)], override_num_blocks=1, suffixes=["txt", "cls"]
     )
     samples = ds.take(100)
     assert len(samples) == 100
@@ -71,7 +71,7 @@ def test_webdataset_suffixes(ray_start_2_cpus, tmp_path):
 
     # test fnmatch patterns for suffixes
     ds = ray.data.read_webdataset(
-        paths=[str(tmp_path)], parallelism=1, suffixes=["*.txt", "*.cls"]
+        paths=[str(tmp_path)], override_num_blocks=1, suffixes=["*.txt", "*.cls"]
     )
     samples = ds.take(100)
     assert len(samples) == 100
@@ -82,7 +82,9 @@ def test_webdataset_suffixes(ray_start_2_cpus, tmp_path):
     def select(name):
         return name.endswith("txt")
 
-    ds = ray.data.read_webdataset(paths=[str(tmp_path)], parallelism=1, suffixes=select)
+    ds = ray.data.read_webdataset(
+        paths=[str(tmp_path)], override_num_blocks=1, suffixes=select
+    )
     samples = ds.take(100)
     assert len(samples) == 100
     for i, sample in enumerate(samples):
@@ -95,7 +97,7 @@ def test_webdataset_suffixes(ray_start_2_cpus, tmp_path):
         return result
 
     ds = ray.data.read_webdataset(
-        paths=[str(tmp_path)], parallelism=1, filerename=renamer
+        paths=[str(tmp_path)], override_num_blocks=1, filerename=renamer
     )
     samples = ds.take(100)
     assert len(samples) == 100
@@ -165,7 +167,7 @@ def test_webdataset_coding(ray_start_2_cpus, tmp_path):
     assert len(paths) == 1
     path = paths[0]
     assert os.path.exists(path)
-    ds = ray.data.read_webdataset(paths=[str(tmp_path)], parallelism=1)
+    ds = ray.data.read_webdataset(paths=[str(tmp_path)], override_num_blocks=1)
     samples = ds.take(1)
     assert len(samples) == 1
     for sample in samples:
@@ -185,7 +187,7 @@ def test_webdataset_coding(ray_start_2_cpus, tmp_path):
 
     # test the format argument to the default decoder and multiple decoders
     ds = ray.data.read_webdataset(
-        paths=[str(tmp_path)], parallelism=1, decoder=["PIL", custom_decoder]
+        paths=[str(tmp_path)], override_num_blocks=1, decoder=["PIL", custom_decoder]
     )
     samples = ds.take(1)
     assert len(samples) == 1
@@ -202,7 +204,7 @@ def test_webdataset_coding(ray_start_2_cpus, tmp_path):
 @pytest.mark.parametrize("num_rows_per_file", [5, 10, 50])
 def test_write_num_rows_per_file(tmp_path, ray_start_regular_shared, num_rows_per_file):
     ray.data.from_items(
-        [{"id": str(i)} for i in range(100)], parallelism=20
+        [{"id": str(i)} for i in range(100)], override_num_blocks=20
     ).write_webdataset(tmp_path, num_rows_per_file=num_rows_per_file)
 
     for filename in os.listdir(tmp_path):

--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -388,7 +388,7 @@ if __name__ == "__main__":
             time.sleep(delay)
             return x
 
-        ray.data.range(1000, parallelism=100).map(
+        ray.data.range(1000, override_num_blocks=100).map(
             sleep, compute=ray.data.ActorPoolStrategy(size=1)
         ).count()
 

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -86,7 +86,7 @@ class TestDatasource(Datasource):
 
 def gen_dataset_func(do_shuffle: Optional[bool] = False) -> Dataset:
     test_datasource = TestDatasource(do_shuffle)
-    return read_datasource(test_datasource, parallelism=1)
+    return read_datasource(test_datasource, override_num_blocks=1)
 
 
 def gen_dataset_func_eager():

--- a/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
@@ -276,7 +276,7 @@ def build_synthetic_dataset(batch_size):
     empty = np.empty(image_dims, dtype=np.uint8)
     ds = ray.data.from_items(
         [{"image": empty, "label": 1} for _ in range(int(batch_size))],
-        parallelism=1,
+        override_num_blocks=1,
     )
     return ds
 

--- a/release/nightly_tests/dataset/data_ingest_benchmark.py
+++ b/release/nightly_tests/dataset/data_ingest_benchmark.py
@@ -119,7 +119,7 @@ def make_ds(size_gb: int, parallelism: int = -1):
     record_size = record_dim * 8
     num_records = int(total_size / record_size)
     dataset = ray.data.range_tensor(
-        num_records, shape=(record_dim,), parallelism=parallelism
+        num_records, shape=(record_dim,), override_num_blocks=parallelism
     )
     print("Created dataset", dataset, "of size", dataset.size_bytes())
     return dataset

--- a/release/nightly_tests/dataset/dataset_random_access.py
+++ b/release/nightly_tests/dataset/dataset_random_access.py
@@ -26,7 +26,7 @@ def main():
         num_workers = 400
         run_time = 15
 
-    ds = ray.data.range(nrow, parallelism=parallelism)
+    ds = ray.data.range(nrow, override_num_blocks=parallelism)
     rmap = ds.to_random_access_dataset("id", num_workers=num_workers)
 
     print("Multiget throughput: ", end="")

--- a/release/nightly_tests/dataset/image_loader_microbenchmark.py
+++ b/release/nightly_tests/dataset/image_loader_microbenchmark.py
@@ -372,7 +372,9 @@ def get_ray_mosaic_dataset(mosaic_data_root):
 
 def get_ray_parquet_dataset(parquet_data_root, parallelism=None):
     if parallelism is not None:
-        ray_dataset = ray.data.read_parquet(parquet_data_root, parallelism=parallelism)
+        ray_dataset = ray.data.read_parquet(
+            parquet_data_root, override_num_blocks=parallelism
+        )
     else:
         ray_dataset = ray.data.read_parquet(parquet_data_root)
     ray_dataset = ray_dataset.map(decode_image_crop_and_flip)

--- a/release/nightly_tests/dataset/map_batches_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_benchmark.py
@@ -165,7 +165,7 @@ def run_map_batches_benchmark(benchmark: Benchmark):
     # And the first one will generate multiple output blocks.
     ray.data._internal.logical.optimizers.PHYSICAL_OPTIMIZER_RULES = []
     parallelism = input_size // batch_size
-    input_ds = ray.data.range(input_size, parallelism=parallelism).materialize()
+    input_ds = ray.data.range(input_size, override_num_blocks=parallelism).materialize()
 
     def map_batches_fn(num_output_blocks, batch):
         """A map_batches function that generates num_output_blocks output blocks."""

--- a/release/nightly_tests/dataset/operator_fusion_benchmark.py
+++ b/release/nightly_tests/dataset/operator_fusion_benchmark.py
@@ -84,7 +84,7 @@ def make_ds(
         block_size=block_size,
         data_format=data_format,
         num_columns=num_columns,
-        parallelism=num_tasks,
+        override_num_blocks=num_tasks,
     )
     for op_spec in ops_spec:
         op = op_spec.pop("op")

--- a/release/nightly_tests/dataset/read_parquet_benchmark.py
+++ b/release/nightly_tests/dataset/read_parquet_benchmark.py
@@ -17,7 +17,7 @@ def read_parquet(
 ) -> Dataset:
     return ray.data.read_parquet(
         paths=root,
-        parallelism=parallelism,
+        override_num_blocks=parallelism,
         use_threads=use_threads,
         filter=filter,
         columns=columns,
@@ -33,7 +33,7 @@ def run_read_parquet_benchmark(benchmark: Benchmark):
                 test_name,
                 read_parquet,
                 root="s3://anonymous@air-example-data/ursa-labs-taxi-data/downsampled_2009_full_year_data.parquet",  # noqa: E501
-                parallelism=parallelism,
+                override_num_blocks=parallelism,
                 use_threads=use_threads,
             )
 
@@ -79,7 +79,7 @@ def run_read_parquet_benchmark(benchmark: Benchmark):
                 test_name,
                 read_parquet,
                 root=data_dirs[-1],
-                parallelism=1,  # We are testing one task to handle N files
+                override_num_blocks=1,  # We are testing one task to handle N files
             )
     for dir in data_dirs:
         shutil.rmtree(dir)

--- a/release/nightly_tests/dataset/sort.py
+++ b/release/nightly_tests/dataset/sort.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
         num_rows_per_partition = partition_size // (8 + args.row_size_bytes)
         ds = ray.data.read_datasource(
             source,
-            parallelism=num_partitions,
+            override_num_blocks=num_partitions,
             n=num_rows_per_partition * num_partitions,
             row_size_bytes=args.row_size_bytes,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is to remove Ray Data read `parallelism`, replace with `override_num_blocks` from all libraries and unit tests. The PR change on Ray Data is https://github.com/ray-project/ray/pull/43113 .

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
