### PR TITLE
[Data] Decrease batch size for Torch batch inference release test

### DIFF
--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -43,7 +43,7 @@ def main(args):
     print(f"Running GPU batch prediction with data from {data_url}")
 
     # Largest batch that can fit on a T4.
-    BATCH_SIZE = 1000
+    BATCH_SIZE = 900
 
     device = "cpu" if smoke_test else "cuda"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The Torch batch inference 10TB test occasionally fails due to CUDA OOM errors. This issue is probably due to the batch size being too high, rather than due to an issue with Ray Data itself. To reduce the flakiness, this PR decreases the batch size by 10%. 

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/43732

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
