### PR TITLE
[Cluster launcher] [Azure] Make cluster termination and networking more configurable and robust

### DIFF
--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -1171,7 +1171,7 @@ controlled by your cloud provider's configuration.
 * **Default:** ``False``
 
 ``provider.use_external_head_ip``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. tab-set::
 

--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -1170,6 +1170,8 @@ controlled by your cloud provider's configuration.
 * **Type:** Boolean
 * **Default:** ``False``
 
+.. _cluster-configuration-use-external-head-ip:
+
 ``provider.use_external_head_ip``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -133,6 +133,7 @@ Provider
             :ref:`msi_resource_group <cluster-configuration-msi-resource-group>`: str
             :ref:`cache_stopped_nodes <cluster-configuration-cache-stopped-nodes>`: bool
             :ref:`use_internal_ips <cluster-configuration-use-internal-ips>`: bool
+            :ref:`use_external_head_ip <cluster-configuration-use-external-head-ip>`: bool
 
     .. tab-item:: GCP
 
@@ -1168,6 +1169,36 @@ controlled by your cloud provider's configuration.
 * **Importance:** Low
 * **Type:** Boolean
 * **Default:** ``False``
+
+``provider.use_external_head_ip``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tab-set::
+
+    .. tab-item:: AWS
+
+        Not available.
+
+    .. tab-item:: Azure
+
+        If enabled, Ray will provision and use a public IP address for communication with the head node,
+        regardless of the value of ``use_internal_ips``. This option can be used in combination with  
+        ``use_internal_ips`` to avoid provisioning excess public IPs for worker nodes (i.e., communicate
+        among nodes using private IPs, but provision a public IP for head node communication only). If
+        ``use_internal_ips`` is ``False``, then this option has no effect. 
+
+        * **Required:** No
+        * **Importance:** Low
+        * **Type:** Boolean
+        * **Default:** ``False``
+
+    .. tab-item:: GCP
+
+        Not available.
+
+    .. tab-item:: vSphere
+
+        Not available.
 
 .. _cluster-configuration-security-group:
 

--- a/python/ray/autoscaler/_private/_azure/config.py
+++ b/python/ray/autoscaler/_private/_azure/config.py
@@ -101,7 +101,7 @@ def _configure_resource_group(config):
     # Addresses issue (https://github.com/Azure/azure-quickstart-templates/issues/2786)
     # where existing subnet properties will get overwritten unless explicitly specified
     # during multiple deployments even if vnet/subnet do not change.
-    # May eventually be addressed by passing an empty list of subnets if they already exist:
+    # May eventually be fixed by passing empty subnet list if they already exist:
     # https://techcommunity.microsoft.com/t5/azure-networking-blog/azure-virtual-network-now-supports-updates-without-subnet/ba-p/4067952
     list_by_rg = get_azure_sdk_function(
         client=resource_client.resources, function_name="list_by_resource_group"

--- a/python/ray/autoscaler/_private/_azure/config.py
+++ b/python/ray/autoscaler/_private/_azure/config.py
@@ -97,6 +97,36 @@ def _configure_resource_group(config):
         subnet_mask = "10.{}.0.0/16".format(random.randint(1, 254))
     logger.info("Using subnet mask: %s", subnet_mask)
 
+    # Copy over properties from existing subnet.
+    # Addresses issue (https://github.com/Azure/azure-quickstart-templates/issues/2786)
+    # where existing subnet properties will get overwritten unless explicitly specified
+    # during multiple deployments even if vnet/subnet do not change.
+    # May eventually be addressed by passing an empty list of subnets if they already exist:
+    # https://techcommunity.microsoft.com/t5/azure-networking-blog/azure-virtual-network-now-supports-updates-without-subnet/ba-p/4067952
+    list_by_rg = get_azure_sdk_function(
+        client=resource_client.resources, function_name="list_by_resource_group"
+    )
+    existing_vnets = list(
+        list_by_rg(
+            resource_group,
+            f"substringof('{unique_id}', name) and "
+            "resourceType eq 'Microsoft.Network/virtualNetworks'",
+        )
+    )
+    if len(existing_vnets) > 0:
+        vnid = existing_vnets[0].id
+        get_by_id = get_azure_sdk_function(
+            client=resource_client.resources, function_name="get_by_id"
+        )
+        subnet = get_by_id(vnid, resource_client.DEFAULT_API_VERSION).properties[
+            "subnets"
+        ][0]
+        template_vnet = next((rs for rs in template["resources"] if rs["type"] == "Microsoft.Network/virtualNetworks"), None)
+        if template_vnet is not None:
+            template_subnets = template_vnet["properties"].get("subnets")
+            if template_subnets is not None:
+                template_subnets[0]["properties"].update(subnet["properties"])
+
     # Get or create an MSI name and resource group.
     # Defaults to current resource group if not provided.
     use_existing_msi = (

--- a/python/ray/autoscaler/_private/_azure/config.py
+++ b/python/ray/autoscaler/_private/_azure/config.py
@@ -121,7 +121,14 @@ def _configure_resource_group(config):
         subnet = get_by_id(vnid, resource_client.DEFAULT_API_VERSION).properties[
             "subnets"
         ][0]
-        template_vnet = next((rs for rs in template["resources"] if rs["type"] == "Microsoft.Network/virtualNetworks"), None)
+        template_vnet = next(
+            (
+                rs
+                for rs in template["resources"]
+                if rs["type"] == "Microsoft.Network/virtualNetworks"
+            ),
+            None,
+        )
         if template_vnet is not None:
             template_subnets = template_vnet["properties"].get("subnets")
             if template_subnets is not None:

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -119,7 +119,10 @@ class AzureNodeProvider(NodeProvider):
             return metadata
 
         for status in instance["statuses"]:
-            code, state = status["code"].split("/")
+            # If ProvisioningState is "failed" (e.g.,
+            # ProvisioningState/failed/RetryableError), we can get a third
+            # string here, so we need to limit to the first two outputs.
+            code, state = status["code"].split("/")[:2]
             # skip provisioning status
             if code == "PowerState":
                 metadata["status"] = state

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -137,9 +137,9 @@ class AzureNodeProvider(NodeProvider):
         )
         ip_config = nic.ip_configurations[0]
 
-        if (
-            not self.provider_config.get("use_internal_ips", False)
-            or (self.provider.config.get("use_external_head_ip", False) and metadata["tags"][TAG_RAY_NODE_KIND] == NODE_KIND_HEAD)
+        if not self.provider_config.get("use_internal_ips", False) or (
+            self.provider.config.get("use_external_head_ip", False)
+            and metadata["tags"][TAG_RAY_NODE_KIND] == NODE_KIND_HEAD
         ):
             public_ip_id = ip_config.public_ip_address.id
             metadata["public_ip_name"] = public_ip_id.split("/")[-1]
@@ -263,8 +263,11 @@ class AzureNodeProvider(NodeProvider):
 
         template_params = node_config["azure_arm_parameters"].copy()
         template_params["vmName"] = vm_name
-        template_params["provisionPublicIp"] = (
-            not self.provider_config.get("use_internal_ips", False) or (self.provider.config.get("use_external_head_ip", False) and config_tags[TAG_RAY_NODE_KIND] == NODE_KIND_HEAD) 
+        template_params["provisionPublicIp"] = not self.provider_config.get(
+            "use_internal_ips", False
+        ) or (
+            self.provider.config.get("use_external_head_ip", False)
+            and config_tags[TAG_RAY_NODE_KIND] == NODE_KIND_HEAD
         )
         template_params["vmTags"] = config_tags
         template_params["vmCount"] = count
@@ -371,9 +374,9 @@ class AzureNodeProvider(NodeProvider):
                 if nint.id is not None:
                     nic_name = nint.id.split("/")[-1]
                     nics.add(nic_name)
-                    if (
-                        not self.provider_config.get("use_internal_ips", False)
-                        or (self.provider.config.get("use_external_head_ip", False) and vm.tags[TAG_RAY_NODE_KIND] == NODE_KIND_HEAD)
+                    if not self.provider_config.get("use_internal_ips", False) or (
+                        self.provider.config.get("use_external_head_ip", False)
+                        and vm.tags[TAG_RAY_NODE_KIND] == NODE_KIND_HEAD
                     ):
                         nic = self.network_client.network_interfaces.get(
                             resource_group_name=resource_group,

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -141,6 +141,8 @@ class AzureNodeProvider(NodeProvider):
         )
         ip_config = nic.ip_configurations[0]
 
+        # Get public IP if not using internal IPs or if this is the
+        # head node and use_external_head_ip is True
         if not self.provider_config.get("use_internal_ips", False) or (
             self.provider_config.get("use_external_head_ip", False)
             and metadata["tags"][TAG_RAY_NODE_KIND] == NODE_KIND_HEAD
@@ -267,6 +269,8 @@ class AzureNodeProvider(NodeProvider):
 
         template_params = node_config["azure_arm_parameters"].copy()
         template_params["vmName"] = vm_name
+        # Provision public IP if not using internal IPs or if this is the 
+        # head node and use_external_head_ip is True
         template_params["provisionPublicIp"] = not self.provider_config.get(
             "use_internal_ips", False
         ) or (
@@ -378,6 +382,8 @@ class AzureNodeProvider(NodeProvider):
                 if nint.id is not None:
                     nic_name = nint.id.split("/")[-1]
                     nics.add(nic_name)
+                    # Get public IP if not using internal IPs or if this is the
+                    # head node and use_external_head_ip is True
                     if not self.provider_config.get("use_internal_ips", False) or (
                         self.provider_config.get("use_external_head_ip", False)
                         and vm.tags[TAG_RAY_NODE_KIND] == NODE_KIND_HEAD

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -269,7 +269,7 @@ class AzureNodeProvider(NodeProvider):
 
         template_params = node_config["azure_arm_parameters"].copy()
         template_params["vmName"] = vm_name
-        # Provision public IP if not using internal IPs or if this is the 
+        # Provision public IP if not using internal IPs or if this is the
         # head node and use_external_head_ip is True
         template_params["provisionPublicIp"] = not self.provider_config.get(
             "use_internal_ips", False

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -97,7 +97,9 @@ class AzureNodeProvider(NodeProvider):
 
         # Update terminating nodes list by removing nodes that
         # have finished termination.
-        self.terminating_nodes = {k: v for k, v in self.terminating_nodes.items() if not v.done()}
+        self.terminating_nodes = {
+            k: v for k, v in self.terminating_nodes.items() if not v.done()
+        }
 
         return {k: v for k, v in self.cached_nodes.items() if match_tags(v["tags"])}
 

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -389,7 +389,9 @@ class AzureNodeProvider(NodeProvider):
             function_name="delete",
         )
         try:
-            delete(resource_group_name=resource_group, vm_name=node_id).wait(timeout=TERMINATION_TIMEOUT)
+            delete(resource_group_name=resource_group, vm_name=node_id).wait(
+                timeout=TERMINATION_TIMEOUT
+            )
         except Exception as e:
             logger.warning("Failed to delete VM: {}".format(e))
 
@@ -426,7 +428,10 @@ class AzureNodeProvider(NodeProvider):
                 logger.warning("Failed to delete NIC: {}".format(e))
 
         st = time.monotonic()
-        while not all(nlro.done() for nlro in nic_lros) and (time.monotonic() - st) < TERMINATION_TIMEOUT:
+        while (
+            not all(nlro.done() for nlro in nic_lros)
+            and (time.monotonic() - st) < TERMINATION_TIMEOUT
+        ):
             time.sleep(0.1)
 
         # Delete Public IPs
@@ -445,12 +450,18 @@ class AzureNodeProvider(NodeProvider):
                 )
             except Exception as e:
                 logger.warning("Failed to delete public IP: {}".format(e))
-        
+
         st = time.monotonic()
-        while not all(dlro.done() for dlro in disk_lros) and (time.monotonic() - st) < TERMINATION_TIMEOUT:
+        while (
+            not all(dlro.done() for dlro in disk_lros)
+            and (time.monotonic() - st) < TERMINATION_TIMEOUT
+        ):
             time.sleep(0.1)
         st = time.monotonic()
-        while not all(iplro.done() for iplro in ip_lros) and (time.monotonic() - st) < TERMINATION_TIMEOUT:
+        while (
+            not all(iplro.done() for iplro in ip_lros)
+            and (time.monotonic() - st) < TERMINATION_TIMEOUT
+        ):
             time.sleep(0.1)
 
     def _get_node(self, node_id):

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -138,7 +138,7 @@ class AzureNodeProvider(NodeProvider):
         ip_config = nic.ip_configurations[0]
 
         if not self.provider_config.get("use_internal_ips", False) or (
-            self.provider.config.get("use_external_head_ip", False)
+            self.provider_config.get("use_external_head_ip", False)
             and metadata["tags"][TAG_RAY_NODE_KIND] == NODE_KIND_HEAD
         ):
             public_ip_id = ip_config.public_ip_address.id
@@ -266,7 +266,7 @@ class AzureNodeProvider(NodeProvider):
         template_params["provisionPublicIp"] = not self.provider_config.get(
             "use_internal_ips", False
         ) or (
-            self.provider.config.get("use_external_head_ip", False)
+            self.provider_config.get("use_external_head_ip", False)
             and config_tags[TAG_RAY_NODE_KIND] == NODE_KIND_HEAD
         )
         template_params["vmTags"] = config_tags
@@ -375,7 +375,7 @@ class AzureNodeProvider(NodeProvider):
                     nic_name = nint.id.split("/")[-1]
                     nics.add(nic_name)
                     if not self.provider_config.get("use_internal_ips", False) or (
-                        self.provider.config.get("use_external_head_ip", False)
+                        self.provider_config.get("use_external_head_ip", False)
                         and vm.tags[TAG_RAY_NODE_KIND] == NODE_KIND_HEAD
                     ):
                         nic = self.network_client.network_interfaces.get(

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -96,12 +96,7 @@ class AzureNodeProvider(NodeProvider):
 
         # Update terminating nodes list by removing nodes that
         # have finished termination.
-        terminated = []
-        for k, v in self.terminating_nodes.items():
-            if v.done():
-                terminated.append(k)
-        for tm in terminated:
-            self.terminating_nodes.pop(tm)
+        self.terminating_nodes = {k: v for k, v in self.terminating_nodes.items() if not v.done()}
 
         return {k: v for k, v in self.cached_nodes.items() if match_tags(v["tags"])}
 
@@ -456,7 +451,7 @@ class AzureNodeProvider(NodeProvider):
         return self.cached_nodes[node_id]
 
     def _get_cached_node(self, node_id):
-        return self.cached_nodes.get(node_id) or self._get_node(node_id=node_id)
+        return self.cached_nodes.get(node_id, self._get_node(node_id=node_id))
 
     @staticmethod
     def bootstrap_config(cluster_config):

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -79,7 +79,9 @@ class AzureNodeProvider(NodeProvider):
 
         # Cache terminating node operations
         self.terminating_nodes: dict[str, Future] = {}
-        self.termination_executor = ThreadPoolExecutor(max_workers=MAX_PARALLEL_SHUTDOWN_WORKERS)
+        self.termination_executor = ThreadPoolExecutor(
+            max_workers=MAX_PARALLEL_SHUTDOWN_WORKERS
+        )
 
     @synchronized
     def _get_filtered_nodes(self, tag_filters):

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -1355,9 +1355,10 @@ def get_head_node_ip(
 
     provider = _get_node_provider(config["provider"], config["cluster_name"])
     head_node = _get_running_head_node(config, config_file, override_cluster_name)
-    if config.get("provider", {}).get("use_internal_ips", False) and not config.get(
-        "provider", {}
-    ).get("use_external_head_ip", False):
+    provider_cfg = config.get("provider", {})
+    # Get internal IP if using internal IPs and
+    # use_external_head_ip is not specified
+    if provider_cfg.get("use_internal_ips", False) and not provider_cfg.get("use_external_head_ip", False):
         head_node_ip = provider.internal_ip(head_node)
     else:
         head_node_ip = provider.external_ip(head_node)

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -1355,7 +1355,9 @@ def get_head_node_ip(
 
     provider = _get_node_provider(config["provider"], config["cluster_name"])
     head_node = _get_running_head_node(config, config_file, override_cluster_name)
-    if config.get("provider", {}).get("use_internal_ips", False) and not config.get("provider", {}).get("use_external_head_ip", False):
+    if config.get("provider", {}).get("use_internal_ips", False) and not config.get(
+        "provider", {}
+    ).get("use_external_head_ip", False):
         head_node_ip = provider.internal_ip(head_node)
     else:
         head_node_ip = provider.external_ip(head_node)

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -605,7 +605,7 @@ def kill_node(
 
     time.sleep(POLL_INTERVAL)
 
-    if config.get("provider", {}).get("use_internal_ips", False) is True:
+    if config.get("provider", {}).get("use_internal_ips", False):
         node_ip = provider.internal_ip(node)
     else:
         node_ip = provider.external_ip(node)
@@ -1378,7 +1378,7 @@ def get_worker_node_ips(
     provider = _get_node_provider(config["provider"], config["cluster_name"])
     nodes = provider.non_terminated_nodes({TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
 
-    if config.get("provider", {}).get("use_internal_ips", False) is True:
+    if config.get("provider", {}).get("use_internal_ips", False):
         return [provider.internal_ip(node) for node in nodes]
     else:
         return [provider.external_ip(node) for node in nodes]

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -530,7 +530,6 @@ def teardown_cluster(
 
     container_name = config.get("docker", {}).get("container_name")
     if container_name:
-
         # This is to ensure that the parallel SSH calls below do not mess with
         # the users terminal.
         output_redir = cmd_output_util.is_output_redirected()
@@ -786,7 +785,6 @@ def get_or_create_head_node(
         # cf.bold(provider.node_tags(head_node)[TAG_RAY_NODE_NAME]),
         _tags=dict(),
     ):  # add id, ARN to tags?
-
         # TODO(ekl) right now we always update the head node even if the
         # hash matches.
         # We could prompt the user for what they want to do here.
@@ -958,7 +956,6 @@ def _should_create_new_head(
         with cli_logger.group(
             "Currently running head node is out-of-date with cluster configuration"
         ):
-
             if hashes_mismatch:
                 cli_logger.print(
                     "Current hash is {}, expected {}",
@@ -1527,7 +1524,6 @@ def get_cluster_dump_archive(
     processes_verbose: bool = False,
     tempfile: Optional[str] = None,
 ) -> Optional[str]:
-
     # Inform the user what kind of logs are collected (before actually
     # collecting, so they can abort)
     content_str = ""

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -1358,7 +1358,9 @@ def get_head_node_ip(
     provider_cfg = config.get("provider", {})
     # Get internal IP if using internal IPs and
     # use_external_head_ip is not specified
-    if provider_cfg.get("use_internal_ips", False) and not provider_cfg.get("use_external_head_ip", False):
+    if provider_cfg.get("use_internal_ips", False) and not provider_cfg.get(
+        "use_external_head_ip", False
+    ):
         head_node_ip = provider.internal_ip(head_node)
     else:
         head_node_ip = provider.external_ip(head_node)

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -1355,7 +1355,7 @@ def get_head_node_ip(
 
     provider = _get_node_provider(config["provider"], config["cluster_name"])
     head_node = _get_running_head_node(config, config_file, override_cluster_name)
-    if config.get("provider", {}).get("use_internal_ips", False):
+    if config.get("provider", {}).get("use_internal_ips", False) and not config.get("provider", {}).get("use_external_head_ip", False):
         head_node_ip = provider.internal_ip(head_node)
     else:
         head_node_ip = provider.external_ip(head_node)

--- a/python/ray/autoscaler/_private/constants.py
+++ b/python/ray/autoscaler/_private/constants.py
@@ -30,8 +30,9 @@ AUTOSCALER_UTILIZATION_SCORER_KEY = "RAY_AUTOSCALER_UTILIZATION_SCORER"
 # Whether to avoid launching GPU nodes for CPU only tasks.
 AUTOSCALER_CONSERVE_GPU_NODES = env_integer("AUTOSCALER_CONSERVE_GPU_NODES", 1)
 
-# How long to wait for a node to start, in seconds.
+# How long to wait for a node to start and terminate, in seconds.
 AUTOSCALER_NODE_START_WAIT_S = env_integer("AUTOSCALER_NODE_START_WAIT_S", 900)
+AUTOSCALER_NODE_TERMINATE_WAIT_S = env_integer("AUTOSCALER_NODE_TERMINATE_WAIT_S", 900)
 
 # Interval at which to check if node SSH became available.
 AUTOSCALER_NODE_SSH_INTERVAL_S = env_integer("AUTOSCALER_NODE_SSH_INTERVAL_S", 5)

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -88,11 +88,13 @@ class NodeUpdater:
         restart_only=False,
         for_recovery=False,
     ):
-
         self.log_prefix = "NodeUpdater: {}: ".format(node_id)
-        use_internal_ip = use_internal_ip or (provider_config.get(
-            "use_internal_ips", False
-        ) and not (is_head_node and provider_config.get("use_external_head_ip", False)))
+        use_internal_ip = use_internal_ip or (
+            provider_config.get("use_internal_ips", False)
+            and not (
+                is_head_node and provider_config.get("use_external_head_ip", False)
+            )
+        )
         self.cmd_runner = provider.get_command_runner(
             self.log_prefix,
             node_id,
@@ -271,7 +273,6 @@ class NodeUpdater:
             "Waiting for SSH to become available", _numbered=("[]", 1, NUM_SETUP_STEPS)
         ):
             with LogTimer(self.log_prefix + "Got remote shell"):
-
                 cli_logger.print("Running `{}` as a test.", cf.bold("uptime"))
                 first_conn_refused_time = None
                 while True:
@@ -465,7 +466,6 @@ class NodeUpdater:
                         with LogTimer(
                             self.log_prefix + "Setup commands", show_status=True
                         ):
-
                             total = len(self.setup_commands)
                             for i, cmd in enumerate(self.setup_commands):
                                 global_event_system.execute_callback(
@@ -501,7 +501,6 @@ class NodeUpdater:
             global_event_system.execute_callback(CreateClusterEvent.start_ray_runtime)
             with LogTimer(self.log_prefix + "Ray start commands", show_status=True):
                 for cmd in self.ray_start_commands:
-
                     env_vars = {}
                     if self.is_head_node:
                         if usage_lib.usage_stats_enabled():

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -92,7 +92,7 @@ class NodeUpdater:
         # Three cases:
         # 1) use_internal_ip arg is True -> use_internal_ip is True
         # 2) worker node -> use value of provider_config["use_internal_ips"]
-        # 3) head node -> use value of provider_config["use_internal_ips"] unless 
+        # 3) head node -> use value of provider_config["use_internal_ips"] unless
         #                 overriden by provider_config["use_external_head_ip"]
         use_internal_ip = use_internal_ip or (
             provider_config.get("use_internal_ips", False)

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -90,9 +90,9 @@ class NodeUpdater:
     ):
 
         self.log_prefix = "NodeUpdater: {}: ".format(node_id)
-        use_internal_ip = use_internal_ip or provider_config.get(
+        use_internal_ip = use_internal_ip or (provider_config.get(
             "use_internal_ips", False
-        )
+        ) and not (is_head_node and provider_config.get("use_external_head_ip", False)))
         self.cmd_runner = provider.get_command_runner(
             self.log_prefix,
             node_id,

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -92,8 +92,8 @@ class NodeUpdater:
         # Three cases:
         # 1) use_internal_ip arg is True -> use_internal_ip is True
         # 2) worker node -> use value of provider_config["use_internal_ips"]
-        # 3) head node -> use value of provider_config["use_internal_ips"] unless overriden by
-        #                 provider_config["use_external_head_ip"]
+        # 3) head node -> use value of provider_config["use_internal_ips"] unless 
+        #                 overriden by provider_config["use_external_head_ip"]
         use_internal_ip = use_internal_ip or (
             provider_config.get("use_internal_ips", False)
             and not (

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -89,6 +89,11 @@ class NodeUpdater:
         for_recovery=False,
     ):
         self.log_prefix = "NodeUpdater: {}: ".format(node_id)
+        # Three cases:
+        # 1) use_internal_ip arg is True -> use_internal_ip is True
+        # 2) worker node -> use value of provider_config["use_internal_ips"]
+        # 3) head node -> use value of provider_config["use_internal_ips"] unless overriden by 
+        #                 provider_config["use_external_head_ip"]
         use_internal_ip = use_internal_ip or (
             provider_config.get("use_internal_ips", False)
             and not (

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -92,7 +92,7 @@ class NodeUpdater:
         # Three cases:
         # 1) use_internal_ip arg is True -> use_internal_ip is True
         # 2) worker node -> use value of provider_config["use_internal_ips"]
-        # 3) head node -> use value of provider_config["use_internal_ips"] unless overriden by 
+        # 3) head node -> use value of provider_config["use_internal_ips"] unless overriden by
         #                 provider_config["use_external_head_ip"]
         use_internal_ip = use_internal_ip or (
             provider_config.get("use_internal_ips", False)

--- a/python/ray/autoscaler/azure/example-full.yaml
+++ b/python/ray/autoscaler/azure/example-full.yaml
@@ -51,6 +51,10 @@ provider:
     # if not set, a default user-assigned identity will be generated in the resource group specified above
     # msi_name: ray-cluster-msi
     # msi_resource_group: other-rg
+    # Set provisioning and use of public/private IPs for head and worker nodes. If both options below are true,
+    # only the head node will have a public IP address provisioned.
+    # use_internal_ips: True
+    # use_external_head_ip: True
 
 # How Ray will authenticate with newly launched nodes.
 auth:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR addresses a few issues when launching clusters with Azure:
1. Any changes made to subnets of the deployed virtual network(s) are bashed upon redeployment.
    -  Any service endpoints, route tables, or delegations are removed when redeploying (which happens on any of the `ray` CLI calls) due to [this open Azure issue](https://github.com/Azure/azure-quickstart-templates/issues/2786). This PR provides a workaround for the issue by copying the existing subnet configuration into the deployment template if a subnet already exists with the cluster unique id within the same resource group.
2. VM termination is extremely lengthy and does not clean up all dependencies.
    - When VMs are provisioned, dependencies such as disks, NICs, and public IP addresses are also provisioned. However, because the termination process does not wait for the VM to be deleted and the dependent resources cannot be deleted at the same time as the VM, these dependencies are often left in the resource group after termination. This can cause issues with quotas (i.e., reaching a limit of public IP addresses or disks) and wastes resources. This PR moves node termination into a pool of threads so that node deletion can be parallelized (since waiting for each node to be deleted takes a long time) and all dependencies can be correctly deleted once their VMs no longer exist.
3. VMs can have status code `ProvisioningState/failed/RetryableError`, causing an unpacking error.
    - [This line](https://github.com/ray-project/ray/blob/187a5c03ced8ce8988ef130a3ee7e4dd1b38b918/python/ray/autoscaler/_private/_azure/node_provider.py#L100) throws an exception when the provisioning state is the string above, resulting in incorrect provisioning/termination of the node. This PR addresses that issue by slicing the list of status strings and only using the first two.
4. The default quota for public IP addresses in Azure is only 100, which can result in quota limits being hit for larger clusters.
    - This PR adds an option (`use_external_head_ip`) for only provisioning a public IP address for the head node (instead of all nodes or no nodes). This allows a user to still communicate with the head node via a public IP address without running into quota limits on public IP addresses. This option works in tandem with `use_internal_ips` - if both are set to `True`, then a public IP address will only be provisioned for the head node. If `use_external_head_ip` is omitted, the behavior is unchanged from the current behavior (i.e., public IPs will be provisioned for all nodes if `use_internal_ips` is `False`, otherwise no public IPs will be provisioned).

I've tested all of these fixes using `ray up`/`ray dashboard`/`ray down` on Azure clusters of 4-32 nodes to make sure the start up/teardown works correctly and the correct amount of resources are provisioned.

## Related issue number
Node termination times are discussed in https://github.com/ray-project/ray/issues/25971

## Checks
- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206743421817428