### PR TITLE
[Data] [Docs] Adding in missing typing imports

### DIFF
--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -290,6 +290,7 @@ if __name__ == "__main__":
                     changed_file.endswith(".py")
                     or changed_file.endswith(".ipynb")
                     or changed_file.endswith("BUILD")
+                    or changed_file.endswith(".rst")
                 ):
                     RAY_CI_DOC_AFFECTED = 1
                 # Else, this affects only a rst file or so. In that case,

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -54,6 +54,8 @@ input and output a dictionary with keys of strings and values of any type. For e
 
 .. testcode::
 
+    from typing import Any, Dict
+
     def fn(row: Dict[str, Any]) -> Dict[str, Any]:
         # access row data
         value = row["col1"]
@@ -94,6 +96,8 @@ input a dictionary with keys of strings and values of any type and output a list
 dictionaries that have the same type as the input, for example:
 
 .. testcode::
+
+    from typing import Any, Dict, List
 
     def fn(row: Dict[str, Any]) -> List[Dict[str, Any]]:
         # access row data
@@ -198,6 +202,7 @@ In this case, your function would look like:
 
 .. testcode::
 
+    from typing import Dict, Iterator
     import numpy as np
 
     def fn(batch: Dict[str, np.ndarray]) -> Iterator[Dict[str, np.ndarray]]:


### PR DESCRIPTION
## Why are these changes needed?
Adds more imports that were missing in #44203. Example failure here: https://buildkite.com/ray-project/postmerge/builds/3659#018e615b-eeeb-4a7a-8aed-b5cd139eb64b

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
