### PR TITLE
[ci] remove ray linkcheck

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -86,16 +86,6 @@ steps:
     commands:
       - ./ci/lint/check-documentation-style.sh
 
-  # premerge linkcheck run; validate links within the ray repository
-  - label: ":lint-roller: lint: ray linkcheck"
-    if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b"
-    instance_type: medium
-    commands:
-      - make -C doc/ linkcheck
-    depends_on: docbuild
-    job_env: docbuild
-
-  # postmerge linkcheck run; validate links within ray and also external links
   - label: ":lint-roller: lint: all linkcheck"
     instance_type: medium
     commands:


### PR DESCRIPTION
Remove ray linkcheck. This check keeps being false positive and blocking people. It's incorrect because there are a lot of link to the master branch that becomes invalid only after the PR is merged.

Test:
- CI