### PR TITLE
[spark] On Ray worker node machine, create temp-dir if it does not exist 

### DIFF
--- a/python/ray/util/spark/start_ray_node.py
+++ b/python/ray/util/spark/start_ray_node.py
@@ -49,6 +49,10 @@ if __name__ == "__main__":
 
         temp_dir = _get_default_ray_tmp_dir()
 
+    # Multiple Ray nodes might be launched in the same machine,
+    # so set `exist_ok` to True
+    os.makedirs(temp_dir, exist_ok=True)
+
     ray_cli_cmd = "ray"
     lock_file = temp_dir + ".lock"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
On Ray worker node machine, create temp-dir if it does not exist.

User often provides a temp directory path, but user does not create the temp directory in all cluster nodes,
In Master Ray code,
this causes `lock_file = temp_dir + ".lock"` creation failed and causes obscure and unfriendly exception.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [X] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
