### PR TITLE
[Serve] fix test_logging failing on python 3.11

### DIFF
--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -500,7 +500,7 @@ def get_component_log_file_name(
     # instead of adding the component type to the component name.
     component_log_file_name = component_name
     if component_type is not None:
-        component_log_file_name = f"{component_type}_{component_name}"
+        component_log_file_name = f"{component_type.value}_{component_name}"
         if component_type != ServeComponentType.REPLICA:
             component_name = f"{component_type}_{component_name}"
     log_file_name = LOG_FILE_FMT.format(

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -711,6 +711,7 @@ def test_logging_disable_stdout(serve_and_ray_shutdown, ray_instance, tmp_dir):
     direct_from_stdout = False
     direct_from_stderr = False
     multiline_log = False
+    structured_logs = []
     for log_file in os.listdir(logs_dir):
         if log_file.startswith("replica_default_disable_stdout"):
             with open(logs_dir / log_file) as f:
@@ -742,12 +743,16 @@ def test_logging_disable_stdout(serve_and_ray_shutdown, ray_instance, tmp_dir):
                         and contain_logging_prefix(_message)
                     ):
                         multiline_log = True
-    assert from_serve_logger_check
-    assert from_print_check
-    assert from_error_check
-    assert direct_from_stdout
-    assert direct_from_stderr
-    assert multiline_log
+                    structured_logs.append(structured_log)
+    all_checks = [
+        from_serve_logger_check,
+        from_print_check,
+        from_error_check,
+        direct_from_stdout,
+        direct_from_stderr,
+        multiline_log,
+    ]
+    assert all(all_checks), structured_logs
 
 
 def test_stream_to_logger():

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -751,6 +751,7 @@ def test_logging_disable_stdout(serve_and_ray_shutdown, ray_instance, tmp_dir):
     assert multiline_log
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Fail to look for temp dir.")
 def test_serve_logging_file_names(serve_and_ray_shutdown, ray_instance):
     """Test to ensure the log file names are correct."""
     logs_dir = Path("/tmp/ray/session_latest/logs/serve")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There is a breaking change in Python 3.11 with string enum getting interpolated to "ServeComponentType.REPLICA" rather than the underlaying value of "replica". Fixes the file name and added a test to ensure serve's log files have correct naming.  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
