### PR TITLE
[ci] mark window wheel build soft fail

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -18,6 +18,7 @@ steps:
       - core_cpp
     job_env: WINDOWS
     mount_windows_artifacts: true
+    soft_fail: true
     instance_type: windows
     commands:
       - bash ci/ray_ci/windows/install_tools.sh


### PR DESCRIPTION
Let's mark the window wheel build as soft fail until it is fixed. We rely on the postmerge pipeline to detect issues so let's not make it all red.

Test:
- CI