### PR TITLE
[Doc] Add support for community examples

### DIFF
--- a/doc/source/_static/css/examples.css
+++ b/doc/source/_static/css/examples.css
@@ -249,3 +249,11 @@ html[data-theme='light'] {
 .example-other-keywords {
   display: none;
 }
+
+.community-text {
+  color: var(--pst-color-text-muted);
+}
+
+.community-emojis {
+  padding-left: 0.5em;
+}

--- a/doc/source/_static/js/examples.js
+++ b/doc/source/_static/js/examples.js
@@ -29,10 +29,20 @@ function getFilterStatuses() {
       isChecked: label.querySelector('input').checked,
     };
   });
+  const contributor = Array.from(
+    document.querySelectorAll('#all-examples-dropdown .checkbox-container'),
+  ).map((label) => {
+    const inputElement = label.querySelector('input');
+    return {
+      name: inputElement.id.replace('-checkbox', ''),
+      isChecked: inputElement.checked,
+    };
+  });
   return {
     useCases,
     libraries,
     frameworks,
+    contributor,
   };
 }
 

--- a/doc/source/_templates/ray-overview/examples.html
+++ b/doc/source/_templates/ray-overview/examples.html
@@ -36,7 +36,7 @@
     </div>
     <div id="dropdown-area">
       {{ render_use_cases_dropdown() }} {{ render_libraries_dropdown() }} {{
-      render_frameworks_dropdown() }}
+      render_frameworks_dropdown() }} {{ render_contributor_dropdown() }}
     </div>
     <div id="no-matches" class="hidden">
       <div id="no-matches-inner-content">

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -404,6 +404,21 @@ class ExampleEnum(Enum):
         raise NotImplementedError
 
 
+class Contributor(ExampleEnum):
+    RAY_TEAM = "Maintained by the Ray Team"
+    COMMUNITY = "Contributed by the Ray community"
+
+    @property
+    def tag(self):
+        if self == Contributor.RAY_TEAM:
+            return "ray-team"
+        return "community"
+
+    @classmethod
+    def formatted_name(cls):
+        return "All Examples"
+
+
 class UseCase(ExampleEnum):
     """Use case type for example metadata."""
 
@@ -504,6 +519,20 @@ class Example:
         self.use_cases = []
         for use_case in config.get("use_cases", []):
             self.use_cases.append(UseCase(use_case.strip()))
+
+        contributor = config.get("contributor", "").strip()
+        if contributor:
+            if contributor == "community":
+                self.contributor = Contributor.COMMUNITY
+            elif contributor == "ray team":
+                self.contributor = Contributor.RAY_TEAM
+            else:
+                raise ValueError(
+                    f"Invalid contributor type specified: {contributor}. Must be "
+                    " either 'ray team' or 'community'."
+                )
+        else:
+            self.contributor = Contributor.RAY_TEAM
 
         self.skill_level = SkillLevel(config.get("skill_level"))
         self.title = config.get("title")
@@ -852,7 +881,23 @@ def setup_context(app, pagename, templatename, context, doctree):
             other_keywords.append(
                 " ".join(use_case.value for use_case in example.use_cases)
             )
+            other_keywords.append(f" {example.contributor.tag}")
             example_text_area.append(other_keywords)
+
+            # Add the appropriate text if the example comes from the community
+            if example.contributor == Contributor.COMMUNITY:
+                community_text_area = soup.new_tag(
+                    "div", attrs={"class": "community-text-area"}
+                )
+                community_text = soup.new_tag("i", attrs={"class": "community-text"})
+                community_text.append("*Contributed by the Ray Community")
+                community_text_area.append(community_text)
+
+                # Add emojis separately; they're not italicized in the mockups
+                emojis = soup.new_tag("span", attrs={"class": "community-emojis"})
+                emojis.append("💪 ✨")
+                community_text_area.append(emojis)
+                example_text_area.append(community_text_area)
 
             example_link.append(example_text_area)
             example_div.append(example_link)
@@ -962,6 +1007,9 @@ def setup_context(app, pagename, templatename, context, doctree):
     def render_frameworks_dropdown() -> bs4.BeautifulSoup:
         return render_example_gallery_dropdown(Framework)
 
+    def render_contributor_dropdown() -> bs4.BeautifulSoup:
+        return render_example_gallery_dropdown(Contributor)
+
     context["cached_toctree"] = preload_sidebar_nav(
         context["toctree"],
         context["pathto"],
@@ -974,6 +1022,7 @@ def setup_context(app, pagename, templatename, context, doctree):
     context["render_use_cases_dropdown"] = render_use_cases_dropdown
     context["render_libraries_dropdown"] = render_libraries_dropdown
     context["render_frameworks_dropdown"] = render_frameworks_dropdown
+    context["render_contributor_dropdown"] = render_contributor_dropdown
 
     # Update the HTML page context with a few extra utilities.
     context["pygments_highlight_python"] = lambda code: highlight(
@@ -1055,14 +1104,15 @@ def render_example_gallery_dropdown(cls: type) -> bs4.BeautifulSoup:
     if cls.values():
         dropdown_options = soup.new_tag("div", attrs={"class": "dropdown-content"})
 
-        for value in cls.values():
+        for member in list(cls):
             label = soup.new_tag("label", attrs={"class": "checkbox-container"})
-            label.append(value)
+            label.append(member.value)
 
+            tag = getattr(member, "tag", member.value)
             checkbox = soup.new_tag(
                 "input",
                 attrs={
-                    "id": f"{value.lower()}-checkbox",
+                    "id": f"{tag}-checkbox",
                     "class": "filter-checkbox",
                     "type": "checkbox",
                 },

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -406,7 +406,7 @@ class ExampleEnum(Enum):
 
 class Contributor(ExampleEnum):
     RAY_TEAM = "Maintained by the Ray Team"
-    COMMUNITY = "Contributed by the Ray community"
+    COMMUNITY = "Contributed by the Ray Community"
 
     @property
     def tag(self):

--- a/doc/source/ray-contribute/getting-involved.rst
+++ b/doc/source/ray-contribute/getting-involved.rst
@@ -334,7 +334,23 @@ For callback APIs, consider adding a ``**kwargs`` placeholder as a "forward comp
     def tune_user_callback(model, score, **future_kwargs):
         pass
 
+Community Examples
+------------------
 
+We're always looking for new example contributions! When contributing an example for a Ray library,
+include a link to your example in the ``examples.yml`` file for that library:
+
+.. code-block:: yaml
+
+     - title: Serve a Java App
+       skill_level: advanced
+       link: tutorials/java
+       contributor: community
+
+Give your example a title, a skill level (``beginner``, ``intermediate``, or ``advanced``), and a
+link (relative links point to other documentation pages, but direct links starting with ``http://``
+also work). Include the ``contributor: community`` metadata to ensure that the example is correctly
+labeled as a community example in the example gallery.
 
 Becoming a Reviewer
 -------------------

--- a/doc/source/train/examples.yml
+++ b/doc/source/train/examples.yml
@@ -47,19 +47,21 @@ examples:
       - horovod
     skill_level: beginner
     link: examples/horovod/horovod_example
-  - title: "[Community Example] Train ResNet model with HPU"
+  - title: "Train ResNet model with HPU"
     frameworks:
       - pytorch
     skill_level: beginner
     use_cases:
       - computer vision
+    contributor: community
     link: examples/hpu/resnet
-  - title: "[Community Example] Train BERT model with HPU"
+  - title: "Train BERT model with HPU"
     frameworks:
       - transformers
     skill_level: beginner
     use_cases:
       - natural language processing
+    contributor: community
     link: examples/hpu/bert
 
   - title: Fine-tune of Stable Diffusion with DreamBooth and Ray Train


### PR DESCRIPTION
## Why are these changes needed?

This PR adds special handling for community-contributed examples in the example gallery. Community examples have a special identifying text added to their cards in the example gallery.

## Related issue number

Closes #42983.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
