### PR TITLE
[Core] Deflake test_ray_debugger

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -274,12 +274,18 @@ def kill_all_redis_server():
     # Find Redis server processes
     redis_procs = []
     for proc in psutil.process_iter(["name", "cmdline"]):
-        if proc.name() == "redis-server":
-            redis_procs.append(proc)
+        try:
+            if proc.name() == "redis-server":
+                redis_procs.append(proc)
+        except psutil.NoSuchProcess:
+            pass
 
     # Kill Redis server processes
     for proc in redis_procs:
-        proc.kill()
+        try:
+            proc.kill()
+        except psutil.NoSuchProcess:
+            pass
 
 
 @contextmanager


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`test_ray_debugger` sometimes failed with

```
[2024-04-05T23:35:40Z] python/ray/tests/conftest.py:317: in maybe_external_redis
[2024-04-05T23:35:40Z]     with _setup_redis(request):
[2024-04-05T23:35:40Z] /opt/miniconda/lib/python3.9/contextlib.py:119: in __enter__
[2024-04-05T23:35:40Z]     return next(self.gen)
[2024-04-05T23:35:40Z] python/ray/tests/conftest.py:288: in _setup_redis
[2024-04-05T23:35:40Z]     kill_all_redis_server()
[2024-04-05T23:35:40Z] python/ray/tests/conftest.py:277: in kill_all_redis_server
[2024-04-05T23:35:40Z]     if proc.name() == "redis-server":
[2024-04-05T23:35:40Z] /rayci/python/ray/thirdparty_files/psutil/__init__.py:651: in name
[2024-04-05T23:35:40Z]     name = self._proc.name()
[2024-04-05T23:35:40Z] /rayci/python/ray/thirdparty_files/psutil/_pslinux.py:1714: in wrapper
[2024-04-05T23:35:40Z]     return fun(self, *args, **kwargs)
[2024-04-05T23:35:40Z] /rayci/python/ray/thirdparty_files/psutil/_pslinux.py:1828: in name
[2024-04-05T23:35:40Z]     name = self._parse_stat_file()['name']
[2024-04-05T23:35:40Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[2024-04-05T23:35:40Z] 
[2024-04-05T23:35:40Z] self = <psutil._pslinux.Process object at 0x7fbe78257090>, args = ()
[2024-04-05T23:35:40Z] kwargs = {}
[2024-04-05T23:35:40Z] 
[2024-04-05T23:35:40Z]     @functools.wraps(fun)
[2024-04-05T23:35:40Z]     def wrapper(self, *args, **kwargs):
[2024-04-05T23:35:40Z]         try:
[2024-04-05T23:35:40Z]             return fun(self, *args, **kwargs)
[2024-04-05T23:35:40Z]         except PermissionError:
[2024-04-05T23:35:40Z]             raise AccessDenied(self.pid, self._name)
[2024-04-05T23:35:40Z]         except ProcessLookupError:
[2024-04-05T23:35:40Z]             self._raise_if_zombie()
[2024-04-05T23:35:40Z]             raise NoSuchProcess(self.pid, self._name)
[2024-04-05T23:35:40Z]         except FileNotFoundError:
[2024-04-05T23:35:40Z]             self._raise_if_zombie()
[2024-04-05T23:35:40Z]             if not os.path.exists("%s/%s" % (self._procfs_path, self.pid)):
[2024-04-05T23:35:40Z] >               raise NoSuchProcess(self.pid, self._name)
[2024-04-05T23:35:40Z] E               psutil.NoSuchProcess: process no longer exists (pid=59941, name='redis-server')
[2024-04-05T23:35:40Z] 
[2024-04-05T23:35:40Z] /rayci/python/ray/thirdparty_files/psutil/_pslinux.py:1723: NoSuchProcess
```

So it's not the test itself failed but the fixture `maybe_external_redis` throws an exception.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
