### PR TITLE
Revert "Revert "[Data] Reduce internal Ray Data stack trace output by default""

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1027,7 +1027,7 @@ cdef c_bool determine_if_retryable(
 
     # For exceptions raised when running UDFs in Ray Data, we need to unwrap the special
     # exception type thrown by Ray Data in order to get the underlying exception.
-    if isinstance(e, ray.data.exceptions.UserCodeException):
+    if isinstance(e, ray.exceptions.UserCodeException):
         e = e.__cause__
     # Check that e is in allowlist.
     return isinstance(e, exception_allowlist)

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1025,6 +1025,10 @@ cdef c_bool determine_if_retryable(
     # Python API should have converted the list of exceptions to a tuple.
     assert isinstance(exception_allowlist, tuple)
 
+    # For exceptions raised when running UDFs in Ray Data, we need to unwrap the special
+    # exception type thrown by Ray Data in order to get the underlying exception.
+    if isinstance(e, ray.data.exceptions.UserCodeException):
+        e = e.__cause__
     # Check that e is in allowlist.
     return isinstance(e, exception_allowlist)
 

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -15,6 +15,7 @@ from ray.data._internal.stats import DatasetStats, DatasetStatsSummary
 from ray.data._internal.util import create_dataset_tag, unify_block_metadata_schema
 from ray.data.block import Block, BlockMetadata
 from ray.data.context import DataContext
+from ray.data.exceptions import omit_traceback_stdout
 from ray.types import ObjectRef
 from ray.util.debug import log_once
 
@@ -463,6 +464,7 @@ class ExecutionPlan:
         else:
             return None
 
+    @omit_traceback_stdout
     def execute_to_iterator(
         self,
         allow_clear_input_blocks: bool = True,
@@ -520,6 +522,7 @@ class ExecutionPlan:
         self._snapshot_stats = executor.get_stats()
         return block_iter, self._snapshot_stats, executor
 
+    @omit_traceback_stdout
     def execute(
         self,
         allow_clear_input_blocks: bool = True,

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -101,6 +101,11 @@ DEFAULT_AUTO_LOG_STATS = False
 # as `extra_metrics` in the stats output, which are excluded by default.
 DEFAULT_VERBOSE_STATS_LOG = False
 
+# Whether to include internal Ray Data/Ray Core code stack frames
+# when logging to stdout. The full stack trace is always written to the
+# Ray Data log file.
+DEFAULT_LOG_INTERNAL_STACK_TRACE_TO_STDOUT = False
+
 # Set this env var to enable distributed tqdm (experimental).
 DEFAULT_USE_RAY_TQDM = bool(int(os.environ.get("RAY_TQDM", "1")))
 
@@ -186,6 +191,7 @@ class DataContext:
         enable_tensor_extension_casting: bool,
         enable_auto_log_stats: bool,
         verbose_stats_log: bool,
+        log_internal_stack_trace_to_stdout: bool,
         trace_allocations: bool,
         execution_options: "ExecutionOptions",
         use_ray_tqdm: bool,
@@ -216,6 +222,7 @@ class DataContext:
         self.enable_tensor_extension_casting = enable_tensor_extension_casting
         self.enable_auto_log_stats = enable_auto_log_stats
         self.verbose_stats_logs = verbose_stats_log
+        self.log_internal_stack_trace_to_stdout = log_internal_stack_trace_to_stdout
         self.trace_allocations = trace_allocations
         # TODO: expose execution options in Dataset public APIs.
         self.execution_options = execution_options
@@ -291,6 +298,9 @@ class DataContext:
                     ),
                     enable_auto_log_stats=DEFAULT_AUTO_LOG_STATS,
                     verbose_stats_log=DEFAULT_VERBOSE_STATS_LOG,
+                    log_internal_stack_trace_to_stdout=(
+                        DEFAULT_LOG_INTERNAL_STACK_TRACE_TO_STDOUT
+                    ),
                     trace_allocations=DEFAULT_TRACE_ALLOCATIONS,
                     execution_options=ray.data.ExecutionOptions(),
                     use_ray_tqdm=DEFAULT_USE_RAY_TQDM,

--- a/python/ray/data/exceptions.py
+++ b/python/ray/data/exceptions.py
@@ -1,0 +1,84 @@
+from typing import Callable
+
+from ray.data._internal.dataset_logger import DatasetLogger
+from ray.data.context import DataContext
+from ray.util import log_once
+from ray.util.annotations import DeveloperAPI
+
+
+@DeveloperAPI
+class UserCodeException(Exception):
+    """Represents an Exception originating from user code, e.g.
+    user-specified UDF used in a Ray Data transformation.
+
+    By default, the frames corresponding to Ray Data internal files are
+    omitted from the stack trace logged to stdout, but will still be
+    emitted to the Ray Data specific log file. To emit all stack frames to stdout,
+    set `DataContext.log_internal_stack_trace_to_stdout` to True."""
+
+    pass
+
+
+@DeveloperAPI
+class SystemException(Exception):
+    """Represents an Exception originating from Ray Data internal code
+    or Ray Core private code paths, as opposed to user code. When
+    Exceptions of this form are raised, it likely indicates a bug
+    in Ray Data or Ray Core."""
+
+    pass
+
+
+# Logger used by Ray Data to log Exceptions while skip internal stack frames.
+data_exception_logger = DatasetLogger(__name__)
+
+
+@DeveloperAPI
+def omit_traceback_stdout(fn: Callable) -> Callable:
+    """Decorator which runs the function, and if there is an exception raised,
+    drops the stack trace before re-raising the exception. The original exception,
+    including the full unmodified stack trace, is always written to the Ray Data
+    log file at `data_exception_logger._log_path`.
+
+    This is useful for stripping long stack traces of internal Ray Data code,
+    which can otherwise obfuscate user code errors."""
+
+    def handle_trace(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as e:
+            # Only log the full internal stack trace to stdout when configured.
+            # The full stack trace will always be emitted to the Ray Data log file.
+            log_to_stdout = DataContext.get_current().log_internal_stack_trace_to_stdout
+
+            is_user_code_exception = isinstance(e, UserCodeException)
+            if is_user_code_exception:
+                # Exception has occurred in user code.
+                if not log_to_stdout and log_once("ray_data_exception_internal_hidden"):
+                    data_exception_logger.get_logger().error(
+                        "Exception occurred in user code, with the abbreviated stack "
+                        "trace below. By default, the Ray Data internal stack trace "
+                        "is omitted from stdout, and only written to the Ray Data log "
+                        f"file at {data_exception_logger._datasets_log_path}. To "
+                        "output the full stack trace to stdout, set "
+                        "`DataContext.log_internal_stack_trace_to_stdout` to True."
+                    )
+            else:
+                # Exception has occurred in internal Ray Data / Ray Core code.
+                data_exception_logger.get_logger().error(
+                    "Exception occurred in Ray Data or Ray Core internal code. "
+                    "If you continue to see this error, please open an issue on "
+                    "the Ray project GitHub page with the full stack trace below: "
+                    "https://github.com/ray-project/ray/issues/new/choose"
+                )
+
+            data_exception_logger.get_logger(log_to_stdout=log_to_stdout).exception(
+                "Full stack trace:"
+            )
+
+            if is_user_code_exception:
+                raise e.with_traceback(None)
+            else:
+                raise e.with_traceback(None) from SystemException()
+
+    return handle_trace

--- a/python/ray/data/exceptions.py
+++ b/python/ray/data/exceptions.py
@@ -2,12 +2,13 @@ from typing import Callable
 
 from ray.data._internal.dataset_logger import DatasetLogger
 from ray.data.context import DataContext
+from ray.exceptions import UserCodeException
 from ray.util import log_once
 from ray.util.annotations import DeveloperAPI
 
 
 @DeveloperAPI
-class UserCodeException(Exception):
+class RayDataUserCodeException(UserCodeException):
     """Represents an Exception originating from user code, e.g.
     user-specified UDF used in a Ray Data transformation.
 

--- a/python/ray/data/tests/preprocessors/test_concatenator.py
+++ b/python/ray/data/tests/preprocessors/test_concatenator.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 import ray
+from ray.data.exceptions import UserCodeException
 from ray.data.preprocessors import Concatenator
 
 
@@ -27,8 +28,9 @@ class TestConcatenator:
             output_column_name="c", exclude=["b"], raise_if_missing=True
         )
 
-        with pytest.raises(ValueError, match="'b'"):
-            prep.transform(ds).materialize()
+        with pytest.raises(UserCodeException):
+            with pytest.raises(ValueError, match="'b'"):
+                prep.transform(ds).materialize()
 
     @pytest.mark.parametrize("exclude", ("b", ["b"]))
     def test_exclude(self, exclude):

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 import ray
+from ray.data.exceptions import UserCodeException
 from ray.data.preprocessor import PreprocessorNotFittedException
 from ray.data.preprocessors import (
     Categorizer,
@@ -96,7 +97,7 @@ def test_ordinal_encoder():
     null_encoder.fit(nonnull_ds)
 
     # Verify transform fails for null values.
-    with pytest.raises(ValueError):
+    with pytest.raises((UserCodeException, ValueError)):
         null_encoder.transform(null_ds).materialize()
     null_encoder.transform(nonnull_ds)
 
@@ -298,7 +299,7 @@ def test_one_hot_encoder():
     null_encoder.fit(nonnull_ds)
 
     # Verify transform fails for null values.
-    with pytest.raises(ValueError):
+    with pytest.raises((UserCodeException, ValueError)):
         null_encoder.transform(null_ds).materialize()
     null_encoder.transform(nonnull_ds)
 
@@ -407,7 +408,7 @@ def test_multi_hot_encoder():
     null_encoder.fit(nonnull_ds)
 
     # Verify transform fails for null values.
-    with pytest.raises(ValueError):
+    with pytest.raises((UserCodeException, ValueError)):
         null_encoder.transform(null_ds).materialize()
     null_encoder.transform(nonnull_ds)
 
@@ -529,7 +530,7 @@ def test_label_encoder():
     null_encoder.fit(nonnull_ds)
 
     # Verify transform fails for null values.
-    with pytest.raises(ValueError):
+    with pytest.raises((UserCodeException, ValueError)):
         null_encoder.transform(null_ds).materialize()
     null_encoder.transform(nonnull_ds)
 

--- a/python/ray/data/tests/preprocessors/test_torch.py
+++ b/python/ray/data/tests/preprocessors/test_torch.py
@@ -4,6 +4,7 @@ import torch
 from torchvision import transforms
 
 import ray
+from ray.data.exceptions import UserCodeException
 from ray.data.preprocessors import TorchVisionPreprocessor
 
 
@@ -115,7 +116,7 @@ class TestTorchVisionPreprocessor:
         transform = transforms.Lambda(lambda tensor: "BLAH BLAH INVALID")
         preprocessor = TorchVisionPreprocessor(columns=["image"], transform=transform)
 
-        with pytest.raises(ValueError):
+        with pytest.raises((UserCodeException, ValueError)):
             preprocessor.transform(dataset).materialize()
 
 

--- a/python/ray/data/tests/test_logger.py
+++ b/python/ray/data/tests/test_logger.py
@@ -2,11 +2,14 @@ import logging
 import os
 import re
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 
 import ray
 from ray.data._internal.dataset_logger import DatasetLogger
+from ray.data.exceptions import SystemException, UserCodeException
+from ray.exceptions import RayTaskError
 from ray.tests.conftest import *  # noqa
 
 
@@ -41,6 +44,89 @@ def test_dataset_logger(shutdown_only):
     assert logged_level == logging.getLevelName(logging.INFO)
     assert re.match(r"test_logger.py:\d+", logged_filepath)
     assert logged_msg == msg
+
+
+def check_full_stack_trace_logged_to_file():
+    # Checks that the prefix text for the full stack trace is present
+    # in the Ray Data log file.
+    log_path = ray.data.exceptions.data_exception_logger._datasets_log_path
+    with open(log_path, "r") as file:
+        data = file.read()
+        assert "Full stack trace:" in data
+
+
+def check_exception_text_logged_to_stdout(text, mock_calls):
+    # Checks that the exception text is present in the log output.
+    found_exception_call = False
+    for call_args in mock_calls:
+        if text in call_args.args[0]:
+            found_exception_call = True
+            break
+    assert found_exception_call, (
+        f"Searched logs for the following text, but did not find: `{text}` "
+        f"All calls: {mock_calls}"
+    )
+
+
+def test_omit_traceback_stdout_user_exception(ray_start_regular_shared):
+    def f(x):
+        1 / 0
+        return x
+
+    def run_with_patch():
+        with pytest.raises(UserCodeException) as exc_info:
+            ray.data.range(10).map(f).take_all()
+        return exc_info
+
+    with patch.object(logging.Logger, "error") as mock_logger:
+        exc_info = run_with_patch()
+
+        issubclass(exc_info.type, ZeroDivisionError)
+        issubclass(exc_info.type, RayTaskError)
+        issubclass(exc_info.type, UserCodeException)
+
+        check_exception_text_logged_to_stdout(
+            "Exception occurred in user code,", mock_logger.mock_calls
+        )
+
+    # To check the output log file, we need to run the code again without
+    # the logging method patched, so that the logger actually writes to the
+    # log file.
+    run_with_patch()
+    check_full_stack_trace_logged_to_file()
+
+
+def test_omit_traceback_stdout_system_exception(ray_start_regular_shared):
+    class FakeException(Exception):
+        pass
+
+    def run_with_patch():
+        with pytest.raises(FakeException) as exc_info:
+            with patch(
+                (
+                    "ray.data._internal.execution.legacy_compat."
+                    "get_legacy_lazy_block_list_read_only"
+                ),
+                side_effect=FakeException("fake exception"),
+            ):
+                ray.data.range(10).materialize()
+            assert issubclass(exc_info.type, FakeException)
+            assert issubclass(exc_info.type, SystemException)
+
+    # Mock `ExecutionPlan.execute()` to raise an exception, to emulate
+    # an error in internal Ray Data code.
+    with patch.object(logging.Logger, "error") as mock_logger:
+        run_with_patch()
+        check_exception_text_logged_to_stdout(
+            "Exception occurred in Ray Data or Ray Core internal code.",
+            mock_logger.mock_calls,
+        )
+
+    # To check the output log file, we need to run the code again without
+    # the logging method patched, so that the logger actually writes to the
+    # log file.
+    run_with_patch()
+    check_full_stack_trace_logged_to_file()
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -13,6 +13,7 @@ import pytest
 
 import ray
 from ray.data.context import DataContext
+from ray.data.exceptions import UserCodeException
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.test_util import ConcurrencyCounter  # noqa
 from ray.data.tests.util import column_udf, column_udf_class, extract_values
@@ -198,7 +199,7 @@ def test_concurrent_callable_classes(shutdown_only):
         def __call__(self, x):
             raise ValueError
 
-    with pytest.raises(ValueError):
+    with pytest.raises((UserCodeException, ValueError)):
         ds.map_batches(ErrorFn, concurrency=1, max_concurrency=2).take_all()
 
 
@@ -319,7 +320,7 @@ def test_drop_columns(ray_start_regular_shared, tmp_path):
             {"col3": 3}
         ]
         # Test dropping non-existent column
-        with pytest.raises(KeyError):
+        with pytest.raises((UserCodeException, KeyError)):
             ds.drop_columns(["dummy_col", "col1", "col2"]).materialize()
 
 
@@ -348,7 +349,7 @@ def test_select_columns(ray_start_regular_shared):
             "col2",
         ]
         # Test selecting a column that is not in the dataset schema
-        with pytest.raises(KeyError):
+        with pytest.raises((UserCodeException, KeyError)):
             each_ds.select_columns(cols=["col1", "col2", "dummy_col"]).materialize()
 
 
@@ -771,11 +772,17 @@ def test_map_batches_batch_zero_copy(
 
     # Apply UDF that mutates the batches, which should fail since the batch is
     # read-only.
-    with pytest.raises(ValueError, match="tried to mutate a zero-copy read-only batch"):
-        ds = ds.map_batches(
-            mutate, batch_format="pandas", batch_size=batch_size, zero_copy_batch=True
-        )
-        ds.materialize()
+    with pytest.raises(UserCodeException):
+        with pytest.raises(
+            ValueError, match="tried to mutate a zero-copy read-only batch"
+        ):
+            ds = ds.map_batches(
+                mutate,
+                batch_format="pandas",
+                batch_size=batch_size,
+                zero_copy_batch=True,
+            )
+            ds.materialize()
 
 
 BLOCK_BUNDLING_TEST_CASES = [

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -353,8 +353,9 @@ class RaySystemError(RayError):
 @DeveloperAPI
 class UserCodeException(RayError):
     """Indicates that an exception occurred while executing user code.
-    Used to catch user code exceptions which arise from executing
-    Ray Data code."""
+    For example, this exception can be used to wrap user code exceptions
+    from a remote task or actor. The `retry_exceptions` parameter will
+    still respect the underlying cause of this exception."""
 
     pass
 

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -350,6 +350,15 @@ class RaySystemError(RayError):
         return error_msg
 
 
+@DeveloperAPI
+class UserCodeException(RayError):
+    """Indicates that an exception occurred while executing user code.
+    Used to catch user code exceptions which arise from executing
+    Ray Data code."""
+
+    pass
+
+
 @PublicAPI
 class ObjectStoreFullError(RayError):
     """Indicates that the object store is full.


### PR DESCRIPTION
Reverts ray-project/ray#43638, adding changes from original PR https://github.com/ray-project/ray/pull/43251 with fix for breaking osx / windows tests.

Closes https://github.com/ray-project/ray/issues/40802

Postmerge test run: https://buildkite.com/ray-project/postmerge/builds/3306