### PR TITLE
[rllib contrib] add a block button on master or release branches

### DIFF
--- a/.buildkite/rllib_contrib.rayci.yml
+++ b/.buildkite/rllib_contrib.rayci.yml
@@ -2,6 +2,9 @@ group: rllib contrib tests
 depends_on:
   - oss-ci-base_build
 steps:
+  - block: "run rllib contrib tests"
+    if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b" && build.branch == "master"
+
   - label: ":collaborator: rllib contrib: {{matrix}} tests"
     if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b"
     instance_type: large


### PR DESCRIPTION
so that they do not auto run on daytime health probes, similar to windows and macos tests

