### PR TITLE
[serve] change detect compact opportunities interface

### DIFF
--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -535,7 +535,9 @@ class DeploymentScheduler(ABC):
         scheduling_request.on_scheduled(actor_handle, placement_group=placement_group)
 
     @abstractmethod
-    def detect_compact_opportunities(self) -> Optional[Tuple[str, float]]:
+    def get_node_to_compact(
+        self, allow_new_compaction: bool
+    ) -> Optional[Tuple[str, float]]:
         """Returns a node ID to be compacted and a compaction deadlne."""
         raise NotImplementedError
 
@@ -707,5 +709,7 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
         if chosen_node:
             return chosen_node
 
-    def detect_compact_opportunities(self) -> Optional[Tuple[str, float]]:
+    def get_node_to_compact(
+        self, allow_new_compaction: bool
+    ) -> Optional[Tuple[str, float]]:
         return None

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2223,12 +2223,11 @@ class DeploymentState:
 
         # Stop replicas whose deadline is up
         for replica in replicas:
+            assert replica.actor_node_id in deadlines
+
             curr_timestamp_ms = time.time() * 1000
             timeout_ms = replica._actor.graceful_shutdown_timeout_s * 1000
-            if (
-                replica.actor_node_id in deadlines
-                and curr_timestamp_ms >= deadlines[replica.actor_node_id] - timeout_ms
-            ):
+            if curr_timestamp_ms >= deadlines[replica.actor_node_id] - timeout_ms:
                 to_stop.append(replica)
             else:
                 remaining.append(replica)
@@ -2236,13 +2235,6 @@ class DeploymentState:
         # Stop excess PENDING_MIGRATION replicas when new "replacement"
         # replicas have transitioned to RUNNING. The replicas with the
         # earliest deadlines should be chosen greedily.
-        def order(deadline: int):
-            if deadline:
-                return deadline
-            else:
-                return float("inf")
-
-        # remaining.sort(key=lambda r: order(deadlines[r.actor_node_id]))
         remaining.sort(key=lambda r: deadlines[r.actor_node_id])
         num_excess = min_replicas_to_stop - len(to_stop)
 
@@ -2253,6 +2245,17 @@ class DeploymentState:
         return to_stop, remaining
 
     def migrate_replicas_on_draining_nodes(self, draining_nodes: Dict[str, int]):
+        # Move replicas back to running if they are no longer on a draining node.
+        # If this causes the number of replicas to exceed the target state,
+        # they will be scaled down because `scale_deployment_replicas` is called on
+        # each deployment after this
+        for replica in self._replicas.pop(states=[ReplicaState.PENDING_MIGRATION]):
+            if replica.actor_node_id not in draining_nodes:
+                self._replicas.add(ReplicaState.RUNNING, replica)
+            else:
+                self._replicas.add(ReplicaState.PENDING_MIGRATION, replica)
+
+        # Migrate replicas on draining nodes
         for replica in self._replicas.pop(
             states=[ReplicaState.UPDATING, ReplicaState.RUNNING, ReplicaState.STARTING]
         ):
@@ -2260,6 +2263,11 @@ class DeploymentState:
                 # For RUNNING replicas, migrate them safely by starting
                 # a replacement replica first.
                 if replica.actor_details.state == ReplicaState.RUNNING:
+                    logger.info(
+                        f"Migrating {replica.replica_id} from draining node "
+                        f"'{replica.actor_node_id}'. A new replica will be created on "
+                        "another node."
+                    )
                     self._replicas.add(ReplicaState.PENDING_MIGRATION, replica)
                 # For replicas that are STARTING or UPDATING, might as
                 # well terminate them immediately to allow replacement
@@ -2706,7 +2714,8 @@ class DeploymentStateManager:
             deployment_state.check_curr_status()
 
         # STEP 3: Drain nodes
-        allow_active_compaction = all(
+        draining_nodes = self._cluster_node_info_cache.get_draining_nodes()
+        allow_new_compaction = len(draining_nodes) == 0 and all(
             ds.curr_status_info.status == DeploymentStatus.HEALTHY
             # TODO(zcin): Make sure that status should never be healthy if
             # the number of running replicas at target version is not at
@@ -2717,16 +2726,16 @@ class DeploymentStateManager:
             and len(ds._replicas.get()) == ds.target_num_replicas
             for ds in self._deployment_states.values()
         )
-        draining_nodes = self._cluster_node_info_cache.get_draining_nodes()
-        if (
-            not draining_nodes
-            and RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY
-            and allow_active_compaction
-        ):
-            compact_opp = self._deployment_scheduler.detect_compact_opportunities()
-            if compact_opp:
-                node, deadline = compact_opp
-                draining_nodes = {node: deadline}
+        if RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY:
+            # Tuple of target node to compact, and its draining deadline
+            node_info: Optional[
+                Tuple[str, float]
+            ] = self._deployment_scheduler.get_node_to_compact(
+                allow_new_compaction=allow_new_compaction
+            )
+            if node_info:
+                target_node_id, deadline = node_info
+                draining_nodes = {target_node_id: deadline}
 
         for deployment_id, deployment_state in self._deployment_states.items():
             deployment_state.migrate_replicas_on_draining_nodes(draining_nodes)

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import threading
 import time
-from copy import deepcopy
+from copy import copy, deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import grpc
@@ -135,6 +135,44 @@ class MockClusterNodeInfoCache:
         self.available_resources_per_node[node_id] = deepcopy(resources)
 
 
+class MockActorHandle:
+    def __init__(self, **kwargs):
+        self._options = kwargs
+
+
+class MockActorClass:
+    def __init__(self):
+        self._init_args = ()
+        self._options = dict()
+
+    def options(self, **kwargs):
+        res = copy(self)
+
+        for k, v in kwargs.items():
+            res._options[k] = v
+
+        return res
+
+    def remote(self, *args) -> MockActorHandle:
+        return MockActorHandle(init_args=args, **self._options)
+
+
+class MockPlacementGroup:
+    def __init__(
+        self,
+        bundles: List[Dict[str, float]],
+        strategy: str = "PACK",
+        name: str = "",
+        lifetime: Optional[str] = None,
+        _soft_target_node_id: Optional[str] = None,
+    ):
+        self._bundles = bundles
+        self._strategy = strategy
+        self._name = name
+        self._lifetime = lifetime
+        self._soft_target_node_id = _soft_target_node_id
+
+
 def check_ray_stopped():
     try:
         requests.get("http://localhost:52365/api/ray/version")
@@ -163,8 +201,10 @@ def check_telemetry_not_recorded(storage_handle, key):
     )
 
 
-def check_deployment_status(name, expected_status) -> DeploymentStatus:
-    app_status = serve.status().applications[SERVE_DEFAULT_APP_NAME]
+def check_deployment_status(
+    name: str, expected_status: DeploymentStatus, app_name=SERVE_DEFAULT_APP_NAME
+) -> bool:
+    app_status = serve.status().applications[app_name]
     assert app_status.deployments[name].status == expected_status
     return True
 

--- a/python/ray/serve/tests/unit/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/unit/test_deployment_scheduler.py
@@ -1,7 +1,6 @@
 import random
 import sys
-from copy import copy
-from typing import Dict, List, Optional
+from typing import List
 from unittest.mock import Mock
 
 import pytest
@@ -18,7 +17,11 @@ from ray.serve._private.deployment_scheduler import (
     Resources,
     SpreadDeploymentSchedulingPolicy,
 )
-from ray.serve._private.test_utils import MockClusterNodeInfoCache
+from ray.serve._private.test_utils import (
+    MockActorClass,
+    MockClusterNodeInfoCache,
+    MockPlacementGroup,
+)
 from ray.tests.conftest import *  # noqa
 from ray.util.scheduling_strategies import (
     NodeAffinitySchedulingStrategy,
@@ -28,44 +31,6 @@ from ray.util.scheduling_strategies import (
 
 def dummy():
     pass
-
-
-class MockActorHandle:
-    def __init__(self, **kwargs):
-        self._options = kwargs
-
-
-class MockActorClass:
-    def __init__(self):
-        self._init_args = ()
-        self._options = dict()
-
-    def options(self, **kwargs):
-        res = copy(self)
-
-        for k, v in kwargs.items():
-            res._options[k] = v
-
-        return res
-
-    def remote(self, *args) -> MockActorHandle:
-        return MockActorHandle(init_args=args, **self._options)
-
-
-class MockPlacementGroup:
-    def __init__(
-        self,
-        bundles: List[Dict[str, float]],
-        strategy: str = "PACK",
-        name: str = "",
-        lifetime: Optional[str] = None,
-        _soft_target_node_id: Optional[str] = None,
-    ):
-        self._bundles = bundles
-        self._strategy = strategy
-        self._name = name
-        self._lifetime = lifetime
-        self._soft_target_node_id = _soft_target_node_id
 
 
 def get_random_resources(n: int) -> List[Resources]:

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -277,6 +277,7 @@ def deployment_info(
     version: Optional[str] = None,
     num_replicas: Optional[int] = 1,
     user_config: Optional[Any] = None,
+    replica_config: Optional[ReplicaConfig] = None,
     **config_opts,
 ) -> Tuple[DeploymentInfo, DeploymentVersion]:
     info = DeploymentInfo(
@@ -285,7 +286,7 @@ def deployment_info(
         deployment_config=DeploymentConfig(
             num_replicas=num_replicas, user_config=user_config, **config_opts
         ),
-        replica_config=ReplicaConfig.create(lambda x: x),
+        replica_config=replica_config or ReplicaConfig.create(lambda x: x),
         deployer_job_id="",
     )
 


### PR DESCRIPTION
[serve] change detect compact opportunities interface

Change interface of `detect_compact_opportunities`.
The parameter `allow_active_compaction` will be used to disable **new** node compaction, but if there is a node compaction *currently in progress* we need to fetch it from `detect_compact_opportunities`.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
