### PR TITLE
[Docs] Code block does not rendered for setup pre-commit

### DIFF
--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -343,7 +343,7 @@ the moment, we have configured a ``.pre-commit-config.yaml`` which runs all the 
 opt-in, with any formatting changes made by ``scripts/format.sh`` expected to be caught by
 ``pre-commit`` as well. To start using ``pre-commit``:
 
-.. code-block: shell
+.. code-block:: shell
 
    pip install pre-commit
    pre-commit install
@@ -352,7 +352,7 @@ This will install pre-commit into the current environment, and enable pre-commit
 you commit new code changes with git. To temporarily skip pre-commit checks, use the ``-n`` or
 ``--no-verify`` flag when committing:
 
-.. code-block: shell
+.. code-block:: shell
 
    git commit -n
 

--- a/python/ray/air/integrations/keras.py
+++ b/python/ray/air/integrations/keras.py
@@ -110,7 +110,7 @@ class ReportCheckpointCallback(_Callback):
         in ``report_metrics_on``.
 
     Example:
-        .. code-block: python
+        .. code-block:: python
 
             ############# Using it in TrainSession ###############
             from ray.air.integrations.keras import ReportCheckpointCallback

--- a/python/ray/air/integrations/wandb.py
+++ b/python/ray/air/integrations/wandb.py
@@ -103,7 +103,7 @@ def setup_wandb(
 
     Example:
 
-        .. code-block: python
+        .. code-block:: python
 
             from ray.air.integrations.wandb import setup_wandb
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Under the documentation [Pre-commit Hooks](https://docs.ray.io/en/latest/ray-contribute/development.html#pre-commit-hooks
) section, the code blocks are not properly rendered.

![image](https://github.com/ray-project/ray/assets/47914085/33adf91b-8d32-4a1c-9d7a-baddeb9ebfb5)

The reason is that `code-block::` is mistakenly written as `code-block:`.

After the changes:

![image](https://github.com/ray-project/ray/assets/47914085/d5f9ab73-0ae4-4905-b1b2-07babc50d357)


## Related issue number

N/A

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
