### PR TITLE
[serve] fix custom resource scheduling bug (#43993)

### DIFF
--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -26,15 +26,6 @@ class SpreadDeploymentSchedulingPolicy:
 
 @total_ordering
 class Resources(dict):
-    @classmethod
-    def from_ray_resource_dict(cls, ray_resource_dict: Dict):
-        num_cpus = ray_resource_dict.get("CPU", 0)
-        num_gpus = ray_resource_dict.get("GPU", 0)
-        memory = ray_resource_dict.get("memory", 0)
-        custom_resources = ray_resource_dict.get("resources", dict())
-
-        return cls(CPU=num_cpus, GPU=num_gpus, memory=memory, **custom_resources)
-
     def get(self, key: str):
         val = super().get(key)
         if val is not None:
@@ -310,14 +301,11 @@ class DeploymentScheduler(ABC):
         assert deployment_id in self._deployments
 
         info = self._deployments[deployment_id]
-        info.actor_resources = Resources.from_ray_resource_dict(
-            replica_config.resource_dict
-        )
+        info.actor_resources = Resources(replica_config.resource_dict)
         info.max_replicas_per_node = replica_config.max_replicas_per_node
         if replica_config.placement_group_bundles:
             info.placement_group_bundles = [
-                Resources.from_ray_resource_dict(bundle)
-                for bundle in replica_config.placement_group_bundles
+                Resources(bundle) for bundle in replica_config.placement_group_bundles
             ]
         if replica_config.placement_group_strategy:
             info.placement_group_strategy = replica_config.placement_group_strategy


### PR DESCRIPTION
Cherry pick https://github.com/ray-project/ray/pull/43993
Addresses https://github.com/ray-project/ray/issues/44002

The attribute `ReplicaConfig.resource_dict` already has done processing to convert the custom resources in a Serve deployment, so we shouldn't use `from_ray_resource_dict`. Also placement group bundles are already flattened as well, so we shouldn't use `from_ray_resource_dict`.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
