### PR TITLE
[ci][release-automation] Move miniconda to /usr/local/bin for forge_arm64

### DIFF
--- a/.buildkite/release-automation/forge_arm64.Dockerfile
+++ b/.buildkite/release-automation/forge_arm64.Dockerfile
@@ -17,9 +17,9 @@ ln -s /usr/bin/clang-12 /usr/bin/clang
 
 # Install miniconda
 curl -sfL https://repo.anaconda.com/miniconda/Miniconda3-py38_23.1.0-1-Linux-aarch64.sh > /tmp/miniconda.sh
-bash /tmp/miniconda.sh -b -u -p /root/miniconda3
+bash /tmp/miniconda.sh -b -u -p /usr/local/bin/miniconda3
 rm /tmp/miniconda.sh
-/root/miniconda3/bin/conda init bash
+/usr/local/bin/miniconda3/bin/conda init bash
 
 # Install Bazelisk
 curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-arm64 --output /usr/local/bin/bazelisk

--- a/.buildkite/release-automation/wheels.rayci.yml
+++ b/.buildkite/release-automation/wheels.rayci.yml
@@ -18,7 +18,6 @@ steps:
     depends_on: 
       - forge
       - forge_arm64
-      - upload-wheels-testpypi
 
   - label: "Linux x86_64 Python {{matrix}}"
     key: validate-linux-x86_64-wheels


### PR DESCRIPTION
- Recently, we switched to install miniconda in `/usr/local/bin` for forge_x86_64.
- This changed the script that verifies Linux wheels to also use conda at `/usr/local/bin/miniconda3/bin/...` path instead of /root/miniconda3/....`.
- The steps for linux arm64 sanity check also use this script which is an issue, so miniconda on `forge_arm64` is now installed at `/usr/local/bin` as well.