### PR TITLE
[Data] Replacing backpressure timing test with less flaky test

### DIFF
--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1147,11 +1147,13 @@ Dataset throughput:
 def test_time_backpressure(ray_start_regular_shared, restore_data_context):
     class TimedBackpressurePolicy(BackpressurePolicy):
         COUNT = 0
+
         def __init__(self, topology: "Topology"):
             pass
 
         def can_add_input(self, op: "PhysicalOperator") -> bool:
-            if TimedBackpressurePolicy.COUNT > 10:
+            if TimedBackpressurePolicy.COUNT > 1:
+                time.sleep(0.01)
                 return True
             else:
                 TimedBackpressurePolicy.COUNT += 1


### PR DESCRIPTION
## Why are these changes needed?
` test_e2e_time_backpressure` has been flaky since it was added (likely caused by it unreliably actually encountering backpressure). This test replaces that test with a mocked backpressure policy that reliably produces backpressure. Ran the test 1000 times (`pytest test_stats.py -k test_time_backpressure --count 1000`) with no failures.
 
## Related issue number
Closes https://github.com/ray-project/ray/issues/43819

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
