### PR TITLE
[Data] Raise unmodified stack trace when Ray debugger is enabled

### DIFF
--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -40,6 +40,7 @@ from ray.data.block import (
 )
 from ray.data.context import DataContext
 from ray.data.exceptions import UserCodeException
+from ray.util.rpdb import _is_ray_debugger_enabled
 
 
 def plan_udf_map_op(
@@ -108,7 +109,7 @@ def _parse_op_fn(op: AbstractUDFMap):
             try:
                 return ray.data._cached_fn(item, *fn_args, **fn_kwargs)
             except Exception as e:
-                raise UserCodeException() from e
+                _handle_debugger_exception(e)
 
         def init_fn():
             if ray.data._cached_fn is None:
@@ -123,12 +124,23 @@ def _parse_op_fn(op: AbstractUDFMap):
             try:
                 return op_fn(item, *fn_args, **fn_kwargs)
             except Exception as e:
-                raise UserCodeException() from e
+                _handle_debugger_exception(e)
 
         def init_fn():
             pass
 
     return fn, init_fn
+
+
+def _handle_debugger_exception(e: Exception):
+    """If the Ray Debugger is enabled, keep the full stack trace unmodified
+    so that the debugger can stop at the initial unhandled exception.
+    Otherwise, clear the stack trace to omit noisy internal code path."""
+
+    if _is_ray_debugger_enabled():
+        raise e
+    else:
+        raise UserCodeException() from e
 
 
 # Following are util functions for converting UDFs to `MapTransformCallable`s.

--- a/python/ray/data/exceptions.py
+++ b/python/ray/data/exceptions.py
@@ -49,9 +49,13 @@ def omit_traceback_stdout(fn: Callable) -> Callable:
         try:
             return fn(*args, **kwargs)
         except Exception as e:
-            # Only log the full internal stack trace to stdout when configured.
+            # Only log the full internal stack trace to stdout when configured
+            # via DataContext, or when the Ray Debugger is enabled.
             # The full stack trace will always be emitted to the Ray Data log file.
             log_to_stdout = DataContext.get_current().log_internal_stack_trace_to_stdout
+            if _is_ray_debugger_enabled() or log_to_stdout:
+                data_exception_logger.get_logger().exception("Full stack trace:")
+                raise e
 
             is_user_code_exception = isinstance(e, UserCodeException)
             if is_user_code_exception:
@@ -78,17 +82,9 @@ def omit_traceback_stdout(fn: Callable) -> Callable:
                 "Full stack trace:"
             )
 
-            # If the Ray Debugger is enabled, keep the full stack trace unmodified
-            # so that the debugger can stop at the initial unhandled exception.
-            # Otherwise, clear the stack trace to omit noisy internal code path.
-            if _is_ray_debugger_enabled():
-                exception_to_raise = e
+            if is_user_code_exception:
+                raise e.with_traceback(None)
             else:
-                exception_to_raise = e.with_traceback(None)
-
-            if is_user_code_exception or _is_ray_debugger_enabled():
-                raise exception_to_raise
-            else:
-                raise exception_to_raise from SystemException()
+                raise e.with_traceback(None) from SystemException()
 
     return handle_trace


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently with Ray Data's default exception handling behavior, the raised exception and the associated stack trace omits Ray Data internal code paths when an exception occurs in user code.

When the Ray debugger is enabled, this is problematic because the debugger will not stop at the initial point where the original exception is raised, but rather stops where the `UserCodeException` is raised ([example](https://github.com/ray-project/ray/blob/4172f7562af726c1272fd06c10203313b72eeb40/python/ray/data/_internal/planner/plan_udf_map_op.py)). Therefore, we disable this stack trace trimming behavior when the Ray debugger is enabled, and instead raise the unmodified stack trace.

With the following example script:
```
import ray

ray.init(runtime_env={"env_vars": {"RAY_DEBUG": "1"},})
ds = ray.data.range(100)
def f(b):
    b.not_afun()
ds.map(f).take_all()
```

We can compare the stack trace output before and after the fix.
<details open>
<summary>Before (debugger enabled):</summary>
<br>

```
'dict' object has no attribute 'not_afun'
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 131, in fn
    return op_fn(item, *fn_args, **fn_kwargs)
  File "/home/ray/default/test.py", line 6, in f
    b.not_afun()
AttributeError: 'dict' object has no attribute 'not_afun'

The above exception was the direct cause of the following exception:

  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 133, in fn
    raise UserCodeException() from e
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 254, in transform_fn
    out_row = fn(row)
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_5057831c3583739b/ray/data/_internal/execution/operators/map_transformer.py", line 216, in __call__
    yield from self._row_fn(input, ctx)
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_5057831c3583739b/ray/data/_internal/execution/operators/map_transformer.py", line 134, in _udf_timed_iter
    output = next(input)
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_5057831c3583739b/ray/data/_internal/execution/operators/map_transformer.py", line 392, in __call__
    for data in iter:
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_5057831c3583739b/ray/data/_internal/execution/operators/map_operator.py", line 419, in _map_task
    for b_out in map_transformer.apply_transform(iter(blocks), ctx):
  File "/home/ray/default/python/ray/_raylet.pyx", line 1382, in ray._raylet.execute_streaming_generator_sync
    for output in gen:
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_5057831c3583739b/ray/_private/worker.py", line 879, in main_loop
    self.core_worker.run_task_loop()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/workers/default_worker.py", line 282, in <module> (Current frame)
    worker.main_loop()
ray.exceptions.UserCodeException: 
```
</details>

<details open>
<summary>After (debugger enabled):</summary>
<br>

```
'dict' object has no attribute 'not_afun'
  File "/home/ray/default/test.py", line 6, in f
    b.not_afun()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 137, in fn
    raise e
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 137, in fn
    raise e
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 254, in transform_fn
    out_row = fn(row)
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_0cb2453b97c70e16/ray/data/_internal/execution/operators/map_transformer.py", line 216, in __call__
    yield from self._row_fn(input, ctx)
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_0cb2453b97c70e16/ray/data/_internal/execution/operators/map_transformer.py", line 134, in _udf_timed_iter
    output = next(input)
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_0cb2453b97c70e16/ray/data/_internal/execution/operators/map_transformer.py", line 392, in __call__
    for data in iter:
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_0cb2453b97c70e16/ray/data/_internal/execution/operators/map_operator.py", line 419, in _map_task
    for b_out in map_transformer.apply_transform(iter(blocks), ctx):
  File "/home/ray/default/python/ray/_raylet.pyx", line 1382, in ray._raylet.execute_streaming_generator_sync
    for output in gen:
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_0cb2453b97c70e16/ray/_private/worker.py", line 879, in main_loop
    self.core_worker.run_task_loop()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/workers/default_worker.py", line 282, in <module> (Current frame)
    worker.main_loop()
AttributeError: 'dict' object has no attribute 'not_afun'
```
</details>

<details open>
<summary>After (debugger disabled):</summary>
<br>

```
Traceback (most recent call last):
  File "/home/ray/default/test.py", line 7, in <module>
    ds.map(f).take_all()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/dataset.py", line 2417, in take_all
    for row in self.iter_rows():
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/iterator.py", line 241, in _wrapped_iterator
    for batch in batch_iterable:
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/iterator.py", line 162, in _create_iterator
    block_iterator, stats, blocks_owned_by_consumer = self._to_block_iterator()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/iterator/iterator_impl.py", line 33, in _to_block_iterator
    block_iterator, stats, executor = ds._plan.execute_to_iterator()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/exceptions.py", line 94, in handle_trace
    raise exception_to_raise
ray.exceptions.RayTaskError(UserCodeException): ray::ReadRange->Map(f)() (pid=43332, ip=10.0.12.214)
  File "/home/ray/default/test.py", line 6, in f
    b.not_afun()
AttributeError: 'dict' object has no attribute 'not_afun'

The above exception was the direct cause of the following exception:

ray::ReadRange->Map(f)() (pid=43332, ip=10.0.12.214)
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_3b6a31058e5031e8/ray/data/_internal/execution/operators/map_operator.py", line 419, in _map_task
    for b_out in map_transformer.apply_transform(iter(blocks), ctx):
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_3b6a31058e5031e8/ray/data/_internal/execution/operators/map_transformer.py", line 392, in __call__
    for data in iter:
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_3b6a31058e5031e8/ray/data/_internal/execution/operators/map_transformer.py", line 134, in _udf_timed_iter
    output = next(input)
  File "/tmp/ray/session_2024-04-05_11-01-56_573097_311/runtime_resources/py_modules_files/_ray_pkg_3b6a31058e5031e8/ray/data/_internal/execution/operators/map_transformer.py", line 216, in __call__
    yield from self._row_fn(input, ctx)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 254, in transform_fn
    out_row = fn(row)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 140, in fn
    raise UserCodeException() from e
ray.exceptions.UserCodeException
```
</details>

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
