### PR TITLE
[serve] add num replicas auto telemetry

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1128,6 +1128,8 @@ def override_deployment_info(
 
             options["autoscaling_config"] = AutoscalingConfig(**new_config)
 
+            ServeUsageTag.AUTO_NUM_REPLICAS_USED.record("1")
+
         # What to pass to info.update
         override_options = dict()
 

--- a/python/ray/serve/_private/usage.py
+++ b/python/ray/serve/_private/usage.py
@@ -35,6 +35,7 @@ class ServeUsageTag(Enum):
         TagKey.SERVE_DEPLOYMENT_CONTAINER_RUNTIME_ENV_USED
     )
     NUM_NODE_COMPACTIONS = TagKey.SERVE_NUM_NODE_COMPACTIONS
+    AUTO_NUM_REPLICAS_USED = TagKey.SERVE_AUTO_NUM_REPLICAS_USED
 
     def record(self, value: str):
         """Record telemetry value."""

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -364,6 +364,8 @@ def deployment(
             max_ongoing_requests, autoscaling_config
         )
 
+        ServeUsageTag.AUTO_NUM_REPLICAS_USED.record("1")
+
     # NOTE: The user_configured_option_names should be the first thing that's
     # defined in this function. It depends on the locals() dictionary storing
     # only the function args/kwargs.

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -12,6 +12,7 @@ from ray.serve._private.config import (
     handle_num_replicas_auto,
 )
 from ray.serve._private.constants import DEFAULT_MAX_ONGOING_REQUESTS, SERVE_LOGGER_NAME
+from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import DEFAULT, Default
 from ray.serve.config import AutoscalingConfig
 from ray.serve.context import _get_global_client
@@ -362,6 +363,8 @@ class Deployment:
             max_ongoing_requests, autoscaling_config = handle_num_replicas_auto(
                 max_ongoing_requests, autoscaling_config
             )
+
+            ServeUsageTag.AUTO_NUM_REPLICAS_USED.record("1")
 
         # NOTE: The user_configured_option_names should be the first thing that's
         # defined in this method. It depends on the locals() dictionary storing

--- a/python/ray/serve/tests/test_telemetry.py
+++ b/python/ray/serve/tests/test_telemetry.py
@@ -144,6 +144,7 @@ def test_rest_api(manage_ray_with_telemetry, tmp_dir):
     assert ServeUsageTag.GRPC_INGRESS_USED.get_value_from_report(report) is None
     assert ServeUsageTag.HTTP_ADAPTER_USED.get_value_from_report(report) is None
     assert ServeUsageTag.DAG_DRIVER_USED.get_value_from_report(report) is None
+    assert ServeUsageTag.AUTO_NUM_REPLICAS_USED.get_value_from_report(report) is None
 
     # Check that app deletions are tracked.
     new_config = {"applications": []}

--- a/python/ray/serve/tests/test_telemetry_2.py
+++ b/python/ray/serve/tests/test_telemetry_2.py
@@ -5,8 +5,10 @@ import pytest
 
 from ray import serve
 from ray._private.test_utils import wait_for_condition
-from ray.serve._private.test_utils import check_telemetry
+from ray.serve._private.test_utils import check_apps_running, check_telemetry
 from ray.serve._private.usage import ServeUsageTag
+from ray.serve.context import _get_global_client
+from ray.serve.schema import ServeDeploySchema
 
 
 @pytest.mark.parametrize("location", ["driver", "deployment", None])
@@ -96,6 +98,40 @@ def test_get_deployment_handle_api_detected(manage_ray_with_telemetry, location)
                 ServeUsageTag.SERVE_GET_DEPLOYMENT_HANDLE_API_USED, expected=None
             )
             time.sleep(1)
+
+
+class Model:
+    pass
+
+
+app_model = serve.deployment(Model).bind()
+
+
+@pytest.mark.parametrize("mode", ["deployment", "options", "config"])
+def test_num_replicas_auto(manage_ray_with_telemetry, mode):
+    check_telemetry(ServeUsageTag.AUTO_NUM_REPLICAS_USED, expected=None)
+
+    if mode == "deployment":
+        serve.run(serve.deployment(num_replicas="auto")(Model).bind())
+    elif mode == "options":
+        serve.run(serve.deployment(Model).options(num_replicas="auto").bind())
+    elif mode == "config":
+        config = {
+            "applications": [
+                {
+                    "name": "default",
+                    "import_path": "ray.serve.tests.test_telemetry_2.app_model",
+                    "deployments": [{"name": "Model", "num_replicas": "auto"}],
+                },
+            ]
+        }
+        client = _get_global_client()
+        client.deploy_apps(ServeDeploySchema(**config))
+        wait_for_condition(check_apps_running, apps=["default"])
+
+    wait_for_condition(
+        check_telemetry, tag=ServeUsageTag.AUTO_NUM_REPLICAS_USED, expected="1"
+    )
 
 
 if __name__ == "__main__":

--- a/src/ray/protobuf/usage.proto
+++ b/src/ray/protobuf/usage.proto
@@ -97,6 +97,8 @@ enum TagKey {
   SERVE_DEPLOYMENT_CONTAINER_RUNTIME_ENV_USED = 29;
   // The number of nodes actively compacted by Serve
   SERVE_NUM_NODE_COMPACTIONS = 30;
+  // Whether the num_replicas="auto" API was used ("1" if used)
+  SERVE_AUTO_NUM_REPLICAS_USED = 31;
 
   // Ray Core State API
   // NOTE(rickyxx): Currently only setting "1" for tracking existence of


### PR DESCRIPTION
[serve] add num replicas auto telemetry

Add telemetry (`SERVE_AUTO_NUM_REPLICAS_USED`) to track whether the `num_replicas="auto"` api is used.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
