### PR TITLE
[dashboard] add `memray` to requirements.txt

### DIFF
--- a/dashboard/modules/reporter/profile_manager.py
+++ b/dashboard/modules/reporter/profile_manager.py
@@ -353,6 +353,9 @@ class MemoryProfilingManager:
             cmd.append("--verbose")
         cmd.append(str(pid))
 
+        if await _can_passwordless_sudo():
+            cmd = ["sudo", "-n"] + cmd
+
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=subprocess.PIPE,

--- a/dashboard/optional_deps.py
+++ b/dashboard/optional_deps.py
@@ -8,6 +8,7 @@
 import opencensus  # noqa: F401
 
 import prometheus_client  # noqa: F401
+import memray  # noqa: F401
 
 import aiohttp  # noqa: F401
 import aiohttp.web  # noqa: F401

--- a/python/ray/tests/test_minimal_install.py
+++ b/python/ray/tests/test_minimal_install.py
@@ -80,6 +80,7 @@ def test_module_import_with_various_non_minimal_deps(pydantic_version: str):
         "aiohttp_cors",
         "pydantic",
         "grpc",
+        "memray",
     ]
     for i in range(len(optional_modules)):
         for install_modules in itertools.combinations(optional_modules, i):

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -58,3 +58,4 @@ pandas>=1.3
 pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3  # Serve users can use pydantic<2
 py-spy>=0.2.0
 watchfiles
+memray

--- a/python/setup.py
+++ b/python/setup.py
@@ -250,6 +250,7 @@ if setup_spec.type == SetupType.RAY:
             "prometheus_client >= 0.7.1",
             "smart_open",
             "virtualenv >=20.0.24, !=20.21.1",  # For pip runtime env.
+            "memray",
         ],
         "client": [
             # The Ray client needs a specific range of gRPC to work:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`memray` is used by the memory profiler but it's currently missing in ray requirements. We will see this error if we try to get the memory profiling from a running actor.


https://github.com/ray-project/ray/assets/18074733/09654b90-2cf1-43e4-8aae-fcbfe3996c0b



## Changes

* Added `memray` to ray dashboard's requirements.
* Run `memray detach` with `sudo` since the attach command is run with `sudo`. 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.

### Testing Strategy

Manually tested the memory profiling page could be loaded with the fix. Note that `memray` requires `gdb` or `lldb` to work and I install them manually in my system. 

https://github.com/ray-project/ray/assets/18074733/c2c1b127-f4c4-4cff-b9cf-3c403d6ddbda


