### PR TITLE
[serve] Drop handle metrics from dead actors

### DIFF
--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -8,6 +8,7 @@ import ray
 from ray.actor import ActorHandle
 from ray.serve._private.common import (
     ApplicationStatus,
+    DeploymentHandleSource,
     DeploymentID,
     DeploymentStatus,
     DeploymentStatusInfo,
@@ -30,7 +31,7 @@ from ray.serve.generated.serve_pb2 import (
     DeploymentStatusInfo as DeploymentStatusInfoProto,
 )
 from ray.serve.generated.serve_pb2 import StatusOverview as StatusOverviewProto
-from ray.serve.handle import DeploymentHandle
+from ray.serve.handle import DeploymentHandle, _HandleOptions
 from ray.serve.schema import LoggingConfig, ServeApplicationSchema, ServeDeploySchema
 
 logger = logging.getLogger(__file__)
@@ -422,6 +423,8 @@ class ServeControllerClient:
         Returns:
             DeploymentHandle
         """
+        from ray.serve.context import _get_internal_replica_context
+
         cache_key = (deployment_name, app_name, missing_ok)
         if cache_key in self.handle_cache:
             return self.handle_cache[cache_key]
@@ -437,10 +440,17 @@ class ServeControllerClient:
                 "exist."
             )
 
-        handle = DeploymentHandle(
-            deployment_name,
-            app_name,
-        )
+        if _get_internal_replica_context() is not None:
+            handle = DeploymentHandle(
+                deployment_name,
+                app_name,
+                handle_options=_HandleOptions(_source=DeploymentHandleSource.REPLICA),
+            )
+        else:
+            handle = DeploymentHandle(
+                deployment_name,
+                app_name,
+            )
 
         self.handle_cache[cache_key] = handle
         if cache_key in self._evicted_handle_keys:

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -668,6 +668,12 @@ class RequestProtocol(str, Enum):
     GRPC = "gRPC"
 
 
+class DeploymentHandleSource(str, Enum):
+    UNKNOWN = "UNKNOWN"
+    PROXY = "PROXY"
+    REPLICA = "REPLICA"
+
+
 @dataclass
 class RequestMetadata:
     request_id: str

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -13,6 +13,7 @@ from ray._raylet import GcsClient
 from ray.actor import ActorHandle
 from ray.serve._private.application_state import ApplicationStateManager
 from ray.serve._private.common import (
+    DeploymentHandleSource,
     DeploymentID,
     MultiplexedReplicaInfo,
     NodeId,
@@ -153,11 +154,11 @@ class ServeController:
         self.cluster_node_info_cache.update()
 
         self.proxy_state_manager = ProxyStateManager(
-            http_config,
-            self._controller_node_id,
-            self.cluster_node_info_cache,
-            self.global_logging_config,
-            grpc_options,
+            config=http_config,
+            head_node_id=self._controller_node_id,
+            cluster_node_info_cache=self.cluster_node_info_cache,
+            logging_config=self.global_logging_config,
+            grpc_options=grpc_options,
         )
 
         self.endpoint_state = EndpointState(self.kv_store, self.long_poll_host)
@@ -260,6 +261,8 @@ class ServeController:
         self,
         deployment_id: str,
         handle_id: str,
+        actor_id: Optional[str],
+        handle_source: DeploymentHandleSource,
         queued_requests: float,
         running_requests: Dict[str, float],
         send_timestamp: float,
@@ -269,7 +272,13 @@ class ServeController:
             f"{queued_requests} queued requests and {running_requests} running requests"
         )
         self.deployment_state_manager.record_handle_metrics(
-            deployment_id, handle_id, queued_requests, running_requests, send_timestamp
+            deployment_id=deployment_id,
+            handle_id=handle_id,
+            actor_id=actor_id,
+            handle_source=handle_source,
+            queued_requests=queued_requests,
+            running_requests=running_requests,
+            send_timestamp=send_timestamp,
         )
 
     def _dump_autoscaling_metrics_for_testing(self):
@@ -430,6 +439,13 @@ class ServeController:
                     )
                 except Exception:
                     logger.exception("Exception updating proxy state.")
+
+            # When the controller is done recovering, drop invalid handle metrics
+            # that may be stale for autoscaling
+            if not any_recovering:
+                self.deployment_state_manager.drop_stale_handle_metrics(
+                    self.proxy_state_manager.get_alive_proxy_actor_ids()
+                )
 
             loop_duration = time.time() - loop_start_time
             if loop_duration > 10:

--- a/python/ray/serve/_private/deployment_graph_build.py
+++ b/python/ray/serve/_private/deployment_graph_build.py
@@ -6,11 +6,12 @@ from ray.dag import ClassNode, DAGNode
 from ray.dag.function_node import FunctionNode
 from ray.dag.utils import _DAGNodeNameGenerator
 from ray.experimental.gradio_utils import type_to_string
+from ray.serve._private.common import DeploymentHandleSource
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve._private.deployment_function_node import DeploymentFunctionNode
 from ray.serve._private.deployment_node import DeploymentNode
 from ray.serve.deployment import Deployment, schema_to_deployment
-from ray.serve.handle import DeploymentHandle
+from ray.serve.handle import DeploymentHandle, _HandleOptions
 from ray.serve.schema import DeploymentSchema
 
 
@@ -145,7 +146,11 @@ def transform_ray_dag_to_serve_dag(
                     DeploymentFunctionNode,
                 ),
             ),
-            apply_fn=lambda node: DeploymentHandle(node._deployment.name, app_name),
+            apply_fn=lambda node: DeploymentHandle(
+                node._deployment.name,
+                app_name,
+                handle_options=_HandleOptions(_source=DeploymentHandleSource.REPLICA),
+            ),
         )
 
         # ClassNode is created via bind on serve.deployment decorated class

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from ray.serve._private.common import (
     ApplicationName,
+    DeploymentHandleSource,
     DeploymentID,
     EndpointInfo,
     RequestProtocol,
@@ -66,6 +67,7 @@ class LongestPrefixRouter(ProxyRouter):
                     # Streaming codepath isn't supported for Java.
                     stream=not info.app_is_cross_language,
                     _prefer_local_routing=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
+                    _source=DeploymentHandleSource.PROXY,
                 )
                 handle._set_request_protocol(self._protocol)
                 self.handles[endpoint] = handle
@@ -149,6 +151,7 @@ class EndpointRouter(ProxyRouter):
                     # Streaming codepath isn't supported for Java.
                     stream=not info.app_is_cross_language,
                     _prefer_local_routing=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
+                    _source=DeploymentHandleSource.PROXY,
                 )
                 handle._set_request_protocol(self._protocol)
                 self.handles[endpoint] = handle

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -350,6 +350,10 @@ class ProxyState:
         return self._actor_name
 
     @property
+    def actor_id(self) -> str:
+        return self._actor_proxy_wrapper.actor_id
+
+    @property
     def status(self) -> ProxyStatus:
         return self._status
 
@@ -565,7 +569,7 @@ class ProxyStateManager:
 
         assert isinstance(head_node_id, str)
 
-    def reconfiture_logging_config(self, logging_config: LoggingConfig):
+    def reconfigure_logging_config(self, logging_config: LoggingConfig):
         self.logging_config = logging_config
 
     def shutdown(self) -> None:
@@ -605,7 +609,10 @@ class ProxyStateManager:
             for node_id, state in self._proxy_states.items()
         }
 
-    def update(self, proxy_nodes: Set[NodeId] = None):
+    def get_alive_proxy_actor_ids(self) -> Set[str]:
+        return {state.actor_id for state in self._proxy_states.values()}
+
+    def update(self, proxy_nodes: Set[NodeId] = None) -> Set[str]:
         """Update the state of all proxies.
 
         Start proxies on all nodes if not already exist and stop the proxies on nodes

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -11,6 +11,7 @@ import ray
 from ray.actor import ActorHandle
 from ray.dag.py_obj_scanner import _PyObjScanner
 from ray.serve._private.common import (
+    DeploymentHandleSource,
     DeploymentID,
     ReplicaID,
     RequestMetadata,
@@ -51,6 +52,7 @@ class RouterMetricsManager:
         deployment_id: DeploymentID,
         handle_id: str,
         self_actor_id: str,
+        handle_source: DeploymentHandleSource,
         controller_handle: ActorHandle,
         router_requests_counter: metrics.Counter,
         queued_requests_gauge: metrics.Gauge,
@@ -58,6 +60,8 @@ class RouterMetricsManager:
     ):
         self._handle_id = handle_id
         self._deployment_id = deployment_id
+        self._self_actor_id = self_actor_id
+        self._handle_source = handle_source
         self._controller_handle = controller_handle
         self._self_actor_id = self_actor_id
 
@@ -245,7 +249,12 @@ class RouterMetricsManager:
         """
 
         self._controller_handle.record_handle_metrics.remote(
-            **self._get_aggregated_requests(), send_timestamp=time.time()
+            send_timestamp=time.time(),
+            deployment_id=self._deployment_id,
+            handle_id=self._handle_id,
+            actor_id=self._self_actor_id,
+            handle_source=self._handle_source,
+            **self._get_aggregated_requests(),
         )
 
     def _add_autoscaling_metrics_point(self):
@@ -274,8 +283,6 @@ class RouterMetricsManager:
             }
 
         return {
-            "deployment_id": self._deployment_id,
-            "handle_id": self._handle_id,
             "queued_requests": self.num_queued_requests,
             "running_requests": running_requests,
         }
@@ -296,6 +303,7 @@ class Router:
         self_node_id: str,
         self_actor_id: str,
         self_availability_zone: Optional[str],
+        handle_source: DeploymentHandleSource,
         event_loop: asyncio.BaseEventLoop = None,
         _prefer_local_node_routing: bool = False,
         enable_queue_len_cache: bool = RAY_SERVE_ENABLE_QUEUE_LENGTH_CACHE,
@@ -360,6 +368,7 @@ class Router:
             deployment_id,
             handle_id,
             self_actor_id,
+            handle_source,
             controller_handle,
             metrics.Counter(
                 "serve_num_router_requests",

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -10,7 +10,12 @@ from typing import Any, AsyncIterator, Dict, Iterator, Optional, Tuple, Union
 import ray
 from ray import serve
 from ray._raylet import GcsClient, ObjectRefGenerator
-from ray.serve._private.common import DeploymentID, RequestMetadata, RequestProtocol
+from ray.serve._private.common import (
+    DeploymentHandleSource,
+    DeploymentID,
+    RequestMetadata,
+    RequestProtocol,
+)
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.default_impl import create_cluster_node_info_cache
 from ray.serve._private.router import Router
@@ -65,6 +70,7 @@ class _HandleOptions:
     stream: bool = False
     _prefer_local_routing: bool = False
     _request_protocol: str = RequestProtocol.UNDEFINED
+    _source: DeploymentHandleSource = DeploymentHandleSource.UNKNOWN
 
     def copy_and_update(
         self,
@@ -73,6 +79,7 @@ class _HandleOptions:
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
         _prefer_local_routing: Union[bool, DEFAULT] = DEFAULT.VALUE,
         _request_protocol: Union[str, DEFAULT] = DEFAULT.VALUE,
+        _source: Union[DeploymentHandleSource, DEFAULT] = DEFAULT.VALUE,
     ) -> "_HandleOptions":
         return _HandleOptions(
             method_name=(
@@ -90,6 +97,7 @@ class _HandleOptions:
             _request_protocol=self._request_protocol
             if _request_protocol == DEFAULT.VALUE
             else _request_protocol,
+            _source=self._source if _source == DEFAULT.VALUE else _source,
         )
 
 
@@ -138,6 +146,7 @@ class _DeploymentHandleBase:
         )
 
     def _get_or_create_router(self) -> Union[Router, asyncio.AbstractEventLoop]:
+
         if self._router is None:
             node_id = ray.get_runtime_context().get_node_id()
             try:
@@ -156,6 +165,7 @@ class _DeploymentHandleBase:
                 node_id,
                 get_current_actor_id(),
                 availability_zone,
+                handle_source=self.handle_options._source,
                 event_loop=_create_or_get_global_asyncio_event_loop_in_thread(),
                 _prefer_local_node_routing=self.handle_options._prefer_local_routing,
             )
@@ -205,6 +215,7 @@ class _DeploymentHandleBase:
         multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
         _prefer_local_routing: Union[bool, DEFAULT] = DEFAULT.VALUE,
+        _source: Union[DeploymentHandleSource, DEFAULT] = DEFAULT.VALUE,
     ):
         if stream is True and inside_ray_client_context():
             raise RuntimeError(
@@ -217,6 +228,7 @@ class _DeploymentHandleBase:
             multiplexed_model_id=multiplexed_model_id,
             stream=stream,
             _prefer_local_routing=_prefer_local_routing,
+            _source=_source,
         )
 
         if self._router is None and _prefer_local_routing == DEFAULT.VALUE:
@@ -741,6 +753,7 @@ class DeploymentHandle(_DeploymentHandleBase):
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
         use_new_handle_api: Union[bool, DEFAULT] = DEFAULT.VALUE,
         _prefer_local_routing: Union[bool, DEFAULT] = DEFAULT.VALUE,
+        _source: Union[bool, DEFAULT] = DEFAULT.VALUE,
     ) -> "DeploymentHandle":
         """Set options for this handle and return an updated copy of it.
 
@@ -764,6 +777,7 @@ class DeploymentHandle(_DeploymentHandleBase):
             multiplexed_model_id=multiplexed_model_id,
             stream=stream,
             _prefer_local_routing=_prefer_local_routing,
+            _source=_source,
         )
 
     def remote(


### PR DESCRIPTION
[serve] Drop handle metrics from dead actors

Drop metrics from handles that lived on dead serve actors. This doesn't cover everything (e.g. handles that live in driver scripts, or tasks, or any non-serve actors), but it should cover most cases, and the remaining cases will be handled by the default 20s timeout invalidation.

Handles living in the proxies and handles living in Serve replicas are identified as the handles living on Serve actors. At any point if the actor on which these handles reside is not alive anymore, the controller will drop metrics from those handles.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
