### PR TITLE
[Core] Deflaky memory_monitor_test

### DIFF
--- a/src/ray/common/test/memory_monitor_test.cc
+++ b/src/ray/common/test/memory_monitor_test.cc
@@ -143,7 +143,7 @@ TEST_F(MemoryMonitorTest, TestMonitorPeriodSetMaxUsageThresholdCallbackExecuted)
                     [has_checked_once](bool is_usage_above_threshold,
                                        MemorySnapshot system_memory,
                                        float usage_threshold) {
-                      ASSERT_EQ(1.0f, usage_threshold);
+                      ASSERT_FLOAT_EQ(1.0f, usage_threshold);
                       ASSERT_GT(system_memory.total_bytes, 0);
                       ASSERT_GT(system_memory.used_bytes, 0);
                       has_checked_once->count_down();
@@ -160,7 +160,7 @@ TEST_F(MemoryMonitorTest, TestMonitorPeriodDisableMinMemoryCallbackExecuted) {
                     [has_checked_once](bool is_usage_above_threshold,
                                        MemorySnapshot system_memory,
                                        float usage_threshold) {
-                      ASSERT_EQ(0.4f, usage_threshold);
+                      ASSERT_FLOAT_EQ(0.4f, usage_threshold);
                       ASSERT_GT(system_memory.total_bytes, 0);
                       ASSERT_GT(system_memory.used_bytes, 0);
                       has_checked_once->count_down();
@@ -178,7 +178,7 @@ TEST_F(MemoryMonitorTest, TestMonitorMinFreeZeroThresholdIsOne) {
                     [has_checked_once](bool is_usage_above_threshold,
                                        MemorySnapshot system_memory,
                                        float usage_threshold) {
-                      ASSERT_EQ(1.0f, usage_threshold);
+                      ASSERT_FLOAT_EQ(1.0f, usage_threshold);
                       ASSERT_GT(system_memory.total_bytes, 0);
                       ASSERT_GT(system_memory.used_bytes, 0);
                       has_checked_once->count_down();


### PR DESCRIPTION
`MemoryMonitorTest::TestMonitorMinFreeZeroThresholdIsOne` was failing because two floats were directly compared for equality rather than equality within a delta. I printed out the hex representation for both floats and saw the following:
`0.4f` has a hex representation of `0x1.99999ap-2`
`usage_threshold` has a hex representation of `0x1.99999cp-2`

Thus, the two floats are different.

I replaced `ASSERT_EQ()` with `ASSERT_FLOAT_EQ()` and the test now passes. There were also a couple other instances of checking for float equality that I updated to use `ASSERT_FLOAT_EQ()`.

Tested: `bazel test src/ray/common/test:memory_monitor_test`

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix for issue #44027

## Related issue number

Close #44027

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
