### PR TITLE
[serve] fix num replicas auto bug

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1057,6 +1057,7 @@ def override_deployment_info(
             ):
                 options["max_ongoing_requests"] = NEW_DEFAULT_MAX_ONGOING_REQUESTS
 
+            new_config = AutoscalingConfig.default().dict()
             # If `autoscaling_config` is specified, its values override
             # the default `num_replicas="auto"` configuration
             autoscaling_config = (
@@ -1064,9 +1065,9 @@ def override_deployment_info(
                 or info.deployment_config.autoscaling_config
             )
             if autoscaling_config:
-                new_config = AutoscalingConfig.default().dict()
                 new_config.update(autoscaling_config)
-                options["autoscaling_config"] = AutoscalingConfig(**new_config)
+
+            options["autoscaling_config"] = AutoscalingConfig(**new_config)
 
         # What to pass to info.update
         override_options = dict()


### PR DESCRIPTION
[serve] fix num replicas auto bug

When only `num_replicas="auto"` is specified (and no autoscaling config), the deployment errors. This was not caught before because all meaningful tests require overriding one or more of the default autoscaling values (e.g. drop downscale delay from 10 minutes to 1 second for reasonable length tests).

This PR adds a test that *only* sets `num_replicas="auto"`.

Closes https://github.com/ray-project/ray/issues/43929.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
