### PR TITLE
Support Darwin for accelerated DAGs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1212,6 +1212,7 @@ ray_cc_test(
     ],
     tags = ["team:core", "no_windows"],
     deps = [
+        ":core_worker_lib",
         ":plasma_store_server_lib",
         "@com_google_absl//absl/random",
         "@com_google_absl//absl/strings:str_format",

--- a/python/ray/dag/tests/test_accelerated_dag.py
+++ b/python/ray/dag/tests/test_accelerated_dag.py
@@ -253,7 +253,7 @@ def test_dag_fault_tolerance_sys_exit(ray_start_regular_shared):
         assert results == [i + 1] * 4
         output_channels.end_read()
 
-    with pytest.raises(RaySystemError, match="channel closed"):
+    with pytest.raises(RaySystemError, match="Channel closed."):
         for i in range(99):
             output_channels = compiled_dag.execute(1)
             output_channels.begin_read()

--- a/python/ray/dag/tests/test_output_node.py
+++ b/python/ray/dag/tests/test_output_node.py
@@ -167,7 +167,7 @@ def test_shared_output(shared_ray_instance):
     x = shared_f.bind()
     dag = MultiOutputNode([g.bind(x), h.bind(x)])
 
-    ray.get(dag.execute()) == [2, 3]
+    assert ray.get(dag.execute()) == [2, 3]
 
     # Verify f ran only once.
     def verify():

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -113,6 +113,7 @@ def test_put_remote_get(ray_start_regular, num_readers):
                 assert chan.begin_read() == val
                 chan.end_read()
 
+    chan.ensure_registered_as_writer()
     num_writes = 1000
     readers = [Reader.remote() for _ in range(num_readers)]
     done = [reader.read.remote(chan, num_writes) for reader in readers]

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -384,7 +384,10 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
             "CoreWorker.HandleException");
       }));
 
-  experimental_mutable_object_manager_.reset(new ExperimentalMutableObjectManager());
+#if defined(__APPLE__) || defined(__linux__)
+  experimental_mutable_object_manager_ =
+      std::make_shared<ExperimentalMutableObjectManager>();
+#endif
 
   auto push_error_callback = [this](const JobID &job_id,
                                     const std::string &type,

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -14,20 +14,146 @@
 
 #include "ray/core_worker/experimental_mutable_object_manager.h"
 
+#include "ray/object_manager/common.h"
+
 namespace ray {
+namespace {
+
+std::string GetSemaphoreObjectName(const std::string &name) {
+  std::string ret = absl::StrCat("obj", name);
+  RAY_CHECK_LE(name.size(), PSEMNAMLEN);
+  return ret;
+}
+
+std::string GetSemaphoreHeaderName(const std::string &name) {
+  std::string ret = absl::StrCat("hdr", name);
+  RAY_CHECK_LE(name.size(), PSEMNAMLEN);
+  return ret;
+}
+
+}  // namespace
+
+ExperimentalMutableObjectManager::~ExperimentalMutableObjectManager() {
+  // Copy `semaphores_` into `tmp` because `DestroySemaphores()` mutates `semaphores_`.
+  absl::flat_hash_map<ObjectID, PlasmaObjectHeader::Semaphores> tmp = semaphores_;
+  for (const auto &[object_id, _] : tmp) {
+    DestroySemaphores(object_id);
+  }
+}
 
 Status ExperimentalMutableObjectManager::RegisterWriterChannel(
     const ObjectID &object_id, std::unique_ptr<plasma::MutableObject> mutable_object) {
-#ifdef __linux__
   auto inserted =
       writer_channels_.emplace(object_id, WriterChannel(std::move(mutable_object)));
   if (!inserted.second) {
     return Status::Invalid("Writer channel already registered");
   }
   RAY_CHECK(inserted.first->second.mutable_object);
+  OpenSemaphores(object_id);
   RAY_LOG(DEBUG) << "Registered writer channel " << object_id;
-#endif
   return Status::OK();
+}
+
+PlasmaObjectHeader *ExperimentalMutableObjectManager::GetHeader(
+    const ObjectID &object_id) {
+  {
+    auto it = writer_channels_.find(object_id);
+    if (it != writer_channels_.end()) {
+      return it->second.mutable_object->header;
+    }
+  }
+  {
+    auto it = reader_channels_.find(object_id);
+    if (it != reader_channels_.end()) {
+      return it->second.mutable_object->header;
+    }
+  }
+  RAY_CHECK(false);
+  return nullptr;
+}
+
+std::string ExperimentalMutableObjectManager::GetSemaphoreName(
+    const ObjectID &object_id) {
+  std::string name = std::string(GetHeader(object_id)->unique_name);
+  RAY_CHECK_LE(name.size(), PSEMNAMLEN);
+  return name;
+}
+
+PlasmaObjectHeader::Semaphores ExperimentalMutableObjectManager::GetSemaphores(
+    const ObjectID &object_id) {
+  auto it = semaphores_.find(object_id);
+  RAY_CHECK(it != semaphores_.end());
+  // We return a copy instead of a reference because absl::flat_hash_map does not provide
+  // pointer stability. In other words, a reference could be invalidated if the map is
+  // mutated.
+  return it->second;
+}
+
+void ExperimentalMutableObjectManager::OpenSemaphores(const ObjectID &object_id) {
+  if (semaphores_.count(object_id)) {
+    // The semaphore already exists.
+    return;
+  }
+
+  bool create = false;
+  PlasmaObjectHeader *header = GetHeader(object_id);
+  PlasmaObjectHeader::SemaphoresCreationLevel level =
+      header->semaphores_created.load(std::memory_order_relaxed);
+  // The first thread to call `OpenSemaphores()` initializes the semaphores. This makes it
+  // easier to set up the channel as the different processes calling this function do not
+  // need to coordinate with each other (beyond this) when constructing the channel.
+  if (level == PlasmaObjectHeader::SemaphoresCreationLevel::kUnitialized) {
+    create = header->semaphores_created.compare_exchange_strong(
+        /*expected=*/level,
+        /*desired=*/PlasmaObjectHeader::SemaphoresCreationLevel::kInitializing,
+        std::memory_order_relaxed);
+  }
+
+  PlasmaObjectHeader::Semaphores semaphores;
+  std::string name = GetSemaphoreName(object_id);
+  if (create) {
+    // This channel is being initialized.
+    // Attempt to unlink the semaphores just in case they were not cleaned up by a
+    // previous test run that crashed.
+    sem_unlink(GetSemaphoreHeaderName(name).c_str());
+    sem_unlink(GetSemaphoreObjectName(name).c_str());
+
+    semaphores.object_sem = sem_open(GetSemaphoreObjectName(name).c_str(),
+                                     /*oflag=*/O_CREAT | O_EXCL,
+                                     /*mode=*/0644,
+                                     /*value=*/1);
+    semaphores.header_sem = sem_open(GetSemaphoreHeaderName(name).c_str(),
+                                     /*oflag=*/O_CREAT | O_EXCL,
+                                     /*mode=*/0644,
+                                     /*value=*/1);
+    header->semaphores_created.store(PlasmaObjectHeader::SemaphoresCreationLevel::kDone,
+                                     std::memory_order_release);
+  } else {
+    // This is a reader initializing the channel.
+    // Wait for another thread to initialize the channel.
+    while (GetHeader(object_id)->semaphores_created.load(std::memory_order_acquire) !=
+           PlasmaObjectHeader::SemaphoresCreationLevel::kDone) {
+      sched_yield();
+    }
+    semaphores.object_sem = sem_open(GetSemaphoreObjectName(name).c_str(), /*oflag=*/0);
+    semaphores.header_sem = sem_open(GetSemaphoreHeaderName(name).c_str(), /*oflag=*/0);
+  }
+  RAY_CHECK_NE(semaphores.object_sem, SEM_FAILED);
+  RAY_CHECK_NE(semaphores.header_sem, SEM_FAILED);
+
+  semaphores_[object_id] = semaphores;
+}
+
+void ExperimentalMutableObjectManager::DestroySemaphores(const ObjectID &object_id) {
+  PlasmaObjectHeader::Semaphores semaphores = GetSemaphores(object_id);
+  RAY_CHECK_EQ(sem_close(semaphores.header_sem), 0);
+  RAY_CHECK_EQ(sem_close(semaphores.object_sem), 0);
+
+  std::string name = GetSemaphoreName(object_id);
+  RAY_CHECK_EQ(sem_unlink(GetSemaphoreHeaderName(name).c_str()), 0);
+  RAY_CHECK_EQ(sem_unlink(GetSemaphoreObjectName(name).c_str()), 0);
+
+  semaphores_.erase(object_id);
 }
 
 Status ExperimentalMutableObjectManager::WriteAcquire(const ObjectID &object_id,
@@ -36,7 +162,6 @@ Status ExperimentalMutableObjectManager::WriteAcquire(const ObjectID &object_id,
                                                       int64_t metadata_size,
                                                       int64_t num_readers,
                                                       std::shared_ptr<Buffer> *data) {
-#ifdef __linux__
   auto writer_channel_entry = writer_channels_.find(object_id);
   if (writer_channel_entry == writer_channels_.end()) {
     return Status::ObjectNotFound("Writer channel has not been registered");
@@ -56,8 +181,9 @@ Status ExperimentalMutableObjectManager::WriteAcquire(const ObjectID &object_id,
   }
 
   RAY_LOG(DEBUG) << "Write mutable object " << object_id;
+  PlasmaObjectHeader::Semaphores sem = GetSemaphores(object_id);
   RAY_RETURN_NOT_OK(channel.mutable_object->header->WriteAcquire(
-      data_size, metadata_size, num_readers));
+      sem, data_size, metadata_size, num_readers));
   channel.is_sealed = false;
 
   *data = SharedMemoryBuffer::Slice(
@@ -68,12 +194,10 @@ Status ExperimentalMutableObjectManager::WriteAcquire(const ObjectID &object_id,
            metadata,
            metadata_size);
   }
-#endif
   return Status::OK();
 }
 
 Status ExperimentalMutableObjectManager::WriteRelease(const ObjectID &object_id) {
-#ifdef __linux__
   auto writer_channel_entry = writer_channels_.find(object_id);
   if (writer_channel_entry == writer_channels_.end()) {
     return Status::ObjectNotFound("Writer channel has not been registered");
@@ -84,23 +208,22 @@ Status ExperimentalMutableObjectManager::WriteRelease(const ObjectID &object_id)
     return Status::Invalid("Must WriteAcquire before WriteRelease on a mutable object");
   }
 
-  RAY_RETURN_NOT_OK(channel.mutable_object->header->WriteRelease());
+  PlasmaObjectHeader::Semaphores sem = GetSemaphores(object_id);
+  RAY_RETURN_NOT_OK(channel.mutable_object->header->WriteRelease(sem));
   channel.is_sealed = true;
 
-#endif
   return Status::OK();
 }
 
 Status ExperimentalMutableObjectManager::RegisterReaderChannel(
     const ObjectID &object_id, std::unique_ptr<plasma::MutableObject> mutable_object) {
-#ifdef __linux__
   auto inserted =
       reader_channels_.emplace(object_id, ReaderChannel(std::move(mutable_object)));
   if (!inserted.second) {
     return Status::Invalid("Reader channel already registered");
   }
+  OpenSemaphores(object_id);
   RAY_LOG(DEBUG) << "Registered reader channel " << object_id;
-#endif
   return Status::OK();
 }
 
@@ -110,8 +233,8 @@ bool ExperimentalMutableObjectManager::ReaderChannelRegistered(
 }
 
 Status ExperimentalMutableObjectManager::ReadAcquire(const ObjectID &object_id,
-                                                     std::shared_ptr<RayObject> *result) {
-#ifdef __linux__
+                                                     std::shared_ptr<RayObject> *result)
+    ABSL_NO_THREAD_SAFETY_ANALYSIS {
   RAY_LOG(DEBUG) << "ReadAcquire  " << object_id;
   auto reader_channel_entry = reader_channels_.find(object_id);
   if (reader_channel_entry == reader_channels_.end()) {
@@ -119,17 +242,18 @@ Status ExperimentalMutableObjectManager::ReadAcquire(const ObjectID &object_id,
   }
   auto &channel = reader_channel_entry->second;
 
-  // If there is a concurrent ReadRelease, wait for that to finish first.
-  sem_wait(&channel.reader_semaphore);
+  // This lock ensures that there is only one reader at a time. The lock is released in
+  // `ReadRelease()`.
+  channel.lock->Lock();
 
   int64_t version_read = 0;
   RAY_LOG(DEBUG) << "ReadAcquire " << object_id
                  << " version: " << channel.next_version_to_read;
+  PlasmaObjectHeader::Semaphores sem = GetSemaphores(object_id);
   RAY_RETURN_NOT_OK(channel.mutable_object->header->ReadAcquire(
-      channel.next_version_to_read, &version_read));
+      sem, channel.next_version_to_read, &version_read));
   RAY_CHECK(version_read > 0);
   channel.next_version_to_read = version_read;
-  channel.read_acquired = true;
 
   RAY_CHECK(static_cast<int64_t>(channel.mutable_object->header->data_size +
                                  channel.mutable_object->header->metadata_size) <=
@@ -144,37 +268,32 @@ Status ExperimentalMutableObjectManager::ReadAcquire(const ObjectID &object_id,
   *result = std::make_shared<RayObject>(
       std::move(data_buf), std::move(metadata_buf), std::vector<rpc::ObjectReference>());
 
-#endif
   return Status::OK();
 }
 
-Status ExperimentalMutableObjectManager::ReadRelease(const ObjectID &object_id) {
-#ifdef __linux__
+Status ExperimentalMutableObjectManager::ReadRelease(const ObjectID &object_id)
+    ABSL_NO_THREAD_SAFETY_ANALYSIS {
   auto reader_channel_entry = reader_channels_.find(object_id);
   if (reader_channel_entry == reader_channels_.end()) {
     return Status::ObjectNotFound("Reader channel has not been registered");
   }
 
   auto &channel = reader_channel_entry->second;
-  if (!channel.read_acquired) {
-    return Status::Invalid(
-        "Caller must call begin_read() before end_read() on a channel");
-  }
+  channel.lock->AssertHeld();
 
+  PlasmaObjectHeader::Semaphores sem = GetSemaphores(object_id);
   RAY_RETURN_NOT_OK(
-      channel.mutable_object->header->ReadRelease(channel.next_version_to_read));
+      channel.mutable_object->header->ReadRelease(sem, channel.next_version_to_read));
   // The next read needs to read at least this version.
   channel.next_version_to_read++;
-  channel.read_acquired = false;
+  // This lock ensures that there is only one reader at a time. The lock is acquired in
+  // `ReadAcquire()`.
+  channel.lock->Unlock();
 
-  sem_post(&channel.reader_semaphore);
-
-#endif
   return Status::OK();
 }
 
 Status ExperimentalMutableObjectManager::SetError(const ObjectID &object_id) {
-#ifdef __linux__
   PlasmaObjectHeader *header = nullptr;
   auto reader_channel_entry = reader_channels_.find(object_id);
   if (reader_channel_entry != reader_channels_.end()) {
@@ -190,8 +309,8 @@ Status ExperimentalMutableObjectManager::SetError(const ObjectID &object_id) {
     return Status::ObjectNotFound("Writer or reader channel has not been registered");
   }
 
-  header->SetErrorUnlocked();
-#endif
+  PlasmaObjectHeader::Semaphores sem = GetSemaphores(object_id);
+  header->SetErrorUnlocked(sem);
   return Status::OK();
 }
 

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -17,6 +17,9 @@
 #include "ray/object_manager/common.h"
 
 namespace ray {
+
+#if defined(__APPLE__) || defined(__linux__)
+
 namespace {
 
 std::string GetSemaphoreObjectName(const std::string &name) {
@@ -313,5 +316,73 @@ Status ExperimentalMutableObjectManager::SetError(const ObjectID &object_id) {
   header->SetErrorUnlocked(sem);
   return Status::OK();
 }
+
+#else  // defined(__APPLE__) || defined(__linux__)
+
+ExperimentalMutableObjectManager::~ExperimentalMutableObjectManager() {}
+
+Status ExperimentalMutableObjectManager::RegisterWriterChannel(
+    const ObjectID &object_id, std::unique_ptr<plasma::MutableObject> mutable_object) {
+  return Status::OK();
+}
+
+PlasmaObjectHeader *ExperimentalMutableObjectManager::GetHeader(
+    const ObjectID &object_id) {
+  return nullptr;
+}
+
+std::string ExperimentalMutableObjectManager::GetSemaphoreName(
+    const ObjectID &object_id) {
+  return "";
+}
+
+PlasmaObjectHeader::Semaphores ExperimentalMutableObjectManager::GetSemaphores(
+    const ObjectID &object_id) {
+  return {};
+}
+
+void ExperimentalMutableObjectManager::OpenSemaphores(const ObjectID &object_id) {}
+
+void ExperimentalMutableObjectManager::DestroySemaphores(const ObjectID &object_id) {}
+
+Status ExperimentalMutableObjectManager::WriteAcquire(const ObjectID &object_id,
+                                                      int64_t data_size,
+                                                      const uint8_t *metadata,
+                                                      int64_t metadata_size,
+                                                      int64_t num_readers,
+                                                      std::shared_ptr<Buffer> *data) {
+  return Status::OK();
+}
+
+Status ExperimentalMutableObjectManager::WriteRelease(const ObjectID &object_id) {
+  return Status::OK();
+}
+
+Status ExperimentalMutableObjectManager::RegisterReaderChannel(
+    const ObjectID &object_id, std::unique_ptr<plasma::MutableObject> mutable_object) {
+  return Status::OK();
+}
+
+bool ExperimentalMutableObjectManager::ReaderChannelRegistered(
+    const ObjectID &object_id) const {
+  return true;
+}
+
+Status ExperimentalMutableObjectManager::ReadAcquire(const ObjectID &object_id,
+                                                     std::shared_ptr<RayObject> *result)
+    ABSL_NO_THREAD_SAFETY_ANALYSIS {
+  return Status::OK();
+}
+
+Status ExperimentalMutableObjectManager::ReadRelease(const ObjectID &object_id)
+    ABSL_NO_THREAD_SAFETY_ANALYSIS {
+  return Status::OK();
+}
+
+Status ExperimentalMutableObjectManager::SetError(const ObjectID &object_id) {
+  return Status::OK();
+}
+
+#endif
 
 }  // namespace ray

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -323,7 +323,7 @@ ExperimentalMutableObjectManager::~ExperimentalMutableObjectManager() {}
 
 Status ExperimentalMutableObjectManager::RegisterWriterChannel(
     const ObjectID &object_id, std::unique_ptr<plasma::MutableObject> mutable_object) {
-  return Status::OK();
+  return Status::NotImplemented("Not supported on Windows.");
 }
 
 PlasmaObjectHeader *ExperimentalMutableObjectManager::GetHeader(
@@ -351,36 +351,36 @@ Status ExperimentalMutableObjectManager::WriteAcquire(const ObjectID &object_id,
                                                       int64_t metadata_size,
                                                       int64_t num_readers,
                                                       std::shared_ptr<Buffer> *data) {
-  return Status::OK();
+  return Status::NotImplemented("Not supported on Windows.");
 }
 
 Status ExperimentalMutableObjectManager::WriteRelease(const ObjectID &object_id) {
-  return Status::OK();
+  return Status::NotImplemented("Not supported on Windows.");
 }
 
 Status ExperimentalMutableObjectManager::RegisterReaderChannel(
     const ObjectID &object_id, std::unique_ptr<plasma::MutableObject> mutable_object) {
-  return Status::OK();
+  return Status::NotImplemented("Not supported on Windows.");
 }
 
 bool ExperimentalMutableObjectManager::ReaderChannelRegistered(
     const ObjectID &object_id) const {
-  return true;
+  return false;
 }
 
 Status ExperimentalMutableObjectManager::ReadAcquire(const ObjectID &object_id,
                                                      std::shared_ptr<RayObject> *result)
     ABSL_NO_THREAD_SAFETY_ANALYSIS {
-  return Status::OK();
+  return Status::NotImplemented("Not supported on Windows.");
 }
 
 Status ExperimentalMutableObjectManager::ReadRelease(const ObjectID &object_id)
     ABSL_NO_THREAD_SAFETY_ANALYSIS {
-  return Status::OK();
+  return Status::NotImplemented("Not supported on Windows.");
 }
 
 Status ExperimentalMutableObjectManager::SetError(const ObjectID &object_id) {
-  return Status::OK();
+  return Status::NotImplemented("Not supported on Windows.");
 }
 
 #endif

--- a/src/ray/object_manager/common.cc
+++ b/src/ray/object_manager/common.cc
@@ -202,7 +202,7 @@ Status PlasmaObjectHeader::ReadRelease(Semaphores &sem, int64_t read_version) {
 #else  // defined(__APPLE__) || defined(__linux__)
 
 Status PlasmaObjectHeader::TryToAcquireSemaphore(sem_t *sem) const {
-  return Status::OK();
+  return Status::NotImplemented("Not supported on Windows.");
 }
 
 void PlasmaObjectHeader::SetErrorUnlocked(Semaphores &sem) {}
@@ -211,15 +211,17 @@ Status PlasmaObjectHeader::WriteAcquire(Semaphores &sem,
                                         uint64_t write_data_size,
                                         uint64_t write_metadata_size,
                                         int64_t write_num_readers) {
-  return Status::OK();
+  return Status::NotImplemented("Not supported on Windows.");
 }
 
-Status PlasmaObjectHeader::WriteRelease(Semaphores &sem) { return Status::OK(); }
+Status PlasmaObjectHeader::WriteRelease(Semaphores &sem) {
+  return Status::NotImplemented("Not supported on Windows.");
+}
 
 Status PlasmaObjectHeader::ReadAcquire(Semaphores &sem,
                                        int64_t version_to_read,
                                        int64_t *version_read) {
-  return Status::OK();
+  return Status::NotImplemented("Not supported on Windows.");
 }
 
 #endif

--- a/src/ray/object_manager/common.cc
+++ b/src/ray/object_manager/common.cc
@@ -14,10 +14,11 @@
 
 #include "ray/object_manager/common.h"
 
+#include "absl/strings/str_format.h"
+
 namespace ray {
 
 void PlasmaObjectHeader::Init() {
-#ifdef __linux__
   // wr_mut is shared between writer and readers.
   pthread_mutexattr_t mutex_attr;
   pthread_mutexattr_init(&mutex_attr);
@@ -25,7 +26,15 @@ void PlasmaObjectHeader::Init() {
   pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_ERRORCHECK);
   pthread_mutex_init(&wr_mut, &mutex_attr);
 
-  sem_init(&rw_semaphore, PTHREAD_PROCESS_SHARED, 1);
+  memset(unique_name, 0, sizeof(unique_name));
+
+  semaphores_created = SemaphoresCreationLevel::kUnitialized;
+
+  pid_t pid = getpid();
+  std::string name =
+      absl::StrCat(pid, "-", absl::ToInt64Nanoseconds(absl::Now() - absl::UnixEpoch()));
+  RAY_CHECK_LE(name.size(), PSEMNAMLEN);
+  memcpy(unique_name, name.c_str(), name.size());
 
   version = 0;
   is_sealed = false;
@@ -35,65 +44,61 @@ void PlasmaObjectHeader::Init() {
   num_read_releases_remaining = 0;
   data_size = 0;
   metadata_size = 0;
-#endif
 }
-
-void PlasmaObjectHeader::Destroy() {
-#ifdef __linux__
-  RAY_CHECK(pthread_mutex_destroy(&wr_mut) == 0);
-  RAY_CHECK(sem_destroy(&rw_semaphore) == 0);
-#endif
-}
-
-#ifdef __linux__
 
 void PrintPlasmaObjectHeader(const PlasmaObjectHeader *header) {
-  RAY_LOG(DEBUG) << "PlasmaObjectHeader: \n"
-                 << "version: " << header->version << "\n"
-                 << "num_readers: " << header->num_readers << "\n"
-                 << "num_read_acquires_remaining: " << header->num_read_acquires_remaining
-                 << "\n"
-                 << "num_read_releases_remaining: " << header->num_read_releases_remaining
-                 << "\n"
-                 << "data_size: " << header->data_size << "\n"
-                 << "metadata_size: " << header->metadata_size << "\n";
+  std::string print;
+  absl::StrAppend(&print, "PlasmaObjectHeader: \n");
+  absl::StrAppend(&print,
+                  "semaphores_created: ",
+                  header->semaphores_created.load(std::memory_order_relaxed),
+                  "\n");
+  absl::StrAppend(&print, "unique_name: ", header->unique_name, "\n");
+  absl::StrAppend(&print, "version: ", header->version, "\n");
+  absl::StrAppend(&print, "num_readers: ", header->num_readers, "\n");
+  absl::StrAppend(
+      &print, "num_read_acquires_remaining: ", header->num_read_acquires_remaining, "\n");
+  absl::StrAppend(
+      &print, "num_read_releases_remaining: ", header->num_read_releases_remaining, "\n");
+  absl::StrAppend(&print, "data_size: ", header->data_size, "\n");
+  absl::StrAppend(&print, "metadata_size: ", header->metadata_size, "\n");
+  RAY_LOG(DEBUG) << print;
 }
 
-Status PlasmaObjectHeader::TryAcquireWriterMutex() {
-  // Try to acquire the lock, checking every 1s for the error bit.
-  struct timespec ts;
-  do {
-    if (has_error) {
-      return Status::IOError("channel closed");
-    }
-    clock_gettime(CLOCK_REALTIME, &ts);
-    ts.tv_sec += 1;
-  } while (pthread_mutex_timedlock(&wr_mut, &ts));
+Status PlasmaObjectHeader::CheckHasError() const {
+  // We do an acquire load so that no loads/stores are reordered before the load to
+  // `has_error`. This acquire load pairs with the release store in `SetErrorUnlocked()`.
+  if (has_error.load(std::memory_order_acquire)) {
+    return Status::IOError("Channel closed.");
+  }
+  return Status::OK();
+}
+
+Status PlasmaObjectHeader::TryToAcquireSemaphore(sem_t *sem) const {
+  // Check `has_error` first to avoid blocking forever on the semaphore.
+  RAY_RETURN_NOT_OK(CheckHasError());
+  RAY_CHECK_EQ(sem_wait(sem), 0);
+  // Check `has_error` again so that no more than one thread is ever in the critical
+  // section after `SetErrorUnlocked()` has been called. One thread could be in the
+  // critical section when that is called, but no additional thread will enter the
+  // critical section.
+  RAY_RETURN_NOT_OK(CheckHasError());
 
   return Status::OK();
 }
 
-Status PlasmaObjectHeader::WriteAcquire(uint64_t write_data_size,
+Status PlasmaObjectHeader::WriteAcquire(Semaphores &sem,
+                                        uint64_t write_data_size,
                                         uint64_t write_metadata_size,
                                         int64_t write_num_readers) {
-  RAY_LOG(DEBUG) << "WriteAcquire. data size " << write_data_size << ", metadata size "
-                 << write_metadata_size << ", num readers: " << write_num_readers;
+  RAY_CHECK(sem.object_sem);
+  RAY_CHECK(sem.header_sem);
 
-  // Try to acquire the semaphore, checking every 1s for the error bit.
-  struct timespec ts;
-  do {
-    if (has_error) {
-      return Status::IOError("channel closed");
-    }
-    clock_gettime(CLOCK_REALTIME, &ts);
-    ts.tv_sec += 1;
-  } while (sem_timedwait(&rw_semaphore, &ts));
+  RAY_RETURN_NOT_OK(TryToAcquireSemaphore(sem.object_sem));
+  RAY_RETURN_NOT_OK(TryToAcquireSemaphore(sem.header_sem));
 
-  RAY_RETURN_NOT_OK(TryAcquireWriterMutex());
-  PrintPlasmaObjectHeader(this);
-
-  RAY_CHECK(num_read_acquires_remaining == 0);
-  RAY_CHECK(num_read_releases_remaining == 0);
+  RAY_CHECK_EQ(num_read_acquires_remaining, 0);
+  RAY_CHECK_EQ(num_read_releases_remaining, 0);
 
   version++;
   is_sealed = false;
@@ -101,45 +106,33 @@ Status PlasmaObjectHeader::WriteAcquire(uint64_t write_data_size,
   metadata_size = write_metadata_size;
   num_readers = write_num_readers;
 
-  RAY_LOG(DEBUG) << "WriteAcquire done";
-  PrintPlasmaObjectHeader(this);
-  RAY_CHECK(pthread_mutex_unlock(&wr_mut) == 0);
+  RAY_CHECK_EQ(sem_post(sem.header_sem), 0);
   return Status::OK();
 }
 
-Status PlasmaObjectHeader::WriteRelease() {
-  RAY_LOG(DEBUG) << "WriteRelease Waiting. version: " << version;
-  RAY_RETURN_NOT_OK(TryAcquireWriterMutex());
-  RAY_LOG(DEBUG) << "WriteRelease " << version;
-  PrintPlasmaObjectHeader(this);
+Status PlasmaObjectHeader::WriteRelease(Semaphores &sem) {
+  RAY_RETURN_NOT_OK(TryToAcquireSemaphore(sem.header_sem));
 
   is_sealed = true;
-  RAY_CHECK(num_readers != 0) << num_readers;
+  RAY_CHECK(num_readers) << num_readers;
   num_read_acquires_remaining = num_readers;
   num_read_releases_remaining = num_readers;
 
-  RAY_LOG(DEBUG) << "WriteRelease done, num_readers: " << num_readers;
-  PrintPlasmaObjectHeader(this);
-  RAY_CHECK(pthread_mutex_unlock(&wr_mut) == 0);
+  RAY_CHECK_EQ(sem_post(sem.header_sem), 0);
   return Status::OK();
 }
 
-Status PlasmaObjectHeader::ReadAcquire(int64_t version_to_read, int64_t *version_read) {
-  RAY_LOG(DEBUG) << "ReadAcquire waiting version " << version_to_read;
-  RAY_RETURN_NOT_OK(TryAcquireWriterMutex());
-  RAY_LOG(DEBUG) << "ReadAcquire " << version_to_read;
-  PrintPlasmaObjectHeader(this);
+Status PlasmaObjectHeader::ReadAcquire(Semaphores &sem,
+                                       int64_t version_to_read,
+                                       int64_t *version_read) {
+  RAY_CHECK(sem.header_sem);
+
+  RAY_RETURN_NOT_OK(TryToAcquireSemaphore(sem.header_sem));
 
   // Wait for the requested version (or a more recent one) to be sealed.
-  int tries = 0;
   while (version < version_to_read || !is_sealed) {
-    RAY_CHECK(pthread_mutex_unlock(&wr_mut) == 0);
-    // Lower values than 100k seem to start impacting perf compared
-    // to mutex.
-    if (tries++ > 100000) {
-      std::this_thread::yield();  // Too many tries, yield thread.
-    }
-    RAY_RETURN_NOT_OK(TryAcquireWriterMutex());
+    RAY_CHECK_EQ(sem_post(sem.header_sem), 0);
+    RAY_RETURN_NOT_OK(TryToAcquireSemaphore(sem.header_sem));
   }
 
   bool success = false;
@@ -154,19 +147,10 @@ Status PlasmaObjectHeader::ReadAcquire(int64_t version_to_read, int64_t *version
       // succeeds.
       num_read_acquires_remaining--;
       success = true;
-    } else if (version > version_to_read) {
-      RAY_LOG(WARNING) << "Version " << version << " already exceeds version to read "
-                       << version_to_read;
-    } else {
-      RAY_LOG(WARNING) << "Version " << version << " already has " << num_readers
-                       << " readers";
     }
   }
 
-  RAY_LOG(DEBUG) << "ReadAcquire done";
-  PrintPlasmaObjectHeader(this);
-
-  RAY_CHECK(pthread_mutex_unlock(&wr_mut) == 0);
+  RAY_CHECK_EQ(sem_post(sem.header_sem), 0);
   if (!success) {
     return Status::Invalid(
         "Reader missed a value. Are you sure there are num_readers many readers?");
@@ -174,33 +158,28 @@ Status PlasmaObjectHeader::ReadAcquire(int64_t version_to_read, int64_t *version
   return Status::OK();
 }
 
-Status PlasmaObjectHeader::ReadRelease(int64_t read_version) {
-  bool all_readers_done = false;
-  RAY_LOG(DEBUG) << "ReadRelease Waiting" << read_version;
-  RAY_RETURN_NOT_OK(TryAcquireWriterMutex());
-  PrintPlasmaObjectHeader(this);
+Status PlasmaObjectHeader::ReadRelease(Semaphores &sem, int64_t read_version) {
+  RAY_CHECK(sem.object_sem);
+  RAY_CHECK(sem.header_sem);
 
-  RAY_LOG(DEBUG) << "ReadRelease " << read_version << " version is currently " << version;
-  RAY_CHECK(version == read_version) << "Version " << version << " modified from version "
-                                     << read_version << " at read start";
+  bool all_readers_done = false;
+  RAY_RETURN_NOT_OK(TryToAcquireSemaphore(sem.header_sem));
+
+  RAY_CHECK_EQ(version, read_version)
+      << "Version " << version << " modified from version " << read_version
+      << " at read start";
 
   if (num_readers != -1) {
     num_read_releases_remaining--;
-    RAY_CHECK(num_read_releases_remaining >= 0);
-    if (num_read_releases_remaining == 0) {
-      all_readers_done = true;
-    }
+    RAY_CHECK_GE(num_read_releases_remaining, 0);
+    all_readers_done = !num_read_releases_remaining;
   }
 
-  PrintPlasmaObjectHeader(this);
-  RAY_LOG(DEBUG) << "ReadRelease done";
-  RAY_CHECK(pthread_mutex_unlock(&wr_mut) == 0);
+  RAY_CHECK_EQ(sem_post(sem.header_sem), 0);
   if (all_readers_done) {
-    sem_post(&rw_semaphore);
+    RAY_CHECK_EQ(sem_post(sem.object_sem), 0);
   }
   return Status::OK();
 }
-
-#endif
 
 }  // namespace ray

--- a/src/ray/object_manager/common.h
+++ b/src/ray/object_manager/common.h
@@ -14,9 +14,7 @@
 
 #pragma once
 
-#ifdef __linux__
 #include <semaphore.h>
-#endif
 
 #include <atomic>
 #include <boost/asio.hpp>
@@ -24,6 +22,14 @@
 
 #include "ray/common/id.h"
 #include "ray/common/status.h"
+
+// On Darwin, named semaphores cannot have names longer than PSEMNAMLEN. On other
+// platforms, we define PSEMNAMLEN to be 30, which is what seems to work in Darwin.
+#ifdef __APPLE__
+#include <sys/posix_sem.h>
+#elif !defined(PSEMNAMLEN)
+#define PSEMNAMLEN 30UL
+#endif
 
 namespace ray {
 
@@ -48,11 +54,27 @@ using RestoreSpilledObjectCallback =
 /// needed once the object has been Sealed. For experimental mutable objects,
 /// we use the header to synchronize between writer and readers.
 struct PlasmaObjectHeader {
-// TODO(swang): PlasmaObjectHeader uses pthreads, POSIX mutex and semaphore.
-#ifdef __linux__
-  // Used to signal to the writer when all readers are done.
-  sem_t rw_semaphore;
+  struct Semaphores {
+    // Synchronizes readers and writers of the mutable object.
+    sem_t *object_sem;
+    // Synchronizes accesses to the object header.
+    sem_t *header_sem;
+  };
 
+  enum class SemaphoresCreationLevel {
+    kUnitialized,
+    kInitializing,
+    kDone,
+  };
+
+  // Used to synchronize initialization of the semaphores. Multiple processes may access
+  // this mutable object, so this variable lets them coordinate to determine who will
+  // initialize the semaphores.
+  std::atomic<SemaphoresCreationLevel> semaphores_created =
+      SemaphoresCreationLevel::kUnitialized;
+  // A unique name for this object. This unique name is used to generate the named
+  // semaphores for this object.
+  char unique_name[32];
   // Protects all following state, used to signal from writer to readers.
   pthread_mutex_t wr_mut;
   // The object version. For immutable objects, this gets incremented to 1 on
@@ -67,7 +89,7 @@ struct PlasmaObjectHeader {
   bool is_sealed = false;
   // Set to indicate an error was encountered computing the next version of
   // the mutable object. Lockless access allowed.
-  std::atomic_bool has_error = false;
+  std::atomic<bool> has_error = false;
   // The total number of reads allowed before the writer can write again. This
   // value should be set by the writer before releasing to readers.
   // For immutable objects, this is set to -1 and infinite reads are allowed.
@@ -93,54 +115,79 @@ struct PlasmaObjectHeader {
   // different data/metadata size.
   uint64_t data_size = 0;
   uint64_t metadata_size = 0;
+
   /// Blocks until all readers for the previous write have ReadRelease'd the
   /// value. Protects against concurrent writers.
   ///
+  /// \param sem The semaphores for this channel.
   /// \param data_size The new data size of the object.
   /// \param metadata_size The new metadata size of the object.
   /// \param num_readers The number of readers for the object.
   /// \return if the acquire was successful.
-  Status WriteAcquire(uint64_t data_size, uint64_t metadata_size, int64_t num_readers);
+  Status WriteAcquire(Semaphores &sem,
+                      uint64_t data_size,
+                      uint64_t metadata_size,
+                      int64_t num_readers);
 
   /// Call after completing a write to signal that readers may read.
   /// num_readers should be set before calling this.
-  Status WriteRelease();
+  ///
+  /// \param sem The semaphores for this channel.
+  Status WriteRelease(Semaphores &sem);
 
-  // Blocks until the given version is ready to read. Returns false if the
-  // maximum number of readers have already read the requested version.
-  //
-  // \param[in] read_version The version to read.
-  // \param[out] version_read For normal immutable objects, this will be set to
-  // 0. Otherwise, the current version.
-  // \return Whether the correct version was read and there were still
-  // reads remaining.
-  Status ReadAcquire(int64_t version_to_read, int64_t *version_read);
+  /// Blocks until the given version is ready to read. Returns false if the
+  /// maximum number of readers have already read the requested version.
+  ///
+  /// \param[in] sem The semaphores for this channel.
+  /// \param[in] read_version The version to read.
+  /// \param[out] version_read For normal immutable objects, this will be set to
+  /// 0. Otherwise, the current version.
+  /// \return Whether the correct version was read and there were still
+  /// reads remaining.
+  Status ReadAcquire(Semaphores &sem, int64_t version_to_read, int64_t *version_read);
 
   // Finishes the read. If all reads are done, signals to the writer. This is
   // not necessary to call for objects that have num_readers=-1.
   ///
+  /// \param sem The semaphores for this channel.
   /// \param read_version This must match the version previously passed in
   /// ReadAcquire.
-  Status ReadRelease(int64_t read_version);
-#endif
+  Status ReadRelease(Semaphores &sem, int64_t read_version);
 
-  /// Setup synchronization primitives.
+  /// Set up synchronization primitives.
   void Init();
 
-  /// Destroy synchronization primitives.
-  void Destroy();
-
-  /// Helper method to acquire the writer mutex while aborting if the
-  /// error bit is set.
-  /// \return if the mutex was acquired successfully.
-  Status TryAcquireWriterMutex();
+  /// Helper method to acquire a semaphore while failing if the error bit is set. This
+  /// method is idempotent.
+  ///
+  /// \return OK if the mutex was acquired successfully.
+  Status TryToAcquireSemaphore(sem_t *sem) const;
 
   /// Set the error bit. This is a non-blocking method.
-  void SetErrorUnlocked() {
-#ifdef __linux__
-    has_error = true;
-#endif
+  ///
+  /// \param sem The semaphores for this channel.
+  void SetErrorUnlocked(Semaphores &sem) {
+    RAY_CHECK(sem.header_sem);
+    RAY_CHECK(sem.object_sem);
+
+    // We do a store release so that no loads/stores are reordered after the store to
+    // `has_error`. This store release pairs with the acquire load in `CheckHasError()`.
+    has_error.store(true, std::memory_order_release);
+    // Increment `sem.object_sem` once to potentially unblock the writer. There will never
+    // be more than one writer.
+    RAY_CHECK_EQ(sem_post(sem.object_sem), 0);
+
+    // Increment `sem.header_sem` by `num_readers` since there could potentially be that
+    // many readers blocked on `sem_wait()`.
+    for (int64_t i = 0; i < num_readers; i++) {
+      RAY_CHECK_EQ(sem_post(sem.header_sem), 0);
+    }
   }
+
+  /// Checks if `has_error` has been set.
+  ///
+  /// \return OK if `has_error` has not been yet, and an IOError otherwise.
+  Status CheckHasError() const;
 };
 
 /// A struct that includes info about the object.

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -618,6 +618,10 @@ Status PlasmaClient::Impl::GetBuffers(
 
 Status PlasmaClient::Impl::GetExperimentalMutableObject(
     const ObjectID &object_id, std::unique_ptr<MutableObject> *mutable_object) {
+#if defined(_WIN32)
+  return Status::NotImplemented("Not supported on Windows.");
+#endif
+
   std::unique_lock<std::recursive_mutex> guard(client_mutex_);
 
   auto object_entry = objects_in_use_.find(object_id);

--- a/src/ray/object_manager/plasma/object_store.cc
+++ b/src/ray/object_manager/plasma/object_store.cc
@@ -49,8 +49,7 @@ const LocalObject *ObjectStore::CreateObject(const ray::ObjectInfo &object_info,
 
   if (object_info.is_mutable) {
     RAY_LOG(DEBUG) << "PlasmaObjectHeader::Init " << object_info.object_id;
-    auto plasma_header = entry->GetPlasmaObjectHeader();
-    plasma_header->Init();
+    entry->GetPlasmaObjectHeader()->Init();
   }
 
   RAY_LOG(DEBUG) << "create object " << object_info.object_id << " succeeded";
@@ -77,12 +76,8 @@ const LocalObject *ObjectStore::SealObject(const ObjectID &object_id) {
 
 bool ObjectStore::DeleteObject(const ObjectID &object_id) {
   auto entry = GetMutableObject(object_id);
-  if (entry == nullptr) {
+  if (!entry) {
     return false;
-  }
-  if (entry->object_info.is_mutable) {
-    auto plasma_header = entry->GetPlasmaObjectHeader();
-    plasma_header->Destroy();
   }
 
   allocator_.Free(std::move(entry->allocation));

--- a/src/ray/object_manager/plasma/object_store.cc
+++ b/src/ray/object_manager/plasma/object_store.cc
@@ -47,10 +47,12 @@ const LocalObject *ObjectStore::CreateObject(const ray::ObjectInfo &object_info,
   entry->construct_duration = -1;
   entry->source = source;
 
+#if defined(__APPLE__) || defined(__linux__)
   if (object_info.is_mutable) {
     RAY_LOG(DEBUG) << "PlasmaObjectHeader::Init " << object_info.object_id;
     entry->GetPlasmaObjectHeader()->Init();
   }
+#endif
 
   RAY_LOG(DEBUG) << "create object " << object_info.object_id << " succeeded";
   return entry;

--- a/src/ray/object_manager/plasma/plasma.h
+++ b/src/ray/object_manager/plasma/plasma.h
@@ -16,7 +16,9 @@
 // under the License.
 
 #pragma once
+
 #include <stddef.h>
+#include <string.h>
 
 #include <memory>
 #include <string>
@@ -60,11 +62,7 @@ struct PlasmaObject {
   bool is_experimental_mutable_object = false;
 
   bool operator==(const PlasmaObject &other) const {
-    return ((store_fd == other.store_fd) && (data_offset == other.data_offset) &&
-            (metadata_offset == other.metadata_offset) &&
-            (data_size == other.data_size) && (metadata_size == other.metadata_size) &&
-            (device_num == other.device_num) &&
-            (fallback_allocated == other.fallback_allocated));
+    return !memcmp(this, &other, sizeof(other));
   }
 };
 

--- a/src/ray/object_manager/plasma/test/mutable_object_test.cc
+++ b/src/ray/object_manager/plasma/test/mutable_object_test.cc
@@ -18,294 +18,581 @@
 #include "absl/strings/str_format.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "ray/core_worker/experimental_mutable_object_manager.h"
 #include "ray/object_manager/common.h"
 
-using namespace ray;
 using namespace testing;
 
+namespace ray {
 namespace {
 
-void Write(uint8_t *object_ptr, int num_writes, int num_readers) {
-  PlasmaObjectHeader *header = reinterpret_cast<ray::PlasmaObjectHeader *>(object_ptr);
-  for (int i = 0; i < num_writes; i++) {
-    std::string data = "hello" + std::to_string(i);
-    std::string metadata = std::to_string(data.length());
-    if (!header->WriteAcquire(data.length(), metadata.length(), num_readers).ok()) {
+constexpr size_t kNumReads = 10000;
+constexpr size_t kNumReadsSuccess = kNumReads / 2;
+constexpr size_t kNumReaders = 24;
+
+uint8_t *GetData(PlasmaObjectHeader *header) {
+  uint8_t *raw_header = reinterpret_cast<uint8_t *>(header);
+  return raw_header + sizeof(PlasmaObjectHeader);
+}
+
+uint8_t *GetMetadata(PlasmaObjectHeader *header) {
+  return GetData(header) + header->data_size;
+}
+
+// Writes `num_write` times to the mutable object.
+void Write(PlasmaObjectHeader *header,
+           PlasmaObjectHeader::Semaphores &sem,
+           size_t num_writes,
+           size_t num_readers) {
+  RAY_CHECK(header);
+  RAY_CHECK(sem.header_sem);
+  RAY_CHECK(sem.object_sem);
+
+  for (size_t i = 0; i < num_writes; i++) {
+    std::string data = absl::StrCat("hello", i);
+    std::string metadata = std::to_string(data.size());
+    if (!header->WriteAcquire(sem, data.size(), metadata.size(), num_readers).ok()) {
       return;
     }
-    auto data_ptr = object_ptr + sizeof(PlasmaObjectHeader);
-    std::memcpy(data_ptr, data.data(), data.length());
-    std::memcpy(data_ptr + data.length(), metadata.data(), metadata.length());
-    if (!header->WriteRelease().ok()) {
+    memcpy(GetData(header), data.data(), data.size());
+    memcpy(GetMetadata(header), metadata.data(), metadata.size());
+    if (!header->WriteRelease(sem).ok()) {
       return;
     }
   }
 }
 
-void Read(uint8_t *object_ptr,
-          int num_reads,
-          std::shared_ptr<std::vector<std::string>> data_results,
-          std::shared_ptr<std::vector<std::string>> metadata_results) {
-  PlasmaObjectHeader *header = reinterpret_cast<ray::PlasmaObjectHeader *>(object_ptr);
-  auto data_ptr = object_ptr + sizeof(PlasmaObjectHeader);
+// Reads `num_reads` times to the mutable object.
+void Read(PlasmaObjectHeader *header,
+          PlasmaObjectHeader::Semaphores &sem,
+          size_t num_reads,
+          std::vector<std::string> &data_results,
+          std::vector<std::string> &metadata_results) {
+  RAY_CHECK(header);
+  RAY_CHECK(sem.header_sem);
+  RAY_CHECK(sem.object_sem);
 
   int64_t version_to_read = 1;
-  for (int i = 0; i < num_reads; i++) {
+  for (size_t i = 0; i < num_reads; i++) {
     int64_t version_read = 0;
-    auto status = header->ReadAcquire(version_to_read, &version_read);
-    if (!status.ok()) {
-      data_results->push_back("error");
-      metadata_results->push_back("error");
+    if (!header->ReadAcquire(sem, version_to_read, &version_read).ok()) {
+      data_results.push_back("error");
+      metadata_results.push_back("error");
       return;
     }
+    RAY_CHECK_EQ(version_read, version_to_read);
 
-    RAY_CHECK(version_read == version_to_read);
+    const char *data_str = reinterpret_cast<const char *>(GetData(header));
+    data_results.push_back(std::string(data_str, header->data_size));
 
-    const char *data_str = reinterpret_cast<const char *>(data_ptr);
-    data_results->push_back(std::string(data_str, header->data_size));
+    const char *metadata_str = reinterpret_cast<const char *>(GetMetadata(header));
+    metadata_results.push_back(std::string(metadata_str, header->metadata_size));
 
-    uint8_t *metadata_ptr = data_ptr + header->data_size;
-    const char *metadata_str = reinterpret_cast<const char *>(metadata_ptr);
-    metadata_results->push_back(std::string(metadata_str, header->metadata_size));
-
-    if (!header->ReadRelease(version_read).ok()) {
-      data_results->push_back("error");
-      metadata_results->push_back("error");
+    if (!header->ReadRelease(sem, version_read).ok()) {
+      data_results.push_back("error");
+      metadata_results.push_back("error");
       return;
     }
     version_to_read++;
   }
 }
 
+// Creates a new mutable object. It is the caller's responsibility to free the backing
+// store.
+std::unique_ptr<plasma::MutableObject> MakeObject() {
+  constexpr size_t kPayloadSize = 128;
+  constexpr size_t kSize = sizeof(PlasmaObjectHeader) + kPayloadSize;
+
+  plasma::PlasmaObject info{};
+  info.header_offset = 0;
+  info.data_offset = sizeof(PlasmaObjectHeader);
+  info.allocated_size = kPayloadSize;
+
+  uint8_t *ptr = static_cast<uint8_t *>(malloc(kSize));
+  return std::make_unique<plasma::MutableObject>(ptr, info);
+}
+
 }  // namespace
 
+// Tests that a single reader can read from a single writer.
 TEST(MutableObjectTest, TestBasic) {
-  uint8_t *object_ptr =
-      reinterpret_cast<uint8_t *>(malloc(sizeof(PlasmaObjectHeader) + 100));
+  ExperimentalMutableObjectManager manager;
+  ObjectID object_id = ObjectID::FromRandom();
+  plasma::PlasmaObjectHeader *header;
+  {
+    std::unique_ptr<plasma::MutableObject> object = MakeObject();
+    header = object->header;
+    header->Init();
+    ASSERT_TRUE(manager.RegisterReaderChannel(object_id, std::move(object)).ok());
+  }
+  manager.OpenSemaphores(object_id);
+  PlasmaObjectHeader::Semaphores sem = manager.GetSemaphores(object_id);
 
-  PlasmaObjectHeader *header = reinterpret_cast<ray::PlasmaObjectHeader *>(object_ptr);
-  header->Init();
+  std::vector<std::string> data_results;
+  std::vector<std::string> metadata_results;
+  std::thread t(Read,
+                header,
+                std::ref(sem),
+                kNumReads,
+                std::ref(data_results),
+                std::ref(metadata_results));
 
-  auto data_results = std::make_shared<std::vector<std::string>>();
-  auto metadata_results = std::make_shared<std::vector<std::string>>();
-  int num_reads = 10000;
-  std::thread t(Read, object_ptr, num_reads, data_results, metadata_results);
+  for (size_t i = 0; i < kNumReads; i++) {
+    std::string data = absl::StrCat("hello", i);
+    std::string metadata = std::to_string(data.size());
 
-  for (int i = 0; i < num_reads; i++) {
-    std::string data = "hello" + std::to_string(i);
-    std::string metadata = std::to_string(data.length());
-    RAY_CHECK_OK(header->WriteAcquire(data.length(), metadata.length(), 1));
-    auto data_ptr = object_ptr + sizeof(PlasmaObjectHeader);
-    std::memcpy(data_ptr, data.data(), data.length());
-    std::memcpy(data_ptr + data.length(), metadata.data(), metadata.length());
-    RAY_CHECK_OK(header->WriteRelease());
+    ASSERT_TRUE(header->WriteAcquire(sem, data.size(), metadata.size(), 1).ok());
+    uint8_t *data_ptr = GetData(header);
+    std::memcpy(data_ptr, data.data(), data.size());
+    std::memcpy(data_ptr + data.size(), metadata.data(), metadata.size());
+    ASSERT_TRUE(header->WriteRelease(sem).ok());
   }
 
   t.join();
+  manager.DestroySemaphores(object_id);
+  free(header);
 
-  for (int i = 0; i < num_reads; i++) {
-    std::string data("hello" + std::to_string(i));
-    ASSERT_EQ((*data_results)[i], data);
-    ASSERT_EQ((*metadata_results)[i], std::to_string(data.length()));
+  for (size_t i = 0; i < kNumReads; i++) {
+    std::string data = absl::StrCat("hello", i);
+    ASSERT_EQ(data_results[i], data);
+    ASSERT_EQ(metadata_results[i], std::to_string(data.size()));
   }
 }
 
+// Tests that multiple readers can read from a single writer.
 TEST(MutableObjectTest, TestMultipleReaders) {
-  uint8_t *object_ptr =
-      reinterpret_cast<uint8_t *>(malloc(sizeof(PlasmaObjectHeader) + 100));
+  ExperimentalMutableObjectManager manager;
+  ObjectID object_id = ObjectID::FromRandom();
+  plasma::PlasmaObjectHeader *header;
+  {
+    std::unique_ptr<plasma::MutableObject> object = MakeObject();
+    header = object->header;
+    header->Init();
+    ASSERT_TRUE(manager.RegisterReaderChannel(object_id, std::move(object)).ok());
+  }
+  manager.OpenSemaphores(object_id);
+  PlasmaObjectHeader::Semaphores sem = manager.GetSemaphores(object_id);
 
-  PlasmaObjectHeader *header = reinterpret_cast<ray::PlasmaObjectHeader *>(object_ptr);
-  header->Init();
-
-  int num_reads = 10000;
-  int num_readers = 24;
-
-  std::vector<std::shared_ptr<std::vector<std::string>>> data_results;
-  std::vector<std::shared_ptr<std::vector<std::string>>> metadata_results;
+  std::vector<std::vector<std::string>> data_results(/*count=*/kNumReaders,
+                                                     std::vector<std::string>());
+  std::vector<std::vector<std::string>> metadata_results(/*count=*/kNumReaders,
+                                                         std::vector<std::string>());
   std::vector<std::thread> threads;
-  for (int i = 0; i < num_readers; i++) {
-    data_results.push_back(std::make_shared<std::vector<std::string>>());
-    metadata_results.push_back(std::make_shared<std::vector<std::string>>());
-    std::thread t(Read, object_ptr, num_reads, data_results[i], metadata_results[i]);
+  for (size_t i = 0; i < kNumReaders; i++) {
+    std::thread t(Read,
+                  header,
+                  std::ref(sem),
+                  kNumReads,
+                  std::ref(data_results[i]),
+                  std::ref(metadata_results[i]));
     threads.emplace_back(std::move(t));
   }
 
-  for (int i = 0; i < num_reads; i++) {
-    std::string data = "hello" + std::to_string(i);
-    std::string metadata = std::to_string(data.length());
-    RAY_CHECK_OK(header->WriteAcquire(data.length(), metadata.length(), num_readers));
-    auto data_ptr = object_ptr + sizeof(PlasmaObjectHeader);
-    std::memcpy(data_ptr, data.data(), data.length());
-    std::memcpy(data_ptr + data.length(), metadata.data(), metadata.length());
-    RAY_CHECK_OK(header->WriteRelease());
+  for (size_t i = 0; i < kNumReads; i++) {
+    std::string data = absl::StrCat("hello", i);
+    std::string metadata = std::to_string(data.size());
+    ASSERT_TRUE(
+        header->WriteAcquire(sem, data.size(), metadata.size(), kNumReaders).ok());
+    uint8_t *data_ptr = GetData(header);
+    std::memcpy(data_ptr, data.data(), data.size());
+    std::memcpy(data_ptr + data.size(), metadata.data(), metadata.size());
+    ASSERT_TRUE(header->WriteRelease(sem).ok());
   }
 
-  for (auto &t : threads) {
+  for (std::thread &t : threads) {
     t.join();
   }
+  manager.DestroySemaphores(object_id);
+  free(header);
 
-  for (int j = 0; j < num_reads; j++) {
-    std::string data("hello" + std::to_string(j));
-    for (int i = 0; i < num_readers; i++) {
-      ASSERT_EQ((*data_results[i])[j], data);
-      ASSERT_EQ((*metadata_results[i])[j], std::to_string(data.length()));
+  for (size_t j = 0; j < kNumReads; j++) {
+    std::string data = absl::StrCat("hello", j);
+    for (size_t i = 0; i < kNumReaders; i++) {
+      ASSERT_EQ(data_results[i][j], data);
+      ASSERT_EQ(metadata_results[i][j], std::to_string(data.size()));
     }
   }
 }
 
+// Tests that multiple readers can detect a failure initiated by the writer.
 TEST(MutableObjectTest, TestWriterFails) {
-  uint8_t *object_ptr =
-      reinterpret_cast<uint8_t *>(malloc(sizeof(PlasmaObjectHeader) + 100));
+  ExperimentalMutableObjectManager manager;
+  ObjectID object_id = ObjectID::FromRandom();
+  plasma::PlasmaObjectHeader *header;
+  {
+    std::unique_ptr<plasma::MutableObject> object = MakeObject();
+    header = object->header;
+    header->Init();
+    ASSERT_TRUE(manager.RegisterReaderChannel(object_id, std::move(object)).ok());
+  }
+  manager.OpenSemaphores(object_id);
+  PlasmaObjectHeader::Semaphores sem = manager.GetSemaphores(object_id);
 
-  PlasmaObjectHeader *header = reinterpret_cast<ray::PlasmaObjectHeader *>(object_ptr);
-  header->Init();
-
-  int num_reads = 10000;
-  int num_reads_success = num_reads / 2;
-  int num_readers = 24;
-
-  std::vector<std::shared_ptr<std::vector<std::string>>> data_results;
-  std::vector<std::shared_ptr<std::vector<std::string>>> metadata_results;
+  std::vector<std::vector<std::string>> data_results(/*count=*/kNumReaders,
+                                                     std::vector<std::string>());
+  std::vector<std::vector<std::string>> metadata_results(/*count=*/kNumReaders,
+                                                         std::vector<std::string>());
   std::vector<std::thread> threads;
-  for (int i = 0; i < num_readers; i++) {
-    data_results.push_back(std::make_shared<std::vector<std::string>>());
-    metadata_results.push_back(std::make_shared<std::vector<std::string>>());
-    std::thread t(Read, object_ptr, num_reads, data_results[i], metadata_results[i]);
+  for (size_t i = 0; i < kNumReaders; i++) {
+    std::thread t(Read,
+                  header,
+                  std::ref(sem),
+                  kNumReads,
+                  std::ref(data_results[i]),
+                  std::ref(metadata_results[i]));
     threads.emplace_back(std::move(t));
   }
 
-  std::thread writer_t(Write, object_ptr, num_reads_success, num_readers);
-  writer_t.join();
+  {
+    std::thread writer(
+        Write, header, std::ref(sem), /*num_writes=*/kNumReadsSuccess, kNumReaders);
+    writer.join();
+  }
 
-  RAY_CHECK_OK(header->WriteAcquire(10, 10, num_readers));
+  header->SetErrorUnlocked(sem);
 
-  header->SetErrorUnlocked();
-
-  for (auto &t : threads) {
+  for (std::thread &t : threads) {
     t.join();
   }
+  manager.DestroySemaphores(object_id);
+  free(header);
 
-  for (int i = 0; i < num_readers; i++) {
-    ASSERT_EQ(data_results[i]->size(), num_reads_success + 1);
+  for (size_t i = 0; i < kNumReaders; i++) {
+    ASSERT_GE(data_results[i].size(), kNumReadsSuccess);
+    ASSERT_LE(data_results[i].size(), kNumReadsSuccess + 1);
   }
-  for (int i = 1; i < num_readers; i++) {
-    for (int j = 0; j < static_cast<int>(data_results[i]->size()); j++) {
-      std::string data("hello" + std::to_string(j));
-      if (j == static_cast<int>(data_results[i]->size()) - 1) {
-        ASSERT_EQ((*data_results[i])[j], "error");
-        ASSERT_EQ((*metadata_results[i])[j], "error");
+  for (size_t i = 1; i < kNumReaders; i++) {
+    for (size_t j = 0; j < data_results[i].size(); j++) {
+      std::string data;
+      std::string metadata;
+      if (j + 1 == data_results[i].size()) {
+        data = "error";
+        metadata = "error";
       } else {
-        ASSERT_EQ((*data_results[i])[j], data);
-        ASSERT_EQ((*metadata_results[i])[j], std::to_string(data.size()));
+        data = absl::StrCat("hello", j);
+        metadata = std::to_string(data.size());
       }
+      ASSERT_EQ(data_results[i][j], data);
+      ASSERT_EQ(metadata_results[i][j], metadata);
     }
   }
 }
 
+// Tests that multiple readers can detect a failure initiated by the writer after
+// `WriteAcquire()` is called.
 TEST(MutableObjectTest, TestWriterFailsAfterAcquire) {
-  uint8_t *object_ptr =
-      reinterpret_cast<uint8_t *>(malloc(sizeof(PlasmaObjectHeader) + 100));
+  ExperimentalMutableObjectManager manager;
+  ObjectID object_id = ObjectID::FromRandom();
+  plasma::PlasmaObjectHeader *header;
+  {
+    std::unique_ptr<plasma::MutableObject> object = MakeObject();
+    header = object->header;
+    header->Init();
+    ASSERT_TRUE(manager.RegisterReaderChannel(object_id, std::move(object)).ok());
+  }
+  manager.OpenSemaphores(object_id);
+  PlasmaObjectHeader::Semaphores sem = manager.GetSemaphores(object_id);
 
-  PlasmaObjectHeader *header = reinterpret_cast<ray::PlasmaObjectHeader *>(object_ptr);
-  header->Init();
-
-  int num_reads = 10000;
-  int num_reads_success = num_reads / 2;
-  int num_readers = 24;
-
-  std::vector<std::shared_ptr<std::vector<std::string>>> data_results;
-  std::vector<std::shared_ptr<std::vector<std::string>>> metadata_results;
+  std::vector<std::vector<std::string>> data_results(/*count=*/kNumReaders,
+                                                     std::vector<std::string>());
+  std::vector<std::vector<std::string>> metadata_results(/*count=*/kNumReaders,
+                                                         std::vector<std::string>());
   std::vector<std::thread> threads;
-  for (int i = 0; i < num_readers; i++) {
-    data_results.push_back(std::make_shared<std::vector<std::string>>());
-    metadata_results.push_back(std::make_shared<std::vector<std::string>>());
-    std::thread t(Read, object_ptr, num_reads, data_results[i], metadata_results[i]);
+  for (size_t i = 0; i < kNumReaders; i++) {
+    std::thread t(Read,
+                  header,
+                  std::ref(sem),
+                  kNumReads,
+                  std::ref(data_results[i]),
+                  std::ref(metadata_results[i]));
     threads.emplace_back(std::move(t));
   }
 
-  std::thread writer_t(Write, object_ptr, num_reads_success, num_readers);
-  writer_t.join();
+  {
+    std::thread writer(Write, header, std::ref(sem), kNumReadsSuccess, kNumReaders);
+    writer.join();
+  }
 
-  RAY_CHECK_OK(header->WriteAcquire(10, 10, num_readers));
+  ASSERT_TRUE(
+      header
+          ->WriteAcquire(
+              sem, /*write_data_size=*/10, /*write_metadata_size=*/10, kNumReaders)
+          .ok());
+  header->SetErrorUnlocked(sem);
 
-  header->SetErrorUnlocked();
-
-  for (auto &t : threads) {
+  for (std::thread &t : threads) {
     t.join();
   }
+  manager.DestroySemaphores(object_id);
+  free(header);
 
-  for (int i = 0; i < num_readers; i++) {
-    ASSERT_EQ(data_results[i]->size(), num_reads_success + 1);
+  for (size_t i = 0; i < kNumReaders; i++) {
+    ASSERT_EQ(data_results[i].size(), kNumReadsSuccess + 1);
   }
-  for (int i = 1; i < num_readers; i++) {
-    for (int j = 0; j < static_cast<int>(data_results[i]->size()); j++) {
-      std::string data("hello" + std::to_string(j));
-      if (j == static_cast<int>(data_results[i]->size()) - 1) {
-        ASSERT_EQ((*data_results[i])[j], "error");
-        ASSERT_EQ((*metadata_results[i])[j], "error");
+  for (size_t i = 1; i < kNumReaders; i++) {
+    for (size_t j = 0; j < data_results[i].size(); j++) {
+      std::string data;
+      std::string metadata;
+      if (j + 1 == data_results[i].size()) {
+        data = "error";
+        metadata = "error";
       } else {
-        ASSERT_EQ((*data_results[i])[j], data);
-        ASSERT_EQ((*metadata_results[i])[j], std::to_string(data.size()));
+        data = absl::StrCat("hello", j);
+        metadata = std::to_string(data.size());
       }
+      ASSERT_EQ(data_results[i][j], data);
+      ASSERT_EQ(metadata_results[i][j], metadata);
     }
   }
 }
 
+// Tests that multiple readers can detect a failure initiated by another reader.
 TEST(MutableObjectTest, TestReaderFails) {
-  uint8_t *object_ptr =
-      reinterpret_cast<uint8_t *>(malloc(sizeof(PlasmaObjectHeader) + 100));
+  ExperimentalMutableObjectManager manager;
+  ObjectID object_id = ObjectID::FromRandom();
+  plasma::PlasmaObjectHeader *header;
+  {
+    std::unique_ptr<plasma::MutableObject> object = MakeObject();
+    header = object->header;
+    header->Init();
+    ASSERT_TRUE(manager.RegisterReaderChannel(object_id, std::move(object)).ok());
+  }
+  manager.OpenSemaphores(object_id);
+  PlasmaObjectHeader::Semaphores sem = manager.GetSemaphores(object_id);
 
-  PlasmaObjectHeader *header = reinterpret_cast<ray::PlasmaObjectHeader *>(object_ptr);
-  header->Init();
-
-  int num_reads = 10000;
-  int num_reads_success = num_reads / 2;
-  int num_readers = 24;
-
-  std::vector<std::shared_ptr<std::vector<std::string>>> data_results;
-  std::vector<std::shared_ptr<std::vector<std::string>>> metadata_results;
+  std::vector<std::vector<std::string>> data_results(/*count=*/kNumReaders,
+                                                     std::vector<std::string>());
+  std::vector<std::vector<std::string>> metadata_results(/*count=*/kNumReaders,
+                                                         std::vector<std::string>());
   std::vector<std::thread> threads;
 
-  data_results.push_back(std::make_shared<std::vector<std::string>>());
-  metadata_results.push_back(std::make_shared<std::vector<std::string>>());
-  std::thread failed_reader_t(
-      Read, object_ptr, num_reads_success, data_results[0], metadata_results[0]);
+  std::thread failed_reader(Read,
+                            header,
+                            std::ref(sem),
+                            kNumReadsSuccess,
+                            std::ref(data_results[0]),
+                            std::ref(metadata_results[0]));
 
-  for (int i = 1; i < num_readers; i++) {
-    data_results.push_back(std::make_shared<std::vector<std::string>>());
-    metadata_results.push_back(std::make_shared<std::vector<std::string>>());
-    std::thread t(Read, object_ptr, num_reads, data_results[i], metadata_results[i]);
+  for (size_t i = 1; i < kNumReaders; i++) {
+    std::thread t(Read,
+                  header,
+                  std::ref(sem),
+                  kNumReads,
+                  std::ref(data_results[i]),
+                  std::ref(metadata_results[i]));
     threads.emplace_back(std::move(t));
   }
 
-  std::thread writer_t(Write, object_ptr, num_reads, num_readers);
+  std::thread writer(Write, header, std::ref(sem), kNumReads, kNumReaders);
 
-  failed_reader_t.join();
-  header->SetErrorUnlocked();
+  failed_reader.join();
+  header->SetErrorUnlocked(sem);
 
-  writer_t.join();
-  for (auto &t : threads) {
+  writer.join();
+  for (std::thread &t : threads) {
     t.join();
   }
+  manager.DestroySemaphores(object_id);
+  free(header);
 
-  ASSERT_EQ(data_results[0]->size(), num_reads_success);
-  for (int i = 1; i < num_readers; i++) {
-    ASSERT_TRUE(static_cast<size_t>(num_reads_success) <= data_results[i]->size());
-    ASSERT_TRUE(data_results[i]->size() <= static_cast<size_t>(num_reads_success + 2));
+  ASSERT_EQ(data_results[0].size(), kNumReadsSuccess);
+  for (size_t i = 1; i < kNumReaders; i++) {
+    ASSERT_LE(kNumReadsSuccess, data_results[i].size());
+    ASSERT_LE(data_results[i].size(), kNumReadsSuccess * 2);
   }
-  for (int i = 1; i < num_readers; i++) {
-    for (int j = 0; j < static_cast<int>(data_results[i]->size()); j++) {
-      std::string data("hello" + std::to_string(j));
-      if (j == static_cast<int>(data_results[i]->size()) - 1) {
-        ASSERT_EQ((*data_results[i])[j], "error");
-        ASSERT_EQ((*metadata_results[i])[j], "error");
+  for (size_t i = 1; i < kNumReaders; i++) {
+    for (size_t j = 0; j < data_results[i].size(); j++) {
+      std::string data;
+      std::string metadata;
+      if (j + 1 == data_results[i].size()) {
+        data = "error";
+        metadata = "error";
       } else {
-        ASSERT_EQ((*data_results[i])[j], data);
-        ASSERT_EQ((*metadata_results[i])[j], std::to_string(data.size()));
+        data = absl::StrCat("hello", j);
+        metadata = std::to_string(data.size());
       }
+      ASSERT_EQ(data_results[i][j], data);
+      ASSERT_EQ(metadata_results[i][j], metadata);
     }
   }
 }
+
+// Tests that a writer can detect a failure while it is in `WriteAcquire()`.
+TEST(MutableObjectTest, TestWriteAcquireDuringFailure) {
+  ExperimentalMutableObjectManager manager;
+  ObjectID object_id = ObjectID::FromRandom();
+  plasma::PlasmaObjectHeader *header;
+  {
+    std::unique_ptr<plasma::MutableObject> object = MakeObject();
+    header = object->header;
+    header->Init();
+    ASSERT_TRUE(manager.RegisterReaderChannel(object_id, std::move(object)).ok());
+  }
+  manager.OpenSemaphores(object_id);
+  PlasmaObjectHeader::Semaphores sem = manager.GetSemaphores(object_id);
+
+  ASSERT_EQ(sem_wait(sem.object_sem), 0);
+  ASSERT_EQ(sem_wait(sem.header_sem), 0);
+  std::thread writer(Write, header, std::ref(sem), /*num_writes=*/kNumReads, kNumReaders);
+
+  // Writer thread is blocked on `sem.object_sem`.
+  header->SetErrorUnlocked(sem);
+  // Writer thread is now unblocked.
+
+  writer.join();
+  // Check that the writer never entered the critical section.
+  ASSERT_EQ(header->version, 0);
+
+  // Check that another writer that calls `WriteAcquire()` exits on its own without
+  // blocking on `sem.header_sem`.
+  writer =
+      std::thread(Write, header, std::ref(sem), /*num_writes=*/kNumReads, kNumReaders);
+  writer.join();
+  ASSERT_EQ(header->version, 0);
+}
+
+// Tests that a reader can detect a failure while it is in `ReadAcquire()`.
+TEST(MutableObjectTest, TestReadAcquireDuringFailure) {
+  ExperimentalMutableObjectManager manager;
+  ObjectID object_id = ObjectID::FromRandom();
+  plasma::PlasmaObjectHeader *header;
+  {
+    std::unique_ptr<plasma::MutableObject> object = MakeObject();
+    header = object->header;
+    header->Init();
+    ASSERT_TRUE(manager.RegisterReaderChannel(object_id, std::move(object)).ok());
+  }
+  manager.OpenSemaphores(object_id);
+  PlasmaObjectHeader::Semaphores sem = manager.GetSemaphores(object_id);
+
+  std::vector<std::string> data_results;
+  std::vector<std::string> metadata_results;
+  std::thread reader(Read,
+                     header,
+                     std::ref(sem),
+                     kNumReads,
+                     std::ref(data_results),
+                     std::ref(metadata_results));
+
+  {
+    std::string data = "hello";
+    std::string metadata = std::to_string(data.size());
+    ASSERT_TRUE(
+        header->WriteAcquire(sem, data.size(), metadata.size(), /*write_num_readers=*/1)
+            .ok());
+    ASSERT_TRUE(header->WriteRelease(sem).ok());
+  }
+
+  // Reader thread is blocked on `sem.header_sem`.
+  header->SetErrorUnlocked(sem);
+  // Reader thread is now unblocked.
+
+  reader.join();
+  // Check that the reader never entered the critical section.
+  ASSERT_EQ(data_results.size(), 1);
+  ASSERT_EQ(metadata_results.size(), 1);
+  ASSERT_EQ(data_results.front(), "error");
+  ASSERT_EQ(metadata_results.front(), "error");
+
+  // Check that another reader that calls `ReadAcquire()` exits on its own without
+  // blocking on `sem.header_sem`.
+  data_results.clear();
+  metadata_results.clear();
+  reader = std::thread(Read,
+                       header,
+                       std::ref(sem),
+                       kNumReads,
+                       std::ref(data_results),
+                       std::ref(metadata_results));
+  reader.join();
+  ASSERT_EQ(data_results.size(), 1);
+  ASSERT_EQ(metadata_results.size(), 1);
+  ASSERT_EQ(data_results.front(), "error");
+  ASSERT_EQ(metadata_results.front(), "error");
+}
+
+// Tests that multiple readers can detect a failure while they are in `ReadAcquire()`.
+TEST(MutableObjectTest, TestReadMultipleAcquireDuringFailure) {
+  ExperimentalMutableObjectManager manager;
+  ObjectID object_id = ObjectID::FromRandom();
+  plasma::PlasmaObjectHeader *header;
+  {
+    std::unique_ptr<plasma::MutableObject> object = MakeObject();
+    header = object->header;
+    header->Init();
+    ASSERT_TRUE(manager.RegisterReaderChannel(object_id, std::move(object)).ok());
+  }
+  manager.OpenSemaphores(object_id);
+  PlasmaObjectHeader::Semaphores sem = manager.GetSemaphores(object_id);
+
+  std::vector<std::vector<std::string>> data_results(/*count=*/kNumReaders,
+                                                     std::vector<std::string>());
+  std::vector<std::vector<std::string>> metadata_results(/*count=*/kNumReaders,
+                                                         std::vector<std::string>());
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < kNumReaders; i++) {
+    std::thread t(Read,
+                  header,
+                  std::ref(sem),
+                  kNumReads,
+                  std::ref(data_results[i]),
+                  std::ref(metadata_results[i]));
+    threads.emplace_back(std::move(t));
+  }
+
+  {
+    std::string data = "hello";
+    std::string metadata = std::to_string(data.size());
+    ASSERT_TRUE(
+        header->WriteAcquire(sem, data.size(), metadata.size(), kNumReaders).ok());
+    ASSERT_TRUE(header->WriteRelease(sem).ok());
+  }
+
+  // Reader threads are blocked on `sem.header_sem`.
+  header->SetErrorUnlocked(sem);
+  // Reader threads are now unblocked.
+
+  for (std::thread &t : threads) {
+    t.join();
+  }
+  // Check that the readers never entered the critical section.
+  for (size_t i = 0; i < kNumReaders; i++) {
+    ASSERT_EQ(data_results[i].size(), metadata_results[i].size());
+    size_t size = data_results[i].size();
+    ASSERT_GE(size, 1);
+    ASSERT_LE(size, 2);
+    ASSERT_EQ(data_results[i].back(), "error");
+    ASSERT_EQ(metadata_results[i].back(), "error");
+  }
+
+  // Check that more readers that call `ReadAcquire()` exit on their own without blocking
+  // on `sem.header_sem`.
+  std::fill(data_results.begin(), data_results.end(), std::vector<std::string>());
+  std::fill(metadata_results.begin(), metadata_results.end(), std::vector<std::string>());
+  threads.clear();
+  for (size_t i = 0; i < kNumReaders; i++) {
+    std::thread t(Read,
+                  header,
+                  std::ref(sem),
+                  kNumReads,
+                  std::ref(data_results[i]),
+                  std::ref(metadata_results[i]));
+    threads.emplace_back(std::move(t));
+  }
+  for (std::thread &t : threads) {
+    t.join();
+  }
+  for (size_t i = 0; i < kNumReaders; i++) {
+    ASSERT_EQ(data_results[i].size(), metadata_results[i].size());
+    size_t size = data_results[i].size();
+    ASSERT_GE(size, 1);
+    ASSERT_LE(size, 2);
+    ASSERT_EQ(data_results[i].back(), "error");
+    ASSERT_EQ(metadata_results[i].back(), "error");
+  }
+}
+
+}  // namespace ray
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/ray/object_manager/plasma/test/mutable_object_test.cc
+++ b/src/ray/object_manager/plasma/test/mutable_object_test.cc
@@ -24,6 +24,9 @@
 using namespace testing;
 
 namespace ray {
+
+#if defined(__APPLE__) || defined(__linux__)
+
 namespace {
 
 constexpr size_t kNumReads = 10000;
@@ -591,6 +594,8 @@ TEST(MutableObjectTest, TestReadMultipleAcquireDuringFailure) {
     ASSERT_EQ(metadata_results[i].back(), "error");
   }
 }
+
+#endif  // defined(__APPLE__) || defined(__linux__)
 
 }  // namespace ray
 


### PR DESCRIPTION
Support Darwin for accelerated DAGs
    
Accelerated DAGs require semaphores. Linux supports unnamed semaphores, though Darwin only supports named semaphores. Thus, this commit updates Ray to use named semaphores.
    
Additionally, I implemented a different synchronization scheme to avoid pthread_mutex_timedlock() and sem_timedwait(), neither of which are available on Darwin.
    
Tested: mutable_object_test on both Linux and macOS (Darwin)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

These changes are needed so that accelerated DAGs can be developed and run on both Linux and macOS (Darwin).

## Related issue number

Closes #43834.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
