### PR TITLE
[WIP] Offload execution of sync methods to event-loop's default executor

### DIFF
--- a/python/ray/_private/async_compat.py
+++ b/python/ray/_private/async_compat.py
@@ -31,14 +31,3 @@ def is_async_func(func):
     """Return True if the function is an async or async generator method."""
     return inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func)
 
-
-def sync_to_async(func):
-    """Convert a blocking function to async function"""
-
-    if is_async_func(func):
-        return func
-
-    async def wrapper(*args, **kwargs):
-        return func(*args, **kwargs)
-
-    return wrapper

--- a/python/ray/_private/async_compat.py
+++ b/python/ray/_private/async_compat.py
@@ -30,4 +30,3 @@ def try_install_uvloop():
 def is_async_func(func):
     """Return True if the function is an async or async generator method."""
     return inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func)
-

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1816,7 +1816,7 @@ cdef void execute_task(
                             )
                         )
 
-                if inspect.isasyncgenfunction(function.method):
+                if inspect.isgeneratorfunction(function.method) or inspect.isasyncgenfunction(function.method):
                     # The coroutine will be handled separately by
                     # execute_dynamic_generator_and_store_task_outputs
                     return function(actor, *arguments, **kwarguments)

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1796,7 +1796,9 @@ cdef void execute_task(
         def function_executor(*arguments, **kwarguments):
             function = execution_info.function
 
-            if core_worker.current_actor_is_asyncio():
+            if not core_worker.current_actor_is_asyncio():
+                return function(actor, *arguments, **kwarguments)
+            else:
                 if len(inspect.getmembers(
                         actor.__class__,
                         predicate=is_async_func)) == 0:
@@ -1852,8 +1854,10 @@ cdef void execute_task(
                                     .deserialize_objects(
                                         metadata_pairs, object_refs))
                         args = core_worker.run_async_func_or_coro_in_event_loop(
-                            deserialize_args, function_descriptor,
-                            name_of_concurrency_group_to_execute)
+                            deserialize_args,
+                            function_descriptor,
+                            name_of_concurrency_group_to_execute,
+                        )
                     else:
                         # Defer task cancellation (SIGINT) until after the task argument
                         # deserialization context has been left.

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -4750,6 +4750,7 @@ cdef class CoreWorker:
 
         async def _async_function():
             try:
+                # TODO fix
                 if task_id:
                     async_task_id.set(task_id)
 
@@ -4814,6 +4815,7 @@ cdef class CoreWorker:
             if task_id:
                 with self._task_id_to_future_lock:
                     self._task_id_to_future.pop(task_id)
+
         return result
 
     def stop_and_join_asyncio_threads_if_exist(self):

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -1796,7 +1796,10 @@ cdef void execute_task(
         def function_executor(*arguments, **kwarguments):
             function = execution_info.function
 
-            if not core_worker.current_actor_is_asyncio():
+            # Just execute the method if either of the following is true
+            #   - It's Ray's internal method
+            #   - Target actor is NOT an async actor (ie all of its methods are sync ones)
+            if not core_worker.current_actor_is_asyncio() or function.name.startswith("__ray"):
                 return function(actor, *arguments, **kwarguments)
             else:
                 if len(inspect.getmembers(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

TBA

Context in: https://github.com/ray-project/ray/issues/44354#issuecomment-2030952474

## Related issue number

Addresses https://github.com/ray-project/ray/issues/44354

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
