### PR TITLE
[Serve] Fix infinite backoff in fulfill_pending_requests

### DIFF
--- a/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
@@ -487,10 +487,17 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
             self.queue_len_response_deadline_s,
             self.max_queue_len_response_deadline_s,
         )
-        queue_len_response_deadline_s = min(
-            self.queue_len_response_deadline_s * (2**backoff_index),
-            max_queue_len_response_deadline_s,
-        )
+
+        try:
+            queue_len_response_deadline_s = min(
+                self.queue_len_response_deadline_s * (2**backoff_index),
+                max_queue_len_response_deadline_s,
+            )
+        except OverflowError:
+            # self.queue_len_response_deadline_s * (2**backoff_index)
+            # can overflow if backoff_index gets sufficiently large (e.g.
+            # 1024 when queue_len_response_deadline_s is 0.1).
+            queue_len_response_deadline_s = max_queue_len_response_deadline_s
 
         get_queue_len_tasks = []
         for r in replicas:
@@ -667,6 +674,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
         """
         try:
             while len(self._scheduling_tasks) <= self.target_num_scheduling_tasks:
+                start_time = time.time()
                 backoff_index = 0
                 request_metadata = self._get_next_pending_request_metadata_to_schedule()
                 async for candidates in self.choose_two_replicas_with_backoff(
@@ -680,6 +688,23 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                         break
 
                     backoff_index += 1
+                    if backoff_index >= 50 and backoff_index % 50 == 0:
+                        scheduling_time_elapsed = time.time() - start_time
+                        warning_log = (
+                            "Failed to schedule request after "
+                            f"{backoff_index} attempts over "
+                            f"{scheduling_time_elapsed:.2f}s. Retrying."
+                        )
+                        if request_metadata is not None:
+                            warning_log += (
+                                f" Request ID: {request_metadata.request_id}."
+                            )
+                            if request_metadata.multiplexed_model_id:
+                                warning_log += (
+                                    " Multiplexed model ID: "
+                                    f"{request_metadata.multiplexed_model_id}."
+                                )
+                        logger.warning(warning_log)
 
         except Exception:
             logger.exception("Unexpected error in fulfill_pending_requests.")

--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -1581,5 +1581,34 @@ async def test_queue_len_cache_entries_added_correctly(pow_2_scheduler):
         TIMER.advance(staleness_timeout_s + 1)
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "pow_2_scheduler",
+    [
+        {"prefer_local_node": True, "prefer_local_az": True},
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("backoff_index", [0, 10, 2048])
+async def test_backoff_index_handling(pow_2_scheduler, backoff_index: int):
+    """Ensure that different ranges of backoff_index are valid.
+
+    In the past, high backoff_indexes (greater than 1024) have caused
+    OverflowErrors. See https://github.com/ray-project/ray/issues/43964.
+    """
+    s = pow_2_scheduler
+
+    r1 = FakeReplicaWrapper("r1")
+    r1.set_queue_len_response(0)
+
+    r2 = FakeReplicaWrapper("r2")
+    r2.set_queue_len_response(0)
+
+    s.update_replicas([r1, r2])
+
+    r = await s.select_from_candidate_replicas([r1, r2], backoff_index)
+    assert r in [r1, r2]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Cherry picks #43956. Original description:

Currently, `fulfill_pending_requests` retries indefinitely when scheduling a request. This increments the `backoff_index`, which is used to calculate a backoff time. Eventually the `backoff_index` causes an `OverflowError`, which terminates the scheduling task.

This change logs warnings when `backoff_index` reaches 50. It also catches `OverflowErrors` and sets the `queue_len_response_deadline_s` to the `max_queue_len_response_deadline_s`.

For posterity, with the default queue length response deadline of 0.1, the `OverflowError` gets hit after the `backoff_index` becomes 1024:

```
>>> 0.1 * (2 ** 1023)
8.98846567431158e+306
>>> 0.1 * (2 ** 1024)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: int too large to convert to float
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/43964

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds a unit test to `test_pow_2_replica_scheduler.py`.
