### PR TITLE
[serve] Avoid deleting dynamically-deployed apps when applying config via REST API

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -244,9 +244,6 @@ class ApplicationState:
         When a request to delete the application has been received, this should be
             ({}, True)
         """
-        if api_type == APIType.UNKNOWN:
-            raise Exception("asdfa")
-
         if deleting:
             self._update_status(ApplicationStatus.DELETING)
         else:

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -11,7 +11,6 @@ from ray import cloudpickle
 from ray._private.utils import import_attr
 from ray.exceptions import RuntimeEnvSetupError
 from ray.serve._private.common import (
-    APISource,
     ApplicationStatus,
     ApplicationStatusInfo,
     DeploymentID,
@@ -62,6 +61,14 @@ class BuildAppStatus(Enum):
     FAILED = 4
 
 
+class APIType(Enum):
+    """Tracks the type of API that an application originates from."""
+
+    UNKNOWN = 0
+    IMPERATIVE = 1
+    DECLARATIVE = 2
+
+
 @dataclass
 class BuildAppTaskInfo:
     """Stores info on the current in-progress build app task.
@@ -108,6 +115,7 @@ class ApplicationTargetState:
     target_capacity: Optional[float]
     target_capacity_direction: Optional[TargetCapacityDirection]
     deleting: bool
+    api_type: APIType
 
 
 class ApplicationState:
@@ -116,7 +124,6 @@ class ApplicationState:
     def __init__(
         self,
         name: str,
-        api_source: APISource,
         deployment_state_manager: DeploymentStateManager,
         endpoint_state: EndpointState,
         save_checkpoint_func: Callable,
@@ -135,7 +142,6 @@ class ApplicationState:
         """
 
         self._name = name
-        self._api_source = APISource
         self._status_msg = ""
         self._deployment_state_manager = deployment_state_manager
         self._endpoint_state = endpoint_state
@@ -156,6 +162,7 @@ class ApplicationState:
             target_capacity=None,
             target_capacity_direction=None,
             deleting=False,
+            api_type=APIType.UNKNOWN,
         )
         self._save_checkpoint_func = save_checkpoint_func
 
@@ -197,6 +204,10 @@ class ApplicationState:
     def ingress_deployment(self) -> Optional[str]:
         return self._ingress_deployment_name
 
+    @property
+    def api_type(self) -> APIType:
+        return self._target_state.api_type
+
     def recover_target_state_from_checkpoint(
         self, checkpoint_data: ApplicationTargetState
     ):
@@ -205,16 +216,19 @@ class ApplicationState:
         )
         self._set_target_state(
             checkpoint_data.deployment_infos,
-            checkpoint_data.code_version,
-            checkpoint_data.config,
-            checkpoint_data.target_capacity,
-            checkpoint_data.target_capacity_direction,
-            checkpoint_data.deleting,
+            api_type=checkpoint_data.api_type,
+            code_version=checkpoint_data.code_version,
+            target_config=checkpoint_data.config,
+            target_capacity=checkpoint_data.target_capacity,
+            target_capacity_direction=checkpoint_data.target_capacity_direction,
+            deleting=checkpoint_data.deleting,
         )
 
     def _set_target_state(
         self,
         deployment_infos: Optional[Dict[str, DeploymentInfo]],
+        *,
+        api_type: APIType,
         code_version: str,
         target_config: Optional[ServeApplicationSchema],
         target_capacity: Optional[float] = None,
@@ -230,6 +244,8 @@ class ApplicationState:
         When a request to delete the application has been received, this should be
             ({}, True)
         """
+        if api_type == APIType.UNKNOWN:
+            raise Exception("asdfa")
 
         if deleting:
             self._update_status(ApplicationStatus.DELETING)
@@ -250,6 +266,7 @@ class ApplicationState:
             target_capacity,
             target_capacity_direction,
             deleting,
+            api_type=api_type,
         )
 
         # Checkpoint ahead, so that if the controller crashes before we
@@ -264,14 +281,26 @@ class ApplicationState:
 
         Wipes the target deployment infos, code version, and config.
         """
-        self._set_target_state(dict(), None, None, None, None, True)
+        self._set_target_state(
+            deployment_infos=dict(),
+            api_type=self._target_state.api_type,
+            code_version=None,
+            target_config=None,
+            deleting=True,
+        )
 
     def _clear_target_state_and_store_config(
-        self, target_config: Optional[ServeApplicationSchema]
+        self,
+        target_config: Optional[ServeApplicationSchema],
     ):
         """Clears the target state and stores the config."""
-
-        self._set_target_state(None, None, target_config, None, None, False)
+        self._set_target_state(
+            deployment_infos=None,
+            api_type=APIType.DECLARATIVE,
+            code_version=None,
+            target_config=target_config,
+            deleting=False,
+        )
 
     def _delete_deployment(self, name):
         id = DeploymentID(name=name, app_name=self._name)
@@ -282,7 +311,7 @@ class ApplicationState:
         """Delete the application"""
         if self._status != ApplicationStatus.DELETING:
             logger.info(
-                f"Deleting application '{self._name}'",
+                f"Deleting app '{self._name}'.",
                 extra={"log_to_stderr": False},
             )
         self._set_target_state_deleting()
@@ -330,11 +359,11 @@ class ApplicationState:
         else:
             self._endpoint_state.delete_endpoint(deployment_id)
 
-    def deploy(self, deployment_infos: Dict[str, DeploymentInfo]):
-        """Deploy application from list of deployment infos.
+    def deploy_app(self, deployment_infos: Dict[str, DeploymentInfo]):
+        """(Re-)deploy the application from list of deployment infos.
 
-        This function should only be called if the app is being deployed
-        through serve.run instead of from a config.
+        This function should only be called to deploy an app from an
+        imperative API (i.e., `serve.run` or Java API).
 
         Raises: RayServeException if there is more than one route prefix
             or docs path.
@@ -345,25 +374,29 @@ class ApplicationState:
 
         self._set_target_state(
             deployment_infos=deployment_infos,
+            api_type=APIType.IMPERATIVE,
             code_version=None,
             target_config=None,
             target_capacity=None,
             target_capacity_direction=None,
         )
 
-    def deploy_config(
+    def apply_app_config(
         self,
         config: ServeApplicationSchema,
         target_capacity: Optional[float],
         target_capacity_direction: Optional[TargetCapacityDirection],
         deployment_time: int,
     ) -> None:
-        """Deploys an application config.
+        """Apply the config to the application.
 
         If the code version matches that of the current live deployments
         then it only applies the updated config to the deployment state
         manager. If the code version doesn't match, this will re-build
         the application.
+
+        This function should only be called to (re-)deploy an app from
+        the declarative API (i.e., through the REST API).
         """
 
         self._deployment_timestamp = deployment_time
@@ -380,6 +413,7 @@ class ApplicationState:
                 self._set_target_state(
                     # Code version doesn't change.
                     code_version=self._target_state.code_version,
+                    api_type=APIType.DECLARATIVE,
                     # Everything else must reflect the new config.
                     deployment_infos=overrided_infos,
                     target_config=config,
@@ -418,7 +452,7 @@ class ApplicationState:
                 ServeUsageTag.APP_CONTAINER_RUNTIME_ENV_USED.record("1")
 
             # Kick off new build app task
-            logger.info(f"Building application '{self._name}'.")
+            logger.info(f"Importing and building app '{self._name}'.")
             build_app_obj_ref = build_serve_application.options(
                 runtime_env=config.runtime_env,
                 enable_task_events=RAY_SERVE_ENABLE_TASK_EVENTS,
@@ -520,7 +554,7 @@ class ApplicationState:
         try:
             args, err = ray.get(self._build_app_task_info.obj_ref)
             if err is None:
-                logger.info(f"Built application '{self._name}' successfully.")
+                logger.info(f"Imported and built app '{self._name}' successfully.")
             else:
                 return (
                     None,
@@ -661,6 +695,7 @@ class ApplicationState:
             self._set_target_state(
                 deployment_infos=infos,
                 code_version=self._build_app_task_info.code_version,
+                api_type=self._target_state.api_type,
                 target_config=self._build_app_task_info.config,
                 target_capacity=self._build_app_task_info.target_capacity,
                 target_capacity_direction=(
@@ -755,10 +790,9 @@ class ApplicationStateManager:
         if checkpoint is not None:
             application_state_info = cloudpickle.loads(checkpoint)
 
-            for (app_name, api_source), checkpoint_data in application_state_info.items():
+            for app_name, checkpoint_data in application_state_info.items():
                 app_state = ApplicationState(
                     app_name,
-                    api_source,
                     self._deployment_state_manager,
                     self._endpoint_state,
                     self._save_checkpoint_func,
@@ -766,14 +800,14 @@ class ApplicationStateManager:
                 app_state.recover_target_state_from_checkpoint(checkpoint_data)
                 self._application_states[app_name] = app_state
 
-    def delete_application(self, name: str) -> None:
+    def delete_app(self, name: str) -> None:
         """Delete application by name"""
         if name not in self._application_states:
             return
         self._application_states[name].delete()
 
-    def apply_deployment_args(self, name: str, deployment_args: List[Dict]) -> None:
-        """Apply list of deployment arguments to application target state.
+    def deploy_app(self, name: str, deployment_args: List[Dict]) -> None:
+        """Deploy the specified app to the list of deployment arguments.
 
         This function should only be called if the app is being deployed
         through serve.run instead of from a config.
@@ -820,32 +854,55 @@ class ApplicationStateManager:
             )
             for params in deployment_args
         }
-        self._application_states[name].deploy(deployment_infos)
+        self._application_states[name].deploy_app(deployment_infos)
 
-    def deploy_config(
+    def apply_app_configs(
         self,
-        name: str,
-        app_config: ServeApplicationSchema,
+        app_configs: List[ServeApplicationSchema],
+        *,
         deployment_time: float = 0,
         target_capacity: Optional[float] = None,
         target_capacity_direction: Optional[TargetCapacityDirection] = None,
-    ) -> None:
-        """Deploy application from config."""
+    ):
+        """Declaratively apply the list of application configs.
 
-        if name not in self._application_states:
-            self._application_states[name] = ApplicationState(
-                name,
-                self._deployment_state_manager,
-                endpoint_state=self._endpoint_state,
-                save_checkpoint_func=self._save_checkpoint_func,
+        The applications will be reconciled to match the target state of the config.
+
+        Any applications previously deployed through this method that are *not*
+        present in the list will be deleted.
+        """
+        # Track all existing apps and pop those that are in the newly applied config.
+        existing_apps = {
+            name
+            for name, app_state in self._application_states.items()
+            if app_state.api_type == APIType.DECLARATIVE
+        }
+
+        for app_config in app_configs:
+            if app_config.name not in existing_apps:
+                logger.info(f"Deploying new app '{app_config.name}'.")
+                self._application_states[app_config.name] = ApplicationState(
+                    app_config.name,
+                    self._deployment_state_manager,
+                    endpoint_state=self._endpoint_state,
+                    save_checkpoint_func=self._save_checkpoint_func,
+                )
+            else:
+                existing_apps.remove(app_config.name)
+
+            self._application_states[app_config.name].apply_app_config(
+                app_config,
+                target_capacity,
+                target_capacity_direction,
+                deployment_time=deployment_time,
             )
+
+        # At this point, `existing_apps` contains apps that were previously deployed
+        # but are no longer present in the config.
+        for app_name in existing_apps:
+            self.delete_app(app_name)
+
         ServeUsageTag.NUM_APPS.record(str(len(self._application_states)))
-        self._application_states[name].deploy_config(
-            app_config,
-            target_capacity,
-            target_capacity_direction,
-            deployment_time=deployment_time,
-        )
 
     def get_deployments(self, app_name: str) -> List[str]:
         """Return all deployment names by app name"""

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -11,6 +11,7 @@ from ray import cloudpickle
 from ray._private.utils import import_attr
 from ray.exceptions import RuntimeEnvSetupError
 from ray.serve._private.common import (
+    APISource,
     ApplicationStatus,
     ApplicationStatusInfo,
     DeploymentID,
@@ -115,6 +116,7 @@ class ApplicationState:
     def __init__(
         self,
         name: str,
+        api_source: APISource,
         deployment_state_manager: DeploymentStateManager,
         endpoint_state: EndpointState,
         save_checkpoint_func: Callable,
@@ -133,6 +135,7 @@ class ApplicationState:
         """
 
         self._name = name
+        self._api_source = APISource
         self._status_msg = ""
         self._deployment_state_manager = deployment_state_manager
         self._endpoint_state = endpoint_state
@@ -752,9 +755,10 @@ class ApplicationStateManager:
         if checkpoint is not None:
             application_state_info = cloudpickle.loads(checkpoint)
 
-            for app_name, checkpoint_data in application_state_info.items():
+            for (app_name, api_source), checkpoint_data in application_state_info.items():
                 app_state = ApplicationState(
                     app_name,
+                    api_source,
                     self._deployment_state_manager,
                     self._endpoint_state,
                     self._save_checkpoint_func,

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -303,7 +303,7 @@ class ServeControllerClient:
                 because a single-app config was deployed after deploying a multi-app
                 config, or vice versa.
         """
-        ray.get(self._controller.deploy_config.remote(config))
+        ray.get(self._controller.apply_config.remote(config))
 
         if _blocking:
             timeout_s = 60

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -712,9 +712,3 @@ class TargetCapacityDirection(str, Enum):
 class ReplicaQueueLengthInfo:
     accepted: bool
     num_ongoing_requests: int
-
-class APISource(Enum):
-    """Used to determine what frontend API an operation originates from."""
-    UNKNOWN = 0
-    PYTHON = 1
-    REST_API = 2

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -712,3 +712,9 @@ class TargetCapacityDirection(str, Enum):
 class ReplicaQueueLengthInfo:
     accepted: bool
     num_ongoing_requests: int
+
+class APISource(Enum):
+    """Used to determine what frontend API an operation originates from."""
+    UNKNOWN = 0
+    PYTHON = 1
+    REST_API = 2

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -66,7 +66,7 @@ def test_deploy_app_custom_exception(serve_instance):
         ]
     }
 
-    ray.get(controller.deploy_config.remote(config=ServeDeploySchema.parse_obj(config)))
+    ray.get(controller.apply_config.remote(config=ServeDeploySchema.parse_obj(config)))
 
     def check_custom_exception() -> bool:
         status = serve.status().applications["broken_app"]

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -1274,6 +1274,10 @@ def test_deploy_does_not_affect_dynamic_apps(client: ServeControllerClient):
         lambda: "declarative-app-1" not in serve.status().applications
     )
 
+    # Also verify that the controller does not delete the dynamic app on recovery.
+    ray.kill(client._controller, no_restart=False)
+    wait_for_condition(check_application_running, name="dynamic-app", route_prefix="/dynamic", msg="Hello!")
+
 
 def test_change_route_prefix(client: ServeControllerClient):
     # Deploy application with route prefix /old

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -30,7 +30,7 @@ from ray.serve._private.test_utils import (
     check_num_replicas_lte,
 )
 from ray.serve.context import _get_global_client
-from ray.serve.schema import ServeDeploySchema, ServeInstanceDetails
+from ray.serve.schema import ServeDeploySchema, ServeInstanceDetails, ServeApplicationSchema
 from ray.serve.tests.common.remote_uris import (
     TEST_DAG_PINNED_URI,
     TEST_RUNTIME_ENV_PINNED_URI,
@@ -1208,6 +1208,71 @@ def test_redeploy_old_config_after_failed_deployment(
     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
 
     wait_for_condition(check_application_running)
+
+
+def test_deploy_does_not_affect_dynamic_apps(client: ServeControllerClient):
+    """
+    Deploy a set of apps via the declarative API (REST API) and then a dynamic
+    app via the imperative API (`serve.run`).
+
+    Check that applying a new config via the declarative API does not affect
+    the app deployed using the imperative API.
+    """
+
+    config = ServeDeploySchema(
+        applications=[
+             ServeApplicationSchema(
+                 name="declarative-app-1",
+                 route_prefix="/app-1",
+                 import_path="ray.serve.tests.test_config_files.world.DagNode",
+             ),
+        ],
+    )
+    client.deploy_apps(config)
+
+    def check_application_running(name: str, route_prefix: str, *, msg: str = "wonderful world"):
+        status = serve.status().applications[name]
+        assert status.status == "RUNNING"
+        assert requests.post(f"http://localhost:8000{route_prefix}/").text == msg
+        return True
+
+    wait_for_condition(check_application_running, name="declarative-app-1", route_prefix="/app-1")
+
+    # Now `serve.run` a dynamic app.
+    @serve.deployment
+    class D:
+        def __call__(self, *args) -> str:
+            return "Hello!"
+
+    serve.run(D.bind(), name="dynamic-app", route_prefix="/dynamic")
+    wait_for_condition(check_application_running, name="dynamic-app", route_prefix="/dynamic", msg="Hello!")
+
+    # Add a new app via declarative API.
+    # Existing declarative app and dynamic app should not be affected.
+    config.applications.append(
+         ServeApplicationSchema(
+             name="declarative-app-2",
+             route_prefix="/app-2",
+             import_path="ray.serve.tests.test_config_files.world.DagNode",
+         ),
+    )
+    client.deploy_apps(config)
+
+    wait_for_condition(check_application_running, name="declarative-app-2", route_prefix="/app-2")
+    wait_for_condition(check_application_running, name="declarative-app-1", route_prefix="/app-1")
+    wait_for_condition(check_application_running, name="dynamic-app", route_prefix="/dynamic", msg="Hello!")
+
+    # Delete one of the apps via declarative API.
+    # Other declarative app and dynamic app should not be affected.
+    config.applications.pop(0)
+    client.deploy_apps(config)
+
+    wait_for_condition(check_application_running, name="declarative-app-2", route_prefix="/app-2")
+    wait_for_condition(check_application_running, name="dynamic-app", route_prefix="/dynamic", msg="Hello!")
+
+    wait_for_condition(
+        lambda: "declarative-app-1" not in serve.status().applications
+    )
 
 
 def test_change_route_prefix(client: ServeControllerClient):

--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -669,7 +669,7 @@ def test_serve_shut_down_without_duplicated_logs(
         with open(os.path.join(get_serve_logs_dir(), filename), "r") as f:
             all_serve_logs += f.read()
     assert all_serve_logs.count("Controller shutdown started") == 1
-    assert all_serve_logs.count("Deleting application 'default'") == 1
+    assert all_serve_logs.count("Deleting app 'default'") == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -6,6 +6,7 @@ import pytest
 
 from ray.exceptions import RayTaskError
 from ray.serve._private.application_state import (
+    APIType,
     ApplicationState,
     ApplicationStateManager,
     override_deployment_info,
@@ -636,6 +637,7 @@ def test_apply_app_configs_deletes_existing(check_obj_ref_ready_nowait):
     a_id = DeploymentID(name="a", app_name="imperative_app")
     app_state_manager.deploy_app("imperative_app", [deployment_params("a", "/hi")])
     imperative_app_state = app_state_manager._application_states["imperative_app"]
+    assert imperative_app_state.api_type == APIType.IMPERATIVE
     assert imperative_app_state.status == ApplicationStatus.DEPLOYING
 
     imperative_app_state.update()
@@ -652,7 +654,9 @@ def test_apply_app_configs_deletes_existing(check_obj_ref_ready_nowait):
     )
     app_state_manager.apply_app_configs([app1_config, app2_config])
     app1_state = app_state_manager._application_states["app1"]
+    assert app1_state.api_type == APIType.DECLARATIVE
     app2_state = app_state_manager._application_states["app2"]
+    assert app2_state.api_type == APIType.DECLARATIVE
     app1_state.update()
     app2_state.update()
     assert app1_state.status == ApplicationStatus.DEPLOYING
@@ -664,6 +668,7 @@ def test_apply_app_configs_deletes_existing(check_obj_ref_ready_nowait):
     )
     app_state_manager.apply_app_configs([app3_config, app2_config])
     app3_state = app_state_manager._application_states["app3"]
+    assert app3_state.api_type == APIType.DECLARATIVE
     app1_state.update()
     app2_state.update()
     app3_state.update()

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -363,7 +363,7 @@ def test_deploy_and_delete_app(mocked_application_state):
     # DEPLOY application with deployments {d1, d2}
     d1_id = DeploymentID(name="d1", app_name="test_app")
     d2_id = DeploymentID(name="d2", app_name="test_app")
-    app_state.deploy(
+    app_state.deploy_app(
         {
             "d1": deployment_info("d1", "/hi", "/documentation"),
             "d2": deployment_info("d2"),
@@ -421,7 +421,7 @@ def test_app_deploy_failed_and_redeploy(mocked_application_state):
     app_state, deployment_state_manager = mocked_application_state
     d1_id = DeploymentID(name="d1", app_name="test_app")
     d2_id = DeploymentID(name="d2", app_name="test_app")
-    app_state.deploy({"d1": deployment_info("d1")})
+    app_state.deploy_app({"d1": deployment_info("d1")})
     assert app_state.status == ApplicationStatus.DEPLOYING
 
     # Before status of deployment changes, app should still be DEPLOYING
@@ -440,7 +440,7 @@ def test_app_deploy_failed_and_redeploy(mocked_application_state):
     assert app_state.status == ApplicationStatus.DEPLOY_FAILED
     assert app_state._status_msg == deploy_failed_msg
 
-    app_state.deploy({"d1": deployment_info("d1"), "d2": deployment_info("d2")})
+    app_state.deploy_app({"d1": deployment_info("d1"), "d2": deployment_info("d2")})
     assert app_state.status == ApplicationStatus.DEPLOYING
     assert app_state._status_msg != deploy_failed_msg
 
@@ -472,7 +472,7 @@ def test_app_deploy_failed_and_recover(mocked_application_state):
     """
     app_state, deployment_state_manager = mocked_application_state
     deployment_id = DeploymentID(name="d1", app_name="test_app")
-    app_state.deploy({"d1": deployment_info("d1")})
+    app_state.deploy_app({"d1": deployment_info("d1")})
     assert app_state.status == ApplicationStatus.DEPLOYING
 
     # Before status of deployment changes, app should still be DEPLOYING
@@ -504,7 +504,7 @@ def test_app_unhealthy(mocked_application_state):
     id_a, id_b = DeploymentID(name="a", app_name="test_app"), DeploymentID(
         name="b", app_name="test_app"
     )
-    app_state.deploy({"a": deployment_info("a"), "b": deployment_info("b")})
+    app_state.deploy_app({"a": deployment_info("a"), "b": deployment_info("b")})
     assert app_state.status == ApplicationStatus.DEPLOYING
     app_state.update()
     assert app_state.status == ApplicationStatus.DEPLOYING
@@ -532,7 +532,7 @@ def test_app_unhealthy(mocked_application_state):
 @patch("ray.serve._private.application_state.build_serve_application", Mock())
 @patch("ray.get", Mock(return_value=([deployment_params("a", "/old", "/docs")], None)))
 @patch("ray.serve._private.application_state.check_obj_ref_ready_nowait")
-def test_deploy_through_config_succeed(check_obj_ref_ready_nowait):
+def test_apply_app_configs_succeed(check_obj_ref_ready_nowait):
     """Test deploying through config successfully.
     Deploy obj ref finishes successfully, so status should transition to running.
     """
@@ -544,8 +544,10 @@ def test_deploy_through_config_succeed(check_obj_ref_ready_nowait):
     )
 
     # Deploy config
-    app_config = ServeApplicationSchema(import_path="fa.ke", route_prefix="/new")
-    app_state_manager.deploy_config(name="test_app", app_config=app_config)
+    app_config = ServeApplicationSchema(
+        name="test_app", import_path="fa.ke", route_prefix="/new"
+    )
+    app_state_manager.apply_app_configs([app_config])
     app_state = app_state_manager._application_states["test_app"]
     assert app_state.status == ApplicationStatus.DEPLOYING
 
@@ -578,7 +580,7 @@ def test_deploy_through_config_succeed(check_obj_ref_ready_nowait):
 @patch("ray.serve._private.application_state.build_serve_application", Mock())
 @patch("ray.get", Mock(side_effect=RayTaskError(None, "intentionally failed", None)))
 @patch("ray.serve._private.application_state.check_obj_ref_ready_nowait")
-def test_deploy_through_config_fail(check_obj_ref_ready_nowait):
+def test_apply_app_configs_fail(check_obj_ref_ready_nowait):
     """Test fail to deploy through config.
     Deploy obj ref errors out, so status should transition to deploy failed.
     """
@@ -587,8 +589,12 @@ def test_deploy_through_config_fail(check_obj_ref_ready_nowait):
     app_state_manager = ApplicationStateManager(
         deployment_state_manager, MockEndpointState(), kv_store
     )
+
     # Deploy config
-    app_state_manager.deploy_config(name="test_app", app_config=Mock())
+    app_config = ServeApplicationSchema(
+        name="test_app", import_path="fa.ke", route_prefix="/new"
+    )
+    app_state_manager.apply_app_configs([app_config])
     app_state = app_state_manager._application_states["test_app"]
     assert app_state.status == ApplicationStatus.DEPLOYING
 
@@ -600,11 +606,70 @@ def test_deploy_through_config_fail(check_obj_ref_ready_nowait):
     app_state.update()
     assert app_state.status == ApplicationStatus.DEPLOYING
 
-    # Object ref is ready, and the task has called apply_deployment_args
+    # Object ref is ready, and the task has called deploy_app
     check_obj_ref_ready_nowait.return_value = True
     app_state.update()
     assert app_state.status == ApplicationStatus.DEPLOY_FAILED
     assert "failed" in app_state._status_msg or "error" in app_state._status_msg
+
+
+@patch(
+    "ray.serve._private.application_state.get_app_code_version",
+    Mock(return_value="123"),
+)
+@patch("ray.serve._private.application_state.build_serve_application", Mock())
+@patch("ray.get", Mock(return_value=([deployment_params("a", "/old", "/docs")], None)))
+@patch("ray.serve._private.application_state.check_obj_ref_ready_nowait")
+def test_apply_app_configs_deletes_existing(check_obj_ref_ready_nowait):
+    """Test that apply_app_configs deletes existing apps that aren't in the new list.
+
+    This should *not* apply to apps that were deployed via `deploy_app` (which is
+    an imperative API).
+    """
+    kv_store = MockKVStore()
+    deployment_state_manager = MockDeploymentStateManager(kv_store)
+    app_state_manager = ApplicationStateManager(
+        deployment_state_manager, MockEndpointState(), kv_store
+    )
+
+    # Deploy an app via `deploy_app` - should not be affected.
+    a_id = DeploymentID(name="a", app_name="imperative_app")
+    app_state_manager.deploy_app("imperative_app", [deployment_params("a", "/hi")])
+    imperative_app_state = app_state_manager._application_states["imperative_app"]
+    assert imperative_app_state.status == ApplicationStatus.DEPLOYING
+
+    imperative_app_state.update()
+    deployment_state_manager.set_deployment_healthy(a_id)
+    imperative_app_state.update()
+    assert imperative_app_state.status == ApplicationStatus.RUNNING
+
+    # Now deploy an initial version of the config with app 1 and app 2.
+    app1_config = ServeApplicationSchema(
+        name="app1", import_path="fa.ke", route_prefix="/1"
+    )
+    app2_config = ServeApplicationSchema(
+        name="app2", import_path="fa.ke", route_prefix="/2"
+    )
+    app_state_manager.apply_app_configs([app1_config, app2_config])
+    app1_state = app_state_manager._application_states["app1"]
+    app2_state = app_state_manager._application_states["app2"]
+    app1_state.update()
+    app2_state.update()
+    assert app1_state.status == ApplicationStatus.DEPLOYING
+    assert app2_state.status == ApplicationStatus.DEPLOYING
+
+    # Now redeploy a new config that removes app 1 and adds app 3.
+    app3_config = ServeApplicationSchema(
+        name="app3", import_path="fa.ke", route_prefix="/3"
+    )
+    app_state_manager.apply_app_configs([app3_config, app2_config])
+    app3_state = app_state_manager._application_states["app3"]
+    app1_state.update()
+    app2_state.update()
+    app3_state.update()
+    assert app1_state.status == ApplicationStatus.DELETING
+    assert app2_state.status == ApplicationStatus.DEPLOYING
+    assert app3_state.status == ApplicationStatus.DEPLOYING
 
 
 def test_redeploy_same_app(mocked_application_state):
@@ -613,7 +678,7 @@ def test_redeploy_same_app(mocked_application_state):
     a_id = DeploymentID(name="a", app_name="test_app")
     b_id = DeploymentID(name="b", app_name="test_app")
     c_id = DeploymentID(name="c", app_name="test_app")
-    app_state.deploy({"a": deployment_info("a"), "b": deployment_info("b")})
+    app_state.deploy_app({"a": deployment_info("a"), "b": deployment_info("b")})
     assert app_state.status == ApplicationStatus.DEPLOYING
 
     # Update
@@ -630,7 +695,7 @@ def test_redeploy_same_app(mocked_application_state):
     assert app_state.status == ApplicationStatus.RUNNING
 
     # Deploy the same app with different deployments
-    app_state.deploy({"b": deployment_info("b"), "c": deployment_info("c")})
+    app_state.deploy_app({"b": deployment_info("b"), "c": deployment_info("c")})
     assert app_state.status == ApplicationStatus.DEPLOYING
     # Target state should be updated immediately
     assert "a" not in app_state.target_deployments
@@ -654,9 +719,9 @@ def test_deploy_with_route_prefix_conflict(mocked_application_state_manager):
     """Test that an application with a route prefix conflict fails to deploy"""
     app_state_manager, _, _ = mocked_application_state_manager
 
-    app_state_manager.apply_deployment_args("app1", [deployment_params("a", "/hi")])
+    app_state_manager.deploy_app("app1", [deployment_params("a", "/hi")])
     with pytest.raises(RayServeException):
-        app_state_manager.apply_deployment_args("app2", [deployment_params("b", "/hi")])
+        app_state_manager.deploy_app("app2", [deployment_params("b", "/hi")])
 
 
 def test_deploy_with_renamed_app(mocked_application_state_manager):
@@ -670,7 +735,7 @@ def test_deploy_with_renamed_app(mocked_application_state_manager):
     )
 
     # deploy app1
-    app_state_manager.apply_deployment_args("app1", [deployment_params("a", "/url1")])
+    app_state_manager.deploy_app("app1", [deployment_params("a", "/url1")])
     app_state = app_state_manager._application_states["app1"]
     assert app_state_manager.get_app_status("app1") == ApplicationStatus.DEPLOYING
 
@@ -685,12 +750,12 @@ def test_deploy_with_renamed_app(mocked_application_state_manager):
     assert app_state_manager.get_app_status("app1") == ApplicationStatus.RUNNING
 
     # delete app1
-    app_state_manager.delete_application("app1")
+    app_state_manager.delete_app("app1")
     assert app_state_manager.get_app_status("app1") == ApplicationStatus.DELETING
     app_state_manager.update()
 
     # deploy app2
-    app_state_manager.apply_deployment_args("app2", [deployment_params("b", "/url1")])
+    app_state_manager.deploy_app("app2", [deployment_params("b", "/url1")])
     assert app_state_manager.get_app_status("app2") == ApplicationStatus.DEPLOYING
     app_state_manager.update()
 
@@ -719,7 +784,7 @@ def test_application_state_recovery(mocked_application_state_manager):
 
     # DEPLOY application with deployments {d1, d2}
     params = deployment_params("d1")
-    app_state_manager.apply_deployment_args(app_name, [params])
+    app_state_manager.deploy_app(app_name, [params])
     app_state = app_state_manager._application_states[app_name]
     assert app_state.status == ApplicationStatus.DEPLOYING
 
@@ -768,7 +833,7 @@ def test_recover_during_update(mocked_application_state_manager):
 
     # DEPLOY application with deployment "d1"
     params = deployment_params("d1")
-    app_state_manager.apply_deployment_args(app_name, [params])
+    app_state_manager.deploy_app(app_name, [params])
     app_state = app_state_manager._application_states[app_name]
     assert app_state.status == ApplicationStatus.DEPLOYING
 
@@ -781,7 +846,7 @@ def test_recover_during_update(mocked_application_state_manager):
 
     # Deploy new version of "d1" (this auto generates new random version)
     params2 = deployment_params("d1")
-    app_state_manager.apply_deployment_args(app_name, [params2])
+    app_state_manager.deploy_app(app_name, [params2])
     assert app_state.status == ApplicationStatus.DEPLOYING
 
     # Before application state manager could propagate new version to
@@ -832,7 +897,7 @@ def test_is_ready_for_shutdown(mocked_application_state_manager):
 
     # DEPLOY application with deployment "d1"
     params = deployment_params(deployment_name)
-    app_state_manager.apply_deployment_args(app_name, [params])
+    app_state_manager.deploy_app(app_name, [params])
     app_state = app_state_manager._application_states[app_name]
     assert app_state.status == ApplicationStatus.DEPLOYING
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See https://github.com/ray-project/ray/issues/44226 for more details, but TL;DR:

- The REST API is declarative, meaning if you deploy a config that does not contain some running applications, they will be deleted.
- However, in some cases users mix-and-match this declarative API with the imperative `serve.run` API. In this case, we should not delete the dynamically-created apps.
- This PR addresses it by tracking the `APIType` and only deleting apps that were applied via the declarative API. There is no public API change. In the future we may want to consider exposing this metadata so external systems like Kuberay can treat the types of apps differently (e.g., for determining high-level status).

## Related issue number

Closes https://github.com/ray-project/ray/issues/44226

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
