### PR TITLE
[Dashboard] Enable customizable refresh frequency for the Metrics page

### DIFF
--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -527,7 +527,7 @@ export const Metrics = () => {
                 </MenuItem>
               ))}
             </TextField>
-            <HelpInfo>Time picker</HelpInfo>
+            <HelpInfo>Time range picker</HelpInfo>
           </Paper>
           <Alert severity="info">
             Tip: You can click on the legend to focus on a specific line in the

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -481,11 +481,12 @@ export const Metrics = () => {
               className={classes.timeRangeButton}
               select
               size="small"
-              sx={{ width: 100 }}
+              sx={{ width: 80 }}
               value={refreshOption}
               onChange={({ target: { value } }) => {
                 setRefreshOption(value as RefreshOptions);
               }}
+              variant="standard"
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">
@@ -504,11 +505,12 @@ export const Metrics = () => {
               className={classes.timeRangeButton}
               select
               size="small"
-              sx={{ width: 100 }}
+              sx={{ width: 140 }}
               value={timeRangeOption}
               onChange={({ target: { value } }) => {
                 setTimeRangeOption(value as TimeRangeOptions);
               }}
+              variant="standard"
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -50,7 +50,6 @@ const useStyles = makeStyles((theme) =>
 
 export enum RefreshOptions {
   OFF = "off",
-  ONE_SECOND = "1s",
   FIVE_SECONDS = "5s",
   TEN_SECONDS = "10s",
   THIRTY_SECONDS = "30s",
@@ -77,7 +76,6 @@ export enum TimeRangeOptions {
 
 export const REFRESH_VALUE: Record<RefreshOptions, string> = {
   [RefreshOptions.OFF]: "",
-  [RefreshOptions.ONE_SECOND]: "1s",
   [RefreshOptions.FIVE_SECONDS]: "5s",
   [RefreshOptions.TEN_SECONDS]: "10s",
   [RefreshOptions.THIRTY_SECONDS]: "30s",

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -391,7 +391,7 @@ export const Metrics = () => {
   const grafanaDefaultDatasource = dashboardDatasource ?? "Prometheus";
 
   const [refreshOption, setRefreshOption] = useState<RefreshOptions>(
-    RefreshOptions.ONE_SECOND,
+    RefreshOptions.FIVE_SECONDS,
   );
 
   const [timeRangeOption, setTimeRangeOption] = useState<TimeRangeOptions>(

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -19,6 +19,7 @@ import { RiExternalLinkLine } from "react-icons/ri";
 import { GlobalContext } from "../../App";
 import { CollapsibleSection } from "../../common/CollapsibleSection";
 import { ClassNameProps } from "../../common/props";
+import { HelpInfo } from "../../components/Tooltip";
 import { MainNavPageInfo } from "../layout/mainNavContext";
 import { MAIN_NAV_HEIGHT } from "../layout/MainNavLayout";
 
@@ -490,7 +491,7 @@ export const Metrics = () => {
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">
-                    <BiRefresh style={{ fontSize: 22 }} />
+                    <BiRefresh style={{ fontSize: 25, paddingBottom: 5 }} />
                   </InputAdornment>
                 ),
               }}
@@ -501,6 +502,7 @@ export const Metrics = () => {
                 </MenuItem>
               ))}
             </TextField>
+            <HelpInfo>Auto-refresh interval</HelpInfo>
             <TextField
               className={classes.timeRangeButton}
               select
@@ -514,7 +516,7 @@ export const Metrics = () => {
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">
-                    <BiTime style={{ fontSize: 22 }} />
+                    <BiTime style={{ fontSize: 22, paddingBottom: 5 }} />
                   </InputAdornment>
                 ),
               }}
@@ -525,6 +527,7 @@ export const Metrics = () => {
                 </MenuItem>
               ))}
             </TextField>
+            <HelpInfo>Time picker</HelpInfo>
           </Paper>
           <Alert severity="info">
             Tip: You can click on the legend to focus on a specific line in the

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -481,7 +481,7 @@ export const Metrics = () => {
               className={classes.timeRangeButton}
               select
               size="small"
-              style={{ width: 100 }}
+              sx={{ width: 100 }}
               value={refreshOption}
               onChange={({ target: { value } }) => {
                 setRefreshOption(value as RefreshOptions);
@@ -509,7 +509,6 @@ export const Metrics = () => {
               onChange={({ target: { value } }) => {
                 setTimeRangeOption(value as TimeRangeOptions);
               }}
-              variant="standard"
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -2,6 +2,7 @@ import {
   Alert,
   AlertProps,
   Button,
+  InputAdornment,
   Link,
   Menu,
   MenuItem,
@@ -12,6 +13,7 @@ import {
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { useContext, useEffect, useState } from "react";
+import { BiRefresh, BiTime } from "react-icons/bi";
 import { RiExternalLinkLine } from "react-icons/ri";
 
 import { GlobalContext } from "../../App";
@@ -45,6 +47,21 @@ const useStyles = makeStyles((theme) =>
   }),
 );
 
+export enum RefreshOptions {
+  OFF = "off",
+  ONE_SECOND = "1s",
+  FIVE_SECONDS = "5s",
+  TEN_SECONDS = "10s",
+  THIRTY_SECONDS = "30s",
+  ONE_MIN = "1m",
+  FIVE_MINS = "5m",
+  FIFTEEN_MINS = "15m",
+  THIRTY_MINS = "30m",
+  ONE_HOUR = "1h",
+  TWO_HOURS = "2h",
+  ONE_DAY = "1d",
+}
+
 export enum TimeRangeOptions {
   FIVE_MINS = "Last 5 minutes",
   THIRTY_MINS = "Last 30 minutes",
@@ -56,6 +73,21 @@ export enum TimeRangeOptions {
   TWO_DAYS = "Last 2 days",
   SEVEN_DAYS = "Last 7 days",
 }
+
+export const REFRESH_VALUE: Record<RefreshOptions, string> = {
+  [RefreshOptions.OFF]: "",
+  [RefreshOptions.ONE_SECOND]: "1s",
+  [RefreshOptions.FIVE_SECONDS]: "5s",
+  [RefreshOptions.TEN_SECONDS]: "10s",
+  [RefreshOptions.THIRTY_SECONDS]: "30s",
+  [RefreshOptions.ONE_MIN]: "1m",
+  [RefreshOptions.FIVE_MINS]: "5m",
+  [RefreshOptions.FIFTEEN_MINS]: "15m",
+  [RefreshOptions.THIRTY_MINS]: "30m",
+  [RefreshOptions.ONE_HOUR]: "1h",
+  [RefreshOptions.TWO_HOURS]: "2h",
+  [RefreshOptions.ONE_DAY]: "1d",
+};
 
 export const TIME_RANGE_TO_FROM_VALUE: Record<TimeRangeOptions, string> = {
   [TimeRangeOptions.FIVE_MINS]: "now-5m",
@@ -358,13 +390,25 @@ export const Metrics = () => {
 
   const grafanaDefaultDatasource = dashboardDatasource ?? "Prometheus";
 
+  const [refreshOption, setRefreshOption] = useState<RefreshOptions>(
+    RefreshOptions.ONE_SECOND,
+  );
+
   const [timeRangeOption, setTimeRangeOption] = useState<TimeRangeOptions>(
     TimeRangeOptions.FIVE_MINS,
   );
+
+  const [refresh, setRefresh] = useState<string | null>(null);
+
   const [[from, to], setTimeRange] = useState<[string | null, string | null]>([
     null,
     null,
   ]);
+
+  useEffect(() => {
+    setRefresh(REFRESH_VALUE[refreshOption]);
+  }, [refreshOption]);
+
   useEffect(() => {
     const from = TIME_RANGE_TO_FROM_VALUE[timeRangeOption];
     setTimeRange([from, "now"]);
@@ -376,6 +420,8 @@ export const Metrics = () => {
   const fromParam = from !== null ? `&from=${from}` : "";
   const toParam = to !== null ? `&to=${to}` : "";
   const timeRangeParams = `${fromParam}${toParam}`;
+
+  const refreshParams = refresh !== "" ? `&refresh=${refresh}` : "";
 
   return (
     <div>
@@ -435,12 +481,42 @@ export const Metrics = () => {
               className={classes.timeRangeButton}
               select
               size="small"
-              style={{ width: 120 }}
+              style={{ width: 80 }}
+              value={refreshOption}
+              onChange={({ target: { value } }) => {
+                setRefreshOption(value as RefreshOptions);
+              }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <BiRefresh style={{ fontSize: 22 }} />
+                  </InputAdornment>
+                ),
+              }}
+            >
+              {Object.entries(RefreshOptions).map(([key, value]) => (
+                <MenuItem key={key} value={value}>
+                  {value}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              className={classes.timeRangeButton}
+              select
+              size="small"
+              sx={{ width: 100 }}
               value={timeRangeOption}
               onChange={({ target: { value } }) => {
                 setTimeRangeOption(value as TimeRangeOptions);
               }}
               variant="standard"
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <BiTime style={{ fontSize: 22 }} />
+                  </InputAdornment>
+                ),
+              }}
             >
               {Object.entries(TimeRangeOptions).map(([key, value]) => (
                 <MenuItem key={key} value={value}>
@@ -459,6 +535,7 @@ export const Metrics = () => {
               <MetricsSection
                 key={config.title}
                 metricConfig={config}
+                refreshParams={refreshParams}
                 timeRangeParams={timeRangeParams}
                 dashboardUid={grafanaDefaultDashboardUid}
                 dashboardDatasource={grafanaDefaultDatasource}
@@ -469,6 +546,7 @@ export const Metrics = () => {
                 <MetricsSection
                   key={config.title}
                   metricConfig={config}
+                  refreshParams={refreshParams}
                   timeRangeParams={timeRangeParams}
                   dashboardUid={dashboardUids["data"]}
                   dashboardDatasource={grafanaDefaultDatasource}
@@ -511,6 +589,7 @@ const useMetricsSectionStyles = makeStyles((theme) =>
 
 type MetricsSectionProps = {
   metricConfig: MetricsSectionConfig;
+  refreshParams: string;
   timeRangeParams: string;
   dashboardUid: string;
   dashboardDatasource: string;
@@ -518,6 +597,7 @@ type MetricsSectionProps = {
 
 const MetricsSection = ({
   metricConfig: { title, contents },
+  refreshParams,
   timeRangeParams,
   dashboardUid,
   dashboardDatasource,
@@ -538,7 +618,7 @@ const MetricsSection = ({
         {contents.map(({ title, pathParams }) => {
           const path =
             `/d-solo/${dashboardUid}?${pathParams}` +
-            `&refresh${timeRangeParams}&var-SessionName=${sessionName}&var-datasource=${dashboardDatasource}`;
+            `&${refreshParams}${timeRangeParams}&var-SessionName=${sessionName}&var-datasource=${dashboardDatasource}`;
           return (
             <Paper
               key={pathParams}

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -421,7 +421,7 @@ export const Metrics = () => {
   const toParam = to !== null ? `&to=${to}` : "";
   const timeRangeParams = `${fromParam}${toParam}`;
 
-  const refreshParams = refresh !== "" ? `&refresh=${refresh}` : "";
+  const refreshParams = refresh ? `&refresh=${refresh}` : "";
 
   return (
     <div>

--- a/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -481,7 +481,7 @@ export const Metrics = () => {
               className={classes.timeRangeButton}
               select
               size="small"
-              style={{ width: 80 }}
+              style={{ width: 100 }}
               value={refreshOption}
               onChange={({ target: { value } }) => {
                 setRefreshOption(value as RefreshOptions);

--- a/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
@@ -121,7 +121,7 @@ export const ServeReplicaMetricsSection = ({
   const fromParam = from !== null ? `&from=${from}` : "";
   const toParam = to !== null ? `&to=${to}` : "";
   const timeRangeParams = `${fromParam}${toParam}`;
-  const refreshParams = refresh !== "" ? `&refresh=${refresh}` : "";
+  const refreshParams = refresh ? `&refresh=${refresh}` : "";
 
   const replicaButtonUrl = useViewServeDeploymentMetricsButtonUrl(
     deploymentName,

--- a/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
@@ -14,6 +14,7 @@ import { RiExternalLinkLine } from "react-icons/ri";
 import { GlobalContext } from "../../App";
 import { CollapsibleSection } from "../../common/CollapsibleSection";
 import { ClassNameProps } from "../../common/props";
+import { HelpInfo } from "../../components/Tooltip";
 import {
   MetricConfig,
   REFRESH_VALUE,
@@ -155,7 +156,7 @@ export const ServeReplicaMetricsSection = ({
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
-                  <BiRefresh style={{ fontSize: 22 }} />
+                  <BiRefresh style={{ fontSize: 25, paddingBottom: 5 }} />
                 </InputAdornment>
               ),
             }}
@@ -166,6 +167,7 @@ export const ServeReplicaMetricsSection = ({
               </MenuItem>
             ))}
           </TextField>
+          <HelpInfo>Auto-refresh interval</HelpInfo>
           <TextField
             className={classes.timeRangeButton}
             select
@@ -179,7 +181,7 @@ export const ServeReplicaMetricsSection = ({
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
-                  <BiTime style={{ fontSize: 22 }} />
+                  <BiTime style={{ fontSize: 22, paddingBottom: 5 }} />
                 </InputAdornment>
               ),
             }}
@@ -190,6 +192,7 @@ export const ServeReplicaMetricsSection = ({
               </MenuItem>
             ))}
           </TextField>
+          <HelpInfo>Time picker</HelpInfo>
         </Box>
         <div className={classes.grafanaEmbedsContainer}>
           {METRICS_CONFIG.map(({ title, pathParams }) => {

--- a/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
@@ -192,7 +192,7 @@ export const ServeReplicaMetricsSection = ({
               </MenuItem>
             ))}
           </TextField>
-          <HelpInfo>Time picker</HelpInfo>
+          <HelpInfo>Time range picker</HelpInfo>
         </Box>
         <div className={classes.grafanaEmbedsContainer}>
           {METRICS_CONFIG.map(({ title, pathParams }) => {

--- a/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
@@ -97,7 +97,7 @@ export const ServeReplicaMetricsSection = ({
     dashboardUids?.serveDeployment ?? "rayServeDashboard";
 
   const [refreshOption, setRefreshOption] = useState<RefreshOptions>(
-    RefreshOptions.ONE_SECOND,
+    RefreshOptions.FIVE_SECONDS,
   );
 
   const [timeRangeOption, setTimeRangeOption] = useState<TimeRangeOptions>(

--- a/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
@@ -146,11 +146,12 @@ export const ServeReplicaMetricsSection = ({
             className={classes.timeRangeButton}
             select
             size="small"
-            sx={{ width: 100 }}
+            sx={{ width: 80 }}
             value={refreshOption}
             onChange={({ target: { value } }) => {
               setRefreshOption(value as RefreshOptions);
             }}
+            variant="standard"
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
@@ -169,11 +170,12 @@ export const ServeReplicaMetricsSection = ({
             className={classes.timeRangeButton}
             select
             size="small"
-            style={{ width: 120 }}
+            style={{ width: 140 }}
             value={timeRangeOption}
             onChange={({ target: { value } }) => {
               setTimeRangeOption(value as TimeRangeOptions);
             }}
+            variant="standard"
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -1,13 +1,23 @@
-import { Box, Button, MenuItem, Paper, TextField } from "@mui/material";
+import {
+  Box,
+  Button,
+  InputAdornment,
+  MenuItem,
+  Paper,
+  TextField,
+} from "@mui/material";
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
 import React, { useContext, useEffect, useState } from "react";
+import { BiRefresh, BiTime } from "react-icons/bi";
 import { RiExternalLinkLine } from "react-icons/ri";
 import { GlobalContext } from "../../App";
 import { CollapsibleSection } from "../../common/CollapsibleSection";
 import { ClassNameProps } from "../../common/props";
 import {
   MetricConfig,
+  REFRESH_VALUE,
+  RefreshOptions,
   TIME_RANGE_TO_FROM_VALUE,
   TimeRangeOptions,
 } from "../metrics";
@@ -110,14 +120,20 @@ export const ServeMetricsSection = ({
   const { grafanaHost, prometheusHealth, dashboardUids, dashboardDatasource } =
     useContext(GlobalContext);
   const grafanaServeDashboardUid = dashboardUids?.serve ?? "rayServeDashboard";
-
+  const [refreshOption, setRefreshOption] = useState<RefreshOptions>(
+    RefreshOptions.ONE_SECOND,
+  );
   const [timeRangeOption, setTimeRangeOption] = useState<TimeRangeOptions>(
     TimeRangeOptions.FIVE_MINS,
   );
+  const [refresh, setRefresh] = useState<string | null>(null);
   const [[from, to], setTimeRange] = useState<[string | null, string | null]>([
     null,
     null,
   ]);
+  useEffect(() => {
+    setRefresh(REFRESH_VALUE[refreshOption]);
+  }, [refreshOption]);
   useEffect(() => {
     const from = TIME_RANGE_TO_FROM_VALUE[timeRangeOption];
     setTimeRange([from, "now"]);
@@ -126,6 +142,7 @@ export const ServeMetricsSection = ({
   const fromParam = from !== null ? `&from=${from}` : "";
   const toParam = to !== null ? `&to=${to}` : "";
   const timeRangeParams = `${fromParam}${toParam}`;
+  const refreshParams = refresh !== "" ? `&refresh=${refresh}` : "";
 
   return grafanaHost === undefined || !prometheusHealth ? null : (
     <CollapsibleSection className={className} title="Metrics" startExpanded>
@@ -143,10 +160,40 @@ export const ServeMetricsSection = ({
             className={classes.timeRangeButton}
             select
             size="small"
+            sx={{ width: 100 }}
+            value={refreshOption}
+            onChange={({ target: { value } }) => {
+              setRefreshOption(value as RefreshOptions);
+            }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <BiRefresh style={{ fontSize: 22 }} />
+                </InputAdornment>
+              ),
+            }}
+          >
+            {Object.entries(RefreshOptions).map(([key, value]) => (
+              <MenuItem key={key} value={value}>
+                {value}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            className={classes.timeRangeButton}
+            select
+            size="small"
             style={{ width: 120 }}
             value={timeRangeOption}
             onChange={({ target: { value } }) => {
               setTimeRangeOption(value as TimeRangeOptions);
+            }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <BiTime style={{ fontSize: 22 }} />
+                </InputAdornment>
+              ),
             }}
           >
             {Object.entries(TimeRangeOptions).map(([key, value]) => (
@@ -160,7 +207,7 @@ export const ServeMetricsSection = ({
           {metricsConfig.map(({ title, pathParams }) => {
             const path =
               `/d-solo/${grafanaServeDashboardUid}?${pathParams}` +
-              `&refresh${timeRangeParams}&var-datasource=${dashboardDatasource}`;
+              `${refreshParams}${timeRangeParams}&var-datasource=${dashboardDatasource}`;
             return (
               <Paper
                 key={pathParams}

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -142,7 +142,7 @@ export const ServeMetricsSection = ({
   const fromParam = from !== null ? `&from=${from}` : "";
   const toParam = to !== null ? `&to=${to}` : "";
   const timeRangeParams = `${fromParam}${toParam}`;
-  const refreshParams = refresh !== "" ? `&refresh=${refresh}` : "";
+  const refreshParams = refresh ? `&refresh=${refresh}` : "";
 
   return grafanaHost === undefined || !prometheusHealth ? null : (
     <CollapsibleSection className={className} title="Metrics" startExpanded>

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -160,11 +160,12 @@ export const ServeMetricsSection = ({
             className={classes.timeRangeButton}
             select
             size="small"
-            sx={{ width: 100 }}
+            sx={{ width: 80 }}
             value={refreshOption}
             onChange={({ target: { value } }) => {
               setRefreshOption(value as RefreshOptions);
             }}
+            variant="standard"
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
@@ -183,11 +184,12 @@ export const ServeMetricsSection = ({
             className={classes.timeRangeButton}
             select
             size="small"
-            style={{ width: 120 }}
+            style={{ width: 140 }}
             value={timeRangeOption}
             onChange={({ target: { value } }) => {
               setTimeRangeOption(value as TimeRangeOptions);
             }}
+            variant="standard"
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -14,6 +14,7 @@ import { RiExternalLinkLine } from "react-icons/ri";
 import { GlobalContext } from "../../App";
 import { CollapsibleSection } from "../../common/CollapsibleSection";
 import { ClassNameProps } from "../../common/props";
+import { HelpInfo } from "../../components/Tooltip";
 import {
   MetricConfig,
   REFRESH_VALUE,
@@ -169,7 +170,7 @@ export const ServeMetricsSection = ({
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
-                  <BiRefresh style={{ fontSize: 22 }} />
+                  <BiRefresh style={{ fontSize: 25, paddingBottom: 5 }} />
                 </InputAdornment>
               ),
             }}
@@ -180,6 +181,7 @@ export const ServeMetricsSection = ({
               </MenuItem>
             ))}
           </TextField>
+          <HelpInfo>Auto-refresh interval</HelpInfo>
           <TextField
             className={classes.timeRangeButton}
             select
@@ -193,7 +195,7 @@ export const ServeMetricsSection = ({
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
-                  <BiTime style={{ fontSize: 22 }} />
+                  <BiTime style={{ fontSize: 22, paddingBottom: 5 }} />
                 </InputAdornment>
               ),
             }}
@@ -204,6 +206,7 @@ export const ServeMetricsSection = ({
               </MenuItem>
             ))}
           </TextField>
+          <HelpInfo>Time picker</HelpInfo>
         </Box>
         <div className={classes.grafanaEmbedsContainer}>
           {metricsConfig.map(({ title, pathParams }) => {

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -206,7 +206,7 @@ export const ServeMetricsSection = ({
               </MenuItem>
             ))}
           </TextField>
-          <HelpInfo>Time picker</HelpInfo>
+          <HelpInfo>Time range picker</HelpInfo>
         </Box>
         <div className={classes.grafanaEmbedsContainer}>
           {metricsConfig.map(({ title, pathParams }) => {

--- a/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -121,7 +121,7 @@ export const ServeMetricsSection = ({
     useContext(GlobalContext);
   const grafanaServeDashboardUid = dashboardUids?.serve ?? "rayServeDashboard";
   const [refreshOption, setRefreshOption] = useState<RefreshOptions>(
-    RefreshOptions.ONE_SECOND,
+    RefreshOptions.FIVE_SECONDS,
   );
   const [timeRangeOption, setTimeRangeOption] = useState<TimeRangeOptions>(
     TimeRangeOptions.FIVE_MINS,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, each chart on the Metrics page is continuously refreshing, which can put strain on the network and frontend. In our application with @nemo9cby @Bye-legumes, we have noticed that during periods of unstable cluster networks, there can be instances of response timeouts or loss. 

Therefore, having the ability to customize the refresh frequency would be helpful.

In the proposed modification, we have set the default refresh frequency to 1 second and provided various frequency configurations, following the example of Grafana. This way, users can choose the refresh interval that best suits their needs.

![refresh_frequency](https://github.com/ray-project/ray/assets/58834787/26fe1a06-42e1-41f7-a85b-faddfc2983f6)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
