### PR TITLE
[CI] On macos, only persist logs, not sockets

### DIFF
--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -103,7 +103,7 @@ _epilogue() {
   bazel run //ci/ray_ci/automation:test_db_bot -- core /tmp/bazel_event_logs
   # Persist ray logs
   mkdir -p /tmp/artifacts/.ray/
-  tar -czf /tmp/artifacts/.ray/logs.tgz /tmp/ray
+  find /tmp/ray -path '*/logs/*' | tar -czf /tmp/artifacts/.ray/ray_logs.tgz -T -
   # Cleanup runtime environment to save storage
   rm -rf /tmp/ray
   # Cleanup local caches - this should not clean up global disk cache


### PR DESCRIPTION
After a MacOS CI test, in `_epilogue` it packages all files in `/tmp/ray` to a tarball to persist. However, `/tmp/ray` contains not only logs but also sockets which are not tar-able, yielding `tar format cannot archive socket` errors repetitively. This PR only persists `/tmp/ray/**/logs/**` to save the hussle.