### PR TITLE
[serve] disable test on windows

### DIFF
--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -237,7 +237,7 @@ py_test_module_list(
     "test_standalone_3.py",
   ],
   size = "large",
-  tags = ["exclusive", "team:serve"],
+  tags = ["exclusive", "no_windows", "team:serve"],
   deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
 )
 


### PR DESCRIPTION
[serve] disable test on windows

Disable `test_standalone_3_with_compact_scheduling` on windows.
Closes https://github.com/ray-project/ray/issues/43776.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
