### PR TITLE
[ci][release-automation] Fix linux wheel sanity check step

### DIFF
--- a/.buildkite/release-automation/forge_x86_64.Dockerfile
+++ b/.buildkite/release-automation/forge_x86_64.Dockerfile
@@ -17,9 +17,9 @@ ln -s /usr/bin/clang-12 /usr/bin/clang
 
 # Install miniconda
 curl -sfL https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-x86_64.sh > /tmp/miniconda.sh
-bash /tmp/miniconda.sh -b -u -p /root/miniconda3
+bash /tmp/miniconda.sh -b -u -p /usr/local/bin/miniconda3
 rm /tmp/miniconda.sh
-/root/miniconda3/bin/conda init bash
+/usr/local/bin/miniconda3/bin/conda init bash
 
 # Install Bazelisk
 curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64 --output /usr/local/bin/bazelisk

--- a/.buildkite/release-automation/verify-linux-wheels.sh
+++ b/.buildkite/release-automation/verify-linux-wheels.sh
@@ -14,7 +14,8 @@ if [[ -z "$RAY_HASH" ]]; then
     exit 1
 fi
 
-export PATH="/root/miniconda3/bin:$PATH"
+export PATH="/usr/local/bin/miniconda3/bin:$PATH"
+source "/usr/local/bin/miniconda3/etc/profile.d/conda.sh"
 
 conda create -n rayio python="${PYTHON_VERSION}" -y
 


### PR DESCRIPTION
- Install `miniconda3` in `/usr/local/bin` instead of `/root` because we are now using non-root user.
- Fix path for miniconda3 to be `/usr/local/bin/....` instead of `/root/....` in the linux wheel check script
- Run `/etc/profile.d/conda.sh` straight from script so we don't have to call conda init again. This was done for macos wheel check script but not yet for Linux.