### PR TITLE
[serve] Warn about removal of nesting `DeploymentResponse` objects in complex objects

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -396,7 +396,9 @@ class Router:
                         "this feature, please file a feature request on GitHub."
                     )
                 elif isinstance(obj, DeploymentResponse):
-                    if not _WARNED_ABOUT_NESTED_OBJ and (obj not in request_args and obj not in kwarg_values):
+                    if not _WARNED_ABOUT_NESTED_OBJ and (
+                        obj not in request_args and obj not in kwarg_values
+                    ):
                         _WARNED_ABOUT_NESTED_OBJ = True
                         warnings.warn(
                             f"`DeploymentResponse` objects passed in nested objects "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The primary motivation for this is to remove the usage of the hacky _PyObjScanner that was the source of the [recent memory leak](https://github.com/ray-project/ray/pull/43763). It has poor performance (we basically have to serialize the arguments twice) and is overall sketchy (likely to have more latent bugs).

I don’t think this capability is currently documented in any of our examples, but I plan to first warn if users do this for a couple of releases, then later remove the support it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
