### PR TITLE
[Doc] Remove time-series and reinforcement-learning example gallery tags

### DIFF
--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -410,9 +410,7 @@ class UseCase(ExampleEnum):
     LARGE_LANGUAGE_MODELS = "Large Language Models"
     GENERATIVE_AI = "Generative AI"
     COMPUTER_VISION = "Computer Vision"
-    TIME_SERIES = "Time Series"
     NATURAL_LANGUAGE_PROCESSING = "Natural Language Processing"
-    REINFORCEMENT_LEARNING = "Reinforcement Learning"
 
     @classmethod
     def formatted_name(cls):


### PR DESCRIPTION
## Why are these changes needed?

This PR removes some unused filters from the example gallery's `Use Cases` dropdown.

## Related issue number

Closes #43673.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
