### PR TITLE
Release Performance Regression 2.9.2 -> 2.9.3

### DIFF
--- a/release/release_logs/2.9.3/benchmarks/many_actors.json
+++ b/release/release_logs/2.9.3/benchmarks/many_actors.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 463.425536,
+    "_dashboard_test_success": true,
+    "_peak_memory": 5.65,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.69GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n821\t0.89GiB\tpython distributed/test_many_actors.py\n266\t0.41GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n426\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n640\t0.07GiB\tray::JobSupervisor\n424\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n582\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n881\t0.06GiB\tray::MemoryMonitorActor.run\n970\t0.06GiB\tray::DashboardTester.run\n365\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/log_m",
+    "actors_per_second": 580.0673086544153,
+    "num_actors": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "actors_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 580.0673086544153
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 46.07
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2643.946
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4855.017
+        }
+    ],
+    "success": "1",
+    "time": 17.239378690719604
+}

--- a/release/release_logs/2.9.3/benchmarks/many_nodes.json
+++ b/release/release_logs/2.9.3/benchmarks/many_nodes.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 189.493248,
+    "_dashboard_test_success": true,
+    "_peak_memory": 11.77,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.51GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n960\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1223\t0.08GiB\tray::StateAPIGeneratorActor.start\n425\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n780\t0.07GiB\tray::JobSupervisor\n423\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n1172\t0.06GiB\tray::DashboardTester.run\n578\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1083\t0.06GiB\tray::MemoryMonitorActor.run",
+    "num_tasks": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 334.39709719072584
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4.569
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 67.669
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 227.35
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 334.39709719072584,
+    "time": 302.9904565811157,
+    "used_cpus": 250.0
+}

--- a/release/release_logs/2.9.3/benchmarks/many_tasks.json
+++ b/release/release_logs/2.9.3/benchmarks/many_tasks.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 752.021504,
+    "_dashboard_test_success": true,
+    "_peak_memory": 16.23,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.29GiB\t/home/ray/anaconda3/lib/python3.8/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t1.2GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/dashboa\n875\t0.72GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1075\t0.08GiB\tray::StateAPIGeneratorActor.start\n426\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/_private/runti\n1022\t0.07GiB\tray::DashboardTester.run\n693\t0.07GiB\tray::JobSupervisor\n424\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/agen\n582\t0.06GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n935\t0.06GiB\tray::MemoryMonitorActor.run",
+    "num_tasks": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 588.9176566466048
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2500.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 7.016
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 15375.92
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 18629.093
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 588.9176566466048,
+    "time": 316.98030257225037,
+    "used_cpus": 2500.0
+}

--- a/release/release_logs/2.9.3/microbenchmark.json
+++ b/release/release_logs/2.9.3/microbenchmark.json
@@ -1,0 +1,283 @@
+{
+    "1_1_actor_calls_async": [
+        8886.334520488972,
+        162.70176061575808
+    ],
+    "1_1_actor_calls_concurrent": [
+        5094.680969545164,
+        87.11742874492249
+    ],
+    "1_1_actor_calls_sync": [
+        2033.2026051359687,
+        34.41191618742325
+    ],
+    "1_1_async_actor_calls_async": [
+        3433.7279719075364,
+        263.47262236065063
+    ],
+    "1_1_async_actor_calls_sync": [
+        1291.6459396975501,
+        21.531584279360413
+    ],
+    "1_1_async_actor_calls_with_args_async": [
+        2307.1821043090586,
+        101.93212013527068
+    ],
+    "1_n_actor_calls_async": [
+        8569.975492315665,
+        26.73161285652371
+    ],
+    "1_n_async_actor_calls_async": [
+        7455.786759826209,
+        263.47378283507356
+    ],
+    "client__1_1_actor_calls_async": [
+        1016.9124198694686,
+        3.1420993798915298
+    ],
+    "client__1_1_actor_calls_concurrent": [
+        1006.917682419336,
+        11.27638176039778
+    ],
+    "client__1_1_actor_calls_sync": [
+        515.3941161613216,
+        9.838496518983977
+    ],
+    "client__get_calls": [
+        1151.5080691737712,
+        18.325926123222192
+    ],
+    "client__put_calls": [
+        824.8334098936486,
+        38.844642840874286
+    ],
+    "client__put_gigabytes": [
+        0.12974771730881268,
+        0.000751867527018087
+    ],
+    "client__tasks_and_get_batch": [
+        0.9476279316222816,
+        0.009765852599647571
+    ],
+    "client__tasks_and_put_batch": [
+        10856.42362647527,
+        343.99850537344395
+    ],
+    "multi_client_put_calls_Plasma_Store": [
+        12676.963384795123,
+        395.92063865671224
+    ],
+    "multi_client_put_gigabytes": [
+        35.88345905855345,
+        2.5218531771237624
+    ],
+    "multi_client_tasks_async": [
+        25165.636559238425,
+        984.7281319955192
+    ],
+    "n_n_actor_calls_async": [
+        27666.557148413103,
+        988.2267878353043
+    ],
+    "n_n_actor_calls_with_arg_async": [
+        2829.273664516542,
+        17.236784622440783
+    ],
+    "n_n_async_actor_calls_async": [
+        22927.080927205752,
+        578.5204193808033
+    ],
+    "perf_metrics": [
+        {
+            "perf_metric_name": "single_client_get_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10181.62979043199
+        },
+        {
+            "perf_metric_name": "single_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5544.9828991335435
+        },
+        {
+            "perf_metric_name": "multi_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 12676.963384795123
+        },
+        {
+            "perf_metric_name": "single_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 20.88066104318644
+        },
+        {
+            "perf_metric_name": "single_client_tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8.480936962317463
+        },
+        {
+            "perf_metric_name": "multi_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 35.88345905855345
+        },
+        {
+            "perf_metric_name": "single_client_get_object_containing_10k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 12.390468024754833
+        },
+        {
+            "perf_metric_name": "single_client_wait_1k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5.492731917768575
+        },
+        {
+            "perf_metric_name": "single_client_tasks_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1006.8942397231415
+        },
+        {
+            "perf_metric_name": "single_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8443.542829436694
+        },
+        {
+            "perf_metric_name": "multi_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 25165.636559238425
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2033.2026051359687
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8886.334520488972
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5094.680969545164
+        },
+        {
+            "perf_metric_name": "1_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8569.975492315665
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 27666.557148413103
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_with_arg_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2829.273664516542
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1291.6459396975501
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 3433.7279719075364
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_with_args_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2307.1821043090586
+        },
+        {
+            "perf_metric_name": "1_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 7455.786759826209
+        },
+        {
+            "perf_metric_name": "n_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 22927.080927205752
+        },
+        {
+            "perf_metric_name": "placement_group_create/removal",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 796.5968326623981
+        },
+        {
+            "perf_metric_name": "client__get_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1151.5080691737712
+        },
+        {
+            "perf_metric_name": "client__put_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 824.8334098936486
+        },
+        {
+            "perf_metric_name": "client__put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.12974771730881268
+        },
+        {
+            "perf_metric_name": "client__tasks_and_put_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10856.42362647527
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 515.3941161613216
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1016.9124198694686
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1006.917682419336
+        },
+        {
+            "perf_metric_name": "client__tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.9476279316222816
+        }
+    ],
+    "placement_group_create/removal": [
+        796.5968326623981,
+        10.395480509719283
+    ],
+    "single_client_get_calls_Plasma_Store": [
+        10181.62979043199,
+        212.4309303728433
+    ],
+    "single_client_get_object_containing_10k_refs": [
+        12.390468024754833,
+        0.08046598916746218
+    ],
+    "single_client_put_calls_Plasma_Store": [
+        5544.9828991335435,
+        84.97036030335191
+    ],
+    "single_client_put_gigabytes": [
+        20.88066104318644,
+        5.497164495831501
+    ],
+    "single_client_tasks_and_get_batch": [
+        8.480936962317463,
+        0.4068079446314347
+    ],
+    "single_client_tasks_async": [
+        8443.542829436694,
+        460.9208696405238
+    ],
+    "single_client_tasks_sync": [
+        1006.8942397231415,
+        8.790934099925817
+    ],
+    "single_client_wait_1k_refs": [
+        5.492731917768575,
+        0.1277047671818338
+    ]
+}

--- a/release/release_logs/2.9.3/scalability/object_store.json
+++ b/release/release_logs/2.9.3/scalability/object_store.json
@@ -1,0 +1,13 @@
+{
+    "broadcast_time": 20.239514524000015,
+    "num_nodes": 50,
+    "object_size": 1073741824,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 20.239514524000015
+        }
+    ],
+    "success": "1"
+}

--- a/release/release_logs/2.9.3/scalability/single_node.json
+++ b/release/release_logs/2.9.3/scalability/single_node.json
@@ -1,0 +1,40 @@
+{
+    "args_time": 17.298580240000007,
+    "get_time": 26.525184749000005,
+    "large_object_size": 107374182400,
+    "large_object_time": 30.736733063999964,
+    "num_args": 10000,
+    "num_get_args": 10000,
+    "num_queued": 1000000,
+    "num_returns": 3000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "10000_args_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 17.298580240000007
+        },
+        {
+            "perf_metric_name": "3000_returns_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 7.027546696999991
+        },
+        {
+            "perf_metric_name": "10000_get_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 26.525184749000005
+        },
+        {
+            "perf_metric_name": "1000000_queued_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 193.74466131
+        },
+        {
+            "perf_metric_name": "107374182400_large_object_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 30.736733063999964
+        }
+    ],
+    "queued_time": 193.74466131,
+    "returns_time": 7.027546696999991,
+    "success": "1"
+}

--- a/release/release_logs/2.9.3/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.9.3/stress_tests/stress_test_dead_actors.json
@@ -1,0 +1,14 @@
+{
+    "avg_iteration_time": 1.708868522644043,
+    "max_iteration_time": 4.649410963058472,
+    "min_iteration_time": 0.3956894874572754,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1.708868522644043
+        }
+    ],
+    "success": 1,
+    "total_time": 170.88705563545227
+}

--- a/release/release_logs/2.9.3/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.9.3/stress_tests/stress_test_many_tasks.json
@@ -1,0 +1,47 @@
+{
+    "perf_metrics": [
+        {
+            "perf_metric_name": "stage_0_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 11.464288711547852
+        },
+        {
+            "perf_metric_name": "stage_1_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 23.26974880695343
+        },
+        {
+            "perf_metric_name": "stage_2_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 52.1217405796051
+        },
+        {
+            "perf_metric_name": "stage_3_creation_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2.3462893962860107
+        },
+        {
+            "perf_metric_name": "stage_3_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3077.3281738758087
+        },
+        {
+            "perf_metric_name": "stage_4_spread",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.7237197137227946
+        }
+    ],
+    "stage_0_time": 11.464288711547852,
+    "stage_1_avg_iteration_time": 23.26974880695343,
+    "stage_1_max_iteration_time": 24.64601492881775,
+    "stage_1_min_iteration_time": 21.87178134918213,
+    "stage_1_time": 232.69758772850037,
+    "stage_2_avg_iteration_time": 52.1217405796051,
+    "stage_2_max_iteration_time": 53.7453818321228,
+    "stage_2_min_iteration_time": 50.861531019210815,
+    "stage_2_time": 260.6095907688141,
+    "stage_3_creation_time": 2.3462893962860107,
+    "stage_3_time": 3077.3281738758087,
+    "stage_4_spread": 0.7237197137227946,
+    "success": 1
+}

--- a/release/release_logs/2.9.3/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.9.3/stress_tests/stress_test_placement_group.json
@@ -1,0 +1,17 @@
+{
+    "avg_pg_create_time_ms": 0.8523581966969843,
+    "avg_pg_remove_time_ms": 0.8910572627625155,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_pg_create_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.8523581966969843
+        },
+        {
+            "perf_metric_name": "avg_pg_remove_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.8910572627625155
+        }
+    ],
+    "success": 1
+}


### PR DESCRIPTION
Collect logs for `2.9.3` and compare perf metrics `2.9.2` -> `2.9.3`

```
REGRESSION 11.40%: placement_group_create/removal (THROUGHPUT) regresses from 899.1009604416595 to 796.5968326623981 (11.40%) in 2.9.3/microbenchmark.json
REGRESSION 10.91%: actors_per_second (THROUGHPUT) regresses from 651.1270434383275 to 580.0673086544153 (10.91%) in 2.9.3/benchmarks/many_actors.json
REGRESSION 9.76%: client__tasks_and_put_batch (THROUGHPUT) regresses from 12030.005606095068 to 10856.42362647527 (9.76%) in 2.9.3/microbenchmark.json
REGRESSION 7.95%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5534.73056654751 to 5094.680969545164 (7.95%) in 2.9.3/microbenchmark.json
REGRESSION 7.43%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 9.162108196113913 to 8.480936962317463 (7.43%) in 2.9.3/microbenchmark.json
REGRESSION 6.17%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1376.5443058239355 to 1291.6459396975501 (6.17%) in 2.9.3/microbenchmark.json
REGRESSION 5.73%: multi_client_tasks_async (THROUGHPUT) regresses from 26696.641001299315 to 25165.636559238425 (5.73%) in 2.9.3/microbenchmark.json
REGRESSION 5.65%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2445.3917020087183 to 2307.1821043090586 (5.65%) in 2.9.3/microbenchmark.json
REGRESSION 5.36%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 544.5787447668264 to 515.3941161613216 (5.36%) in 2.9.3/microbenchmark.json
REGRESSION 5.19%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10738.562473287413 to 10181.62979043199 (5.19%) in 2.9.3/microbenchmark.json
REGRESSION 5.07%: client__put_calls (THROUGHPUT) regresses from 868.8457104788757 to 824.8334098936486 (5.07%) in 2.9.3/microbenchmark.json
REGRESSION 5.02%: 1_n_actor_calls_async (THROUGHPUT) regresses from 9023.20183457132 to 8569.975492315665 (5.02%) in 2.9.3/microbenchmark.json
REGRESSION 4.91%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2138.2053853346897 to 2033.2026051359687 (4.91%) in 2.9.3/microbenchmark.json
REGRESSION 4.65%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7819.413819348124 to 7455.786759826209 (4.65%) in 2.9.3/microbenchmark.json
REGRESSION 4.34%: n_n_actor_calls_async (THROUGHPUT) regresses from 28921.500058081027 to 27666.557148413103 (4.34%) in 2.9.3/microbenchmark.json
REGRESSION 3.87%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.889352554386498 to 12.390468024754833 (3.87%) in 2.9.3/microbenchmark.json
REGRESSION 3.73%: single_client_tasks_sync (THROUGHPUT) regresses from 1045.9572930683776 to 1006.8942397231415 (3.73%) in 2.9.3/microbenchmark.json
REGRESSION 3.23%: 1_1_actor_calls_async (THROUGHPUT) regresses from 9183.17944721335 to 8886.334520488972 (3.23%) in 2.9.3/microbenchmark.json
REGRESSION 3.22%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23691.103253812682 to 22927.080927205752 (3.22%) in 2.9.3/microbenchmark.json
REGRESSION 2.91%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1037.112715415745 to 1006.917682419336 (2.91%) in 2.9.3/microbenchmark.json
REGRESSION 2.26%: tasks_per_second (THROUGHPUT) regresses from 602.534829993774 to 588.9176566466048 (2.26%) in 2.9.3/benchmarks/many_tasks.json
REGRESSION 1.85%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1036.1143314918054 to 1016.9124198694686 (1.85%) in 2.9.3/microbenchmark.json
REGRESSION 1.45%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5626.784525019393 to 5544.9828991335435 (1.45%) in 2.9.3/microbenchmark.json
REGRESSION 1.01%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2858.2486735378648 to 2829.273664516542 (1.01%) in 2.9.3/microbenchmark.json
REGRESSION 0.28%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 3443.4109493516467 to 3433.7279719075364 (0.28%) in 2.9.3/microbenchmark.json
REGRESSION 0.04%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12681.58168167148 to 12676.963384795123 (0.04%) in 2.9.3/microbenchmark.json
REGRESSION 122.46%: dashboard_p95_latency_ms (LATENCY) regresses from 30.418 to 67.669 (122.46%) in 2.9.3/benchmarks/many_nodes.json
REGRESSION 84.55%: dashboard_p95_latency_ms (LATENCY) regresses from 8331.543 to 15375.92 (84.55%) in 2.9.3/benchmarks/many_tasks.json
REGRESSION 69.94%: dashboard_p99_latency_ms (LATENCY) regresses from 133.785 to 227.35 (69.94%) in 2.9.3/benchmarks/many_nodes.json
REGRESSION 36.29%: dashboard_p99_latency_ms (LATENCY) regresses from 3562.385 to 4855.017 (36.29%) in 2.9.3/benchmarks/many_actors.json
REGRESSION 32.16%: dashboard_p99_latency_ms (LATENCY) regresses from 14095.515 to 18629.093 (32.16%) in 2.9.3/benchmarks/many_tasks.json
REGRESSION 13.00%: stage_3_creation_time (LATENCY) regresses from 2.076388359069824 to 2.3462893962860107 (13.00%) in 2.9.3/stress_tests/stress_test_many_tasks.json
REGRESSION 12.00%: stage_4_spread (LATENCY) regresses from 0.64618222013863 to 0.7237197137227946 (12.00%) in 2.9.3/stress_tests/stress_test_many_tasks.json
REGRESSION 10.00%: avg_iteration_time (LATENCY) regresses from 1.5535523080825806 to 1.708868522644043 (10.00%) in 2.9.3/stress_tests/stress_test_dead_actors.json
REGRESSION 9.51%: stage_0_time (LATENCY) regresses from 10.46918272972107 to 11.464288711547852 (9.51%) in 2.9.3/stress_tests/stress_test_many_tasks.json
REGRESSION 5.85%: 10000_get_time (LATENCY) regresses from 25.059263131999984 to 26.525184749000005 (5.85%) in 2.9.3/scalability/single_node.json
REGRESSION 4.55%: dashboard_p50_latency_ms (LATENCY) regresses from 4.37 to 4.569 (4.55%) in 2.9.3/benchmarks/many_nodes.json
REGRESSION 4.19%: 107374182400_large_object_time (LATENCY) regresses from 29.50047878800001 to 30.736733063999964 (4.19%) in 2.9.3/scalability/single_node.json
REGRESSION 3.87%: dashboard_p50_latency_ms (LATENCY) regresses from 44.354 to 46.07 (3.87%) in 2.9.3/benchmarks/many_actors.json
REGRESSION 3.66%: 3000_returns_time (LATENCY) regresses from 6.779333391999998 to 7.027546696999991 (3.66%) in 2.9.3/scalability/single_node.json
REGRESSION 3.18%: avg_pg_remove_time_ms (LATENCY) regresses from 0.863579004504134 to 0.8910572627625155 (3.18%) in 2.9.3/stress_tests/stress_test_placement_group.json
REGRESSION 2.93%: stage_1_avg_iteration_time (LATENCY) regresses from 22.608211970329286 to 23.26974880695343 (2.93%) in 2.9.3/stress_tests/stress_test_many_tasks.json
REGRESSION 0.64%: stage_3_time (LATENCY) regresses from 3057.80943608284 to 3077.3281738758087 (0.64%) in 2.9.3/stress_tests/stress_test_many_tasks.json
REGRESSION 0.32%: dashboard_p95_latency_ms (LATENCY) regresses from 2635.463 to 2643.946 (0.32%) in 2.9.3/benchmarks/many_actors.json
REGRESSION 0.24%: 1000000_queued_time (LATENCY) regresses from 193.28140517800003 to 193.74466131 (0.24%) in 2.9.3/scalability/single_node.json
```