### PR TITLE
[ci] mark data 1b tests as unstable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5091,6 +5091,7 @@
 
   frequency: nightly
   team: data
+  stable: False
 
   cluster:
     byod:
@@ -5151,6 +5152,7 @@
 
   frequency: nightly
   team: data
+  stable: False
 
   cluster:
     byod:


### PR DESCRIPTION
These tests are pretty flaky. Please help mark them as stable again after we can de-flake them. At its current state, it's blocking the release process pretty hard.

Test:
- CI