### PR TITLE
[Data] Fix test_pipelined_execution

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -776,6 +776,11 @@ class DatasetStats:
         stats_summary_parents = []
         if self.parents is not None:
             stats_summary_parents = [p.to_summary() for p in self.parents]
+        streaming_exec_schedule = (
+            self.streaming_exec_schedule_s.get()
+            if self.streaming_exec_schedule_s
+            else 0
+        )
         return DatasetStatsSummary(
             operators_stats,
             iter_stats,
@@ -788,7 +793,7 @@ class DatasetStats:
             self.global_bytes_spilled,
             self.global_bytes_restored,
             self.dataset_bytes_spilled,
-            self.streaming_exec_schedule_s.get(),
+            streaming_exec_schedule,
         )
 
     def runtime_metrics(self) -> str:

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -776,7 +776,7 @@ class DatasetStats:
         stats_summary_parents = []
         if self.parents is not None:
             stats_summary_parents = [p.to_summary() for p in self.parents]
-        streaming_exec_schedule = (
+        streaming_exec_schedule_s = (
             self.streaming_exec_schedule_s.get()
             if self.streaming_exec_schedule_s
             else 0
@@ -793,7 +793,7 @@ class DatasetStats:
             self.global_bytes_spilled,
             self.global_bytes_restored,
             self.dataset_bytes_spilled,
-            streaming_exec_schedule,
+            streaming_exec_schedule_s,
         )
 
     def runtime_metrics(self) -> str:


### PR DESCRIPTION
## Why are these changes needed?
This adds an extra `None` check before accessing the `streaming_exec_schedule_s` timer on the `DatasetStatsSummary` object.

## Related issue number
Closes #43481

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
