### PR TITLE
[serve] Guard `object_ref_or_future` resolution to enable calling `DeploymentResponse.result()` twice (#43883)

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -287,6 +287,24 @@ class _DeploymentResponseBase:
         # The result of `object_ref_future` must be an ObjectRef or ObjectRefGenerator.
         self._object_ref_future = object_ref_future
 
+        # Cached result of the `object_ref_future`.
+        # This is guarded by the below locks for async and sync methods.
+        # It's not expected that user code can mix async and sync methods (sync methods
+        # raise an exception when running in an `asyncio` loop).
+        # The `asyncio` lock is lazily constructed because the constructor may run on
+        # a different `asyncio` loop than method calls (or not run on one at all).
+        self._object_ref_or_gen = None
+        self.__lazy_object_ref_or_gen_asyncio_lock = None
+        self._object_ref_or_gen_sync_lock = threading.Lock()
+
+    @property
+    def _object_ref_or_gen_asyncio_lock(self) -> asyncio.Lock:
+        """Lazy `asyncio.Lock` object."""
+        if self.__lazy_object_ref_or_gen_asyncio_lock is None:
+            self.__lazy_object_ref_or_gen_asyncio_lock = asyncio.Lock()
+
+        return self.__lazy_object_ref_or_gen_asyncio_lock
+
     def _should_resolve_gen_to_obj_ref(
         self, obj_ref_or_gen: Union[ray.ObjectRef, ray.ObjectRefGenerator]
     ) -> bool:
@@ -312,13 +330,22 @@ class _DeploymentResponseBase:
         if _record_telemetry:
             ServeUsageTag.DEPLOYMENT_HANDLE_TO_OBJECT_REF_API_USED.record("1")
 
-        # Use `asyncio.wrap_future` so `self._object_ref_future` can be awaited safely
-        # from any asyncio loop.
-        obj_ref_or_gen = await asyncio.wrap_future(self._object_ref_future)
-        if self._should_resolve_gen_to_obj_ref(obj_ref_or_gen):
-            obj_ref_or_gen = await obj_ref_or_gen.__anext__()
+        # NOTE(edoakes): this section needs to be guarded with a lock and the resulting
+        # object ref or generator cached in order to avoid calling `__anext__()` to
+        # resolve to the underlying object ref more than once.
+        #
+        # See: https://github.com/ray-project/ray/issues/43879.
+        async with self._object_ref_or_gen_asyncio_lock:
+            if self._object_ref_or_gen is None:
+                # Use `asyncio.wrap_future` so `self._object_ref_future` can be awaited
+                # safely from any asyncio loop.
+                obj_ref_or_gen = await asyncio.wrap_future(self._object_ref_future)
+                if self._should_resolve_gen_to_obj_ref(obj_ref_or_gen):
+                    obj_ref_or_gen = await obj_ref_or_gen.__anext__()
 
-        return obj_ref_or_gen
+                self._object_ref_or_gen = obj_ref_or_gen
+
+            return self._object_ref_or_gen
 
     def _to_object_ref_or_gen_sync(
         self,
@@ -337,24 +364,31 @@ class _DeploymentResponseBase:
             ServeUsageTag.DEPLOYMENT_HANDLE_TO_OBJECT_REF_API_USED.record("1")
 
         start_time_s = time.time()
+        # NOTE(edoakes): this section needs to be guarded with a lock and the resulting
+        # object ref or generator cached in order to avoid calling `__next__()` to
+        # resolve to the underlying object ref more than once.
+        #
+        # See: https://github.com/ray-project/ray/issues/43879.
+        with self._object_ref_or_gen_sync_lock:
+            if self._object_ref_or_gen is None:
+                try:
+                    obj_ref_or_gen = self._object_ref_future.result(timeout=_timeout_s)
+                except concurrent.futures.TimeoutError:
+                    raise TimeoutError("Timed out resolving to ObjectRef.") from None
 
-        try:
-            obj_ref_or_gen = self._object_ref_future.result(timeout=_timeout_s)
-        except concurrent.futures.TimeoutError:
-            raise TimeoutError("Timed out resolving to ObjectRef.") from None
+                if self._should_resolve_gen_to_obj_ref(obj_ref_or_gen):
+                    obj_ref_or_gen = obj_ref_or_gen._next_sync(
+                        timeout_s=calculate_remaining_timeout(
+                            timeout_s=_timeout_s,
+                            start_time_s=start_time_s,
+                            curr_time_s=time.time(),
+                        )
+                    )
+                    if obj_ref_or_gen.is_nil():
+                        raise TimeoutError("Timed out resolving to ObjectRef.")
+                self._object_ref_or_gen = obj_ref_or_gen
 
-        if self._should_resolve_gen_to_obj_ref(obj_ref_or_gen):
-            obj_ref_or_gen = obj_ref_or_gen._next_sync(
-                timeout_s=calculate_remaining_timeout(
-                    timeout_s=_timeout_s,
-                    start_time_s=start_time_s,
-                    curr_time_s=time.time(),
-                )
-            )
-            if obj_ref_or_gen.is_nil():
-                raise TimeoutError("Timed out resolving to ObjectRef.")
-
-        return obj_ref_or_gen
+        return self._object_ref_or_gen
 
     def cancel(self):
         """Attempt to cancel the `DeploymentHandle` call.

--- a/python/ray/serve/tests/test_handle_api.py
+++ b/python/ray/serve/tests/test_handle_api.py
@@ -31,11 +31,21 @@ def test_basic(serve_instance):
             response = self._handle.remote()
             assert isinstance(response, DeploymentResponse)
             val = await response
+
+            # Check that the response can be awaited multiple times.
+            for _ in range(10):
+                assert (await response) == val
+
             return val
 
     handle: DeploymentHandle = serve.run(Deployment.bind(downstream.bind()))
     assert isinstance(handle, DeploymentHandle)
-    assert handle.remote().result() == "hello"
+    r = handle.remote()
+    assert r.result() == "hello"
+
+    # Check that `.result()` can be called multiple times.
+    for _ in range(10):
+        assert r.result() == "hello"
 
 
 def test_result_timeout(serve_instance):


### PR DESCRIPTION
## Why are these changes needed?

Cherry-pick https://github.com/ray-project/ray/pull/43883

## Related issue number

Closes https://github.com/ray-project/ray/issues/43879

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
