### PR TITLE
[data] fix env var for enabling resource reservation

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -3,7 +3,7 @@ import threading
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import ray
-from ray._private.ray_constants import env_integer
+from ray._private.ray_constants import env_integer, env_bool
 from ray.util.annotations import DeveloperAPI
 from ray.util.scheduling_strategies import SchedulingStrategyT
 
@@ -144,8 +144,8 @@ DEFAULT_WRITE_FILE_RETRY_ON_ERRORS = [
 DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS = False
 
 # Whether to enable ReservationOpResourceAllocator by default.
-DEFAULT_ENABLE_OP_RESOURCE_RESERVATION = bool(
-    os.environ.get("RAY_DATA_ENABLE_OP_RESOURCE_RESERVATION", "1")
+DEFAULT_ENABLE_OP_RESOURCE_RESERVATION = env_bool(
+    "RAY_DATA_ENABLE_OP_RESOURCE_RESERVATION", True
 )
 
 # The default reservation ratio for ReservationOpResourceAllocator.

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -3,7 +3,7 @@ import threading
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import ray
-from ray._private.ray_constants import env_integer, env_bool
+from ray._private.ray_constants import env_bool, env_integer
 from ray.util.annotations import DeveloperAPI
 from ray.util.scheduling_strategies import SchedulingStrategyT
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix the issue that the `RAY_DATA_ENABLE_OP_RESOURCE_RESERVATION` env var doesn't work. Because `bool("0")` returns `True`. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
