### PR TITLE
[Data] Stabilize `dataset_shuffle_push_based_random_shuffle_1tb` (#43697)

### DIFF
--- a/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances.yaml
+++ b/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances.yaml
@@ -6,7 +6,7 @@ aws:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: true
-            VolumeSize: 1000
+            VolumeSize: 1250
 
 head_node_type:
     name: head_node

--- a/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances_gce.yaml
+++ b/release/nightly_tests/shuffle/datasets_large_scale_compute_small_instances_gce.yaml
@@ -9,7 +9,7 @@ gcp_advanced_configurations_json:
       - boot: true
         auto_delete: true
         initialize_params:
-          disk_size_gb: 1000
+          disk_size_gb: 1250
 
 head_node_type:
     name: head_node


### PR DESCRIPTION
Pick of https://github.com/ray-project/ray/pull/43697.

`dataset_shuffle_push_based_random_shuffle_1tb` has been flaky for several months. To prevent flaky runs, this PR increases the amount of disk by 25%.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
