### PR TITLE
[ci] Exit with code 42 for blocker count check

### DIFF
--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -49,6 +49,7 @@ def main(production: bool, check: bool) -> None:
         logger.info("Weekly green metric updated successfully")
 
     if check and blockers.totalCount != 0:
+        logger.error(f"Found {blockers.totalCount} release blockers")
         sys.exit(42)  # Not retrying the check on Buildkite jobs
 
 

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -50,8 +50,7 @@ def main(production: bool, check: bool) -> None:
 
     if check and blockers.totalCount != 0:
         print(
-            f"Found {blockers.totalCount} release blockers. "
-            "Please fix before proceeding.",
+            f"Found {blockers.totalCount} release blockers.",
             file=sys.stderr,
         )
         sys.exit(42)  # Not retrying the check on Buildkite jobs

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -49,7 +49,11 @@ def main(production: bool, check: bool) -> None:
         logger.info("Weekly green metric updated successfully")
 
     if check and blockers.totalCount != 0:
-        logger.error(f"Found {blockers.totalCount} release blockers")
+        print(
+            f"Found {blockers.totalCount} release blockers. "
+            "Please fix before proceeding.",
+            file=sys.stderr,
+        )
         sys.exit(42)  # Not retrying the check on Buildkite jobs
 
 

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -1,5 +1,6 @@
 import json
 import time
+import os
 
 import boto3
 import click
@@ -48,7 +49,7 @@ def main(production: bool, check: bool) -> None:
         logger.info("Weekly green metric updated successfully")
 
     if check and blockers.totalCount != 0:
-        raise Exception(f"Found {blockers.totalCount} release blockers")
+        os.exit(42)  # Not retrying the check on Buildkite jobs
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -1,6 +1,6 @@
 import json
 import time
-import os
+import sys
 
 import boto3
 import click
@@ -49,7 +49,7 @@ def main(production: bool, check: bool) -> None:
         logger.info("Weekly green metric updated successfully")
 
     if check and blockers.totalCount != 0:
-        os.exit(42)  # Not retrying the check on Buildkite jobs
+        sys.exit(42)  # Not retrying the check on Buildkite jobs
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Exit with 42 in `weekly_green_metric` when checking whether blocker count is 0, in order for Buildkite to not retry the check