### PR TITLE
[Data] Change Parquet encoding ratio lower bound from 2 to 1

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -83,7 +83,7 @@ FILE_READING_RETRY = 8
 PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT = 5
 
 # The lower bound size to estimate Parquet encoding ratio.
-PARQUET_ENCODING_RATIO_ESTIMATE_LOWER_BOUND = 2
+PARQUET_ENCODING_RATIO_ESTIMATE_LOWER_BOUND = 1
 
 # The percentage of files (1% by default) to be sampled from the dataset to estimate
 # Parquet encoding ratio.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ray Data estimates the in-memory size of file-based datasets. To estimate the size of Parquet datasets, Ray Data samples rows and estimates the ratio between in-memory data size and raw data size. If this ratio is off, Ray Data can perform too few block splits.

Currently, Ray Data clamps the estimated ratio to 2. However, for some Parquet datasets, the actual ratio is closer to 1. So, this PR lowers to lower bound from 2 to 1.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
