### PR TITLE
[cluster launcher] ray down should destroy security groups

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -808,6 +808,14 @@ def _create_security_group(config, vpc_id, group_name):
         Description="Auto-created security group for Ray workers",
         GroupName=group_name,
         VpcId=vpc_id,
+        TagSpecifications=[
+            {
+                "ResourceType": "security-group",
+                "Tags": [
+                    {"Key": RAY, "Value": "true"},
+                ],
+            },
+        ],
     )
     security_group = _get_security_group(config, vpc_id, group_name)
     cli_logger.doassert(security_group, "Failed to create security group")  # err msg

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -560,6 +560,8 @@ def teardown_cluster(
             cli_logger.print(
                 "{} nodes remaining after {} second(s).", cf.bold(len(A)), POLL_INTERVAL
             )
+
+        provider.cleanup(config)
         cli_logger.success("No nodes remaining.")
 
 

--- a/python/ray/autoscaler/launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/launch_and_verify_cluster.py
@@ -240,8 +240,6 @@ def run_ray_commands(cluster_config, retries, no_config_cache, num_expected_node
         no_config_cache: Whether to pass the --no-config-cache flag to the ray CLI
             commands.
     """
-    print("======================================")
-    cleanup_cluster(cluster_config)
 
     print("======================================")
     print("Starting new cluster...")
@@ -344,6 +342,7 @@ if __name__ == "__main__":
         override_docker_image(config_yaml, docker_override_image)
 
     provider_type = config_yaml.get("provider", {}).get("type")
+    config_yaml["provider"]["cache_stopped_nodes"] = False
     if provider_type == "aws":
         download_ssh_key_aws()
     elif provider_type == "gcp":

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -174,6 +174,10 @@ class NodeProvider:
             self.terminate_node(node_id)
         return None
 
+    def cleanup(self, config: Dict[str, Any]) -> None:
+        """Cleanup the associated resources of the cluster."""
+        pass
+
     @property
     def max_terminate_nodes(self) -> Optional[int]:
         """The maximum number of nodes which can be terminated in one single

--- a/python/ray/tests/aws/utils/constants.py
+++ b/python/ray/tests/aws/utils/constants.py
@@ -115,7 +115,12 @@ DEFAULT_SG = {
             "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
         }
     ],
-    "Tags": [],
+    "Tags": [
+        {
+            "Key": ray.autoscaler._private.aws.config.RAY,
+            "Value": "true",
+        }
+    ],
 }
 
 # Secondary security group settings after creation

--- a/python/ray/tests/aws/utils/stubs.py
+++ b/python/ray/tests/aws/utils/stubs.py
@@ -140,6 +140,12 @@ def create_sg_echo(ec2_client_stub, security_group):
             "Description": security_group["Description"],
             "GroupName": security_group["GroupName"],
             "VpcId": security_group["VpcId"],
+            "TagSpecifications": [
+                {
+                    "ResourceType": "security-group",
+                    "Tags": security_group["Tags"],
+                },
+            ],
         },
         service_response={"GroupId": security_group["GroupId"]},
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->


## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`ray down` only takes down the ec2 instances, but doesn't delete the security groups created via `ray up`.
We should destroy them.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/43863
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
