### PR TITLE
[Serve] Fix deployment route prefix override by default route prefix from serve run cli

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -30,6 +30,7 @@ from ray.serve._private.deployment_graph_build import build as pipeline_build
 from ray.serve._private.deployment_graph_build import (
     get_and_validate_ingress_deployment,
 )
+from ray.serve._private.utils import DEFAULT
 from ray.serve.config import DeploymentMode, ProxyLocation, gRPCOptions
 from ray.serve.deployment import Application, deployment_to_schema
 from ray.serve.schema import (
@@ -439,7 +440,6 @@ def deploy(
 @click.option(
     "--route-prefix",
     required=False,
-    default="/",
     type=str,
     help=(
         "Route prefix for the application. This should only be used "
@@ -468,9 +468,11 @@ def run(
     address: str,
     blocking: bool,
     reload: bool,
-    route_prefix: str,
+    route_prefix: Optional[str],
     name: str,
 ):
+    if route_prefix is None:
+        route_prefix = DEFAULT.VALUE
     sys.path.insert(0, app_dir)
     args_dict = convert_args_to_dict(arguments)
     final_runtime_env = parse_runtime_env_args(

--- a/python/ray/serve/tests/test_cli_2.py
+++ b/python/ray/serve/tests/test_cli_2.py
@@ -931,5 +931,38 @@ def test_grpc_proxy_model_composition(ray_start_stop):
     ping_fruit_stand(channel, app)
 
 
+@serve.deployment(route_prefix="/foo")
+async def deployment_with_route_prefix(args):
+    return "bar..."
+
+
+route_prefix_app = deployment_with_route_prefix.bind()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
+def test_serve_run_mount_to_correct_deployment_route_prefix(ray_start_stop):
+    """Test running serve run with deployment with route_prefix should mount the
+    deployment to the correct route."""
+
+    import_path = "ray.serve.tests.test_cli_2.route_prefix_app"
+    subprocess.Popen(["serve", "run", import_path])
+
+    # /-/routes should show the app having the correct route.
+    wait_for_condition(
+        lambda: requests.get("http://localhost:8000/-/routes").text
+        == '{"/foo":"default"}'
+    )
+
+    # Ping root path directly should 404.
+    wait_for_condition(
+        lambda: requests.get("http://localhost:8000/").status_code == 404
+    )
+
+    # Ping the mounting route should return 200.
+    wait_for_condition(
+        lambda: requests.get("http://localhost:8000/foo").status_code == 200
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_config_files/deployment_with_route_prefix.py
+++ b/python/ray/serve/tests/test_config_files/deployment_with_route_prefix.py
@@ -1,1 +1,0 @@
-from ray import serve

--- a/python/ray/serve/tests/test_config_files/deployment_with_route_prefix.py
+++ b/python/ray/serve/tests/test_config_files/deployment_with_route_prefix.py
@@ -1,0 +1,1 @@
+from ray import serve


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The default `route_prefix` ("/") on `serve run` cli is wrongly overrode the `route_prefix` from the deployment. If the `route_prefix` is not passed into the `serve run` cli, we should keep `route_prefix` as `DEFAULT.VALUE`, so the downstream `serve.run` api can determine how to override. Also added a test to ensure this will be caught in the future. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/43800

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
