### PR TITLE
Revert "[ci][flake/01] remove tests.yml"

### DIFF
--- a/ci/ray_ci/core.tests.yml
+++ b/ci/ray_ci/core.tests.yml
@@ -1,1 +1,12 @@
-flaky_tests: []
+flaky_tests:
+  - windows://:metric_exporter_grpc_test
+  - windows://python/ray/tests:test_actor_retry
+  - windows://python/ray/tests:test_object_spilling
+  - windows://python/ray/tests:test_object_spilling_asan
+  - windows://python/ray/tests:test_object_spilling_debug_mode
+  - windows://python/ray/tests:test_placement_group_3
+  - windows://python/ray/tests:test_reference_counting_2 
+  - windows://python/ray/tests:test_runtime_env_working_dir_3
+  - windows://python/ray/tests:test_task_events_2
+  # Flaky when keep starting many ray sessions on windows.
+  - windows://python/ray/tests:test_task_events_3 

--- a/ci/ray_ci/data.tests.yml
+++ b/ci/ray_ci/data.tests.yml
@@ -1,1 +1,2 @@
-flaky_tests: []
+flaky_tests:
+  - //python/ray/data:test_streaming_integration

--- a/ci/ray_ci/ml.tests.yml
+++ b/ci/ray_ci/ml.tests.yml
@@ -1,1 +1,3 @@
-flaky_tests: []
+flaky_tests:
+  # non-gpu tests
+  - //python/ray/train:horovod_cifar_pbt_example

--- a/ci/ray_ci/rllib.tests.yml
+++ b/ci/ray_ci/rllib.tests.yml
@@ -1,4 +1,17 @@
 flaky_tests:
+  # torch, tf2-static-graph, tf2-eager-tracing
+  - //rllib:learning_tests_multi_agent_cartpole_impala 
+  - //rllib:learning_tests_multi_agent_pendulum_ppo
+  - //rllib:learning_tests_stateless_cartpole_r2d2
+  - //rllib:learning_tests_cartpole_appo_fake_gpus
+  - //rllib:learning_tests_cartpole_ddppo
+  - //rllib:learning_tests_two_step_game_qmix
+  - //rllib:learning_tests_pendulum_cql
+  - //rllib:learning_tests_two_step_game_qmix_no_mixer
+  - //rllib:learning_tests_cartpole_crashing_and_stalling_appo
+  - //rllib:learning_tests_multi_agent_cartpole_crashing_appo
+  - //rllib:learning_tests_multi_agent_cartpole_crashing_and_stalling_appo
+  - //rllib:examples/self_play_with_open_spiel_connect_4_appo_w_rlm_tf2
   # algorithm, model and other tests
   - //rllib:test_bc 
   - //rllib:test_a3c


### PR DESCRIPTION
Reverts ray-project/ray#44244. A lot of rllib tests get way more sensitive when running in parallel.