### PR TITLE
[Tune]Add support for new style lightning import

### DIFF
--- a/python/ray/tune/integration/pytorch_lightning.py
+++ b/python/ray/tune/integration/pytorch_lightning.py
@@ -6,7 +6,11 @@ import warnings
 from contextlib import contextmanager
 from typing import Dict, List, Optional, Type, Union
 
-from pytorch_lightning import Callback, Trainer, LightningModule
+try:
+    from lightning import Callback, Trainer, LightningModule
+else:
+    from pytorch_lightning import Callback, Trainer, LightningModule
+
 from ray import train
 from ray.util import log_once
 from ray.util.annotations import PublicAPI, Deprecated

--- a/python/ray/tune/integration/pytorch_lightning.py
+++ b/python/ray/tune/integration/pytorch_lightning.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Type, Union
 
 try:
     from lightning import Callback, Trainer, LightningModule
-else:
+except ModuleNotFoundError:
     from pytorch_lightning import Callback, Trainer, LightningModule
 
 from ray import train


### PR DESCRIPTION
## Why are these changes needed?

`from lightning` and `from pytorch_lightning` import styles cannot be mixed. Implemented a simple workaround as in [`train`](https://github.com/ray-project/ray/blob/31d2025cda9bdbfb73a292df4d3ca2529552d56c/python/ray/train/lightning/_lightning_utils.py#L18) module where we first try to import from `lightning` as this is the new syntax and only if it fails as a backup we import from `pytorch_lightning`. 

## Related issue number

None

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
