### PR TITLE
[dashboard] Fix dashboard stack trace error when sudo is not found

### DIFF
--- a/dashboard/modules/reporter/profile_manager.py
+++ b/dashboard/modules/reporter/profile_manager.py
@@ -61,15 +61,19 @@ def _format_failed_profiler_command(cmd, profiler, stdout, stderr) -> str:
 # If we can sudo, always try that. Otherwise, py-spy will only work if the user has
 # root privileges or has configured setuid on the py-spy script.
 async def _can_passwordless_sudo() -> bool:
-    process = await asyncio.create_subprocess_exec(
-        "sudo",
-        "-n",
-        "true",
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    _, _ = await process.communicate()
-    return process.returncode == 0
+    try:
+        process = await asyncio.create_subprocess_exec(
+            "sudo",
+            "-n",
+            "true",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        return False
+    else:
+        _, _ = await process.communicate()
+        return process.returncode == 0
 
 
 class CpuProfilingManager:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When Ray runs on k8s with the images that does not install "sudo" and runs as non-root in containers, the "Stack Trace (Driver)" of the dashboard goes wrong and returns "`sudo` FileNotFound". In fact, py-spy can be used even if `sudo` is not installed. 
The code previous forget to handle the case `where the sudo` FileNotFound exception is thrown and directly returns it to the user. This PR fixes this issue, treat sudo not found as "cannot do passwordless sudo"

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/44242
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
