### PR TITLE
[ci] do not move test out of FLAKY state automatically

### DIFF
--- a/release/ray_release/test_automation/ci_state_machine.py
+++ b/release/ray_release/test_automation/ci_state_machine.py
@@ -113,7 +113,10 @@ class CITestStateMachine(TestStateMachine):
         )
 
     def _flaky_to_passing(self) -> bool:
-        return self._is_recently_stable()
+        # A flaky test is considered passing if it has been passing for a certain
+        # period and the github issue is closed (by a human).
+        issue = self.ray_repo.get_issue(self.test.get(Test.KEY_GITHUB_ISSUE_NUMBER))
+        return self._is_recently_stable() and issue.state == "closed"
 
     def _is_recently_stable(self) -> bool:
         return len(self.test_results) >= CONTINUOUS_PASSING_TO_PASSING and all(

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -189,6 +189,9 @@ def test_ci_move_from_passing_to_failing_to_flaky():
         TestResult.from_result(Result(status=ResultStatus.SUCCESS.value)),
     ] * CONTINUOUS_PASSING_TO_PASSING
     CITestStateMachine(test).move()
+    assert test.get_state() == TestState.FLAKY
+    issue.state = "closed"
+    CITestStateMachine(test).move()
     assert test.get_state() == TestState.PASSING
     assert test.get(Test.KEY_GITHUB_ISSUE_NUMBER) is None
     assert issue.state == "closed"


### PR DESCRIPTION
Require a human to explicitly close the flaky test issue to indicate that the test has stopped being flaky. Automation is not good at this judgment.

Test:
- CI