### PR TITLE
[runtime env] Improve runtime env timeout log

### DIFF
--- a/dashboard/modules/job/tests/test_http_job_server.py
+++ b/dashboard/modules/job/tests/test_http_job_server.py
@@ -377,7 +377,7 @@ def test_timeout(job_sdk_client):
     data = client.get_job_info(job_id)
     assert "Failed to set up runtime environment" in data.message
     assert "Timeout" in data.message
-    assert "consider increasing `setup_timeout_seconds`" in data.message
+    assert "setup_timeout_seconds" in data.message
 
 
 def test_per_task_runtime_env(job_sdk_client: JobSubmissionClient):

--- a/dashboard/modules/job/tests/test_job_agent.py
+++ b/dashboard/modules/job/tests/test_job_agent.py
@@ -308,7 +308,7 @@ async def test_timeout(job_sdk_client):
     data = head_client.get_job_info(job_id)
     assert "Failed to set up runtime environment" in data.message
     assert "Timeout" in data.message
-    assert "consider increasing `setup_timeout_seconds`" in data.message
+    assert "setup_timeout_seconds" in data.message
 
 
 @pytest.mark.asyncio

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -399,12 +399,14 @@ class RuntimeEnvAgent:
                     )
                     if isinstance(e, asyncio.TimeoutError):
                         hint = (
-                            f"Failed due to timeout; check runtime_env setup logs"
-                            " and consider increasing `setup_timeout_seconds` beyond "
-                            f"the default of {DEFAULT_RUNTIME_ENV_TIMEOUT_SECONDS}."
+                            f"Failed to install runtime_env within the provided "
+                            f"timeout of {setup_timeout_seconds} seconds. Consider "
+                            "increasing the timeout in the runtime_env config. "
                             "For example: \n"
                             '    runtime_env={"config": {"setup_timeout_seconds":'
                             " 1800}, ...}\n"
+                            "If not provided, the default timeout is "
+                            f"{DEFAULT_RUNTIME_ENV_TIMEOUT_SECONDS} seconds. "
                         )
                         error_message = hint + error_message
                     await asyncio.sleep(

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -399,7 +399,7 @@ class RuntimeEnvAgent:
                     )
                     if isinstance(e, asyncio.TimeoutError):
                         hint = (
-                            f"Failed to install runtime_env within the provided "
+                            f"Failed to install runtime_env within the "
                             f"timeout of {setup_timeout_seconds} seconds. Consider "
                             "increasing the timeout in the runtime_env config. "
                             "For example: \n"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When a runtime env hits a timeout, the current error message doesn't show the provided timeout, and is confusing (it seems to imply the default timeout was used, even if it wasn't.) This PR clarifies the error message.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
