### PR TITLE
[ci] mark rllib_learner_group_checkpointing_multinode as unstable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2841,6 +2841,7 @@
 
   frequency: nightly
   team: rllib
+  stable: False
 
   cluster:
     byod:


### PR DESCRIPTION
Mark rllib_learner_group_checkpointing_multinode as unstable. It has been failing since December and the API it uses has been deleted seen

Test:
- CI