### PR TITLE
[RLlib] `on_environment_created` callback called with incorrect arg names by EnvRunners.

### DIFF
--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -175,20 +175,23 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
         *,
         env_runner: "EnvRunner",
         env: gym.Env,
-        env_config: EnvContext,
+        env_context: EnvContext,
         **kwargs,
     ) -> None:
         """Callback run when a new environment object has been created.
 
         Note: This only applies to the new API stack. The env used is usually a
-        gym.Env (or more specificallly a gym.vector.Env).
+        gym.Env (or more specifically a gym.vector.Env).
 
         Args:
             env_runner: Reference to the current EnvRunner instance.
             env: The environment object that has been created on `env_runner`. This is
                 usually a gym.Env (or a gym.vector.Env) object.
-            env_config: The config dict that has been passed to the `gym.make()` call
-                as kwargs.
+            env_context: The `EnvContext` object that has been passed to the
+                `gym.make()` call as kwargs (and to the gym.Env as `config`). It should
+                have all the config key/value pairs in it as well as the
+                EnvContext-typical properties: `worker_index`, `num_workers`, and
+                `remote`.
             kwargs: Forward compatibility placeholder.
         """
         pass
@@ -692,7 +695,6 @@ def make_multi_callbacks(
             env_runner: "EnvRunner",
             env: gym.Env,
             env_context: EnvContext,
-            env_index: Optional[int] = None,
             **kwargs,
         ) -> None:
             for callback in self._callback_list:
@@ -700,7 +702,6 @@ def make_multi_callbacks(
                     env_runner=env_runner,
                     env=env,
                     env_context=env_context,
-                    env_index=env_index,
                     **kwargs,
                 )
 

--- a/rllib/algorithms/tests/test_callbacks_on_env_runner.py
+++ b/rllib/algorithms/tests/test_callbacks_on_env_runner.py
@@ -30,15 +30,15 @@ class EpisodeAndSampleCallbacks(DefaultCallbacks):
 
 
 class OnEnvironmentCreatedCallback(DefaultCallbacks):
-    def on_environment_created(self, *, worker, sub_environment, env_context, **kwargs):
+    def on_environment_created(self, *, env_runner, env, env_context, **kwargs):
         # Create a vector-index-sum property per remote worker.
-        if not hasattr(worker, "sum_sub_env_vector_indices"):
-            worker.sum_sub_env_vector_indices = 0
+        if not hasattr(env_runner, "sum_sub_env_vector_indices"):
+            env_runner.sum_sub_env_vector_indices = 0
         # Add the sub-env's vector index to the counter.
-        worker.sum_sub_env_vector_indices += env_context.vector_index
+        env_runner.sum_sub_env_vector_indices += env_context.vector_index
         print(
-            f"sub-env {sub_environment} created; "
-            f"worker={worker.worker_index}; "
+            f"sub-env {env} created; "
+            f"worker={env_runner.worker_index}; "
             f"vector-idx={env_context.vector_index}"
         )
 

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -699,7 +699,7 @@ class MultiAgentEnvRunner(EnvRunner):
         self._callbacks.on_environment_created(
             env_runner=self,
             env=self.env,
-            env_config=env_ctx,
+            env_context=env_ctx,
         )
 
     def _make_module(self):

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -663,7 +663,7 @@ class SingleAgentEnvRunner(EnvRunner):
         self._callbacks.on_environment_created(
             env_runner=self,
             env=self.env,
-            env_config=env_ctx,
+            env_context=env_ctx,
         )
 
     def _new_episode(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Bug fix:
RLlib's new EnvRunners (SingleAgentEnvRunner and MultiAgentEnvRunner) both call the `on_environment_created` callback with a wrong set of args: `env_context` should be used instead of `env_config` and `env_index` should not be used b/c on the new stack, the gym.env (or gym.vector.Env) is only created once and without a particular vector index for the individual sub-envs.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
