### PR TITLE
Pick of 44208

### DIFF
--- a/ci/ray_ci/windows_builder_container.py
+++ b/ci/ray_ci/windows_builder_container.py
@@ -21,6 +21,12 @@ class WindowsBuilderContainer(WindowsContainer):
     def run(self) -> None:
         cmds = [
             "powershell ci/pipeline/fix-windows-container-networking.ps1",
+            # fix symlink issue across windows and linux
+            "git config --global core.symlinks true",
+            "git config --global core.autocrlf false",
+            "git clone . ray",
+            "cd ray",
+            # build wheel
             f"export BUILD_ONE_PYTHON_ONLY={self.python_version}",
             "./python/build-wheel-windows.sh",
         ]


### PR DESCRIPTION
Pick of https://github.com/ray-project/ray/pull/44208/files to fix the window build script on 2.10.0. We managed to re-build the wheel without picking this, but just in case we want to reuse this branch for 2.10.1

Test:
- CI