### PR TITLE
[Job] ray job subcommand is missing in command line help message

### DIFF
--- a/dashboard/modules/job/cli.py
+++ b/dashboard/modules/job/cli.py
@@ -98,6 +98,7 @@ async def _tail_logs(client: JobSubmissionClient, job_id: str) -> JobStatus:
 
 @click.group("job")
 def job_cli_group():
+    """Submit, stop, delete, or list Ray jobs."""
     pass
 
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2593,7 +2593,7 @@ except ImportError as e:
 try:
     from ray.dashboard.modules.job.cli import job_cli_group
 
-    add_command_alias(job_cli_group, name="job", hidden=True)
+    add_command_alias(job_cli_group, name="job", hidden=False)
 except Exception as e:
     logger.debug(f"Integrating ray jobs command line tool failed with {e}")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* "`hidden` ([bool](https://docs.python.org/3/library/functions.html#bool)) – hide this command from help outputs." ([ref](https://click.palletsprojects.com/en/8.1.x/api/))

## Related issue number

Closes #42391 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<img width="1047" alt="Screen Shot 2024-03-17 at 6 11 13 AM" src="https://github.com/ray-project/ray/assets/20109646/f68e9031-b401-41db-bb8f-0eed8830e2ed">

   