### PR TITLE
[Data] Remove `DEBUG_TRACE_SCHEDULING`

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -438,7 +438,7 @@ def _debug_dump_topology(topology: Topology, resource_manager: ResourceManager) 
     """
     logger.get_logger(log_to_stdout=False).info("Execution Progress:")
     for i, (op, state) in enumerate(topology.items()):
-        logger.info(
+        logger.get_logger(log_to_stdout=False).info(
             f"{i}: {state.summary_str(resource_manager)}, "
             f"Blocks Outputted: {state.num_completed_tasks}/{op.num_outputs_total()}"
         )

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -1,4 +1,3 @@
-import os
 import threading
 import time
 import uuid

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -37,10 +37,6 @@ from ray.data.context import DataContext
 
 logger = DatasetLogger(__name__)
 
-# Set this environment variable for detailed scheduler debugging logs.
-# If not set, execution state will still be logged after each scheduling loop.
-DEBUG_TRACE_SCHEDULING = "RAY_DATA_TRACE_SCHEDULING" in os.environ
-
 # Force a progress bar update after this many events processed . This avoids the
 # progress bar seeming to stall for very large scale workloads.
 PROGRESS_BAR_UPDATE_INTERVAL = 50
@@ -270,10 +266,6 @@ class StreamingExecutor(Executor, threading.Thread):
         Returns:
             True if we should continue running the scheduling loop.
         """
-
-        if DEBUG_TRACE_SCHEDULING:
-            logger.get_logger().info("Scheduling loop step...")
-
         self._resource_manager.update_usages()
         # Note: calling process_completed_tasks() is expensive since it incurs
         # ray.wait() overhead, so make sure to allow multiple dispatch per call for
@@ -304,8 +296,6 @@ class StreamingExecutor(Executor, threading.Thread):
             i += 1
             if i > PROGRESS_BAR_UPDATE_INTERVAL:
                 break
-            if DEBUG_TRACE_SCHEDULING:
-                _debug_dump_topology(topology, self._resource_manager)
             topology[op].dispatch_next_task()
             self._resource_manager.update_usages()
             op = select_operator_to_run(
@@ -326,10 +316,7 @@ class StreamingExecutor(Executor, threading.Thread):
         self._update_stats_metrics(state="RUNNING")
         if time.time() - self._last_debug_log_time >= DEBUG_LOG_INTERVAL_SECONDS:
             _log_op_metrics(topology)
-            if not DEBUG_TRACE_SCHEDULING:
-                _debug_dump_topology(
-                    topology, self._resource_manager, log_to_stdout=False
-                )
+            _debug_dump_topology(topology, self._resource_manager)
             self._last_debug_log_time = time.time()
 
         # Log metrics of newly completed operators.
@@ -443,22 +430,20 @@ def _validate_dag(dag: PhysicalOperator, limits: ExecutionResources) -> None:
         raise ValueError(error_message.strip())
 
 
-def _debug_dump_topology(
-    topology: Topology, resource_manager: ResourceManager, log_to_stdout: bool = True
-) -> None:
-    """Print out current execution state for the topology for debugging.
+def _debug_dump_topology(topology: Topology, resource_manager: ResourceManager) -> None:
+    """Log current execution state for the topology for debugging.
 
     Args:
         topology: The topology to debug.
         resource_manager: The resource manager for this topology.
     """
-    logger.get_logger(log_to_stdout).info("Execution Progress:")
+    logger.get_logger(log_to_stdout=False).info("Execution Progress:")
     for i, (op, state) in enumerate(topology.items()):
-        logger.get_logger(log_to_stdout).info(
+        logger.info(
             f"{i}: {state.summary_str(resource_manager)}, "
             f"Blocks Outputted: {state.num_completed_tasks}/{op.num_outputs_total()}"
         )
-    logger.get_logger(log_to_stdout).info("")
+    logger.get_logger(log_to_stdout=False).info("")
 
 
 def _log_op_metrics(topology: Topology) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you enable `DEBUG_TRACE_SCHEDULING`, Ray Data prints additional execution information to the console. This option isn't frequently used, so this PR removes it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
