### PR TITLE
[RLlib] Address possible memory inefficiency in `WorkerSet.sync_weights` (b/c not using `ray.put()`).

### DIFF
--- a/doc/source/rllib/package_ref/algorithm.rst
+++ b/doc/source/rllib/package_ref/algorithm.rst
@@ -173,7 +173,6 @@ Saving and Restoring
     ~Algorithm.export_model
     ~Algorithm.export_policy_checkpoint
     ~Algorithm.export_policy_model
-    ~Algorithm.import_policy_model_from_h5
     ~Algorithm.restore
     ~Algorithm.restore_workers
     ~Algorithm.save

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -1211,13 +1211,13 @@ class Impala(Algorithm):
             weights = local_worker.get_weights(policy_ids)
             if self.config.policy_states_are_swappable:
                 local_worker.unlock()
-            weights = ray.put(weights)
+            weights_ref = ray.put(weights)
 
             self._learner_thread.policy_ids_updated.clear()
             self._counters[NUM_TRAINING_STEP_CALLS_SINCE_LAST_SYNCH_WORKER_WEIGHTS] = 0
             self._counters[NUM_SYNCH_WORKER_WEIGHTS] += 1
             self.workers.foreach_worker(
-                func=lambda w: w.set_weights(ray.get(weights), global_vars),
+                func=lambda w: w.set_weights(ray.get(weights_ref), global_vars),
                 local_worker=False,
                 remote_worker_ids=list(workers_that_need_updates),
                 timeout_seconds=0,  # Don't wait for the workers to finish.

--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -428,9 +428,9 @@ class WorkerSet:
             )
             # Update the global number of environment steps for each worker.
             if "env_steps_sampled" in env_runner_states:
-                _env_runner.global_num_env_steps_sampled = (
-                    env_runner_states["env_steps_sampled"]
-                )
+                _env_runner.global_num_env_steps_sampled = env_runner_states[
+                    "env_steps_sampled"
+                ]
 
         # Broadcast updated states back to all workers (including the local one).
         self.foreach_worker(

--- a/rllib/evaluation/worker_set.py
+++ b/rllib/evaluation/worker_set.py
@@ -413,7 +413,8 @@ class WorkerSet:
         if env_steps_sampled:
             env_runner_states["env_steps_sampled"] = env_steps_sampled
 
-        # Put the state dicitonary into Ray's object store.
+        # Put the state dicitonary into Ray's object store to avoid having to make n
+        # pickled copies of the state dict.
         ref_env_runner_states = ray.put(env_runner_states)
 
         def _update(w):
@@ -482,13 +483,17 @@ class WorkerSet:
                     "should have local_worker. But local_worker is also None."
                 )
             weights = weights_src.get_weights(policies)
+            # Move weights to the object store to avoid having to make n pickled copies
+            # of the weights dict for each worker.
+            weights_ref = ray.put(weights)
 
-            def set_weight(w):
-                w.set_weights(weights, global_vars)
+            def _set_weights(env_runner):
+                _weights = ray.get(weights_ref)
+                env_runner.set_weights(_weights, global_vars)
 
             # Sync to specified remote workers in this WorkerSet.
             self.foreach_worker(
-                func=set_weight,
+                func=_set_weights,
                 local_worker=False,  # Do not sync back to local worker.
                 remote_worker_ids=to_worker_indices,
                 # We can only sync to healthy remote workers.

--- a/rllib/examples/multi_agent_and_self_play/utils/self_play_league_based_callback.py
+++ b/rllib/examples/multi_agent_and_self_play/utils/self_play_league_based_callback.py
@@ -180,13 +180,16 @@ class SelfPlayLeagueBasedCallback(DefaultCallbacks):
                         module_state=marl_module[module_id].get_state(),
                     )
 
+                # Avoid `self` being pickled into the remote function below.
+                _trainable_policies = self.trainable_policies
+
                 algorithm.workers.foreach_worker(
                     lambda env_runner: env_runner.config.multi_agent(
                         policy_mapping_fn=agent_to_module_mapping_fn,
                         # This setting doesn't really matter for EnvRunners (no
                         # training going on there, but we'll update this as well
                         # here for good measure).
-                        policies_to_train=self.trainable_policies,
+                        policies_to_train=_trainable_policies,
                     ),
                     local_worker=True,
                 )
@@ -194,7 +197,7 @@ class SelfPlayLeagueBasedCallback(DefaultCallbacks):
                 # value.
                 algorithm.learner_group.foreach_learner(
                     lambda learner: learner.config.multi_agent(
-                        policies_to_train=self.trainable_policies,
+                        policies_to_train=_trainable_policies,
                     )
                 )
                 league_changed = True

--- a/rllib/examples/multi_agent_and_self_play/utils/self_play_league_based_callback.py
+++ b/rllib/examples/multi_agent_and_self_play/utils/self_play_league_based_callback.py
@@ -35,6 +35,9 @@ class SelfPlayLeagueBasedCallback(DefaultCallbacks):
     def on_train_result(self, *, algorithm, result, **kwargs):
         local_worker = algorithm.workers.local_worker()
 
+        # Avoid `self` being pickled into the remote function below.
+        _trainable_policies = self.trainable_policies
+
         # Get the win rate for the train batch.
         # Note that normally, one should set up a proper evaluation config,
         # such that evaluation always happens on the already updated policy,
@@ -179,9 +182,6 @@ class SelfPlayLeagueBasedCallback(DefaultCallbacks):
                         module_spec=SingleAgentRLModuleSpec.from_module(main_module),
                         module_state=marl_module[module_id].get_state(),
                     )
-
-                # Avoid `self` being pickled into the remote function below.
-                _trainable_policies = self.trainable_policies
 
                 algorithm.workers.foreach_worker(
                     lambda env_runner: env_runner.config.multi_agent(

--- a/rllib/examples/multi_agent_and_self_play/utils/self_play_league_based_callback_old_api_stack.py
+++ b/rllib/examples/multi_agent_and_self_play/utils/self_play_league_based_callback_old_api_stack.py
@@ -29,6 +29,9 @@ class SelfPlayLeagueBasedCallbackOldAPIStack(DefaultCallbacks):
         self.win_rates = {}
 
     def on_train_result(self, *, algorithm, result, **kwargs):
+        # Avoid `self` being pickled into the remote function below.
+        _trainable_policies = self.trainable_policies
+
         # Get the win rate for the train batch.
         # Note that normally, one should set up a proper evaluation config,
         # such that evaluation always happens on the already updated policy,
@@ -156,8 +159,6 @@ class SelfPlayLeagueBasedCallbackOldAPIStack(DefaultCallbacks):
                     algorithm.workers.sync_weights(
                         policies=["main_0", "league_exploiter_1", "main_exploiter_1"]
                     )
-                    # Avoid `self` being pickled into the remote function below.
-                    _trainable_policies = self.trainable_policies
 
                     def _set(worker):
                         worker.set_policy_mapping_fn(policy_mapping_fn)

--- a/rllib/examples/multi_agent_and_self_play/utils/self_play_league_based_callback_old_api_stack.py
+++ b/rllib/examples/multi_agent_and_self_play/utils/self_play_league_based_callback_old_api_stack.py
@@ -156,10 +156,12 @@ class SelfPlayLeagueBasedCallbackOldAPIStack(DefaultCallbacks):
                     algorithm.workers.sync_weights(
                         policies=["main_0", "league_exploiter_1", "main_exploiter_1"]
                     )
+                    # Avoid `self` being pickled into the remote function below.
+                    _trainable_policies = self.trainable_policies
 
                     def _set(worker):
                         worker.set_policy_mapping_fn(policy_mapping_fn)
-                        worker.set_is_policy_to_train(self.trainable_policies)
+                        worker.set_is_policy_to_train(_trainable_policies)
 
                     algorithm.workers.foreach_worker(_set)
                 else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

- Address possible memory inefficiency in `WorkerSet.sync_weights` (b/c not using `ray.put()`). NOTE that this is already implemented correctly for the new API stack (see `Algorithm.sync_env_runner_states()`), but we missed retro-fixing this for the old API stack.
- Address instances of RLlib referencing larger objects (via `self`) from within a remote function, causing this large object to be pickle-copied `num_worker` times (instead of just passing the necessary property value from that `self`).
- Minor Algorithm method deprecation and cleanup.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
