### PR TITLE
[core] resets last_export_session_and_job in pickling

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -543,6 +543,12 @@ class _ActorClassMetadata:
             modified_class, actor_creation_function_descriptor
         )
 
+    def __getstate__(self):
+        # `last_export_session_and_job` is worker-local. Reset it when pickling.
+        state = dict(self.__dict__)
+        state["last_export_session_and_job"] = None
+        return state
+
 
 @PublicAPI
 class ActorClassInheritanceException(TypeError):

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -151,6 +151,7 @@ class RemoteFunction:
     def __getstate__(self):
         attrs = self.__dict__.copy()
         del attrs["_inject_lock"]
+        attrs["_last_export_session_and_job"] = None
         return attrs
 
     def __setstate__(self, state):

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1394,6 +1394,9 @@ def test_can_create_actor_in_multiple_sessions(shutdown_only):
     https://github.com/ray-project/ray/issues/44380
     """
 
+    # To avoid interference with other tests, we need a fresh cluster.
+    ray.shutdown()
+
     @ray.remote
     class A:
         def __init__(self):

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1388,33 +1388,6 @@ def test_actor_equal(ray_start_regular_shared):
     assert origin == remote
 
 
-def test_can_create_actor_in_multiple_sessions(shutdown_only):
-    """Validates a bugfix that, if you create an actor in driver, then you shutdown and
-    restart and create the actor in task, it fails.
-    https://github.com/ray-project/ray/issues/44380
-    """
-
-    # To avoid interference with other tests, we need a fresh cluster.
-    ray.shutdown()
-
-    @ray.remote
-    class A:
-        def __init__(self):
-            print("A.__init__")
-
-    @ray.remote
-    def make_actor_in_task():
-        a = A.remote()
-        return a
-
-    ray.init()
-    A.remote()
-    ray.shutdown()
-
-    ray.init()
-    ray.get(make_actor_in_task.remote())
-
-
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -394,6 +394,59 @@ def test_temp_dir_with_node_ip_address(ray_start_cluster, short_tmp_path):
     assert short_tmp_path == ray._private.worker._global_node.get_temp_dir_path()
 
 
+def test_can_create_actor_in_multiple_sessions(shutdown_only):
+    """Validates a bugfix that, if you create an actor in driver, then you shutdown and
+    restart and create the actor in task, it fails.
+    https://github.com/ray-project/ray/issues/44380
+    """
+
+    # To avoid interference with other tests, we need a fresh cluster.
+    ray.shutdown()
+
+    @ray.remote
+    class A:
+        def __init__(self):
+            print("A.__init__")
+
+    @ray.remote
+    def make_actor_in_task():
+        a = A.remote()
+        return a
+
+    ray.init()
+    A.remote()
+    ray.shutdown()
+
+    ray.init()
+    ray.get(make_actor_in_task.remote())
+
+
+def test_can_create_task_in_multiple_sessions(shutdown_only):
+    """Validates a bugfix that, if you create a task in driver, then you shutdown and
+    restart and create the task in task, it hangs.
+    https://github.com/ray-project/ray/issues/44380
+    """
+
+    # To avoid interference with other tests, we need a fresh cluster.
+    ray.shutdown()
+
+    @ray.remote
+    def the_task():
+        print("the task")
+        return "the task"
+
+    @ray.remote
+    def run_task_in_task():
+        return ray.get(the_task.remote())
+
+    ray.init()
+    assert ray.get(the_task.remote()) == "the task"
+    ray.shutdown()
+
+    ray.init()
+    assert ray.get(run_task_in_task.remote()) == "the task"
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -401,7 +401,7 @@ def test_can_create_actor_in_multiple_sessions(shutdown_only):
     """
 
     # To avoid interference with other tests, we need a fresh cluster.
-    ray.shutdown()
+    assert not ray.is_initialized()
 
     @ray.remote
     class A:
@@ -428,7 +428,7 @@ def test_can_create_task_in_multiple_sessions(shutdown_only):
     """
 
     # To avoid interference with other tests, we need a fresh cluster.
-    ray.shutdown()
+    assert not ray.is_initialized()
 
     @ray.remote
     def the_task():


### PR DESCRIPTION
In `actor.py`, field `_ActorClassMetadata.last_export_session_and_job` is meant to be worker-local and default to None. However in pickling and unpickling it's copied to remote workers, causing actor creation failures if the timing is right (see the unit test).

In `remote_function.py` field `RemoteFunction._last_export_session_and_job` serves similar objective and shares the same bug (hangs if hit). Fixed that.

Fixes #44380.