### PR TITLE
[ci] add stability tag to test failure issues

### DIFF
--- a/release/ray_release/test_automation/ci_state_machine.py
+++ b/release/ray_release/test_automation/ci_state_machine.py
@@ -61,6 +61,7 @@ class CITestStateMachine(TestStateMachine):
             "ci-test",
             "ray-test-bot",
             "flaky-tracker",
+            "stability",
             "triage",
             self.test.get_oncall(),
             WEEKLY_RELEASE_BLOCKER_TAG,

--- a/release/ray_release/test_automation/release_state_machine.py
+++ b/release/ray_release/test_automation/release_state_machine.py
@@ -70,6 +70,7 @@ class ReleaseTestStateMachine(TestStateMachine):
             "bug",
             "release-test",
             "ray-test-bot",
+            "stability",
             "triage",
             self.test.get_oncall(),
         ]


### PR DESCRIPTION
Add 'stability' to test failure issues, as requested by Sam

Test:
- CI