### PR TITLE
Remove CancelTaskForOwner in favor of CancelTaskOwnedBy

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1515,7 +1515,7 @@ void NodeManager::DisconnectClient(const std::shared_ptr<ClientConnection> &clie
   }
 
   local_task_manager_->ClearWorkerBacklog(worker->WorkerId());
-  cluster_task_manager_->CancelTaskForOwner(worker->GetAssignedTaskId());
+  cluster_task_manager_->CancelAllTaskOwnedBy(worker->WorkerId());
 
   client->Close();
 

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -86,17 +86,6 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
                       rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
                   const std::string &scheduling_failure_message = "") override;
 
-  /// Attempt to cancel an already queued task that belongs to an owner.
-  ///
-  /// \param owner_task_id: The id of the parent.
-  /// \param failure_type: The failure type.
-  /// \param scheduling_failure_message: The failure message.
-  void CancelTaskForOwner(
-      const TaskID &owner_task_id,
-      rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type =
-          rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
-      const std::string &scheduling_failure_message = "") override;
-
   /// Cancel all tasks owned by a specific worker.
   bool CancelAllTaskOwnedBy(
       const WorkerID &worker_id,

--- a/src/ray/raylet/scheduling/cluster_task_manager_interface.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager_interface.h
@@ -54,17 +54,6 @@ class ClusterTaskManagerInterface {
           rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
       const std::string &scheduling_failure_message = "") = 0;
 
-  /// Attempt to cancel an already queued task that belongs to an owner.
-  ///
-  /// \param owner_task_id: The id of the parent.
-  /// \param failure_type: The failure type.
-  /// \param scheduling_failure_message: The failure message.
-  virtual void CancelTaskForOwner(
-      const TaskID &owner_task_id,
-      rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type =
-          rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
-      const std::string &scheduling_failure_message = "") = 0;
-
   /// Queue task and schedule. This hanppens when processing the worker lease request.
   ///
   /// \param task: The incoming task to be queued and scheduled.


### PR DESCRIPTION
In   cluster_task_manager there are 2 methods: CancelTaskForOwner(task_id) and 
CancelAllTaskOwnedBy(worker_id). The former is called on a worker normal exit; the latter is called on a worker unexpected exit. Both are clean up functions to remove any pending tasks issued from the worker.

I think they are actually doing the same thing, because "cancel all tasks whose caller worker = this worker" and "cancel all task whose parent task = this worker's current task" should be always equivalent, and there's no need to keep 2 separate impls.

This PR removed the former, favoring the filter by worker id because it's more direct logic.
