### PR TITLE
[Data] [Docs] Adding in references to explain how to use credentials with Ray Data

### DIFF
--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -209,6 +209,10 @@ To read formats other than Parquet, see the :ref:`Input/Output reference <input-
             petal.width   double
             variety       string
 
+        Ray Data relies on PyArrow for authenticaion with Amazon S3. For more on how to configure
+        your credentials to be compatible with PyArrow, see their
+        `S3 Filesytem docs <https://arrow.apache.org/docs/python/filesystems.html#s3>`_.
+
     .. tab-item:: GCS
 
         To read files from Google Cloud Storage, install the
@@ -227,7 +231,7 @@ To read formats other than Parquet, see the :ref:`Input/Output reference <input-
 
             filesystem = gcsfs.GCSFileSystem(project="my-google-project")
             ds = ray.data.read_parquet(
-                "s3://anonymous@ray-example-data/iris.parquet",
+                "gcs://anonymous@ray-example-data/iris.parquet",
                 filesystem=filesystem
             )
 
@@ -242,6 +246,10 @@ To read formats other than Parquet, see the :ref:`Input/Output reference <input-
             petal.length  double
             petal.width   double
             variety       string
+
+        Ray Data relies on PyArrow for authenticaion with Google Cloud Storage. For more on how
+        to configure your credentials to be compatible with PyArrow, see their
+        `GCS Filesytem docs <https://arrow.apache.org/docs/python/filesystems.html#google-cloud-storage-file-system>`_.
 
     .. tab-item:: ABS
 
@@ -276,6 +284,10 @@ To read formats other than Parquet, see the :ref:`Input/Output reference <input-
             petal.length  double
             petal.width   double
             variety       string
+
+        Ray Data relies on PyArrow for authenticaion with Azure Blob Storage. For more on how
+        to configure your credentials to be compatible with PyArrow, see their
+        `fsspec-compatible filesystems docs <https://arrow.apache.org/docs/python/filesystems.html#using-fsspec-compatible-filesystems-with-arrow>`_.
 
 Reading files from NFS
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/data/saving-data.rst
+++ b/doc/source/data/saving-data.rst
@@ -47,6 +47,8 @@ with your cloud service provider. Then, call a method like
 :meth:`Dataset.write_parquet <ray.data.Dataset.write_parquet>` and specify a URI with
 the appropriate scheme. URI can point to buckets or folders.
 
+To write data to formats other than Parquet, read the :ref:`Input/Output reference <input-output>`.
+
 .. tab-set::
 
     .. tab-item:: S3
@@ -61,6 +63,10 @@ the appropriate scheme. URI can point to buckets or folders.
             ds = ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv")
 
             ds.write_parquet("s3://my-bucket/my-folder")
+
+        Ray Data relies on PyArrow for authenticaion with Amazon S3. For more on how to configure
+        your credentials to be compatible with PyArrow, see their
+        `S3 Filesytem docs <https://arrow.apache.org/docs/python/filesystems.html#s3>`_.
 
     .. tab-item:: GCS
 
@@ -83,6 +89,10 @@ the appropriate scheme. URI can point to buckets or folders.
             filesystem = gcsfs.GCSFileSystem(project="my-google-project")
             ds.write_parquet("gcs://my-bucket/my-folder", filesystem=filesystem)
 
+        Ray Data relies on PyArrow for authenticaion with Google Cloud Storage. For more on how
+        to configure your credentials to be compatible with PyArrow, see their
+        `GCS Filesytem docs <https://arrow.apache.org/docs/python/filesystems.html#google-cloud-storage-file-system>`_.
+
     .. tab-item:: ABS
 
         To save data to Azure Blob Storage, install the
@@ -104,8 +114,9 @@ the appropriate scheme. URI can point to buckets or folders.
             filesystem = adlfs.AzureBlobFileSystem(account_name="azureopendatastorage")
             ds.write_parquet("az://my-bucket/my-folder", filesystem=filesystem)
 
-To write data to formats other than Parquet, read the
-:ref:`Input/Output reference <input-output>`.
+        Ray Data relies on PyArrow for authenticaion with Azure Blob Storage. For more on how
+        to configure your credentials to be compatible with PyArrow, see their
+        `fsspec-compatible filesystems docs <https://arrow.apache.org/docs/python/filesystems.html#using-fsspec-compatible-filesystems-with-arrow>`_.
 
 Writing data to NFS
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Why are these changes needed?
Our docs currently do not explain how to configure credentials to be used with Ray Data. This adds references to PyArrow that explain how to setup credentials for S3, GCS, and ABS.

Docs from PR:
[Loading data](https://anyscale-ray--44205.com.readthedocs.build/en/44205/data/loading-data.html#reading-files-from-cloud-storage)
[Saving data](https://anyscale-ray--44205.com.readthedocs.build/en/44205/data/saving-data.html#writing-data-to-cloud-storage)

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
