### PR TITLE
[Data] Remove `ConsumptionAPI` label from `Dataset.stats()`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4568,7 +4568,6 @@ class Dataset:
         output._set_uuid(copy._get_uuid())
         return output
 
-    @ConsumptionAPI(pattern="timing information.", insert_after=True)
     def stats(self) -> str:
         """Returns a string containing execution timing information.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Update current usages of `ConsumptionAPI`, found the only one to update is the removal from `Dataset.stats()` method.

[After](https://anyscale-ray--43766.com.readthedocs.build/en/43766/data/api/doc/ray.data.Dataset.stats.html#ray-data-dataset-stats):
![Screenshot at Mar 06 18-10-55](https://github.com/ray-project/ray/assets/5122851/2d2c7630-aeef-4f21-8ef6-489bd35a8d2b)


## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/42183

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
