### PR TITLE
[Data] Fix `read_parquet_benchmark_single_node` by update `parallelism` -> `override_num_blocks`

### DIFF
--- a/release/nightly_tests/dataset/read_parquet_benchmark.py
+++ b/release/nightly_tests/dataset/read_parquet_benchmark.py
@@ -6,34 +6,36 @@ from parquet_data_generator import generate_data
 
 import shutil
 import tempfile
+from typing import Optional
 
 
 def read_parquet(
     root: str,
-    parallelism: int = -1,
+    override_num_blocks: Optional[int] = None,
     use_threads: bool = False,
     filter=None,
     columns=None,
 ) -> Dataset:
     return ray.data.read_parquet(
         paths=root,
-        override_num_blocks=parallelism,
+        override_num_blocks=override_num_blocks,
         use_threads=use_threads,
         filter=filter,
         columns=columns,
-    ).materialize()
+    )
 
 
 def run_read_parquet_benchmark(benchmark: Benchmark):
-    # Test with different parallelism (multi-processing for single node) and threading.
-    for parallelism in [1, 2, 4]:
+    # Test with different override_num_blocks (multi-processing for single node)
+    # and threading.
+    for override_num_blocks in [1, 2, 4]:
         for use_threads in [True, False]:
-            test_name = f"read-parquet-downsampled-nyc-taxi-2009-{parallelism}-{use_threads}"  # noqa: E501
+            test_name = f"read-parquet-downsampled-nyc-taxi-2009-{override_num_blocks}-{use_threads}"  # noqa: E501
             benchmark.run_materialize_ds(
                 test_name,
                 read_parquet,
                 root="s3://anonymous@air-example-data/ursa-labs-taxi-data/downsampled_2009_full_year_data.parquet",  # noqa: E501
-                override_num_blocks=parallelism,
+                override_num_blocks=override_num_blocks,
                 use_threads=use_threads,
             )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Continuation of https://github.com/ray-project/ray/pull/43692, update release test code with remaining needed changes for replacing `parallelism` parameter with `override_num_blocks`.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/43745

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests https://buildkite.com/ray-project/release/builds/10649
   - [ ] This PR is not tested :(
