### PR TITLE
[ci] pin dependencies for window wheel uploading

### DIFF
--- a/ci/build/copy_build_artifacts.sh
+++ b/ci/build/copy_build_artifacts.sh
@@ -33,8 +33,9 @@ if [[ "$OSTYPE" == "msys" ]]; then
   ARTIFACT_MOUNT="/c/artifact-mount"
 fi
 
-export PATH=/opt/python/cp38-cp38/bin:$PATH
-pip install -q -c python/requirements_compiled.txt aws_requests_auth boto3 pyopenssl
+export PATH=/opt/python/cp39-cp39/bin:$PATH
+pip install -U --ignore-installed -c python/requirements_compiled.txt \
+  aws_requests_auth boto3 urllib3 cryptography pyopenssl
 ./ci/env/env_info.sh
 
 # Sync the directory to buildkite artifacts

--- a/ci/build/upload_build_info.sh
+++ b/ci/build/upload_build_info.sh
@@ -31,6 +31,6 @@ mkdir -p "$BAZEL_LOG_DIR"
 
 ./ci/build/get_build_info.py > "$BAZEL_LOG_DIR"/metadata.json
 
-# Keep cryptography/openssl in sync with `requirements/test-requirements.txt`
-pip install -q -c "${RAY_DIR}/python/requirements.txt" docker aws_requests_auth boto3 cryptography==38.0.1 PyOpenSSL==23.0.0
+pip install -U --ignore-installed -c "${RAY_DIR}/python/requirements_compiled.txt" \
+  docker aws_requests_auth boto3 urllib3 cryptography pyopenssl
 python .buildkite/copy_files.py --destination logs --path "$BAZEL_LOG_DIR"


### PR DESCRIPTION
windows wheel failed to upload after the conda upgrade, need to pin urllib3 as well (https://buildkite.com/ray-project/postmerge/builds/3449#018e3477-dec1-4b4f-b3d6-e27ea94fc478/6-12043). Also remove the pinning versions of other packages while I'm here, they are constrained by the constraint files.

Test:
- windows upload https://buildkite.com/ray-project/postmerge/builds/3466