### PR TITLE
[core][experimental] AccDag: Support more than one tasks per actor

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -237,6 +237,7 @@ class ActorMethod:
         _generator_backpressure_num_objects=None,
     ):
         from ray.dag.class_node import (
+            BIND_INDEX_KEY,
             PARENT_CLASS_NODE_KEY,
             PREV_CLASS_METHOD_CALL_KEY,
             ClassMethodNode,
@@ -259,7 +260,9 @@ class ActorMethod:
         other_args_to_resolve = {
             PARENT_CLASS_NODE_KEY: actor,
             PREV_CLASS_METHOD_CALL_KEY: None,
+            BIND_INDEX_KEY: actor._ray_bind_index,
         }
+        actor._ray_bind_index += 1
 
         node = ClassMethodNode(
             self._method_name,
@@ -1306,6 +1309,7 @@ class ActorHandle:
             actor_creation_function_descriptor
         )
         self._ray_function_descriptor = {}
+        self._ray_bind_index = 0
 
         if not self._ray_is_cross_language:
             assert isinstance(

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -260,9 +260,9 @@ class ActorMethod:
         other_args_to_resolve = {
             PARENT_CLASS_NODE_KEY: actor,
             PREV_CLASS_METHOD_CALL_KEY: None,
-            BIND_INDEX_KEY: actor._ray_bind_index,
+            BIND_INDEX_KEY: actor._ray_dag_bind_index,
         }
-        actor._ray_bind_index += 1
+        actor._ray_dag_bind_index += 1
 
         node = ClassMethodNode(
             self._method_name,
@@ -1309,7 +1309,9 @@ class ActorHandle:
             actor_creation_function_descriptor
         )
         self._ray_function_descriptor = {}
-        self._ray_bind_index = 0
+        # This is incremented each time `bind()` is called on the actor method
+        # (in Ray DAGs), therefore capturing the bind order of the actor methods.
+        self._ray_dag_bind_index = 0
 
         if not self._ray_is_cross_language:
             assert isinstance(

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1309,8 +1309,10 @@ class ActorHandle:
             actor_creation_function_descriptor
         )
         self._ray_function_descriptor = {}
-        # This is incremented each time `bind()` is called on the actor method
+        # This is incremented each time `bind()` is called on an actor handle
         # (in Ray DAGs), therefore capturing the bind order of the actor methods.
+        # TODO: this does not work properly if the caller has two copies of the
+        # same actor handle, and needs to be fixed.
         self._ray_dag_bind_index = 0
 
         if not self._ray_is_cross_language:

--- a/python/ray/dag/class_node.py
+++ b/python/ray/dag/class_node.py
@@ -4,7 +4,11 @@ import ray
 from ray.dag.dag_node import DAGNode
 from ray.dag.input_node import InputNode
 from ray.dag.format_utils import get_dag_node_str
-from ray.dag.constants import PARENT_CLASS_NODE_KEY, PREV_CLASS_METHOD_CALL_KEY
+from ray.dag.constants import (
+    PARENT_CLASS_NODE_KEY,
+    PREV_CLASS_METHOD_CALL_KEY,
+    BIND_INDEX_KEY,
+)
 from ray.util.annotations import DeveloperAPI
 
 from typing import Any, Dict, List, Union, Tuple, Optional
@@ -156,6 +160,9 @@ class ClassMethodNode(DAGNode):
         self._prev_class_method_call: Optional[
             ClassMethodNode
         ] = other_args_to_resolve.get(PREV_CLASS_METHOD_CALL_KEY, None)
+        self._bind_index: Optional[int] = other_args_to_resolve.get(
+            BIND_INDEX_KEY, None
+        )
 
         # The actor creation task dependency is encoded as the first argument,
         # and the ordering dependency as the second, which ensures they are
@@ -202,6 +209,9 @@ class ClassMethodNode(DAGNode):
 
     def get_method_name(self) -> str:
         return self._method_name
+
+    def _get_bind_index(self) -> int:
+        return self._bind_index
 
     def _get_remote_method(self, method_name):
         method_body = getattr(self._parent_class_node, method_name)

--- a/python/ray/dag/class_node.py
+++ b/python/ray/dag/class_node.py
@@ -160,6 +160,7 @@ class ClassMethodNode(DAGNode):
         self._prev_class_method_call: Optional[
             ClassMethodNode
         ] = other_args_to_resolve.get(PREV_CLASS_METHOD_CALL_KEY, None)
+        # The index/order when bind() is called on this class method
         self._bind_index: Optional[int] = other_args_to_resolve.get(
             BIND_INDEX_KEY, None
         )

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -26,22 +26,23 @@ logger = logging.getLogger(__name__)
 
 @DeveloperAPI
 def do_allocate_channel(
-    self, readers: List[Optional["ray.actor.ActorHandle"]], buffer_size_bytes: int
+    self,
+    readers: List[Optional["ray.actor.ActorHandle"]],
+    buffer_size_bytes: int,
+    reader_node_id: Optional["ray.NodeID"] = None,
 ) -> Channel:
     """Generic actor method to allocate an output channel.
 
     Args:
+        readers: The actor handles of the readers.
         buffer_size_bytes: The maximum size of messages in the channel.
-        num_readers: The number of readers per message.
+        reader_node_id: The node ID of the readers (must be the same for all readers).
 
     Returns:
         The allocated channel.
     """
-    self._output_channel = Channel(
-        readers,
-        buffer_size_bytes,
-    )
-    return self._output_channel
+    output_channel = Channel(readers, buffer_size_bytes, _reader_node_id=reader_node_id)
+    return output_channel
 
 
 def _wrap_exception(exc):
@@ -50,7 +51,7 @@ def _wrap_exception(exc):
         task_exception=True,
     )
     wrapped = RayTaskError(
-        function_name="do_exec_compiled_task",
+        function_name="do_exec_tasks",
         traceback_str=backtrace,
         cause=exc,
     )
@@ -58,77 +59,87 @@ def _wrap_exception(exc):
 
 
 @DeveloperAPI
-def do_exec_compiled_task(
+def do_exec_tasks(
     self,
-    inputs: List[Union[Any, Channel]],
-    actor_method_name: str,
-    output_wrapper_fn: Optional[Callable[[Any], Any]],
+    tasks: List["ExecutableTask"],
     has_type_hints: bool,
 ) -> None:
-    """Generic actor method to begin executing a compiled DAG. This runs an
-    infinite loop to repeatedly read input channel(s), execute the given
-    method, and write output channel(s). It only exits if the actor dies or an
-    exception is thrown.
+    """Generic actor method to begin executing the tasks belonging to an actor.
+    This runs an infinite loop to run each task in turn (following the order specified
+    in the list): reading input channel(s), executing the given taks, and writing output
+    channel(s). It only exits if the actor dies or an exception is thrown.
 
     Args:
-        inputs: The arguments to the task. Arguments that are not Channels will
-            get passed through to the actor method. If the argument is a channel,
-            it will be replaced by the value read from the channel before the
-            method execute.
-        actor_method_name: The name of the actual actor method to execute in
-            the loop.
+        tasks: the executable tasks corresponding to the actor methods.
     """
     try:
         if has_type_hints:
             _do_register_custom_dag_serializers(self)
 
-        method = getattr(self, actor_method_name)
+        self._uuid_to_input_reader = {}
+        self._uuid_to_output_writer = {}
+        for task in tasks:
+            task.resolved_inputs = []
+            task.input_channels = []
+            task.input_channel_idxs = []
+            # Add placeholders for input channels.
+            for idx, inp in enumerate(task.resolved_args):
+                if isinstance(inp, Channel):
+                    task.input_channels.append(inp)
+                    task.input_channel_idxs.append(idx)
+                    task.resolved_inputs.append(None)
+                else:
+                    task.resolved_inputs.append(inp)
 
-        resolved_inputs = []
-        input_channels = []
-        input_channel_idxs = []
-        # Add placeholders for input channels.
-        for idx, inp in enumerate(inputs):
-            if isinstance(inp, Channel):
-                input_channels.append(inp)
-                input_channel_idxs.append(idx)
-                resolved_inputs.append(None)
-            else:
-                resolved_inputs.append(inp)
+            input_reader: ReaderInterface = SynchronousReader(task.input_channels)
+            output_writer: WriterInterface = SynchronousWriter(task.output_channel)
+            self._uuid_to_input_reader[task.uuid] = input_reader
+            self._uuid_to_output_writer[task.uuid] = output_writer
 
-        self._input_reader: ReaderInterface = SynchronousReader(input_channels)
-        self._output_writer: WriterInterface = SynchronousWriter(self._output_channel)
-        self._input_reader.start()
-        self._output_writer.start()
+            input_reader.start()
+            output_writer.start()
 
+        done = False
         while True:
-            try:
-                res = self._input_reader.begin_read()
-            except ValueError as exc:
-                # ValueError is raised if a type hint was set and the returned
-                # type did not match the hint.
-                self._output_writer.write(exc)
-                self._input_reader.end_read()
-                continue
-            except IOError:
+            if done:
                 break
+            for task in tasks:
+                # TODO: for cases where output is passed as input to a task on
+                # the same actor, introduce a "LocalChannel" to avoid the overhead
+                # of serialization/deserialization and synchronization.
+                method = getattr(self, task.method_name)
+                input_reader = self._uuid_to_input_reader[task.uuid]
+                output_writer = self._uuid_to_output_writer[task.uuid]
+                res = None
+                try:
+                    res = input_reader.begin_read()
+                except ValueError as exc:
+                    # ValueError is raised if a type hint was set and the returned
+                    # type did not match the hint.
+                    output_writer.write(exc)
+                    input_reader.end_read()
+                    continue
+                except IOError:
+                    done = True
+                    break
 
-            for idx, output in zip(input_channel_idxs, res):
-                resolved_inputs[idx] = output
+                for idx, output in zip(task.input_channel_idxs, res):
+                    task.resolved_inputs[idx] = output
 
-            try:
-                output_val = method(*resolved_inputs)
-                if output_wrapper_fn is not None:
-                    output_val = output_wrapper_fn(output_val)
-            except Exception as exc:
-                self._output_writer.write(_wrap_exception(exc))
-            else:
-                self._output_writer.write(output_val)
+                try:
+                    output_val = method(*task.resolved_inputs)
+                    if task.output_wrapper_fn is not None:
+                        output_val = task.output_wrapper_fn(output_val)
+                except Exception as exc:
+                    output_writer.write(_wrap_exception(exc))
+                else:
+                    output_writer.write(output_val)
 
-            try:
-                self._input_reader.end_read()
-            except IOError:
-                break
+                try:
+                    input_reader.end_read()
+                except IOError:
+                    done = True
+                    break
 
     except Exception:
         logging.exception("Compiled DAG task exited with exception")
@@ -136,9 +147,10 @@ def do_exec_compiled_task(
 
 
 @DeveloperAPI
-def do_cancel_compiled_task(self):
-    self._input_reader.close()
-    self._output_writer.close()
+def do_cancel_executable_tasks(self, tasks: List["ExecutableTask"]) -> None:
+    for task in tasks:
+        self._uuid_to_input_reader[task.uuid].close()
+        self._uuid_to_output_writer[task.uuid].close()
 
 
 @PublicAPI(stability="alpha")
@@ -219,6 +231,33 @@ Output: {self.output_channel}
 
 
 @DeveloperAPI
+class ExecutableTask:
+    """A task that can be executed in a compiled DAG, and it
+    corresponds to an actor method.
+    """
+
+    def __init__(
+        self,
+        task: "CompiledTask",
+        resolved_args: List[Any],
+    ):
+        """
+        Args:
+            task: The CompiledTask that this ExecutableTask corresponds to.
+            resolved_args: The arguments to the method. Arguments that are
+                not Channels will get passed through to the actor method.
+                If the argument is a channel, it will be replaced by the
+                value read from the channel before the method executes.
+        """
+        self.method_name = task.dag_node.get_method_name()
+        self.uuid = task.dag_node.get_stable_uuid()
+        self.bind_index = task.dag_node._get_bind_index()
+        self.output_channel = task.output_channel
+        self.output_wrapper_fn = task.output_wrapper_fn
+        self.resolved_args = resolved_args
+
+
+@DeveloperAPI
 class CompiledDAG:
     """Experimental class for accelerated execution.
 
@@ -296,8 +335,13 @@ class CompiledDAG:
         # ObjectRef for each worker's task. The task is an infinite loop that
         # repeatedly executes the method specified in the DAG.
         self.worker_task_refs: Dict["ray.actor.ActorHandle", "ray.ObjectRef"] = {}
-        # Set of actors present in the DAG.
-        self.actor_refs = set()
+        self.actor_to_handle: Dict["ray._raylet.ActorID", "ray.actor.ActorHandle"] = {}
+        self.actor_to_tasks: Dict[
+            "ray._raylet.ActorID", List["CompiledTask"]
+        ] = defaultdict(list)
+        self.actor_to_executable_tasks: Dict[
+            "ray._raylet.ActorID", List["ExecutableTask"]
+        ] = {}
 
         # Type hints specified by the user for DAG (intermediate) outputs.
         self._type_hints = []
@@ -370,13 +414,6 @@ class CompiledDAG:
             if dag_node.type_hint is not None:
                 self._type_hints.append(dag_node.type_hint)
 
-        for actor_id, task_count in self.actor_task_count.items():
-            if task_count > 1:
-                raise NotImplementedError(
-                    "Compiled DAGs can contain at most one task per actor handle. "
-                    f"Actor with ID {actor_id} appears {task_count}x."
-                )
-
         # Find the input node to the DAG.
         for idx, task in self.idx_to_task.items():
             if isinstance(task.dag_node, InputNode):
@@ -442,11 +479,16 @@ class CompiledDAG:
             # add them.
 
             task = self.idx_to_task[cur_idx]
-            # Create an output buffer on the actor.
+            # Create an output buffer for the actor method.
             assert task.output_channel is None
             if isinstance(task.dag_node, ClassMethodNode):
                 readers = [self.idx_to_task[idx] for idx in task.downstream_node_idxs]
                 assert len(readers) == 1
+                reader_node_id = None
+
+                def _get_node_id(self):
+                    return ray.get_runtime_context().get_node_id()
+
                 if isinstance(readers[0].dag_node, MultiOutputNode):
                     # This node is a multi-output node, which means that it will only be
                     # read by the driver, not an actor. Thus, we handle this case by
@@ -454,9 +496,6 @@ class CompiledDAG:
                     reader_handles = [None]
 
                     fn = task.dag_node._get_remote_method("__ray_call__")
-
-                    def _get_node_id(self):
-                        return ray.get_runtime_context().get_node_id()
 
                     actor_node = ray.get(fn.remote(_get_node_id))
 
@@ -471,15 +510,28 @@ class CompiledDAG:
                     reader_handles = [
                         reader.dag_node._get_actor_handle() for reader in readers
                     ]
+                    for reader in readers:
+                        fn = reader.dag_node._get_remote_method("__ray_call__")
+                        current_reader_node_id = ray.get(fn.remote(_get_node_id))
+                        if reader_node_id is None:
+                            reader_node_id = current_reader_node_id
+                        elif reader_node_id != current_reader_node_id:
+                            raise NotImplementedError(
+                                "All readers of a channel must be "
+                                "on the same node for now."
+                            )
                 fn = task.dag_node._get_remote_method("__ray_call__")
                 task.output_channel = ray.get(
                     fn.remote(
                         do_allocate_channel,
                         reader_handles,
                         buffer_size_bytes=self._buffer_size_bytes,
+                        reader_node_id=reader_node_id,
                     )
                 )
-                self.actor_refs.add(task.dag_node._get_actor_handle())
+                actor_handle = task.dag_node._get_actor_handle()
+                self.actor_to_handle[actor_handle._actor_id] = actor_handle
+                self.actor_to_tasks[actor_handle._actor_id].append(task)
             elif isinstance(task.dag_node, InputNode):
                 readers = [self.idx_to_task[idx] for idx in task.downstream_node_idxs]
                 reader_handles = [
@@ -495,43 +547,90 @@ class CompiledDAG:
             for idx in task.downstream_node_idxs:
                 frontier.append(idx)
 
+        # Validate input channels for tasks that have not been visited
         for node_idx, task in self.idx_to_task.items():
             if node_idx == self.input_task_idx:
-                # We don't need to assign an actual task for the input node.
                 continue
-
             if node_idx == self.output_task_idx:
-                # We don't need to assign an actual task for the input node.
                 continue
+            if node_idx not in visited:
+                has_at_least_one_channel_input = False
+                for arg in task.args:
+                    if isinstance(arg, DAGNode):
+                        has_at_least_one_channel_input = True
+                if not has_at_least_one_channel_input:
+                    raise ValueError(
+                        "Compiled DAGs require each task to take a ray.dag.InputNode "
+                        "or at least one other DAGNode as an input"
+                    )
 
-            resolved_args = []
-            has_at_least_one_channel_input = False
-            for arg in task.args:
-                if isinstance(arg, DAGNode):
-                    arg_idx = self.dag_node_to_idx[arg]
-                    arg_channel = self.idx_to_task[arg_idx].output_channel
-                    assert arg_channel is not None
-                    resolved_args.append(arg_channel)
-                    has_at_least_one_channel_input = True
-                else:
-                    resolved_args.append(arg)
-            # TODO: Support no-input DAGs (use an empty object to signal).
-            if not has_at_least_one_channel_input:
-                raise ValueError(
-                    "Compiled DAGs require each task to take a "
-                    "ray.dag.InputNode or at least one other DAGNode as an "
-                    "input"
+        # Create executable tasks for each actor
+        for actor_id, tasks in self.actor_to_tasks.items():
+            executable_tasks = []
+            worker_fn = None
+            for task in tasks:
+                resolved_args = []
+                has_at_least_one_channel_input = False
+                for arg in task.args:
+                    if isinstance(arg, DAGNode):
+                        arg_idx = self.dag_node_to_idx[arg]
+                        arg_channel = self.idx_to_task[arg_idx].output_channel
+                        assert arg_channel is not None
+                        resolved_args.append(arg_channel)
+                        has_at_least_one_channel_input = True
+                    else:
+                        resolved_args.append(arg)
+                # TODO: Support no-input DAGs (use an empty object to signal).
+                if not has_at_least_one_channel_input:
+                    raise ValueError(
+                        "Compiled DAGs require each task to take a "
+                        "ray.dag.InputNode or at least one other DAGNode as an "
+                        "input"
+                    )
+                executable_task = ExecutableTask(
+                    task,
+                    resolved_args,
                 )
+                executable_tasks.append(executable_task)
+                if worker_fn is None:
+                    worker_fn = task.dag_node._get_remote_method("__ray_call__")
+            # Sort executable tasks based on their bind index, i.e., submission order
+            # so that they will be executed in that order.
+            executable_tasks.sort(key=lambda task: task.bind_index)
 
+            # Check unsupported case: binding the same actor method to the same
+            # input multiple times
+            import itertools
+
+            for _, g in itertools.groupby(executable_tasks, lambda x: x.method_name):
+                group = list(g)
+                if len(group) > 1:
+                    resolved_args = set()
+                    for executable_task in group:
+                        if (
+                            len(
+                                set(executable_task.resolved_args).intersection(
+                                    resolved_args
+                                )
+                            )
+                            > 0
+                        ):
+                            # TODO: Support binding the same actor method to the
+                            # same input multiple times.
+                            raise NotImplementedError(
+                                f"Compiled DAGs currently do not support binding the "
+                                f"same actor method to the same input multiple times. "
+                                f"Method: {executable_task.method_name}"
+                            )
+                        resolved_args.update(executable_task.resolved_args)
+
+            self.actor_to_executable_tasks[actor_id] = executable_tasks
             # Assign the task with the correct input and output buffers.
-            worker_fn = task.dag_node._get_remote_method("__ray_call__")
             self.worker_task_refs[
                 task.dag_node._get_actor_handle()
             ] = worker_fn.options(concurrency_group="_ray_system").remote(
-                do_exec_compiled_task,
-                resolved_args,
-                task.dag_node.get_method_name(),
-                output_wrapper_fn=task.output_wrapper_fn,
+                do_exec_tasks,
+                executable_tasks,
                 has_type_hints=bool(self._type_hints),
             )
 
@@ -623,12 +722,15 @@ class CompiledDAG:
                 outer._dag_output_fetcher.close()
 
                 self.in_teardown = True
-                for actor in outer.actor_refs:
-                    logger.info(f"Cancelling compiled worker on actor: {actor}")
-                    # TODO(swang): Suppress exceptions from actors trying to
-                    # read closed channels when DAG is being torn down.
+                for actor_id, tasks in outer.actor_to_executable_tasks.items():
                     try:
-                        ray.get(actor.__ray_call__.remote(do_cancel_compiled_task))
+                        # TODO(swang): Suppress exceptions from actors trying to
+                        # read closed channels when DAG is being torn down.
+                        ray.get(
+                            outer.actor_to_handle[actor_id].__ray_call__.remote(
+                                do_cancel_executable_tasks, tasks
+                            )
+                        )
                     except Exception:
                         logger.exception("Error cancelling worker task")
                         pass

--- a/python/ray/dag/constants.py
+++ b/python/ray/dag/constants.py
@@ -1,6 +1,7 @@
 # Reserved keys used to handle ClassMethodNode in Ray DAG building.
 PARENT_CLASS_NODE_KEY = "parent_class_node"
 PREV_CLASS_METHOD_CALL_KEY = "prev_class_method_call"
+BIND_INDEX_KEY = "bind_index"
 
 # Reserved key to distinguish DAGNode type and avoid collision with user dict.
 DAGNODE_TYPE_KEY = "__dag_node_type__"

--- a/python/ray/dag/tests/test_accelerated_dag.py
+++ b/python/ray/dag/tests/test_accelerated_dag.py
@@ -41,6 +41,11 @@ class Actor:
                     raise ValueError("injected fault")
         return self.i
 
+    def double_and_inc(self, x):
+        self.i *= 2
+        self.i += x
+        return self.i
+
     def echo(self, x):
         return x
 
@@ -74,6 +79,56 @@ def test_basic(ray_start_regular):
 
     # Note: must teardown before starting a new Ray session, otherwise you'll get
     # a segfault from the dangling monitor thread upon the new Ray init.
+    compiled_dag.teardown()
+
+
+def test_actor_multi_methods(ray_start_regular):
+    a = Actor.remote(0)
+    with InputNode() as inp:
+        dag = a.inc.bind(inp)
+        dag = a.echo.bind(dag)
+
+    compiled_dag = dag.experimental_compile()
+    output_channel = compiled_dag.execute(1)
+    result = output_channel.begin_read()
+    assert result == 1
+    output_channel.end_read()
+
+    compiled_dag.teardown()
+
+
+def test_actor_methods_execution_order(ray_start_regular):
+    actor1 = Actor.remote(0)
+    actor2 = Actor.remote(0)
+    with InputNode() as inp:
+        branch1 = actor1.inc.bind(inp)
+        branch1 = actor2.double_and_inc.bind(branch1)
+        branch2 = actor2.inc.bind(inp)
+        branch2 = actor1.double_and_inc.bind(branch2)
+        dag = MultiOutputNode([branch2, branch1])
+
+    compiled_dag = dag.experimental_compile()
+    output_channel = compiled_dag.execute(1)
+    result = output_channel.begin_read()
+    # test that double_and_inc() is called after inc() on actor1
+    assert result == [4, 1]
+    output_channel.end_read()
+
+    compiled_dag.teardown()
+
+
+def test_actor_method_multi_binds(ray_start_regular):
+    a = Actor.remote(0)
+    with InputNode() as inp:
+        dag = a.inc.bind(inp)
+        dag = a.inc.bind(dag)
+
+    compiled_dag = dag.experimental_compile()
+    output_channel = compiled_dag.execute(1)
+    result = output_channel.begin_read()
+    assert result == 2
+    output_channel.end_read()
+
     compiled_dag.teardown()
 
 
@@ -172,6 +227,17 @@ def test_dag_errors(ray_start_regular):
     ):
         dag.experimental_compile()
 
+    with InputNode() as inp:
+        dag = a.inc.bind(inp)
+        dag2 = a.inc.bind(inp)
+        dag3 = a.inc_two.bind(dag, dag2)
+    with pytest.raises(
+        NotImplementedError,
+        match=r"Compiled DAGs currently do not support binding the same "
+        "actor method to the same input multiple times.*",
+    ):
+        dag3.experimental_compile()
+
     @ray.remote
     def f(x):
         return x
@@ -181,15 +247,6 @@ def test_dag_errors(ray_start_regular):
     with pytest.raises(
         NotImplementedError,
         match="Compiled DAGs currently only support actor method nodes",
-    ):
-        dag.experimental_compile()
-
-    with InputNode() as inp:
-        dag = a.inc.bind(inp)
-        dag = a.inc.bind(dag)
-    with pytest.raises(
-        NotImplementedError,
-        match="Compiled DAGs can contain at most one task per actor handle.",
     ):
         dag.experimental_compile()
 

--- a/python/ray/experimental/channel.py
+++ b/python/ray/experimental/channel.py
@@ -101,15 +101,18 @@ class Channel:
                 self._reader_ref = self._writer_ref
             else:
                 # Reader and writer are on different nodes.
-                fn = readers[0].__ray_call__
-                self._reader_node_id = ray.get(fn.remote(_get_node_id))
-                for reader in readers:
-                    fn = reader.__ray_call__
-                    reader_node_id = ray.get(fn.remote(_get_node_id))
-                    if reader_node_id != self._reader_node_id:
-                        raise NotImplementedError(
-                            "All readers must be on the same node for now."
-                        )
+                if _reader_node_id is not None:
+                    self._reader_node_id = _reader_node_id
+                else:
+                    fn = readers[0].__ray_call__
+                    self._reader_node_id = ray.get(fn.remote(_get_node_id))
+                    for reader in readers:
+                        fn = reader.__ray_call__
+                        reader_node_id = ray.get(fn.remote(_get_node_id))
+                        if reader_node_id != self._reader_node_id:
+                            raise NotImplementedError(
+                                "All readers must be on the same node for now."
+                            )
                 if self.is_remote():
                     self._reader_ref = ray.get(
                         fn.remote(_create_channel_ref, buffer_size_bytes)

--- a/python/ray/experimental/channel.py
+++ b/python/ray/experimental/channel.py
@@ -102,6 +102,12 @@ class Channel:
             else:
                 # Reader and writer are on different nodes.
                 if _reader_node_id is not None:
+                    # Note: if the reader actor is the same as current actor that
+                    # is creating the channel, we must pass in _reader_node_id as
+                    # an argument to avoid making a blocking call to _get_node_id()
+                    # on the "else" branch below. If that happens, the blocking call
+                    # will never return since it will not get a chance to run before
+                    # this method finishes, in other words, there is a deadlock.
                     self._reader_node_id = _reader_node_id
                 else:
                     fn = readers[0].__ray_call__

--- a/python/ray/experimental/channel.py
+++ b/python/ray/experimental/channel.py
@@ -17,6 +17,26 @@ def _get_node_id(self) -> "ray.NodeID":
     return ray.get_runtime_context().get_node_id()
 
 
+def _get_reader_node_id(self, reader_actor: "ray.actor.ActorHandle") -> "ray.NodeID":
+    """
+    Get the node ID of the reader actor.
+    If the reader actor is the same as the current actor, make a local method call
+    to get the node ID. Otherwise, make a remote ray.get() call to get the node ID.
+    """
+    current_actor_id = ray.get_runtime_context().get_actor_id()
+    if current_actor_id is None:
+        # We are calling from the driver, make a remote call
+        fn = reader_actor.__ray_call__
+        return ray.get(fn.remote(_get_node_id))
+
+    current_actor = ray.get_runtime_context().current_actor
+    if reader_actor == current_actor:
+        return _get_node_id(self)
+    else:
+        fn = reader_actor.__ray_call__
+        return ray.get(fn.remote(_get_node_id))
+
+
 def _create_channel_ref(
     self,
     buffer_size_bytes: int,
@@ -101,25 +121,15 @@ class Channel:
                 self._reader_ref = self._writer_ref
             else:
                 # Reader and writer are on different nodes.
-                if _reader_node_id is not None:
-                    # Note: if the reader actor is the same as current actor that
-                    # is creating the channel, we must pass in _reader_node_id as
-                    # an argument to avoid making a blocking call to _get_node_id()
-                    # on the "else" branch below. If that happens, the blocking call
-                    # will never return since it will not get a chance to run before
-                    # this method finishes, in other words, there is a deadlock.
-                    self._reader_node_id = _reader_node_id
-                else:
-                    fn = readers[0].__ray_call__
-                    self._reader_node_id = ray.get(fn.remote(_get_node_id))
-                    for reader in readers:
-                        fn = reader.__ray_call__
-                        reader_node_id = ray.get(fn.remote(_get_node_id))
-                        if reader_node_id != self._reader_node_id:
-                            raise NotImplementedError(
-                                "All readers must be on the same node for now."
-                            )
+                self._reader_node_id = _get_reader_node_id(self, readers[0])
+                for reader in readers:
+                    reader_node_id = _get_reader_node_id(self, reader)
+                    if reader_node_id != self._reader_node_id:
+                        raise NotImplementedError(
+                            "All readers must be on the same node for now."
+                        )
                 if self.is_remote():
+                    fn = readers[0].__ray_call__
                     self._reader_ref = ray.get(
                         fn.remote(_create_channel_ref, buffer_size_bytes)
                     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Accelerated Dag currently does not support multiple methods within the same actor. This PR adds the support.

<!-- Please give a short summary of the change and the problem this solves. -->

In this PR, the methods from the same actor are first grouped together, and then executed in the same execution loop based on their submission (binding) order.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #44194
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
