### PR TITLE
[Serve] Validate placement group bundles when deployment is defined

### DIFF
--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -35,7 +35,7 @@ from ray.serve.generated.serve_pb2 import DeploymentLanguage
 from ray.serve.generated.serve_pb2 import EncodingType as EncodingTypeProto
 from ray.serve.generated.serve_pb2 import LoggingConfig as LoggingConfigProto
 from ray.serve.generated.serve_pb2 import ReplicaConfig as ReplicaConfigProto
-from ray.util.placement_group import VALID_PLACEMENT_GROUP_STRATEGIES
+from ray.util.placement_group import validate_placement_group
 
 
 def _needs_pickle(deployment_language: DeploymentLanguage, is_cross_language: bool):
@@ -586,86 +586,57 @@ class ReplicaConfig:
             )
 
     def _validate_placement_group_options(self) -> None:
-        if (
-            self.placement_group_strategy is not None
-            and self.placement_group_strategy not in VALID_PLACEMENT_GROUP_STRATEGIES
-        ):
-            raise ValueError(
-                f"Invalid placement group strategy '{self.placement_group_strategy}'. "
-                f"Supported strategies are: {VALID_PLACEMENT_GROUP_STRATEGIES}."
-            )
-
-        if (
-            self.placement_group_strategy is not None
-            and self.placement_group_bundles is None
-        ):
-            raise ValueError(
-                "If `placement_group_strategy` is provided, `placement_group_bundles` "
-                "must also be provided."
-            )
-
-        if self.placement_group_bundles is not None:
-            if (
-                not isinstance(self.placement_group_bundles, list)
-                or len(self.placement_group_bundles) == 0
-            ):
+        if self.placement_group_strategy is not None:
+            if self.placement_group_bundles is None:
                 raise ValueError(
-                    "`placement_group_bundles` must be a non-empty list of resource "
-                    'dictionaries. For example: `[{"CPU": 1.0}, {"GPU": 1.0}]`.'
+                    "If `placement_group_strategy` is provided, "
+                    "`placement_group_bundles` must also be provided."
                 )
 
-            for i, bundle in enumerate(self.placement_group_bundles):
-                if (
-                    not isinstance(bundle, dict)
-                    or not all(isinstance(k, str) for k in bundle.keys())
-                    or not all(isinstance(v, (int, float)) for v in bundle.values())
-                ):
+        if self.placement_group_bundles is not None:
+            validate_placement_group(
+                bundles=self.placement_group_bundles,
+                strategy=self.placement_group_strategy or "PACK",
+                lifetime="detached",
+            )
+
+            resource_error_prefix = (
+                "When using `placement_group_bundles`, the replica actor "
+                "will be placed in the first bundle, so the resource "
+                "requirements for the actor must be a subset of the first "
+                "bundle."
+            )
+
+            first_bundle = self.placement_group_bundles[0]
+
+            # Validate that the replica actor fits in the first bundle.
+            bundle_cpu = first_bundle.get("CPU", 0)
+            replica_actor_num_cpus = self.ray_actor_options.get("num_cpus", 0)
+            if bundle_cpu < replica_actor_num_cpus:
+                raise ValueError(
+                    f"{resource_error_prefix} `num_cpus` for the actor is "
+                    f"{replica_actor_num_cpus}, but the bundle only has "
+                    f"{bundle_cpu} `CPU` specified."
+                )
+
+            bundle_gpu = first_bundle.get("GPU", 0)
+            replica_actor_num_gpus = self.ray_actor_options.get("num_gpus", 0)
+            if bundle_gpu < replica_actor_num_gpus:
+                raise ValueError(
+                    f"{resource_error_prefix} `num_gpus` for the actor is "
+                    f"{replica_actor_num_gpus}, but the bundle only has "
+                    f"{bundle_gpu} `GPU` specified."
+                )
+
+            replica_actor_resources = self.ray_actor_options.get("resources", {})
+            for actor_resource, actor_value in replica_actor_resources.items():
+                bundle_value = first_bundle.get(actor_resource, 0)
+                if bundle_value < actor_value:
                     raise ValueError(
-                        "`placement_group_bundles` must be a non-empty list of "
-                        "resource dictionaries. For example: "
-                        '`[{"CPU": 1.0}, {"GPU": 1.0}]`.'
+                        f"{resource_error_prefix} `{actor_resource}` requirement "
+                        f"for the actor is {actor_value}, but the bundle only "
+                        f"has {bundle_value} `{actor_resource}` specified."
                     )
-
-                # Validate that the replica actor fits in the first bundle.
-                if i == 0:
-                    bundle_cpu = bundle.get("CPU", 0)
-                    replica_actor_num_cpus = self.ray_actor_options.get("num_cpus", 0)
-                    if bundle_cpu < replica_actor_num_cpus:
-                        raise ValueError(
-                            "When using `placement_group_bundles`, the replica actor "
-                            "will be placed in the first bundle, so the resource "
-                            "requirements for the actor must be a subset of the first "
-                            "bundle. `num_cpus` for the actor is "
-                            f"{replica_actor_num_cpus} but the bundle only has "
-                            f"{bundle_cpu} `CPU` specified."
-                        )
-
-                    bundle_gpu = bundle.get("GPU", 0)
-                    replica_actor_num_gpus = self.ray_actor_options.get("num_gpus", 0)
-                    if bundle_gpu < replica_actor_num_gpus:
-                        raise ValueError(
-                            "When using `placement_group_bundles`, the replica actor "
-                            "will be placed in the first bundle, so the resource "
-                            "requirements for the actor must be a subset of the first "
-                            "bundle. `num_gpus` for the actor is "
-                            f"{replica_actor_num_gpus} but the bundle only has "
-                            f"{bundle_gpu} `GPU` specified."
-                        )
-
-                    replica_actor_resources = self.ray_actor_options.get(
-                        "resources", {}
-                    )
-                    for actor_resource, actor_value in replica_actor_resources.items():
-                        bundle_value = bundle.get(actor_resource, 0)
-                        if bundle_value < actor_value:
-                            raise ValueError(
-                                "When using `placement_group_bundles`, the replica "
-                                "actor will be placed in the first bundle, so the "
-                                "resource requirements for the actor must be a subset "
-                                f"of the first bundle. `{actor_resource}` requirement "
-                                f"for the actor is {actor_value} but the bundle only "
-                                f"has {bundle_value} `{actor_resource}` specified."
-                            )
 
     @property
     def deployment_def(self) -> Union[Callable, str]:

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -308,7 +308,7 @@ class TestReplicaConfig:
 
         # Invalid: unsupported placement_group_strategy.
         with pytest.raises(
-            ValueError, match="Invalid placement group strategy 'FAKE_NEWS'"
+            ValueError, match="Invalid placement group strategy FAKE_NEWS"
         ):
             ReplicaConfig.create(
                 Class,
@@ -321,16 +321,26 @@ class TestReplicaConfig:
         # Invalid: malformed placement_group_bundles.
         with pytest.raises(
             ValueError,
-            match=(
-                "`placement_group_bundles` must be a non-empty list "
-                "of resource dictionaries."
-            ),
+            match=("Bundles must be a non-empty list " "of resource dictionaries."),
         ):
             ReplicaConfig.create(
                 Class,
                 tuple(),
                 dict(),
                 placement_group_bundles=[{"CPU": "1.0"}],
+            )
+
+        # Invalid: invalid placement_group_bundles.
+        with pytest.raises(
+            ValueError,
+            match="cannot be an empty dictionary or resources with only 0",
+        ):
+            ReplicaConfig.create(
+                Class,
+                tuple(),
+                dict(),
+                ray_actor_options={"num_cpus": 0, "num_gpus": 0},
+                placement_group_bundles=[{"CPU": 0, "GPU": 0}],
             )
 
         # Invalid: replica actor does not fit in the first bundle (CPU).

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -11,6 +11,11 @@ from ray._private.test_utils import placement_group_assert_no_leak
 from ray._private.test_utils import skip_flaky_core_test_premerge
 from ray.util.client.ray_client_helpers import connect_to_client_or_not
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+from ray.util.placement_group import (
+    validate_placement_group,
+    _validate_bundles,
+    VALID_PLACEMENT_GROUP_STRATEGIES,
+)
 
 
 def are_pairwise_unique(g):
@@ -678,6 +683,48 @@ def test_omp_num_threads_in_pg(ray_start_cluster):
         )
     ).remote()
     assert ray.get(ref) == 3
+
+
+class TestPlacementGroupValidation:
+    def test_strategy_validation(self):
+        """Test strategy validation when creating a placement group."""
+
+        # Valid strategies should not raise an exception.
+        for strategy in VALID_PLACEMENT_GROUP_STRATEGIES:
+            validate_placement_group(bundles=[{"CPU": 1}], strategy=strategy)
+
+        # Any other strategy should raise a ValueError.
+        with pytest.raises(ValueError, match="Invalid placement group strategy"):
+            validate_placement_group(bundles=[{"CPU": 1}], strategy="invalid")
+
+    def test_bundle_validation(self):
+        """Test _validate_bundle()."""
+
+        # Valid bundles should not raise an exception.
+        valid_bundles = [{"CPU": 1, "custom-resource": 2.2}, {"GPU": 0.75}]
+        _validate_bundles(valid_bundles)
+
+        # Non-list bundles should raise an exception.
+        with pytest.raises(ValueError, match="must be a list"):
+            _validate_bundles("not a list")
+
+        # Empty list bundles should raise an exception.
+        with pytest.raises(ValueError, match="must be a non-empty list"):
+            _validate_bundles([])
+
+        # List that doesn't contain dictionaries should raise an exception.
+        with pytest.raises(ValueError, match="resource dictionaries"):
+            _validate_bundles([{"CPU": 1}, "not a dict"])
+
+        # List with invalid dictionary entries should raise an exception.
+        with pytest.raises(ValueError, match="resource dictionaries"):
+            _validate_bundles([{8: 7}, {5: 3.5}])
+        with pytest.raises(ValueError, match="resource dictionaries"):
+            _validate_bundles([{"CPU": "6"}, {"GPU": "5"}])
+
+        # Bundles with resources that all have 0 values should raise an exception.
+        with pytest.raises(ValueError, match="only 0 values"):
+            _validate_bundles([{"CPU": 0, "GPU": 0}])
 
 
 if __name__ == "__main__":

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -191,72 +191,22 @@ def placement_group(
     Return:
         PlacementGroup: Placement group object.
     """
+
     worker = ray._private.worker.global_worker
     worker.check_connected()
 
-    if not isinstance(bundles, list):
-        raise ValueError("The type of bundles must be list, got {}".format(bundles))
+    validate_placement_group(
+        bundles=bundles,
+        strategy=strategy,
+        lifetime=lifetime,
+        _max_cpu_fraction_per_node=_max_cpu_fraction_per_node,
+        _soft_target_node_id=_soft_target_node_id,
+    )
 
-    if not bundles:
-        raise ValueError(
-            "The placement group `bundles` argument cannot contain an empty list"
-        )
-
-    assert _max_cpu_fraction_per_node is not None
-
-    if _max_cpu_fraction_per_node <= 0 or _max_cpu_fraction_per_node > 1:
-        raise ValueError(
-            "Invalid argument `_max_cpu_fraction_per_node`: "
-            f"{_max_cpu_fraction_per_node}. "
-            "_max_cpu_fraction_per_node must be a float between 0 and 1. "
-        )
-
-    if _soft_target_node_id and strategy != "STRICT_PACK":
-        raise ValueError(
-            "_soft_target_node_id currently only works "
-            f"with STRICT_PACK but got {strategy}"
-        )
-
-    if _soft_target_node_id and ray.NodeID.from_hex(_soft_target_node_id).is_nil():
-        raise ValueError(
-            f"Invalid hex ID of _soft_target_node_id, got {_soft_target_node_id}"
-        )
-
-    # Validate bundles
-    for bundle in bundles:
-        if len(bundle) == 0 or all(
-            resource_value == 0 for resource_value in bundle.values()
-        ):
-            raise ValueError(
-                "Bundles cannot be an empty dictionary or "
-                f"resources with only 0 values. Bundles: {bundles}"
-            )
-
-        if "object_store_memory" in bundle.keys():
-            warnings.warn(
-                "Setting 'object_store_memory' for"
-                " bundles is deprecated since it doesn't actually"
-                " reserve the required object store memory."
-                f" Use object spilling that's enabled by default (https://docs.ray.io/en/{get_ray_doc_version()}/ray-core/objects/object-spilling.html) "  # noqa: E501
-                "instead to bypass the object store memory size limitation.",
-                DeprecationWarning,
-                stacklevel=1,
-            )
-
-    if strategy not in VALID_PLACEMENT_GROUP_STRATEGIES:
-        raise ValueError(
-            f"Invalid placement group strategy {strategy}. "
-            f"Supported strategies are: {VALID_PLACEMENT_GROUP_STRATEGIES}."
-        )
-
-    if lifetime is None:
-        detached = False
-    elif lifetime == "detached":
+    if lifetime == "detached":
         detached = True
     else:
-        raise ValueError(
-            "placement group `lifetime` argument must be either `None` or 'detached'"
-        )
+        detached = False
 
     placement_group_id = worker.core_worker.create_placement_group(
         name,
@@ -389,6 +339,100 @@ def check_placement_group_index(
             f"is invalid. Valid placement group indexes: "
             f"0-{placement_group.bundle_count}"
         )
+
+
+def validate_placement_group(
+    bundles: List[Dict[str, float]],
+    strategy: str = "PACK",
+    lifetime: Optional[str] = None,
+    _max_cpu_fraction_per_node: float = 1.0,
+    _soft_target_node_id: Optional[str] = None,
+) -> bool:
+    """Validates inputs for placement_group.
+
+    Raises ValueError if inputs are invalid.
+    """
+
+    assert _max_cpu_fraction_per_node is not None
+
+    if _max_cpu_fraction_per_node <= 0 or _max_cpu_fraction_per_node > 1:
+        raise ValueError(
+            "Invalid argument `_max_cpu_fraction_per_node`: "
+            f"{_max_cpu_fraction_per_node}. "
+            "_max_cpu_fraction_per_node must be a float between 0 and 1. "
+        )
+
+    if _soft_target_node_id and strategy != "STRICT_PACK":
+        raise ValueError(
+            "_soft_target_node_id currently only works "
+            f"with STRICT_PACK but got {strategy}"
+        )
+
+    if _soft_target_node_id and ray.NodeID.from_hex(_soft_target_node_id).is_nil():
+        raise ValueError(
+            f"Invalid hex ID of _soft_target_node_id, got {_soft_target_node_id}"
+        )
+
+    _validate_bundles(bundles)
+
+    if strategy not in VALID_PLACEMENT_GROUP_STRATEGIES:
+        raise ValueError(
+            f"Invalid placement group strategy {strategy}. "
+            f"Supported strategies are: {VALID_PLACEMENT_GROUP_STRATEGIES}."
+        )
+
+    if lifetime not in [None, "detached"]:
+        raise ValueError(
+            "Placement group `lifetime` argument must be either `None` or "
+            f"'detached'. Got {lifetime}."
+        )
+
+
+def _validate_bundles(bundles: List[Dict[str, float]]):
+    """Validates each bundle and raises a ValueError if any bundle is invalid."""
+
+    if not isinstance(bundles, list):
+        raise ValueError(
+            "Placement group bundles must be a list, " f"got {type(bundles)}."
+        )
+
+    if len(bundles) == 0:
+        raise ValueError(
+            "Bundles must be a non-empty list of resource "
+            'dictionaries. For example: `[{"CPU": 1.0}, {"GPU": 1.0}]`. '
+            "Got empty list instead."
+        )
+
+    for bundle in bundles:
+        if (
+            not isinstance(bundle, dict)
+            or not all(isinstance(k, str) for k in bundle.keys())
+            or not all(isinstance(v, (int, float)) for v in bundle.values())
+        ):
+            raise ValueError(
+                "Bundles must be a non-empty list of "
+                "resource dictionaries. For example: "
+                '`[{"CPU": 1.0}, {"GPU": 1.0}]`.'
+            )
+
+        if len(bundle) == 0 or all(
+            resource_value == 0 for resource_value in bundle.values()
+        ):
+            raise ValueError(
+                "Bundles cannot be an empty dictionary or "
+                f"resources with only 0 values. Bundles: {bundles}"
+            )
+
+        if "object_store_memory" in bundle.keys():
+            warnings.warn(
+                "Setting 'object_store_memory' for"
+                " bundles is deprecated since it doesn't actually"
+                " reserve the required object store memory."
+                f" Use object spilling that's enabled by default (https://docs.ray.io/en/{get_ray_doc_version()}/ray-core/objects/object-spilling.html) "  # noqa: E501
+                "instead to bypass the object store memory size limitation.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
 
 
 def _valid_resource_shape(resources, bundle_specs):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change cherry-picks https://github.com/ray-project/ray/pull/43930.

**Original description:**

This change makes Serve validate placement group bundles when deployments are defined rather than when deployments are deployed.

This change also pulls placement group validation logic out into new `validate_strategy` and `validate_bundles` functions in `placement_group.py` and uses these functions in the Serve validation.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/43888.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds unit tests that check the validation logic.
