### PR TITLE
[serve] Restructure dsm update

### DIFF
--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -535,7 +535,7 @@ class DeploymentScheduler(ABC):
         scheduling_request.on_scheduled(actor_handle, placement_group=placement_group)
 
     @abstractmethod
-    def detect_compact_opportunities(self) -> Tuple[Optional[str], Optional[float]]:
+    def detect_compact_opportunities(self) -> Optional[Tuple[str, float]]:
         """Returns a node ID to be compacted and a compaction deadlne."""
         raise NotImplementedError
 
@@ -707,5 +707,5 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
         if chosen_node:
             return chosen_node
 
-    def detect_compact_opportunities(self) -> Tuple[Optional[str], Optional[float]]:
-        return None, None
+    def detect_compact_opportunities(self) -> Optional[Tuple[str, float]]:
+        return None


### PR DESCRIPTION
[serve] Restructure dsm update

Remove `DeploymentState.update` and instead call `check_and_update_replicas`, `migrate_replicas_on_draining_nodes`, `scale_deployment_replicas`, `check_curr_status` inside `DeploymentStateManager.update`.

Before, we would make these calls a, b, c, a, b, c, etc. for each deployment. However `migrate_replicas_on_draining_nodes` (and potentially other tasks in the future) needs to observe the full cluster state (of all deployments) _after_ all `check_and_update_replicas` have been called. So now we need to switch the order to a, a, a, b, b, b, c, c, c, etc.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
