### PR TITLE
[tune] Fix flaky `test_controller_checkpointing_integration` test suite

### DIFF
--- a/python/ray/tune/tests/execution/test_controller_callback_integration.py
+++ b/python/ray/tune/tests/execution/test_controller_callback_integration.py
@@ -52,7 +52,7 @@ def test_callback_save_restore(
         runner._callbacks.on_trial_result(
             iteration=i, trials=None, trial=None, result=None
         )
-    runner.checkpoint(force=True)
+    runner.checkpoint(force=True, wait=True)
     callback = StatefulCallback()
     runner2 = TuneController(callbacks=[callback], storage=storage)
     assert callback.counter == 0

--- a/python/ray/tune/tests/execution/test_controller_checkpointing_integration.py
+++ b/python/ray/tune/tests/execution/test_controller_checkpointing_integration.py
@@ -427,9 +427,7 @@ def test_checkpoint_user_checkpoint(
         {"TUNE_RESULT_BUFFER_LENGTH": "1", "TUNE_MAX_PENDING_TRIALS_PG": "1"},
     ):
         runner = TuneController(
-            resource_manager_factory=lambda: resource_manager_cls(),
-            storage=STORAGE,
-            checkpoint_period=0,
+            resource_manager_factory=lambda: resource_manager_cls(), storage=STORAGE
         )
         runner.add_trial(
             Trial("__fake", config={"user_checkpoint_freq": 2}, storage=STORAGE)
@@ -452,6 +450,7 @@ def test_checkpoint_user_checkpoint(
         runner.step()
 
         assert trials[0].has_checkpoint()
+        runner.checkpoint(force=True, wait=True)
 
         runner2 = TuneController(
             resource_manager_factory=lambda: resource_manager_cls(),

--- a/python/ray/tune/tests/execution/test_controller_checkpointing_integration.py
+++ b/python/ray/tune/tests/execution/test_controller_checkpointing_integration.py
@@ -274,7 +274,7 @@ def test_checkpoint_num_to_keep(
     assert len(cp_dirs) == 2, f"Checkpoint dirs: {cp_dirs}"
 
     # Re-instantiate trial runner and resume
-    runner.checkpoint(force=True)
+    runner.checkpoint(force=True, wait=True)
     runner = TuneController(
         resource_manager_factory=lambda: resource_manager_cls(),
         storage=STORAGE,

--- a/python/ray/tune/tests/execution/test_controller_resume_integration.py
+++ b/python/ray/tune/tests/execution/test_controller_resume_integration.py
@@ -150,7 +150,7 @@ def test_controller_restore_no_error_resume(
     while not runner.is_finished():
         runner.step()
 
-    runner.checkpoint(force=True)
+    runner.checkpoint(force=True, wait=True)
 
     assert trials[0].status == Trial.ERROR
     del runner
@@ -195,7 +195,7 @@ def test_controller_restore_error_only_resume(
     while not runner.is_finished():
         runner.step()
 
-    runner.checkpoint(force=True)
+    runner.checkpoint(force=True, wait=True)
 
     assert trials[0].status == Trial.ERROR
     del runner
@@ -508,7 +508,7 @@ def test_controller_restore_with_dataset(
     )
     runner.add_trial(trial)
     # Req: TrialRunner checkpointing shouldn't error
-    runner.checkpoint(force=True)
+    runner.checkpoint(force=True, wait=True)
 
     # Manually clear all block refs that may have been created
     ray.shutdown()

--- a/python/ray/tune/tests/tune_test_util.py
+++ b/python/ray/tune/tests/tune_test_util.py
@@ -43,7 +43,7 @@ def create_tune_experiment_checkpoint(trials: list, **runner_kwargs) -> str:
         for trial in trials:
             runner.add_trial(trial)
 
-        runner.checkpoint(force=True)
+        runner.checkpoint(force=True, wait=True)
     finally:
         os.environ.clear()
         os.environ.update(orig_env)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The recent local directory refactor (https://github.com/ray-project/ray/pull/43369, https://github.com/ray-project/ray/pull/43403, https://github.com/ray-project/ray/pull/43689) made it so that driver syncing of experiment state files to `storage_path` is the only codepath. However, many CI tests relied on the fact that the driver state would be loaded from the "local" staging path, which is written to more frequently than the syncs happen. Now, the experiment always resumes from the state found in `storage_path`.

This PR deflakes unit tests facing problems with the new sync behavior:
* Some unit tests call `runner.checkpoint(force=True)`, which forces a snapshot write to the local staging directory, but doesn't wait for the sync to finish afterwards. I need to add `wait=True` to avoid situations where the experiment snapshot is corrupted because we don't wait for the upload to finish before trying to resume from it.
* Some tests set the "global checkpoint period" to 0, which kicks off many, many experiment snapshots, but still doesn't guarantee that the state will be synced up properly before trying to resume. I replace this with an explicit call to `runner.checkpoint(force=True, wait=True)`.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/43854

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
