### PR TITLE
[cluster launcher] skip cleanup security groups on non-aws tests

### DIFF
--- a/python/ray/autoscaler/launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/launch_and_verify_cluster.py
@@ -252,6 +252,10 @@ def cleanup_security_group(ec2_client, id):
 
 
 def cleanup_security_groups(config):
+    provider_type = config.get("provider", {}).get("type")
+    if provider_type != "aws":
+        return
+
     try:
         ec2_client = boto3.client("ec2", region_name="us-west-2")
         response = ec2_client.describe_security_groups(
@@ -268,7 +272,7 @@ def cleanup_security_groups(config):
         )
         for security_group in response["SecurityGroups"]:
             cleanup_security_group(ec2_client, security_group["GroupId"])
-    except botocore.exceptions.ClientError as e:
+    except Exception as e:
         print(f"Error cleaning up security groups: {e}")
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We only need to cleanup security groups for cluster launcher tests on AWS environments. Skip it on others.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/ray/issues/44034

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
