### PR TITLE
[kuberay][autoscaler] Update KubeRay version to v1.1.0

### DIFF
--- a/ci/k8s/install-k8s-tools.sh
+++ b/ci/k8s/install-k8s-tools.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 if [[ ! -f /usr/local/bin/kind ]]; then
     echo "--- Installing kind"
-    curl -sfL "https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64" -o /usr/local/bin/kind
+    curl -sfL "https://github.com/kubernetes-sigs/kind/releases/download/v0.22.0/kind-linux-amd64" -o /usr/local/bin/kind
     chmod +x /usr/local/bin/kind
     kind --help
 fi

--- a/python/ray/autoscaler/kuberay/init-config.sh
+++ b/python/ray/autoscaler/kuberay/init-config.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 # Clone pinned KubeRay commit to temporary directory, copy the CRD definitions
 # into the autoscaler folder.
-KUBERAY_BRANCH="v1.1.0-rc.0"
-OPERATOR_TAG="v1.1.0-rc.0"
+KUBERAY_BRANCH="v1.1.0"
+OPERATOR_TAG="v1.1.0"
 
 # Requires Kustomize
 if ! command -v kustomize &> /dev/null

--- a/python/ray/tests/chaos/prepare_env.sh
+++ b/python/ray/tests/chaos/prepare_env.sh
@@ -16,8 +16,8 @@ kind load docker-image ray-ci:kuberay-test
 echo "--- Installing KubeRay operator from official Helm repo."
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm install kuberay-operator kuberay/kuberay-operator
-kubectl wait pod  -l app.kubernetes.io/name=kuberay-operator \
-    --for=condition=Ready=True  --timeout=5m
+# kubectl wait pod  -l app.kubernetes.io/name=kuberay-operator \
+#     --for=condition=Ready=True  --timeout=5m
 
 sleep 7200
 echo "--- Installing KubeRay cluster and port forward."

--- a/python/ray/tests/chaos/prepare_env.sh
+++ b/python/ray/tests/chaos/prepare_env.sh
@@ -16,10 +16,9 @@ kind load docker-image ray-ci:kuberay-test
 echo "--- Installing KubeRay operator from official Helm repo."
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm install kuberay-operator kuberay/kuberay-operator
-# kubectl wait pod  -l app.kubernetes.io/name=kuberay-operator \
-#     --for=condition=Ready=True  --timeout=5m
+kubectl wait pod  -l app.kubernetes.io/name=kuberay-operator \
+    --for=condition=Ready=True  --timeout=2m
 
-sleep 7200
 echo "--- Installing KubeRay cluster and port forward."
 
 helm install raycluster kuberay/ray-cluster \

--- a/python/ray/tests/chaos/prepare_env.sh
+++ b/python/ray/tests/chaos/prepare_env.sh
@@ -19,6 +19,7 @@ helm install kuberay-operator kuberay/kuberay-operator
 kubectl wait pod  -l app.kubernetes.io/name=kuberay-operator \
     --for=condition=Ready=True  --timeout=5m
 
+sleep 7200
 echo "--- Installing KubeRay cluster and port forward."
 
 helm install raycluster kuberay/ray-cluster \

--- a/python/ray/tests/kuberay/setup/raycluster_test.yaml
+++ b/python/ray/tests/kuberay/setup/raycluster_test.yaml
@@ -1,12 +1,11 @@
 ---
-apiVersion: ray.io/v1alpha1
+apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
   name: raycluster-test
 spec:
   headGroupSpec:
     serviceType: ClusterIP
-    replicas: 1
     rayStartParams: {}
     template:
       spec:

--- a/release/k8s_tests/run_gcs_ft_on_k8s.py
+++ b/release/k8s_tests/run_gcs_ft_on_k8s.py
@@ -51,7 +51,7 @@ def generate_cluster_variable():
 
 def check_kuberay_installed():
     # Make sure the ray namespace exists
-    KUBERAY_VERSION = "v1.1.0-rc.0"
+    KUBERAY_VERSION = "v1.1.0"
     uri = (
         "github.com/ray-project/kuberay/manifests"
         f"/base?ref={KUBERAY_VERSION}&timeout=90s"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Update the KubeRay image from v1.1.0-rc.0 to v1.1.0.
* Upgrade Kind version to avoid https://github.com/ray-project/kuberay/issues/1935.
* Remove the deprecated field `spec.headGroupSpec.replicas`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
