### PR TITLE
[Serve] Fix serve deploy not getting current directory added to sys.path

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2369,10 +2369,7 @@ def connect(
             # see https://peps.python.org/pep-0338/),
             # then we shouldn't add it to the workers.
             if script_directory in sys.path:
-                if not (
-                    namespace
-                    and namespace == ray_constants.RAY_INTERNAL_DASHBOARD_NAMESPACE
-                ):
+                if namespace != ray_constants.RAY_INTERNAL_DASHBOARD_NAMESPACE:
                     code_paths.add(script_directory)
             current_directory = os.path.abspath(os.path.curdir)
             code_paths.add(current_directory)

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2348,7 +2348,7 @@ def connect(
         # Formally, the local path(s) should be added when all of these are true:
         # (1) there's no working_dir (or code search path should be in working_dir),
         # (2) it's not interactive mode, (there's no script file in interactive mode),
-        # (3) it's not in dashboard (should only skip script location, but still append
+        # (3) it's not in dashboard (should only skip script location but still append
         #   current directory),
         # (4) it's not client mode, (handled by client code)
         # (5) the driver is at the same node (machine) as the worker.
@@ -2369,6 +2369,11 @@ def connect(
             # see https://peps.python.org/pep-0338/),
             # then we shouldn't add it to the workers.
             if script_directory in sys.path:
+                # If user code contains names like `utils`, it will be conflicting with
+                # the `utils` module in the dashboard module. We should skip adding
+                # script directory for dashboard clients and should have the
+                # current directory available for loading user code.
+                # See: https://github.com/anyscale/product/issues/20746
                 if namespace != ray_constants.RAY_INTERNAL_DASHBOARD_NAMESPACE:
                     code_paths.add(script_directory)
             current_directory = os.path.abspath(os.path.curdir)

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2348,7 +2348,8 @@ def connect(
         # Formally, the local path(s) should be added when all of these are true:
         # (1) there's no working_dir (or code search path should be in working_dir),
         # (2) it's not interactive mode, (there's no script file in interactive mode),
-        # (3) it's not in dashboard,
+        # (3) it's not in dashboard (should only skip script location, but still append
+        #   current directory),
         # (4) it's not client mode, (handled by client code)
         # (5) the driver is at the same node (machine) as the worker.
         #
@@ -2358,8 +2359,6 @@ def connect(
             [
                 job_config._runtime_env_has_working_dir(),
                 interactive_mode,
-                namespace
-                and namespace == ray_constants.RAY_INTERNAL_DASHBOARD_NAMESPACE,
                 job_config._client_job,
             ]
         ):
@@ -2370,7 +2369,11 @@ def connect(
             # see https://peps.python.org/pep-0338/),
             # then we shouldn't add it to the workers.
             if script_directory in sys.path:
-                code_paths.add(script_directory)
+                if not (
+                    namespace
+                    and namespace == ray_constants.RAY_INTERNAL_DASHBOARD_NAMESPACE
+                ):
+                    code_paths.add(script_directory)
             current_directory = os.path.abspath(os.path.curdir)
             code_paths.add(current_directory)
             if len(code_paths) != 0:

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -123,6 +123,7 @@ py_test_module_list(
   size = "large",
   tags = ["exclusive", "no_windows", "team:serve"],
   deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
+  data = glob(["test_config_files/**/*"]),
 )
 
 # Minimal tests

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -123,7 +123,6 @@ py_test_module_list(
   size = "large",
   tags = ["exclusive", "no_windows", "team:serve"],
   deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
-  data = glob(["test_config_files/**/*"]),
 )
 
 # Minimal tests

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -169,14 +169,15 @@ def ray_start_stop_in_specific_directory(request):
     try:
         yield
     finally:
+        # Change the directory back to the original one.
+        os.chdir(original_working_dir)
+        print(f"\nChanged working directory back to {original_working_dir}\n")
+
         subprocess.check_output(["ray", "stop", "--force"])
         wait_for_condition(
             check_ray_stop,
             timeout=15,
         )
-        # Change the directory back to the original one.
-        os.chdir(original_working_dir)
-        print(f"\nChanged working directory back to {original_working_dir}\n")
 
 
 @pytest.fixture

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -153,9 +153,12 @@ def ray_start_stop():
 
 @pytest.fixture(scope="function")
 def ray_start_stop_in_specific_directory(request):
-    # Change working directory so Ray will start in the correct directory.
-    working_dir = request.param
-    os.chdir(working_dir)
+    original_working_dir = os.getcwd()
+
+    # Change working directory so Ray will start in the requested directory.
+    new_working_dir = request.param
+    os.chdir(new_working_dir)
+    print(f"\nChanged working directory to {new_working_dir}\n")
 
     subprocess.check_output(["ray", "start", "--head"])
     wait_for_condition(
@@ -171,6 +174,9 @@ def ray_start_stop_in_specific_directory(request):
             check_ray_stop,
             timeout=15,
         )
+        # Change the directory back to the original one.
+        os.chdir(original_working_dir)
+        print(f"\nChanged working directory back to {original_working_dir}\n")
 
 
 @pytest.fixture

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -45,7 +45,7 @@ def check_http_response(expected_text: str, json: Optional[Dict] = None):
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
 def test_deploy_basic(ray_start_stop):
     """Deploys some valid config files and checks that the deployments work."""
-    # ray.init(address="auto", namespace=SERVE_NAMESPACE)
+    ray.init(address="auto", namespace=SERVE_NAMESPACE)
 
     # Create absolute file names to YAML config files
     pizza_file_name = os.path.join(

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -65,8 +65,6 @@ def test_deploy_basic(ray_start_stop):
         print("Deploying pizza config.")
         deploy_response = subprocess.check_output(["serve", "deploy", pizza_file_name])
         assert success_message_fragment in deploy_response
-        status_response = subprocess.check_output(["serve", "status"])
-        print("status_response!!!", status_response)
 
         print("Deploy request sent successfully.")
 

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -709,11 +709,13 @@ def test_deploy_from_import_path(ray_start_stop):
     indirect=True,
 )
 def test_deploy_with_access_to_current_directory(ray_start_stop_in_specific_directory):
-    """Test serve deploy with using current directory is able to deploy the app.
+    """Test serve deploy using modules in the current directory succeeds.
 
-    We had issue where dashboard client no longer has the current working added to
-    the sys.path and unable to deploy Serve application in the current directory. This
-    test will ensure the files in the current directory can be accessed and deployed.
+    There was an issue where dashboard client doesn't add the current directory to
+    the sys.path and failed to deploy a Serve app defined in the directory. This
+    test ensures that files in the current directory can be accessed and deployed.
+
+    See: https://github.com/ray-project/ray/issues/43889
     """
     # Deploy Serve application with a config in the current directory.
     subprocess.check_output(["serve", "deploy", "use_current_working_directory.yaml"])

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -65,7 +65,6 @@ def test_deploy_basic(ray_start_stop):
         print("Deploying pizza config.")
         deploy_response = subprocess.check_output(["serve", "deploy", pizza_file_name])
         assert success_message_fragment in deploy_response
-
         print("Deploy request sent successfully.")
 
         wait_for_condition(

--- a/python/ray/serve/tests/test_config_files/use_current_working_directory.py
+++ b/python/ray/serve/tests/test_config_files/use_current_working_directory.py
@@ -1,0 +1,9 @@
+from ray import serve
+
+
+@serve.deployment
+def f():
+    return "hi"
+
+
+app = f.bind()

--- a/python/ray/serve/tests/test_config_files/use_current_working_directory.yaml
+++ b/python/ray/serve/tests/test_config_files/use_current_working_directory.yaml
@@ -1,0 +1,6 @@
+applications:
+  - name: app1
+    route_prefix: /
+    import_path: use_current_working_directory:app
+    deployments:
+      - name: f


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Re: https://github.com/ray-project/ray/pull/43214 There is a core change that stopped adding script directory and current directory for different conditions. This accidentally stopped adding current directory when it's coming from the dashboard where in that case we only want to stop adding the script directory. This PR fixes the issue and allow `serve deploy` to continue working with the current directory.

## Related issue number

Closes https://github.com/ray-project/ray/issues/43889

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
