### PR TITLE
[serve] fix autoscaling metrics on handle

### DIFF
--- a/python/ray/serve/_private/autoscaling_policy.py
+++ b/python/ray/serve/_private/autoscaling_policy.py
@@ -110,3 +110,7 @@ class AutoscalingPolicyManager:
             target_capacity_direction,
         )
         return max(lower_bound, min(upper_bound, curr_target_num_replicas))
+
+    def get_metrics_interval_s(self) -> Optional[float]:
+        if self.config:
+            return self.config.metrics_interval_s

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -296,6 +296,10 @@ RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE = (
     os.environ.get("RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE", "1") == "1"
 )
 
+RAY_SERVE_HANDLE_METRICS_TIMEOUT_S = float(
+    os.environ.get("RAY_SERVE_HANDLE_METRICS_TIMEOUT_S", 10.0)
+)
+
 # Feature flag to always run a proxy on the head node even if it has no replicas.
 RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE = (
     os.environ.get("RAY_SERVE_ALWAYS_RUN_PROXY_ON_HEAD_NODE", "1") == "1"

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -296,8 +296,8 @@ RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE = (
     os.environ.get("RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE", "1") == "1"
 )
 
-RAY_SERVE_HANDLE_METRICS_TIMEOUT_S = float(
-    os.environ.get("RAY_SERVE_HANDLE_METRICS_TIMEOUT_S", 10.0)
+RAY_SERVE_MIN_HANDLE_METRICS_TIMEOUT_S = float(
+    os.environ.get("RAY_SERVE_MIN_HANDLE_METRICS_TIMEOUT_S", 10.0)
 )
 
 # Feature flag to always run a proxy on the head node even if it has no replicas.

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -135,9 +135,28 @@ class MockClusterNodeInfoCache:
         self.available_resources_per_node[node_id] = deepcopy(resources)
 
 
+class FakeRemoteFunction:
+    def remote(self):
+        pass
+
+
 class MockActorHandle:
     def __init__(self, **kwargs):
         self._options = kwargs
+        self._actor_id = "fake_id"
+        self.initialize_and_get_metadata_called = False
+        self.is_allocated_called = False
+
+    @property
+    def initialize_and_get_metadata(self):
+        self.initialize_and_get_metadata_called = True
+        # return a mock object so that we can call `remote()` on it.
+        return FakeRemoteFunction()
+
+    @property
+    def is_allocated(self):
+        self.is_allocated_called = True
+        return FakeRemoteFunction()
 
 
 class MockActorClass:

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import logging
 import threading
 import time
 import warnings
@@ -10,6 +11,7 @@ import ray
 from ray import serve
 from ray._raylet import GcsClient, ObjectRefGenerator
 from ray.serve._private.common import DeploymentID, RequestMetadata, RequestProtocol
+from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.default_impl import create_cluster_node_info_cache
 from ray.serve._private.router import Router
 from ray.serve._private.usage import ServeUsageTag
@@ -27,6 +29,7 @@ from ray.util.annotations import DeveloperAPI, PublicAPI
 
 _global_async_loop = None
 _global_async_loop_creation_lock = threading.Lock()
+logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
 def _create_or_get_global_asyncio_event_loop_in_thread():
@@ -111,6 +114,7 @@ class _DeploymentHandleBase:
         )
 
         self._router: Optional[Router] = _router
+        logger.info(f"New handle created with handle ID {self.handle_id}.")
 
     def _record_telemetry_if_needed(self):
         # Record telemetry once per handle and not when used from the proxy

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -59,7 +59,6 @@ py_test_module_list(
     "test_regression.py",
     "test_request_timeout.py",
     "test_cluster.py",
-    "test_autoscaling_policy.py",
     "test_cancellation.py",
     "test_streaming_response.py",
     "test_controller_recovery.py",
@@ -80,7 +79,7 @@ py_test_module_list(
 # Test autoscaling with RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE set to 0
 py_test(
     name = "test_autoscaling_policy_with_metr_disab",
-    size = "medium",
+    size = "large",
     main = "test_autoscaling_policy.py",
     srcs = ["test_autoscaling_policy.py"],
     tags = ["exclusive", "team:serve", "autoscaling"],
@@ -110,6 +109,7 @@ py_test_module_list(
     "test_standalone.py",
     "test_standalone_3.py",
     "test_deploy_app.py",
+    "test_autoscaling_policy.py",
   ],
   size = "large",
   tags = ["exclusive", "team:serve"],
@@ -185,7 +185,6 @@ py_test_module_list(
   name_suffix="_with_queue_len_cache_disabled",
   env={"RAY_SERVE_ENABLE_QUEUE_LENGTH_CACHE": "0"},
   files = [
-    "test_autoscaling_policy.py",
     "test_cancellation.py",
     "test_handle.py",
     "test_handle_api.py",
@@ -197,6 +196,17 @@ py_test_module_list(
   tags = ["exclusive", "no_windows", "team:serve"],
   deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
   data = glob(["test_config_files/**/*"]),
+)
+
+py_test_module_list(
+  name_suffix="_with_queue_len_cache_disabled",
+  env={"RAY_SERVE_ENABLE_QUEUE_LENGTH_CACHE": "0"},
+  files = [
+    "test_autoscaling_policy.py",
+  ],
+  size = "large",
+  tags = ["exclusive", "no_windows", "team:serve"],
+  deps = ["//python/ray/serve:serve_lib", ":conftest", ":common"],
 )
 
 # Test old stop-fully-then-start behavior.

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -37,7 +37,9 @@ from ray.serve._private.test_utils import (
     get_num_alive_replicas,
 )
 from ray.serve.config import AutoscalingConfig
+from ray.serve.handle import DeploymentHandle
 from ray.serve.schema import ServeDeploySchema
+from ray.util.state import list_actors
 
 
 def get_running_replica_ids(name: str, controller: ServeController) -> List[ReplicaID]:
@@ -102,84 +104,228 @@ def test_assert_no_replicas_deprovisioned():
         assert_no_replicas_deprovisioned(replica_ids_2, replica_ids_1)
 
 
-@pytest.mark.parametrize(
-    "use_target_ongoing_requests,use_target_num_ongoing_requests_per_replica",
-    [(True, True), (True, False), (False, True)],
-)
-def test_autoscaling_metrics(
-    serve_instance,
-    use_target_num_ongoing_requests_per_replica,
-    use_target_ongoing_requests,
-):
-    """Test that request metrics are sent correctly to the controller."""
+def get_num_requests(client, dep_id: DeploymentID):
+    ref = client._controller._dump_autoscaling_metrics_for_testing.remote()
+    total_num_requests = ray.get(ref)[dep_id]
+    print("total num requests", total_num_requests)
+    return total_num_requests
 
-    signal = SignalActor.remote()
 
-    autoscaling_config = {
-        "metrics_interval_s": 0.1,
-        "min_replicas": 1,
-        "max_replicas": 10,
-        "upscale_delay_s": 0,
-        "downscale_delay_s": 0,
-        "look_back_period_s": 1,
-    }
-    if use_target_ongoing_requests and not use_target_num_ongoing_requests_per_replica:
-        autoscaling_config["target_ongoing_requests"] = 10
-    elif use_target_ongoing_requests and use_target_num_ongoing_requests_per_replica:
-        autoscaling_config["target_ongoing_requests"] = 10
-        # Random setting, should get ignored
-        autoscaling_config["target_num_ongoing_requests_per_replica"] = 234
-    else:
-        autoscaling_config["target_num_ongoing_requests_per_replica"] = 10
+def check_num_requests_eq(client, id: DeploymentID, expected: int):
+    assert get_num_requests(client, id) == expected
+    return True
 
-    @serve.deployment(
-        autoscaling_config=autoscaling_config,
-        # We will send over a lot of queries. This will make sure replicas are
-        # killed quickly during cleanup.
-        graceful_shutdown_timeout_s=1,
-        max_ongoing_requests=25,
-        version="v1",
+
+def check_num_requests_ge(client, id: DeploymentID, expected: int):
+    assert get_num_requests(client, id) >= expected
+    return True
+
+
+class TestAutoscalingMetrics:
+    @pytest.mark.parametrize(
+        "use_target_ongoing_requests,use_target_num_ongoing_requests_per_replica",
+        [(True, True), (True, False), (False, True)],
     )
-    class A:
-        async def __call__(self):
-            await signal.wait.remote()
+    def test_basic(
+        self,
+        serve_instance,
+        use_target_num_ongoing_requests_per_replica,
+        use_target_ongoing_requests,
+    ):
+        """Test that request metrics are sent correctly to the controller."""
 
-    handle = serve.run(A.bind())
-    dep_id = DeploymentID(name="A")
-    [handle.remote() for _ in range(50)]
+        client = serve_instance
+        signal = SignalActor.remote()
 
-    # Wait for metrics to propagate
-    def get_data():
-        data = ray.get(
-            serve_instance._controller._dump_autoscaling_metrics_for_testing.remote()
-        )[dep_id]
-        print(data)
-        return data
+        autoscaling_config = {
+            "metrics_interval_s": 0.1,
+            "min_replicas": 1,
+            "max_replicas": 10,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 0,
+            "look_back_period_s": 1,
+        }
+        if (
+            use_target_ongoing_requests
+            and not use_target_num_ongoing_requests_per_replica
+        ):
+            autoscaling_config["target_ongoing_requests"] = 10
+        elif (
+            use_target_ongoing_requests and use_target_num_ongoing_requests_per_replica
+        ):
+            autoscaling_config["target_ongoing_requests"] = 10
+            # Random setting, should get ignored
+            autoscaling_config["target_num_ongoing_requests_per_replica"] = 234
+        else:
+            autoscaling_config["target_num_ongoing_requests_per_replica"] = 10
 
-    wait_for_condition(lambda: get_data() > 0)
-    print("Autoscaling metrics started recording on controller.")
+        @serve.deployment(
+            autoscaling_config=autoscaling_config,
+            # We will send over a lot of queries. This will make sure replicas are
+            # killed quickly during cleanup.
+            graceful_shutdown_timeout_s=1,
+            max_ongoing_requests=25,
+            version="v1",
+        )
+        class A:
+            async def __call__(self):
+                await signal.wait.remote()
 
-    # Many queries should be inflight.
-    def last_timestamp_value_high():
-        metrics = get_data()
-        assert metrics > 45
-        return True
+        handle = serve.run(A.bind())
+        dep_id = DeploymentID(name="A")
+        [handle.remote() for _ in range(50)]
 
-    wait_for_condition(last_timestamp_value_high)
-    print("Confirmed many queries are inflight.")
+        # Wait for metrics to propagate
+        wait_for_condition(check_num_requests_ge, client=client, id=dep_id, expected=1)
+        print("Autoscaling metrics started recording on controller.")
 
-    wait_for_condition(check_num_replicas_eq, name="A", target=5)
-    print("Confirmed deployment scaled to 5 replicas.")
-    print("Releasing signal.")
-    signal.send.remote()
+        # Many queries should be inflight.
+        wait_for_condition(check_num_requests_ge, client=client, id=dep_id, expected=45)
+        print("Confirmed many queries are inflight.")
 
-    # After traffic stops, num replica should drop to 1
-    wait_for_condition(check_num_replicas_eq, name="A", target=1, timeout=15)
-    print("Num replicas dropped to 1.")
+        wait_for_condition(check_num_replicas_eq, name="A", target=5)
+        print("Confirmed deployment scaled to 5 replicas.")
+        print("Releasing signal.")
+        signal.send.remote()
 
-    # Request metrics should drop to 0
-    wait_for_condition(lambda: get_data() == 0)
-    print("Queued and ongoing requests dropped to 0.")
+        # After traffic stops, num replica should drop to 1
+        wait_for_condition(check_num_replicas_eq, name="A", target=1, timeout=15)
+        print("Num replicas dropped to 1.")
+
+        # Request metrics should drop to 0
+        wait_for_condition(check_num_requests_eq, client=client, id=dep_id, expected=0)
+        print("Queued and ongoing requests dropped to 0.")
+
+    @pytest.mark.parametrize("use_generator", [True, False])
+    def test_replicas_die(self, serve_instance, use_generator):
+        """If replicas die while requests are still executing, that
+        should be tracked correctly."""
+
+        client = serve_instance
+        signal = SignalActor.remote()
+
+        config = {
+            "autoscaling_config": {
+                "target_ongoing_requests": 10,
+                "metrics_interval_s": 0.1,
+                "min_replicas": 1,
+                "max_replicas": 10,
+                "upscale_delay_s": 0,
+                "downscale_delay_s": 0,
+                "look_back_period_s": 1,
+            },
+            "graceful_shutdown_timeout_s": 0.1,
+            "max_ongoing_requests": 25,
+        }
+
+        if use_generator:
+
+            @serve.deployment(**config)
+            class A:
+                async def __call__(self):
+                    await signal.wait.remote()
+                    async for i in range(3):
+                        yield i
+
+        else:
+
+            @serve.deployment(**config)
+            class A:
+                async def __call__(self):
+                    await signal.wait.remote()
+
+        handle = serve.run(A.bind(), name="app1").options(stream=use_generator)
+        dep_id = DeploymentID(name="A", app_name="app1")
+        [handle.remote() for _ in range(50)]
+
+        # Many queries should be inflight.
+        wait_for_condition(check_num_requests_ge, client=client, id=dep_id, expected=45)
+        print("Confirmed many queries are inflight.")
+
+        wait_for_condition(check_num_replicas_eq, name="A", target=5, app_name="app1")
+        print("Confirmed deployment scaled to 5 replicas.")
+
+        # Remove all replicas before they can finish the requests.
+        serve.delete("app1")
+
+        # Num requests should still drop to 0 despite all requests failing.
+        def check_handle_metrics(handle):
+            num_requests = handle._router._metrics_manager.num_requests_sent_to_replicas
+            for replica_id, num in num_requests.items():
+                assert (
+                    num == 0
+                ), f"Replica {replica_id} still has {num} ongoing requests"
+
+            return True
+
+        wait_for_condition(check_handle_metrics, handle=handle)
+
+    def test_handle_deleted(self, serve_instance):
+        """If handles are deleted while requests are still inflight, the
+        metrics should be invalidated after a certain time so the info
+        doesn't become stale.
+        """
+
+        client = serve_instance
+        dep_id = DeploymentID(name="A")
+        signal = SignalActor.remote()
+
+        @serve.deployment(
+            autoscaling_config={
+                "target_ongoing_requests": 4,
+                "metrics_interval_s": 0.1,
+                "min_replicas": 0,
+                "max_replicas": 10,
+                "upscale_delay_s": 1,
+                "downscale_delay_s": 1,
+                "look_back_period_s": 30,
+            },
+            graceful_shutdown_timeout_s=0.1,
+            max_ongoing_requests=10,
+        )
+        class A:
+            async def __call__(self):
+                await signal.wait.remote()
+                return "sup"
+
+        @serve.deployment(graceful_shutdown_timeout_s=1)
+        class Router:
+            def __init__(self, handle: DeploymentHandle):
+                self._handle = handle
+                self.x = list()
+
+            async def __call__(self):
+                return await self._handle.remote()
+
+        app = Router.bind(A.bind())
+        handle = serve.run(app)
+        refs = [handle.remote() for _ in range(20)]
+
+        # Wait for deployment A to scale up
+        wait_for_condition(check_num_requests_eq, client=client, id=dep_id, expected=20)
+        wait_for_condition(check_num_replicas_eq, name="A", target=5)
+        print("Confirmed deployment scaled to 5 replicas.")
+
+        router_name = [
+            actor
+            for actor in list_actors(filters=[("state", "=", "ALIVE")])
+            if actor["class_name"] == "ServeReplica:default:Router"
+        ][0]["name"]
+        router = ray.get_actor(router_name, namespace=SERVE_NAMESPACE)
+
+        # import pdb; pdb.set_trace()
+        print("Releasing signal at", time.time())
+        signal.send.remote()
+        print("Request results:", [ref.result() for ref in refs])
+
+        # Kill Router replica
+        print("Killing Router at", time.time())
+        ray.kill(router)
+
+        wait_for_condition(check_num_replicas_eq, name="A", target=0, timeout=20)
+        wait_for_condition(
+            check_num_requests_eq, client=client, id=dep_id, expected=0, timeout=20
+        )
 
 
 @pytest.mark.parametrize("min_replicas", [1, 2])


### PR DESCRIPTION
[serve] fix autoscaling metrics on handle

Clear cached autoscaling metrics from handles after a timeout to avoid holding stale autoscaling metrics.

Example warning when stale handle metrics are invalidated:
```
2024-03-14 18:47:39,901 WARNING deployment_state.py:1620 -- No metrics have been received from handle 'random' for 20.0 seconds; marking last received data as stale: 0 queued requests and running requests: {Replica(id='sfzrlq6u', deployment='test_deployment', app='test_app'): 2}. If you see over-aggressive downscaling because of this, try either increasing the timeout by setting the environment variable RAY_SERVE_HANDLE_METRICS_TIMEOUT_S (default 10) to a larger value, or turn off handle-collected autoscaling metrics by setting RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE=0.
```

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
