### PR TITLE
do not call absl::InitializeSymbolizer on windows

### DIFF
--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -383,6 +383,9 @@ void RayLog::InstallFailureSignalHandler(const char *argv0, bool call_previous_h
   if (is_failure_signal_handler_installed_) {
     return;
   }
+  // InitializeSymbolizer cannot be called twice, and is called in
+  // other libraries like pytorchaudio. So do not call it here.
+  // absl::InitializeSymbolizer(argv0);
   absl::InitializeSymbolizer(argv0);
   absl::FailureSignalHandlerOptions options;
   options.call_previous_handler = call_previous_handler;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -383,10 +383,11 @@ void RayLog::InstallFailureSignalHandler(const char *argv0, bool call_previous_h
   if (is_failure_signal_handler_installed_) {
     return;
   }
-  // InitializeSymbolizer cannot be called twice, and is called in
-  // other libraries like pytorchaudio. So do not call it here.
+  // InitializeSymbolizer cannot be called twice, (causes a crash)and is called
+  // in other libraries like pytorchaudio. It does not seem there is a API to
+  // determine if it has already been called, and is only needed to provide
+  // better stack traces on crahses. So do not call it here.
   // absl::InitializeSymbolizer(argv0);
-  absl::InitializeSymbolizer(argv0);
   absl::FailureSignalHandlerOptions options;
   options.call_previous_handler = call_previous_handler;
   options.writerfn = WriteFailureMessage;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -383,11 +383,13 @@ void RayLog::InstallFailureSignalHandler(const char *argv0, bool call_previous_h
   if (is_failure_signal_handler_installed_) {
     return;
   }
-  // InitializeSymbolizer cannot be called twice, (causes a crash)and is called
-  // in other libraries like pytorchaudio. It does not seem there is a API to
-  // determine if it has already been called, and is only needed to provide
-  // better stack traces on crahses. So do not call it here.
-  // absl::InitializeSymbolizer(argv0);
+#ifndef _WIN32
+  // InitializeSymbolizer cannot be called twice on windows, (causes a
+  // crash)and is called in other libraries like pytorchaudio. It does not seem
+  // there is a API to determine if it has already been called, and is only
+  // needed to provide better stack traces on crashes. So do not call it here.
+  absl::InitializeSymbolizer(argv0);
+#endif
   absl::FailureSignalHandlerOptions options;
   options.call_previous_handler = call_previous_handler;
   options.writerfn = WriteFailureMessage;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Calling `absl::InitializeSymbolizer` twice will crash on windows. Other libraries, like pytorchaudio, call it on import. So ray should not call it. The function is "nice to have", it gives a better traceback on crashes.

## Related issue number
Closes #42690

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
