### PR TITLE
[ci] fix release blocker check

### DIFF
--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -32,14 +32,18 @@ AWS_WEEKLY_GREEN_METRIC = "ray_weekly_green_metric"
 def main(production: bool, check: bool) -> None:
     ci_init()
     blockers = TestStateMachine.get_release_blockers()
-    logger.info(f"Found {blockers.totalCount} release blockers")
-
-    blocker_teams = [TestStateMachine.get_issue_owner(blocker) for blocker in blockers]
-    num_blocker_by_team = {team: blocker_teams.count(team) for team in blocker_teams}
-    for team, num_blocker in num_blocker_by_team.items():
-        logger.info(f"\t- Team {team} has {num_blocker} release blockers")
 
     if production:
+        logger.info(f"Found {blockers.totalCount} release blockers")
+        blocker_teams = [
+            TestStateMachine.get_issue_owner(blocker) for blocker in blockers
+        ]
+        num_blocker_by_team = {
+            team: blocker_teams.count(team) for team in blocker_teams
+        }
+        for team, num_blocker in num_blocker_by_team.items():
+            logger.info(f"\t- Team {team} has {num_blocker} release blockers")
+
         boto3.client("s3").put_object(
             Bucket=get_global_config()["state_machine_aws_bucket"],
             Key=f"{AWS_WEEKLY_GREEN_METRIC}/blocker_{int(time.time() * 1000)}.json",


### PR DESCRIPTION
Fix the release blocker check. After the pagination is iterated, the 'totalCount' becomes bogus. Separate the metric and the check logic.

Test:
- CI
- bazel run //ci/ray_ci/automation:weekly_green_metric -- --check