### PR TITLE
[ci] migrate rllib contrib a2c to civ2

### DIFF
--- a/.buildkite/pipeline.ml.yml
+++ b/.buildkite/pipeline.ml.yml
@@ -8,22 +8,6 @@
 #    - INSTALL_LUDWIG=1 INSTALL_HOROVOD=1 ./ci/env/install-dependencies.sh
 #    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only python/ray/tests/ludwig/...
 
-- label: ":exploding_death_star: RLlib Contrib: A2C Tests"
-  conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_CONTRIB_AFFECTED"]
-  commands:
-    - cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }; trap cleanup EXIT
-    - conda deactivate
-    - conda create -n rllib_contrib python=3.8 -y
-    - conda activate rllib_contrib
-    - (cd rllib_contrib/a2c && pip install -r requirements.txt && pip install -e ".[development]")
-    - ./ci/env/env_info.sh
-    # Download files needed for running the bazel tests.
-    - wget https://raw.githubusercontent.com/ray-project/ray/releases/2.5.1/rllib/tests/run_regression_tests.py -P rllib_contrib/a2c/
-    # BAZEL (learning and compilation) tests:
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-flaky rllib_contrib/a2c/...
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-flaky,learning_tests --test_arg=--framework=torch rllib_contrib/a2c/...
-    - bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-flaky,learning_tests,-no_tf_eager_tracing --test_arg=--framework=tf2 rllib_contrib/a2c/...
-
 - label: ":exploding_death_star: RLlib Contrib: A3C Tests"
   conditions: ["NO_WHEELS_REQUIRED", "RAY_CI_RLLIB_CONTRIB_AFFECTED"]
   commands:

--- a/.buildkite/rllib_contrib.rayci.yml
+++ b/.buildkite/rllib_contrib.rayci.yml
@@ -1,0 +1,11 @@
+group: rllib contrib tests
+depends_on:
+  - oss-ci-base_build
+steps:
+  - label: ":exploding_death_star: rllib contrib: a2c tests"
+    if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b"
+    instance_type: medium
+    tags: rllib_contrib
+    commands:
+      - ./ci/ray_ci/rllib_contrib/rllib_contrib_ci.sh test_a2c
+    job_env: oss-ci-base_build

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -207,7 +207,11 @@ if __name__ == "__main__":
                 RAY_CI_RLLIB_DIRECTLY_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_MACOS_WHEELS_AFFECTED = 1
-            elif re.match("rllib_contrib/", changed_file):
+            elif (
+                re.match("rllib_contrib/", changed_file)
+                or changed_file == ".buildkite/rllib_contrib.rayci.yml"
+                or changed_file == ".buildkite/pipeline.ml.yml"
+            ):
                 if not changed_file.endswith(".md"):
                     RAY_CI_RLLIB_CONTRIB_AFFECTED = 1
             elif (
@@ -261,7 +265,6 @@ if __name__ == "__main__":
                 changed_file == "ci/docker/min.build.Dockerfile"
                 or changed_file == "ci/docker/min.build.wanda.yaml"
                 or changed_file == ".buildkite/serverless.rayci.yml"
-                or changed_file == ".buildkite/pipeline.ml.yml"
             ):
                 RAY_CI_PYTHON_AFFECTED = 1
             elif (
@@ -330,7 +333,6 @@ if __name__ == "__main__":
                 or changed_file == "ci/docker/forge.wanda.yaml"
                 or changed_file == "ci/docker/forge.aarch64.wanda.yaml"
                 or changed_file == ".buildkite/pipeline.build.yml"
-                or changed_file == ".buildkite/pipeline.ml.yml"
                 or changed_file == ".buildkite/hooks/post-command"
             ):
                 # These scripts are always run as part of the build process

--- a/ci/ray_ci/rllib_contrib/rllib_contrib_ci.sh
+++ b/ci/ray_ci/rllib_contrib/rllib_contrib_ci.sh
@@ -17,7 +17,6 @@ build() {
 
 test_a2c() {
   build "a2c"
-
   # BAZEL (learning and compilation) tests:
   bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-flaky rllib_contrib/a2c/...
   bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-flaky,learning_tests --test_arg=--framework=torch rllib_contrib/a2c/...

--- a/ci/ray_ci/rllib_contrib/rllib_contrib_ci.sh
+++ b/ci/ray_ci/rllib_contrib/rllib_contrib_ci.sh
@@ -17,6 +17,7 @@ build() {
 
 test_a2c() {
   build "a2c"
+
   # BAZEL (learning and compilation) tests:
   bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-flaky rllib_contrib/a2c/...
   bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-flaky,learning_tests --test_arg=--framework=torch rllib_contrib/a2c/...

--- a/ci/ray_ci/rllib_contrib/rllib_contrib_ci.sh
+++ b/ci/ray_ci/rllib_contrib/rllib_contrib_ci.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -i
+# shellcheck disable=SC2046
+
+set -exuo pipefail
+
+PYTHON="3.9"
+
+build() {
+  LIB=$1
+  conda create -n rllib_contrib python="$PYTHON" -y
+  conda activate rllib_contrib
+  (cd rllib_contrib/"$LIB" && pip install -r requirements.txt && pip install -e ".[development]")
+  ./ci/env/env_info.sh
+  # Download files needed for running the bazel tests.
+  wget https://raw.githubusercontent.com/ray-project/ray/releases/2.5.1/rllib/tests/run_regression_tests.py -P rllib_contrib/"$LIB"/
+}
+
+test_a2c() {
+  build "a2c"
+  # BAZEL (learning and compilation) tests:
+  bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-flaky rllib_contrib/a2c/...
+  bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-flaky,learning_tests --test_arg=--framework=torch rllib_contrib/a2c/...
+  bazel test --config=ci $(./ci/run/bazel_export_options) --build_tests_only --test_tag_filters=-flaky,learning_tests,-no_tf_eager_tracing --test_arg=--framework=tf2 rllib_contrib/a2c/...
+}
+
+"$@"


### PR DESCRIPTION
Migrate one of the rllib contrib algorithm to CIv2. This is much straightforward than I anticipate. 

Test:
- CI