### PR TITLE
[Data] Pin `ipywidgets==7.7.2` to enable Data progress bars in VSCode Web

### DIFF
--- a/python/requirements/anyscale-requirements.txt
+++ b/python/requirements/anyscale-requirements.txt
@@ -1,5 +1,9 @@
 jupyterlab
-ipywidgets
+# Ray Data progress bars do not load with newer versions of
+# ipywidgets + older versions of VSCode Web. Pin the version
+# until VSCode Web is updated, as recommended in
+# https://github.com/microsoft/vscode-jupyter/issues/8552.
+ipywidgets==7.7.2
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-otlp

--- a/python/requirements/anyscale-requirements.txt
+++ b/python/requirements/anyscale-requirements.txt
@@ -1,9 +1,5 @@
 jupyterlab
-# Ray Data progress bars do not load with newer versions of
-# ipywidgets + older versions of VSCode Web. Pin the version
-# until VSCode Web is updated, as recommended in
-# https://github.com/microsoft/vscode-jupyter/issues/8552.
-ipywidgets==7.7.2
+ipywidgets
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-otlp

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -72,7 +72,7 @@ xlrd==2.0.1
 yq==3.2.2
 memray; platform_system != "Windows" and sys_platform != "darwin" and platform_machine != 'aarch64'
 numpy==1.24.4
-ipywidgets==7.8.1
+ipywidgets==7.7.2
 
 # For doc tests
 myst-parser==0.15.2

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -817,7 +817,7 @@ ipython-genutils==0.2.0
     #   ipywidgets
     #   nbclassic
     #   notebook
-ipywidgets==7.8.1
+ipywidgets==7.7.2
     # via
     #   -r /ray/ci/../python/requirements/anyscale-requirements.txt
     #   -r /ray/ci/../python/requirements/docker/ray-docker-requirements.txt

--- a/release/ray_release/byod/requirements_ml_byod_3.9.in
+++ b/release/ray_release/byod/requirements_ml_byod_3.9.in
@@ -18,7 +18,11 @@ fastapi
 filelock
 gcsfs==2023.5.0
 gsutil
-ipywidgets
+# Ray Data progress bars do not load with newer versions of
+# ipywidgets + older versions of VSCode Web. Pin the version
+# until VSCode Web is updated, as recommended in
+# https://github.com/microsoft/vscode-jupyter/issues/8552.
+ipywidgets==7.7.2
 jupytext
 lm_eval
 matplotlib

--- a/release/ray_release/byod/requirements_ml_byod_3.9.txt
+++ b/release/ray_release/byod/requirements_ml_byod_3.9.txt
@@ -1406,7 +1406,7 @@ ipython-genutils==0.2.0 \
     #   ipywidgets
     #   nbclassic
     #   notebook
-ipywidgets==7.8.1 \
+ipywidgets==7.7.2 \
     --hash=sha256:050b87bb9ac11641859af4c36cdb639ca072fb5e121f0f1a401f8a80f9fa008d \
     --hash=sha256:29f7056d368bf0a7b35d51cf0c56b58582da57c78bb9f765965fef7c332e807c
     # via


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
With older versions of VSCode for Web (e.g. the current version on Anyscale Platform), Ray Data progress bars do not appear at all when using `ipywidgets>=8`. This is a known issue, and the current workaround is to pin `ipywidgets` to `7.x.x`, as recommended in: https://github.com/microsoft/vscode-jupyter/issues/8552

To fix the issue for now, pin `ipywidgets` to `7.x.x` in requirements files.

We can remove this pin once we upgrade VSCode for Web. cc @sofianhnaide 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
