### PR TITLE
[gRPC] Adding retry policies for all gRPC clients

### DIFF
--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -165,6 +165,11 @@ inline grpc::ChannelArguments CreateDefaultChannelArguments(
                      ::RayConfig::instance().grpc_client_keepalive_timeout_ms());
   }
 
+  arguments.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA,
+                    ::RayConfig::instance().grpc_http2_max_pings_without_data());
+  arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+                      ::RayConfig::instance().grpc_keepalive_permit_without_calls());
+
   arguments.SetInt(GRPC_ARG_CLIENT_IDLE_TIMEOUT_MS,
                    ::RayConfig::instance().grpc_client_idle_timeout_ms());
 

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -153,7 +153,7 @@ inline absl::flat_hash_map<K, V> MapFromProtobuf(
 inline grpc::ChannelArguments CreateDefaultChannelArguments(const std::string& service_config_json) {
   grpc::ChannelArguments arguments;
 
-  RAY_CHECK(service_config_json.size() > 0, "Provided service config JSON could not be empty");
+  RAY_CHECK(service_config_json.size() > 0);
 
   arguments.SetServiceConfigJSON(service_config_json);
 

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -150,7 +150,8 @@ inline absl::flat_hash_map<K, V> MapFromProtobuf(
   return absl::flat_hash_map<K, V>(pb_map.begin(), pb_map.end());
 }
 
-inline grpc::ChannelArguments CreateDefaultChannelArguments(const std::string& service_config_json) {
+inline grpc::ChannelArguments CreateDefaultChannelArguments(
+    const std::string &service_config_json) {
   grpc::ChannelArguments arguments;
 
   RAY_CHECK(service_config_json.size() > 0);

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -166,9 +166,9 @@ inline grpc::ChannelArguments CreateDefaultChannelArguments(
   }
 
   arguments.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA,
-                    ::RayConfig::instance().grpc_http2_max_pings_without_data());
+                   ::RayConfig::instance().grpc_http2_max_pings_without_data());
   arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS,
-                      ::RayConfig::instance().grpc_keepalive_permit_without_calls());
+                   ::RayConfig::instance().grpc_keepalive_permit_without_calls());
 
   arguments.SetInt(GRPC_ARG_CLIENT_IDLE_TIMEOUT_MS,
                    ::RayConfig::instance().grpc_client_idle_timeout_ms());

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -150,16 +150,23 @@ inline absl::flat_hash_map<K, V> MapFromProtobuf(
   return absl::flat_hash_map<K, V>(pb_map.begin(), pb_map.end());
 }
 
-inline grpc::ChannelArguments CreateDefaultChannelArguments() {
+inline grpc::ChannelArguments CreateDefaultChannelArguments(const std::string& service_config_json) {
   grpc::ChannelArguments arguments;
+
+  RAY_CHECK(service_config_json.size() > 0, "Provided service config JSON could not be empty");
+
+  arguments.SetServiceConfigJSON(service_config_json);
+
   if (::RayConfig::instance().grpc_client_keepalive_time_ms() > 0) {
     arguments.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,
                      ::RayConfig::instance().grpc_client_keepalive_time_ms());
     arguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
                      ::RayConfig::instance().grpc_client_keepalive_timeout_ms());
   }
+
   arguments.SetInt(GRPC_ARG_CLIENT_IDLE_TIMEOUT_MS,
                    ::RayConfig::instance().grpc_client_idle_timeout_ms());
+
   return arguments;
 }
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -777,12 +777,15 @@ RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 300000)
 /// gRPC keep-alive timeout for client.
 RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)
 /// Number of keep-alive pings client can send before needing to send a data/header frame
-/// (0 indicates that an infinite number of pings can be sent without sending a data frame or header frame)
+/// (0 indicates that an infinite number of pings can be sent without sending a data frame
+/// or header frame)
 RAY_CONFIG(int64_t, grpc_http2_max_pings_without_data, 0)
-/// Is it permissible to send keepalive pings from the client without any outstanding streams
+/// Is it permissible to send keepalive pings from the client without any outstanding
+/// streams
 RAY_CONFIG(int64_t, grpc_keepalive_permit_without_calls, 1)
 
-/// Timeout after the last RPC finishes on the client channel at which the channel goes back into IDLE state
+/// Timeout after the last RPC finishes on the client channel at which the channel goes
+/// back into IDLE state
 RAY_CONFIG(int64_t, grpc_client_idle_timeout_ms, 1800000)
 
 /// gRPC streaming buffer size

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -768,19 +768,19 @@ RAY_CONFIG(int64_t, grpc_keepalive_time_ms, 10000)
 /// grpc keepalive timeout.
 RAY_CONFIG(int64_t, grpc_keepalive_timeout_ms, 20000)
 
-/// NOTE: we set a loose client keep alive because
+/// NOTE: We set a loose client keep alive because
 /// they have a failure model that considers network failures as component failures
 /// and this configuration break that assumption. We should apply to every other component
 /// after we change this failure assumption from code.
 /// grpc keepalive timeout for client.
 RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 300000)
-
-/// grpc keepalive timeout for client.
+/// gRPC keep-alive timeout for client.
 RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)
 
+/// Timeout after the last RPC finishes on the client channel at which the channel goes back into IDLE state
 RAY_CONFIG(int64_t, grpc_client_idle_timeout_ms, 1800000)
 
-/// grpc streaming buffer size
+/// gRPC streaming buffer size
 /// Set it to 512kb
 RAY_CONFIG(int64_t, grpc_stream_buffer_size, 512 * 1024);
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -776,6 +776,11 @@ RAY_CONFIG(int64_t, grpc_keepalive_timeout_ms, 20000)
 RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 300000)
 /// gRPC keep-alive timeout for client.
 RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)
+/// Number of keep-alive pings client can send before needing to send a data/header frame
+/// (0 indicates that an infinite number of pings can be sent without sending a data frame or header frame)
+RAY_CONFIG(int64_t, grpc_http2_max_pings_without_data, 0)
+/// Is it permissible to send keepalive pings from the client without any outstanding streams
+RAY_CONFIG(int64_t, grpc_keepalive_permit_without_calls, 1)
 
 /// Timeout after the last RPC finishes on the client channel at which the channel goes back into IDLE state
 RAY_CONFIG(int64_t, grpc_client_idle_timeout_ms, 1800000)

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -176,7 +176,8 @@ class GcsRpcClient {
  public:
   static std::shared_ptr<grpc::Channel> CreateGcsChannel(const std::string &address,
                                                          int port) {
-    std::string service_config_json = R"{
+    std::string service_config_json = R"(
+    {
       "methodConfig": [{
         "name": [
           ////////////////////////////////////////////////////////////////
@@ -246,7 +247,8 @@ class GcsRpcClient {
           ]
         }
       }]
-    }";
+    }
+    )";
 
     grpc::ChannelArguments arguments = CreateDefaultChannelArguments(service_config_json);
 

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -179,64 +179,64 @@ class GcsRpcClient {
     // Please refer to explanation of gRPC returned statuses for more details:
     // REF: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
     std::string service_config_json = R"(
-    {
-      "methodConfig": [{
-        "name": [
-          {"service": "ray.rpc.NodeInfoGcsService", "method": "DrainNode"},
+      {
+        "methodConfig": [{
+          "name": [
+            {"service": "ray.rpc.NodeInfoGcsService", "method": "DrainNode"},
 
-          {"service": "ray.rpc.JobInfoGcsService", "method": "MarkJobFinished"},
-          {"service": "ray.rpc.JobInfoGcsService", "method": "ReportJobError"},
+            {"service": "ray.rpc.JobInfoGcsService", "method": "MarkJobFinished"},
+            {"service": "ray.rpc.JobInfoGcsService", "method": "ReportJobError"},
 
-          {"service": "ray.rpc.ActorInfoGcsService", "method": "RegisterActor"},
+            {"service": "ray.rpc.ActorInfoGcsService", "method": "RegisterActor"},
 
-          {"service": "ray.rpc.WorkerInfoGcsService", "method": "ReportWorkerFailure"},
-          {"service": "ray.rpc.WorkerInfoGcsService", "method": "UpdateWorkerDebuggerPort"},
+            {"service": "ray.rpc.WorkerInfoGcsService", "method": "ReportWorkerFailure"},
+            {"service": "ray.rpc.WorkerInfoGcsService", "method": "UpdateWorkerDebuggerPort"},
 
-          {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVPut"},
-          {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVDel"},
+            {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVPut"},
+            {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVDel"},
 
-          {"service": "ray.rpc.NodeResourceInfoGcsService", "method": "GetAllAvailableResources"},
-          {"service": "ray.rpc.NodeResourceInfoGcsService", "method": "GetAllResourceUsage"},
-          {"service": "ray.rpc.NodeResourceInfoGcsService", "method": "GetDrainingNodesRequest"},
+            {"service": "ray.rpc.NodeResourceInfoGcsService", "method": "GetAllAvailableResources"},
+            {"service": "ray.rpc.NodeResourceInfoGcsService", "method": "GetAllResourceUsage"},
+            {"service": "ray.rpc.NodeResourceInfoGcsService", "method": "GetDrainingNodesRequest"},
 
-          {"service": "ray.rpc.NodeInfoGcsService", "method": "GetClusterId"},
-          {"service": "ray.rpc.NodeInfoGcsService", "method": "GetAllNodeInfo"},
-          {"service": "ray.rpc.NodeInfoGcsService", "method": "GetInternalConfig"},
-          {"service": "ray.rpc.NodeInfoGcsService", "method": "CheckAlive"},
+            {"service": "ray.rpc.NodeInfoGcsService", "method": "GetClusterId"},
+            {"service": "ray.rpc.NodeInfoGcsService", "method": "GetAllNodeInfo"},
+            {"service": "ray.rpc.NodeInfoGcsService", "method": "GetInternalConfig"},
+            {"service": "ray.rpc.NodeInfoGcsService", "method": "CheckAlive"},
 
-          {"service": "ray.rpc.JobInfoGcsService", "method": "GetAllJobInfo"},
+            {"service": "ray.rpc.JobInfoGcsService", "method": "GetAllJobInfo"},
 
-          {"service": "ray.rpc.ActorInfoGcsService", "method": "GetActorInfo"},
-          {"service": "ray.rpc.ActorInfoGcsService", "method": "GetNamedActorInfo"},
-          {"service": "ray.rpc.ActorInfoGcsService", "method": "ListNamedActors"},
-          {"service": "ray.rpc.ActorInfoGcsService", "method": "GetAllActorInfo"},
+            {"service": "ray.rpc.ActorInfoGcsService", "method": "GetActorInfo"},
+            {"service": "ray.rpc.ActorInfoGcsService", "method": "GetNamedActorInfo"},
+            {"service": "ray.rpc.ActorInfoGcsService", "method": "ListNamedActors"},
+            {"service": "ray.rpc.ActorInfoGcsService", "method": "GetAllActorInfo"},
 
-          {"service": "ray.rpc.WorkerInfoGcsService", "method": "GetWorkerInfo"},
-          {"service": "ray.rpc.WorkerInfoGcsService", "method": "GetAllWorkerInfo"},
+            {"service": "ray.rpc.WorkerInfoGcsService", "method": "GetWorkerInfo"},
+            {"service": "ray.rpc.WorkerInfoGcsService", "method": "GetAllWorkerInfo"},
 
-          {"service": "ray.rpc.PlacementGroupInfoGcsService", "method": "GetPlacementGroup"},
-          {"service": "ray.rpc.PlacementGroupInfoGcsService", "method": "GetNamedPlacementGroup"},
-          {"service": "ray.rpc.PlacementGroupInfoGcsService", "method": "GetAllPlacementGroup"},
+            {"service": "ray.rpc.PlacementGroupInfoGcsService", "method": "GetPlacementGroup"},
+            {"service": "ray.rpc.PlacementGroupInfoGcsService", "method": "GetNamedPlacementGroup"},
+            {"service": "ray.rpc.PlacementGroupInfoGcsService", "method": "GetAllPlacementGroup"},
 
-          {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVGet"},
-          {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVMultiGet"},
-          {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVExists"},
-          {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVKeys"},
-        ],
-        "retryPolicy": {
-          "maxAttempts": 3,
-          "initialBackoff": "0.5s",
-          "maxBackoff": "2s",
-          "backoffMultiplier": 2,
-          "retryableStatusCodes": [
-              "UNAVAILABLE",
-              "DEADLINE_EXCEEDED",
-              "INTERNAL",
-              "UNKNOWN",
+            {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVGet"},
+            {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVMultiGet"},
+            {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVExists"},
+            {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVKeys"}
           ],
-        }
-      }]
-    }
+          "retryPolicy": {
+            "maxAttempts": 3,
+            "initialBackoff": "0.5s",
+            "maxBackoff": "2s",
+            "backoffMultiplier": 2,
+            "retryableStatusCodes": [
+                "UNAVAILABLE",
+                "DEADLINE_EXCEEDED",
+                "INTERNAL",
+                "UNKNOWN"
+            ]
+          }
+        }]
+      }
     )";
 
     grpc::ChannelArguments arguments = CreateDefaultChannelArguments(service_config_json);

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -229,14 +229,11 @@ class GcsRpcClient {
           "maxBackoff": "2s",
           "backoffMultiplier": 2,
           "retryableStatusCodes": [
-            "retryableStatusCodes": [
-                "UNAVAILABLE",
-                "DEADLINE_EXCEEDED",
-                "INTERNAL",
-                "UNKNOWN",
-                "ABORTED",
-            ],
-          ]
+              "UNAVAILABLE",
+              "DEADLINE_EXCEEDED",
+              "INTERNAL",
+              "UNKNOWN",
+          ],
         }
       }]
     }

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -176,14 +176,12 @@ class GcsRpcClient {
  public:
   static std::shared_ptr<grpc::Channel> CreateGcsChannel(const std::string &address,
                                                          int port) {
+    // Please refer to explanation of gRPC returned statuses for more details:
+    // REF: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
     std::string service_config_json = R"(
     {
       "methodConfig": [{
         "name": [
-          ////////////////////////////////////////////////////////////////
-          // Mutating, but idempotent
-          ////////////////////////////////////////////////////////////////
-
           {"service": "ray.rpc.NodeInfoGcsService", "method": "DrainNode"},
 
           {"service": "ray.rpc.JobInfoGcsService", "method": "MarkJobFinished"},
@@ -196,10 +194,6 @@ class GcsRpcClient {
 
           {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVPut"},
           {"service": "ray.rpc.InternalKVGcsService", "method": "InternalKVDel"},
-
-          ////////////////////////////////////////////////////////////////
-          // Read-only
-          ////////////////////////////////////////////////////////////////
 
           {"service": "ray.rpc.NodeResourceInfoGcsService", "method": "GetAllAvailableResources"},
           {"service": "ray.rpc.NodeResourceInfoGcsService", "method": "GetAllResourceUsage"},
@@ -235,8 +229,6 @@ class GcsRpcClient {
           "maxBackoff": "2s",
           "backoffMultiplier": 2,
           "retryableStatusCodes": [
-            // Please refer to explanation of gRPC returned statuses for more details:
-            // REF: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
             "retryableStatusCodes": [
                 "UNAVAILABLE",
                 "DEADLINE_EXCEEDED",

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -177,7 +177,8 @@ class GrpcClient {
 };
 
 inline grpc::ChannelArguments CreateClientDefaultChannelArguments() {
-  std::string service_config_json = R"{
+  std::string service_config_json = R"(
+  {
     "methodConfig": [{
       "name": [
         // Mutating, but idempotent
@@ -209,8 +210,8 @@ inline grpc::ChannelArguments CreateClientDefaultChannelArguments() {
           ],
         ]
       }
-    }]
-  }";
+    }]}
+  )";
 
   grpc::ChannelArguments arguments = CreateDefaultChannelArguments(service_config_json);
 

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -104,7 +104,7 @@ class GrpcClient {
              ClientCallManager &call_manager,
              bool use_tls = false)
       : client_call_manager_(call_manager), use_tls_(use_tls) {
-    channel_ = BuildChannel(address, port, CreateDefaultChannelArguments());
+    channel_ = BuildChannel(address, port, CreateClientDefaultChannelArguments());
     stub_ = GrpcService::NewStub(channel_);
   }
 
@@ -114,16 +114,10 @@ class GrpcClient {
              int num_threads,
              bool use_tls = false)
       : client_call_manager_(call_manager), use_tls_(use_tls) {
-    grpc::ChannelArguments argument = CreateDefaultChannelArguments();
     grpc::ResourceQuota quota;
     quota.SetMaxThreads(num_threads);
-    argument.SetResourceQuota(quota);
-    argument.SetInt(GRPC_ARG_ENABLE_HTTP_PROXY,
-                    ::RayConfig::instance().grpc_enable_http_proxy() ? 1 : 0);
-    argument.SetMaxSendMessageSize(::RayConfig::instance().max_grpc_message_size());
-    argument.SetMaxReceiveMessageSize(::RayConfig::instance().max_grpc_message_size());
 
-    channel_ = BuildChannel(address, port, argument);
+    channel_ = BuildChannel(address, port, CreateClientDefaultChannelArguments());
     stub_ = GrpcService::NewStub(channel_);
   }
 
@@ -181,6 +175,53 @@ class GrpcClient {
   /// Whether CallMethod is invoked.
   bool call_method_invoked_ = false;
 };
+
+inline grpc::ChannelArguments CreateClientDefaultChannelArguments() {
+  std::string service_config_json = R"{
+    "methodConfig": [{
+      "name": [
+        // Mutating, but idempotent
+        {"service": "ray.rpc.CoreWorkerService", "method": "ReportGeneratorItemReturns"},
+        {"service": "ray.rpc.CoreWorkerService", "method": "DeleteObjects"},
+        {"service": "ray.rpc.CoreWorkerService", "method": "CancelTask"},
+
+        // Read-only
+        {"service": "ray.rpc.CoreWorkerService", "method": "GetCoreWorkerStats"},
+        {"service": "ray.rpc.CoreWorkerService", "method": "NumPendingTasks"},
+        {"service": "ray.rpc.CoreWorkerService", "method": "PlasmaObjectReady"},
+        {"service": "ray.rpc.CoreWorkerService", "method": "GetObjectLocationsOwner"},
+        {"service": "ray.rpc.CoreWorkerService", "method": "GetObjectStatus"},
+      ],
+      "retryPolicy": {
+        "maxAttempts": 5,
+        "initialBackoff": "0.1s",
+        "maxBackoff": "1s",
+        "backoffMultiplier": 1.5,
+        "retryableStatusCodes": [
+          // Please refer to explanation of gRPC returned statuses for more details:
+          // REF: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+          "retryableStatusCodes": [
+              "UNAVAILABLE",
+              "DEADLINE_EXCEEDED",
+              "INTERNAL",
+              "UNKNOWN",
+              "ABORTED",
+          ],
+        ]
+      }
+    }]
+  }";
+
+  grpc::ChannelArguments arguments = CreateDefaultChannelArguments(service_config_json);
+
+  arguments.SetResourceQuota(quota);
+  arguments.SetInt(GRPC_ARG_ENABLE_HTTP_PROXY,
+                  ::RayConfig::instance().grpc_enable_http_proxy() ? 1 : 0);
+  arguments.SetMaxSendMessageSize(::RayConfig::instance().max_grpc_message_size());
+  arguments.SetMaxReceiveMessageSize(::RayConfig::instance().max_grpc_message_size());
+
+  return arguments;
+}
 
 }  // namespace rpc
 }  // namespace ray

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -92,32 +92,33 @@ inline grpc::ChannelArguments CreateClientDefaultChannelArguments() {
   // Please refer to explanation of gRPC returned statuses for more details:
   // REF: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
   std::string service_config_json = R"(
-  {
-    "methodConfig": [{
-      "name": [
-        {"service": "ray.rpc.CoreWorkerService", "method": "ReportGeneratorItemReturns"},
-        {"service": "ray.rpc.CoreWorkerService", "method": "DeleteObjects"},
-        {"service": "ray.rpc.CoreWorkerService", "method": "CancelTask"},
+    {
+      "methodConfig": [{
+        "name": [
+          {"service": "ray.rpc.CoreWorkerService", "method": "ReportGeneratorItemReturns"},
+          {"service": "ray.rpc.CoreWorkerService", "method": "DeleteObjects"},
+          {"service": "ray.rpc.CoreWorkerService", "method": "CancelTask"},
 
-        {"service": "ray.rpc.CoreWorkerService", "method": "GetCoreWorkerStats"},
-        {"service": "ray.rpc.CoreWorkerService", "method": "NumPendingTasks"},
-        {"service": "ray.rpc.CoreWorkerService", "method": "PlasmaObjectReady"},
-        {"service": "ray.rpc.CoreWorkerService", "method": "GetObjectLocationsOwner"},
-        {"service": "ray.rpc.CoreWorkerService", "method": "GetObjectStatus"},
-      ],
-      "retryPolicy": {
-        "maxAttempts": 5,
-        "initialBackoff": "0.1s",
-        "maxBackoff": "1s",
-        "backoffMultiplier": 1.5,
-        "retryableStatusCodes": [
-            "UNAVAILABLE",
-            "DEADLINE_EXCEEDED",
-            "INTERNAL",
-            "UNKNOWN",
+          {"service": "ray.rpc.CoreWorkerService", "method": "GetCoreWorkerStats"},
+          {"service": "ray.rpc.CoreWorkerService", "method": "NumPendingTasks"},
+          {"service": "ray.rpc.CoreWorkerService", "method": "PlasmaObjectReady"},
+          {"service": "ray.rpc.CoreWorkerService", "method": "GetObjectLocationsOwner"},
+          {"service": "ray.rpc.CoreWorkerService", "method": "GetObjectStatus"}
         ],
-      }
-    }]}
+        "retryPolicy": {
+          "maxAttempts": 5,
+          "initialBackoff": "0.1s",
+          "maxBackoff": "1s",
+          "backoffMultiplier": 1.5,
+          "retryableStatusCodes": [
+              "UNAVAILABLE",
+              "DEADLINE_EXCEEDED",
+              "INTERNAL",
+              "UNKNOWN"
+          ]
+        }
+      }]
+    }
   )";
 
   grpc::ChannelArguments arguments = CreateDefaultChannelArguments(service_config_json);

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -128,7 +128,7 @@ inline grpc::ChannelArguments CreateClientDefaultChannelArguments() {
   grpc::ChannelArguments arguments = CreateDefaultChannelArguments(service_config_json);
 
   arguments.SetInt(GRPC_ARG_ENABLE_HTTP_PROXY,
-                  ::RayConfig::instance().grpc_enable_http_proxy() ? 1 : 0);
+                   ::RayConfig::instance().grpc_enable_http_proxy() ? 1 : 0);
   arguments.SetMaxSendMessageSize(::RayConfig::instance().max_grpc_message_size());
   arguments.SetMaxReceiveMessageSize(::RayConfig::instance().max_grpc_message_size());
 
@@ -161,7 +161,6 @@ class GrpcClient {
              int num_threads,
              bool use_tls = false)
       : client_call_manager_(call_manager), use_tls_(use_tls) {
-
     grpc::ResourceQuota quota;
     quota.SetMaxThreads(num_threads);
 

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -111,14 +111,11 @@ inline grpc::ChannelArguments CreateClientDefaultChannelArguments() {
         "maxBackoff": "1s",
         "backoffMultiplier": 1.5,
         "retryableStatusCodes": [
-          "retryableStatusCodes": [
-              "UNAVAILABLE",
-              "DEADLINE_EXCEEDED",
-              "INTERNAL",
-              "UNKNOWN",
-              "ABORTED",
-          ],
-        ]
+            "UNAVAILABLE",
+            "DEADLINE_EXCEEDED",
+            "INTERNAL",
+            "UNKNOWN",
+        ],
       }
     }]}
   )";

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -89,16 +89,16 @@ inline std::shared_ptr<grpc::Channel> BuildChannel(
 }
 
 inline grpc::ChannelArguments CreateClientDefaultChannelArguments() {
+  // Please refer to explanation of gRPC returned statuses for more details:
+  // REF: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
   std::string service_config_json = R"(
   {
     "methodConfig": [{
       "name": [
-        // Mutating, but idempotent
         {"service": "ray.rpc.CoreWorkerService", "method": "ReportGeneratorItemReturns"},
         {"service": "ray.rpc.CoreWorkerService", "method": "DeleteObjects"},
         {"service": "ray.rpc.CoreWorkerService", "method": "CancelTask"},
 
-        // Read-only
         {"service": "ray.rpc.CoreWorkerService", "method": "GetCoreWorkerStats"},
         {"service": "ray.rpc.CoreWorkerService", "method": "NumPendingTasks"},
         {"service": "ray.rpc.CoreWorkerService", "method": "PlasmaObjectReady"},
@@ -111,8 +111,6 @@ inline grpc::ChannelArguments CreateClientDefaultChannelArguments() {
         "maxBackoff": "1s",
         "backoffMultiplier": 1.5,
         "retryableStatusCodes": [
-          // Please refer to explanation of gRPC returned statuses for more details:
-          // REF: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
           "retryableStatusCodes": [
               "UNAVAILABLE",
               "DEADLINE_EXCEEDED",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Troubleshooting some streaming generator issue i've realized that neither of the gRPC clients actually do not have basic transport-layer retry policy set up, in turn necessitating retrying logic to be implemented in the application itself.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
