### PR TITLE
[ci] let automation close flaky issues again

### DIFF
--- a/release/ray_release/test_automation/ci_state_machine.py
+++ b/release/ray_release/test_automation/ci_state_machine.py
@@ -7,7 +7,7 @@ from ray_release.test import Test, TestState
 
 
 CONTINUOUS_FAILURE_TO_FLAKY = 10  # Number of continuous failures before flaky
-CONTINUOUS_PASSING_TO_PASSING = 20  # Number of continuous passing before passing
+CONTINUOUS_PASSING_TO_PASSING = 30  # Number of continuous passing before passing
 FLAKY_PERCENTAGE_THRESHOLD = 5  # Percentage threshold to be considered as flaky
 FAILING_TO_FLAKY_MESSAGE = (
     "This test is now considered as flaky because it has been "
@@ -126,8 +126,7 @@ class CITestStateMachine(TestStateMachine):
     def _flaky_to_passing(self) -> bool:
         # A flaky test is considered passing if it has been passing for a certain
         # period and the github issue is closed (by a human).
-        issue = self.ray_repo.get_issue(self.test.get(Test.KEY_GITHUB_ISSUE_NUMBER))
-        return self._is_recently_stable() and issue.state == "closed"
+        return self._is_recently_stable()
 
     def _is_recently_stable(self) -> bool:
         return len(self.test_results) >= CONTINUOUS_PASSING_TO_PASSING and all(

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -195,9 +195,6 @@ def test_ci_move_from_passing_to_failing_to_flaky():
         TestResult.from_result(Result(status=ResultStatus.SUCCESS.value)),
     ] * CONTINUOUS_PASSING_TO_PASSING
     CITestStateMachine(test).move()
-    assert test.get_state() == TestState.FLAKY
-    issue.state = "closed"
-    CITestStateMachine(test).move()
     assert test.get_state() == TestState.PASSING
     assert test.get(Test.KEY_GITHUB_ISSUE_NUMBER) == issue.number
     assert issue.state == "closed"


### PR DESCRIPTION
As discussed, let automation close flaky issues, but extending the bar to continuously pass 30 times in a row

Test:
- CI