### PR TITLE
[train] Remove base config deepcopy when initializing the trainer actor

### DIFF
--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -13,7 +13,7 @@ import pyarrow.fs
 
 import ray
 import ray.cloudpickle as pickle
-from ray._private.dict import merge_dicts
+from ray._private.dict import deep_update
 from ray.air._internal import usage as air_usage
 from ray.air._internal.config import ensure_only_allowed_dataclass_keys_updated
 from ray.air._internal.usage import AirEntrypoint
@@ -739,11 +739,15 @@ class BaseTrainer(abc.ABC):
 
             def setup(self, config, **kwargs):
                 base_config = dict(kwargs)
-                # Create a new config by merging the dicts.
+                # Merge Tuner param space hyperparameters in `config` into the
+                # base config passed to the Trainer constructor, which is `base_config`.
+                # `base_config` is pulled from the object store from the usage of
+                # tune.with_parameters in `BaseTrainer.as_trainable`.
+
                 # run_config is not a tunable hyperparameter so it does not need to be
                 # merged.
                 run_config = base_config.pop("run_config", None)
-                self._merged_config = merge_dicts(base_config, self.config)
+                self._merged_config = deep_update(base_config, self.config)
                 self._merged_config["run_config"] = run_config
                 merged_scaling_config = self._merged_config.get(
                     "scaling_config", ScalingConfig()

--- a/python/ray/train/base_trainer.py
+++ b/python/ray/train/base_trainer.py
@@ -747,7 +747,9 @@ class BaseTrainer(abc.ABC):
                 # run_config is not a tunable hyperparameter so it does not need to be
                 # merged.
                 run_config = base_config.pop("run_config", None)
-                self._merged_config = deep_update(base_config, self.config)
+                self._merged_config = deep_update(
+                    base_config, self.config, new_keys_allowed=True
+                )
                 self._merged_config["run_config"] = run_config
                 merged_scaling_config = self._merged_config.get(
                     "scaling_config", ScalingConfig()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`merge_dicts` first creates a deepcopy of the base config before doing a deep update. The deepcopy is unnecessary for this usage in Ray Train, so we can skip it and just perform a deep update.

This causes issues with large objects passed into the trainer, increasing the peak memory usage of the Ray Train coordinator actor (which is labeled `_Inner` in the Ray dashboard). For example, this problem surfaced for Ray Data datasets that held a lot of metadata being passed into the trainer. (The size of the datasets is a separate issue that will be fixed.)

The large objects are deep copied, which increases the memory usage of the Trainer actor by 2x. The original copy comes from [the object store via `tune.with_parameters`](https://github.com/ray-project/ray/blob/7480c90481970925c53edc70aead2d53fb7f5794/python/ray/tune/trainable/util.py#L119). This copy should get garbage collected immediately after the [Trainer Trainable setup](https://github.com/ray-project/ray/blob/7480c90481970925c53edc70aead2d53fb7f5794/python/ray/train/base_trainer.py#L740) is called, but for some reason the copy's memory usage sticks around for the rest of training.



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
