### PR TITLE
[ci][config/03] store pr test results into s3 bucket

### DIFF
--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -45,7 +45,7 @@ def main(production: bool, check: bool) -> None:
             logger.info(f"\t- Team {team} has {num_blocker} release blockers")
 
         boto3.client("s3").put_object(
-            Bucket=get_global_config()["state_machine_aws_bucket"],
+            Bucket=get_global_config()["state_machine_master_aws_bucket"],
             Key=f"{AWS_WEEKLY_GREEN_METRIC}/blocker_{int(time.time() * 1000)}.json",
             Body=json.dumps(num_blocker_by_team),
         )

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -5,9 +5,9 @@ import sys
 import boto3
 import click
 
-from ci.ray_ci.utils import logger, ci_init, get_state_machine_aws_bucket
+from ci.ray_ci.utils import logger, ci_init
 from ray_release.test_automation.state_machine import TestStateMachine
-from ray_release.configs.global_config import get_global_config
+from ray_release.util import get_write_state_machine_aws_bucket
 
 
 AWS_WEEKLY_GREEN_METRIC = "ray_weekly_green_metric"
@@ -45,7 +45,7 @@ def main(production: bool, check: bool) -> None:
             logger.info(f"\t- Team {team} has {num_blocker} release blockers")
 
         boto3.client("s3").put_object(
-            Bucket=get_state_machine_aws_bucket(),
+            Bucket=get_write_state_machine_aws_bucket(),
             Key=f"{AWS_WEEKLY_GREEN_METRIC}/blocker_{int(time.time() * 1000)}.json",
             Body=json.dumps(num_blocker_by_team),
         )

--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -5,7 +5,7 @@ import sys
 import boto3
 import click
 
-from ci.ray_ci.utils import logger, ci_init
+from ci.ray_ci.utils import logger, ci_init, get_state_machine_aws_bucket
 from ray_release.test_automation.state_machine import TestStateMachine
 from ray_release.configs.global_config import get_global_config
 
@@ -45,7 +45,7 @@ def main(production: bool, check: bool) -> None:
             logger.info(f"\t- Team {team} has {num_blocker} release blockers")
 
         boto3.client("s3").put_object(
-            Bucket=get_global_config()["state_machine_master_aws_bucket"],
+            Bucket=get_state_machine_aws_bucket(),
             Key=f"{AWS_WEEKLY_GREEN_METRIC}/blocker_{int(time.time() * 1000)}.json",
             Body=json.dumps(num_blocker_by_team),
         )

--- a/ci/ray_ci/oss_config.yaml
+++ b/ci/ray_ci/oss_config.yaml
@@ -11,4 +11,3 @@ state_machine:
     aws_bucket: ray-ci-pr-results
   master:
     aws_bucket: ray-ci-results
-  aws_bucket: ray-ci-results

--- a/ci/ray_ci/oss_config.yaml
+++ b/ci/ray_ci/oss_config.yaml
@@ -7,4 +7,8 @@ release_byod:
   gcp_cr: us-west1-docker.pkg.dev/anyscale-oss-ci
   aws2gce_credentials: release/aws2gce_iam.json
 state_machine:
+  pr:
+    aws_bucket: ray-ci-pr-results
+  master:
+    aws_bucket: ray-ci-results
   aws_bucket: ray-ci-results

--- a/ci/ray_ci/oss_config.yaml
+++ b/ci/ray_ci/oss_config.yaml
@@ -9,5 +9,5 @@ release_byod:
 state_machine:
   pr:
     aws_bucket: ray-ci-pr-results
-  master:
+  branch:
     aws_bucket: ray-ci-results

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -12,7 +12,7 @@ from ci.ray_ci.utils import shard_tests, chunk_into_n
 from ci.ray_ci.utils import logger
 from ci.ray_ci.container import Container
 from ray_release.test import TestResult, Test
-from release.ray_release.configs.global_config import BRANCH_PIPELINES
+from release.ray_release.configs.global_config import BRANCH_PIPELINES, PR_PIPELINES
 
 
 class TesterContainer(Container):
@@ -105,12 +105,18 @@ class TesterContainer(Container):
         return all(exit == 0 for exit in exits)
 
     def _persist_test_results(self, team: str, bazel_log_dir: str) -> None:
-        if os.environ.get("BUILDKITE_BRANCH") != "master":
-            logger.info("Skip upload test results. We only upload on master branch.")
-            return
-        if os.environ.get("BUILDKITE_PIPELINE_ID") not in BRANCH_PIPELINES:
+        pipeline_id = os.environ.get("BUILDKITE_PIPELINE_ID")
+        branch = os.environ.get("BUILDKITE_BRANCH")
+        if pipeline_id not in BRANCH_PIPELINES + PR_PIPELINES:
             logger.info(
-                "Skip upload test results. We only upload on postmerge pipeline."
+                "Skip upload test results. "
+                "We only upload results on branch and PR pipelines",
+            )
+            return
+        if pipeline_id in BRANCH_PIPELINES and branch != "master":
+            logger.info(
+                "Skip upload test results. "
+                "We only upload the master branch results on a branch pipeline",
             )
             return
         self._upload_build_info(bazel_log_dir)

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -13,7 +13,7 @@ from math import ceil
 import ci.ray_ci.bazel_sharding as bazel_sharding
 from ray_release.bazel import bazel_runfile
 from ray_release.test import Test, TestState
-from ray_release.configs.global_config import init_global_config, get_global_config
+from ray_release.configs.global_config import init_global_config
 
 GLOBAL_CONFIG_FILE = (
     os.environ.get("RAYCI_GLOBAL_CONFIG") or "ci/ray_ci/oss_config.yaml"
@@ -26,21 +26,6 @@ def ci_init() -> None:
     Initialize global config
     """
     init_global_config(bazel_runfile(GLOBAL_CONFIG_FILE))
-
-
-def get_state_machine_aws_bucket() -> Optional[str]:
-    bucket_v1 = get_global_config()["state_machine_aws_bucket"]
-    if bucket_v1:
-        return bucket_v1
-
-    pipeline_id = os.environ.get("BUILDKITE_PIPELINE_ID")
-    branch = os.environ.get("BUILDKITE_BRANCH")
-    if pipeline_id == PREMERGE_PIPELINE:
-        return get_global_config()["state_machine_pr_aws_bucket"]
-    if pipeline_id == POSTMERGE_PIPELINE and branch == "master":
-        return get_global_config()["state_machine_master_aws_bucket"]
-
-    return None
 
 
 def chunk_into_n(list: List[str], n: int) -> List[List[str]]:

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -13,7 +13,7 @@ from math import ceil
 import ci.ray_ci.bazel_sharding as bazel_sharding
 from ray_release.bazel import bazel_runfile
 from ray_release.test import Test, TestState
-from ray_release.configs.global_config import init_global_config
+from ray_release.configs.global_config import init_global_config, get_global_config
 
 GLOBAL_CONFIG_FILE = (
     os.environ.get("RAYCI_GLOBAL_CONFIG") or "ci/ray_ci/oss_config.yaml"
@@ -26,6 +26,21 @@ def ci_init() -> None:
     Initialize global config
     """
     init_global_config(bazel_runfile(GLOBAL_CONFIG_FILE))
+
+
+def get_state_machine_aws_bucket() -> Optional[str]:
+    bucket_v1 = get_global_config()["state_machine_aws_bucket"]
+    if bucket_v1:
+        return bucket_v1
+
+    pipeline_id = os.environ.get("BUILDKITE_PIPELINE_ID")
+    branch = os.environ.get("BUILDKITE_BRANCH")
+    if pipeline_id == PREMERGE_PIPELINE:
+        return get_global_config()["state_machine_pr_aws_bucket"]
+    if pipeline_id == POSTMERGE_PIPELINE and branch == "master":
+        return get_global_config()["state_machine_master_aws_bucket"]
+
+    return None
 
 
 def chunk_into_n(list: List[str], n: int) -> List[List[str]]:

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -399,6 +399,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         bk_require("anyscale"),
+        bk_require("aws-requests-auth"),
         bk_require("bazel-runfiles"),
         bk_require("boto3"),
         bk_require("botocore"),
@@ -407,6 +408,7 @@ py_library(
         bk_require("jinja2"),
         bk_require("pybuildkite"),
         bk_require("pygithub"),
+        bk_require("requests"),
         bk_require("retry"),
     ],
 )

--- a/release/ray_release/configs/global_config.py
+++ b/release/ray_release/configs/global_config.py
@@ -20,6 +20,8 @@ class GlobalConfig(TypedDict):
     byod_aws_cr: str
     byod_gcp_cr: str
     state_machine_aws_bucket: str
+    state_machine_pr_aws_bucket: str
+    state_machine_master_aws_bucket: str
     aws2gce_credentials: str
 
 
@@ -77,6 +79,12 @@ def _init_global_config(config_file: str):
             or config_content.get("release_byod", {}).get("aws2gce_credentials")
         ),
         state_machine_aws_bucket=config_content.get("state_machine", {}).get(
+            "aws_bucket",
+        ),
+        state_machine_pr_aws_bucket=config_content.get("state_machine", {}).get("pr", {}).get(
+            "aws_bucket",
+        ),
+        state_machine_master_aws_bucket=config_content.get("state_machine", {}).get("master", {}).get(
             "aws_bucket",
         ),
     )

--- a/release/ray_release/configs/global_config.py
+++ b/release/ray_release/configs/global_config.py
@@ -9,6 +9,7 @@ PR_PIPELINES = [
 BRANCH_PIPELINES = [
     "0189e759-8c96-4302-b6b5-b4274406bf89",  # postmerge
     "018e0f94-ccb6-45c2-b072-1e624fe9a404",  # postmerge-macos
+    "018af6d3-58e1-463f-90ec-d9aa4a4f57f1",  # release
 ]
 
 
@@ -21,7 +22,7 @@ class GlobalConfig(TypedDict):
     byod_gcp_cr: str
     state_machine_aws_bucket: str
     state_machine_pr_aws_bucket: str
-    state_machine_master_aws_bucket: str
+    state_machine_branch_aws_bucket: str
     aws2gce_credentials: str
 
 
@@ -81,10 +82,14 @@ def _init_global_config(config_file: str):
         state_machine_aws_bucket=config_content.get("state_machine", {}).get(
             "aws_bucket",
         ),
-        state_machine_pr_aws_bucket=config_content.get("state_machine", {}).get("pr", {}).get(
+        state_machine_pr_aws_bucket=config_content.get("state_machine", {})
+        .get("pr", {})
+        .get(
             "aws_bucket",
         ),
-        state_machine_master_aws_bucket=config_content.get("state_machine", {}).get("master", {}).get(
+        state_machine_branch_aws_bucket=config_content.get("state_machine", {})
+        .get("branch", {})
+        .get(
             "aws_bucket",
         ),
     )

--- a/release/ray_release/reporter/ray_test_db.py
+++ b/release/ray_release/reporter/ray_test_db.py
@@ -1,5 +1,7 @@
 import json
+import os
 
+from ray_release.configs.global_config import BRANCH_PIPELINES
 from ray_release.reporter.reporter import Reporter
 from ray_release.result import Result, ResultStatus
 from ray_release.test import Test
@@ -17,6 +19,12 @@ class RayTestDBReporter(Reporter):
     """
 
     def report_result(self, test: Test, result: Result) -> None:
+        if os.environ.get("BUILDKITE_BRANCH") != "master":
+            logger.info("Skip upload test results. We only upload on master branch.")
+            return
+        if os.environ.get("BUILDKITE_PIPELINE_ID") not in BRANCH_PIPELINES:
+            logger.info("Skip upload test results. We only upload on branch pipeline.")
+            return
         if result.status == ResultStatus.TRANSIENT_INFRA_ERROR.value:
             logger.info(
                 f"Skip recording result for test {test.get_name()} due to transient "

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -11,6 +11,7 @@ import boto3
 from botocore.exceptions import ClientError
 from github import Repository
 
+from ray_release.aws import s3_put_rayci_test_data
 from ray_release.configs.global_config import get_global_config
 from ray_release.result import (
     ResultStatus,
@@ -429,7 +430,7 @@ class Test(dict):
         """
         Persist test result object to s3
         """
-        boto3.client("s3").put_object(
+        s3_put_rayci_test_data(
             Bucket=get_write_state_machine_aws_bucket(),
             Key=f"{AWS_TEST_RESULT_KEY}/"
             f"{self._get_s3_name()}-{int(time.time() * 1000)}.json",
@@ -440,7 +441,7 @@ class Test(dict):
         """
         Persist test object to s3
         """
-        boto3.client("s3").put_object(
+        s3_put_rayci_test_data(
             Bucket=get_write_state_machine_aws_bucket(),
             Key=f"{AWS_TEST_KEY}/{self._get_s3_name()}.json",
             Body=json.dumps(self),

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -128,7 +128,7 @@ class Test(dict):
         """
         Obtain all tests whose names start with the given prefix from s3
         """
-        bucket = get_global_config()["state_machine_aws_bucket"]
+        bucket = get_global_config()["state_machine_master_aws_bucket"]
         s3_client = boto3.client("s3")
         pages = s3_client.get_paginator("list_objects_v2").paginate(
             Bucket=bucket,
@@ -241,7 +241,7 @@ class Test(dict):
             data = (
                 boto3.client("s3")
                 .get_object(
-                    Bucket=get_global_config()["state_machine_aws_bucket"],
+                    Bucket=get_global_config()["state_machine_master_aws_bucket"],
                     Key=f"{AWS_TEST_KEY}/{self._get_s3_name()}.json",
                 )
                 .get("Body")
@@ -391,7 +391,7 @@ class Test(dict):
 
         s3_client = boto3.client("s3")
         pages = s3_client.get_paginator("list_objects_v2").paginate(
-            Bucket=get_global_config()["state_machine_aws_bucket"],
+            Bucket=get_global_config()["state_machine_master_aws_bucket"],
             Prefix=f"{AWS_TEST_RESULT_KEY}/{self._get_s3_name()}-",
         )
         files = sorted(
@@ -403,7 +403,7 @@ class Test(dict):
             TestResult.from_dict(
                 json.loads(
                     s3_client.get_object(
-                        Bucket=get_global_config()["state_machine_aws_bucket"],
+                        Bucket=get_global_config()["state_machine_master_aws_bucket"],
                         Key=file["Key"],
                     )
                     .get("Body")
@@ -426,7 +426,7 @@ class Test(dict):
         Persist test result object to s3
         """
         boto3.client("s3").put_object(
-            Bucket=get_global_config()["state_machine_aws_bucket"],
+            Bucket=get_global_config()["state_machine_master_aws_bucket"],
             Key=f"{AWS_TEST_RESULT_KEY}/"
             f"{self._get_s3_name()}-{int(time.time() * 1000)}.json",
             Body=json.dumps(test_result.__dict__),
@@ -437,7 +437,7 @@ class Test(dict):
         Persist test object to s3
         """
         boto3.client("s3").put_object(
-            Bucket=get_global_config()["state_machine_aws_bucket"],
+            Bucket=get_global_config()["state_machine_master_aws_bucket"],
             Key=f"{AWS_TEST_KEY}/{self._get_s3_name()}.json",
             Body=json.dumps(self),
         )

--- a/release/ray_release/tests/test_step.py
+++ b/release/ray_release/tests/test_step.py
@@ -1,4 +1,5 @@
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -24,12 +25,14 @@ def _stub_test(val: dict) -> Test:
     return test
 
 
-def test_get_step():
+@patch("ray_release.test.Test.update_from_s3", return_value=None)
+def test_get_step(mock):
     step = get_step(_stub_test({}), run_id=2)
     assert step["label"] == "test (None) (2)"
 
 
-def test_get_step_for_test_group():
+@patch("ray_release.test.Test.update_from_s3", return_value=None)
+def test_get_step_for_test_group(mock):
     grouped_tests = {
         "group1": [
             (_stub_test({"name": "test1", "repeated_run": 3}), False),

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -12,6 +12,7 @@ from ray_release.bazel import bazel_runfile
 from ray_release.configs.global_config import (
     init_global_config,
     get_global_config,
+    BRANCH_PIPELINES,
 )
 from ray_release.test import (
     Test,
@@ -189,6 +190,7 @@ def test_from_bazel_event() -> None:
 
 
 @patch.object(boto3, "client")
+@patch.dict(os.environ, {"BUILDKITE_PIPELINE_ID": BRANCH_PIPELINES[0]})
 def test_update_from_s3(mock_client) -> None:
     mock_object = mock.Mock()
     mock_object.return_value.get.return_value.read.return_value = json.dumps(

--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -64,7 +64,8 @@ def get_write_state_machine_aws_bucket() -> str:
         "Test state machine is only supported for branch or pr pipeline, "
         f"{pipeline_id} is given"
     )
-    # TODO(can): return the pr bucket once that is setup
+    if pipeline_id in PR_PIPELINES:
+        return get_global_config()["state_machine_pr_aws_bucket"]
     return get_global_config()["state_machine_branch_aws_bucket"]
 
 

--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -10,6 +10,11 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import requests
 from ray_release.logger import logger
+from ray_release.configs.global_config import (
+    get_global_config,
+    PR_PIPELINES,
+    BRANCH_PIPELINES,
+)
 
 if TYPE_CHECKING:
     from anyscale.sdk.anyscale_client.sdk import AnyscaleSDK
@@ -32,6 +37,35 @@ ERROR_LOG_PATTERNS = [
     "ERROR",
     "Traceback (most recent call last)",
 ]
+
+
+def get_read_state_machine_aws_bucket(allow_pr_bucket: bool = False) -> str:
+    # We support by default reading from the branch bucket only, since most of the use
+    # cases are on branch pipelines. Changing the default flag to read from the bucket
+    # according to the current pipeline
+    if allow_pr_bucket:
+        return get_write_state_machine_aws_bucket()
+    return (
+        get_global_config()["state_machine_aws_bucket"]
+        or get_global_config()["state_machine_branch_aws_bucket"]
+    )
+
+
+def get_write_state_machine_aws_bucket() -> str:
+    # We support different buckets for writing test result data; one for pr and one for
+    # branch. This is because pr and branch pipeline have different permissions, and we
+    # want data on branch pipeline being protected.
+    bucket_v1 = get_global_config()["state_machine_aws_bucket"]
+    if bucket_v1:
+        return bucket_v1
+
+    pipeline_id = os.environ.get("BUILDKITE_PIPELINE_ID")
+    assert pipeline_id in BRANCH_PIPELINES + PR_PIPELINES, (
+        "Test state machine is only supported for branch or pr pipeline, "
+        f"{pipeline_id} is given"
+    )
+    # TODO(can): return the pr bucket once that is setup
+    return get_global_config()["state_machine_branch_aws_bucket"]
 
 
 def deep_update(d, u) -> Dict:

--- a/release/requirements_buildkite.in
+++ b/release/requirements_buildkite.in
@@ -20,3 +20,5 @@ docker == 7.0.0
 
 # Below are requirements only used by ray_ci
 tzdata
+aws_requests_auth
+requests

--- a/release/requirements_buildkite.txt
+++ b/release/requirements_buildkite.txt
@@ -137,6 +137,10 @@ attrs==23.1.0 \
     # via
     #   aiohttp
     #   jsonschema
+aws-requests-auth==0.4.3 \
+    --hash=sha256:33593372018b960a31dbbe236f89421678b885c35f0b6a7abfae35bb77e069b2 \
+    --hash=sha256:646bc37d62140ea1c709d20148f5d43197e6bd2d63909eb36fa4bb2345759977
+    # via -r release/requirements_buildkite.in
 bazel-runfiles==0.21.0 \
     --hash=sha256:3e430dd9a5aba90a90bc2493fdcfce02a3ece47fb574db0f4ac898261e6b068d
     # via -r release/requirements_buildkite.in
@@ -1018,6 +1022,7 @@ requests==2.31.0 \
     # via
     #   -r release/requirements_buildkite.in
     #   anyscale
+    #   aws-requests-auth
     #   docker
     #   google-api-core
     #   google-cloud-storage


### PR DESCRIPTION
Add state machine aws bucket for pr branch. We need a separated bucket because pr has less permissions. We gather this additional data because why not ;). Seriously though, test results data gathered from PR will help us build another way of test selection algorithm.

Also store the data into s3 bucket.

Test:
- CI