### PR TITLE
[Core] Remove external storage upon sigterm for ray start

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2501,6 +2501,9 @@ cdef void delete_spilled_objects_handler(
                 traceback.format_exc() + exception_str,
                 job_id=None)
 
+cdef void destroy_external_storage():
+    # with gil?
+    external_storage.destroy_external_storage()
 
 cdef void cancel_async_task(
         const CTaskID &c_task_id,
@@ -3318,6 +3321,7 @@ cdef class CoreWorker:
         options.spill_objects = spill_objects_handler
         options.restore_spilled_objects = restore_spilled_objects_handler
         options.delete_spilled_objects = delete_spilled_objects_handler
+        options.destroy_external_storage = destroy_external_storage
         options.unhandled_exception_handler = unhandled_exception_handler
         options.cancel_async_task = cancel_async_task
         options.get_lang_stack = get_py_stack

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2501,9 +2501,9 @@ cdef void delete_spilled_objects_handler(
                 traceback.format_exc() + exception_str,
                 job_id=None)
 
-cdef void destroy_external_storage():
-    # with gil?
-    external_storage.destroy_external_storage()
+cdef void destroy_external_storage() nogil:
+    with gil:
+        external_storage.destroy_external_storage()
 
 cdef void cancel_async_task(
         const CTaskID &c_task_id,

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -385,7 +385,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         (void(
             const c_vector[c_string]&,
             CWorkerType) nogil) delete_spilled_objects
-        (void()) destroy_external_storage
+        (void() nogil) destroy_external_storage
         (void(
             const c_string&,
             const c_vector[c_string]&) nogil) run_on_util_worker_handler

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -385,6 +385,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         (void(
             const c_vector[c_string]&,
             CWorkerType) nogil) delete_spilled_objects
+        (void()) destroy_external_storage
         (void(
             const c_string&,
             const c_vector[c_string]&) nogil) run_on_util_worker_handler

--- a/src/mock/ray/core_worker/core_worker.h
+++ b/src/mock/ray/core_worker/core_worker.h
@@ -154,6 +154,12 @@ class MockCoreWorker : public CoreWorker {
                rpc::SendReplyCallback send_reply_callback),
               (override));
   MOCK_METHOD(void,
+              HandleDestroyExternalStorage,
+              (rpc::DestroyExternalStorageRequest request,
+               rpc::DestroyExternalStorageReply *reply,
+               rpc::SendReplyCallback send_reply_callback),
+              (override));
+  MOCK_METHOD(void,
               HandleExit,
               (rpc::ExitRequest request,
                rpc::ExitReply *reply,

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -4200,6 +4200,13 @@ void CoreWorker::HandleDeleteSpilledObjects(rpc::DeleteSpilledObjectsRequest req
   }
 }
 
+void CoreWorker::HandleDestroyExternalStorage(rpc::DestroyExternalStorageRequest request,
+                                    rpc::DestroyExternalStorageReply *reply,
+                                    rpc::SendReplyCallback send_reply_callback) {
+  options_.destroy_external_storage();
+  send_reply_callback(Status::OK(), nullptr, nullptr);
+}
+
 void CoreWorker::HandleExit(rpc::ExitRequest request,
                             rpc::ExitReply *reply,
                             rpc::SendReplyCallback send_reply_callback) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -4200,9 +4200,10 @@ void CoreWorker::HandleDeleteSpilledObjects(rpc::DeleteSpilledObjectsRequest req
   }
 }
 
-void CoreWorker::HandleDestroyExternalStorage(rpc::DestroyExternalStorageRequest request,
-                                    rpc::DestroyExternalStorageReply *reply,
-                                    rpc::SendReplyCallback send_reply_callback) {
+void CoreWorker::HandleDestroyExternalStorage(
+    rpc::DestroyExternalStorageRequest request,
+    rpc::DestroyExternalStorageReply *reply,
+    rpc::SendReplyCallback send_reply_callback) {
   options_.destroy_external_storage();
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1288,6 +1288,10 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
                                   rpc::DeleteSpilledObjectsReply *reply,
                                   rpc::SendReplyCallback send_reply_callback) override;
 
+  void HandleDestroyExternalStorage(rpc::DestroyExternalStorageRequest request,
+                                    rpc::DestroyExternalStorageReply *reply,
+                                    rpc::SendReplyCallback send_reply_callback) override;
+
   // Make the this worker exit.
   // This request fails if the core worker owns any object.
   void HandleExit(rpc::ExitRequest request,

--- a/src/ray/core_worker/core_worker_options.h
+++ b/src/ray/core_worker/core_worker_options.h
@@ -86,6 +86,7 @@ struct CoreWorkerOptions {
         spill_objects(nullptr),
         restore_spilled_objects(nullptr),
         delete_spilled_objects(nullptr),
+        destroy_external_storage(nullptr),
         unhandled_exception_handler(nullptr),
         get_lang_stack(nullptr),
         kill_main(nullptr),
@@ -159,6 +160,8 @@ struct CoreWorkerOptions {
   /// Application-language callback to delete objects from external storage.
   std::function<void(const std::vector<std::string> &, rpc::WorkerType)>
       delete_spilled_objects;
+  /// Function that destroys external storage
+  std::function<void()> destroy_external_storage;
   /// Function to call on error objects never retrieved.
   std::function<void(const RayObject &error)> unhandled_exception_handler;
   /// Language worker callback to get the current call stack.

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -360,6 +360,10 @@ message DeleteSpilledObjectsRequest {
 
 message DeleteSpilledObjectsReply {}
 
+message DestroyExternalStorageRequest {}
+
+message DestroyExternalStorageReply {}
+
 message ExitRequest {
   /// Whether to force exit the worker, regardless of whether the core worker
   /// owns object.
@@ -474,6 +478,8 @@ service CoreWorkerService {
   // Delete spilled objects from external storage. Caller: raylet; callee: I/O worker.
   rpc DeleteSpilledObjects(DeleteSpilledObjectsRequest)
       returns (DeleteSpilledObjectsReply);
+  rpc DestroyExternalStorage(DestroyExternalStorageRequest)
+      returns (DestroyExternalStorageReply);
   // Notification from raylet that an object ID is available in local plasma.
   rpc PlasmaObjectReady(PlasmaObjectReadyRequest) returns (PlasmaObjectReadyReply);
   // Request for a worker to exit.

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -594,19 +594,19 @@ void LocalObjectManager::DeleteSpilledObjects(std::vector<std::string> urls_to_d
 }
 
 void LocalObjectManager::DestroyExternalStorage() {
-  io_worker_pool_.PopDeleteWorker(
-    [this](std::shared_ptr<WorkerInterface> io_worker) {
-      rpc::DestroyExternalStorageRequest request;
-      io_worker->rpc_client()->DestroyExternalStorage(
+  io_worker_pool_.PopDeleteWorker([this](std::shared_ptr<WorkerInterface> io_worker) {
+    rpc::DestroyExternalStorageRequest request;
+    io_worker->rpc_client()->DestroyExternalStorage(
         request,
-        [this, io_worker](const ray::Status &status, const rpc::DestroyExternalStorageReply &reply) {
+        [this, io_worker](const ray::Status &status,
+                          const rpc::DestroyExternalStorageReply &reply) {
           io_worker_pool_.PushDeleteWorker(io_worker);
           if (!status.ok()) {
             RAY_LOG(ERROR) << "Failed to send destroy external storage request: "
-                << status.ToString();
+                           << status.ToString();
           }
-      });
-    });
+        });
+  });
 }
 
 void LocalObjectManager::FillObjectStoreStats(rpc::GetNodeStatsReply *reply) const {

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -600,7 +600,7 @@ void LocalObjectManager::DestroyExternalStorage() {
     io_worker->rpc_client()->DestroyExternalStorage(
         request,
         [this, io_worker, &promise](const ray::Status &status,
-                          const rpc::DestroyExternalStorageReply &reply) {
+                                    const rpc::DestroyExternalStorageReply &reply) {
           io_worker_pool_.PushDeleteWorker(io_worker);
           if (!status.ok()) {
             RAY_LOG(ERROR) << "Failed to send destroy external storage request: "
@@ -608,12 +608,12 @@ void LocalObjectManager::DestroyExternalStorage() {
           }
           promise.set_value(status);
         });
-      auto future = promise.get_future();
-      // TODO: make the timeout configurable
-      using namespace std::chrono_literals;
-      if (future.wait_for(10s) != std::future_status::ready) {
-        RAY_LOG(ERROR) << "Failed to destroy external storage within ";
-      }
+    auto future = promise.get_future();
+    // TODO: make the timeout configurable
+    using namespace std::chrono_literals;
+    if (future.wait_for(10s) != std::future_status::ready) {
+      RAY_LOG(ERROR) << "Failed to destroy external storage within ";
+    }
   });
 }
 

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -138,7 +138,7 @@ class LocalObjectManager {
   /// invocation.
   void ProcessSpilledObjectsDeleteQueue(uint32_t max_batch_size);
 
-   /// Destroy external storage
+  /// Destroy external storage
   void DestroyExternalStorage();
 
   /// Return True if spilling is in progress.

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -138,6 +138,9 @@ class LocalObjectManager {
   /// invocation.
   void ProcessSpilledObjectsDeleteQueue(uint32_t max_batch_size);
 
+   /// Destroy external storage
+  void DestroyExternalStorage();
+
   /// Return True if spilling is in progress.
   /// This is a narrow interface that is accessed by plasma store.
   /// We are using the narrow interface here because plasma store is running in a

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -138,7 +138,7 @@ class LocalObjectManager {
   /// invocation.
   void ProcessSpilledObjectsDeleteQueue(uint32_t max_batch_size);
 
-  /// Destroy external storage
+  /// Destroy external storage in a synchronous fashion.
   void DestroyExternalStorage();
 
   /// Return True if spilling is in progress.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2647,6 +2647,7 @@ void NodeManager::Stop() {
   // This never fails.
   RAY_CHECK_OK(store_client_.Disconnect());
   object_manager_.Stop();
+  local_object_manager_.DestroyExternalStorage();
   dashboard_agent_manager_.reset();
   runtime_env_agent_manager_.reset();
 }

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -179,6 +179,10 @@ class CoreWorkerClientInterface : public pubsub::SubscriberClientInterface {
       const DeleteSpilledObjectsRequest &request,
       const ClientCallback<DeleteSpilledObjectsReply> &callback) {}
 
+  virtual void DestroyExternalStorage(
+      const DestroyExternalStorageRequest &request,
+      const ClientCallback<DestroyExternalStorageReply> &callback) {}
+
   virtual void PlasmaObjectReady(const PlasmaObjectReadyRequest &request,
                                  const ClientCallback<PlasmaObjectReadyReply> &callback) {
   }

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -52,6 +52,7 @@ namespace rpc {
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(SpillObjects)                   \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(RestoreSpilledObjects)          \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(DeleteSpilledObjects)           \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(DestroyExternalStorage)         \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(PlasmaObjectReady)              \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(Exit)                           \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(AssignObjectOwner)              \
@@ -77,6 +78,7 @@ namespace rpc {
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(SpillObjects)                   \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(RestoreSpilledObjects)          \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(DeleteSpilledObjects)           \
+  DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(DestroyExternalStorage)         \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(PlasmaObjectReady)              \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(Exit)                           \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(AssignObjectOwner)              \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, spilled directories are destroyed only when driver cluster (ray.init) is terminated, but not cluster started by ray start.

<!-- Please give a short summary of the change and the problem this solves. -->
This PR fixes the issue by always removing external storage upon SIGTERM by calling IO worker.
## Related issue number

<!-- For example: "Closes #1234" -->
Closes #17790 
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
