### PR TITLE
[Serve] [Dashboard] Add serve controller metrics to serve system dashboard page

### DIFF
--- a/dashboard/client/src/pages/serve/ServeDeploymentsListPage.tsx
+++ b/dashboard/client/src/pages/serve/ServeDeploymentsListPage.tsx
@@ -20,7 +20,10 @@ import { HelpInfo } from "../../components/Tooltip";
 import { useServeDeployments } from "./hook/useServeApplications";
 import { ServeApplicationRows } from "./ServeApplicationRow";
 import { ServeEntityLogViewer } from "./ServeEntityLogViewer";
-import { ServeMetricsSection } from "./ServeMetricsSection";
+import {
+  APPS_METRICS_CONFIG,
+  ServeMetricsSection,
+} from "./ServeMetricsSection";
 import { ServeSystemPreview } from "./ServeSystemDetails";
 
 const useStyles = makeStyles((theme) =>
@@ -172,7 +175,10 @@ export const ServeDeploymentsListPage = () => {
           </CollapsibleSection>
         </React.Fragment>
       )}
-      <ServeMetricsSection className={classes.section} />
+      <ServeMetricsSection
+        className={classes.section}
+        metricsConfig={APPS_METRICS_CONFIG}
+      />
     </div>
   );
 };

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
@@ -73,8 +73,8 @@ describe("ServeMetricsSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders system metrics", async () => {
-    expect.assertions(5);
+  it("renders serve system metrics", async () => {
+    expect.assertions(7);
 
     render(
       <ServeMetricsSection metricsConfig={SERVE_SYSTEM_METRICS_CONFIG} />,
@@ -84,7 +84,7 @@ describe("ServeMetricsSection", () => {
     );
     await screen.findByText(/View in Grafana/);
     expect(screen.getByTitle("Ongoing HTTP Requests")).toBeInTheDocument();
-    expect(screen.getByTitle("Controller Starts")).toBeInTheDocument();
+    expect(screen.getByTitle("Ongoing gRPC Requests")).toBeInTheDocument();
     expect(screen.getByTitle("Scheduling Tasks")).toBeInTheDocument();
     expect(
       screen.getByTitle("Scheduling Tasks in Backoff"),
@@ -92,6 +92,7 @@ describe("ServeMetricsSection", () => {
     expect(
       screen.getByTitle("Controller Control Loop Duration"),
     ).toBeInTheDocument();
+    expect(screen.getByTitle("Number of Control Loops")).toBeInTheDocument();
   });
 
   it("renders nothing when grafana is not available", async () => {

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
@@ -74,7 +74,7 @@ describe("ServeMetricsSection", () => {
   });
 
   it("renders serve system metrics", async () => {
-    expect.assertions(7);
+    expect.assertions(6);
 
     render(
       <ServeMetricsSection metricsConfig={SERVE_SYSTEM_METRICS_CONFIG} />,

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
@@ -3,8 +3,8 @@ import React, { PropsWithChildren } from "react";
 import { GlobalContext } from "../../App";
 import {
   APPS_METRICS_CONFIG,
-  ServeMetricsSection,
   SERVE_SYSTEM_METRICS_CONFIG,
+  ServeMetricsSection,
 } from "./ServeMetricsSection";
 
 const Wrapper = ({ children }: PropsWithChildren<{}>) => {
@@ -76,9 +76,12 @@ describe("ServeMetricsSection", () => {
   it("renders system metrics", async () => {
     expect.assertions(5);
 
-    render(<ServeMetricsSection metricsConfig={SERVE_SYSTEM_METRICS_CONFIG} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <ServeMetricsSection metricsConfig={SERVE_SYSTEM_METRICS_CONFIG} />,
+      {
+        wrapper: Wrapper,
+      },
+    );
     await screen.findByText(/View in Grafana/);
     expect(screen.getByTitle("Ongoing HTTP Requests")).toBeInTheDocument();
     expect(screen.getByTitle("Controller Starts")).toBeInTheDocument();

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
@@ -4,7 +4,7 @@ import { GlobalContext } from "../../App";
 import {
   APPS_METRICS_CONFIG,
   ServeMetricsSection,
-  SYSTEM_METRICS_CONFIG,
+  SERVE_SYSTEM_METRICS_CONFIG,
 } from "./ServeMetricsSection";
 
 const Wrapper = ({ children }: PropsWithChildren<{}>) => {
@@ -76,7 +76,7 @@ describe("ServeMetricsSection", () => {
   it("renders system metrics", async () => {
     expect.assertions(5);
 
-    render(<ServeMetricsSection metricsConfig={SYSTEM_METRICS_CONFIG} />, {
+    render(<ServeMetricsSection metricsConfig={SERVE_SYSTEM_METRICS_CONFIG} />, {
       wrapper: Wrapper,
     });
     await screen.findByText(/View in Grafana/);

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import React, { PropsWithChildren } from "react";
 import { GlobalContext } from "../../App";
-import { ServeMetricsSection } from "./ServeMetricsSection";
+import {
+  APPS_METRICS_CONFIG,
+  ServeMetricsSection,
+  SYSTEM_METRICS_CONFIG,
+} from "./ServeMetricsSection";
 
 const Wrapper = ({ children }: PropsWithChildren<{}>) => {
   return (
@@ -54,10 +58,12 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
 };
 
 describe("ServeMetricsSection", () => {
-  it("renders", async () => {
+  it("renders app metrics", async () => {
     expect.assertions(4);
 
-    render(<ServeMetricsSection />, { wrapper: Wrapper });
+    render(<ServeMetricsSection metricsConfig={APPS_METRICS_CONFIG} />, {
+      wrapper: Wrapper,
+    });
     await screen.findByText(/View in Grafana/);
     expect(screen.getByText(/5 minutes/)).toBeVisible();
     expect(screen.getByTitle("QPS per application")).toBeInTheDocument();
@@ -67,10 +73,30 @@ describe("ServeMetricsSection", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders system metrics", async () => {
+    expect.assertions(5);
+
+    render(<ServeMetricsSection metricsConfig={SYSTEM_METRICS_CONFIG} />, {
+      wrapper: Wrapper,
+    });
+    await screen.findByText(/View in Grafana/);
+    expect(screen.getByTitle("Ongoing HTTP Requests")).toBeInTheDocument();
+    expect(screen.getByTitle("Controller Starts")).toBeInTheDocument();
+    expect(screen.getByTitle("Scheduling Tasks")).toBeInTheDocument();
+    expect(
+      screen.getByTitle("Scheduling Tasks in Backoff"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTitle("Controller Control Loop Duration"),
+    ).toBeInTheDocument();
+  });
+
   it("renders nothing when grafana is not available", async () => {
     expect.assertions(5);
 
-    render(<ServeMetricsSection />, { wrapper: MetricsDisabledWrapper });
+    render(<ServeMetricsSection metricsConfig={APPS_METRICS_CONFIG} />, {
+      wrapper: MetricsDisabledWrapper,
+    });
     // Wait .1 seconds for render to finish
     await waitFor(() => new Promise((r) => setTimeout(r, 100)));
 

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -98,7 +98,7 @@ export const SERVE_SYSTEM_METRICS_CONFIG: MetricConfig[] = [
     pathParams: "orgId=1&theme=light&panelId=24",
   },
   {
-    title: "Controller Starts",
+    title: "Number of Control Loops",
     pathParams: "orgId=1&theme=light&panelId=25",
   },
 ];

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -101,10 +101,6 @@ export const SERVE_SYSTEM_METRICS_CONFIG: MetricConfig[] = [
     title: "Controller Starts",
     pathParams: "orgId=1&theme=light&panelId=25",
   },
-  {
-    title: "Number of Control Loops",
-    pathParams: "orgId=1&theme=light&panelId=26",
-  },
 ];
 
 type ServeMetricsSectionProps = ClassNameProps & {

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -82,7 +82,7 @@ export const SERVE_SYSTEM_METRICS_CONFIG: MetricConfig[] = [
     pathParams: "orgId=1&theme=light&panelId=20",
   },
   {
-    title: "Controller Starts",
+    title: "Ongoing gRPC Requests",
     pathParams: "orgId=1&theme=light&panelId=21",
   },
   {
@@ -96,6 +96,14 @@ export const SERVE_SYSTEM_METRICS_CONFIG: MetricConfig[] = [
   {
     title: "Controller Control Loop Duration",
     pathParams: "orgId=1&theme=light&panelId=24",
+  },
+  {
+    title: "Controller Starts",
+    pathParams: "orgId=1&theme=light&panelId=25",
+  },
+  {
+    title: "Number of Control Loops",
+    pathParams: "orgId=1&theme=light&panelId=26",
   },
 ];
 

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -76,7 +76,7 @@ export const APPS_METRICS_CONFIG: MetricConfig[] = [
 ];
 
 // NOTE: please keep the titles here in sync with dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
-export const SYSTEM_METRICS_CONFIG: MetricConfig[] = [
+export const SERVE_SYSTEM_METRICS_CONFIG: MetricConfig[] = [
   {
     title: "Ongoing HTTP Requests",
     pathParams: "orgId=1&theme=light&panelId=20",

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -60,7 +60,7 @@ const useStyles = makeStyles((theme) =>
 );
 
 // NOTE: please keep the titles here in sync with dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
-const METRICS_CONFIG: MetricConfig[] = [
+export const APPS_METRICS_CONFIG: MetricConfig[] = [
   {
     title: "QPS per application",
     pathParams: "orgId=1&theme=light&panelId=7",
@@ -75,11 +75,39 @@ const METRICS_CONFIG: MetricConfig[] = [
   },
 ];
 
-type ServeMetricsSectionProps = ClassNameProps;
+// NOTE: please keep the titles here in sync with dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
+export const SYSTEM_METRICS_CONFIG: MetricConfig[] = [
+  {
+    title: "Ongoing HTTP Requests",
+    pathParams: "orgId=1&theme=light&panelId=20",
+  },
+  {
+    title: "Controller Starts",
+    pathParams: "orgId=1&theme=light&panelId=21",
+  },
+  {
+    title: "Scheduling Tasks",
+    pathParams: "orgId=1&theme=light&panelId=22",
+  },
+  {
+    title: "Scheduling Tasks in Backoff",
+    pathParams: "orgId=1&theme=light&panelId=23",
+  },
+  {
+    title: "Controller Control Loop Duration",
+    pathParams: "orgId=1&theme=light&panelId=24",
+  },
+];
+
+type ServeMetricsSectionProps = ClassNameProps & {
+  metricsConfig: MetricConfig[];
+};
 
 export const ServeMetricsSection = ({
   className,
+  metricsConfig,
 }: ServeMetricsSectionProps) => {
+  console.log(metricsConfig);
   const classes = useStyles();
   const { grafanaHost, prometheusHealth, dashboardUids, dashboardDatasource } =
     useContext(GlobalContext);
@@ -131,7 +159,7 @@ export const ServeMetricsSection = ({
           </TextField>
         </Paper>
         <div className={classes.grafanaEmbedsContainer}>
-          {METRICS_CONFIG.map(({ title, pathParams }) => {
+          {metricsConfig.map(({ title, pathParams }) => {
             const path =
               `/d-solo/${grafanaServeDashboardUid}?${pathParams}` +
               `&refresh${timeRangeParams}&var-datasource=${dashboardDatasource}`;

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -107,7 +107,6 @@ export const ServeMetricsSection = ({
   className,
   metricsConfig,
 }: ServeMetricsSectionProps) => {
-  console.log(metricsConfig);
   const classes = useStyles();
   const { grafanaHost, prometheusHealth, dashboardUids, dashboardDatasource } =
     useContext(GlobalContext);

--- a/dashboard/client/src/pages/serve/ServeSystemDetailPage.tsx
+++ b/dashboard/client/src/pages/serve/ServeSystemDetailPage.tsx
@@ -6,8 +6,8 @@ import Loading from "../../components/Loading";
 import { MainNavPageInfo } from "../layout/mainNavContext";
 import { useServeDeployments } from "./hook/useServeApplications";
 import {
-  ServeMetricsSection,
   SERVE_SYSTEM_METRICS_CONFIG,
+  ServeMetricsSection,
 } from "./ServeMetricsSection";
 import { ServeSystemDetails } from "./ServeSystemDetails";
 const useStyles = makeStyles((theme) =>

--- a/dashboard/client/src/pages/serve/ServeSystemDetailPage.tsx
+++ b/dashboard/client/src/pages/serve/ServeSystemDetailPage.tsx
@@ -5,8 +5,11 @@ import { Outlet } from "react-router-dom";
 import Loading from "../../components/Loading";
 import { MainNavPageInfo } from "../layout/mainNavContext";
 import { useServeDeployments } from "./hook/useServeApplications";
+import {
+  ServeMetricsSection,
+  SYSTEM_METRICS_CONFIG,
+} from "./ServeMetricsSection";
 import { ServeSystemDetails } from "./ServeSystemDetails";
-
 const useStyles = makeStyles((theme) =>
   createStyles({
     root: {
@@ -14,6 +17,9 @@ const useStyles = makeStyles((theme) =>
     },
     serveInstanceWarning: {
       marginBottom: theme.spacing(2),
+    },
+    section: {
+      marginTop: theme.spacing(4),
     },
   }),
 );
@@ -53,6 +59,10 @@ export const ServeSystemDetailPage = () => {
           setPage={setProxiesPage}
         />
       )}
+      <ServeMetricsSection
+        className={classes.section}
+        metricsConfig={SYSTEM_METRICS_CONFIG}
+      />
     </div>
   );
 };

--- a/dashboard/client/src/pages/serve/ServeSystemDetailPage.tsx
+++ b/dashboard/client/src/pages/serve/ServeSystemDetailPage.tsx
@@ -7,7 +7,7 @@ import { MainNavPageInfo } from "../layout/mainNavContext";
 import { useServeDeployments } from "./hook/useServeApplications";
 import {
   ServeMetricsSection,
-  SYSTEM_METRICS_CONFIG,
+  SERVE_SYSTEM_METRICS_CONFIG,
 } from "./ServeMetricsSection";
 import { ServeSystemDetails } from "./ServeSystemDetails";
 const useStyles = makeStyles((theme) =>
@@ -61,7 +61,7 @@ export const ServeSystemDetailPage = () => {
       )}
       <ServeMetricsSection
         className={classes.section}
-        metricsConfig={SYSTEM_METRICS_CONFIG}
+        metricsConfig={SERVE_SYSTEM_METRICS_CONFIG}
       />
     </div>
   );

--- a/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
@@ -389,19 +389,6 @@ SERVE_GRAFANA_PANELS = [
     ),
     Panel(
         id=25,
-        title="Controller Starts",
-        description="The number of times the Ray Serve controller has started.",
-        unit="starts",
-        targets=[
-            Target(
-                expr="ray_serve_controller_num_starts{{{global_filters}}}",
-                legend="Controller Starts",
-            ),
-        ],
-        grid_pos=GridPos(16, 7, 8, 8),
-    ),
-    Panel(
-        id=26,
         title="Number of Control Loops",
         description="The number of control loops performed by the controller. Increases monotonically over the controller's lifetime.",
         unit="loops",
@@ -411,7 +398,7 @@ SERVE_GRAFANA_PANELS = [
                 legend="Control Loops",
             ),
         ],
-        grid_pos=GridPos(0, 8, 8, 8),
+        grid_pos=GridPos(16, 7, 8, 8),
     ),
 ]
 

--- a/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
@@ -322,6 +322,71 @@ SERVE_GRAFANA_PANELS = [
         stack=False,
         grid_pos=GridPos(16, 5, 8, 8),
     ),
+    Panel(
+        id=20,
+        title="Ongoing HTTP Requests",
+        description="The number of ongoing HTTP requests in Ray Serve.",
+        unit="requests",
+        targets=[
+            Target(
+                expr="ray_serve_num_ongoing_http_requests{{{global_filters}}}",
+                legend="Ongoing HTTP Requests",
+            ),
+        ],
+        grid_pos=GridPos(0, 6, 8, 8),
+    ),
+    Panel(
+        id=21,
+        title="Controller Starts",
+        description="The number of times the Ray Serve controller has started.",
+        unit="starts",
+        targets=[
+            Target(
+                expr="ray_serve_controller_num_starts{{{global_filters}}}",
+                legend="Controller Starts",
+            ),
+        ],
+        grid_pos=GridPos(8, 6, 8, 8),
+    ),
+    Panel(
+        id=22,
+        title="Scheduling Tasks",
+        description="The number of tasks currently being scheduled in Ray Serve.",
+        unit="tasks",
+        targets=[
+            Target(
+                expr="ray_serve_num_scheduling_tasks{{{global_filters}}}",
+                legend="Scheduling Tasks",
+            ),
+        ],
+        grid_pos=GridPos(16, 6, 8, 8),
+    ),
+    Panel(
+        id=23,
+        title="Scheduling Tasks in Backoff",
+        description="The number of scheduling tasks in backoff state in Ray Serve.",
+        unit="tasks",
+        targets=[
+            Target(
+                expr="ray_serve_num_scheduling_tasks_in_backoff{{{global_filters}}}",
+                legend="Scheduling Tasks in Backoff",
+            ),
+        ],
+        grid_pos=GridPos(0, 7, 8, 8),
+    ),
+    Panel(
+        id=24,
+        title="Controller Control Loop Duration",
+        description="The duration of the control loop within the Ray Serve controller.",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="ray_serve_controller_control_loop_duration_s{{{global_filters}}}",
+                legend="Control Loop Duration",
+            ),
+        ],
+        grid_pos=GridPos(8, 7, 8, 8),
+    ),
 ]
 
 ids = []

--- a/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
@@ -325,7 +325,7 @@ SERVE_GRAFANA_PANELS = [
     Panel(
         id=20,
         title="Ongoing HTTP Requests",
-        description="The number of ongoing HTTP requests in Ray Serve.",
+        description="The number of ongoing requests in the HTTP Proxy.",
         unit="requests",
         targets=[
             Target(
@@ -351,7 +351,7 @@ SERVE_GRAFANA_PANELS = [
     Panel(
         id=22,
         title="Scheduling Tasks",
-        description="The number of tasks currently being scheduled in Ray Serve.",
+        description="The number of request scheduling tasks in the router.",
         unit="tasks",
         targets=[
             Target(
@@ -364,7 +364,7 @@ SERVE_GRAFANA_PANELS = [
     Panel(
         id=23,
         title="Scheduling Tasks in Backoff",
-        description="The number of scheduling tasks in backoff state in Ray Serve.",
+        description="The number of request scheduling tasks in the router that are undergoing backoff.",
         unit="tasks",
         targets=[
             Target(
@@ -377,7 +377,7 @@ SERVE_GRAFANA_PANELS = [
     Panel(
         id=24,
         title="Controller Control Loop Duration",
-        description="The duration of the control loop within the Ray Serve controller.",
+        description="The duration of the last control loop.",
         unit="seconds",
         targets=[
             Target(

--- a/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
+++ b/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
@@ -337,13 +337,13 @@ SERVE_GRAFANA_PANELS = [
     ),
     Panel(
         id=21,
-        title="Controller Starts",
-        description="The number of times the Ray Serve controller has started.",
-        unit="starts",
+        title="Ongoing gRPC Requests",
+        description="The number of ongoing requests in the gRPC Proxy.",
+        unit="requests",
         targets=[
             Target(
-                expr="ray_serve_controller_num_starts{{{global_filters}}}",
-                legend="Controller Starts",
+                expr="ray_serve_num_ongoing_grpc_requests{{{global_filters}}}",
+                legend="Ongoing gRPC Requests",
             ),
         ],
         grid_pos=GridPos(8, 6, 8, 8),
@@ -386,6 +386,32 @@ SERVE_GRAFANA_PANELS = [
             ),
         ],
         grid_pos=GridPos(8, 7, 8, 8),
+    ),
+    Panel(
+        id=25,
+        title="Controller Starts",
+        description="The number of times the Ray Serve controller has started.",
+        unit="starts",
+        targets=[
+            Target(
+                expr="ray_serve_controller_num_starts{{{global_filters}}}",
+                legend="Controller Starts",
+            ),
+        ],
+        grid_pos=GridPos(16, 7, 8, 8),
+    ),
+    Panel(
+        id=26,
+        title="Number of Control Loops",
+        description="The number of control loops performed by the controller. Increases monotonically over the controller's lifetime.",
+        unit="loops",
+        targets=[
+            Target(
+                expr="ray_serve_controller_num_control_loops{{{global_filters}}}",
+                legend="Control Loops",
+            ),
+        ],
+        grid_pos=GridPos(0, 8, 8, 8),
     ),
 ]
 

--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -623,7 +623,7 @@ The following metrics are exposed by Ray Serve:
        * replica
        * application
        * model_id
-     - The mutlplexed model ID registered on the current replica.
+     - The mutliplexed model ID registered on the current replica.
    * - ``ray_serve_multiplexed_get_model_requests_counter``
      - * deployment
        * replica

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -212,7 +212,7 @@ class ServeController:
         # Track the number of times the controller has started
         metrics.Counter(
             "serve_controller_num_starts",
-            description="The number of times that controller has started.",
+            description="The number of times the controller has started.",
         ).inc()
 
     def reconfigure_global_logging_config(self, global_logging_config: LoggingConfig):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Adds the following Serve controller metrics to the Serve details page on the dashboard:

```
ray_serve_num_ongoing_http_requests
ray_serve_num_ongoing_grpc_requests
ray_serve_controller_num_starts
ray_serve_num_scheduling_tasks
ray_serve_num_scheduling_tasks_in_backoff
ray_serve_controller_num_control_loops
```
https://github.com/ray-project/ray/pull/43797#issuecomment-1989365742 contains a screenshot.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/35667
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
