### PR TITLE
[serve] deflake test deploy

### DIFF
--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -163,7 +163,7 @@ def check_deployment_status(name, expected_status) -> DeploymentStatus:
     return True
 
 
-def get_num_running_replicas(
+def get_num_alive_replicas(
     deployment_name: str, app_name: str = SERVE_DEFAULT_APP_NAME
 ) -> int:
     """Get the replicas currently running for the given deployment."""
@@ -183,7 +183,7 @@ def check_num_replicas_gte(
 ) -> int:
     """Check if num replicas is >= target."""
 
-    assert get_num_running_replicas(name, app_name) >= target
+    assert get_num_alive_replicas(name, app_name) >= target
     return True
 
 
@@ -192,7 +192,7 @@ def check_num_replicas_eq(
 ) -> int:
     """Check if num replicas is == target."""
 
-    assert get_num_running_replicas(name, app_name) == target
+    assert get_num_alive_replicas(name, app_name) == target
     return True
 
 
@@ -201,7 +201,7 @@ def check_num_replicas_lte(
 ) -> int:
     """Check if num replicas is <= target."""
 
-    assert get_num_running_replicas(name, app_name) <= target
+    assert get_num_alive_replicas(name, app_name) <= target
     return True
 
 

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -33,7 +33,7 @@ from ray.serve._private.test_utils import (
     check_num_replicas_eq,
     check_num_replicas_gte,
     check_num_replicas_lte,
-    get_num_running_replicas,
+    get_num_alive_replicas,
 )
 from ray.serve.config import AutoscalingConfig
 from ray.serve.schema import ServeDeploySchema
@@ -381,7 +381,7 @@ def test_e2e_bursty(serve_instance):
 
     wait_for_condition(check_num_replicas_gte, name="A", target=2)
 
-    num_replicas = get_num_running_replicas("A")
+    num_replicas = get_num_alive_replicas("A")
     signal.send.remote()
 
     # Execute a bursty workload that issues 100 requests every 0.05 seconds


### PR DESCRIPTION
[serve] deflake test deploy

Deflake `test_deploy.py`.
Example failure of `test_redeploy_multiple_replicas`: https://buildkite.com/ray-project/postmerge/builds/3291#018e102d-7a24-4b1c-a4af-f113cda3c018.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
