### PR TITLE
Allow configurable managed identity when launching Azure clusters

### DIFF
--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -1051,6 +1051,62 @@ The user that Ray will authenticate with when launching new nodes.
 
         Not available.
 
+.. _cluster-configuration-msi-name:
+
+``provider.msi_name``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tab-set::
+
+    .. tab-item:: AWS
+
+        Not available.
+
+    .. tab-item:: Azure
+
+        The name of the managed identity to use for deployment of the Ray cluster. If not specified, Ray will create a default user-assigned managed identity.
+
+        * **Required:** No
+        * **Importance:** High
+        * **Type:** String
+        * **Default:** ray-default-msi
+
+    .. tab-item:: GCP
+
+        Not available.
+
+    .. tab-item:: vSphere
+
+        Not available.
+
+.. _cluster-configuration-msi-resource-group:
+
+``provider.msi_resource_group``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tab-set::
+
+    .. tab-item:: AWS
+
+        Not available.
+
+    .. tab-item:: Azure
+
+        The name of the managed identity's resource group to use for deployment of the Ray cluster, used in conjunction with msi_name. If not specified, Ray will create a default user-assigned managed identity in resource group specified in the provider config.
+
+        * **Required:** No
+        * **Importance:** High
+        * **Type:** String
+        * **Default:** ray-cluster
+
+    .. tab-item:: GCP
+
+        Not available.
+
+    .. tab-item:: vSphere
+
+        Not available.
+
 .. _cluster-configuration-project-id:
 
 ``provider.project_id``

--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -1054,7 +1054,7 @@ The user that Ray will authenticate with when launching new nodes.
 .. _cluster-configuration-msi-name:
 
 ``provider.msi_name``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. tab-set::
 
@@ -1082,7 +1082,7 @@ The user that Ray will authenticate with when launching new nodes.
 .. _cluster-configuration-msi-resource-group:
 
 ``provider.msi_resource_group``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. tab-set::
 

--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -1067,7 +1067,7 @@ The user that Ray will authenticate with when launching new nodes.
         The name of the managed identity to use for deployment of the Ray cluster. If not specified, Ray will create a default user-assigned managed identity.
 
         * **Required:** No
-        * **Importance:** High
+        * **Importance:** Low
         * **Type:** String
         * **Default:** ray-default-msi
 
@@ -1095,7 +1095,7 @@ The user that Ray will authenticate with when launching new nodes.
         The name of the managed identity's resource group to use for deployment of the Ray cluster, used in conjunction with msi_name. If not specified, Ray will create a default user-assigned managed identity in resource group specified in the provider config.
 
         * **Required:** No
-        * **Importance:** High
+        * **Importance:** Low
         * **Type:** String
         * **Default:** ray-cluster
 

--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -129,6 +129,8 @@ Provider
             :ref:`location <cluster-configuration-location>`: str
             :ref:`resource_group <cluster-configuration-resource-group>`: str
             :ref:`subscription_id <cluster-configuration-subscription-id>`: str
+            :ref:`msi_name <cluster-configuration-msi-name>`: str
+            :ref:`msi_resource_group <cluster-configuration-msi-resource-group>`: str
             :ref:`cache_stopped_nodes <cluster-configuration-cache-stopped-nodes>`: bool
             :ref:`use_internal_ips <cluster-configuration-use-internal-ips>`: bool
 

--- a/python/ray/autoscaler/_private/_azure/azure-config-template.json
+++ b/python/ray/autoscaler/_private/_azure/azure-config-template.json
@@ -13,12 +13,27 @@
             "metadata": {
                 "description": "Subnet parameters."
             }
+        },
+        "msiName": {
+            "type": "string",
+            "metadata": {
+                "description": "Managed service identity."
+            }
+        },
+        "msiResourceGroup": {
+            "type": "string",
+            "metadata": {
+                "description": "Managed service identity resource group."
+            }
+        },
+        "createMsi": {
+            "type": "bool",
+            "defaultValue": "true"
         }
     },
     "variables": {
         "contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
         "location": "[resourceGroup().location]",
-        "msiName": "[concat('ray-', parameters('clusterId'), '-msi')]",
         "roleAssignmentName": "[concat('ray-', parameters('clusterId'), '-ra')]",
         "nsgName": "[concat('ray-', parameters('clusterId'), '-nsg')]",
         "nsg": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]",
@@ -27,23 +42,24 @@
     },
     "resources": [
        {
+            "condition": "[parameters('createMsi')]",
             "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
             "apiVersion": "2018-11-30",
             "location": "[variables('location')]",
-            "name": "[variables('msiName')]"
+            "name": "[parameters('msiName')]"
         },
         {
             "type": "Microsoft.Authorization/roleAssignments",
             "apiVersion": "2020-08-01-preview",
             "name": "[guid(variables('roleAssignmentName'))]",
             "properties": {
-                "principalId": "[reference(variables('msiName')).principalId]",
+                "principalId": "[reference(resourceId(parameters('msiResourceGroup'), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('msiName')), '2018-11-30').principalId]",
                 "roleDefinitionId": "[variables('contributor')]",
                 "scope": "[resourceGroup().id]",
                 "principalType": "ServicePrincipal"
             },
             "dependsOn": [
-                "[variables('msiName')]"
+                "[parameters('msiName')]"
             ]
         },
         {
@@ -108,7 +124,7 @@
         },
         "msi": {
             "type": "string",
-            "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('msiName'))]"
+            "value": "[resourceId(parameters('msiResourceGroup'), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('msiName'))]"
         }
     }
 }

--- a/python/ray/autoscaler/_private/_azure/config.py
+++ b/python/ray/autoscaler/_private/_azure/config.py
@@ -97,6 +97,13 @@ def _configure_resource_group(config):
         subnet_mask = "10.{}.0.0/16".format(random.randint(1, 254))
     logger.info("Using subnet mask: %s", subnet_mask)
 
+    # Get or create an MSI name and resource group.
+    # Defaults to current resource group if not provided.
+    use_existing_msi = "msi_name" in config["provider"] and "msi_resource_group" in config["provider"]
+    msi_resource_group = config["provider"].get("msi_resource_group", resource_group)
+    msi_name = config["provider"].get("msi_name", f"ray-{cluster_id}-msi")
+    logger.info("Using msi_name: %s from msi_resource_group: %s", msi_name, msi_resource_group)
+
     parameters = {
         "properties": {
             "mode": DeploymentMode.incremental,
@@ -104,6 +111,9 @@ def _configure_resource_group(config):
             "parameters": {
                 "subnet": {"value": subnet_mask},
                 "clusterId": {"value": cluster_id},
+                "msiName": {"value": msi_name},
+                "msiResourceGroup": {"value": msi_resource_group},
+                "createMsi": {"value": not use_existing_msi},
             },
         }
     }

--- a/python/ray/autoscaler/_private/_azure/config.py
+++ b/python/ray/autoscaler/_private/_azure/config.py
@@ -99,10 +99,14 @@ def _configure_resource_group(config):
 
     # Get or create an MSI name and resource group.
     # Defaults to current resource group if not provided.
-    use_existing_msi = "msi_name" in config["provider"] and "msi_resource_group" in config["provider"]
+    use_existing_msi = (
+        "msi_name" in config["provider"] and "msi_resource_group" in config["provider"]
+    )
     msi_resource_group = config["provider"].get("msi_resource_group", resource_group)
     msi_name = config["provider"].get("msi_name", f"ray-{cluster_id}-msi")
-    logger.info("Using msi_name: %s from msi_resource_group: %s", msi_name, msi_resource_group)
+    logger.info(
+        "Using msi_name: %s from msi_resource_group: %s", msi_name, msi_resource_group
+    )
 
     parameters = {
         "properties": {

--- a/python/ray/autoscaler/azure/example-full.yaml
+++ b/python/ray/autoscaler/azure/example-full.yaml
@@ -47,6 +47,10 @@ provider:
     # set unique id for resources in this cluster
     # if not set a default id will be generated based on the resource group and cluster name
     # unique_id: RAY1
+    # set managed identity name and resource group
+    # if not set, a default user-assigned identity will be generated in the resource group specified above
+    # msi_name: ray-cluster-msi
+    # msi_resource_group: other-rg
 
 # How Ray will authenticate with newly launched nodes.
 auth:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, one is not able to use a previously configured managed identity when launching Azure clusters. This can cause issues with trying to connect multiple clusters to shared resources such as storage accounts or key vaults that lie outside the resource group of the created VMs as they won't able to access those shared resources. It also makes it much easier to tear down clusters, as the entire resource group can be deleted without fear of deleting any shared resources between clusters.

This change allows the user to pass the name of an existing managed identity and its resource group as part of the provider options in the cluster yaml file. If those fields are provided, a new managed identity is not created and the existing one is used. This change is backwards-compatible since if the new fields are not provided, the default behavior is the same as before - create a new managed identity in the same resource group as the deployment. I've verified both cases locally by launching a cluster with/without these parameters specified and viewing the (created) MSIs in the portal.

## Related issue number
Discussed in https://github.com/ray-project/ray/issues/29215, but does not appear that it was ever PRed.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
