### PR TITLE
[ci] give rllib_contrib test group a sort key

### DIFF
--- a/.buildkite/rllib_contrib.rayci.yml
+++ b/.buildkite/rllib_contrib.rayci.yml
@@ -1,4 +1,5 @@
 group: rllib contrib tests
+sort_key: "|rllib_contrib"
 depends_on:
   - oss-ci-base_build
 steps:


### PR DESCRIPTION
so that it is put at the last, but before windows and mac test groups
