### PR TITLE
[Serve] fix test_autoscaling_policy_with_handle_metrics_disabled on windows

### DIFF
--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -79,7 +79,7 @@ py_test_module_list(
 
 # Test autoscaling with RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE set to 0
 py_test(
-    name = "test_autoscaling_policy_with_handle_metrics_disabled",
+    name = "test_autoscaling_policy_with_metr_disab",
     size = "medium",
     main = "test_autoscaling_policy.py",
     srcs = ["test_autoscaling_policy.py"],

--- a/python/ray/serve/tests/unit/BUILD
+++ b/python/ray/serve/tests/unit/BUILD
@@ -39,7 +39,7 @@ py_test_module_list(
 )
 
 py_test_module_list(
-  name_suffix="_with_handle_metrics_disabled",
+  name_suffix="_with_metr_disab",
   env={"RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0"},
   files = [
     "test_deployment_state.py",


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Windows can't run tests with long name. Shorten test_autoscaling_policy_with_handle_metrics_disabled a bit

## Related issue number

Closes https://github.com/ray-project/ray/issues/43848

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
