### PR TITLE
[release] Update Doc - Dask on Ray version for 2.10.0

### DIFF
--- a/doc/source/ray-more-libs/dask-on-ray.rst
+++ b/doc/source/ray-more-libs/dask-on-ray.rst
@@ -31,6 +31,8 @@ workload. Using the Dask-on-Ray scheduler, the entire Dask ecosystem can be exec
 
      * - Ray Version
        - Dask Version
+     * - ``2.10.0``
+       - ``2022.10.1 (Python version >= 3.8)``
      * - ``2.9.1``
        - ``2022.10.1 (Python version >= 3.8)``
      * - ``2.9.0``


### PR DESCRIPTION
Add Ray 2.10 and the Dask version that is compatible with Ray 2.10 to doc