### PR TITLE
[serve] warning about changing target ongoing requests default

### DIFF
--- a/dashboard/modules/serve/serve_rest_api_impl.py
+++ b/dashboard/modules/serve/serve_rest_api_impl.py
@@ -216,6 +216,8 @@ def create_serve_rest_api(
                 )
 
         def log_config_change_default_warning(self, config):
+            from ray.serve.config import AutoscalingConfig
+
             for deployment in [
                 d for app in config.applications for d in app.deployments
             ]:
@@ -223,6 +225,28 @@ def create_serve_rest_api(
                     logger.warning(
                         "The default value for `max_ongoing_requests` will "
                         "change from 100 to 5 in an upcoming release."
+                    )
+                    break
+
+            for deployment in [
+                d for app in config.applications for d in app.deployments
+            ]:
+                if isinstance(deployment.autoscaling_config, dict):
+                    autoscaling_config = deployment.autoscaling_config
+                elif isinstance(deployment.autoscaling_config, AutoscalingConfig):
+                    autoscaling_config = deployment.autoscaling_config.dict(
+                        exclude_unset=True
+                    )
+                else:
+                    continue
+
+                if (
+                    "target_num_ongoing_requests_per_replica" not in autoscaling_config
+                    and "target_ongoing_requests" not in autoscaling_config
+                ):
+                    logger.warning(
+                        "The default value for `target_ongoing_requests` will "
+                        "change from 1.0 to 2.0 in an upcoming release."
                     )
                     break
 

--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -18,6 +18,9 @@ To define what the steady state of your deployments should be, set values for `t
 This parameter is renamed to `target_ongoing_requests`. `target_num_ongoing_requests_per_replica` will be removed in a future release.
 
 #### **target_ongoing_requests [default=1]**
+:::{note}
+The default for `target_ongoing_requests` will be changed to 2.0 in an upcoming Ray release. You can continue to set it manually to override the default.
+:::
 Serve scales the number of replicas for a deployment up or down based on the average number of ongoing requests per replica. Specifically, Serve compares the *actual* number of ongoing requests per replica with the target value you set in the autoscaling config and makes upscale or downscale decisions from that. Set the target value with `target_ongoing_requests`, and Serve attempts to ensure that each replica has roughly that number
 of requests being processed and waiting in the queue. 
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -350,6 +350,22 @@ def deployment(
                 "version."
             )
 
+        if (
+            isinstance(autoscaling_config, dict)
+            and "target_num_ongoing_requests_per_replica" not in autoscaling_config
+            and "target_ongoing_requests" not in autoscaling_config
+        ) or (
+            isinstance(autoscaling_config, AutoscalingConfig)
+            and "target_num_ongoing_requests_per_replica"
+            not in autoscaling_config.dict(exclude_unset=True)
+            and "target_ongoing_requests"
+            not in autoscaling_config.dict(exclude_unset=True)
+        ):
+            logger.warning(
+                "The default value for `target_ongoing_requests` is currently 1.0, "
+                "but will change to 2.0 in an upcoming release."
+            )
+
     max_ongoing_requests = (
         max_ongoing_requests
         if max_ongoing_requests is not DEFAULT.VALUE


### PR DESCRIPTION
[serve] warning about changing target ongoing requests default

Add warning that default value for `target_ongoing_requests` will change.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
