### PR TITLE
[ci][port/01] make pipeline id in rayci configurable

### DIFF
--- a/ci/ray_ci/automation/test_db_bot.py
+++ b/ci/ray_ci/automation/test_db_bot.py
@@ -3,8 +3,8 @@ import os
 import click
 
 from ci.ray_ci.utils import logger
-from ci.ray_ci.tester_container import TesterContainer, PIPELINE_MACOS_POSTMERGE
-from ray_release.configs.global_config import init_global_config
+from ci.ray_ci.tester_container import TesterContainer
+from ray_release.configs.global_config import init_global_config, get_global_config
 from ray_release.bazel import bazel_runfile
 
 
@@ -18,7 +18,10 @@ def main(team: str, bazel_log_dir: str) -> None:
         logger.info("Skip upload test results. We only upload on master branch.")
         return
 
-    if os.environ.get("BUILDKITE_PIPELINE_ID") != PIPELINE_MACOS_POSTMERGE:
+    if (
+        os.environ.get("BUILDKITE_PIPELINE_ID")
+        not in get_global_config()["pipeline_postmerge"]
+    ):
         logger.info("Skip upload test results. We only upload on postmerge pipeline.")
         return
 

--- a/ci/ray_ci/ray_docker_container.py
+++ b/ci/ray_ci/ray_docker_container.py
@@ -4,7 +4,8 @@ from typing import List
 from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.docker_container import DockerContainer
 from ci.ray_ci.builder_container import PYTHON_VERSIONS, DEFAULT_ARCHITECTURE
-from ci.ray_ci.utils import docker_pull, RAY_VERSION, POSTMERGE_PIPELINE
+from ci.ray_ci.utils import docker_pull, RAY_VERSION
+from ray_release.configs.global_config import get_global_config
 
 
 class RayDockerContainer(DockerContainer):
@@ -58,7 +59,7 @@ class RayDockerContainer(DockerContainer):
     def _should_upload(self) -> bool:
         if not self.upload:
             return False
-        if os.environ.get("BUILDKITE_PIPELINE_ID") != POSTMERGE_PIPELINE:
+        if os.environ.get("BUILDKITE_PIPELINE_ID") not in get_global_config()["pipeline_postmerge"]:
             return False
         if os.environ.get("BUILDKITE_BRANCH", "").startswith("releases/"):
             return True

--- a/ci/ray_ci/ray_docker_container.py
+++ b/ci/ray_ci/ray_docker_container.py
@@ -59,7 +59,10 @@ class RayDockerContainer(DockerContainer):
     def _should_upload(self) -> bool:
         if not self.upload:
             return False
-        if os.environ.get("BUILDKITE_PIPELINE_ID") not in get_global_config()["pipeline_postmerge"]:
+        if (
+            os.environ.get("BUILDKITE_PIPELINE_ID")
+            not in get_global_config()["pipeline_postmerge"]
+        ):
             return False
         if os.environ.get("BUILDKITE_BRANCH", "").startswith("releases/"):
             return True

--- a/ci/ray_ci/test_base.py
+++ b/ci/ray_ci/test_base.py
@@ -1,12 +1,12 @@
 import os
 import unittest
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch
 
 from ci.ray_ci.builder_container import PYTHON_VERSIONS
 from ci.ray_ci.builder import DEFAULT_PYTHON_VERSION
-import ray_release.configs.global_config
 
-POSTMERGE_PIPELINE = "w00tw00t"
+
+PIPELINE_POSTMERGE = "w00tw00t"
 
 
 class RayCITestBase(unittest.TestCase):

--- a/ci/ray_ci/test_base.py
+++ b/ci/ray_ci/test_base.py
@@ -1,9 +1,12 @@
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 from ci.ray_ci.builder_container import PYTHON_VERSIONS
 from ci.ray_ci.builder import DEFAULT_PYTHON_VERSION
+import ray_release.configs.global_config
+
+POSTMERGE_PIPELINE = "w00tw00t"
 
 
 class RayCITestBase(unittest.TestCase):

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -8,9 +8,9 @@ from unittest import mock
 from typing import List, Optional
 
 from ci.ray_ci.linux_tester_container import LinuxTesterContainer
-from ci.ray_ci.tester_container import PIPELINE_POSTMERGE
 from ci.ray_ci.utils import chunk_into_n
 from ci.ray_ci.container import _DOCKER_ECR_REPO, _RAYCI_BUILD_ID
+from ci.ray_ci.test_base import PIPELINE_POSTMERGE
 
 
 class MockPopen:
@@ -39,6 +39,9 @@ def test_persist_test_results(mock_upload_build_info, mock_upload_test_result) -
             "BUILDKITE_BRANCH": "master",
             "BUILDKITE_PIPELINE_ID": "non-id",
         },
+    ), mock.patch(
+        "ci.ray_ci.tester_container.get_global_config",
+        return_value={"pipeline_postmerge": [PIPELINE_POSTMERGE]},
     ):
         container._persist_test_results("team", "log_dir")
         assert not mock_upload_build_info.called
@@ -48,6 +51,9 @@ def test_persist_test_results(mock_upload_build_info, mock_upload_test_result) -
             "BUILDKITE_BRANCH": "master",
             "BUILDKITE_PIPELINE_ID": PIPELINE_POSTMERGE,
         },
+    ), mock.patch(
+        "ci.ray_ci.tester_container.get_global_config",
+        return_value={"pipeline_postmerge": [PIPELINE_POSTMERGE]},
     ):
         container._persist_test_results("team", "log_dir")
         assert mock_upload_build_info.called

--- a/ci/ray_ci/test_ray_docker_container.py
+++ b/ci/ray_ci/test_ray_docker_container.py
@@ -2,17 +2,15 @@ import os
 import sys
 from typing import List
 from unittest import mock
-from unittest.mock import patch
 from datetime import datetime
 import pytest
 
 from ci.ray_ci.builder_container import DEFAULT_PYTHON_VERSION
 from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.ray_docker_container import RayDockerContainer
-from ci.ray_ci.test_base import RayCITestBase
+from ci.ray_ci.test_base import RayCITestBase, PIPELINE_POSTMERGE
 from ci.ray_ci.utils import RAY_VERSION
 
-POSTMERGE_PIPELINE = "w00tw00t"
 
 class TestRayDockerContainer(RayCITestBase):
     cmds = []
@@ -315,11 +313,9 @@ class TestRayDockerContainer(RayCITestBase):
         container = RayDockerContainer(v, "cu11.8.0", "ray")
         assert container.get_platform_tag() == "-cu118"
 
-    @patch(
+    @mock.patch(
         "ci.ray_ci.ray_docker_container.get_global_config",
-        return_value={
-            "pipeline_postmerge": [POSTMERGE_PIPELINE]
-        },
+        return_value={"pipeline_postmerge": [PIPELINE_POSTMERGE]},
     )
     def test_should_upload(self, mock_config) -> None:
         v = DEFAULT_PYTHON_VERSION
@@ -327,14 +323,14 @@ class TestRayDockerContainer(RayCITestBase):
             # environment_variables, expected_result (with upload flag on)
             (
                 {
-                    "BUILDKITE_PIPELINE_ID": POSTMERGE_PIPELINE,
+                    "BUILDKITE_PIPELINE_ID": PIPELINE_POSTMERGE,
                     "BUILDKITE_BRANCH": "releases/1.0.0",
                 },
                 True,  # satisfy upload requirements
             ),
             (
                 {
-                    "BUILDKITE_PIPELINE_ID": POSTMERGE_PIPELINE,
+                    "BUILDKITE_PIPELINE_ID": PIPELINE_POSTMERGE,
                     "BUILDKITE_BRANCH": "master",
                     "RAYCI_SCHEDULE": "nightly",
                 },
@@ -350,14 +346,14 @@ class TestRayDockerContainer(RayCITestBase):
             ),
             (
                 {
-                    "BUILDKITE_PIPELINE_ID": POSTMERGE_PIPELINE,
+                    "BUILDKITE_PIPELINE_ID": PIPELINE_POSTMERGE,
                     "BUILDKITE_BRANCH": "non-release/1.2.3",
                 },
                 False,  # not satisfied: branch is not release/master
             ),
             (
                 {
-                    "BUILDKITE_PIPELINE_ID": POSTMERGE_PIPELINE,
+                    "BUILDKITE_PIPELINE_ID": PIPELINE_POSTMERGE,
                     "BUILDKITE_BRANCH": "123",
                     "RAYCI_SCHEDULE": "nightly",
                 },

--- a/ci/ray_ci/test_ray_docker_container.py
+++ b/ci/ray_ci/test_ray_docker_container.py
@@ -2,6 +2,7 @@ import os
 import sys
 from typing import List
 from unittest import mock
+from unittest.mock import patch
 from datetime import datetime
 import pytest
 
@@ -9,8 +10,9 @@ from ci.ray_ci.builder_container import DEFAULT_PYTHON_VERSION
 from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.ray_docker_container import RayDockerContainer
 from ci.ray_ci.test_base import RayCITestBase
-from ci.ray_ci.utils import RAY_VERSION, POSTMERGE_PIPELINE
+from ci.ray_ci.utils import RAY_VERSION
 
+POSTMERGE_PIPELINE = "w00tw00t"
 
 class TestRayDockerContainer(RayCITestBase):
     cmds = []
@@ -313,7 +315,13 @@ class TestRayDockerContainer(RayCITestBase):
         container = RayDockerContainer(v, "cu11.8.0", "ray")
         assert container.get_platform_tag() == "-cu118"
 
-    def test_should_upload(self) -> None:
+    @patch(
+        "ci.ray_ci.ray_docker_container.get_global_config",
+        return_value={
+            "pipeline_postmerge": [POSTMERGE_PIPELINE]
+        },
+    )
+    def test_should_upload(self, mock_config) -> None:
         v = DEFAULT_PYTHON_VERSION
         test_cases = [
             # environment_variables, expected_result (with upload flag on)

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -12,10 +12,7 @@ from ci.ray_ci.utils import shard_tests, chunk_into_n
 from ci.ray_ci.utils import logger
 from ci.ray_ci.container import Container
 from ray_release.test import TestResult, Test
-
-
-PIPELINE_POSTMERGE = "0189e759-8c96-4302-b6b5-b4274406bf89"
-PIPELINE_MACOS_POSTMERGE = "018e0f94-ccb6-45c2-b072-1e624fe9a404"
+from ray_release.configs.global_config import get_global_config
 
 
 class TesterContainer(Container):
@@ -111,7 +108,10 @@ class TesterContainer(Container):
         if os.environ.get("BUILDKITE_BRANCH") != "master":
             logger.info("Skip upload test results. We only upload on master branch.")
             return
-        if os.environ.get("BUILDKITE_PIPELINE_ID") != PIPELINE_POSTMERGE:
+        if (
+            os.environ.get("BUILDKITE_PIPELINE_ID")
+            not in get_global_config()["pipeline_postmerge"]
+        ):
             logger.info(
                 "Skip upload test results. We only upload on postmerge pipeline."
             )

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -13,7 +13,6 @@ import ci.ray_ci.bazel_sharding as bazel_sharding
 from ray_release.test import Test, TestState
 
 
-POSTMERGE_PIPELINE = "0189e759-8c96-4302-b6b5-b4274406bf89"
 RAY_VERSION = "3.0.0.dev0"
 
 

--- a/release/ray_release/configs/global_config.py
+++ b/release/ray_release/configs/global_config.py
@@ -1,6 +1,7 @@
 import os
 
 import yaml
+from typing import List
 from typing_extensions import TypedDict
 
 
@@ -13,6 +14,8 @@ class GlobalConfig(TypedDict):
     byod_gcp_cr: str
     state_machine_aws_bucket: str
     aws2gce_credentials: str
+    pipeline_premerge: List[str]
+    pipeline_postmerge: List[str]
 
 
 config = None
@@ -48,6 +51,8 @@ def _init_global_config(config_file: str):
         byod_gcp_cr=config_content["byod"].get("gcp_cr"),
         state_machine_aws_bucket=config_content["state_machine"]["aws_bucket"],
         aws2gce_credentials=config_content.get("credentials", {}).get("aws2gce"),
+        pipeline_premerge=config_content.get("pipeline", {}).get("premerge", []),
+        pipeline_postmerge=config_content.get("pipeline", {}).get("postmerge", []),
     )
     # setup GCP workload identity federation
     os.environ[

--- a/release/ray_release/configs/oss_config.yaml
+++ b/release/ray_release/configs/oss_config.yaml
@@ -9,3 +9,9 @@ state_machine:
   aws_bucket: ray-ci-results
 credentials:
   aws2gce: release/aws2gce_iam.json
+pipeline:
+  premerge:
+    - 0189942e-0876-4b8f-80a4-617f988ec59b
+  postmerge: 
+    - 0189e759-8c96-4302-b6b5-b4274406bf89
+    - 018e0f94-ccb6-45c2-b072-1e624fe9a404

--- a/release/ray_release/tests/test_global_config.py
+++ b/release/ray_release/tests/test_global_config.py
@@ -22,7 +22,7 @@ state_machine:
 credentials:
   aws2gce: release/aws2gce_iam.json
 pipeline:
-  postmerge: 
+  postmerge:
     - hi
     - w00t
 """

--- a/release/ray_release/tests/test_global_config.py
+++ b/release/ray_release/tests/test_global_config.py
@@ -21,6 +21,10 @@ state_machine:
   aws_bucket: ray-ci-results
 credentials:
   aws2gce: release/aws2gce_iam.json
+pipeline:
+  postmerge: 
+    - hi
+    - w00t
 """
 
 
@@ -37,6 +41,8 @@ def test_init_global_config() -> None:
             os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
             == "/workdir/release/aws2gce_iam.json"
         )
+        assert config["pipeline_premerge"] == []
+        assert config["pipeline_postmerge"] == ["hi", "w00t"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make pipeline configuration in rayci so we can support it across repos

Test:
- CI
- e2e uploading: https://buildkite.com/ray-project/postmerge/builds/3713