### PR TITLE
[RLlib] Fix CI `test_io` (now re-broken due to moved example script).

### DIFF
--- a/rllib/examples/offline_rl/custom_input_api.py
+++ b/rllib/examples/offline_rl/custom_input_api.py
@@ -87,13 +87,13 @@ if __name__ == "__main__":
         default_config.environment("Pendulum-v1", clip_actions=True)
         .framework(args.framework)
         .offline_data(
-            # we can either use the tune registry, class path, or direct function
-            # to connect our input api.
+            # We can either use the tune registry ...
             input_="custom_input",
-            # "input": "ray.rllib.examples.custom_input_api.CustomJsonReader",
-            # "input": input_creator,
-            # this gets passed to the IOContext
-            input_config={"input_files": args.input_files},
+            # ... full classpath
+            # input_: "ray.rllib.examples.offline_rl.custom_input_api.CustomJsonReader"
+            # ... or a direct function to connect our input api.
+            # input_: input_creator
+            input_config={"input_files": args.input_files},  # <- passed to IOContext
             actions_in_input_normalized=True,
         )
         .training(train_batch_size=2000)

--- a/rllib/tests/test_io.py
+++ b/rllib/tests/test_io.py
@@ -232,7 +232,7 @@ class AgentIOTest(unittest.TestCase):
         test_input_procedure = [
             "custom_input",
             input_creator,
-            "ray.rllib.examples.custom_input_api.CustomJsonReader",
+            "ray.rllib.examples.offline_rl/custom_input_api.CustomJsonReader",
         ]
 
         for input_procedure in test_input_procedure:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix CI `test_io` (now re-broken due to moved example script).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
