### PR TITLE
[Core] Fix race condition in multi-threaded actor creation

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -91,6 +91,9 @@ class FunctionActorManager:
         #         -> _load_actor_class_from_gcs (acquire lock, too)
         # So, the lock should be a reentrant lock.
         self.lock = threading.RLock()
+        # This is to ensure the export_actor_class() method is called only once
+        # when multiple threads call it at the same time
+        self.export_actor_lock = threading.Lock()
 
         self.execution_infos = {}
         # This is the counter to keep track of how many keys have already

--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -91,9 +91,6 @@ class FunctionActorManager:
         #         -> _load_actor_class_from_gcs (acquire lock, too)
         # So, the lock should be a reentrant lock.
         self.lock = threading.RLock()
-        # This is to ensure the export_actor_class() method is called only once
-        # when multiple threads call it at the same time
-        self.export_actor_lock = threading.Lock()
 
         self.execution_infos = {}
         # This is the counter to keep track of how many keys have already

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1034,8 +1034,9 @@ class ActorClass:
             # we need to export this function again, because current GCS
             # doesn't have it.
             with meta.export_lock:
-                # With the lock held, check meta.last_export_session_and_job one more time
-                # before exporting the actor class as it might have been exported by another thread.
+                # With the lock held, check meta.last_export_session_and_job
+                # one more time before exporting the actor class as it might
+                # have been exported by another thread.
                 if meta.last_export_session_and_job != worker.current_session_and_job:
                     # After serialize / deserialize modified class, the __module__
                     # of modified class will be ray.cloudpickle.cloudpickle.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1,6 +1,5 @@
 import inspect
 import logging
-import threading
 import weakref
 from typing import Any, Dict, List, Optional, Union
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -539,9 +539,7 @@ class _ActorClassMetadata:
         self.runtime_env = runtime_env
         self.concurrency_groups = concurrency_groups
         self.scheduling_strategy = scheduling_strategy
-        # Guarded by self.export_lock
         self.last_export_session_and_job = None
-        self.export_lock = threading.Lock()
         self.method_meta = _ActorClassMethodMetadata.create(
             modified_class, actor_creation_function_descriptor
         )
@@ -1033,21 +1031,17 @@ class ActorClass:
             # If this actor class was not exported in this session and job,
             # we need to export this function again, because current GCS
             # doesn't have it.
-            with meta.export_lock:
-                # With the lock held, check meta.last_export_session_and_job
-                # one more time before exporting the actor class as it might
-                # have been exported by another thread.
-                if meta.last_export_session_and_job != worker.current_session_and_job:
-                    # After serialize / deserialize modified class, the __module__
-                    # of modified class will be ray.cloudpickle.cloudpickle.
-                    # So, here pass actor_creation_function_descriptor to make
-                    # sure export actor class correct.
-                    worker.function_actor_manager.export_actor_class(
-                        meta.modified_class,
-                        meta.actor_creation_function_descriptor,
-                        meta.method_meta.methods.keys(),
-                    )
-                    meta.last_export_session_and_job = worker.current_session_and_job
+
+            # After serialize / deserialize modified class, the __module__
+            # of modified class will be ray.cloudpickle.cloudpickle.
+            # So, here pass actor_creation_function_descriptor to make
+            # sure export actor class correct.
+            worker.function_actor_manager.export_actor_class(
+                meta.modified_class,
+                meta.actor_creation_function_descriptor,
+                meta.method_meta.methods.keys(),
+            )
+            meta.last_export_session_and_job = worker.current_session_and_job
 
         resources = ray._private.utils.resources_from_ray_options(actor_options)
         # Set the actor's default resources if not already set. First three

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1173,7 +1173,7 @@ def test_get_actor_race_condition(shutdown_only):
         assert ["ok"] * CONCURRENCY == results
 
 
-def test_create_actor_race_condition():
+def test_create_actor_race_condition(shutdown_only):
     """Make sure we can create actors in multiple threads without
     race conditions.
 

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1224,6 +1224,7 @@ def test_create_actor_race_condition(shutdown_only):
         )  # Creation and get should be successful
         ray.kill(actor)  # Cleanup
 
+    ray.init()
     for _ in range(50):
         run_and_check()
 

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1175,13 +1175,19 @@ def test_get_actor_race_condition(shutdown_only):
 def test_create_actor_race_condition():
     ACTOR_NAME = "TestActor"
     ACTOR_NAMESPACE = "TestNamespace"
+
     @ray.remote
     class Actor:
         pass
 
     def create():
         time.sleep(random.random())
-        Actor.options(name=ACTOR_NAME, namespace=ACTOR_NAMESPACE, get_if_exists=True, lifetime="detached").remote()
+        Actor.options(
+            name=ACTOR_NAME,
+            namespace=ACTOR_NAMESPACE,
+            get_if_exists=True,
+            lifetime="detached",
+        ).remote()
 
     threads = []
     for _ in range(1000):
@@ -1193,7 +1199,10 @@ def test_create_actor_race_condition():
     for thread in threads:
         thread.join()
 
-    ray.get_actor(ACTOR_NAME, namespace=ACTOR_NAMESPACE) # Creation and get should be successful
+    ray.get_actor(
+        ACTOR_NAME, namespace=ACTOR_NAMESPACE
+    )  # Creation and get should be successful
+
 
 def test_get_actor_in_remote_workers(ray_start_cluster):
     """Make sure we can get and create actors without


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is to fix race condition in multi-threaded actor creation. The race condition is between
setting and checking meta.last_export_session_and_job, specifically:

When thread1 is exporting the actor by calling `worker.function_actor_manager.export_actor_class` in the following block:
```
        if not meta.is_cross_language and (
            meta.last_export_session_and_job != worker.current_session_and_job
        ):
            meta.last_export_session_and_job = worker.current_session_and_job
            worker.function_actor_manager.export_actor_class(
                meta.modified_class,
                meta.actor_creation_function_descriptor,
                meta.method_meta.methods.keys(),
            )
```
Thread2 could be executing the `if` condition in the above code (which evaluates to `False`) and continue to create the actor, however thread2 will fail with an AssersionError later (aborts the process) as it expects the actor to be already exported.

This code fixes the race condition by setting the flag meta.last_export_session_and_job only when the export is done. More details can be found at #41324 .

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #41324
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [x] Run the script that exposes this problem 100 times and all passed
   - [ ] This PR is not tested :(
