### PR TITLE
[ci] fix a few tests on macosx

### DIFF
--- a/.buildkite/macos/macos.rayci.yml
+++ b/.buildkite/macos/macos.rayci.yml
@@ -84,7 +84,6 @@ steps:
       - oss
     job_env: MACOS
     instance_type: macos
-    soft_fail: true
     commands:
       - ./ci/ray_ci/macos/macos_ci.sh run_core_dashboard_test
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1217,6 +1217,9 @@ ray_cc_test(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest_main",
     ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
 )
 
 ray_cc_test(

--- a/dashboard/BUILD
+++ b/dashboard/BUILD
@@ -84,7 +84,7 @@ py_test(
 py_test(
     name = "test_metrics_integration",
     size = "medium",
-    srcs = ["tests/test_metrics_integration.py"],
+    srcs = ["modules/tests/test_metrics_integration.py"],
     deps = [":conftest"],
     tags = ["exclusive", "team:clusters"],
 )


### PR DESCRIPTION
Fix the 'core and dashboard tests', they are currently fail to build these two tests: https://buildkite.com/ray-project/postmerge-macos/builds/210#018e5df5-b706-4629-96e4-b0612621d205/3815-5824

One of the test the path to the test file is incorrect (however it's symlink version runs fine https://buildkite.com/ray-project/postmerge-macos/builds/210#018e5df5-b706-4629-96e4-b0612621d205/3815-5952)

The other one should not be run on macos

Test:
- CI