### PR TITLE
[Data] Hide lineage serialization APIs from documentation

### DIFF
--- a/doc/source/data/api/dataset.rst
+++ b/doc/source/data/api/dataset.rst
@@ -142,17 +142,6 @@ Execution
 
     Dataset.materialize
 
-Serialization
--------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   Dataset.has_serializable_lineage
-   Dataset.serialize_lineage
-   Dataset.deserialize_lineage
-
 .. _block-api:
 
 Internals

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4630,6 +4630,7 @@ class Dataset:
         self._synchronize_progress_bar()
         return blocks
 
+    @DeveloperAPI
     def has_serializable_lineage(self) -> bool:
         """Whether this dataset's lineage is able to be serialized for storage and
         later deserialized, possibly on a different cluster.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The serialization APIs are esoteric. We use it in one place internally, and possibly no users use it. So, this PR hides it from the documentation.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
