### PR TITLE
[serve][regression] allow max ongoing requests none

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -16,7 +16,11 @@ from ray.serve._private.config import (
     ReplicaConfig,
     handle_num_replicas_auto,
 )
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_LOGGER_NAME
+from ray.serve._private.constants import (
+    DEFAULT_MAX_ONGOING_REQUESTS,
+    SERVE_DEFAULT_APP_NAME,
+    SERVE_LOGGER_NAME,
+)
 from ray.serve._private.deployment_graph_build import build as pipeline_build
 from ray.serve._private.deployment_graph_build import (
     get_and_validate_ingress_deployment,
@@ -347,11 +351,13 @@ def deployment(
                 "version."
             )
 
-    max_ongoing_requests = (
-        max_ongoing_requests
-        if max_ongoing_requests is not DEFAULT.VALUE
-        else max_concurrent_queries
-    )
+    if max_ongoing_requests is None:
+        raise ValueError("`max_ongoing_requests` must be non-null, got None.")
+    elif max_ongoing_requests is DEFAULT.VALUE:
+        if max_concurrent_queries is None:
+            max_ongoing_requests = DEFAULT_MAX_ONGOING_REQUESTS
+        else:
+            max_ongoing_requests = max_concurrent_queries
     if num_replicas == "auto":
         num_replicas = None
         max_ongoing_requests, autoscaling_config = handle_num_replicas_auto(

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -1002,6 +1002,56 @@ def test_deployment_handle_nested_in_obj(serve_instance):
     assert h.remote().result() == "hi"
 
 
+def test_max_ongoing_requests_none(serve_instance):
+    """We should not allow setting `max_ongoing_requests` to None. To maintain backwards
+    compatibility, we SHOULD allow setting `max_concurrent_queries` to None.
+    """
+
+    def get_max_ongoing_requests():
+        details = serve_instance.get_serve_details()
+        return details["applications"]["default"]["deployments"]["A"][
+            "deployment_config"
+        ]["max_ongoing_requests"]
+
+    class A:
+        pass
+
+    with pytest.raises(ValueError):
+        serve.deployment(max_ongoing_requests=None)(A).bind()
+    with pytest.raises(ValueError):
+        serve.deployment(A).options(max_ongoing_requests=None).bind()
+    with pytest.raises(ValueError):
+        serve.deployment(max_ongoing_requests=None, max_concurrent_queries=None)(
+            A
+        ).bind()
+
+    with pytest.raises(ValueError):
+        serve.deployment(max_ongoing_requests=None, max_concurrent_queries=7)(A).bind()
+
+    with pytest.raises(ValueError):
+        serve.deployment(A).options(
+            max_ongoing_requests=None, max_concurrent_queries=7
+        ).bind()
+
+    serve.run(serve.deployment(max_concurrent_queries=None)(A).bind())
+    assert get_max_ongoing_requests() == 100
+
+    serve.run(serve.deployment(A).options(max_concurrent_queries=None).bind())
+    assert get_max_ongoing_requests() == 100
+
+    serve.run(
+        serve.deployment(max_ongoing_requests=8, max_concurrent_queries=None)(A).bind()
+    )
+    assert get_max_ongoing_requests() == 8
+
+    serve.run(
+        serve.deployment(A)
+        .options(max_ongoing_requests=12, max_concurrent_queries=None)
+        .bind()
+    )
+    assert get_max_ongoing_requests() == 12
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
[serve][regression] allow max ongoing requests none

Fix breaking change introduced in 2.10. Previously we allowed setting `max_concurrent_queries` to None in Python API (only, not in rest API), but it no longer works in 2.10.
However going forward we will not allow setting the new field `max_ongoing_requests` to None.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
