### PR TITLE
[Core] Allow py_driver_sys_path to be added to sys.path regardless the node

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2351,10 +2351,6 @@ def connect(
         # (3) it's not in dashboard (should only skip script location but still append
         #   current directory),
         # (4) it's not client mode, (handled by client code)
-        # (5) the driver is at the same node (machine) as the worker.
-        #
-        # We only do the first 4 checks here. The (5) check is done in _raylet.pyx
-        # maybe_initialize_job_config.
         if not any(
             [
                 job_config._runtime_env_has_working_dir(),

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2565,14 +2565,16 @@ def maybe_initialize_job_config():
                 sys.path.insert(0, p)
         ray._private.worker.global_worker.set_load_code_from_local(load_code_from_local)
 
-        # If this worker is on the same node with the driver, add driver's system path
-        # to sys.path.
+        # Add driver's system path to sys.path regardless of the node. This is required
+        # for Kuberay to run correctly as there is currently no options to change
+        # runtime env during start.
+        # See: https://github.com/ray-project/ray/issues/44329
         this_node_id = ray._private.worker.global_worker.current_node_id
         driver_node_id = ray.NodeID(core_worker.get_job_config().driver_node_id)
         py_driver_sys_path = core_worker.get_job_config().py_driver_sys_path
         if py_driver_sys_path:
             for p in py_driver_sys_path:
-                sys.path.insert(0, p)
+                sys.path.append(p)
 
         # Cache and set the current job id.
         job_id = core_worker.get_current_job_id()

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2574,7 +2574,7 @@ def maybe_initialize_job_config():
         py_driver_sys_path = core_worker.get_job_config().py_driver_sys_path
         if py_driver_sys_path:
             for p in py_driver_sys_path:
-                sys.path.append(p)
+                sys.path.insert(0, p)
 
         # Cache and set the current job id.
         job_id = core_worker.get_current_job_id()

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2569,11 +2569,10 @@ def maybe_initialize_job_config():
         # to sys.path.
         this_node_id = ray._private.worker.global_worker.current_node_id
         driver_node_id = ray.NodeID(core_worker.get_job_config().driver_node_id)
-        if this_node_id == driver_node_id:
-            py_driver_sys_path = core_worker.get_job_config().py_driver_sys_path
-            if py_driver_sys_path:
-                for p in py_driver_sys_path:
-                    sys.path.insert(0, p)
+        py_driver_sys_path = core_worker.get_job_config().py_driver_sys_path
+        if py_driver_sys_path:
+            for p in py_driver_sys_path:
+                sys.path.insert(0, p)
 
         # Cache and set the current job id.
         job_id = core_worker.get_current_job_id()

--- a/python/ray/tests/test_basic_3.py
+++ b/python/ray/tests/test_basic_3.py
@@ -350,12 +350,12 @@ print(ray.get(my_file.remote()))
     ],
     indirect=True,
 )
-def test_worker_exception_if_no_working_dir_diff_node(ray_start_cluster):
+def test_worker_no_exception_if_no_working_dir_diff_node(ray_start_cluster):
     """
     Tests that, in a cluster of 2 nodes, a job with no working_dir that runs
     a function with an import from driver's path, on both nodes.
 
-    On the driver's node it should work, but on the other node it should raise an
+    On the driver's node it should work, and on the other node it should not raise an
     error about failing to import.
     """
     lib_code = """
@@ -387,7 +387,7 @@ assert ray.get(my_file.options(
     )
 ).remote()) == lib_path
 
-# runs on different node, fails
+# runs on different node does not fail
 exc = None
 try:
     ray.get(my_file.options(
@@ -398,8 +398,8 @@ try:
     ).remote())
 except ray.exceptions.RayTaskError as e:
     exc = e
-assert isinstance(exc, ray.exceptions.RayTaskError), type(exc)
-assert "The remote function failed to import on the worker" in str(exc), str(exc)
+assert not isinstance(exc, ray.exceptions.RayTaskError), type(exc)
+assert not "The remote function failed to import on the worker" in str(exc), str(exc)
     """
 
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A lot of users are complaining seeing `ModuleNotFoundError` using Ray 2.10.0 with Kuberay. After some researching this seemed to be cased by https://github.com/ray-project/ray/pull/43214 where `py_driver_sys_path` is no longer getting added to `sys.path` when the worker node is different from the driver node. This PR revert this behavior to always allow `py_driver_sys_path` to be added to `sys.path` regardless the node, so Kuberay users can use their deployments again. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/44301
Closes https://github.com/ray-project/ray/issues/44329

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
