### PR TITLE
[Data] Remove unused return value of `autodetect_parallelism`

### DIFF
--- a/python/ray/data/_internal/logical/rules/set_read_parallelism.py
+++ b/python/ray/data/_internal/logical/rules/set_read_parallelism.py
@@ -22,7 +22,7 @@ def compute_additional_split_factor(
     cur_additional_split_factor: Optional[int] = None,
 ) -> Tuple[int, str, int, Optional[int]]:
     ctx = DataContext.get_current()
-    detected_parallelism, reason, _, _ = _autodetect_parallelism(
+    detected_parallelism, reason, _ = _autodetect_parallelism(
         parallelism, target_max_block_size, ctx, datasource_or_legacy_reader, mem_size
     )
     num_read_tasks = len(

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -108,7 +108,7 @@ def _autodetect_parallelism(
     mem_size: Optional[int] = None,
     placement_group: Optional["PlacementGroup"] = None,
     avail_cpus: Optional[int] = None,
-) -> (int, str, int, Optional[int]):
+) -> Tuple[int, str, Optional[int]]:
     """Returns parallelism to use and the min safe parallelism to avoid OOMs.
 
     This detects parallelism using the following heuristics, applied in order:
@@ -140,9 +140,8 @@ def _autodetect_parallelism(
 
     Returns:
         Tuple of detected parallelism (only if -1 was specified), the reason
-        for the detected parallelism (only if -1 was specified), the min safe
-        parallelism (which can be used to generate warnings about large
-        blocks), and the estimated inmemory size of the dataset.
+        for the detected parallelism (only if -1 was specified), and the estimated
+        inmemory size of the dataset.
     """
     min_safe_parallelism = 1
     max_reasonable_parallelism = sys.maxsize
@@ -207,7 +206,7 @@ def _autodetect_parallelism(
             f"estimated_data_size={mem_size}."
         )
 
-    return parallelism, reason, min_safe_parallelism, mem_size
+    return parallelism, reason, mem_size
 
 
 def _estimate_avail_cpus(cur_pg: Optional["PlacementGroup"]) -> int:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -142,7 +142,7 @@ def from_items(
     if parallelism == 0:
         raise ValueError(f"parallelism must be -1 or > 0, got: {parallelism}")
 
-    detected_parallelism, _, _, _ = _autodetect_parallelism(
+    detected_parallelism, _, _ = _autodetect_parallelism(
         parallelism,
         ray.util.get_current_placement_group(),
         DataContext.get_current(),
@@ -385,7 +385,7 @@ def read_datasource(
         )
 
     cur_pg = ray.util.get_current_placement_group()
-    requested_parallelism, _, _, inmemory_size = _autodetect_parallelism(
+    requested_parallelism, _, inmemory_size = _autodetect_parallelism(
         parallelism,
         ctx.target_max_block_size,
         DataContext.get_current(),

--- a/python/ray/data/tests/test_auto_parallelism.py
+++ b/python/ray/data/tests/test_auto_parallelism.py
@@ -113,7 +113,7 @@ def test_autodetect_parallelism(
         def estimate_inmemory_data_size(self):
             return data_size
 
-    result, _, _, _ = _autodetect_parallelism(
+    result, _, _ = _autodetect_parallelism(
         parallelism=-1,
         target_max_block_size=target_max_block_size,
         ctx=DataContext.get_current(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `min_safe_parallelism` return value of `autodetect_parallelism` isn't used anywhere, so this PR removes it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
