### PR TITLE
[RPC] Added appropriate keep-alive configuration for Ray's internal RPCs

### DIFF
--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -152,14 +152,21 @@ inline absl::flat_hash_map<K, V> MapFromProtobuf(
 
 inline grpc::ChannelArguments CreateDefaultChannelArguments() {
   grpc::ChannelArguments arguments;
+
   if (::RayConfig::instance().grpc_client_keepalive_time_ms() > 0) {
     arguments.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,
                      ::RayConfig::instance().grpc_client_keepalive_time_ms());
     arguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
                      ::RayConfig::instance().grpc_client_keepalive_timeout_ms());
   }
+
+  arguments.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA,
+                    ::RayConfig::instance().grpc_http2_max_pings_without_data());
+  arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+                      ::RayConfig::instance().grpc_keepalive_permit_without_calls());
   arguments.SetInt(GRPC_ARG_CLIENT_IDLE_TIMEOUT_MS,
                    ::RayConfig::instance().grpc_client_idle_timeout_ms());
+
   return arguments;
 }
 

--- a/src/ray/common/grpc_util.h
+++ b/src/ray/common/grpc_util.h
@@ -161,9 +161,9 @@ inline grpc::ChannelArguments CreateDefaultChannelArguments() {
   }
 
   arguments.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA,
-                    ::RayConfig::instance().grpc_http2_max_pings_without_data());
+                   ::RayConfig::instance().grpc_http2_max_pings_without_data());
   arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS,
-                      ::RayConfig::instance().grpc_keepalive_permit_without_calls());
+                   ::RayConfig::instance().grpc_keepalive_permit_without_calls());
   arguments.SetInt(GRPC_ARG_CLIENT_IDLE_TIMEOUT_MS,
                    ::RayConfig::instance().grpc_client_idle_timeout_ms());
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -768,19 +768,19 @@ RAY_CONFIG(int64_t, grpc_keepalive_time_ms, 10000)
 /// grpc keepalive timeout.
 RAY_CONFIG(int64_t, grpc_keepalive_timeout_ms, 20000)
 
-/// NOTE: we set a loose client keep alive because
+/// NOTE: We set a loose client keep alive because
 /// they have a failure model that considers network failures as component failures
 /// and this configuration break that assumption. We should apply to every other component
 /// after we change this failure assumption from code.
 /// grpc keepalive timeout for client.
 RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 300000)
-
-/// grpc keepalive timeout for client.
+/// gRPC keep-alive timeout for client.
 RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)
 
+/// Timeout after the last RPC finishes on the client channel at which the channel goes back into IDLE state
 RAY_CONFIG(int64_t, grpc_client_idle_timeout_ms, 1800000)
 
-/// grpc streaming buffer size
+/// gRPC streaming buffer size
 /// Set it to 512kb
 RAY_CONFIG(int64_t, grpc_stream_buffer_size, 512 * 1024);
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -776,6 +776,11 @@ RAY_CONFIG(int64_t, grpc_keepalive_timeout_ms, 20000)
 RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 300000)
 /// gRPC keep-alive timeout for client.
 RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)
+/// Number of keep-alive pings client can send before needing to send a data/header frame
+/// (0 indicates that an infinite number of pings can be sent without sending a data frame or header frame)
+RAY_CONFIG(int64_t, grpc_http2_max_pings_without_data, 0)
+/// Is it permissible to send keepalive pings from the client without any outstanding streams
+RAY_CONFIG(int64_t, grpc_keepalive_permit_without_calls, 1)
 
 /// Timeout after the last RPC finishes on the client channel at which the channel goes back into IDLE state
 RAY_CONFIG(int64_t, grpc_client_idle_timeout_ms, 1800000)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -773,8 +773,12 @@ RAY_CONFIG(int64_t, grpc_keepalive_timeout_ms, 20000)
 /// and this configuration break that assumption. We should apply to every other component
 /// after we change this failure assumption from code.
 /// grpc keepalive timeout for client.
+/// TODO this should be lowered to 30s after
+/// https://github.com/ray-project/ray/issues/29656
 RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 300000)
 /// gRPC keep-alive timeout for client.
+/// TODO this should be lowered to 15s after
+/// https://github.com/ray-project/ray/issues/29656
 RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)
 /// Number of keep-alive pings client can send before needing to send a data/header frame
 /// (0 indicates that an infinite number of pings can be sent without sending a data frame or header frame)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -773,12 +773,8 @@ RAY_CONFIG(int64_t, grpc_keepalive_timeout_ms, 20000)
 /// and this configuration break that assumption. We should apply to every other component
 /// after we change this failure assumption from code.
 /// grpc keepalive timeout for client.
-/// TODO this should be lowered to 30s after
-/// https://github.com/ray-project/ray/issues/29656
 RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 300000)
 /// gRPC keep-alive timeout for client.
-/// TODO this should be lowered to 15s after
-/// https://github.com/ray-project/ray/issues/29656
 RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)
 /// Number of keep-alive pings client can send before needing to send a data/header frame
 /// (0 indicates that an infinite number of pings can be sent without sending a data frame

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -779,8 +779,8 @@ RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)
 /// Number of keep-alive pings client can send before needing to send a data/header frame
 /// (0 indicates that an infinite number of pings can be sent without sending a data frame or header frame)
 RAY_CONFIG(int64_t, grpc_http2_max_pings_without_data, 0)
-/// Is it permissible to send keepalive pings from the client without any outstanding streams
-RAY_CONFIG(int64_t, grpc_keepalive_permit_without_calls, 1)
+/// Is it permissible to send keepalive pings from the client without any outstanding streams (default is 0)
+RAY_CONFIG(int64_t, grpc_keepalive_permit_without_calls, 0)
 
 /// Timeout after the last RPC finishes on the client channel at which the channel goes back into IDLE state
 RAY_CONFIG(int64_t, grpc_client_idle_timeout_ms, 1800000)

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -781,12 +781,15 @@ RAY_CONFIG(int64_t, grpc_client_keepalive_time_ms, 300000)
 /// https://github.com/ray-project/ray/issues/29656
 RAY_CONFIG(int64_t, grpc_client_keepalive_timeout_ms, 120000)
 /// Number of keep-alive pings client can send before needing to send a data/header frame
-/// (0 indicates that an infinite number of pings can be sent without sending a data frame or header frame)
+/// (0 indicates that an infinite number of pings can be sent without sending a data frame
+/// or header frame)
 RAY_CONFIG(int64_t, grpc_http2_max_pings_without_data, 0)
-/// Is it permissible to send keepalive pings from the client without any outstanding streams (default is 0)
+/// Is it permissible to send keepalive pings from the client without any outstanding
+/// streams (default is 0)
 RAY_CONFIG(int64_t, grpc_keepalive_permit_without_calls, 0)
 
-/// Timeout after the last RPC finishes on the client channel at which the channel goes back into IDLE state
+/// Timeout after the last RPC finishes on the client channel at which the channel goes
+/// back into IDLE state
 RAY_CONFIG(int64_t, grpc_client_idle_timeout_ms, 1800000)
 
 /// gRPC streaming buffer size


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Enabling gRPC client's keep-alive protocol allows to detect transport-level issues with the connection, which otherwise might go unnoticed.

Currently in the following scenario, driver will just hang:

 - Driver submits the task to Worker
 - Worker accepts the task, then immediately crashes (can simulate by SIGTERM-ing it) 
 - Driver will be hanging forever expecting a response from the Worker that will never come

With these change however, Driver will be able to notice that the TCP transport underlying gRPC channel is actually broken, by periodically sending KAs (every 5m, w/ 2m timeout by default) and therefore eventually terminate all outstanding RPC calls (`PushApply`) that would result in task failure.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
