### PR TITLE
[data] fix nested ragged ndarray

### DIFF
--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -26,10 +26,13 @@ def is_valid_udf_return(udf_return_col: Any) -> bool:
 
 def is_scalar_list(udf_return_col: Any) -> bool:
     """Check whether a UDF column is is a scalar list."""
-
-    return isinstance(udf_return_col, list) and (
-        not udf_return_col or np.isscalar(udf_return_col[0])
-    )
+    if not (isinstance(udf_return_col, (list, np.ndarray))):
+        return False
+    if len(udf_return_col) == 0:
+        return True
+    if np.isscalar(udf_return_col[0]):
+        return True
+    return is_scalar_list(udf_return_col[0])
 
 
 def convert_udf_returns_to_numpy(udf_return_col: Any) -> Any:

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -32,7 +32,7 @@ def is_scalar_list(udf_return_col: Any) -> bool:
     )
 
 
-def is_nested_list(udf_return_col: Any) -> bool:
+def is_nested_list(udf_return_col: List[Any]) -> bool:
     if not udf_return_col:
         return False
     for e in udf_return_col:

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -24,14 +24,6 @@ def is_valid_udf_return(udf_return_col: Any) -> bool:
     return isinstance(udf_return_col, list) or is_array_like(udf_return_col)
 
 
-def is_scalar_list(udf_return_col: Any) -> bool:
-    """Check whether a UDF column is is a scalar list."""
-
-    return isinstance(udf_return_col, list) and (
-        not udf_return_col or np.isscalar(udf_return_col[0])
-    )
-
-
 def is_nested_list(udf_return_col: List[Any]) -> bool:
     for e in udf_return_col:
         if isinstance(e, list):

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -81,13 +81,13 @@ def test_ragged_array_like(ray_start_regular_shared):
 def test_scalar_nested_arrays(ray_start_regular_shared):
     data = [[[1]], [[2]]]
     output = do_map_batches(data)
-    assert_structure_equals(output, create_ragged_ndarray([[[1]], [[2]]]))
+    assert_structure_equals(output, create_ragged_ndarray(data))
 
 
 def test_scalar_nested_ragged_arrays(ray_start_regular_shared):
-    data = [[[1]], [[2, 3]]]
+    data = [[[1], [2, 3]]]
     output = do_map_batches(data)
-    assert_structure_equals(output, create_ragged_ndarray([[[1]], [[2, 3]]]))
+    assert_structure_equals(output, create_ragged_ndarray(data))
 
 
 def test_scalar_lists_not_converted(ray_start_regular_shared):

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -154,11 +154,13 @@ def test_scalar_ragged_array_like(ray_start_regular_shared):
         output, create_ragged_ndarray([np.zeros((3, 5, 10)), np.zeros((3, 8, 8))])
     )
 
+
 def test_nested_ragged_arrays(ray_start_regular_shared):
     data = [
         {"a": [[1], [2, 3]]},
         {"a": [[4, 5], [6]]},
     ]
+
     def f(row):
         return data[row["id"]]
 

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -81,7 +81,13 @@ def test_ragged_array_like(ray_start_regular_shared):
 def test_scalar_nested_arrays(ray_start_regular_shared):
     data = [[[1]], [[2]]]
     output = do_map_batches(data)
-    assert_structure_equals(output, np.array([[[1]], [[2]]]))
+    assert_structure_equals(output, create_ragged_ndarray([[[1]], [[2]]]))
+
+
+def test_scalar_nested_ragged_arrays(ray_start_regular_shared):
+    data = [[[1]], [[2, 3]]]
+    output = do_map_batches(data)
+    assert_structure_equals(output, create_ragged_ndarray([[[1]], [[2, 3]]]))
 
 
 def test_scalar_lists_not_converted(ray_start_regular_shared):

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -84,12 +84,6 @@ def test_scalar_nested_arrays(ray_start_regular_shared):
     assert_structure_equals(output, create_ragged_ndarray(data))
 
 
-def test_scalar_nested_ragged_arrays(ray_start_regular_shared):
-    data = [[[1], [2, 3]]]
-    output = do_map_batches(data)
-    assert_structure_equals(output, create_ragged_ndarray(data))
-
-
 def test_scalar_lists_not_converted(ray_start_regular_shared):
     data = [[1, 2], [1, 2]]
     output = do_map_batches(data)
@@ -159,6 +153,17 @@ def test_scalar_ragged_array_like(ray_start_regular_shared):
     assert_structure_equals(
         output, create_ragged_ndarray([np.zeros((3, 5, 10)), np.zeros((3, 8, 8))])
     )
+
+def test_nested_ragged_arrays(ray_start_regular_shared):
+    data = [
+        {"a": [[1], [2, 3]]},
+        {"a": [[4, 5], [6]]},
+    ]
+    def f(row):
+        return data[row["id"]]
+
+    output = ray.data.range(2).map(f).take_all()
+    assert output == data
 
 
 # https://github.com/ray-project/ray/issues/35340


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently we support single level of ragged ndarray, i.e, shape of each row is different. But "nested ragged ndarray" isn't supported. I.e, when a row already contains a ragged ndarray, the following error will occur. 

Repro:
```python
import ray

def f(row):
    return {"result": [[], [1, 2]]}

ray.data.range(1).map(f).materialize()
```
Error:
```
ray.exceptions.RayTaskError(ArrowNotImplementedError): ray::Map(f)() (pid=39856, ip=127.0.0.1)
  File "/Users/chenh/code/ray/python/ray/data/_internal/execution/operators/map_operator.py", line 419, in _map_task
    for b_out in map_transformer.apply_transform(iter(blocks), ctx):
  File "/Users/chenh/code/ray/python/ray/data/_internal/execution/operators/map_transformer.py", line 393, in __call__
    add_fn(data)
  File "/Users/chenh/code/ray/python/ray/data/_internal/output_buffer.py", line 43, in add
    self._buffer.add(item)
  File "/Users/chenh/code/ray/python/ray/data/_internal/delegating_block_builder.py", line 24, in add
    check.build()
  File "/Users/chenh/code/ray/python/ray/data/_internal/table_block.py", line 128, in build
    tables = [self._table_from_pydict(columns)]
  File "/Users/chenh/code/ray/python/ray/data/_internal/arrow_block.py", line 143, in _table_from_pydict
    columns[col_name] = ArrowTensorArray.from_numpy(col, col_name)
  File "/Users/chenh/code/ray/python/ray/air/util/tensor_extensions/arrow.py", line 333, in from_numpy
    return ArrowVariableShapedTensorArray.from_numpy(arr)
  File "/Users/chenh/code/ray/python/ray/air/util/tensor_extensions/arrow.py", line 789, in from_numpy
    pa_dtype = pa.from_numpy_dtype(dtype)
  File "pyarrow/types.pxi", line 5140, in pyarrow.lib.from_numpy_dtype
  File "pyarrow/error.pxi", line 91, in pyarrow.lib.check_status
pyarrow.lib.ArrowNotImplementedError: Unsupported numpy type 17
```


## Related issue number

Fixes #44235, #41078, #44062

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
