### PR TITLE
[core] expose failure on function loading error

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -82,7 +82,7 @@ class FunctionActorManager:
         # This field is a dictionary that maps function IDs
         # to a FunctionExecutionInfo object. This should only be used on
         # workers that execute remote functions.
-        self._function_execution_info = defaultdict(lambda: {})
+        self._function_execution_info = {}
         self._num_task_executions = defaultdict(lambda: {})
         # A set of all of the actor class keys that have been imported by the
         # import thread. It is safe to convert this worker into an actor of


### PR DESCRIPTION
Class `FunctionActorManager`  manages loading functions from the GCS as `execution_info`. If a function load failed, it should store a mock info and raise exception. And next read would get the error. However, the table for execution infos is a `defaultdict`, so it never triggers that error, and would return an empty dict, causing issues like #36869. We need to surface the problem earlier.