### PR TITLE
[KubeRay] [Doc] [Clusters] Fix RayCluster quickstart and VM quickstart for mac

### DIFF
--- a/doc/source/cluster/doc_code/simple-trainer.py
+++ b/doc/source/cluster/doc_code/simple-trainer.py
@@ -19,7 +19,7 @@ print(ray.nodes())
 @ray.remote
 def f():
     time.sleep(1)
-    return socket.gethostbyname('localhost')
+    return socket.gethostbyname("localhost")
 
 
 # The following takes one second (assuming that

--- a/doc/source/cluster/doc_code/simple-trainer.py
+++ b/doc/source/cluster/doc_code/simple-trainer.py
@@ -19,7 +19,7 @@ print(ray.nodes())
 @ray.remote
 def f():
     time.sleep(1)
-    return socket.gethostbyname(socket.gethostname())
+    return socket.gethostbyname('localhost')
 
 
 # The following takes one second (assuming that

--- a/doc/source/cluster/kubernetes/getting-started/raycluster-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycluster-quick-start.md
@@ -41,10 +41,26 @@ KubeRay offers multiple options for operator installations, such as Helm, Kustom
 
 Once the KubeRay operator is running, we are ready to deploy a RayCluster. To do so, we create a RayCluster Custom Resource (CR) in the `default` namespace.
 
-```sh
-# Deploy a sample RayCluster CR from the KubeRay Helm chart repo:
-helm install raycluster kuberay/ray-cluster --version 1.1.0-rc.0
+  ::::{tab-set}
 
+  :::{tab-item} ARM64 (Apple Silicon)
+  ```sh
+  # Deploy a sample RayCluster CR from the KubeRay Helm chart repo:
+  helm install raycluster kuberay/ray-cluster --version 1.1.0-rc.0 --set 'image.tag=2.9.0-aarch64'
+  ```
+  :::
+
+  :::{tab-item} x86-64 (Intel/Linux)
+  ```sh
+  # Deploy a sample RayCluster CR from the KubeRay Helm chart repo:
+  helm install raycluster kuberay/ray-cluster --version 1.1.0-rc.0
+  ```
+  :::
+
+  ::::
+
+
+```sh
 # Once the RayCluster CR has been created, you can view it by running:
 kubectl get rayclusters
 

--- a/doc/source/cluster/vms/getting-started.rst
+++ b/doc/source/cluster/vms/getting-started.rst
@@ -142,7 +142,7 @@ We will write a simple Python application that tracks the IP addresses of the ma
     def f():
         time.sleep(0.001)
         # Return IP address.
-        return socket.gethostbyname('localhost')
+        return socket.gethostbyname("localhost")
 
     ip_addresses = [f() for _ in range(10000)]
     print(Counter(ip_addresses))
@@ -165,7 +165,7 @@ With some small changes, we can make this application run on Ray (for more infor
     def f():
         time.sleep(0.001)
         # Return IP address.
-        return socket.gethostbyname('localhost')
+        return socket.gethostbyname("localhost")
 
     object_ids = [f.remote() for _ in range(10000)]
     ip_addresses = ray.get(object_ids)
@@ -192,7 +192,7 @@ Finally, let's add some code to make the output more interesting:
     def f():
         time.sleep(0.001)
         # Return IP address.
-        return socket.gethostbyname('localhost')
+        return socket.gethostbyname("localhost")
 
     object_ids = [f.remote() for _ in range(10000)]
     ip_addresses = ray.get(object_ids)

--- a/doc/source/cluster/vms/getting-started.rst
+++ b/doc/source/cluster/vms/getting-started.rst
@@ -142,7 +142,7 @@ We will write a simple Python application that tracks the IP addresses of the ma
     def f():
         time.sleep(0.001)
         # Return IP address.
-        return socket.gethostbyname(socket.gethostname())
+        return socket.gethostbyname('localhost')
 
     ip_addresses = [f() for _ in range(10000)]
     print(Counter(ip_addresses))
@@ -165,7 +165,7 @@ With some small changes, we can make this application run on Ray (for more infor
     def f():
         time.sleep(0.001)
         # Return IP address.
-        return socket.gethostbyname(socket.gethostname())
+        return socket.gethostbyname('localhost')
 
     object_ids = [f.remote() for _ in range(10000)]
     ip_addresses = ray.get(object_ids)
@@ -192,7 +192,7 @@ Finally, let's add some code to make the output more interesting:
     def f():
         time.sleep(0.001)
         # Return IP address.
-        return socket.gethostbyname(socket.gethostname())
+        return socket.gethostbyname('localhost')
 
     object_ids = [f.remote() for _ in range(10000)]
     ip_addresses = ray.get(object_ids)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
The KubeRay RayCluster quickstart didn't work out of the box for Apple silicon macs (M1, M2, etc).  This PR fixes it by adding an alternative instruction to use the `-aarch64` image.

The code snippet `socket.gethostbyname(socket.gethostname())` in the VM cluster quickstart didn't work for newer Mac OS versions; see the linked issue for full details.  This PR fixes the issue by using `socket.gethostbyname("localhost")` instead.

Thanks to @darktempla for diagnosing the issue and providing the fix!
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/42964
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
