### PR TITLE
[rel][pkg/2] use test definition root to get to release_tests.yaml and

### DIFF
--- a/.buildkite/release.rayci.yml
+++ b/.buildkite/release.rayci.yml
@@ -8,7 +8,8 @@ steps:
       - skip-on-premerge
       - oss
     commands:
-      - ./release/run_release_test.sh microbenchmark.aws --report
+      - ./release/run_release_test.sh microbenchmark.aws --report 
+        --test-definition-root /ray/release --test-collection-file release_tests.yaml
     instance_type: release
     job_env: oss-ci-base_build
     depends_on:

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -41,12 +41,18 @@ RELEASE_TEST_SCHEMA_FILE = bazel_runfile("release/ray_release/schema.json")
 
 def read_and_validate_release_test_collection(
     config_files: List[str],
+    test_definition_root: str = None,
     schema_file: Optional[str] = None,
 ) -> List[Test]:
     """Read and validate test collection from config file"""
     tests = []
     for config_file in config_files:
-        with open(bazel_runfile(config_file), "rt") as fp:
+        path = (
+            os.path.join(test_definition_root, config_file)
+            if test_definition_root
+            else bazel_runfile(config_file)
+        )
+        with open(path, "rt") as fp:
             tests += parse_test_definition(yaml.safe_load(fp))
 
     validate_release_test_collection(tests, schema_file=schema_file)

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -74,6 +74,7 @@ def _load_test_configuration(
     result: Result,
     smoke_test: bool = False,
     no_terminate: bool = False,
+    test_definition_root: Optional[str] = None,
 ) -> Tuple[ClusterManager, CommandRunner, str]:
     logger.info(f"Test config: {test}")
 
@@ -89,7 +90,7 @@ def _load_test_configuration(
 
     # Setting up working directory
     working_dir = test["working_dir"]
-    new_wd = os.path.join(RELEASE_PACKAGE_DIR, working_dir)
+    new_wd = os.path.join(test_definition_root or RELEASE_PACKAGE_DIR, working_dir)
     os.chdir(new_wd)
 
     run_type = test["run"].get("type", DEFAULT_RUN_TYPE)
@@ -387,6 +388,7 @@ def run_release_test(
     cluster_id: Optional[str] = None,
     cluster_env_id: Optional[str] = None,
     no_terminate: bool = False,
+    test_definition_root: Optional[str] = None,
 ) -> Result:
     old_wd = os.getcwd()
     start_time = time.monotonic()
@@ -403,6 +405,7 @@ def run_release_test(
             result,
             smoke_test,
             no_terminate,
+            test_definition_root,
         )
         buildkite_group(":nut_and_bolt: Setting up cluster environment")
         (

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -25,6 +25,14 @@ from ray_release.result import Result
 @click.command()
 @click.argument("test_name", required=True, type=str)
 @click.option(
+    "--test-definition-root",
+    type=str,
+    help=(
+        "The root where the test definition is located. "
+        "Default is the root of the repo.",
+    ),
+)
+@click.option(
     "--test-collection-file",
     multiple=True,
     type=str,
@@ -85,6 +93,7 @@ from ray_release.result import Result
 )
 def main(
     test_name: str,
+    test_definition_root: str,
     test_collection_file: Tuple[str],
     smoke_test: bool = False,
     report: bool = False,
@@ -99,7 +108,8 @@ def main(
     )
     init_global_config(global_config_file)
     test_collection = read_and_validate_release_test_collection(
-        test_collection_file or ["release/release_tests.yaml"]
+        test_collection_file or ["release/release_tests.yaml"],
+        test_definition_root,
     )
     test = find_test(test_collection, test_name)
 
@@ -148,6 +158,7 @@ def main(
             cluster_id=cluster_id,
             cluster_env_id=cluster_env_id,
             no_terminate=no_terminate,
+            test_definition_root=test_definition_root,
         )
         return_code = result.return_code
     except ReleaseTestError as e:

--- a/release/ray_release/scripts/run_release_test.py
+++ b/release/ray_release/scripts/run_release_test.py
@@ -25,14 +25,6 @@ from ray_release.result import Result
 @click.command()
 @click.argument("test_name", required=True, type=str)
 @click.option(
-    "--test-definition-root",
-    type=str,
-    help=(
-        "The root where the test definition is located. "
-        "Default is the root of the repo.",
-    ),
-)
-@click.option(
     "--test-collection-file",
     multiple=True,
     type=str,
@@ -91,9 +83,14 @@ from ray_release.result import Result
         "Will switch `anyscale_job` run type to `job` (Ray Job)."
     ),
 )
+@click.option(
+    "--test-definition-root",
+    default=None,
+    type=str,
+    help="Root of the test definition files. Default is the root of the repo.",
+)
 def main(
     test_name: str,
-    test_definition_root: str,
     test_collection_file: Tuple[str],
     smoke_test: bool = False,
     report: bool = False,
@@ -102,6 +99,7 @@ def main(
     env: Optional[str] = None,
     global_config: str = "oss_config.yaml",
     no_terminate: bool = False,
+    test_definition_root: Optional[str] = None,
 ):
     global_config_file = os.path.join(
         os.path.dirname(__file__), "..", "configs", global_config


### PR DESCRIPTION
Currently the release_tests.yaml and test working directory assumes that their path is relative to the ray release package. This PR makes it so that users can define a test_definition_root where the release_tests.yaml and working directory are located. 

This will make it possible for users to define only the test definitions, and reuse the implementation of ray_release to run them.

Test:
- CI
- release test: https://buildkite.com/ray-project/postmerge/builds/3941