### PR TITLE
[RLlib] User warnings and guidance in `synchronous_parallel_sample`.

### DIFF
--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -100,6 +100,17 @@ def synchronous_parallel_sample(
             # There is no point staying in this loop, since we will not be able to
             # get any new samples if we don't have any healthy remote workers left.
             if not sampled_data or worker_set.num_healthy_remote_workers() <= 0:
+                if not sampled_data:
+                    logger.warning(
+                        "No samples returned from remote workers. If you have a "
+                        "slow environment or model, consider increasing the "
+                        "`sample_timeout_s` or decreasing the "
+                        "`rollout_fragment_length` in `AlgorithmConfig.rollouts()."
+                    )
+                elif worker_set.num_healthy_remote_workers() <= 0:
+                    logger.warning(
+                        "No healthy remote workers left. Trying to restore workers ..."
+                    )
                 break
         # Update our counters for the stopping criterion of the while loop.
         for batch_or_episode in sampled_data:


### PR DESCRIPTION
## Why are these changes needed?

When sampling from remote workers  the new `synchronous_parallel_sample` logic added the `sample_timeout_s` to the remote workers call. This can lead to errors in the `Learner.update_from_batch` (and related methods) as the list of episodes is empty. To decrease debugging efforts we give some warnings instead that should also guide the user to related parameters that could be tuned to avoid the errors.

## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
