### PR TITLE
[ci] check out right commit for bisect

### DIFF
--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -38,9 +38,8 @@ export RAY_TEST_REPO RAY_TEST_BRANCH RELEASE_RESULTS_DIR BUILDKITE_MAX_RETRIES B
 if [ -n "${RAY_COMMIT_OF_WHEEL-}" ]; then 
   git config --global --add safe.directory /workdir
   HEAD_COMMIT=$(git rev-parse HEAD)
-  HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo "The test repo has head commit of ${HEAD_COMMIT}"
-  if [[ "${HEAD_COMMIT}" != "${RAY_COMMIT_OF_WHEEL}" && ("${HEAD_BRANCH}" == "master" || "${HEAD_BRANCH}" = releases/*) ]]; then
+  if [[ "${HEAD_COMMIT}" != "${RAY_COMMIT_OF_WHEEL}" ]]; then
     echo "The checked out test code doesn't match with the installed wheel. \
           This is likely due to a racing condition when a PR is landed between \
           a wheel is installed and test code is checked out."


### PR DESCRIPTION
The 'RAY_COMMIT_OF_WHEEL' is a env variable used by bisect to switch the code base between commits. It has a check to perform the switch only on master or release branch however. That check is irrelevant, remove it.

Test:
- CI
- Bisect: https://buildkite.com/ray-project/release-tests-bisect/builds/936