### PR TITLE
[RLlib] Hot fix for `PPOTorchRLModule._compute_values` with non-shared stateful encoder and batch slicing with non-empty `info`s.

### DIFF
--- a/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
+++ b/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
@@ -90,6 +90,10 @@ class PPOTorchRLModule(TorchRLModule, PPORLModule):
 
         # Separate vf-encoder.
         if hasattr(self.encoder, "critic_encoder"):
+            if self.is_stateful():
+                # The recurrent encoders expect a `(state_in, h)`  key in the
+                # input dict while the key returned is `(state_in, critic, h)`.
+                batch[Columns.STATE_IN] = batch[Columns.STATE_IN][CRITIC]
             encoder_outs = self.encoder.critic_encoder(batch)[ENCODER_OUT]
         # Shared encoder.
         else:

--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -716,7 +716,9 @@ class SampleBatch(dict):
 
         # Exclude INFOs from regular array slicing as the data under this column might
         # be a list (not good for `tree.map_structure` call).
-        infos = self.get(SampleBatch.INFOS)
+        # Furthermore, slicing does not work when the data in the column is
+        # singular (not a list or array).
+        infos = self.pop(SampleBatch.INFOS, None)
         data = tree.map_structure(lambda value: value[start:stop], self)
         if infos is not None:
             data[SampleBatch.INFOS] = infos[start:stop]


### PR DESCRIPTION
## Why are these changes needed?

Running `PPO` with `use_lstm=True` and `vf_share_layers=False` results in an error in the `PPOTorchRLModule._compute_values` method as the specs checker expects a different spec for the `state_in`: 

```
raise SpecCheckingError(
ray.rllib.core.models.specs.checker.SpecCheckingError: input spec validation failed on TorchLSTMEncoder.forward, The data dict does not match the model specs. Keys ('state_in', 'h') are in the spec dict but not on the data dict. Data keys are {('state_in', 'critic', 'c'), ('rewards',), ('action_logp',), ('state_in', 'actor', 'h'), ('state_in', 'critic', 'h'), ('terminateds',), ('obs',), ('truncateds',), ('vf_preds',), ('loss_mask',), ('seq_lens',), ('action_dist_inputs',), ('infos',), ('actions',), ('state_in', 'actor', 'c')}.
```
Exctracting the `state_in` for the `critic` solves this problem. 

Another problem is solved related to non-empty infos in batch slicing (mainly occuring in `MinibatchIterator`s). The reason is that slicing via `tree.map_structure` tries to slice also the entries of the `info`s which are usually singular values: 

```
data = tree.map_structure(lambda value: value[start:stop], self)
IndexError: slice() cannot be applied to a 0-dim tensor.
```


## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
