### PR TITLE
[core] In raylet, don't handle new lease request if the owner is already dead.

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -87,6 +87,7 @@ py_test_module_list(
   files = [
     "test_client.py",
     "test_client_reconnect.py",
+    "test_client_infeasible_shutdown.py",
   ],
   size = "large",
   tags = ["exclusive", "client_tests", "team:core"],

--- a/python/ray/tests/test_client_infeasible_shutdown.py
+++ b/python/ray/tests/test_client_infeasible_shutdown.py
@@ -1,0 +1,52 @@
+import ray
+import os
+import time
+import sys
+import subprocess
+from ray._private.test_utils import make_global_state_accessor
+import ray._private.gcs_utils as gcs_utils
+import pytest
+
+CLIENT_SERVER_PORT = 25555
+
+
+# Tests that if a client has infesible tasks when shutting down, the demands from tasks
+# are removed from the resource usage.
+# See https://github.com/ray-project/ray/issues/43687
+@pytest.mark.parametrize(
+    "call_ray_start",
+    [f"ray start --head --ray-client-server-port={CLIENT_SERVER_PORT}"],
+    indirect=True,
+)
+def test_client_infeasible_shutdown(call_ray_start):
+    script = """
+#!/usr/bin/env python3
+import ray
+import time
+
+ray.init("ray://127.0.0.1:25555")
+
+@ray.remote(num_cpus=1000)
+def cant_schedule():
+    return "absurd"
+
+ref = cant_schedule.remote()
+time.sleep(10)
+"""
+
+    for _ in range(10):
+        subprocess.check_call([sys.executable, "-c", script])
+    time.sleep(10)  # give gcs some time to update status
+    cluster = ray.init()
+    resource_usage_msg = make_global_state_accessor(cluster).get_all_resource_usage()
+    resource_usage = gcs_utils.ResourceUsageBatchData.FromString(resource_usage_msg)
+    assert (
+        len(resource_usage.resource_load_by_shape.resource_demands) == 0
+    ), resource_usage
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -328,16 +328,14 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
            "return values are greater than the remaining capacity.";
     max_task_args_memory = 0;
   }
-  auto is_owner_alive = [this](const WorkerID &owner_worker_id,
-                               const NodeID &owner_node_id) {
-    return !(failed_workers_cache_.count(owner_worker_id) > 0 ||
-             failed_nodes_cache_.count(owner_node_id) > 0);
-  };
+
   local_task_manager_ = std::make_shared<LocalTaskManager>(
       self_node_id_,
       std::dynamic_pointer_cast<ClusterResourceScheduler>(cluster_resource_scheduler_),
       dependency_manager_,
-      is_owner_alive,
+      [this](const WorkerID &owner_worker_id, const NodeID &owner_node_id) {
+        return this->IsOwnerAlive(owner_worker_id, owner_node_id);
+      },
       get_node_info_func,
       worker_pool_,
       leased_workers_,
@@ -387,6 +385,12 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
   periodical_runner_.RunFnPeriodically([this]() { GCTaskFailureReason(); },
                                        RayConfig::instance().task_failure_entry_ttl_ms(),
                                        "NodeManager.GCTaskFailureReason");
+}
+
+bool NodeManager::IsOwnerAlive(const WorkerID &owner_worker_id,
+                               const NodeID &owner_node_id) const {
+  return !(failed_workers_cache_.count(owner_worker_id) > 0 ||
+           failed_nodes_cache_.count(owner_node_id) > 0);
 }
 
 ray::Status NodeManager::RegisterGcs() {
@@ -1714,6 +1718,18 @@ void NodeManager::HandleReportWorkerBacklog(rpc::ReportWorkerBacklogRequest requ
 void NodeManager::HandleRequestWorkerLease(rpc::RequestWorkerLeaseRequest request,
                                            rpc::RequestWorkerLeaseReply *reply,
                                            rpc::SendReplyCallback send_reply_callback) {
+  const auto &caller_addr = request.resource_spec().caller_address();
+  if (!IsOwnerAlive(WorkerID::FromBinary(caller_addr.worker_id()),
+                    NodeID::FromBinary(caller_addr.raylet_id()))) {
+    RAY_LOG(WARNING) << "Caller " << caller_addr.raylet_id() << " is dead. Skip leasing.";
+    reply->set_canceled(true);
+    reply->set_failure_type(rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED);
+    reply->set_scheduling_failure_message(
+        "Cancelled leasing because the caller worker or node is dead.");
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+    return;
+  };
+
   rpc::Task task_message;
   task_message.mutable_task_spec()->CopyFrom(request.resource_spec());
   RayTask task(task_message);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1719,9 +1719,11 @@ void NodeManager::HandleRequestWorkerLease(rpc::RequestWorkerLeaseRequest reques
                                            rpc::RequestWorkerLeaseReply *reply,
                                            rpc::SendReplyCallback send_reply_callback) {
   const auto &caller_addr = request.resource_spec().caller_address();
-  if (!IsOwnerAlive(WorkerID::FromBinary(caller_addr.worker_id()),
-                    NodeID::FromBinary(caller_addr.raylet_id()))) {
-    RAY_LOG(WARNING) << "Caller " << caller_addr.raylet_id() << " is dead. Skip leasing.";
+  const auto caller_worker = WorkerID::FromBinary(caller_addr.worker_id());
+  const auto caller_node = NodeID::FromBinary(caller_addr.raylet_id());
+  if (!IsOwnerAlive(caller_worker, caller_node)) {
+    RAY_LOG(INFO) << "Caller is dead. worker = " << caller_worker
+                  << ", node = " << caller_node << " Skip leasing.";
     reply->set_canceled(true);
     reply->set_failure_type(rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED);
     reply->set_scheduling_failure_message(

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -695,6 +695,10 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   std::unique_ptr<AgentManager> CreateRuntimeEnvAgentManager(
       const NodeID &self_node_id, const NodeManagerConfig &config);
 
+  // If Node Manager already knows this (node, worker) is dead, return false.
+  // Otherwise returns true.
+  bool IsOwnerAlive(const WorkerID &owner_worker_id, const NodeID &owner_node_id) const;
+
   /// ID of this node.
   NodeID self_node_id_;
   /// The user-given identifier or name of this node.


### PR DESCRIPTION
This can happen when a core worker is shutting down and still retrying a request.

Fixes #43687.