### PR TITLE
[ci] fix release tests

### DIFF
--- a/release/ray_release/byod/byod_agent_stress_test.sh
+++ b/release/ray_release/byod/byod_agent_stress_test.sh
@@ -5,5 +5,3 @@
 set -exo pipefail
 
 pip install https://ray-ci-deps-wheels.s3.us-west-2.amazonaws.com/AutoROM.accept_rom_license-0.5.4-py3-none-any.whl
-echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -


### PR DESCRIPTION
Release tests are failing because of https://buildkite.com/ray-project/release/builds/10982#018e314a-2433-4888-9484-ecd269aab921/6-123

Remove these lines from `byod_agent_stress_tests.sh`, we do not install any google cli/sdk so we don't need these lines anyway.

Test:
- Release test