### PR TITLE
[ci] handle empty result list for test state machine

### DIFF
--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -90,6 +90,9 @@ class TestStateMachine(abc.ABC):
         """
         Move the test to the next state.
         """
+        if not self.test_results:
+            # No result to move the state
+            return
         from_state = self.test.get_state()
         to_state = self._next_state(from_state)
         self.test.set_state(to_state)

--- a/release/ray_release/tests/test_state_machine.py
+++ b/release/ray_release/tests/test_state_machine.py
@@ -125,6 +125,14 @@ TestStateMachine.ray_repo = MockRepo()
 TestStateMachine.ray_buildkite = MockBuildkite()
 
 
+def test_ci_empty_results():
+    test = Test(name="w00t", team="ci", state=TestState.FLAKY)
+    test.test_results = []
+    CITestStateMachine(test).move()
+    # do not change the state
+    assert test.get_state() == TestState.FLAKY
+
+
 def test_ci_move_from_passing_to_flaky():
     """
     Test the entire lifecycle of a CI test when it moves from passing to flaky.


### PR DESCRIPTION
After the clean up of old test results, some deleted tests now don't have results and the state machine does not handle that well. Handle the empty result list situation.

Test:
- CI