### PR TITLE
[release] Change version from 3.0.0.dev0 to 2.10.0

### DIFF
--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -14,7 +14,7 @@ from ray_release.test import Test, TestState
 
 
 POSTMERGE_PIPELINE = "0189e759-8c96-4302-b6b5-b4274406bf89"
-RAY_VERSION = "3.0.0.dev0"
+RAY_VERSION = "2.10.0"
 
 
 def chunk_into_n(list: List[str], n: int) -> List[List[str]]:

--- a/java/api/pom_template.xml
+++ b/java/api/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.10.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/performance_test/pom_template.xml
+++ b/java/performance_test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.10.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.ray</groupId>
   <artifactId>ray-superpom</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.10.0</version>
   <packaging>pom</packaging>
   <name>Ray Project Parent POM</name>
   <description>An open source framework that provides a simple, universal API for building distributed applications.
@@ -63,7 +63,7 @@
   <properties>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.version>2.0.0-SNAPSHOT</project.version>
+    <project.version>2.10.0</project.version>
   </properties>
 
   <dependencyManagement>

--- a/java/runtime/pom_template.xml
+++ b/java/runtime/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.10.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/serve/pom_template.xml
+++ b/java/serve/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.10.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/test/pom_template.xml
+++ b/java/test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.10.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/python/ray/_version.py
+++ b/python/ray/_version.py
@@ -1,6 +1,6 @@
 # Replaced with the current commit when building the wheels.
 commit = "{{RAY_COMMIT_SHA}}"
-version = "3.0.0.dev0"
+version = "2.10.0"
 
 if __name__ == "__main__":
     print("%s %s" % (version, commit))

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -64,7 +64,7 @@ constexpr int kMessagePackOffset = 9;
 constexpr char kSetupWorkerFilename[] = "setup_worker.py";
 
 /// The version of Ray
-constexpr char kRayVersion[] = "3.0.0.dev0";
+constexpr char kRayVersion[] = "2.10.0";
 
 /*****************************/
 /* ENV labels for autoscaler */


### PR DESCRIPTION
Ran `bazel run //ci/ray_ci/automation:update_version -- --new_version=2.10.0` to update release version.