### PR TITLE
[Data] Allow clearing all keys with `reset_log_once`

### DIFF
--- a/python/ray/util/debug.py
+++ b/python/ray/util/debug.py
@@ -63,6 +63,7 @@ def enable_periodic_logging():
     _periodic_log = True
 
 
+@DeveloperAPI
 def reset_log_once(key: Optional[str] = None):
     """Resets log_once for the provided key.
 

--- a/python/ray/util/debug.py
+++ b/python/ray/util/debug.py
@@ -63,11 +63,15 @@ def enable_periodic_logging():
     _periodic_log = True
 
 
-@DeveloperAPI
-def reset_log_once(key):
-    """Resets log_once for the provided key."""
+def reset_log_once(key: Optional[str] = None):
+    """Resets log_once for the provided key.
 
-    _logged.discard(key)
+    If you don't provide a key, resets log_once for all keys.
+    """
+    if key is None:
+        _logged.clear()
+    else:
+        _logged.discard(key)
 
 
 # A suspicious memory-allocating stack-trace that we should re-test


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Some messages are only logged once, and `reset_log_once` lets you repeat messages that have already been logged. Currently, you can only reset one message at a time. To facilitate testing, this PR updates the function to allow you to reset all messages at once.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
