### PR TITLE
[data] increase default interval for idle detection

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -283,7 +283,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         # The interval to detect idle operators.
         # When downstream is idle, we'll allow reading at least one task output
         # per this interval,
-        DETECTION_INTERVAL_S = 1.0
+        DETECTION_INTERVAL_S = 10.0
         # Print a warning if an operator is idle for this time.
         WARN_ON_IDLE_TIME_S = 60.0
         # Whether a warning has been printed.

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -373,11 +373,9 @@ def process_completed_tasks(
 
     # All active tasks, keyed by their waitables.
     active_tasks: Dict[Waitable, Tuple[OpState, OpTask]] = {}
-    first_task_index = defaultdict(lambda: float("inf"))
     for op, state in topology.items():
         for task in op.get_active_tasks():
             active_tasks[task.get_waitable()] = (state, task)
-            first_task_index[op] = min(first_task_index[op], task.task_index())
 
     max_bytes_to_read_per_op: Dict[OpState, int] = {}
     if resource_manager.op_resource_allocator_enabled():
@@ -406,9 +404,6 @@ def process_completed_tasks(
         ready_tasks_by_op = defaultdict(list)
         for ref in ready:
             state, task = active_tasks[ref]
-            if max_bytes_to_read_per_op.get(state, 0) == 1:
-                if task.task_index() != first_task_index[state.op]:
-                    continue
             ready_tasks_by_op[state].append(task)
 
         for state, ready_tasks in ready_tasks_by_op.items():

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -406,7 +406,7 @@ def process_completed_tasks(
         ready_tasks_by_op = defaultdict(list)
         for ref in ready:
             state, task = active_tasks[ref]
-            if max_bytes_to_read_per_op[state] == 1:
+            if max_bytes_to_read_per_op.get(state, 0) == 1:
                 if task.task_index() != first_task_index[state.op]:
                     continue
             ready_tasks_by_op[state].append(task)

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -373,9 +373,11 @@ def process_completed_tasks(
 
     # All active tasks, keyed by their waitables.
     active_tasks: Dict[Waitable, Tuple[OpState, OpTask]] = {}
+    first_task_index = defaultdict(lambda: float("inf"))
     for op, state in topology.items():
         for task in op.get_active_tasks():
             active_tasks[task.get_waitable()] = (state, task)
+            first_task_index[op] = min(first_task_index[op], task.task_index())
 
     max_bytes_to_read_per_op: Dict[OpState, int] = {}
     if resource_manager.op_resource_allocator_enabled():
@@ -404,6 +406,9 @@ def process_completed_tasks(
         ready_tasks_by_op = defaultdict(list)
         for ref in ready:
             state, task = active_tasks[ref]
+            if max_bytes_to_read_per_op[state] == 1:
+                if task.task_index() != first_task_index[state.op]:
+                    continue
             ready_tasks_by_op[state].append(task)
 
         for state, ready_tasks in ready_tasks_by_op.items():

--- a/python/ray/data/tests/test_backpressure_e2e.py
+++ b/python/ray/data/tests/test_backpressure_e2e.py
@@ -1,4 +1,5 @@
 import time
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -183,7 +184,13 @@ def test_no_deadlock_on_resource_contention(
         block_size=block_size,
         insert_limit_op=insert_limit_op,
     )
-    assert len(ds.take_all()) == num_blocks
+
+    with patch.object(
+        ray.data._internal.execution.resource_manager.ReservationOpResourceAllocator.IdleDetector,
+        "DETECTION_INTERVAL_S",
+        0.1,
+    ):
+        assert len(ds.take_all()) == num_blocks
 
 
 def test_no_deadlock_with_preserve_order(

--- a/python/ray/data/tests/test_backpressure_e2e.py
+++ b/python/ray/data/tests/test_backpressure_e2e.py
@@ -185,8 +185,9 @@ def test_no_deadlock_on_resource_contention(
         insert_limit_op=insert_limit_op,
     )
 
-    from ray.data._internal.execution.resource_manager import \
-        ReservationOpResourceAllocator
+    from ray.data._internal.execution.resource_manager import (
+        ReservationOpResourceAllocator,
+    )
 
     with patch.object(
         ReservationOpResourceAllocator.IdleDetector,

--- a/python/ray/data/tests/test_backpressure_e2e.py
+++ b/python/ray/data/tests/test_backpressure_e2e.py
@@ -185,8 +185,11 @@ def test_no_deadlock_on_resource_contention(
         insert_limit_op=insert_limit_op,
     )
 
+    from ray.data._internal.execution.resource_manager import \
+        ReservationOpResourceAllocator
+
     with patch.object(
-        ray.data._internal.execution.resource_manager.ReservationOpResourceAllocator.IdleDetector,
+        ReservationOpResourceAllocator.IdleDetector,
         "DETECTION_INTERVAL_S",
         0.1,
     ):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This idle detection is used to deal with the resource contention issue. Previously, we allow pulling one block per second. This is too aggressive and will cause exceeded memory usage. Change the default interval to 10 seconds. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
