### PR TITLE
[core] Streaming generator task waits for all object report acks before finishing the task

### DIFF
--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -88,7 +88,10 @@ cdef extern from "ray/core_worker/context.h" nogil:
 
 cdef extern from "ray/core_worker/generator_waiter.h" nogil:
     cdef cppclass CGeneratorBackpressureWaiter "ray::core::GeneratorBackpressureWaiter": # noqa
-        CGeneratorBackpressureWaiter(int64_t generator_backpressure_num_objects) # noqa
+        CGeneratorBackpressureWaiter(
+                int64_t generator_backpressure_num_objects,
+                (CRayStatus() nogil) check_signals)
+        CRayStatus WaitAllObjectsReported()
 
 cdef extern from "ray/core_worker/core_worker.h" nogil:
     cdef cppclass CActorHandle "ray::core::ActorHandle":

--- a/src/ray/core_worker/generator_waiter.h
+++ b/src/ray/core_worker/generator_waiter.h
@@ -23,30 +23,90 @@ namespace core {
 /// A class to pause a task execution while a generator is backpressured.
 class GeneratorBackpressureWaiter {
  public:
-  GeneratorBackpressureWaiter(int64_t generator_backpressure_num_objects);
-  /// Block a thread and wait until objects are consumed from a consumer.
-  /// It return OK status if the backpressure is not needed or backpressure is
-  /// finished.
-  /// It periodically checks the signals (Python code has to keep checking
-  /// signals while it is blocked by cpp) using a callback `check_signals`.
-  /// If check_signals returns non-ok status, it finishes blocking and returns
-  /// the non-ok status to the caller.
-  Status WaitUntilObjectConsumed(std::function<Status()> check_signals);
-  void UpdateTotalObjectConsumed(int64_t total_objects_consumed);
+  /// Create a generator backpressure waiter. One instance should be created
+  /// for each streaming generator task.
+  ///
+  /// \param[in] generator_backpressure_num_objects The number of objects to
+  /// generate before requiring a signal from the consumer that ObjectRefs have
+  /// been consumed (yield'ed) to continue generation. This ensures that we do
+  /// not generate too many objects in the object store during execution if the
+  /// producer is faster than the consumer. Set to -1 to disable.
+  /// \param[in] check_signals A callback to check Python signals while we are
+  /// blocked in C++ code. If check_signals returns non-ok status, it finishes
+  /// blocking and returns the non-ok status to the caller.
+  GeneratorBackpressureWaiter(int64_t generator_backpressure_num_objects,
+                              std::function<Status()> check_signals);
+
+  /// Block and wait until enough objects are consumed from the consumer, so
+  /// that we are under the backpressure threshold. Returns OK status if
+  /// backpressure is not set or if backpressure is relieved.
+  ///
+  /// \return Status OK if backpressure is released and the executor may
+  /// generate another item. Else, returns the status returned by check_signals
+  /// callback.
+  Status WaitUntilObjectConsumed();
+
+  /// Block and wait until all objects that have been generated so far have
+  /// been reported to the consumer.
+  ///
+  /// At the end of a streaming generator task, the executor should call this
+  /// before sending the PushTaskReply RPC reply to the caller. Otherwise, we
+  /// may fail after completing a task but before we have reported a return.
+  /// Then, the consumer will mark the task as completed but will never receive
+  /// the dynamic return's value.
+  ///
+  /// \return Status OK if all generator items have been reported. Else,
+  /// returns the status returned by check_signals callback.
+  Status WaitAllObjectsReported();
+
+  void UpdateTotalObjectConsumed();
+
+  /// Increment the number of objects generated. The executor should call this
+  /// before sending an object report to the caller.
   void IncrementObjectGenerated();
-  int64_t TotalObjectConsumed();
-  int64_t TotalObjectGenerated();
+
+  /// Handle a completed object report. The executor should call this after
+  /// receiving an ack from the caller for an object report.
+  ///
+  /// Updates the total number of objects that have been consumed by the
+  /// caller.  The caller "consumes" an object by calling next() on the
+  /// ObjectRef generator.
+  ///
+  /// \param[in] total_objects_consumed The number of objects consumed by the
+  /// caller will be set to this value, if it is greater than the previous
+  /// value. Unblocks execution if the updated number of objects consumed puts
+  /// us under the backpressure threshold. Setting this to the total objects
+  /// generated will always unblock execution.
+  void HandleObjectReported(int64_t total_objects_consumed);
+
+  /// Get the total number of objects consumed by the caller so far.
+  int64_t TotalObjectConsumed() const;
+
+  /// Get the total number of objects generated so far.
+  int64_t TotalObjectGenerated() const;
 
  private:
-  absl::Mutex mutex_;
-  absl::CondVar cond_var_;
+  mutable absl::Mutex mutex_;
+  // Used to signal when backpressure is released and
+  // execution may continue. Only used if
+  // backpressure_threshold_ > 0.
+  absl::CondVar backpressure_cond_var_;
+  // Used to signal when all objects that have been generated so far have been
+  // reported to the caller. At the end of a streaming generator task, we
+  // should wait on this cond var before sending the PushTaskReply RPC reply to
+  // the caller. Otherwise, we may fail after completing a task but before we
+  // have reported a return.
+  absl::CondVar all_objects_reported_cond_var_;
   // If total_objects_generated_ - total_objects_consumed_ < this
   // the task will stop.
   const int64_t backpressure_threshold_;
+  const std::function<Status()> check_signals_;
   // Total number of objects generated from a generator.
-  int64_t total_objects_generated_;
+  int64_t total_objects_generated_ = 0;
+  // Total number of objects whose reports to the caller are in flight.
+  int64_t num_object_reports_in_flight_ = 0;
   // Total number of objects consumed from a generator.
-  int64_t total_objects_consumed_;
+  int64_t total_objects_consumed_ = 0;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/test/generator_waiter_test.cc
+++ b/src/ray/core_worker/test/generator_waiter_test.cc
@@ -24,11 +24,12 @@ namespace core {
 
 TEST(GeneratorWaiterTest, TestBasic) {
   std::shared_ptr<GeneratorBackpressureWaiter> waiter =
-      std::make_shared<GeneratorBackpressureWaiter>(1);
+      std::make_shared<GeneratorBackpressureWaiter>(
+          1,
+          /*check_signals*/ []() { return Status::OK(); });
 
   auto wait = [waiter]() {
-    auto status =
-        waiter->WaitUntilObjectConsumed(/*check_signals*/ []() { return Status::OK(); });
+    auto status = waiter->WaitUntilObjectConsumed();
     ASSERT_TRUE(status.ok());
   };
 
@@ -40,28 +41,71 @@ TEST(GeneratorWaiterTest, TestBasic) {
   // 1 generated -> wait -> 1 consumed
   waiter->IncrementObjectGenerated();
   std::thread t2(wait);
-  waiter->UpdateTotalObjectConsumed(1);
+  waiter->HandleObjectReported(1);
   t2.join();
 
   // 2 generated -> wait -> 0 consumed (ignored) -> 3 consumed (resume).
   waiter->IncrementObjectGenerated();
   std::thread t3(wait);
   // If a lower value is given, it should ignore.
-  waiter->UpdateTotalObjectConsumed(0);
+  waiter->HandleObjectReported(0);
   ASSERT_EQ(waiter->TotalObjectConsumed(), 1);
   // Larger value should resume.
-  waiter->UpdateTotalObjectConsumed(3);
+  waiter->HandleObjectReported(3);
   ASSERT_EQ(waiter->TotalObjectConsumed(), 3);
   t3.join();
 }
 
+TEST(GeneratorWaiterTest, TestAllObjectsReported) {
+  std::shared_ptr<GeneratorBackpressureWaiter> waiter =
+      std::make_shared<GeneratorBackpressureWaiter>(
+          -1,
+          /*check_signals*/ []() { return Status::OK(); });
+
+  absl::Mutex mutex;
+  absl::CondVar cond_var;
+  bool done = false;
+
+  auto wait = [&]() {
+    auto status = waiter->WaitAllObjectsReported();
+    ASSERT_TRUE(status.ok());
+
+    absl::MutexLock lock(&mutex);
+    done = true;
+    cond_var.SignalAll();
+  };
+
+  // First object report in flight.
+  waiter->IncrementObjectGenerated();
+  std::thread t(wait);
+
+  {
+    absl::MutexLock lock(&mutex);
+    cond_var.WaitWithTimeout(&mutex, absl::Milliseconds(10));
+    ASSERT_FALSE(done);
+    // Second object report in flight.
+    waiter->IncrementObjectGenerated();
+    // First object report acked, still blocked.
+    waiter->HandleObjectReported(0);
+    cond_var.WaitWithTimeout(&mutex, absl::Milliseconds(10));
+    ASSERT_FALSE(done);
+    // Second object report acked, unblocked.
+    waiter->HandleObjectReported(0);
+    cond_var.WaitWithTimeout(&mutex, absl::Milliseconds(10));
+    ASSERT_TRUE(done);
+  }
+
+  t.join();
+}
+
 TEST(GeneratorWaiterTest, TestLargerThreshold) {
   std::shared_ptr<GeneratorBackpressureWaiter> waiter =
-      std::make_shared<GeneratorBackpressureWaiter>(3);
+      std::make_shared<GeneratorBackpressureWaiter>(
+          3,
+          /*check_signals*/ []() { return Status::OK(); });
 
   auto wait = [waiter]() {
-    auto status =
-        waiter->WaitUntilObjectConsumed(/*check_signals*/ []() { return Status::OK(); });
+    auto status = waiter->WaitUntilObjectConsumed();
     ASSERT_TRUE(status.ok());
   };
 
@@ -73,26 +117,26 @@ TEST(GeneratorWaiterTest, TestLargerThreshold) {
 
   waiter->IncrementObjectGenerated();
   std::thread t3(wait);
-  waiter->UpdateTotalObjectConsumed(1);
+  waiter->HandleObjectReported(1);
   t3.join();
 }
 
 TEST(GeneratorWaiterTest, TestSignalFailure) {
-  std::shared_ptr<GeneratorBackpressureWaiter> waiter =
-      std::make_shared<GeneratorBackpressureWaiter>(1);
   std::shared_ptr<std::atomic<bool>> signal_failed =
       std::make_shared<std::atomic<bool>>(false);
+  std::shared_ptr<GeneratorBackpressureWaiter> waiter =
+      std::make_shared<GeneratorBackpressureWaiter>(1,
+                                                    /*check_signals*/ [signal_failed]() {
+                                                      if (*signal_failed) {
+                                                        return Status::NotFound("");
+                                                      } else {
+                                                        return Status::OK();
+                                                      }
+                                                    });
   waiter->IncrementObjectGenerated();
 
   auto wait = [signal_failed, waiter]() {
-    auto status = waiter->WaitUntilObjectConsumed(/*check_signals*/ [signal_failed]() {
-      if (*signal_failed) {
-        return Status::NotFound("");
-      } else {
-        return Status::OK();
-      }
-    });
-
+    auto status = waiter->WaitUntilObjectConsumed();
     if (*signal_failed) {
       ASSERT_TRUE(status.IsNotFound());
     } else {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cherry-pick #44079, fixes for #43914 and #43978.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
