### PR TITLE
[cluster launcher] clean up security groups after release test

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -808,6 +808,15 @@ def _create_security_group(config, vpc_id, group_name):
         Description="Auto-created security group for Ray workers",
         GroupName=group_name,
         VpcId=vpc_id,
+        TagSpecifications=[
+            {
+                "ResourceType": "security-group",
+                "Tags": [
+                    {"Key": RAY, "Value": "true"},
+                    {"Key": "ray-cluster-name", "Value": config["cluster_name"]},
+                ],
+            },
+        ],
     )
     security_group = _get_security_group(config, vpc_id, group_name)
     cli_logger.doassert(security_group, "Failed to create security group")  # err msg

--- a/python/ray/tests/aws/utils/stubs.py
+++ b/python/ray/tests/aws/utils/stubs.py
@@ -12,6 +12,7 @@ from ray.tests.aws.utils.constants import (
     A_THOUSAND_SUBNETS_IN_DIFFERENT_VPCS,
     DEFAULT_LT,
     TWENTY_SUBNETS_IN_DIFFERENT_AZS,
+    DEFAULT_CLUSTER_NAME,
 )
 from ray.autoscaler._private.aws.config import key_pair
 from ray.tests.aws.utils.helpers import (
@@ -140,6 +141,18 @@ def create_sg_echo(ec2_client_stub, security_group):
             "Description": security_group["Description"],
             "GroupName": security_group["GroupName"],
             "VpcId": security_group["VpcId"],
+            "TagSpecifications": [
+                {
+                    "ResourceType": "security-group",
+                    "Tags": [
+                        {
+                            "Key": ray.autoscaler._private.aws.config.RAY,
+                            "Value": "true",
+                        },
+                        {"Key": "ray-cluster-name", "Value": DEFAULT_CLUSTER_NAME},
+                    ],
+                },
+            ],
         },
         service_response={"GroupId": security_group["GroupId"]},
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In release test, cleanup only takes down ec2 instances, but doesn't delete security groups.
We should destroy them.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/43863

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
