### PR TITLE
Fixes the flaky mutable_object_test

### DIFF
--- a/src/ray/object_manager/plasma/test/mutable_object_test.cc
+++ b/src/ray/object_manager/plasma/test/mutable_object_test.cc
@@ -112,7 +112,9 @@ std::unique_ptr<plasma::MutableObject> MakeObject() {
   info.allocated_size = kPayloadSize;
 
   uint8_t *ptr = static_cast<uint8_t *>(malloc(kSize));
-  return std::make_unique<plasma::MutableObject>(ptr, info);
+  auto ret = std::make_unique<plasma::MutableObject>(ptr, info);
+  ret->header->Init();
+  return ret;
 }
 
 }  // namespace


### PR DESCRIPTION
Based on a local issue I resolved, I believe this commit should fix the flaky mutable_object_test in #44396.

The header of the mutable object was not being explicitly initialized. In some cases, this caused deadlock due to a spinlock backed by garbage memory.

This commit explicitly initializes the header, which should resolve the issue.

Tested: mutable_object_test

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See above.

## Related issue number

Closes #44396.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
