### PR TITLE
[ci][postmerge/1] create a scheduler for postmerge pipeline

### DIFF
--- a/ci/ray_ci/pipeline/BUILD.bazel
+++ b/ci/ray_ci/pipeline/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@py_deps_buildkite//:requirements.bzl", ci_require = "requirement")
+
+py_library(
+    name = "pipeline",
+    srcs = glob(
+        ["*.py"],
+        exclude = [
+            "test_*.py",
+        ],
+    ),
+    visibility = ["//ci/ray_ci/pipeline:__subpackages__"],
+    deps = [
+        "//ci/ray_ci:ray_ci_lib",
+    ],
+)
+
+py_test(
+    name = "test_gap_filling_scheduler",
+    size = "small",
+    srcs = ["test_gap_filling_scheduler.py"],
+    exec_compatible_with = ["//:hermetic_python"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":pipeline",
+        ci_require("pytest"),
+    ],
+)

--- a/ci/ray_ci/pipeline/gap_filling_scheduler.py
+++ b/ci/ray_ci/pipeline/gap_filling_scheduler.py
@@ -1,0 +1,67 @@
+import subprocess
+from datetime import datetime, timedelta
+from typing import List, Dict, Optional, Any
+
+from pybuildkite.buildkite import Buildkite
+
+
+BRANCH = "master"
+
+
+class GapFillingScheduler:
+    """
+    This buildkite pipeline scheduler is responsible for scheduling gap filling builds
+    when the latest build is failing.
+    """
+
+    def __init__(
+        self,
+        buildkite_organization: str,
+        buildkite_pipeline: str,
+        buildkite_access_token: str,
+        repo_checkout: str,
+        days_ago: int = 1,
+    ):
+        self.buildkite_organization = buildkite_organization
+        self.buildkite_pipeline = buildkite_pipeline
+        self.buildkite = Buildkite()
+        self.buildkite.set_access_token(buildkite_access_token)
+        self.repo_checkout = repo_checkout
+        self.days_ago = days_ago
+
+    def _get_latest_commit_for_build_state(self, build_state: str) -> Optional[str]:
+        latest_commits = self._get_latest_commits()
+        commit_to_index = {commit: index for index, commit in enumerate(latest_commits)}
+        builds = []
+        for build in self._get_builds():
+            if build["state"] == build_state and build["commit"] in latest_commits:
+                builds.append(build)
+        if not builds:
+            return None
+
+        builds = sorted(builds, key=lambda build: commit_to_index[build["commit"]])
+        return builds[0]["commit"]
+
+    def _get_latest_commits(self) -> List[str]:
+        return (
+            subprocess.check_output(
+                [
+                    "git",
+                    "log",
+                    "--pretty=tformat:'%H'",
+                    f"--since={self.days_ago}.days",
+                ],
+                cwd=self.repo_checkout,
+            )
+            .decode("utf-8")
+            .strip()
+            .split("\n")
+        )
+
+    def _get_builds(self) -> List[Dict[str, Any]]:
+        return self.buildkite.builds().list_all_for_pipeline(
+            self.buildkite_organization,
+            self.buildkite_pipeline,
+            created_from=datetime.now() - timedelta(days=self.days_ago),
+            branch=BRANCH,
+        )

--- a/ci/ray_ci/pipeline/test_gap_filling_scheduler.py
+++ b/ci/ray_ci/pipeline/test_gap_filling_scheduler.py
@@ -1,0 +1,41 @@
+import sys
+from unittest import mock
+
+import pytest
+
+from ci.ray_ci.pipeline.gap_filling_scheduler import GapFillingScheduler
+
+
+@mock.patch(
+    "ci.ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._get_latest_commits"
+)
+@mock.patch("ci.ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._get_builds")
+def test_get_latest_commit_for_build_state(mock_get_builds, mock_get_latest_commits):
+    mock_get_builds.return_value = [
+        {
+            "state": "failed",
+            "commit": "000",
+        },
+        {
+            "state": "passed",
+            "commit": "111",
+        },
+        {
+            "state": "failed",
+            "commit": "222",
+        },
+    ]
+    mock_get_latest_commits.return_value = [
+        "222",
+        "111",
+        "000",
+        "/ray",
+    ]
+    scheduler = GapFillingScheduler("org", "pipeline", "token", "/ray")
+    assert scheduler._get_latest_commit_for_build_state("failed") == "222"
+    assert scheduler._get_latest_commit_for_build_state("passed") == "111"
+    assert scheduler._get_latest_commit_for_build_state("something") is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Create a scheduler that implements the fill-in-the-gap for postmerge pipeline. This PR:

- create a skeleton class with buildkite credentials
- a function to get the latest build given a status and some test cases

Test:
- CI