### PR TITLE
[RLlib] Fix broken docs link for RLlib new API stack.

### DIFF
--- a/doc/source/_includes/rllib/new_api_stack.rst
+++ b/doc/source/_includes/rllib/new_api_stack.rst
@@ -8,4 +8,4 @@
     support the "new API stack" and continue to run by default with the old APIs.
     You can continue to use the existing custom (old stack) classes.
 
-    `See </rllib/package_ref/rllib-new-api-stack.html>`__ for more details on how to use the new API stack.
+    `See </rllib/rllib-new-api-stack.html>`__ for more details on how to use the new API stack.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix broken docs link for RLlib new API stack.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
