### PR TITLE
[ci] fix test result upload on release branch

### DIFF
--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -110,6 +110,7 @@ class TesterContainer(Container):
     def _persist_test_results(self, team: str, bazel_log_dir: str) -> None:
         if os.environ.get("BUILDKITE_BRANCH") != "master":
             logger.info("Skip upload test results. We only upload on master branch.")
+            return
         if os.environ.get("BUILDKITE_PIPELINE_ID") != PIPELINE_POSTMERGE:
             logger.info(
                 "Skip upload test results. We only upload on postmerge pipeline."


### PR DESCRIPTION
We should not upload test results on the release branch. I missed a return statement here.

Test:
- CI