### PR TITLE
[cluster launcher] ray down should destroy security groups

### DIFF
--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -365,5 +365,5 @@ class AzureNodeProvider(NodeProvider):
         return self._get_node(node_id=node_id)
 
     @staticmethod
-    def bootstrap_config(cluster_config):
+    def bootstrap_config(cluster_config, **kwargs):
         return bootstrap_azure(cluster_config)

--- a/python/ray/autoscaler/_private/aliyun/node_provider.py
+++ b/python/ray/autoscaler/_private/aliyun/node_provider.py
@@ -320,5 +320,5 @@ class AliyunNodeProvider(NodeProvider):
         return self._get_node(node_id)
 
     @staticmethod
-    def bootstrap_config(cluster_config):
+    def bootstrap_config(cluster_config, **kwargs):
         return bootstrap_aliyun(cluster_config)

--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -222,7 +222,7 @@ def log_to_cli(config: Dict[str, Any]) -> None:
     cli_logger.newline()
 
 
-def bootstrap_aws(config):
+def bootstrap_aws(config, no_create=False):
     # create a copy of the input config to modify
     config = copy.deepcopy(config)
 
@@ -256,7 +256,7 @@ def bootstrap_aws(config):
 
     # Cluster workers should be in a security group that permits traffic within
     # the group, and also SSH access from outside.
-    config = _configure_security_group(config)
+    config = _configure_security_group(config, no_create)
 
     # Provide a helpful message for missing AMI.
     _check_ami(config)
@@ -652,7 +652,7 @@ def _get_vpc_id_of_sg(sg_ids: List[str], config: Dict[str, Any]) -> str:
     return vpc_ids[0]
 
 
-def _configure_security_group(config):
+def _configure_security_group(config, no_create):
     # map from node type key -> source of SecurityGroupIds field
     security_group_info_src = {}
     _set_config_info(security_group_src=security_group_info_src)
@@ -673,11 +673,12 @@ def _configure_security_group(config):
         # in tests
         node_types_to_configure.remove(head_node_type)
         node_types_to_configure.append(head_node_type)
-    security_groups = _upsert_security_groups(config, node_types_to_configure)
+    security_groups = _upsert_security_groups(
+        config, node_types_to_configure, no_create
+    )
 
-    for node_type_key in node_types_to_configure:
+    for node_type_key, sg in security_groups:
         node_config = config["available_node_types"][node_type_key]["node_config"]
-        sg = security_groups[node_type_key]
         node_config["SecurityGroupIds"] = [sg.id]
         security_group_info_src[node_type_key] = "default"
 
@@ -709,14 +710,14 @@ def _check_ami(config):
                 ami_src_info[key] = "dlami"
 
 
-def _upsert_security_groups(config, node_types):
-    security_groups = _get_or_create_vpc_security_groups(config, node_types)
+def _upsert_security_groups(config, node_types, no_create):
+    security_groups = _get_or_create_vpc_security_groups(config, node_types, no_create)
     _upsert_security_group_rules(config, security_groups)
 
     return security_groups
 
 
-def _get_or_create_vpc_security_groups(conf, node_types):
+def _get_or_create_vpc_security_groups(conf, node_types, no_create):
     # Figure out which VPC each node_type is in...
     ec2 = _resource("ec2", conf)
     node_type_to_vpc = {
@@ -744,16 +745,23 @@ def _get_or_create_vpc_security_groups(conf, node_types):
         )
     }
 
-    # Lazily create any security group we're missing for each VPC...
-    vpc_to_sg = LazyDefaultDict(
-        partial(_create_security_group, conf, group_name=expected_sg_name),
-        vpc_to_existing_sg,
-    )
-
-    # Then return a mapping from each node_type to its security group...
-    return {
-        node_type: vpc_to_sg[vpc_id] for node_type, vpc_id in node_type_to_vpc.items()
-    }
+    if no_create:
+        return {
+            node_type: vpc_to_existing_sg[vpc_id]
+            for node_type, vpc_id in node_type_to_vpc.items()
+            if vpc_id in vpc_to_existing_sg
+        }
+    else:
+        # Lazily create any security group we're missing for each VPC...
+        vpc_to_sg = LazyDefaultDict(
+            partial(_create_security_group, conf, group_name=expected_sg_name),
+            vpc_to_existing_sg,
+        )
+        # Then return a mapping from each node_type to its security group...
+        return {
+            node_type: vpc_to_sg[vpc_id]
+            for node_type, vpc_id in node_type_to_vpc.items()
+        }
 
 
 def _get_vpc_id_or_die(ec2, subnet_id: str):

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -522,6 +522,22 @@ class AWSNodeProvider(NodeProvider):
                 cwa_installed = True
         return cwa_installed
 
+    def cleanup_security_groups(self, config):
+        node_types = [
+            node_type_key
+            for node_type_key, node_type in config["available_node_types"].items()
+            if "SecurityGroupIds" in node_type["node_config"]
+        ]
+        for node_type_key in node_types:
+            security_group_ids = config["available_node_types"][node_type_key][
+                "node_config"
+            ]["SecurityGroupIds"]
+            for security_group_id in security_group_ids:
+                self.ec2.meta.client.delete_security_group(GroupId=security_group_id)
+
+    def cleanup(self, config):
+        self.cleanup_security_groups(config)
+
     def terminate_nodes(self, node_ids):
         if not node_ids:
             return
@@ -602,8 +618,8 @@ class AWSNodeProvider(NodeProvider):
         return self._get_node(node_id)
 
     @staticmethod
-    def bootstrap_config(cluster_config):
-        return bootstrap_aws(cluster_config)
+    def bootstrap_config(cluster_config, **kwargs):
+        return bootstrap_aws(cluster_config, kwargs["no_create"])
 
     @staticmethod
     def fillout_available_node_types_resources(

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -330,7 +330,9 @@ CONFIG_CACHE_VERSION = 1
 
 
 def _bootstrap_config(
-    config: Dict[str, Any], no_config_cache: bool = False
+    config: Dict[str, Any],
+    no_config_cache: bool = False,
+    no_create: bool = False,
 ) -> Dict[str, Any]:
     config = prepare_config(config)
     # NOTE: multi-node-type autoscaler is guaranteed to be in use after this.
@@ -413,7 +415,7 @@ def _bootstrap_config(
             'only be usable via `pip install "ray[default]"`. Please '
             "update your install command."
         )
-    resolved_config = provider_cls.bootstrap_config(config)
+    resolved_config = provider_cls.bootstrap_config(config, no_create=no_create)
 
     if not no_config_cache:
         with open(cache_key, "w") as f:
@@ -438,7 +440,7 @@ def teardown_cluster(
     if override_cluster_name is not None:
         config["cluster_name"] = override_cluster_name
 
-    config = _bootstrap_config(config)
+    config = _bootstrap_config(config, no_config_cache=True, no_create=True)
 
     cli_logger.confirm(yes, "Destroying cluster.", _abort=True)
 
@@ -560,6 +562,8 @@ def teardown_cluster(
             cli_logger.print(
                 "{} nodes remaining after {} second(s).", cf.bold(len(A)), POLL_INTERVAL
             )
+
+        provider.cleanup(config)
         cli_logger.success("No nodes remaining.")
 
 

--- a/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/node_provider.py
@@ -406,7 +406,7 @@ class FakeMultiNodeProvider(NodeProvider):
         node["node"].kill_all_processes(check_alive=False, allow_graceful=True)
 
     @staticmethod
-    def bootstrap_config(cluster_config):
+    def bootstrap_config(cluster_config, **kwargs):
         return cluster_config
 
     ############################
@@ -721,5 +721,5 @@ class FakeMultiNodeDockerProvider(FakeMultiNodeProvider):
         self._save_node_state()
 
     @staticmethod
-    def bootstrap_config(cluster_config):
+    def bootstrap_config(cluster_config, **kwargs):
         return cluster_config

--- a/python/ray/autoscaler/_private/gcp/node_provider.py
+++ b/python/ray/autoscaler/_private/gcp/node_provider.py
@@ -273,7 +273,7 @@ class GCPNodeProvider(NodeProvider):
         return self._get_node(node_id)
 
     @staticmethod
-    def bootstrap_config(cluster_config):
+    def bootstrap_config(cluster_config, **kwargs):
         return bootstrap_gcp(cluster_config)
 
     @staticmethod

--- a/python/ray/autoscaler/_private/local/node_provider.py
+++ b/python/ray/autoscaler/_private/local/node_provider.py
@@ -274,7 +274,7 @@ class LocalNodeProvider(NodeProvider):
         self.state.put(node_id, info)
 
     @staticmethod
-    def bootstrap_config(cluster_config):
+    def bootstrap_config(cluster_config, **kwargs):
         return bootstrap_local(cluster_config)
 
 

--- a/python/ray/autoscaler/_private/readonly/node_provider.py
+++ b/python/ray/autoscaler/_private/readonly/node_provider.py
@@ -76,5 +76,5 @@ class ReadOnlyNodeProvider(NodeProvider):
         raise AssertionError("Readonly node provider cannot be updated")
 
     @staticmethod
-    def bootstrap_config(cluster_config):
+    def bootstrap_config(cluster_config, **kwargs):
         return cluster_config

--- a/python/ray/autoscaler/_private/spark/node_provider.py
+++ b/python/ray/autoscaler/_private/spark/node_provider.py
@@ -242,5 +242,5 @@ class SparkNodeProvider(NodeProvider):
         logger.info(f"Spark node provider terminates node {node_id}")
 
     @staticmethod
-    def bootstrap_config(cluster_config):
+    def bootstrap_config(cluster_config, **kwargs):
         return cluster_config

--- a/python/ray/autoscaler/_private/vsphere/node_provider.py
+++ b/python/ray/autoscaler/_private/vsphere/node_provider.py
@@ -72,7 +72,7 @@ class VsphereNodeProvider(NodeProvider):
         return self.get_pyvmomi_sdk_provider().wait_until_vm_is_frozen(frozen_vm_name)
 
     @staticmethod
-    def bootstrap_config(cluster_config):
+    def bootstrap_config(cluster_config, **kwargs):
         return bootstrap_vsphere(cluster_config)
 
     def non_terminated_nodes(self, tag_filters):

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -174,6 +174,10 @@ class NodeProvider:
             self.terminate_node(node_id)
         return None
 
+    def cleanup(self, config: Dict[str, Any]) -> None:
+        """Cleanup the associated resources of the cluster."""
+        pass
+
     @property
     def max_terminate_nodes(self) -> Optional[int]:
         """The maximum number of nodes which can be terminated in one single
@@ -191,7 +195,7 @@ class NodeProvider:
         return None
 
     @staticmethod
-    def bootstrap_config(cluster_config: Dict[str, Any]) -> Dict[str, Any]:
+    def bootstrap_config(cluster_config: Dict[str, Any], **kwargs) -> Dict[str, Any]:
         """Bootstraps the cluster config by adding env defaults if needed."""
         return cluster_config
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`ray down` only takes down the ec2 instances, but doesn't delete the security groups created via `ray up`.
We should destroy them.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #43863

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
