### PR TITLE
[ci][config/02] move oss_config.yaml to ci directory

### DIFF
--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -12,6 +12,7 @@ py_library(
         ],
     ),
     visibility = ["//ci/ray_ci:__subpackages__"],
+    data = glob(["*.yaml"]),
     deps = [
         ci_require("boto3"),
         ci_require("pyyaml"),

--- a/ci/ray_ci/automation/filter_tests.py
+++ b/ci/ray_ci/automation/filter_tests.py
@@ -1,9 +1,7 @@
 import sys
 import click
 
-from ci.ray_ci.utils import filter_tests
-from ray_release.configs.global_config import init_global_config
-from ray_release.bazel import bazel_runfile
+from ci.ray_ci.utils import filter_tests, ci_init
 
 
 @click.command()
@@ -22,7 +20,7 @@ def main(prefix: str, state_filter: str) -> None:
         state_filter: Options on what test to filter: "flaky" or "-flaky".
     """
     # Initialize global config
-    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    ci_init()
 
     filter_tests(sys.stdin, sys.stdout, prefix, state_filter)
 

--- a/ci/ray_ci/automation/state_machine_bot.py
+++ b/ci/ray_ci/automation/state_machine_bot.py
@@ -2,11 +2,9 @@ from typing import List
 
 import click
 
-from ci.ray_ci.utils import logger
+from ci.ray_ci.utils import logger, ci_init
 from ray_release.test import Test
 from ray_release.test_automation.ci_state_machine import CITestStateMachine
-from ray_release.configs.global_config import init_global_config
-from ray_release.bazel import bazel_runfile
 
 
 ALL_TEST_PREFIXES = ["linux:", "windows:", "darwin:"]
@@ -34,7 +32,7 @@ def main(production: bool, test_prefix: List[str]) -> None:
     Run state machine on all CI tests.
     """
     logger.info("Starting state machine bot ...")
-    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    ci_init()
     test_prefix = test_prefix or ALL_TEST_PREFIXES
     tests = _get_ci_tests(test_prefix)
     for test in tests:

--- a/ci/ray_ci/automation/test_db_bot.py
+++ b/ci/ray_ci/automation/test_db_bot.py
@@ -2,18 +2,16 @@ import os
 
 import click
 
-from ci.ray_ci.utils import logger
+from ci.ray_ci.utils import logger, ci_init
 from ci.ray_ci.tester_container import TesterContainer
-from ray_release.configs.global_config import init_global_config
 from release.ray_release.configs.global_config import BRANCH_PIPELINES
-from ray_release.bazel import bazel_runfile
 
 
 @click.command()
 @click.argument("team", required=True, type=str)
 @click.argument("bazel_log_dir", required=True, type=str)
 def main(team: str, bazel_log_dir: str) -> None:
-    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    ci_init()
 
     if os.environ.get("BUILDKITE_BRANCH") != "master":
         logger.info("Skip upload test results. We only upload on master branch.")

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -5,10 +5,9 @@ import sys
 import boto3
 import click
 
-from ci.ray_ci.utils import logger
+from ci.ray_ci.utils import logger, ci_init
 from ray_release.test_automation.state_machine import TestStateMachine
-from ray_release.configs.global_config import init_global_config, get_global_config
-from ray_release.bazel import bazel_runfile
+from ray_release.configs.global_config import get_global_config
 
 
 AWS_WEEKLY_GREEN_METRIC = "ray_weekly_green_metric"
@@ -31,7 +30,7 @@ AWS_WEEKLY_GREEN_METRIC = "ray_weekly_green_metric"
     help=("Check whether there is 0 blockers."),
 )
 def main(production: bool, check: bool) -> None:
-    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    ci_init()
     blockers = TestStateMachine.get_release_blockers()
     logger.info(f"Found {blockers.totalCount} release blockers")
 

--- a/ci/ray_ci/oss_config.yaml
+++ b/ci/ray_ci/oss_config.yaml
@@ -1,0 +1,10 @@
+release_byod:
+  ray_ecr: rayproject
+  ray_cr_repo: ray
+  ray_ml_cr_repo: ray-ml
+  byod_ecr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
+  aws_cr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
+  gcp_cr: us-west1-docker.pkg.dev/anyscale-oss-ci
+  aws2gce_credentials: release/aws2gce_iam.json
+state_machine:
+  aws_bucket: ray-ci-results

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -16,9 +16,7 @@ from ci.ray_ci.builder_container import (
 from ci.ray_ci.linux_tester_container import LinuxTesterContainer
 from ci.ray_ci.windows_tester_container import WindowsTesterContainer
 from ci.ray_ci.tester_container import TesterContainer
-from ci.ray_ci.utils import docker_login
-from ray_release.configs.global_config import init_global_config
-from ray_release.bazel import bazel_runfile
+from ci.ray_ci.utils import docker_login, ci_init
 from ray_release.test import Test, TestState
 
 CUDA_COPYRIGHT = """
@@ -185,7 +183,7 @@ def main(
     if not bazel_workspace_dir:
         raise Exception("Please use `bazelisk run //ci/ray_ci`")
     os.chdir(bazel_workspace_dir)
-    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    ci_init()
     docker_login(_DOCKER_ECR_REPO.split("/")[0])
 
     if build_type == "wheel" or build_type == "wheel-aarch64":

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import logging
+import os
 import subprocess
 import sys
 import tempfile
@@ -10,10 +11,21 @@ from typing import List
 from math import ceil
 
 import ci.ray_ci.bazel_sharding as bazel_sharding
+from ray_release.bazel import bazel_runfile
 from ray_release.test import Test, TestState
+from ray_release.configs.global_config import init_global_config
 
-
+GLOBAL_CONFIG_FILE = (
+    os.environ.get("RAYCI_GLOBAL_CONFIG") or "ci/ray_ci/oss_config.yaml"
+)
 RAY_VERSION = "3.0.0.dev0"
+
+
+def ci_init() -> None:
+    """
+    Initialize global config
+    """
+    init_global_config(bazel_runfile(GLOBAL_CONFIG_FILE))
 
 
 def chunk_into_n(list: List[str], n: int) -> List[List[str]]:

--- a/release/ray_release/configs/oss_config.yaml
+++ b/release/ray_release/configs/oss_config.yaml
@@ -1,10 +1,1 @@
-release_byod:
-  ray_ecr: rayproject
-  ray_cr_repo: ray
-  ray_ml_cr_repo: ray-ml
-  byod_ecr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
-  aws_cr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
-  gcp_cr: us-west1-docker.pkg.dev/anyscale-oss-ci
-  aws2gce_credentials: release/aws2gce_iam.json
-state_machine:
-  aws_bucket: ray-ci-results
+../../../ci/ray_ci/oss_config.yaml


### PR DESCRIPTION
Move the oss_config.yaml to ci directory; leave the symlink in release directory for now since there are a lot of places hard link to it.

Test:
- CI
- Release tests