### PR TITLE
[ci][7up/2] remove python 3.8

### DIFF
--- a/.buildkite/_forge.aarch64.rayci.yml
+++ b/.buildkite/_forge.aarch64.rayci.yml
@@ -18,7 +18,6 @@ steps:
     matrix:
       setup:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -41,7 +40,6 @@ steps:
       - core_cpp
     wanda: ci/docker/ray.cpu.base.aarch64.wanda.yaml
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"

--- a/.buildkite/_forge.rayci.yml
+++ b/.buildkite/_forge.rayci.yml
@@ -15,7 +15,6 @@ steps:
     matrix:
       setup:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -39,7 +38,6 @@ steps:
       - serve
     wanda: ci/docker/ray.cpu.base.wanda.yaml
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -56,7 +54,6 @@ steps:
     matrix:
       setup:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
         cuda:
@@ -73,7 +70,6 @@ steps:
     wanda: ci/docker/ray-ml.cpu.base.wanda.yaml
     depends_on: raycpubase
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
     env:

--- a/.buildkite/base.rayci.yml
+++ b/.buildkite/base.rayci.yml
@@ -7,7 +7,6 @@ steps:
     label: "wanda: oss-ci-base_test-py{{matrix}}"
     wanda: ci/docker/base.test.wanda.yaml
     matrix:
-      - "3.8"
       - "3.10"
       - "3.11"
     env:
@@ -21,7 +20,6 @@ steps:
     label: "wanda: oss-ci-base_build-py{{matrix}}"
     wanda: ci/docker/base.build.wanda.yaml
     matrix:
-      - "3.8"
       - "3.10"
       - "3.11"
     env:
@@ -45,7 +43,6 @@ steps:
     label: "wanda: oss-ci-base_ml-py{{matrix}}"
     wanda: ci/docker/base.ml.wanda.yaml
     matrix:
-      - "3.8"
       - "3.10"
     env:
       PYTHON: "{{matrix}}"
@@ -58,7 +55,6 @@ steps:
     label: "wanda: oss-ci-base_gpu-py{{matrix}}"
     wanda: ci/docker/base.gpu.wanda.yaml
     matrix:
-      - "3.8"
       - "3.10"
     env:
       PYTHON: "{{matrix}}"

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -8,7 +8,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- wheel --python-version {{matrix}} --architecture x86_64 --upload
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -24,7 +23,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- wheel --python-version {{matrix}} --architecture aarch64 --upload
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -81,7 +79,6 @@ steps:
       - raycudabase
       - raycpubase
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -107,7 +104,6 @@ steps:
       - raycpubase-aarch64
     job_env: forge-aarch64
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -128,6 +124,5 @@ steps:
       - ray-mlcudabase
       - ray-mlcpubase
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -11,7 +11,6 @@ steps:
     label: "wanda: corebuild-py{{matrix}}"
     wanda: ci/docker/core.build.wanda.yaml
     matrix:
-      - "3.8"
       - "3.10"
     env:
       PYTHON: "{{matrix}}"
@@ -21,7 +20,6 @@ steps:
     label: "wanda: minbuild-core-py{{matrix}}"
     wanda: ci/docker/min.build.wanda.yaml
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -44,23 +42,6 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual
-
-  - label: ":ray: core: python {{matrix.python}} tests ({{matrix.worker_id}})"
-    if: build.env("RAYCI_CONTINUOUS_BUILD") == "1" || build.pull_request.labels includes "continuous-build"
-    tags: 
-      - python
-      - dashboard
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core
-        --workers 4 --worker-id {{matrix.worker_id}} --parallelism-per-worker 3
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual
-        --python-version {{matrix.python}}
-    depends_on: corebuild-multipy
-    matrix:
-      setup:
-        python: ["3.8"]
-        worker_id: ["0", "1", "2", "3"]
 
   - label: ":ray: core: redis tests"
     tags: python
@@ -256,7 +237,6 @@ steps:
     depends_on:
       - minbuild-core
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -13,7 +13,7 @@ steps:
   - name: databuild-multipy
     label: "wanda: databuild-py{{matrix}}"
     wanda: ci/docker/data.build.wanda.yaml
-    matrix: ["3.8", "3.10"]
+    matrix: ["3.10"]
     env:
       PYTHON: "{{matrix}}"
     depends_on: oss-ci-base_build-multipy
@@ -55,23 +55,6 @@ steps:
         --build-name data15build
         --except-tags data_integration,doctest
     depends_on: data15build
-
-  - label: ":database: data: python {{matrix.python}} tests ({{matrix.worker_id}})"
-    if: build.env("RAYCI_CONTINUOUS_BUILD") == "1" || build.pull_request.labels includes "continuous-build"
-    tags: 
-      - python
-      - data
-    instance_type: medium
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
-        --workers 2 --worker-id {{matrix.worker_id}} --parallelism-per-worker 3
-        --except-tags data_integration,doctest
-        --python-version {{matrix.python}}
-    depends_on: databuild-multipy
-    matrix:
-      setup:
-        python: ["3.8"]
-        worker_id: ["0", "1"]
 
   - label: ":database: data: arrow nightly tests"
     tags: 

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -25,7 +25,7 @@ steps:
       IMAGE_TO: mlbuild-py{{matrix}}
       RAYCI_IS_GPU_BUILD: "false"
     matrix:
-      - "3.8"
+      - "3.10"
 
   - name: mllightning2gpubuild
     wanda: ci/docker/mllightning2gpu.build.wanda.yaml
@@ -47,7 +47,7 @@ steps:
       IMAGE_TO: mlgpubuild-py{{matrix}}
       RAYCI_IS_GPU_BUILD: "true"
     matrix:
-      - "3.8"
+      - "3.10"
 
   # tests
   - label: ":train: ml: train tests"
@@ -59,21 +59,6 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --except-tags gpu_only,gpu,minimal,tune,doctest,needs_credentials 
     depends_on: [ "mlbuild", "forge" ]
-
-  - label: ":train: ml: train python {{matrix.python}} tests ({{matrix.worker_id}})"
-    if: build.env("RAYCI_CONTINUOUS_BUILD") == "1" || build.pull_request.labels includes "continuous-build"
-    tags: train
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml 
-        --workers 2 --worker-id {{matrix.worker_id}} --parallelism-per-worker 3
-        --except-tags gpu_only,gpu,minimal,tune,doctest,needs_credentials 
-        --python-version {{matrix.python}}
-    depends_on: [ "mlbuild-multipy", "forge" ]
-    matrix:
-      setup:
-        python: ["3.8"]
-        worker_id: ["0", "1"]
 
   - label: ":train: ml: train gpu tests"
     tags: 
@@ -87,24 +72,6 @@ steps:
         --build-name mlgpubuild
         --only-tags gpu,gpu_only
     depends_on: [ "mlgpubuild", "forge" ]
-
-  - label: ":train: ml: train gpu python {{matrix.python}} tests ({{matrix.worker_id}})"
-    if: build.env("RAYCI_CONTINUOUS_BUILD") == "1" || build.pull_request.labels includes "continuous-build"
-    tags: 
-      - train
-      - gpu
-    instance_type: gpu-large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... //python/ray/air/... //doc/... ml
-        --workers 2 --worker-id {{matrix.worker_id}} --parallelism-per-worker 2
-        --build-name mlgpubuild-py{{matrix.python}}
-        --only-tags gpu,gpu_only
-        --python-version {{matrix.python}}
-    depends_on: [ "mlgpubuild-multipy", "forge" ]
-    matrix:
-      setup:
-        python: ["3.8"]
-        worker_id: ["0", "1"]
 
   - label: ":train: ml: train authentication tests"
     tags:
@@ -130,18 +97,6 @@ steps:
         --parallelism-per-worker 3
         --except-tags soft_imports,gpu_only,rllib,multinode
     depends_on: [ "mlbuild", "forge" ]
-
-  - label: ":train: ml: tune python {{matrix}} tests"
-    if: build.env("RAYCI_CONTINUOUS_BUILD") == "1" || build.pull_request.labels includes "continuous-build"
-    tags: tune
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tune/... ml 
-        --parallelism-per-worker 3
-        --except-tags soft_imports,gpu_only,rllib,multinode
-        --python-version {{matrix}}
-    depends_on: [ "mlbuild-multipy", "forge" ]
-    matrix: ["3.8"]
 
   - label: ":train: ml: tune new output tests"
     tags: tune
@@ -174,23 +129,6 @@ steps:
         --only-tags ray_air
         --skip-ray-installation
     depends_on: [ "mlbuild", "forge" ]
-
-  - label: ":train: ml: air python {{matrix}} tests"
-    if: build.env("RAYCI_CONTINUOUS_BUILD") == "1" || build.pull_request.labels includes "continuous-build"
-    tags: ml
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/air/... ml 
-        --parallelism-per-worker 3
-        --except-tags gpu
-        --python-version {{matrix}}
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... ml 
-        --parallelism-per-worker 3
-        --only-tags ray_air
-        --python-version {{matrix}}
-        --skip-ray-installation
-    depends_on: [ "mlbuild-multipy", "forge" ]
-    matrix: ["3.8"]
 
   - label: ":train: ml: train+tune tests"
     tags: train

--- a/.buildkite/release-automation/verify-macos-wheels.sh
+++ b/.buildkite/release-automation/verify-macos-wheels.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 set -x
 
-PYTHON_VERSIONS=("3.8" "3.9" "3.10" "3.11")
+PYTHON_VERSIONS=("3.9" "3.10" "3.11")
 BAZELISK_VERSION="v1.16.0"
 
 # Check arguments

--- a/.buildkite/release-automation/wheels.rayci.yml
+++ b/.buildkite/release-automation/wheels.rayci.yml
@@ -29,7 +29,6 @@ steps:
       - export RAY_HASH="$RAY_HASH"
       - bash -i .buildkite/release-automation/verify-linux-wheels.sh
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"
@@ -44,7 +43,6 @@ steps:
       - export RAY_HASH="$RAY_HASH"
       - bash -i .buildkite/release-automation/verify-linux-wheels.sh
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -11,7 +11,6 @@ steps:
     label: "wanda: servebuild-py{{matrix}}"
     wanda: ci/docker/serve.build.wanda.yaml
     matrix:
-      - "3.8"
       - "3.11"
     env:
       PYTHON: "{{matrix}}"
@@ -73,7 +72,7 @@ steps:
     depends_on: servebuild-multipy
     matrix:
       setup:
-        python: ["3.8", "3.11"]
+        python: ["3.11"]
         worker_id: ["0", "1"]
 
   - label: ":ray-serve: serve: release tests"

--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -23,7 +23,6 @@ steps:
       - bash ci/ray_ci/windows/install_tools.sh
       - bazel run //ci/ray_ci:build_in_docker_windows -- wheel --python-version {{matrix}} --operating-system windows --upload
     matrix:
-      - "3.8"
       - "3.9"
       - "3.10"
       - "3.11"

--- a/ci/build/build-docker-images.py
+++ b/ci/build/build-docker-images.py
@@ -38,14 +38,13 @@ DOCKER_HUB_DESCRIPTION = {
 }
 
 PY_MATRIX = {
-    "py38": "3.8",
     "py39": "3.9",
     "py310": "3.10",
     "py311": "3.11",
 }
 
 # Versions for which we build the ray-ml image
-ML_IMAGES_PY_VERSIONS = {"py38", "py39", "py310"}
+ML_IMAGES_PY_VERSIONS = {"py39", "py310"}
 
 BASE_IMAGES = {
     "cu121": "nvidia/cuda:12.1.1-cudnn8-devel-ubuntu20.04",

--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -48,8 +48,8 @@ function retry {
 
 if [[ "$platform" == "linux" ]]; then
   # Install miniconda.
-  PY_WHEEL_VERSIONS=("38" "39")
-  PY_MMS=("3.8.10" "3.9.5")
+  PY_WHEEL_VERSIONS=("39")
+  PY_MMS=("3.9.5")
   wget --quiet "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O miniconda3.sh
   "${ROOT_DIR}"/../suppress_output bash miniconda3.sh -b -p "$HOME/miniconda3"
   export PATH="$HOME/miniconda3/bin:$PATH"
@@ -93,8 +93,8 @@ if [[ "$platform" == "linux" ]]; then
 elif [[ "$platform" == "macosx" ]]; then
   MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
 
-  PY_WHEEL_VERSIONS=("38" "39" "310")
-  PY_MMS=("3.8" "3.9" "3.10")
+  PY_WHEEL_VERSIONS=("39" "310")
+  PY_MMS=("3.9" "3.10")
 
   for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     PY_MM="${PY_MMS[i]}"

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -79,7 +79,7 @@ install_miniconda() {
 
   if [ ! -x "${conda}" ] || [ "${MINIMAL_INSTALL-}" = 1 ]; then  # If no conda is found, install it
     local miniconda_dir  # Keep directories user-independent, to help with Bazel caching
-    local miniconda_version="Miniconda3-py39_23.1.0-1"
+    local miniconda_version="Miniconda3-py39_24.1.2-0"
     local miniconda_platform=""
     local exe_suffix=".sh"
 

--- a/ci/env/install-minimal.sh
+++ b/ci/env/install-minimal.sh
@@ -2,13 +2,11 @@
 
 set -xe
 
-# Python version can be specified as 3.8, 3.9, etc..
+# Python version can be specified as 3.9, etc..
 if [ -z "$1" ]; then
-    PYTHON_VERSION=${PYTHON-3.8}
+    PYTHON_VERSION=${PYTHON-3.9}
 else
-    if [ "$1" = "3.8" ]; then
-        PYTHON_VERSION="3.8"
-    elif [ "$1" = "3.9" ]; then
+    if [ "$1" = "3.9" ]; then
         PYTHON_VERSION="3.9"
     elif [ "$1" = "3.10" ]; then
         PYTHON_VERSION="3.10"

--- a/ci/ray_ci/builder_container.py
+++ b/ci/ray_ci/builder_container.py
@@ -17,7 +17,6 @@ ARCHITECTURE = [
     "aarch64",
 ]
 PYTHON_VERSIONS = {
-    "3.8": PythonVersionInfo(bin_path="cp38-cp38"),
     "3.9": PythonVersionInfo(bin_path="cp39-cp39"),
     "3.10": PythonVersionInfo(bin_path="cp310-cp310"),
     "3.11": PythonVersionInfo(bin_path="cp311-cp311"),

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -3,7 +3,7 @@
 set -ex
 
 export CI="true"
-export PYTHON="3.8"
+export PYTHON="3.9"
 export RAY_USE_RANDOM_PORTS="1"
 export RAY_DEFAULT_BUILD="1"
 export LC_ALL="en_US.UTF-8"

--- a/ci/ray_ci/macos/macos_ci_build.sh
+++ b/ci/ray_ci/macos/macos_ci_build.sh
@@ -3,7 +3,7 @@
 set -ex
 
 export CI="true"
-export PYTHON="3.8"
+export PYTHON="3.9"
 export RAY_USE_RANDOM_PORTS="1"
 export RAY_DEFAULT_BUILD="1"
 export LC_ALL="en_US.UTF-8"

--- a/python/ray/tests/test_runtime_env_2.py
+++ b/python/ray/tests/test_runtime_env_2.py
@@ -44,12 +44,13 @@ def test_invalid_conda_env(
             pass
 
     # TODO(somebody): track cache hit/miss statistics.
+    error_message = "PackagesNotFoundError"
 
     bad_env = runtime_env_class(conda={"dependencies": ["this_doesnt_exist"]})
     with pytest.raises(
         RuntimeEnvSetupError,
         # The actual error message should be included in the exception.
-        match="ResolvePackageNotFound",
+        match=error_message,
     ):
         ray.get(f.options(runtime_env=bad_env).remote())
 
@@ -57,18 +58,16 @@ def test_invalid_conda_env(
     ray.get(f.remote())
 
     a = A.options(runtime_env=bad_env).remote()
-    with pytest.raises(
-        ray.exceptions.RuntimeEnvSetupError, match="ResolvePackageNotFound"
-    ):
+    with pytest.raises(ray.exceptions.RuntimeEnvSetupError, match=error_message):
         ray.get(a.f.remote())
 
-    with pytest.raises(RuntimeEnvSetupError, match="ResolvePackageNotFound"):
+    with pytest.raises(RuntimeEnvSetupError, match=error_message):
         ray.get(f.options(runtime_env=bad_env).remote())
 
     # Sleep to wait bad runtime env cache removed.
     time.sleep(bad_runtime_env_cache_ttl_seconds)
 
-    with pytest.raises(RuntimeEnvSetupError, match="ResolvePackageNotFound"):
+    with pytest.raises(RuntimeEnvSetupError, match=error_message):
         ray.get(f.options(runtime_env=bad_env).remote())
 
 

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -286,7 +286,7 @@ def test_failed_task_runtime_env_setup(shutdown_only):
         verify_failed_task,
         name="task-runtime-env-failed",
         error_type="RUNTIME_ENV_SETUP_FAILED",
-        error_message="ResolvePackageNotFound",
+        error_message="PackagesNotFoundError",
     )
 
 


### PR DESCRIPTION
Redo of a previous PR which broke macos test. New change in this PR is to upgrade conda to the latest 24.x.x version. Note that this version also no longer support python 3.8.

Test:
- CI