### PR TITLE
[Data] Move imports into `TFPRedictor` in batch inference example

### DIFF
--- a/doc/source/data/batch_inference.rst
+++ b/doc/source/data/batch_inference.rst
@@ -289,8 +289,6 @@ The remaining is the same as the :ref:`Quickstart <batch_inference_quickstart>`.
 
             from typing import Dict
             import numpy as np
-            import tensorflow as tf
-            from tensorflow import keras
 
             import ray
 
@@ -298,6 +296,9 @@ The remaining is the same as the :ref:`Quickstart <batch_inference_quickstart>`.
 
             class TFPredictor:
                 def __init__(self):
+                    import tensorflow as tf
+                    from tensorflow import keras
+
                     # Move the neural network to GPU by specifying the GPU device.
                     with tf.device("GPU:0"):
                         input_layer = keras.Input(shape=(100,))
@@ -305,6 +306,8 @@ The remaining is the same as the :ref:`Quickstart <batch_inference_quickstart>`.
                         self.model = keras.Sequential([input_layer, output_layer])
 
                 def __call__(self, batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+                    import tensorflow as tf
+
                     # Move the input batch to GPU by specifying GPU device.
                     with tf.device("GPU:0"):
                         return {"output": self.model(batch["data"]).numpy()}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We're updating our CI to use Python 3.11. Accordingly, we're updating the TensorFlow version to 2.15. To avoid test failures from https://github.com/ray-project/ray/issues/44274, this PR moves the TensorFlow imports into the `TFPredictor` methods.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
