### PR TITLE
[Core] Remove deadcode RayletClient::RequestObjectSpillage() and corresponding RPCs

### DIFF
--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -261,20 +261,6 @@ message FormatGlobalMemoryInfoReply {
   ObjectStoreStats store_stats = 2;
 }
 
-message RequestObjectSpillageRequest {
-  // ObjectID to spill.
-  bytes object_id = 1;
-}
-
-message RequestObjectSpillageReply {
-  // Whether the object spilling was successful or not.
-  bool success = 1;
-  // Object URL where the object is spilled.
-  string object_url = 2;
-  // The node id of a node where the object is spilled.
-  bytes spilled_node_id = 3;
-}
-
 message ReleaseUnusedBundlesRequest {
   repeated Bundle bundles_in_use = 1;
 }
@@ -405,9 +391,6 @@ service NodeManagerService {
   // Get global object reference stats in formatted form.
   rpc FormatGlobalMemoryInfo(FormatGlobalMemoryInfoRequest)
       returns (FormatGlobalMemoryInfoReply);
-  // Ask the raylet to spill an object to external storage.
-  rpc RequestObjectSpillage(RequestObjectSpillageRequest)
-      returns (RequestObjectSpillageReply);
   // This method is only used by GCS, and the purpose is to release bundles
   // that may be leaked. When GCS restarts, it doesn't know which bundles it has leased
   // in the previous lifecycle. In this case, GCS will send a list of bundles that

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -620,26 +620,6 @@ void NodeManager::DoLocalGC(bool triggered_by_global_gc) {
   local_gc_run_time_ns_ = absl::GetCurrentTimeNanos();
 }
 
-void NodeManager::HandleRequestObjectSpillage(
-    rpc::RequestObjectSpillageRequest request,
-    rpc::RequestObjectSpillageReply *reply,
-    rpc::SendReplyCallback send_reply_callback) {
-  const auto &object_id = ObjectID::FromBinary(request.object_id());
-  RAY_LOG(DEBUG) << "Received RequestObjectSpillage for object " << object_id;
-  local_object_manager_.SpillObjects(
-      {object_id}, [object_id, reply, send_reply_callback](const ray::Status &status) {
-        if (status.ok()) {
-          RAY_LOG(DEBUG) << "Object " << object_id
-                         << " has been spilled, replying to owner";
-          reply->set_success(true);
-          // TODO(Clark): Add spilled URLs and spilled node ID to owner RPC reply here
-          // if OBOD is enabled, instead of relying on automatic raylet spilling path to
-          // send an extra RPC to the owner.
-        }
-        send_reply_callback(Status::OK(), nullptr, nullptr);
-      });
-}
-
 void NodeManager::HandleReleaseUnusedBundles(rpc::ReleaseUnusedBundlesRequest request,
                                              rpc::ReleaseUnusedBundlesReply *reply,
                                              rpc::SendReplyCallback send_reply_callback) {

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -571,11 +571,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
                                     rpc::FormatGlobalMemoryInfoReply *reply,
                                     rpc::SendReplyCallback send_reply_callback) override;
 
-  /// Handle a `RequestObjectSpillage` request.
-  void HandleRequestObjectSpillage(rpc::RequestObjectSpillageRequest request,
-                                   rpc::RequestObjectSpillageReply *reply,
-                                   rpc::SendReplyCallback send_reply_callback) override;
-
   /// Handle a `ReleaseUnusedBundles` request.
   void HandleReleaseUnusedBundles(rpc::ReleaseUnusedBundlesRequest request,
                                   rpc::ReleaseUnusedBundlesReply *reply,

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -335,15 +335,6 @@ void raylet::RayletClient::RequestWorkerLease(
   grpc_client_->RequestWorkerLease(*request, callback);
 }
 
-/// Spill objects to external storage.
-void raylet::RayletClient::RequestObjectSpillage(
-    const ObjectID &object_id,
-    const rpc::ClientCallback<rpc::RequestObjectSpillageReply> &callback) {
-  rpc::RequestObjectSpillageRequest request;
-  request.set_object_id(object_id.Binary());
-  grpc_client_->RequestObjectSpillage(request, callback);
-}
-
 std::shared_ptr<grpc::Channel> raylet::RayletClient::GetChannel() const {
   return grpc_client_->Channel();
 }

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -385,14 +385,6 @@ class RayletClient : public RayletClientInterface {
   /// \return ray::Status.
   ray::Status FreeObjects(const std::vector<ray::ObjectID> &object_ids, bool local_only);
 
-  /// Ask the raylet to spill an object to external storage.
-  /// \param object_id The ID of the object to be spilled.
-  /// \param callback Callback that will be called after raylet completes the
-  /// object spilling (or it fails).
-  void RequestObjectSpillage(
-      const ObjectID &object_id,
-      const rpc::ClientCallback<rpc::RequestObjectSpillageReply> &callback);
-
   std::shared_ptr<grpc::Channel> GetChannel() const override;
 
   /// Implements WorkerLeaseInterface.

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -162,12 +162,6 @@ class NodeManagerWorkerClient
                          grpc_client_,
                          /*method_timeout_ms*/ -1, )
 
-  /// Ask the raylet to spill an object to external storage.
-  VOID_RPC_CLIENT_METHOD(NodeManagerService,
-                         RequestObjectSpillage,
-                         grpc_client_,
-                         /*method_timeout_ms*/ -1, )
-
   /// Release unused bundles.
   VOID_RPC_CLIENT_METHOD(NodeManagerService,
                          ReleaseUnusedBundles,

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -43,7 +43,6 @@ namespace rpc {
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(PrepareBundleResources) \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(CommitBundleResources)  \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(CancelResourceReserve)  \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(RequestObjectSpillage)  \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReleaseUnusedBundles)   \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetSystemConfig)        \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ShutdownRaylet)         \
@@ -132,10 +131,6 @@ class NodeManagerServiceHandler {
   virtual void HandleFormatGlobalMemoryInfo(FormatGlobalMemoryInfoRequest request,
                                             FormatGlobalMemoryInfoReply *reply,
                                             SendReplyCallback send_reply_callback) = 0;
-
-  virtual void HandleRequestObjectSpillage(RequestObjectSpillageRequest request,
-                                           RequestObjectSpillageReply *reply,
-                                           SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleReleaseUnusedBundles(ReleaseUnusedBundlesRequest request,
                                           ReleaseUnusedBundlesReply *reply,


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
The code RayletClient::RequestObjectSpillage() is dead (no caller). This PR cleans up this code as well as the related RPCs.

## Related issue number
Closes #43915

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
