### PR TITLE
[Data] Remove dead `DEFAULT_MAX_TASKS_IN_FLIGHT_PER_ACTOR` constant

### DIFF
--- a/python/ray/data/_internal/compute.py
+++ b/python/ray/data/_internal/compute.py
@@ -21,8 +21,6 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 U = TypeVar("U")
 
-DEFAULT_MAX_TASKS_IN_FLIGHT_PER_ACTOR = 2
-
 
 # Block transform function applied by task and actor pools.
 BlockTransform = Union[


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

There are two constants for the number of tasks in-flight per actor: 
https://github.com/ray-project/ray/blob/5e2a27630346b4bbc19c336dc90affac6a8da24a/python/ray/data/_internal/compute.py#L24
https://github.com/ray-project/ray/blob/5e2a27630346b4bbc19c336dc90affac6a8da24a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py#L27

However, only one constant is actually used. This PR removes the dead constant.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
