### PR TITLE
[ci][config/01] rename fields in global config

### DIFF
--- a/release/ray_release/configs/global_config.py
+++ b/release/ray_release/configs/global_config.py
@@ -40,14 +40,37 @@ def _init_global_config(config_file: str):
     global config
     config_content = yaml.safe_load(open(config_file, "rt"))
     config = GlobalConfig(
-        byod_ray_ecr=config_content["byod"]["ray_ecr"],
-        byod_ray_cr_repo=config_content["byod"]["ray_cr_repo"],
-        byod_ray_ml_cr_repo=config_content["byod"]["ray_ml_cr_repo"],
-        byod_ecr=config_content["byod"]["byod_ecr"],
-        byod_aws_cr=config_content["byod"].get("aws_cr"),
-        byod_gcp_cr=config_content["byod"].get("gcp_cr"),
-        state_machine_aws_bucket=config_content["state_machine"]["aws_bucket"],
-        aws2gce_credentials=config_content.get("credentials", {}).get("aws2gce"),
+        byod_ray_ecr=(
+            config_content.get("byod", {}).get("ray_ecr")
+            or config_content.get("release_byod", {}).get("ray_ecr")
+        ),
+        byod_ray_cr_repo=(
+            config_content.get("byod", {}).get("ray_cr_repo")
+            or config_content.get("release_byod", {}).get("ray_cr_repo")
+        ),
+        byod_ray_ml_cr_repo=(
+            config_content.get("byod", {}).get("ray_ml_cr_repo")
+            or config_content.get("release_byod", {}).get("ray_ml_cr_repo")
+        ),
+        byod_ecr=(
+            config_content.get("byod", {}).get("byod_ecr")
+            or config_content.get("release_byod", {}).get("byod_ecr")
+        ),
+        byod_aws_cr=(
+            config_content.get("byod", {}).get("aws_cr")
+            or config_content.get("release_byod", {}).get("aws_cr")
+        ),
+        byod_gcp_cr=(
+            config_content.get("byod", {}).get("gcp_cr")
+            or config_content.get("release_byod", {}).get("gcp_cr")
+        ),
+        aws2gce_credentials=(
+            config_content.get("credentials", {}).get("aws2gce")
+            or config_content.get("release_byod", {}).get("aws2gce_credentials")
+        ),
+        state_machine_aws_bucket=config_content.get("state_machine", {}).get(
+            "aws_bucket",
+        ),
     )
     # setup GCP workload identity federation
     os.environ[

--- a/release/ray_release/configs/oss_config.yaml
+++ b/release/ray_release/configs/oss_config.yaml
@@ -1,11 +1,10 @@
-byod:
+release_byod:
   ray_ecr: rayproject
   ray_cr_repo: ray
   ray_ml_cr_repo: ray-ml
   byod_ecr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
   aws_cr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
   gcp_cr: us-west1-docker.pkg.dev/anyscale-oss-ci
+  aws2gce_credentials: release/aws2gce_iam.json
 state_machine:
   aws_bucket: ray-ci-results
-credentials:
-  aws2gce: release/aws2gce_iam.json

--- a/release/ray_release/tests/test_global_config.py
+++ b/release/ray_release/tests/test_global_config.py
@@ -13,6 +13,7 @@ _TEST_CONFIG = """
 byod:
   ray_ecr: rayproject
   ray_cr_repo: ray
+release_byod:
   ray_ml_cr_repo: ray-ml
   byod_ecr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
   aws_cr: 029272617770.dkr.ecr.us-west-2.amazonaws.com


### PR DESCRIPTION
Rename `byod --> release_byod` in the global config. We want to reuse this same config across release and ci, so add a namespace mechanism to the top level field for readability. Do it this way for safe deployment.

The schema will be:

```
release_<feature>
   ...
ci_<feature>
   ...
<common_feature>
  ...
```

Test:
- CI
- release test