### PR TITLE
[serve] expose running requests metrics from handles

### DIFF
--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -548,6 +548,8 @@ The following metrics are exposed by Ray Serve:
      - * deployment
        * route
        * application
+       * handle
+       * actor_id
      - The number of requests processed by the router.
    * - ``ray_serve_num_scheduling_tasks`` [*][†]
      - * deployment
@@ -565,8 +567,16 @@ The following metrics are exposed by Ray Serve:
      - The number of requests processed by this DeploymentHandle.
    * - ``ray_serve_deployment_queued_queries`` [*]
      - * deployment
-       * route
-     - The number of queries for this deployment waiting to be assigned to a replica.
+       * application
+       * handle
+       * actor_id
+     - The current number of requests to this deployment that have been submitted to a replica.
+   * - ``ray_serve_num_ongoing_requests_at_replicas`` [*]
+     - * deployment
+       * application
+       * handle
+       * actor_id
+     - The current number of requests to this deployment that's been assigned and sent to execute on a replica.
    * - ``ray_serve_num_deployment_http_error_requests_total`` [*]
      - * deployment
        * error_code

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2196,9 +2196,9 @@ class DeploymentState:
                 required, available = pending_allocation[0].resource_requirements()
                 message = (
                     f"Deployment '{self.deployment_name}' in application "
-                    f"'{self.app_name}' {len(pending_allocation)} replicas that have "
-                    f"taken more than {SLOW_STARTUP_WARNING_S}s to be scheduled. This "
-                    "may be due to waiting for the cluster to auto-scale or for a "
+                    f"'{self.app_name}' has {len(pending_allocation)} replicas that "
+                    f"have taken more than {SLOW_STARTUP_WARNING_S}s to be scheduled. "
+                    "This may be due to waiting for the cluster to auto-scale or for a "
                     "runtime environment to be installed. Resources required for each "
                     f"replica: {required}, total resources available: {available}. Use "
                     "`ray status` for more details."

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -50,29 +50,52 @@ class RouterMetricsManager:
         self,
         deployment_id: DeploymentID,
         handle_id: str,
+        self_actor_id: str,
         controller_handle: ActorHandle,
         router_requests_counter: metrics.Counter,
         queued_requests_gauge: metrics.Gauge,
+        running_requests_gauge: metrics.Gauge,
     ):
         self._handle_id = handle_id
         self._deployment_id = deployment_id
         self._controller_handle = controller_handle
+        self._self_actor_id = self_actor_id
 
         # Exported metrics
         self.num_router_requests = router_requests_counter
         self.num_router_requests.set_default_tags(
-            {"deployment": deployment_id.name, "application": deployment_id.app_name}
+            {
+                "deployment": deployment_id.name,
+                "application": deployment_id.app_name,
+                "handle": self._handle_id,
+                "actor_id": self._self_actor_id,
+            }
         )
 
         self.num_queued_requests = 0
         self.num_queued_requests_gauge = queued_requests_gauge
         self.num_queued_requests_gauge.set_default_tags(
-            {"deployment": deployment_id.name, "application": deployment_id.app_name}
+            {
+                "deployment": deployment_id.name,
+                "application": deployment_id.app_name,
+                "handle": self._handle_id,
+                "actor_id": self._self_actor_id,
+            }
         )
+        self.num_queued_requests_gauge.set(0)
 
         # Track queries sent to replicas for the autoscaling algorithm.
         self.num_requests_sent_to_replicas: DefaultDict[ReplicaID, int] = defaultdict(
             int
+        )
+        self.num_running_requests_gauge = running_requests_gauge
+        self.num_running_requests_gauge.set_default_tags(
+            {
+                "deployment": deployment_id.name,
+                "application": deployment_id.app_name,
+                "handle": self._handle_id,
+                "actor_id": self._self_actor_id,
+            }
         )
         # We use Ray object ref callbacks to update state when tracking
         # number of requests running on replicas. The callbacks will be
@@ -197,10 +220,16 @@ class RouterMetricsManager:
     def inc_num_running_requests_for_replica(self, replica_id: ReplicaID):
         with self._queries_lock:
             self.num_requests_sent_to_replicas[replica_id] += 1
+            self.num_running_requests_gauge.set(
+                sum(self.num_requests_sent_to_replicas.values())
+            )
 
     def process_finished_request(self, replica_id: ReplicaID, *args):
         with self._queries_lock:
             self.num_requests_sent_to_replicas[replica_id] -= 1
+            self.num_running_requests_gauge.set(
+                sum(self.num_requests_sent_to_replicas.values())
+            )
 
     def should_send_scaled_to_zero_optimized_push(self, curr_num_replicas: int) -> bool:
         return (
@@ -283,10 +312,6 @@ class Router:
         self._event_loop = event_loop
         self.deployment_id = deployment_id
 
-        logger.info(
-            f"Created DeploymentHandle '{handle_id}' for {deployment_id}.",
-            extra={"log_to_stderr": False},
-        )
         if inside_ray_client_context():
             # Streaming ObjectRefGenerators are not supported in Ray Client, so we need
             # to override the behavior.
@@ -334,11 +359,12 @@ class Router:
         self._metrics_manager = RouterMetricsManager(
             deployment_id,
             handle_id,
+            self_actor_id,
             controller_handle,
             metrics.Counter(
                 "serve_num_router_requests",
                 description="The number of requests processed by the router.",
-                tag_keys=("deployment", "route", "application"),
+                tag_keys=("deployment", "route", "application", "handle", "actor_id"),
             ),
             metrics.Gauge(
                 "serve_deployment_queued_queries",
@@ -346,7 +372,15 @@ class Router:
                     "The current number of queries to this deployment waiting"
                     " to be assigned to a replica."
                 ),
-                tag_keys=("deployment", "application"),
+                tag_keys=("deployment", "application", "handle", "actor_id"),
+            ),
+            metrics.Gauge(
+                "serve_num_ongoing_requests_at_replicas",
+                description=(
+                    "The current number of requests to this deployment that "
+                    "have been submitted to a replica."
+                ),
+                tag_keys=("deployment", "application", "handle", "actor_id"),
             ),
         )
 

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -519,50 +519,78 @@ class FakeGrpcContext:
 class FakeGauge:
     def __init__(self, name: str = None, tag_keys: Tuple[str] = None):
         self.name = name
-        self.value = 0
-        if tag_keys:
-            self.tags = {key: None for key in tag_keys}
-        else:
-            self.tags = dict()
+        self.values = dict()
+
+        self.tags = tag_keys or ()
+        self.default_tags = dict()
 
     def set_default_tags(self, tags: Dict[str, str]):
         for key, tag in tags.items():
             assert key in self.tags
-            self.tags[key] = tag
+            self.default_tags[key] = tag
 
     def set(self, value: Union[int, float], tags: Dict[str, str] = None):
-        self.value = value
-        if tags:
-            self.tags.update(tags)
+        merged_tags = self.default_tags.copy()
+        merged_tags.update(tags or {})
+        assert set(merged_tags.keys()) == set(self.tags)
 
-    def get_value(self):
-        return self.value
+        d = self.values
+        for tag in self.tags[:-1]:
+            tag_value = merged_tags[tag]
+            if tag_value not in d:
+                d[tag_value] = dict()
+            d = d[tag_value]
 
-    def get_tags(self):
-        return self.tags
+        d[merged_tags[self.tags[-1]]] = value
+
+    def get_value(self, tags: Dict[str, str]):
+        value = self.values
+        for tag in self.tags:
+            tag_value = tags[tag]
+            value = value.get(tag_value)
+            if value is None:
+                return
+
+        return value
 
 
 class FakeCounter:
     def __init__(self, name: str = None, tag_keys: Tuple[str] = None):
         self.name = name
-        self.count: int = 0
-        if tag_keys:
-            self.tags = {key: None for key in tag_keys}
-        else:
-            self.tags = dict()
+        self.counts = dict()
+
+        self.tags = tag_keys or ()
+        self.default_tags = dict()
 
     def set_default_tags(self, tags: Dict[str, str]):
         for key, tag in tags.items():
             assert key in self.tags
-            self.tags[key] = tag
+            self.default_tags[key] = tag
 
     def inc(self, value: Union[int, float] = 1.0, tags: Dict[str, str] = None):
-        self.count += value
-        if tags:
-            self.tags.update(tags)
+        merged_tags = self.default_tags.copy()
+        merged_tags.update(tags or {})
+        assert set(merged_tags.keys()) == set(self.tags)
 
-    def get_count(self) -> int:
-        return self.count
+        d = self.counts
+        for tag in self.tags[:-1]:
+            tag_value = merged_tags[tag]
+            if tag_value not in d:
+                d[tag_value] = dict()
+            d = d[tag_value]
+
+        key = merged_tags[self.tags[-1]]
+        d[key] = d.get(key, 0) + value
+
+    def get_count(self, tags: Dict[str, str]) -> int:
+        value = self.counts
+        for tag in self.tags:
+            tag_value = tags[tag]
+            value = value.get(tag_value)
+            if value is None:
+                return
+
+        return value
 
     def get_tags(self):
         return self.tags

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -115,6 +115,11 @@ class _DeploymentHandleBase:
 
         self._router: Optional[Router] = _router
 
+        logger.info(
+            f"Created DeploymentHandle '{self.handle_id}' for {self.deployment_id}.",
+            extra={"log_to_stderr": False},
+        )
+
     def _record_telemetry_if_needed(self):
         # Record telemetry once per handle and not when used from the proxy
         # (detected via request protocol).

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -1,4 +1,5 @@
 import os
+import random
 import sys
 from typing import DefaultDict, Dict, List, Optional
 
@@ -10,7 +11,11 @@ from fastapi import FastAPI
 import ray
 import ray.util.state as state_api
 from ray import serve
-from ray._private.test_utils import SignalActor, wait_for_condition
+from ray._private.test_utils import (
+    SignalActor,
+    fetch_prometheus_metrics,
+    wait_for_condition,
+)
 from ray.serve._private.constants import DEFAULT_LATENCY_BUCKET_MS
 from ray.serve._private.long_poll import LongPollHost, UpdatedObject
 from ray.serve._private.test_utils import (
@@ -24,12 +29,14 @@ from ray.serve.handle import DeploymentHandle
 from ray.serve.metrics import Counter, Gauge, Histogram
 from ray.serve.tests.test_config_files.grpc_deployment import g, g2
 
+TEST_METRICS_EXPORT_PORT = 9999
+
 
 @pytest.fixture
 def serve_start_shutdown():
     """Fixture provides a fresh Ray cluster to prevent metrics state sharing."""
     ray.init(
-        _metrics_export_port=9999,
+        _metrics_export_port=TEST_METRICS_EXPORT_PORT,
         _system_config={
             "metrics_report_interval_ms": 100,
             "task_retry_delay_ms": 50,
@@ -48,6 +55,139 @@ def serve_start_shutdown():
     )
     serve.shutdown()
     ray.shutdown()
+    ray._private.utils.reset_ray_address()
+
+
+def extract_tags(line: str) -> Dict[str, str]:
+    """Extracts any tags from the metrics line."""
+
+    try:
+        tags_string = line.replace("{", "}").split("}")[1]
+    except IndexError:
+        # No tags were found in this line.
+        return {}
+
+    detected_tags = {}
+    for tag_pair in tags_string.split(","):
+        sanitized_pair = tag_pair.replace('"', "")
+        tag, value = sanitized_pair.split("=")
+        detected_tags[tag] = value
+
+    return detected_tags
+
+
+def contains_tags(line: str, expected_tags: Optional[Dict[str, str]] = None) -> bool:
+    """Checks if the metrics line contains the expected tags.
+
+    Does nothing if expected_tags is None.
+    """
+
+    if expected_tags is not None:
+        detected_tags = extract_tags(line)
+
+        # Check if expected_tags is a subset of detected_tags
+        return expected_tags.items() <= detected_tags.items()
+    else:
+        return True
+
+
+def get_metric_float(
+    metric: str, expected_tags: Optional[Dict[str, str]] = None
+) -> float:
+    """Gets the float value of metric.
+
+    If tags is specified, searched for metric with matching tags.
+
+    Returns -1 if the metric isn't available.
+    """
+
+    metrics = requests.get("http://127.0.0.1:9999").text
+    metric_value = -1
+    for line in metrics.split("\n"):
+        if metric in line and contains_tags(line, expected_tags):
+            metric_value = line.split(" ")[-1]
+    return metric_value
+
+
+def check_metric_float_eq(
+    metric: str, expected: float, expected_tags: Optional[Dict[str, str]] = None
+) -> bool:
+    metric_value = get_metric_float(metric, expected_tags)
+    assert float(metric_value) == expected
+    return True
+
+
+def check_sum_metric_eq(
+    metric_name: str,
+    expected: float,
+    tags: Optional[Dict[str, str]] = None,
+) -> bool:
+    metrics = fetch_prometheus_metrics([f"localhost:{TEST_METRICS_EXPORT_PORT}"])
+    metric_samples = metrics.get(metric_name, None)
+    if metric_samples is None:
+        metric_sum = 0
+    else:
+        metric_samples = [
+            sample for sample in metric_samples if tags.items() <= sample.labels.items()
+        ]
+        metric_sum = sum(sample.value for sample in metric_samples)
+
+    # Check the metrics sum to the expected number
+    assert (
+        metric_sum == expected
+    ), f"The following metrics don't sum to {expected}: {metric_samples}. {metrics}"
+
+    # # For debugging
+    if metric_samples:
+        print(f"The following sum to {expected} for '{metric_name}' and tags {tags}:")
+        for sample in metric_samples:
+            print(sample)
+
+    return True
+
+
+def get_metric_dictionaries(name: str, timeout: float = 20) -> List[Dict]:
+    """Gets a list of metric's tags from metrics' text output.
+
+    Return:
+        Example:
+
+        >>> get_metric_dictionaries("ray_serve_num_http_requests")
+        [
+            {
+                'Component': 'core_worker',
+                'JobId': '01000000',
+                ...
+                'method': 'GET',
+                'route': '/hello'
+            },
+            {
+                'Component': 'core_worker',
+                ...
+                'method': 'GET',
+                'route': '/hello/'
+            }
+        ]
+    """
+
+    def metric_available() -> bool:
+        metrics = requests.get("http://127.0.0.1:9999").text
+        return name in metrics
+
+    wait_for_condition(metric_available, retry_interval_ms=1000, timeout=timeout)
+
+    metrics = requests.get("http://127.0.0.1:9999").text
+    print("metrics", metrics)
+
+    metric_dicts = []
+    for line in metrics.split("\n"):
+        if name + "{" in line:
+            dict_body_start, dict_body_end = line.find("{") + 1, line.rfind("}")
+            metric_dict_str = f"dict({line[dict_body_start:dict_body_end]})"
+            metric_dicts.append(eval(metric_dict_str))
+
+    print(metric_dicts)
+    return metric_dicts
 
 
 def test_serve_metrics_for_successful_connection(serve_start_shutdown):
@@ -1070,142 +1210,302 @@ def test_multiplexed_metrics(serve_start_shutdown):
     )
 
 
-def test_queued_queries_disconnected(serve_start_shutdown):
-    """Check that disconnected queued queries are tracked correctly."""
-
-    signal = SignalActor.remote()
-
-    @serve.deployment(
-        max_ongoing_requests=1,
-    )
-    async def hang_on_first_request():
+@serve.deployment
+class WaitForSignal:
+    async def __call__(self):
+        signal = ray.get_actor("signal123")
         await signal.wait.remote()
 
-    serve.run(hang_on_first_request.bind())
 
-    print("Deployed hang_on_first_request deployment.")
+@serve.deployment
+class Router:
+    def __init__(self, handles):
+        self.handles = handles
 
-    wait_for_condition(
-        check_metric_float_eq,
-        timeout=15,
-        metric="ray_serve_num_scheduling_tasks",
-        expected=-1,  # -1 means not expected to be present yet.
-        # TODO(zcin): this tag shouldn't be necessary, there shouldn't be a mix of
-        # metrics from new and old sessions.
-        expected_tags={
-            "SessionName": ray._private.worker.global_worker.node.session_name
-        },
-    )
-    print("ray_serve_num_scheduling_tasks updated successfully.")
-    wait_for_condition(
-        check_metric_float_eq,
-        timeout=15,
-        metric="serve_num_scheduling_tasks_in_backoff",
-        expected=-1,  # -1 means not expected to be present yet.
-        # TODO(zcin): this tag shouldn't be necessary, there shouldn't be a mix of
-        # metrics from new and old sessions.
-        expected_tags={
-            "SessionName": ray._private.worker.global_worker.node.session_name
-        },
-    )
-    print("serve_num_scheduling_tasks_in_backoff updated successfully.")
+    async def __call__(self, index: int):
+        return await self.handles[index - 1].remote()
 
-    @ray.remote(num_cpus=0)
-    def do_request():
-        r = requests.get("http://localhost:8000/")
-        r.raise_for_status()
-        return r
 
-    # Make a request to block the deployment from accepting other requests.
-    request_refs = [do_request.remote()]
-    wait_for_condition(
-        lambda: ray.get(signal.cur_num_waiters.remote()) == 1, timeout=10
-    )
+@ray.remote
+def call(deployment_name, app_name, *args):
+    handle = DeploymentHandle(deployment_name, app_name)
+    handle.remote(*args)
 
-    print("First request is executing.")
-    wait_for_condition(
-        check_metric_float_eq,
-        timeout=15,
-        metric="ray_serve_num_ongoing_http_requests",
-        expected=1,
-    )
-    print("ray_serve_num_ongoing_http_requests updated successfully.")
 
-    num_queued_requests = 3
-    request_refs.extend([do_request.remote() for _ in range(num_queued_requests)])
-    print(f"{num_queued_requests} more requests now queued.")
+@ray.remote
+class CallActor:
+    def __init__(self, deployment_name: str, app_name: str):
+        self.handle = DeploymentHandle(deployment_name, app_name)
 
-    # First request should be processing. All others should be queued.
-    wait_for_condition(
-        check_metric_float_eq,
-        timeout=15,
-        metric="ray_serve_deployment_queued_queries",
-        expected=num_queued_requests,
-    )
-    print("ray_serve_deployment_queued_queries updated successfully.")
-    wait_for_condition(
-        check_metric_float_eq,
-        timeout=15,
-        metric="ray_serve_num_ongoing_http_requests",
-        expected=num_queued_requests + 1,
-    )
-    print("ray_serve_num_ongoing_http_requests updated successfully.")
+    async def call(self, *args):
+        await self.handle.remote(*args)
 
-    # There should be 2 scheduling tasks (which is the max, since
-    # 2 = 2 * 1 replica) that are attempting to schedule the hanging requests.
-    wait_for_condition(
-        check_metric_float_eq,
-        timeout=15,
-        metric="ray_serve_num_scheduling_tasks",
-        expected=2,
-    )
-    print("ray_serve_num_scheduling_tasks updated successfully.")
-    wait_for_condition(
-        check_metric_float_eq,
-        timeout=15,
-        metric="serve_num_scheduling_tasks_in_backoff",
-        expected=2,
-    )
-    print("serve_num_scheduling_tasks_in_backoff updated successfully.")
 
-    # Disconnect all requests by cancelling the Ray tasks.
-    [ray.cancel(ref, force=True) for ref in request_refs]
-    print("Cancelled all HTTP requests.")
+class TestHandleMetrics:
+    def test_queued_queries_basic(self, serve_start_shutdown):
+        signal = SignalActor.options(name="signal123").remote()
+        serve.run(WaitForSignal.options(max_ongoing_requests=1).bind(), name="app1")
 
-    wait_for_condition(
-        check_metric_float_eq,
-        timeout=15,
-        metric="ray_serve_deployment_queued_queries",
-        expected=0,
-    )
-    print("ray_serve_deployment_queued_queries updated successfully.")
+        # First call should get assigned to a replica
+        # call.remote("WaitForSignal", "app1")
+        caller = CallActor.remote("WaitForSignal", "app1")
+        caller.call.remote()
 
-    # Task should get cancelled.
-    wait_for_condition(
-        check_metric_float_eq,
-        timeout=15,
-        metric="ray_serve_num_ongoing_http_requests",
-        expected=0,
-    )
-    print("ray_serve_num_ongoing_http_requests updated successfully.")
+        for i in range(5):
+            # call.remote("WaitForSignal", "app1")
+            # c.call.remote()
+            caller.call.remote()
+            wait_for_condition(
+                check_sum_metric_eq,
+                metric_name="ray_serve_deployment_queued_queries",
+                tags={"application": "app1"},
+                expected=i + 1,
+            )
 
-    wait_for_condition(
-        check_metric_float_eq,
-        timeout=15,
-        metric="ray_serve_num_scheduling_tasks",
-        expected=0,
-    )
-    print("ray_serve_num_scheduling_tasks updated successfully.")
-    wait_for_condition(
-        check_metric_float_eq,
-        timeout=15,
-        metric="serve_num_scheduling_tasks_in_backoff",
-        expected=0,
-    )
-    print("serve_num_scheduling_tasks_in_backoff updated successfully.")
+        # Release signal
+        ray.get(signal.send.remote())
+        wait_for_condition(
+            check_sum_metric_eq,
+            metric_name="ray_serve_deployment_queued_queries",
+            tags={"application": "app1", "deployment": "WaitForSignal"},
+            expected=0,
+        )
 
-    # Unblock hanging request.
-    ray.get(signal.send.remote())
+    def test_queued_queries_multiple_handles(self, serve_start_shutdown):
+        signal = SignalActor.options(name="signal123").remote()
+        serve.run(WaitForSignal.options(max_ongoing_requests=1).bind(), name="app1")
+
+        # Send first request
+        call.remote("WaitForSignal", "app1")
+        wait_for_condition(
+            check_sum_metric_eq,
+            metric_name="ray_serve_deployment_queued_queries",
+            tags={"application": "app1", "deployment": "WaitForSignal"},
+            expected=0,
+        )
+
+        # Send second request (which should stay queued)
+        call.remote("WaitForSignal", "app1")
+        wait_for_condition(
+            check_sum_metric_eq,
+            metric_name="ray_serve_deployment_queued_queries",
+            tags={"application": "app1", "deployment": "WaitForSignal"},
+            expected=1,
+        )
+
+        # Send third request (which should stay queued)
+        call.remote("WaitForSignal", "app1")
+        wait_for_condition(
+            check_sum_metric_eq,
+            metric_name="ray_serve_deployment_queued_queries",
+            tags={"application": "app1", "deployment": "WaitForSignal"},
+            expected=2,
+        )
+
+        # Release signal
+        ray.get(signal.send.remote())
+        wait_for_condition(
+            check_sum_metric_eq,
+            metric_name="ray_serve_deployment_queued_queries",
+            tags={"application": "app1", "deployment": "WaitForSignal"},
+            expected=0,
+        )
+
+    def test_queued_queries_disconnected(self, serve_start_shutdown):
+        """Check that disconnected queued queries are tracked correctly."""
+
+        signal = SignalActor.remote()
+
+        @serve.deployment(
+            max_ongoing_requests=1,
+        )
+        async def hang_on_first_request():
+            await signal.wait.remote()
+
+        serve.run(hang_on_first_request.bind())
+
+        print("Deployed hang_on_first_request deployment.")
+
+        wait_for_condition(
+            check_metric_float_eq,
+            timeout=15,
+            metric="ray_serve_num_scheduling_tasks",
+            expected=-1,  # -1 means not expected to be present yet.
+            # TODO(zcin): this tag shouldn't be necessary, there shouldn't be a mix of
+            # metrics from new and old sessions.
+            expected_tags={
+                "SessionName": ray._private.worker.global_worker.node.session_name
+            },
+        )
+        print("ray_serve_num_scheduling_tasks updated successfully.")
+        wait_for_condition(
+            check_metric_float_eq,
+            timeout=15,
+            metric="serve_num_scheduling_tasks_in_backoff",
+            expected=-1,  # -1 means not expected to be present yet.
+            # TODO(zcin): this tag shouldn't be necessary, there shouldn't be a mix of
+            # metrics from new and old sessions.
+            expected_tags={
+                "SessionName": ray._private.worker.global_worker.node.session_name
+            },
+        )
+        print("serve_num_scheduling_tasks_in_backoff updated successfully.")
+
+        @ray.remote(num_cpus=0)
+        def do_request():
+            r = requests.get("http://localhost:8000/")
+            r.raise_for_status()
+            return r
+
+        # Make a request to block the deployment from accepting other requests.
+        request_refs = [do_request.remote()]
+        wait_for_condition(
+            lambda: ray.get(signal.cur_num_waiters.remote()) == 1, timeout=10
+        )
+
+        print("First request is executing.")
+        wait_for_condition(
+            check_metric_float_eq,
+            timeout=15,
+            metric="ray_serve_num_ongoing_http_requests",
+            expected=1,
+        )
+        print("ray_serve_num_ongoing_http_requests updated successfully.")
+
+        num_queued_requests = 3
+        request_refs.extend([do_request.remote() for _ in range(num_queued_requests)])
+        print(f"{num_queued_requests} more requests now queued.")
+
+        # First request should be processing. All others should be queued.
+        wait_for_condition(
+            check_metric_float_eq,
+            timeout=15,
+            metric="ray_serve_deployment_queued_queries",
+            expected=num_queued_requests,
+        )
+        print("ray_serve_deployment_queued_queries updated successfully.")
+        wait_for_condition(
+            check_metric_float_eq,
+            timeout=15,
+            metric="ray_serve_num_ongoing_http_requests",
+            expected=num_queued_requests + 1,
+        )
+        print("ray_serve_num_ongoing_http_requests updated successfully.")
+
+        # There should be 2 scheduling tasks (which is the max, since
+        # 2 = 2 * 1 replica) that are attempting to schedule the hanging requests.
+        wait_for_condition(
+            check_metric_float_eq,
+            timeout=15,
+            metric="ray_serve_num_scheduling_tasks",
+            expected=2,
+        )
+        print("ray_serve_num_scheduling_tasks updated successfully.")
+        wait_for_condition(
+            check_metric_float_eq,
+            timeout=15,
+            metric="serve_num_scheduling_tasks_in_backoff",
+            expected=2,
+        )
+        print("serve_num_scheduling_tasks_in_backoff updated successfully.")
+
+        # Disconnect all requests by cancelling the Ray tasks.
+        [ray.cancel(ref, force=True) for ref in request_refs]
+        print("Cancelled all HTTP requests.")
+
+        wait_for_condition(
+            check_metric_float_eq,
+            timeout=15,
+            metric="ray_serve_deployment_queued_queries",
+            expected=0,
+        )
+        print("ray_serve_deployment_queued_queries updated successfully.")
+
+        # Task should get cancelled.
+        wait_for_condition(
+            check_metric_float_eq,
+            timeout=15,
+            metric="ray_serve_num_ongoing_http_requests",
+            expected=0,
+        )
+        print("ray_serve_num_ongoing_http_requests updated successfully.")
+
+        wait_for_condition(
+            check_metric_float_eq,
+            timeout=15,
+            metric="ray_serve_num_scheduling_tasks",
+            expected=0,
+        )
+        print("ray_serve_num_scheduling_tasks updated successfully.")
+        wait_for_condition(
+            check_metric_float_eq,
+            timeout=15,
+            metric="serve_num_scheduling_tasks_in_backoff",
+            expected=0,
+        )
+        print("serve_num_scheduling_tasks_in_backoff updated successfully.")
+
+        # Unblock hanging request.
+        ray.get(signal.send.remote())
+
+    def test_running_requests_gauge(self, serve_start_shutdown):
+        signal = SignalActor.options(name="signal123").remote()
+        serve.run(
+            Router.options(num_replicas=2, ray_actor_options={"num_cpus": 0}).bind(
+                [
+                    WaitForSignal.options(
+                        name="d1",
+                        ray_actor_options={"num_cpus": 0},
+                        max_ongoing_requests=2,
+                        num_replicas=3,
+                    ).bind(),
+                    WaitForSignal.options(
+                        name="d2",
+                        ray_actor_options={"num_cpus": 0},
+                        max_ongoing_requests=2,
+                        num_replicas=3,
+                    ).bind(),
+                ],
+            ),
+            name="app1",
+        )
+
+        requests_sent = {1: 0, 2: 0}
+        for i in range(5):
+            index = random.choice([1, 2])
+            print(f"Sending request to d{index}")
+            call.remote("Router", "app1", index)
+            requests_sent[index] += 1
+
+            wait_for_condition(
+                check_sum_metric_eq,
+                metric_name="ray_serve_num_ongoing_requests_at_replicas",
+                tags={"application": "app1", "deployment": "d1"},
+                expected=requests_sent[1],
+            )
+
+            wait_for_condition(
+                check_sum_metric_eq,
+                metric_name="ray_serve_num_ongoing_requests_at_replicas",
+                tags={"application": "app1", "deployment": "d2"},
+                expected=requests_sent[2],
+            )
+
+            wait_for_condition(
+                check_sum_metric_eq,
+                metric_name="ray_serve_num_ongoing_requests_at_replicas",
+                tags={"application": "app1", "deployment": "Router"},
+                expected=i + 1,
+            )
+
+        # Release signal, the number of running requests should drop to 0
+        ray.get(signal.send.remote())
+        wait_for_condition(
+            check_sum_metric_eq,
+            metric_name="ray_serve_num_ongoing_requests_at_replicas",
+            tags={"application": "app1"},
+            expected=0,
+        )
 
 
 def test_long_poll_host_sends_counted(serve_instance):
@@ -1265,65 +1565,6 @@ def test_long_poll_host_sends_counted(serve_instance):
     )
 
 
-def extract_tags(line: str) -> Dict[str, str]:
-    """Extracts any tags from the metrics line."""
-
-    try:
-        tags_string = line.replace("{", "}").split("}")[1]
-    except IndexError:
-        # No tags were found in this line.
-        return {}
-
-    detected_tags = {}
-    for tag_pair in tags_string.split(","):
-        sanitized_pair = tag_pair.replace('"', "")
-        tag, value = sanitized_pair.split("=")
-        detected_tags[tag] = value
-
-    return detected_tags
-
-
-def contains_tags(line: str, expected_tags: Optional[Dict[str, str]] = None) -> bool:
-    """Checks if the metrics line contains the expected tags.
-
-    Does nothing if expected_tags is None.
-    """
-
-    if expected_tags is not None:
-        detected_tags = extract_tags(line)
-
-        # Check if expected_tags is a subset of detected_tags
-        return expected_tags.items() <= detected_tags.items()
-    else:
-        return True
-
-
-def get_metric_float(
-    metric: str, expected_tags: Optional[Dict[str, str]] = None
-) -> float:
-    """Gets the float value of metric.
-
-    If tags is specified, searched for metric with matching tags.
-
-    Returns -1 if the metric isn't available.
-    """
-
-    metrics = requests.get("http://127.0.0.1:9999").text
-    metric_value = -1
-    for line in metrics.split("\n"):
-        if metric in line and contains_tags(line, expected_tags):
-            metric_value = line.split(" ")[-1]
-    return metric_value
-
-
-def check_metric_float_eq(
-    metric: str, expected: float, expected_tags: Optional[Dict[str, str]] = None
-) -> bool:
-    metric_value = get_metric_float(metric, expected_tags)
-    assert float(metric_value) == expected
-    return True
-
-
 def test_actor_summary(serve_instance):
     @serve.deployment
     def f():
@@ -1335,49 +1576,6 @@ def test_actor_summary(serve_instance):
     assert class_names.issuperset(
         {"ServeController", "ProxyActor", "ServeReplica:app:f"}
     )
-
-
-def get_metric_dictionaries(name: str, timeout: float = 20) -> List[Dict]:
-    """Gets a list of metric's tags from metrics' text output.
-
-    Return:
-        Example:
-
-        >>> get_metric_dictionaries("ray_serve_num_http_requests")
-        [
-            {
-                'Component': 'core_worker',
-                'JobId': '01000000',
-                ...
-                'method': 'GET',
-                'route': '/hello'
-            },
-            {
-                'Component': 'core_worker',
-                ...
-                'method': 'GET',
-                'route': '/hello/'
-            }
-        ]
-    """
-
-    def metric_available() -> bool:
-        metrics = requests.get("http://127.0.0.1:9999").text
-        return name in metrics
-
-    wait_for_condition(metric_available, retry_interval_ms=1000, timeout=timeout)
-
-    metrics = requests.get("http://127.0.0.1:9999").text
-
-    metric_dicts = []
-    for line in metrics.split("\n"):
-        if name + "{" in line:
-            dict_body_start, dict_body_end = line.find("{") + 1, line.rfind("}")
-            metric_dict_str = f"dict({line[dict_body_start:dict_body_end]})"
-            metric_dicts.append(eval(metric_dict_str))
-
-    print(metric_dicts)
-    return metric_dicts
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -2184,8 +2184,8 @@ def test_downscaling_reclaiming_starting_replicas_first(
         )
     elif target_startup_status == ReplicaStartupStatus.PENDING_ALLOCATION:
         expected_message = (
-            "Deployment 'test_deployment' in application "
-            "'test_app' 3 replicas that have taken more than 30s to be scheduled. This "
+            "Deployment 'test_deployment' in application 'test_app' "
+            "has 3 replicas that have taken more than 30s to be scheduled. This "
             "may be due to waiting for the cluster to auto-scale or for a runtime "
             "environment to be installed. Resources required for each replica: "
             '{"CPU": 0.1}, total resources available: {}. Use `ray status` for '

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -504,54 +504,71 @@ def running_replica_info(replica_id: ReplicaID) -> RunningReplicaInfo:
 
 class TestRouterMetricsManager:
     def test_num_router_requests(self):
-        metrics_manager = RouterMetricsManager(
-            DeploymentID(name="a", app_name="b"),
-            "random",
-            Mock(),
-            FakeCounter(tag_keys=("deployment", "route", "application")),
-            FakeGauge(tag_keys=("deployment", "application")),
-        )
-        assert metrics_manager.num_router_requests.get_count() == 0
-
-        n = random.randint(0, 10)
-        for _ in range(n):
-            metrics_manager.inc_num_total_requests(route="/alice")
-        assert metrics_manager.num_router_requests.get_count() == n
-        assert metrics_manager.num_router_requests.get_tags() == {
+        tags = {
             "deployment": "a",
             "application": "b",
             "route": "/alice",
+            "handle": "random_handle",
+            "actor_id": "random_actor",
         }
-
-    def test_num_queued_requests_gauge(self):
         metrics_manager = RouterMetricsManager(
             DeploymentID(name="a", app_name="b"),
-            "random",
+            "random_handle",
+            "random_actor",
             Mock(),
-            FakeCounter(tag_keys=("deployment", "route", "application")),
-            FakeGauge(tag_keys=("deployment", "application")),
+            FakeCounter(
+                tag_keys=("deployment", "route", "application", "handle", "actor_id")
+            ),
+            FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
+            FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
         )
-        assert metrics_manager.num_queued_requests_gauge.get_value() == 0
+        assert metrics_manager.num_router_requests.get_count(tags) is None
+
+        n = random.randint(1, 10)
+        for _ in range(n):
+            metrics_manager.inc_num_total_requests(route="/alice")
+        assert metrics_manager.num_router_requests.get_count(tags) == n
+
+    def test_num_queued_requests_gauge(self):
+        tags = {
+            "deployment": "a",
+            "application": "b",
+            "handle": "random_handle",
+            "actor_id": "random_actor",
+        }
+        metrics_manager = RouterMetricsManager(
+            DeploymentID(name="a", app_name="b"),
+            "random_handle",
+            "random_actor",
+            Mock(),
+            FakeCounter(
+                tag_keys=("deployment", "route", "application", "handle", "actor_id")
+            ),
+            FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
+            FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
+        )
+        assert metrics_manager.num_queued_requests_gauge.get_value(tags) == 0
 
         n, m = random.randint(0, 10), random.randint(0, 5)
         for _ in range(n):
             metrics_manager.inc_num_queued_requests()
-        assert metrics_manager.num_queued_requests_gauge.get_value() == n
+        assert metrics_manager.num_queued_requests_gauge.get_value(tags) == n
         for _ in range(m):
             metrics_manager.dec_num_queued_requests()
-        assert metrics_manager.num_queued_requests_gauge.get_value() == n - m
-        assert metrics_manager.num_queued_requests_gauge.get_tags() == {
-            "deployment": "a",
-            "application": "b",
-        }
+        assert metrics_manager.num_queued_requests_gauge.get_value(tags) == n - m
 
     def test_track_requests_sent_to_replicas(self):
+        d_id = DeploymentID(name="a", app_name="b")
         metrics_manager = RouterMetricsManager(
-            DeploymentID(name="a", app_name="b"),
+            d_id,
             "random",
+            "random_actor",
             Mock(),
-            FakeCounter(tag_keys=("deployment", "route", "application")),
-            FakeGauge(tag_keys=("deployment", "application")),
+            FakeCounter(
+                tag_keys=("deployment", "route", "application", "handle", "actor_id")
+            ),
+            FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
+            FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
         )
 
         # r1: number requests -> 0, removed from list of running replicas -> prune
@@ -559,9 +576,7 @@ class TestRouterMetricsManager:
         # r3: number requests > 0, removed from list of running replicas -> don't prune
         # r4: number requests > 0, remains on list of running replicas -> don't prune
         replica_ids = [
-            ReplicaID(
-                unique_id=f"test-replica-{i}", deployment_id=DeploymentID(name="test")
-            )
+            ReplicaID(unique_id=f"test-replica-{i}", deployment_id=d_id)
             for i in range(1, 5)
         ]
         r1, r2, r3, r4 = replica_ids
@@ -574,6 +589,17 @@ class TestRouterMetricsManager:
         # All 4 replicas should have a positive number of requests
         for i, r in enumerate(replica_ids):
             assert metrics_manager.num_requests_sent_to_replicas[r] == i + 1
+        assert (
+            metrics_manager.num_running_requests_gauge.get_value(
+                {
+                    "deployment": "a",
+                    "application": "b",
+                    "handle": "random",
+                    "actor_id": "random_actor",
+                }
+            )
+            == 10
+        )
 
         # Requests at r1 and r2 drop to 0
         for _ in range(1):
@@ -582,6 +608,19 @@ class TestRouterMetricsManager:
             metrics_manager.process_finished_request(r2, None)
         assert metrics_manager.num_requests_sent_to_replicas[r1] == 0
         assert metrics_manager.num_requests_sent_to_replicas[r2] == 0
+
+        # 3 requests finished processing
+        assert (
+            metrics_manager.num_running_requests_gauge.get_value(
+                {
+                    "deployment": "a",
+                    "application": "b",
+                    "handle": "random",
+                    "actor_id": "random_actor",
+                }
+            )
+            == 7
+        )
 
         # Running replicas reduces to [r2, r4]
         metrics_manager.update_running_replicas(
@@ -601,9 +640,13 @@ class TestRouterMetricsManager:
         metrics_manager = RouterMetricsManager(
             DeploymentID(name="a", app_name="b"),
             "random",
+            "random_actor",
             Mock(),
-            FakeCounter(tag_keys=("deployment", "route", "application")),
-            FakeGauge(tag_keys=("deployment", "application")),
+            FakeCounter(
+                tag_keys=("deployment", "route", "application", "handle", "actor_id")
+            ),
+            FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
+            FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
         )
 
         # Not an autoscaling deployment, should not push metrics
@@ -637,9 +680,19 @@ class TestRouterMetricsManager:
             metrics_manager = RouterMetricsManager(
                 deployment_id,
                 handle_id,
+                "random_actor",
                 mock_controller_handle,
-                FakeCounter(tag_keys=("deployment", "route", "application")),
-                FakeGauge(tag_keys=("deployment", "application")),
+                FakeCounter(
+                    tag_keys=(
+                        "deployment",
+                        "route",
+                        "application",
+                        "handle",
+                        "actor_id",
+                    )
+                ),
+                FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
+                FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
             )
             metrics_manager.deployment_config = DeploymentConfig(
                 autoscaling_config=AutoscalingConfig()
@@ -647,7 +700,9 @@ class TestRouterMetricsManager:
 
             # Set up some requests
             n = random.randint(0, 5)
-            replica_ids = [get_random_string() for _ in range(3)]
+            replica_ids = [
+                ReplicaID(get_random_string(), DeploymentID("d", "a")) for _ in range(3)
+            ]
             running_requests = defaultdict(int)
             for _ in range(n):
                 metrics_manager.inc_num_queued_requests()
@@ -674,9 +729,13 @@ class TestRouterMetricsManager:
         metrics_manager = RouterMetricsManager(
             DeploymentID(name="a", app_name="b"),
             "random",
+            "random_actor",
             Mock(),
-            FakeCounter(tag_keys=("deployment", "route", "application")),
-            FakeGauge(tag_keys=("deployment", "application")),
+            FakeCounter(
+                tag_keys=("deployment", "route", "application", "handle", "actor_id")
+            ),
+            FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
+            FakeGauge(tag_keys=("deployment", "application", "handle", "actor_id")),
         )
 
         # Without autoscaling config, do nothing


### PR DESCRIPTION
[serve] expose running requests metrics from handles

Add new metric `serve_num_ongoing_requests_at_replicas` that exposes the number of requests sent to replicas from handles that handles use for autoscaling metrics.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
