### PR TITLE
Revert "[data] disable locality-aware scheduling by default"

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -214,7 +214,7 @@ class ExecutionOptions:
         preserve_order: Set this to preserve the ordering between blocks processed by
             operators. Off by default.
         actor_locality_enabled: Whether to enable locality-aware task dispatch to
-            actors (off by default). This parameter applies to both stateful map and
+            actors (on by default). This parameter applies to both stateful map and
             streaming_split operations.
         verbose_progress: Whether to report progress individually per operator. By
             default, only AllToAll operators and global progress is reported. This
@@ -227,8 +227,6 @@ class ExecutionOptions:
         exclude_resources: Optional[ExecutionResources] = None,
         locality_with_output: Union[bool, List[NodeIdStr]] = False,
         preserve_order: bool = False,
-        # TODO(hchen): Re-enable `actor_locality_enabled` by default after fixing
-        # https://github.com/ray-project/ray/issues/43466
         actor_locality_enabled: bool = True,
         verbose_progress: Optional[bool] = None,
     ):

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -483,7 +483,7 @@ def test_limit_resource_reporting(ray_start_10_cpus_shared):
 def test_output_splitter_resource_reporting(ray_start_10_cpus_shared):
     input_op = InputDataBuffer(make_ref_bundles([[SMALL_STR] for i in range(4)]))
     op = OutputSplitter(input_op, 2, equal=False, locality_hints=["0", "1"])
-    op.start(ExecutionOptions(actor_locality_enabled=True))
+    op.start(ExecutionOptions())
 
     assert op.current_processor_usage() == ExecutionResources(
         cpu=0, gpu=0, object_store_memory=0

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -211,7 +211,7 @@ def test_map_operator_streamed(ray_start_regular_shared, use_actors):
 
     # Feed data and implement streaming exec.
     output = []
-    op.start(ExecutionOptions(actor_locality_enabled=True))
+    op.start(ExecutionOptions())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
         while not op.has_next():
@@ -327,7 +327,7 @@ def test_split_operator_locality_hints(ray_start_regular_shared):
 
     # Feed data and implement streaming exec.
     output_splits = collections.defaultdict(list)
-    op.start(ExecutionOptions(actor_locality_enabled=True))
+    op.start(ExecutionOptions())
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
     op.all_inputs_done()

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -120,16 +120,14 @@ class DataConfig:
     def default_ingest_options() -> ExecutionOptions:
         """The default Ray Data options used for data ingest.
 
-        By default, configurations are carried over from what is already set
-        in DataContext.
+        By default, output locality is enabled, which means that Ray Data will try to
+        place tasks on the node the data is consumed. The remaining configurations are
+        carried over from what is already set in DataContext.
         """
         ctx = ray.data.DataContext.get_current()
         return ExecutionOptions(
-            # TODO(hchen): Re-enable `locality_with_output` by default after fixing
-            # https://github.com/ray-project/ray/issues/40607
-            locality_with_output=ctx.execution_options.locality_with_output,
+            locality_with_output=True,
             resource_limits=ctx.execution_options.resource_limits,
-            exclude_resources=ctx.execution_options.exclude_resources,
             preserve_order=ctx.execution_options.preserve_order,
             verbose_progress=ctx.execution_options.verbose_progress,
         )


### PR DESCRIPTION
Reverts ray-project/ray#43463, which may potentially be causing a release test failure: https://github.com/ray-project/ray/issues/43704