### PR TITLE
[Core] Ignore worker lease requests from dead caller

### DIFF
--- a/python/ray/tests/test_node_manager.py
+++ b/python/ray/tests/test_node_manager.py
@@ -191,6 +191,11 @@ ray.get(f.options(num_cpus=99999999).remote())
     indirect=True,
 )
 def test_exiting_driver_clears_infeasible(call_ray_start):
+    # Test that there is no leaking infeasible demands
+    # from an exited driver.
+    # See https://github.com/ray-project/ray/issues/43687
+    # for a bug where it happened.
+
     driver = """
 import ray
 

--- a/python/ray/tests/test_node_manager.py
+++ b/python/ray/tests/test_node_manager.py
@@ -185,6 +185,54 @@ ray.get(f.options(num_cpus=99999999).remote())
     )
 
 
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ["ray start --head --ray-client-server-port=25555"],
+    indirect=True,
+)
+def test_exiting_driver_clears_infeasible(call_ray_start):
+    driver = """
+import ray
+
+ray.init()
+
+@ray.remote
+def f():
+    pass
+
+f.options(num_cpus=99999999).remote()
+  """
+    proc = run_string_as_driver_nonblocking(driver)
+    proc.wait()
+
+    client_driver = """
+import ray
+
+ray.init("ray://127.0.0.1:25555")
+
+@ray.remote
+def f():
+    pass
+
+f.options(num_cpus=99999999).remote()
+  """
+    proc = run_string_as_driver_nonblocking(client_driver)
+    proc.wait()
+
+    ctx = ray.init(address=call_ray_start)
+
+    # Give gcs some time to update the load
+    time.sleep(1)
+
+    wait_for_condition(
+        check_infeasible,
+        timeout=10,
+        retry_interval_ms=1000,
+        expect_infeasible=False,
+        ray_ctx=ctx,
+    )
+
+
 def test_kill_driver_keep_infeasible_detached_actor(ray_start_cluster):
     cluster = ray_start_cluster
     address = cluster.address

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -328,16 +328,13 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
            "return values are greater than the remaining capacity.";
     max_task_args_memory = 0;
   }
-  auto is_owner_alive = [this](const WorkerID &owner_worker_id,
-                               const NodeID &owner_node_id) {
-    return !(failed_workers_cache_.count(owner_worker_id) > 0 ||
-             failed_nodes_cache_.count(owner_node_id) > 0);
-  };
   local_task_manager_ = std::make_shared<LocalTaskManager>(
       self_node_id_,
       std::dynamic_pointer_cast<ClusterResourceScheduler>(cluster_resource_scheduler_),
       dependency_manager_,
-      is_owner_alive,
+      [this](const WorkerID &owner_worker_id, const NodeID &owner_node_id) {
+        return !this->IsWorkerDead(owner_worker_id, owner_node_id);
+      },
       get_node_info_func,
       worker_pool_,
       leased_workers_,
@@ -387,6 +384,11 @@ NodeManager::NodeManager(instrumented_io_context &io_service,
   periodical_runner_.RunFnPeriodically([this]() { GCTaskFailureReason(); },
                                        RayConfig::instance().task_failure_entry_ttl_ms(),
                                        "NodeManager.GCTaskFailureReason");
+}
+
+bool NodeManager::IsWorkerDead(const WorkerID &worker_id, const NodeID &node_id) const {
+  return failed_workers_cache_.count(worker_id) > 0 ||
+         failed_nodes_cache_.count(node_id) > 0;
 }
 
 ray::Status NodeManager::RegisterGcs() {
@@ -1714,6 +1716,20 @@ void NodeManager::HandleReportWorkerBacklog(rpc::ReportWorkerBacklogRequest requ
 void NodeManager::HandleRequestWorkerLease(rpc::RequestWorkerLeaseRequest request,
                                            rpc::RequestWorkerLeaseReply *reply,
                                            rpc::SendReplyCallback send_reply_callback) {
+  const auto &caller_addr = request.resource_spec().caller_address();
+  const auto caller_worker = WorkerID::FromBinary(caller_addr.worker_id());
+  const auto caller_node = NodeID::FromBinary(caller_addr.raylet_id());
+  if (IsWorkerDead(caller_worker, caller_node)) {
+    RAY_LOG(INFO) << "Caller of RequestWorkerLease is dead. worker = " << caller_worker
+                  << ", node = " << caller_node << ". Skip leasing.";
+    reply->set_canceled(true);
+    reply->set_failure_type(rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED);
+    reply->set_scheduling_failure_message(
+        "Cancelled leasing because the caller worker is dead.");
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+    return;
+  };
+
   rpc::Task task_message;
   task_message.mutable_task_spec()->CopyFrom(request.resource_spec());
   RayTask task(task_message);

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -695,6 +695,10 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   std::unique_ptr<AgentManager> CreateRuntimeEnvAgentManager(
       const NodeID &self_node_id, const NodeManagerConfig &config);
 
+  /// If Node Manager already knows this (worker, node) is dead, return true.
+  /// Otherwise returns false.
+  bool IsWorkerDead(const WorkerID &worker_id, const NodeID &node_id) const;
+
   /// ID of this node.
   NodeID self_node_id_;
   /// The user-given identifier or name of this node.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently we clear all the pending lease requests when raylet receives the worker death notification. However if the lease request comes in after the notification (CoreWorker calls `Disconnect` and then `Shutdown`, the worker death notification happen after `Disconnect` but at that time there can be in-flight lease requests to the raylet), the lease request won't have chance to be cleared. This PR fixes this by ignoring those lease requests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #43687
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
