### PR TITLE
[ci] run test_client_builder in isolation

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -41,7 +41,10 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
+        --only-tags use_all_core --skip-ray-installation
 
   - label: ":ray: core: redis tests"
     tags: python
@@ -51,7 +54,10 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --test-env=TEST_EXTERNAL_REDIS=1
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... python/ray/autoscaler/v2/... core
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
+        --only-tags use_all_core --skip-ray-installation
 
   - label: ":ray: core: memory pressure tests"
     tags:
@@ -285,7 +291,6 @@ steps:
         //python/ray/tests:test_placement_group
         //python/ray/tests:test_runtime_env_working_dir_3 
         //python/ray/tests:test_state_api_log
-        //python/ray/tests:test_client_builder
         //python/ray/tests:test_object_assign_owner_client_mode core 
         --test-env CI_SKIP_FLAKY_TEST=0
         --skip-ray-installation

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -96,6 +96,14 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_client_builder.py",
+  ],
+  size = "medium",
+  tags = ["exclusive", "client_tests", "use_all_core", "team:core"],
+  deps = ["//:ray_lib", ":conftest"],
+)
+
+py_test_module_list(
+  files = [
     "test_client_proxy.py",
     "test_client_compat.py",
     "test_client_multi.py",


### PR DESCRIPTION
The test `linux://python/ray/tests:test_client_builder` seems to be flaky again once we mark it as non-flaky (and move it into running in parallel with other tests). Mark this test as 'use_all_core' so that it can run in isolation.

Test:
- CI