### PR TITLE
[Docs][KubeRay] Tell users to install wget in docker image to run KubeRay

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/config.md
+++ b/doc/source/cluster/kubernetes/user-guides/config.md
@@ -182,6 +182,8 @@ See {ref}`this guide <docker-images>` to learn more about the official Ray image
 For dynamic dependency management geared towards iteration and developement,
 you can also use {ref}`Runtime Environments <runtime-environments>`.
 
+For `kuberay-operator` versions 1.1.0 and later, the Ray container image must have `wget` installed in it.
+
 #### metadata.name and metadata.generateName
 The KubeRay operator will ignore the values of `metadata.name` and `metadata.generateName` set by users.
 The KubeRay operator will generate a `generateName` automatically to avoid name conflicts.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

For `kuberay-operator` versions 1.1.0 and later, the Ray container image must have `wget` installed for readiness and liveness probing purpose.

## Related issue number

Closes ray-project/kuberay#2063

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
