### PR TITLE
Fix: "[RLlib] Fix broken docs link for RLlib new API stack."

### DIFF
--- a/doc/source/_includes/rllib/new_api_stack.rst
+++ b/doc/source/_includes/rllib/new_api_stack.rst
@@ -8,4 +8,4 @@
     support the "new API stack" and continue to run by default with the old APIs.
     You can continue to use the existing custom (old stack) classes.
 
-    `See </rllib/rllib-new-api-stack.html>`__ for more details on how to use the new API stack.
+    `See </rllib/package_ref/rllib-new-api-stack.html>`__ for more details on how to use the new API stack.


### PR DESCRIPTION
Reverts ray-project/ray#44562