### PR TITLE
[Data] [Doc] Add Ray Data Execution Configurations doc page

### DIFF
--- a/doc/source/data/execution-configurations.rst
+++ b/doc/source/data/execution-configurations.rst
@@ -4,8 +4,8 @@
 Execution Configurations
 =================================
 
-Ray Data provides a number of configurations that can be used to control various aspects
-of Ray Dataset execution. These configurations can be modified by the user using
+Ray Data provides a number of configurations that control various aspects
+of Ray Dataset execution. You can modify these configurations by using
 :class:`~ray.data.ExecutionOptions` and :class:`~ray.data.DataContext`. 
 This guide describes the most important of these configurations and when to use them.
 
@@ -13,42 +13,52 @@ Configuring :class:`~ray.data.ExecutionOptions`
 ===============================================
 
 The :class:`~ray.data.ExecutionOptions` class is used to configure options during Ray Dataset execution.
-To use it, you can modify the attributes in the current :class:`~ray.data.DataContext` object's `execution_options`. For example:
+To use it, modify the attributes in the current :class:`~ray.data.DataContext` object's `execution_options`. For example:
 
-.. code-block::
+.. testcode::
+   :hide:
+    
+   import ray
+
+.. testcode::
 
    ctx = ray.data.DataContext.get_current()
    ctx.execution_options.verbose_progress = True
 
-* `resource_limits`: Set a soft limit on the resource usage during execution. Auto-detected by default.
+* `resource_limits`: Set a soft limit on the resource usage during execution. For example, if there are other parts of the code which require some minimum amount of resources, you may want to limit the amount of resources that Ray Data uses. Auto-detected by default.
 * `exclude_resources`: Amount of resources to exclude from Ray Data. Set this if you have other workloads running on the same cluster. Note: 
 
-  * If using Ray Data with Ray Train, training resources are automatically excluded. Otherwise, off by default.
-  * For each resource type, ``resource_limits`` and ``exclude_resources`` can not be both set.
+  * If you're using Ray Data with Ray Train, training resources are automatically excluded. Otherwise, off by default.
+  * For each resource type, you can't set both ``resource_limits`` and ``exclude_resources``.
 
-* `locality_with_output`: Set this to prefer running tasks on the same node as the output node (node driving the execution). It can also be set to a list of node ids to spread the outputs across those nodes. Off by default.
+* `locality_with_output`: Set this to prefer running tasks on the same node as the output node (node driving the execution). It can also be set to a list of node ids to spread the outputs across those nodes. This parameter applies to both :meth:`~ray.data.Dataset.map` and :meth:`~ray.data.Dataset.streaming_split` operations. This setting is useful if you know you are consuming the output data directly on the consumer node (such as for ML training ingest). However, other use cases can incur a performance penalty with this setting. Off by default.
 * `preserve_order`: Set this to preserve the ordering between blocks processed by operators under the streaming executor. Off by default.
-* `actor_locality_enabled`: Whether to enable locality-aware task dispatch to actors. This parameter applies to both stateful :meth:`~ray.data.Dataset.map` and :meth:`~ray.data.Dataset.streaming_split` operations. Off by default.
+* `actor_locality_enabled`: Whether to enable locality-aware task dispatch to actors. This parameter applies to stateful :meth:`~ray.data.Dataset.map` operations. This setting is useful if you know you are consuming the output data directly on the consumer node (such as for ML batch inference). However, other use cases can incur a performance penalty with this setting. Off by default.
 * `verbose_progress`: Whether to report progress individually per operator. By default, only AllToAll operators and global progress is reported. This option is useful for performance debugging. On by default.
 
-For more details on each of the preceding options, see the API documentation for :class:`~ray.data.ExecutionOptions`.
+For more details on each of the preceding options, see :class:`~ray.data.ExecutionOptions`.
 
 Configuring :class:`~ray.data.DataContext`
 ==========================================
 The :class:`~ray.data.DataContext` class is used to configure more general options for Ray Data usage, such as observability/logging options,
-error handling/retry behavior, and internal data formats. To use it, you can modify the attributes in the current :class:`~ray.data.DataContext` object. For example:
+error handling/retry behavior, and internal data formats. To use it, modify the attributes in the current :class:`~ray.data.DataContext` object. For example:
 
-.. code-block::
+.. testcode::
+	   :hide:
+	    
+	   import ray 
+	    
+.. testcode::
 
    ctx = ray.data.DataContext.get_current()
    ctx.verbose_stats_logs = True
 
-Many of the options in :class:`~ray.data.DataContext` are intended for advanced use cases or for debugging purposes, 
-and most users should not need to modify them. However, some of the most important options are:
+Many of the options in :class:`~ray.data.DataContext` are intended for advanced use cases or debugging, 
+and most users shouldn't need to modify them. However, some of the most important options are:
 
 * `max_errored_blocks`: Max number of blocks that are allowed to have errors, unlimited if negative. This option allows application-level exceptions in block processing tasks. These exceptions may be caused by UDFs (for example, due to corrupted data samples) or IO errors. Data in the failed blocks are dropped. This option can be useful to prevent a long-running job from failing due to a small number of bad blocks. By default, no retries are allowed.
 * `write_file_retry_on_errors`: A list of sub-strings of error messages that should trigger a retry when writing files. This is useful for handling transient errors when writing to remote storage systems. By default, retries on common transient AWS S3 errors.
 * `verbose_stats_logs`: Whether stats logs should be verbose. This includes fields such as ``extra_metrics`` in the stats output, which are excluded by default. Off by default.
 * `log_internal_stack_trace_to_stdout`: Whether to include internal Ray Data/Ray Core code stack frames when logging to ``stdout``. The full stack trace is always written to the Ray Data log file. Off by default.
 
-For more details on each of the preceding options, see the API documentation for :class:`~ray.data.DataContext`.
+For more details on each of the preceding options, see :class:`~ray.data.DataContext`.

--- a/doc/source/data/execution-configurations.rst
+++ b/doc/source/data/execution-configurations.rst
@@ -1,8 +1,8 @@
 .. _execution_configurations:
 
-=================================
+========================
 Execution Configurations
-=================================
+========================
 
 Ray Data provides a number of configurations that control various aspects
 of Ray Dataset execution. You can modify these configurations by using

--- a/doc/source/data/execution-configurations.rst
+++ b/doc/source/data/execution-configurations.rst
@@ -20,18 +20,18 @@ To use it, you can modify the attributes in the current :class:`~ray.data.DataCo
    ctx = ray.data.DataContext.get_current()
    ctx.execution_options.verbose_progress = True
 
-* `resource_limits`: Set a soft limit on the resource usage during execution. Autodetected by default.
+* `resource_limits`: Set a soft limit on the resource usage during execution. Auto-detected by default.
 * `exclude_resources`: Amount of resources to exclude from Ray Data. Set this if you have other workloads running on the same cluster. Note: 
 
-  * If using Ray Data with Ray Train, training resources will be automatically excluded. Otherwise, off by default.
+  * If using Ray Data with Ray Train, training resources are automatically excluded. Otherwise, off by default.
   * For each resource type, ``resource_limits`` and ``exclude_resources`` can not be both set.
 
 * `locality_with_output`: Set this to prefer running tasks on the same node as the output node (node driving the execution). It can also be set to a list of node ids to spread the outputs across those nodes. Off by default.
 * `preserve_order`: Set this to preserve the ordering between blocks processed by operators under the streaming executor. Off by default.
-* `actor_locality_enabled`: Whether to enable locality-aware task dispatch to actors. This parameter applies to both stateful map and streaming_split operations. Off by default.
+* `actor_locality_enabled`: Whether to enable locality-aware task dispatch to actors. This parameter applies to both stateful :meth:`~ray.data.Dataset.map` and :meth:`~ray.data.Dataset.streaming_split` operations. Off by default.
 * `verbose_progress`: Whether to report progress individually per operator. By default, only AllToAll operators and global progress is reported. This option is useful for performance debugging. On by default.
 
-For more details on each of the options above, see the API documentation for :class:`~ray.data.ExecutionOptions`.
+For more details on each of the preceding options, see the API documentation for :class:`~ray.data.ExecutionOptions`.
 
 Configuring :class:`~ray.data.DataContext`
 ==========================================
@@ -46,9 +46,9 @@ error handling/retry behavior, and internal data formats. To use it, you can mod
 Many of the options in :class:`~ray.data.DataContext` are intended for advanced use cases or for debugging purposes, 
 and most users should not need to modify them. However, some of the most important options are:
 
-* `max_errored_blocks`: Max number of blocks that are allowed to have errors, unlimited if negative. This option allows application-level exceptions in block processing tasks. These exceptions may be caused by UDFs (e.g., due to corrupted data samples) or IO errors. Data in the failed blocks are dropped. This option can be useful to prevent a long-running job from failing due to a small number of bad blocks. By default, no retries are allowed.
-* `write_file_retry_on_errors`: A list of substrings of error messages that should trigger a retry when writing files. This is useful for handling transient errors when writing to remote storage systems. By default, retries on common transient AWS S3 errors.
+* `max_errored_blocks`: Max number of blocks that are allowed to have errors, unlimited if negative. This option allows application-level exceptions in block processing tasks. These exceptions may be caused by UDFs (for example, due to corrupted data samples) or IO errors. Data in the failed blocks are dropped. This option can be useful to prevent a long-running job from failing due to a small number of bad blocks. By default, no retries are allowed.
+* `write_file_retry_on_errors`: A list of sub-strings of error messages that should trigger a retry when writing files. This is useful for handling transient errors when writing to remote storage systems. By default, retries on common transient AWS S3 errors.
 * `verbose_stats_logs`: Whether stats logs should be verbose. This includes fields such as ``extra_metrics`` in the stats output, which are excluded by default. Off by default.
-* `log_internal_stack_trace_to_stdout`: Whether to include internal Ray Data/Ray Core code stack frames when logging to stdout. The full stack trace is always written to the Ray Data log file. Off by default.
+* `log_internal_stack_trace_to_stdout`: Whether to include internal Ray Data/Ray Core code stack frames when logging to ``stdout``. The full stack trace is always written to the Ray Data log file. Off by default.
 
-For more details on each of the options above, see the API documentation for :class:`~ray.data.DataContext`.
+For more details on each of the preceding options, see the API documentation for :class:`~ray.data.DataContext`.

--- a/doc/source/data/execution-configurations.rst
+++ b/doc/source/data/execution-configurations.rst
@@ -1,7 +1,7 @@
 .. _execution_configurations:
 
 =================================
-Ray Data Execution Configurations
+Execution Configurations
 =================================
 
 Ray Data provides a number of configurations that can be used to control various aspects

--- a/doc/source/data/execution-configurations.rst
+++ b/doc/source/data/execution-configurations.rst
@@ -1,0 +1,54 @@
+.. _execution_configurations:
+
+=================================
+Ray Data Execution Configurations
+=================================
+
+Ray Data provides a number of configurations that can be used to control various aspects
+of Ray Dataset execution. These configurations can be modified by the user using
+:class:`~ray.data.ExecutionOptions` and :class:`~ray.data.DataContext`. 
+This guide describes the most important of these configurations and when to use them.
+
+Configuring :class:`~ray.data.ExecutionOptions`
+===============================================
+
+The :class:`~ray.data.ExecutionOptions` class is used to configure options during Ray Dataset execution.
+To use it, you can modify the attributes in the current :class:`~ray.data.DataContext` object's `execution_options`. For example:
+
+.. code-block::
+
+   ctx = ray.data.DataContext.get_current()
+   ctx.execution_options.verbose_progress = True
+
+* `resource_limits`: Set a soft limit on the resource usage during execution. Autodetected by default.
+* `exclude_resources`: Amount of resources to exclude from Ray Data. Set this if you have other workloads running on the same cluster. Note: 
+
+  * If using Ray Data with Ray Train, training resources will be automatically excluded. Otherwise, off by default.
+  * For each resource type, ``resource_limits`` and ``exclude_resources`` can not be both set.
+
+* `locality_with_output`: Set this to prefer running tasks on the same node as the output node (node driving the execution). It can also be set to a list of node ids to spread the outputs across those nodes. Off by default.
+* `preserve_order`: Set this to preserve the ordering between blocks processed by operators under the streaming executor. Off by default.
+* `actor_locality_enabled`: Whether to enable locality-aware task dispatch to actors. This parameter applies to both stateful map and streaming_split operations. Off by default.
+* `verbose_progress`: Whether to report progress individually per operator. By default, only AllToAll operators and global progress is reported. This option is useful for performance debugging. On by default.
+
+For more details on each of the options above, see the API documentation for :class:`~ray.data.ExecutionOptions`.
+
+Configuring :class:`~ray.data.DataContext`
+==========================================
+The :class:`~ray.data.DataContext` class is used to configure more general options for Ray Data usage, such as observability/logging options,
+error handling/retry behavior, and internal data formats. To use it, you can modify the attributes in the current :class:`~ray.data.DataContext` object. For example:
+
+.. code-block::
+
+   ctx = ray.data.DataContext.get_current()
+   ctx.verbose_stats_logs = True
+
+Many of the options in :class:`~ray.data.DataContext` are intended for advanced use cases or for debugging purposes, 
+and most users should not need to modify them. However, some of the most important options are:
+
+* `max_errored_blocks`: Max number of blocks that are allowed to have errors, unlimited if negative. This option allows application-level exceptions in block processing tasks. These exceptions may be caused by UDFs (e.g., due to corrupted data samples) or IO errors. Data in the failed blocks are dropped. This option can be useful to prevent a long-running job from failing due to a small number of bad blocks. By default, no retries are allowed.
+* `write_file_retry_on_errors`: A list of substrings of error messages that should trigger a retry when writing files. This is useful for handling transient errors when writing to remote storage systems. By default, retries on common transient AWS S3 errors.
+* `verbose_stats_logs`: Whether stats logs should be verbose. This includes fields such as ``extra_metrics`` in the stats output, which are excluded by default. Off by default.
+* `log_internal_stack_trace_to_stdout`: Whether to include internal Ray Data/Ray Core code stack frames when logging to stdout. The full stack trace is always written to the Ray Data log file. Off by default.
+
+For more details on each of the options above, see the API documentation for :class:`~ray.data.DataContext`.

--- a/doc/source/data/user-guide.rst
+++ b/doc/source/data/user-guide.rst
@@ -17,6 +17,7 @@ show you how achieve several tasks.
     inspecting-data
     iterating-over-data
     saving-data
+    execution-configurations
     working-with-images
     working-with-text
     working-with-tensors

--- a/doc/source/data/user-guide.rst
+++ b/doc/source/data/user-guide.rst
@@ -17,11 +17,11 @@ show you how achieve several tasks.
     inspecting-data
     iterating-over-data
     saving-data
-    execution-configurations
     working-with-images
     working-with-text
     working-with-tensors
     working-with-pytorch
+    execution-configurations
     batch_inference
     performance-tips
     monitoring-your-workload


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Add a page to describe the various configurations for Ray Data from `ExecutionOptions` and `DataContext`.

New page: https://anyscale-ray--44105.com.readthedocs.build/en/44105/data/execution-configurations.html

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
