### PR TITLE
[Data] Fix the config to disable progress bar

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -198,8 +198,8 @@ class OpState:
         """
         is_all_to_all = isinstance(self.op, AllToAllOperator)
         # Only show 1:1 ops when in verbose progress mode.
-        enabled = DataContext.get_current().enable_progress_bars and (
-            verbose_progress or is_all_to_all
+        enabled = is_all_to_all or (
+            DataContext.get_current().enable_progress_bars and verbose_progress
         )
         self.progress_bar = ProgressBar(
             "- " + self.op.name,

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -34,6 +34,7 @@ from ray.data._internal.execution.operators.base_physical_operator import (
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.resource_manager import ResourceManager
 from ray.data._internal.progress_bar import ProgressBar
+from ray.data.context import DataContext
 
 logger = logging.getLogger(__name__)
 
@@ -197,7 +198,9 @@ class OpState:
         """
         is_all_to_all = isinstance(self.op, AllToAllOperator)
         # Only show 1:1 ops when in verbose progress mode.
-        enabled = verbose_progress or is_all_to_all
+        enabled = DataContext.get_current().enable_progress_bars and (
+            verbose_progress or is_all_to_all
+        )
         self.progress_bar = ProgressBar(
             "- " + self.op.name,
             self.op.num_outputs_total(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This is a followup of https://github.com/ray-project/ray/pull/43360 to fix the behavior of disabling progress bar. After this PR, users only need to set `ray.data.DataContext.get_current().enable_progress_bars = False` to disable all progress bar (main + verbose bar per operator).

Tested locally and verified config is working. 

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/44267 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
