### PR TITLE
[Serve] Fix serve deploy not getting current directory added to sys.path (#43899)

### DIFF
--- a/python/ray/serve/tests/test_config_files/use_current_working_directory.py
+++ b/python/ray/serve/tests/test_config_files/use_current_working_directory.py
@@ -1,0 +1,9 @@
+from ray import serve
+
+
+@serve.deployment
+def f():
+    return "hi"
+
+
+app = f.bind()

--- a/python/ray/serve/tests/test_config_files/use_current_working_directory.yaml
+++ b/python/ray/serve/tests/test_config_files/use_current_working_directory.yaml
@@ -1,0 +1,6 @@
+applications:
+  - name: app1
+    route_prefix: /
+    import_path: use_current_working_directory:app
+    deployments:
+      - name: f


### PR DESCRIPTION


Re: #43214 There is a core change that stopped adding script directory and current directory for different conditions. This accidentally stopped adding current directory when it's coming from the dashboard where in that case we only want to stop adding the script directory. This PR fixes the issue and allow serve deploy to continue working with the current directory.

---------

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Cherry-pick https://github.com/ray-project/ray/pull/43899

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
