### PR TITLE
[train] Fix `ScalingConfig(accelerator_type)` to request a small fraction of the accelerator label

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -206,7 +206,7 @@ class ScalingConfig:
 
         if self.accelerator_type:
             accelerator = f"{RESOURCE_CONSTRAINT_PREFIX}{self.accelerator_type}"
-            resources_per_worker.setdefault(accelerator, 1)
+            resources_per_worker.setdefault(accelerator, 0.001)
         return resources_per_worker
 
     @property

--- a/python/ray/air/tests/test_api.py
+++ b/python/ray/air/tests/test_api.py
@@ -149,14 +149,14 @@ def test_scaling_config_accelerator_type():
     }
     assert scaling_config._resources_per_worker_not_none == {
         "GPU": 1,
-        "accelerator_type:A100": 1,
+        "accelerator_type:A100": 0.001,
     }
     assert scaling_config.additional_resources_per_worker == {
-        "accelerator_type:A100": 1
+        "accelerator_type:A100": 0.001
     }
     assert scaling_config.as_placement_group_factory().bundles == [
-        {"GPU": 1, "accelerator_type:A100": 1, "CPU": 1},
-        {"GPU": 1, "accelerator_type:A100": 1},
+        {"GPU": 1, "accelerator_type:A100": 0.001, "CPU": 1},
+        {"GPU": 1, "accelerator_type:A100": 0.001},
     ]
 
     # With resources_per_worker
@@ -172,15 +172,15 @@ def test_scaling_config_accelerator_type():
     assert scaling_config._resources_per_worker_not_none == {
         "GPU": 1,
         "custom_resource": 1,
-        "accelerator_type:A100": 1,
+        "accelerator_type:A100": 0.001,
     }
     assert scaling_config.additional_resources_per_worker == {
         "custom_resource": 1,
-        "accelerator_type:A100": 1,
+        "accelerator_type:A100": 0.001,
     }
     assert scaling_config.as_placement_group_factory().bundles == [
-        {"GPU": 1, "custom_resource": 1, "accelerator_type:A100": 1, "CPU": 1},
-        {"GPU": 1, "custom_resource": 1, "accelerator_type:A100": 1},
+        {"GPU": 1, "custom_resource": 1, "accelerator_type:A100": 0.001, "CPU": 1},
+        {"GPU": 1, "custom_resource": 1, "accelerator_type:A100": 0.001},
     ]
 
     # With trainer_resources
@@ -195,14 +195,14 @@ def test_scaling_config_accelerator_type():
     }
     assert scaling_config._resources_per_worker_not_none == {
         "GPU": 1,
-        "accelerator_type:A100": 1,
+        "accelerator_type:A100": 0.001,
     }
     assert scaling_config.additional_resources_per_worker == {
-        "accelerator_type:A100": 1
+        "accelerator_type:A100": 0.001
     }
     assert scaling_config.as_placement_group_factory().bundles == [
-        {"GPU": 1, "accelerator_type:A100": 1, "memory": 10 * 1024**3},
-        {"GPU": 1, "accelerator_type:A100": 1},
+        {"GPU": 1, "accelerator_type:A100": 0.001, "memory": 10 * 1024**3},
+        {"GPU": 1, "accelerator_type:A100": 0.001},
     ]
 
 

--- a/python/ray/train/tests/test_data_parallel_trainer.py
+++ b/python/ray/train/tests/test_data_parallel_trainer.py
@@ -51,9 +51,11 @@ def ray_start_heterogenous_cluster():
             cluster.add_node(
                 num_cpus=4,
                 num_gpus=4,
-                resources={f"{RESOURCE_CONSTRAINT_PREFIX}{accelerator_type}": 4}
-                if accelerator_type
-                else {},
+                resources=(
+                    {f"{RESOURCE_CONSTRAINT_PREFIX}{accelerator_type}": 1.0}
+                    if accelerator_type
+                    else {}
+                ),
             )
 
     ray.init(address=cluster.address)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`accelerator_type` is currently implemented as a custom resource with a quantity of 1 if an instance has an accelerator of that type. For example, both a machine with 1 A10G GPU and a machine with 4 A10G GPUs will have `{"accelerator_type:A10G": 1.0}`. This label is just an indicator of whether the machine contains the accelerator, rather than a count of the number of accelerators of that type.

This PR makes our accelerator type resource request match Ray Core by setting it to a fractional value (0.001). This is needed to fix autoscaling behavior to request the correct number of GPUs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
