### PR TITLE
[RLlib] 2 fixes for 2.10 release: 1) DDP + GPU fix; 2) py3.8 fix for uniting two dicts

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -871,7 +871,7 @@ class Algorithm(Trainable, AlgorithmBase):
         results = self._compile_iteration_results(
             episodes_this_iter=episodes_this_iter,
             step_ctx=train_iter_ctx,
-            iteration_results=train_results | eval_results,
+            iteration_results={**train_results, **eval_results},
         )
 
         # TODO (sven): Deprecate this API, this should be done via a custom Callback.

--- a/rllib/core/rl_module/torch/torch_rl_module.py
+++ b/rllib/core/rl_module/torch/torch_rl_module.py
@@ -183,6 +183,13 @@ class TorchDDPRLModule(RLModule, nn.parallel.DistributedDataParallel):
     def _module_metadata(self, *args, **kwargs):
         return self.unwrapped()._module_metadata(*args, **kwargs)
 
+    # TODO (sven): Figure out a better way to avoid having to method-spam this wrapper
+    #  class, whenever we add a new API to any wrapped RLModule here. We could try
+    #  auto generating the wrapper methods, but this will bring its own challenge
+    #  (e.g. recursive calls due to __getattr__ checks, etc..).
+    def _compute_values(self, *args, **kwargs):
+        return self.unwrapped()._compute_values(*args, **kwargs)
+
     @override(RLModule)
     def unwrapped(self) -> "RLModule":
         return self.module


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

2 fixes for 2.10 release: 1) DDP + GPU fix; 2) py3.8 fix for uniting two dicts

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
