### PR TITLE
[cluster launcher] ray down should destroy security groups

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -675,9 +675,8 @@ def _configure_security_group(config):
         node_types_to_configure.append(head_node_type)
     security_groups = _upsert_security_groups(config, node_types_to_configure)
 
-    for node_type_key in node_types_to_configure:
+    for node_type_key, sg in security_groups:
         node_config = config["available_node_types"][node_type_key]["node_config"]
-        sg = security_groups[node_type_key]
         node_config["SecurityGroupIds"] = [sg.id]
         security_group_info_src[node_type_key] = "default"
 

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -522,6 +522,22 @@ class AWSNodeProvider(NodeProvider):
                 cwa_installed = True
         return cwa_installed
 
+    def cleanup_security_groups(self, config):
+        node_types = [
+            node_type_key
+            for node_type_key, node_type in config["available_node_types"].items()
+            if "SecurityGroupIds" in node_type["node_config"]
+        ]
+        for node_type_key in node_types:
+            security_group_ids = config["available_node_types"][node_type_key][
+                "node_config"
+            ]["SecurityGroupIds"]
+            for security_group_id in security_group_ids:
+                self.ec2.meta.client.delete_security_group(GroupId=security_group_id)
+
+    def cleanup(self, config):
+        self.cleanup_security_groups(config)
+
     def terminate_nodes(self, node_ids):
         if not node_ids:
             return

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -560,6 +560,8 @@ def teardown_cluster(
             cli_logger.print(
                 "{} nodes remaining after {} second(s).", cf.bold(len(A)), POLL_INTERVAL
             )
+
+        provider.cleanup(config)
         cli_logger.success("No nodes remaining.")
 
 

--- a/python/ray/autoscaler/launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/launch_and_verify_cluster.py
@@ -240,8 +240,6 @@ def run_ray_commands(cluster_config, retries, no_config_cache, num_expected_node
         no_config_cache: Whether to pass the --no-config-cache flag to the ray CLI
             commands.
     """
-    print("======================================")
-    cleanup_cluster(cluster_config)
 
     print("======================================")
     print("Starting new cluster...")

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -174,6 +174,10 @@ class NodeProvider:
             self.terminate_node(node_id)
         return None
 
+    def cleanup(self, config: Dict[str, Any]) -> None:
+        """Cleanup the associated resources of the cluster."""
+        pass
+
     @property
     def max_terminate_nodes(self) -> Optional[int]:
         """The maximum number of nodes which can be terminated in one single


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->


## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`ray down` only takes down the ec2 instances, but doesn't delete the security groups created via `ray up`.
We should destroy them.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #43863

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
