### PR TITLE
[ci] move flaky + serverless windows tests to scheduled run

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -66,6 +66,7 @@ steps:
     depends_on: windowsbuild
 
   - label: ":serverless: serverless: :windows: tests"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
     tags: python
     job_env: WINDOWS
     mount_windows_artifacts: true
@@ -119,6 +120,7 @@ steps:
     depends_on: windowsbuild
 
   - label: "flaky :windows: tests"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
     tags: skip-on-premerge
     job_env: WINDOWS
     mount_windows_artifacts: true


### PR DESCRIPTION
As title, we missed these two test jobs in the previous migration to scheduled run, just for consistency

Test:
- CI