### PR TITLE
[ci] automated release tests to release-automation

### DIFF
--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -37,6 +37,11 @@ steps:
       branch: "${BUILDKITE_BRANCH}"
       message: "Triggered by release-automation build #${BUILDKITE_BUILD_NUMBER}"
 
+  - block: "Trigger Release nightly test"
+    if: build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") != "1"
+    key: block-release-nightly-test
+    depends_on: check-commit-hash
+
   - label: "Trigger Release nightly test"
     key: trigger-release-nightly
     trigger: "release"
@@ -50,6 +55,7 @@ steps:
         RELEASE_FREQUENCY: "nightly"
 
   - block: "Trigger Release nightly-3x test"
+    if: build.env("RAYCI_WEEKLY_RELEASE_NIGHLTY_3X") != "1"
     key: block-release-nightly-3x-test
     depends_on: check-commit-hash
 
@@ -66,6 +72,7 @@ steps:
         RELEASE_FREQUENCY: "nightly-3x"
 
   - block: "Trigger Release weekly test"
+    if: build.env("RAYCI_WEEKLY_RELEASE_WEEKLY") != "1"
     key: block-release-weekly-test
     depends_on: check-commit-hash
 


### PR DESCRIPTION
- Add a couple of env variable to control when to trigger nightly, nightly-3x and weekly release test run. This is so that we can move the automated release tests completely to release-automation pipeline
- Add a condition to block the nightly release test run. This is so that we can run postmerge more regularly, gives us significant more changes to get a green build.

Test:
- CI