### PR TITLE
[Doc] [Jobs] Add more links to remote port forwarding setup

### DIFF
--- a/doc/source/cluster/running-applications/job-submission/sdk.rst
+++ b/doc/source/cluster/running-applications/job-submission/sdk.rst
@@ -49,13 +49,13 @@ Let's start with a sample script that can be run locally. The following script u
     print(ray.get(hello_world.remote()))
 
 SDK calls are made via a ``JobSubmissionClient`` object.  To initialize the client, provide the Ray cluster head node address and the port used by the Ray Dashboard (``8265`` by default). For this example, we'll use a local Ray cluster, but the same example will work for remote Ray cluster addresses; see 
-:ref:`Using a Remote Cluster <jobs-remote-cluster>` for details on setting up the necessary port forwarding.
+:ref:`Using a Remote Cluster <jobs-remote-cluster>` for details on setting up port forwarding.
 
 .. code-block:: python
 
     from ray.job_submission import JobSubmissionClient
 
-    # If using a remote cluster, replace 127.0.0.1 with the head node's IP address and set up port forwarding.
+    # If using a remote cluster, replace 127.0.0.1 with the head node's IP address or set up port forwarding.
     client = JobSubmissionClient("http://127.0.0.1:8265")
     job_id = client.submit_job(
         # Entrypoint shell command to execute

--- a/doc/source/cluster/running-applications/job-submission/sdk.rst
+++ b/doc/source/cluster/running-applications/job-submission/sdk.rst
@@ -48,13 +48,14 @@ Let's start with a sample script that can be run locally. The following script u
     ray.init()
     print(ray.get(hello_world.remote()))
 
-SDK calls are made via a ``JobSubmissionClient`` object.  To initialize the client, provide the Ray cluster head node address and the port used by the Ray Dashboard (``8265`` by default). For this example, we'll use a local Ray cluster, but the same example will work for remote Ray cluster addresses.
+SDK calls are made via a ``JobSubmissionClient`` object.  To initialize the client, provide the Ray cluster head node address and the port used by the Ray Dashboard (``8265`` by default). For this example, we'll use a local Ray cluster, but the same example will work for remote Ray cluster addresses; see 
+:ref:`Using a Remote Cluster <jobs-remote-cluster>` for details on setting up the necessary port forwarding.
 
 .. code-block:: python
 
     from ray.job_submission import JobSubmissionClient
 
-    # If using a remote cluster, replace 127.0.0.1 with the head node's IP address.
+    # If using a remote cluster, replace 127.0.0.1 with the head node's IP address and set up port forwarding.
     client = JobSubmissionClient("http://127.0.0.1:8265")
     job_id = client.submit_job(
         # Entrypoint shell command to execute


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`ray dashboard` must be run to set up port forwarding before the Ray Dashboard can be used for REST APIs like the Ray Jobs API.  This is described in a docs section, but the section isn't linked to from all the relevant places.  This PR adds some links to it from the Job SDK doc, to help reduce user confusion.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
