### PR TITLE
Add Pex support for ray-on-spark, this allows users to 'ship' any ver…

### DIFF
--- a/python/ray/autoscaler/_private/spark/node_provider.py
+++ b/python/ray/autoscaler/_private/spark/node_provider.py
@@ -202,6 +202,7 @@ class SparkNodeProvider(NodeProvider):
                     "object_store_memory_per_node": object_store_memory_per_node,
                     "worker_node_options": conf["worker_node_options"],
                     "collect_log_to_path": conf["collect_log_to_path"],
+                    "uses_pex": conf["uses_pex"],
                 },
             )
 

--- a/python/ray/autoscaler/_private/spark/spark_job_server.py
+++ b/python/ray/autoscaler/_private/spark/spark_job_server.py
@@ -40,6 +40,7 @@ class SparkJobServerRequestHandler(BaseHTTPRequestHandler):
             object_store_memory_per_node = data["object_store_memory_per_node"]
             worker_node_options = data["worker_node_options"]
             collect_log_to_path = data["collect_log_to_path"]
+            uses_pex=data["uses_pex"]
 
             def start_ray_worker_thread_fn():
                 try:
@@ -60,6 +61,7 @@ class SparkJobServerRequestHandler(BaseHTTPRequestHandler):
                         collect_log_to_path=collect_log_to_path,
                         autoscale_mode=True,
                         spark_job_server_port=self.server.server_address[1],
+                        uses_pex=uses_pex,
                     )
                 except Exception:
                     if spark_job_group_id in self.server.task_status_dict:

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -98,6 +98,7 @@ class RayClusterOnSpark:
         spark_job_server,
         global_cluster_lock_fd,
         ray_client_server_port,
+        uses_pex,
     ):
         self.autoscale = autoscale
         self.address = address
@@ -112,6 +113,7 @@ class RayClusterOnSpark:
         self.spark_job_server = spark_job_server
         self.global_cluster_lock_fd = global_cluster_lock_fd
         self.ray_client_server_port = ray_client_server_port
+        self.uses_pex = uses_pex
 
         self.is_shutdown = False
         self.spark_job_is_canceled = False
@@ -663,6 +665,7 @@ def _setup_ray_cluster(
                 "worker_node_options": worker_node_options,
                 "collect_log_to_path": collect_log_to_path,
                 "spark_job_server_port": spark_job_server_port,
+                "uses_pex": uses_pex,
             },
             upscaling_speed=autoscale_upscaling_speed,
             idle_timeout_minutes=autoscale_idle_timeout_minutes,
@@ -764,6 +767,7 @@ def _setup_ray_cluster(
         spark_job_server=spark_job_server,
         global_cluster_lock_fd=global_cluster_lock_fd,
         ray_client_server_port=ray_client_server_port,
+        uses_pex=uses_pex,
     )
 
     if not autoscale:


### PR DESCRIPTION
…sion of ray to any spark cluster using the only universally compatible mechanism, pex

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
PEX is a very powerful python dependency distribution tool. It especially shines when it is used in conjunction with PySpark. It is currently the only dependency distribution utility capable of being used with any spark cluster, allowing users to "bootstrap" python dependencies isolated "per-SparkSession". In it's existing form, ray-on-spark is not capable of being deployed and executed from a .pex file on a spark cluster. This PR changes that and makes ray-on-spark fully portable with .pex. This has numerous benefits (multiple ray versions supported on a single spark cluster for complex dependency chains, lighter-weight more generic spark images, easier per-job python dependency resolution, and more).

<!-- Please give a short summary of the change and the problem this solves. -->
These changes primarily impact the way subprocesses are called within Ray node and service launch scripts, when a specific flag is set.  

From the user-facing side the only change is a default=False option under ray.util.spark.setup_ray_cluster. If users add "uses_pex=True" the cluster-init will first check for an environment variable called "RAY_PEX_FILE" which must be set on the spark driver (where the cluster_init is running). This should be a local path to the pex file like "~./ray-pex-deps.pex". It can be distributed to the spark workers using spark.files (s3_location or local_location), from that point a second check for that environment variable runs for the spark workers. It must be configured in the spark.conf like spark.executorEnv.RAY_PEX_FILE. If it is set, it will be used as the python executable instead of sys.executable. 

### Example
#### Generate Ray Pex File using future version of ray
`/opt/conda/bin/pex ray[default,rllib,tune]==2.10.1 -o $(pwd)/ray-pex-deps.pex --inherit-path=fallback`

#### Initialize PySpark SparkSession
(Lots of options here, could use spark-submit, google-sparksubmit-operator for kubernetes, python kernel in Jupyter, etc)
 
For Jupyter you would do below individually in notebook cells -- note require [pants-jupyter-plugin](https://pypi.org/project/pants-jupyter-plugin/#description)
`%reload_ext pants_jupyter_plugin`
`%pex_load ray-pex-deps.pex`
 
In a python script or notebook cell
 ```
import pyspark
from pyspark import SparkContext, SparkConf
from pyspark.sql import SparkSession
import os

pyspark_deps_name = 'ray-pex-deps.pex'
os.environ['PYSPARK_PYTHON'] = f"./{pyspark_deps_name}"
#required for ray on spark to utilize pex file for subprocesses
os.environ['RAY_PEX_FILE'] = f"./{pyspark_deps_name}"

conf = SparkConf().setMaster("spark://spark-master:7077") # or for local .setMaster('local[*]')
hostname = os.popen("hostname -i").read().split("\n")[0]
conf.set("spark.deployMode","client")
conf.set("spark.driver.host",hostname)
#shipping pex dependencies from local or s3, the pex file must exist locally for most use cases
conf.set("spark.files",pyspark_deps_name)
#required for ray on spark to utilize pex file for subprocesses
conf.set("spark.executorEnv.RAY_PEX_FILE", f"./{pyspark_deps_name}")

sc = pyspark.SparkContext(conf=conf)
sc.setLogLevel("warn")
spark = SparkSession(sc)

from ray.util.spark import setup_ray_cluster, shutdown_ray_cluster
conn_str = setup_ray_cluster(uses_pex=True)

import ray
ray.init(conn_str[0])

#Ray code below
#End ray code
shutdown_ray_cluster()
spark.stop()
 ```
 You could launch via a python script on the spark cluster like `ray-pex-deps.pex my_example_python.py`

I'm planning on posting some material and examples once this is merged, happy to share some links. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
          `No doc identified`
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
