### PR TITLE
[WIP] In Driver CoreWorkerProcess, shutdown with the Exit method

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -667,6 +667,7 @@ void CoreWorker::Shutdown() {
   }
 
   RAY_LOG(INFO) << "Shutting down a core worker.";
+  RAY_LOG(ERROR) << ray::StackTrace();
   is_shutdown_ = true;
   if (options_.worker_type == WorkerType::WORKER) {
     // Running in a main thread.

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -252,9 +252,8 @@ void CoreWorkerProcessImpl::ShutdownDriver() {
       << "The `Shutdown` interface is for driver only.";
   auto global_worker = GetCoreWorker();
   RAY_CHECK(global_worker);
-  global_worker->Disconnect(/*exit_type*/ rpc::WorkerExitType::INTENDED_USER_EXIT,
-                            /*exit_detail*/ "Shutdown by ray.shutdown().");
-  global_worker->Shutdown();
+  global_worker->Exit(
+      rpc::WorkerExitType::INTENDED_USER_EXIT, "Shutdown by ray.shutdown().", nullptr);
   {
     absl::WriterMutexLock lock(&mutex_);
     core_worker_.reset();


### PR DESCRIPTION
Previously we have hand rolled logic in `CoreWorkerProcessImpl::ShutdownDriver()` to shutdown. But it did not count for the nuances e.g. on cancelling pending tasks that is handled by the Exit().