### PR TITLE
[Data] [Docs] Adding in missing imports to code in doc

### DIFF
--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -183,7 +183,9 @@ pandas DataFrame or a dictionary with string keys and NumPy ndarrays values. For
 
 .. testcode::
 
-    def fn(batch: pandas.DataFrame) -> pandas.DataFrame:
+    import pandas as pd
+
+    def fn(batch: pd.DataFrame) -> pd.DataFrame:
         # modify batch
         batch = ...
 
@@ -195,6 +197,8 @@ be of type ``Callable[DataBatch, Iterator[[DataBatch]]``, where ``DataBatch = Un
 In this case, your function would look like:
 
 .. testcode::
+
+    import numpy as np
 
     def fn(batch: Dict[str, np.ndarray]) -> Iterator[Dict[str, np.ndarray]]:
         # yield the same batch multiple times


### PR DESCRIPTION
## Why are these changes needed?
#44093 broke one of the data doc tests that was not run on premerge (example here: https://buildkite.com/ray-project/postmerge/builds/3645). This adds missing imports to fix that.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
