### PR TITLE
[ci][config/00] refactor pipeline id constants

### DIFF
--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -12,6 +12,7 @@ py_library(
         ],
     ),
     visibility = ["//ci/ray_ci:__subpackages__"],
+    data = glob(["*.yaml"]),
     deps = [
         ci_require("boto3"),
         ci_require("pyyaml"),

--- a/ci/ray_ci/automation/filter_tests.py
+++ b/ci/ray_ci/automation/filter_tests.py
@@ -1,9 +1,7 @@
 import sys
 import click
 
-from ci.ray_ci.utils import filter_tests
-from ray_release.configs.global_config import init_global_config
-from ray_release.bazel import bazel_runfile
+from ci.ray_ci.utils import filter_tests, ci_init
 
 
 @click.command()
@@ -22,7 +20,7 @@ def main(prefix: str, state_filter: str) -> None:
         state_filter: Options on what test to filter: "flaky" or "-flaky".
     """
     # Initialize global config
-    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    ci_init()
 
     filter_tests(sys.stdin, sys.stdout, prefix, state_filter)
 

--- a/ci/ray_ci/automation/state_machine_bot.py
+++ b/ci/ray_ci/automation/state_machine_bot.py
@@ -2,11 +2,9 @@ from typing import List
 
 import click
 
-from ci.ray_ci.utils import logger
+from ci.ray_ci.utils import logger, ci_init
 from ray_release.test import Test
 from ray_release.test_automation.ci_state_machine import CITestStateMachine
-from ray_release.configs.global_config import init_global_config
-from ray_release.bazel import bazel_runfile
 
 
 ALL_TEST_PREFIXES = ["linux:", "windows:", "darwin:"]
@@ -34,7 +32,7 @@ def main(production: bool, test_prefix: List[str]) -> None:
     Run state machine on all CI tests.
     """
     logger.info("Starting state machine bot ...")
-    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    ci_init()
     test_prefix = test_prefix or ALL_TEST_PREFIXES
     tests = _get_ci_tests(test_prefix)
     for test in tests:

--- a/ci/ray_ci/automation/test_db_bot.py
+++ b/ci/ray_ci/automation/test_db_bot.py
@@ -3,8 +3,9 @@ import os
 import click
 
 from ci.ray_ci.utils import logger
-from ci.ray_ci.tester_container import TesterContainer, PIPELINE_MACOS_POSTMERGE
+from ci.ray_ci.tester_container import TesterContainer
 from ray_release.configs.global_config import init_global_config
+from release.ray_release.configs.global_config import BRANCH_PIPELINES
 from ray_release.bazel import bazel_runfile
 
 
@@ -18,7 +19,7 @@ def main(team: str, bazel_log_dir: str) -> None:
         logger.info("Skip upload test results. We only upload on master branch.")
         return
 
-    if os.environ.get("BUILDKITE_PIPELINE_ID") != PIPELINE_MACOS_POSTMERGE:
+    if os.environ.get("BUILDKITE_PIPELINE_ID") not in BRANCH_PIPELINES:
         logger.info("Skip upload test results. We only upload on postmerge pipeline.")
         return
 

--- a/ci/ray_ci/automation/test_db_bot.py
+++ b/ci/ray_ci/automation/test_db_bot.py
@@ -2,18 +2,16 @@ import os
 
 import click
 
-from ci.ray_ci.utils import logger
+from ci.ray_ci.utils import logger, ci_init
 from ci.ray_ci.tester_container import TesterContainer
-from ray_release.configs.global_config import init_global_config
 from release.ray_release.configs.global_config import BRANCH_PIPELINES
-from ray_release.bazel import bazel_runfile
 
 
 @click.command()
 @click.argument("team", required=True, type=str)
 @click.argument("bazel_log_dir", required=True, type=str)
 def main(team: str, bazel_log_dir: str) -> None:
-    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    ci_init()
 
     if os.environ.get("BUILDKITE_BRANCH") != "master":
         logger.info("Skip upload test results. We only upload on master branch.")

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -5,10 +5,9 @@ import sys
 import boto3
 import click
 
-from ci.ray_ci.utils import logger
+from ci.ray_ci.utils import logger, ci_init
 from ray_release.test_automation.state_machine import TestStateMachine
-from ray_release.configs.global_config import init_global_config, get_global_config
-from ray_release.bazel import bazel_runfile
+from ray_release.configs.global_config import get_global_config
 
 
 AWS_WEEKLY_GREEN_METRIC = "ray_weekly_green_metric"
@@ -31,7 +30,7 @@ AWS_WEEKLY_GREEN_METRIC = "ray_weekly_green_metric"
     help=("Check whether there is 0 blockers."),
 )
 def main(production: bool, check: bool) -> None:
-    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    ci_init()
     blockers = TestStateMachine.get_release_blockers()
     logger.info(f"Found {blockers.totalCount} release blockers")
 

--- a/ci/ray_ci/oss_config.yaml
+++ b/ci/ray_ci/oss_config.yaml
@@ -1,0 +1,10 @@
+release_byod:
+  ray_ecr: rayproject
+  ray_cr_repo: ray
+  ray_ml_cr_repo: ray-ml
+  byod_ecr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
+  aws_cr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
+  gcp_cr: us-west1-docker.pkg.dev/anyscale-oss-ci
+  aws2gce_credentials: release/aws2gce_iam.json
+state_machine:
+  aws_bucket: ray-ci-results

--- a/ci/ray_ci/ray_docker_container.py
+++ b/ci/ray_ci/ray_docker_container.py
@@ -4,7 +4,8 @@ from typing import List
 from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.docker_container import DockerContainer
 from ci.ray_ci.builder_container import PYTHON_VERSIONS, DEFAULT_ARCHITECTURE
-from ci.ray_ci.utils import docker_pull, RAY_VERSION, POSTMERGE_PIPELINE
+from ci.ray_ci.utils import docker_pull, RAY_VERSION
+from release.ray_release.configs.global_config import BRANCH_PIPELINES
 
 
 class RayDockerContainer(DockerContainer):
@@ -58,7 +59,7 @@ class RayDockerContainer(DockerContainer):
     def _should_upload(self) -> bool:
         if not self.upload:
             return False
-        if os.environ.get("BUILDKITE_PIPELINE_ID") != POSTMERGE_PIPELINE:
+        if os.environ.get("BUILDKITE_PIPELINE_ID") not in BRANCH_PIPELINES:
             return False
         if os.environ.get("BUILDKITE_BRANCH", "").startswith("releases/"):
             return True

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -8,9 +8,9 @@ from unittest import mock
 from typing import List, Optional
 
 from ci.ray_ci.linux_tester_container import LinuxTesterContainer
-from ci.ray_ci.tester_container import PIPELINE_POSTMERGE
 from ci.ray_ci.utils import chunk_into_n
 from ci.ray_ci.container import _DOCKER_ECR_REPO, _RAYCI_BUILD_ID
+from release.ray_release.configs.global_config import BRANCH_PIPELINES
 
 
 class MockPopen:
@@ -46,7 +46,7 @@ def test_persist_test_results(mock_upload_build_info, mock_upload_test_result) -
         os.environ,
         {
             "BUILDKITE_BRANCH": "master",
-            "BUILDKITE_PIPELINE_ID": PIPELINE_POSTMERGE,
+            "BUILDKITE_PIPELINE_ID": BRANCH_PIPELINES[0],
         },
     ):
         container._persist_test_results("team", "log_dir")

--- a/ci/ray_ci/test_ray_docker_container.py
+++ b/ci/ray_ci/test_ray_docker_container.py
@@ -9,7 +9,8 @@ from ci.ray_ci.builder_container import DEFAULT_PYTHON_VERSION
 from ci.ray_ci.container import _DOCKER_ECR_REPO
 from ci.ray_ci.ray_docker_container import RayDockerContainer
 from ci.ray_ci.test_base import RayCITestBase
-from ci.ray_ci.utils import RAY_VERSION, POSTMERGE_PIPELINE
+from ci.ray_ci.utils import RAY_VERSION
+from release.ray_release.configs.global_config import BRANCH_PIPELINES
 
 
 class TestRayDockerContainer(RayCITestBase):
@@ -319,14 +320,14 @@ class TestRayDockerContainer(RayCITestBase):
             # environment_variables, expected_result (with upload flag on)
             (
                 {
-                    "BUILDKITE_PIPELINE_ID": POSTMERGE_PIPELINE,
+                    "BUILDKITE_PIPELINE_ID": BRANCH_PIPELINES[0],
                     "BUILDKITE_BRANCH": "releases/1.0.0",
                 },
                 True,  # satisfy upload requirements
             ),
             (
                 {
-                    "BUILDKITE_PIPELINE_ID": POSTMERGE_PIPELINE,
+                    "BUILDKITE_PIPELINE_ID": BRANCH_PIPELINES[0],
                     "BUILDKITE_BRANCH": "master",
                     "RAYCI_SCHEDULE": "nightly",
                 },
@@ -342,14 +343,14 @@ class TestRayDockerContainer(RayCITestBase):
             ),
             (
                 {
-                    "BUILDKITE_PIPELINE_ID": POSTMERGE_PIPELINE,
+                    "BUILDKITE_PIPELINE_ID": BRANCH_PIPELINES[-1],
                     "BUILDKITE_BRANCH": "non-release/1.2.3",
                 },
                 False,  # not satisfied: branch is not release/master
             ),
             (
                 {
-                    "BUILDKITE_PIPELINE_ID": POSTMERGE_PIPELINE,
+                    "BUILDKITE_PIPELINE_ID": BRANCH_PIPELINES[-1],
                     "BUILDKITE_BRANCH": "123",
                     "RAYCI_SCHEDULE": "nightly",
                 },

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -16,9 +16,7 @@ from ci.ray_ci.builder_container import (
 from ci.ray_ci.linux_tester_container import LinuxTesterContainer
 from ci.ray_ci.windows_tester_container import WindowsTesterContainer
 from ci.ray_ci.tester_container import TesterContainer
-from ci.ray_ci.utils import docker_login
-from ray_release.configs.global_config import init_global_config
-from ray_release.bazel import bazel_runfile
+from ci.ray_ci.utils import docker_login, ci_init
 from ray_release.test import Test, TestState
 
 CUDA_COPYRIGHT = """
@@ -185,7 +183,7 @@ def main(
     if not bazel_workspace_dir:
         raise Exception("Please use `bazelisk run //ci/ray_ci`")
     os.chdir(bazel_workspace_dir)
-    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    ci_init()
     docker_login(_DOCKER_ECR_REPO.split("/")[0])
 
     if build_type == "wheel" or build_type == "wheel-aarch64":

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -12,10 +12,7 @@ from ci.ray_ci.utils import shard_tests, chunk_into_n
 from ci.ray_ci.utils import logger
 from ci.ray_ci.container import Container
 from ray_release.test import TestResult, Test
-
-
-PIPELINE_POSTMERGE = "0189e759-8c96-4302-b6b5-b4274406bf89"
-PIPELINE_MACOS_POSTMERGE = "018e0f94-ccb6-45c2-b072-1e624fe9a404"
+from release.ray_release.configs.global_config import BRANCH_PIPELINES
 
 
 class TesterContainer(Container):
@@ -111,7 +108,7 @@ class TesterContainer(Container):
         if os.environ.get("BUILDKITE_BRANCH") != "master":
             logger.info("Skip upload test results. We only upload on master branch.")
             return
-        if os.environ.get("BUILDKITE_PIPELINE_ID") != PIPELINE_POSTMERGE:
+        if os.environ.get("BUILDKITE_PIPELINE_ID") not in BRANCH_PIPELINES:
             logger.info(
                 "Skip upload test results. We only upload on postmerge pipeline."
             )

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -13,7 +13,6 @@ import ci.ray_ci.bazel_sharding as bazel_sharding
 from ray_release.test import Test, TestState
 
 
-POSTMERGE_PIPELINE = "0189e759-8c96-4302-b6b5-b4274406bf89"
 RAY_VERSION = "3.0.0.dev0"
 
 

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import logging
+import os
 import subprocess
 import sys
 import tempfile
@@ -10,10 +11,21 @@ from typing import List
 from math import ceil
 
 import ci.ray_ci.bazel_sharding as bazel_sharding
+from ray_release.bazel import bazel_runfile
 from ray_release.test import Test, TestState
+from ray_release.configs.global_config import init_global_config
 
-
+GLOBAL_CONFIG_FILE = (
+    os.environ.get("RAYCI_GLOBAL_CONFIG") or "ci/ray_ci/oss_config.yaml"
+)
 RAY_VERSION = "3.0.0.dev0"
+
+
+def ci_init() -> None:
+    """
+    Initialize global config
+    """
+    init_global_config(bazel_runfile(GLOBAL_CONFIG_FILE))
 
 
 def chunk_into_n(list: List[str], n: int) -> List[List[str]]:

--- a/release/ray_release/configs/global_config.py
+++ b/release/ray_release/configs/global_config.py
@@ -3,6 +3,14 @@ import os
 import yaml
 from typing_extensions import TypedDict
 
+PR_PIPELINES = [
+    "0189942e-0876-4b8f-80a4-617f988ec59b",  # premerge
+]
+BRANCH_PIPELINES = [
+    "0189e759-8c96-4302-b6b5-b4274406bf89",  # postmerge
+    "018e0f94-ccb6-45c2-b072-1e624fe9a404",  # postmerge-macos
+]
+
 
 class GlobalConfig(TypedDict):
     byod_ray_ecr: str

--- a/release/ray_release/configs/oss_config.yaml
+++ b/release/ray_release/configs/oss_config.yaml
@@ -1,10 +1,1 @@
-release_byod:
-  ray_ecr: rayproject
-  ray_cr_repo: ray
-  ray_ml_cr_repo: ray-ml
-  byod_ecr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
-  aws_cr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
-  gcp_cr: us-west1-docker.pkg.dev/anyscale-oss-ci
-  aws2gce_credentials: release/aws2gce_iam.json
-state_machine:
-  aws_bucket: ray-ci-results
+../../../ci/ray_ci/oss_config.yaml


### PR DESCRIPTION
Move all pipeline constants to one place. Rename them into branch vs pr pipelines. Pure refactoring, doesn't change any existing logic so does not affect upstream in anyway.

Test:
- CI