### PR TITLE
[ci] fix windows wheel build

### DIFF
--- a/ci/ray_ci/windows_builder_container.py
+++ b/ci/ray_ci/windows_builder_container.py
@@ -21,6 +21,12 @@ class WindowsBuilderContainer(WindowsContainer):
     def run(self) -> None:
         cmds = [
             "powershell ci/pipeline/fix-windows-container-networking.ps1",
+            # fix symlink issue across windows and linux
+            "git config --global core.symlinks true",
+            "git config --global core.autocrlf false",
+            "git clone . ray",
+            "cd ray",
+            # build wheel
             f"export BUILD_ONE_PYTHON_ONLY={self.python_version}",
             "./python/build-wheel-windows.sh",
         ]


### PR DESCRIPTION
Currently the windows wheel is missing the python/ray/dashboard directory, since it is a symlink to the dashboard directory. Need to explicitly fix the symlink on windows across OS system.

Test:
- CI