### PR TITLE
Remove verifying the body of the prometheus health check

### DIFF
--- a/dashboard/modules/metrics/metrics_head.py
+++ b/dashboard/modules/metrics/metrics_head.py
@@ -163,17 +163,6 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
                         status=resp.status,
                     )
 
-                text = await resp.text()
-                # Basic sanity check of prometheus health check schema
-                # Different flavors of Prometheus may use different health check strings
-                if "Prometheus" not in text:
-                    return dashboard_optional_utils.rest_response(
-                        success=False,
-                        message="prometheus healthcheck failed.",
-                        status=resp.status,
-                        text=text,
-                    )
-
                 return dashboard_optional_utils.rest_response(
                     success=True,
                     message="prometheus running",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This check is too fragile as we've seen:
- prometheus change it's health check message with newer versions
- Other flavors of prometheus (ex: cortex) has a completely different message.

We simplify the healthcheck to only verify that a 200 response is returned.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
