### PR TITLE
[Serve] log deployment success message in serve.run before blocking

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -541,6 +541,7 @@ def run(
     name: str = SERVE_DEFAULT_APP_NAME,
     route_prefix: str = DEFAULT.VALUE,
     logging_config: Optional[Union[Dict, LoggingConfig]] = None,
+    deploy_success_callback: Optional[Callable] = None,
 ) -> DeploymentHandle:
     """Run an application and return a handle to its ingress deployment.
 
@@ -563,6 +564,7 @@ def run(
             nor in the ingress deployment, the route prefix will default to '/'.
         logging_config: Application logging config. If provided, the config will
             be applied to all deployments which doesn't have logging config.
+        deploy_success_callback: The callable to call after the deployment is succeeded.
 
     Returns:
         DeploymentHandle: A handle that can be used to call the application.
@@ -573,6 +575,9 @@ def run(
         route_prefix=route_prefix,
         logging_config=logging_config,
     )
+
+    if deploy_success_callback:
+        deploy_success_callback()
 
     if blocking:
         try:

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -16,7 +16,7 @@ from ray.serve._private.config import (
     ReplicaConfig,
     handle_num_replicas_auto,
 )
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
+from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_LOGGER_NAME
 from ray.serve._private.deployment_graph_build import build as pipeline_build
 from ray.serve._private.deployment_graph_build import (
     get_and_validate_ingress_deployment,
@@ -55,7 +55,7 @@ from ray.util.annotations import DeveloperAPI, PublicAPI
 
 from ray.serve._private import api as _private_api  # isort:skip
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
 @PublicAPI(stability="stable")
@@ -573,7 +573,7 @@ def run(
         route_prefix=route_prefix,
         logging_config=logging_config,
     )
-    logger.warning("Deployed app successfully.")
+    logger.info(f"Deployed app '{name}' successfully.")
 
     if blocking:
         try:
@@ -581,7 +581,7 @@ def run(
                 # Block, letting Ray print logs to the terminal.
                 time.sleep(10)
         except KeyboardInterrupt:
-            logger.warning("Got KeyboardInterrupt, release blocking...")
+            logger.warning("Got KeyboardInterrupt, exiting...")
     return handle
 
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -541,7 +541,6 @@ def run(
     name: str = SERVE_DEFAULT_APP_NAME,
     route_prefix: str = DEFAULT.VALUE,
     logging_config: Optional[Union[Dict, LoggingConfig]] = None,
-    deploy_success_callback: Optional[Callable] = None,
 ) -> DeploymentHandle:
     """Run an application and return a handle to its ingress deployment.
 
@@ -564,7 +563,6 @@ def run(
             nor in the ingress deployment, the route prefix will default to '/'.
         logging_config: Application logging config. If provided, the config will
             be applied to all deployments which doesn't have logging config.
-        deploy_success_callback: The callable to call after the deployment is succeeded.
 
     Returns:
         DeploymentHandle: A handle that can be used to call the application.
@@ -575,9 +573,7 @@ def run(
         route_prefix=route_prefix,
         logging_config=logging_config,
     )
-
-    if deploy_success_callback:
-        deploy_success_callback()
+    logger.warning("Deployed app successfully.")
 
     if blocking:
         try:
@@ -585,7 +581,7 @@ def run(
                 # Block, letting Ray print logs to the terminal.
                 time.sleep(10)
         except KeyboardInterrupt:
-            logger.info("Got KeyboardInterrupt, release blocking...")
+            logger.warning("Got KeyboardInterrupt, release blocking...")
     return handle
 
 

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -544,10 +544,19 @@ def run(
                     # Block, letting Ray print logs to the terminal.
                     time.sleep(10)
         else:
+
+            def log_deploy_success_message():
+                cli_logger.success("Deployed app successfully.")
+
             # This should not block if reload is true so the watchfiles can be triggered
             should_block = blocking and not reload
-            serve.run(app, blocking=should_block, name=name, route_prefix=route_prefix)
-            cli_logger.success("Deployed app successfully.")
+            serve.run(
+                target=app,
+                blocking=should_block,
+                name=name,
+                route_prefix=route_prefix,
+                deploy_success_callback=log_deploy_success_message,
+            )
 
         if reload:
             if not blocking:
@@ -558,6 +567,9 @@ def run(
                 watch_dir = working_dir
             else:
                 watch_dir = app_dir
+
+            def log_redeploy_success_message():
+                cli_logger.success("Redeployed app successfully.")
 
             for changes in watchfiles.watch(
                 watch_dir,
@@ -574,9 +586,12 @@ def run(
                         import_attr(import_path, reload_module=True), args_dict
                     )
                     serve.run(
-                        target=app, blocking=True, name=name, route_prefix=route_prefix
+                        target=app,
+                        blocking=True,
+                        name=name,
+                        route_prefix=route_prefix,
+                        deploy_success_callback=log_redeploy_success_message,
                     )
-                    cli_logger.success("Redeployed app successfully.")
 
     except KeyboardInterrupt:
         cli_logger.info("Got KeyboardInterrupt, shutting down...")

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -544,19 +544,9 @@ def run(
                     # Block, letting Ray print logs to the terminal.
                     time.sleep(10)
         else:
-
-            def log_deploy_success_message():
-                cli_logger.success("Deployed app successfully.")
-
             # This should not block if reload is true so the watchfiles can be triggered
             should_block = blocking and not reload
-            serve.run(
-                target=app,
-                blocking=should_block,
-                name=name,
-                route_prefix=route_prefix,
-                deploy_success_callback=log_deploy_success_message,
-            )
+            serve.run(app, blocking=should_block, name=name, route_prefix=route_prefix)
 
         if reload:
             if not blocking:
@@ -567,9 +557,6 @@ def run(
                 watch_dir = working_dir
             else:
                 watch_dir = app_dir
-
-            def log_redeploy_success_message():
-                cli_logger.success("Redeployed app successfully.")
 
             for changes in watchfiles.watch(
                 watch_dir,
@@ -586,11 +573,7 @@ def run(
                         import_attr(import_path, reload_module=True), args_dict
                     )
                     serve.run(
-                        target=app,
-                        blocking=True,
-                        name=name,
-                        route_prefix=route_prefix,
-                        deploy_success_callback=log_redeploy_success_message,
+                        target=app, blocking=True, name=name, route_prefix=route_prefix
                     )
 
     except KeyboardInterrupt:

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -974,41 +974,6 @@ def test_deployment_handle_nested_in_obj(serve_instance):
     assert h.remote().result() == "hi"
 
 
-@pytest.mark.parametrize("fail_deployment", [False, True])
-def test_serve_run_callback(serve_instance, fail_deployment):
-    """Test the `deploy_success_callback` arg on serve.run.
-
-    If the deployment succeeded, the function passed by `deploy_success_callback`
-    should be called. If the deployment failed, the function passed by
-    `deploy_success_callback` should not be called.
-    """
-    callback_called = False
-
-    def deploy_success_callback():
-        nonlocal callback_called
-        callback_called = True
-
-    @serve.deployment
-    class Foo:
-        def __init__(self):
-            if fail_deployment:
-                1 / 0
-
-        def __call__(self):
-            return "foo"
-
-    if fail_deployment:
-        with pytest.raises(RuntimeError):
-            serve.run(
-                target=Foo.bind(), deploy_success_callback=deploy_success_callback
-            )
-
-        assert callback_called is False
-    else:
-        serve.run(target=Foo.bind(), deploy_success_callback=deploy_success_callback)
-        assert callback_called is True
-
-
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the previous PR, I accidentally blocked the cli logger from logging the deployment success message. log deployment success message in serve.run before blocking.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
