### PR TITLE
[doc] Remove support for SHA prefix on Docker images 

### DIFF
--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -338,8 +338,6 @@ Images are `tagged` with the format ``{Ray version}[-{Python version}][-{Platfor
      - A specific Ray release, e.g. 1.12.1
    * - nightly
      - The most recent Ray development build (a recent commit from Github ``master``)
-   * - 6 character Git SHA prefix
-     - A specific development build (uses a SHA from the Github ``master``, e.g. ``8960af``).
 
 The optional ``Python version`` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. ``py38``, ``py39`` and ``py310``. If unspecified, the tag points to an image using ``Python 3.8``.
 

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -335,7 +335,7 @@ Images are `tagged` with the format ``{Ray version}[-{Python version}][-{Platfor
    * - latest
      - The most recent Ray release.
    * - x.y.z
-     - A specific Ray release, e.g. 1.12.1
+     - A specific Ray release, e.g. 2.9.3
    * - nightly
      - The most recent Ray development build (a recent commit from Github ``master``)
 

--- a/docker/base-deps/README.md
+++ b/docker/base-deps/README.md
@@ -11,8 +11,8 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | Ray version tag | Description |
 | --------------- | ----------- |
 | `latest`                     | The most recent Ray release. |
-| `x.y.z`                      | A specific Ray release, e.g. 1.12.1 |
-| `nightly`                    | The most recent Ray development build (a recent commit from Github `master`) |
+| `x.y.z`                      | A specific Ray release, e.g. 2.9.3 |
+| `nightly`                    | The most recent Ray development build (a recent commit from GitHub `master`) |
 
 The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
 

--- a/docker/base-deps/README.md
+++ b/docker/base-deps/README.md
@@ -13,7 +13,6 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | `latest`                     | The most recent Ray release. |
 | `x.y.z`                      | A specific Ray release, e.g. 1.12.1 |
 | `nightly`                    | The most recent Ray development build (a recent commit from Github `master`) |
-| `6 character Git SHA prefix` | A specific development build (uses a SHA from the Github `master`, e.g. `8960af`). |
 
 The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
 

--- a/docker/ray-deps/README.md
+++ b/docker/ray-deps/README.md
@@ -10,8 +10,8 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | Ray version tag | Description |
 | --------------- | ----------- |
 | `latest`                     | The most recent Ray release. |
-| `x.y.z`                      | A specific Ray release, e.g. 1.12.1 |
-| `nightly`                    | The most recent Ray development build (a recent commit from Github `master`) |
+| `x.y.z`                      | A specific Ray release, e.g. 2.9.3 |
+| `nightly`                    | The most recent Ray development build (a recent commit from GitHub `master`) |
 
 The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
 

--- a/docker/ray-deps/README.md
+++ b/docker/ray-deps/README.md
@@ -12,7 +12,6 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | `latest`                     | The most recent Ray release. |
 | `x.y.z`                      | A specific Ray release, e.g. 1.12.1 |
 | `nightly`                    | The most recent Ray development build (a recent commit from Github `master`) |
-| `6 character Git SHA prefix` | A specific development build (uses a SHA from the Github `master`, e.g. `8960af`). |
 
 The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
 

--- a/docker/ray-ml/README.md
+++ b/docker/ray-ml/README.md
@@ -10,7 +10,6 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | `latest`                     | The most recent Ray release. |
 | `x.y.z`                      | A specific Ray release, e.g. 1.12.1 |
 | `nightly`                    | The most recent Ray development build (a recent commit from Github `master`) |
-| `6 character Git SHA prefix` | A specific development build (uses a SHA from the Github `master`, e.g. `8960af`). |
 
 The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
 

--- a/docker/ray-ml/README.md
+++ b/docker/ray-ml/README.md
@@ -8,8 +8,8 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | Ray version tag | Description |
 | --------------- | ----------- |
 | `latest`                     | The most recent Ray release. |
-| `x.y.z`                      | A specific Ray release, e.g. 1.12.1 |
-| `nightly`                    | The most recent Ray development build (a recent commit from Github `master`) |
+| `x.y.z`                      | A specific Ray release, e.g. 2.9.3 |
+| `nightly`                    | The most recent Ray development build (a recent commit from GitHub `master`) |
 
 The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
 

--- a/docker/ray/README.md
+++ b/docker/ray/README.md
@@ -11,7 +11,6 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | `latest`                     | The most recent Ray release. |
 | `x.y.z`                      | A specific Ray release, e.g. 1.12.1 |
 | `nightly`                    | The most recent Ray development build (a recent commit from Github `master`) |
-| `6 character Git SHA prefix` | A specific development build (uses a SHA from the Github `master`, e.g. `8960af`). |
 
 The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
 

--- a/docker/ray/README.md
+++ b/docker/ray/README.md
@@ -9,8 +9,8 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | Ray version tag | Description |
 | --------------- | ----------- |
 | `latest`                     | The most recent Ray release. |
-| `x.y.z`                      | A specific Ray release, e.g. 1.12.1 |
-| `nightly`                    | The most recent Ray development build (a recent commit from Github `master`) |
+| `x.y.z`                      | A specific Ray release, e.g. 2.9.3 |
+| `nightly`                    | The most recent Ray development build (a recent commit from GitHub `master`) |
 
 The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
 


### PR DESCRIPTION
- We are no longer tagging Docker images with 6-char git SHA prefix soon. Thus the reason for removing this info from docs. 
- Update some small details in README