### PR TITLE
Use regular python / conda-forge for container images

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -46,7 +46,7 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
         netbase \
         openssh-client \
         gnupg; fi) \
-    && sudo apt install python3 pip -y \
+    && sudo apt install python3 python3-dev pip -y \
     && sudo ln -s /usr/bin/python3 /usr/bin/python \
     && wget -O /tmp/Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" \
     && bash /tmp/Miniforge3.sh -b -p "${HOME}/conda" \

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -1,7 +1,7 @@
 # The base-deps Docker image installs main libraries needed to run Ray
 
 # The GPU options are NVIDIA CUDA developer images.
-ARG BASE_IMAGE="ubuntu:focal"
+ARG BASE_IMAGE="ubuntu:jammy"
 FROM ${BASE_IMAGE}
 # FROM directive resets ARG
 ARG BASE_IMAGE
@@ -11,9 +11,9 @@ ENV TZ=America/Los_Angeles
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 # TODO(ilr) $HOME seems to point to result in "" instead of "/home/ray"
-ENV PATH "/home/ray/anaconda3/bin:$PATH"
+#ENV PATH "/home/ray/anaconda3/bin:$PATH"
 ARG DEBIAN_FRONTEND=noninteractive
-ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.10.14
 ARG HOSTTYPE=${HOSTTYPE:-x86_64}
 
 ARG RAY_UID=1000
@@ -37,7 +37,7 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
         libjemalloc-dev \
         wget \
         cmake \
-        g++ \ 
+        g++ \
         zlib1g-dev \
         $(if [ "$AUTOSCALER" = "autoscaler" ]; then echo \
         tmux \
@@ -46,17 +46,17 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
         netbase \
         openssh-client \
         gnupg; fi) \
-    && wget --quiet \
-        "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.10.0-1-Linux-${HOSTTYPE}.sh" \
-        -O /tmp/miniconda.sh \
-    && /bin/bash /tmp/miniconda.sh -b -u -p $HOME/anaconda3 \
-    && $HOME/anaconda3/bin/conda init \ 
-    && echo 'export PATH=$HOME/anaconda3/bin:$PATH' >> /home/ray/.bashrc \
-    && rm /tmp/miniconda.sh  \
-    && $HOME/anaconda3/bin/conda install -y libgcc-ng python=$PYTHON_VERSION \
-    && $HOME/anaconda3/bin/conda install -y -c conda-forge libffi=3.4.2 \
-    && $HOME/anaconda3/bin/conda clean -y --all \
-    && $HOME/anaconda3/bin/pip install --no-cache-dir \
+    && sudo apt install python3 pip -y \
+    && sudo ln -s /usr/bin/python3 /usr/bin/python \
+    && wget -O /tmp/Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" \
+    && bash /tmp/Miniforge3.sh -b -p "${HOME}/conda" \
+    && source "${HOME}/conda/etc/profile.d/conda.sh" \
+    && echo "export PATH=$HOME/.local/bin:$PATH" >> /home/ray/.bashrc \
+    && rm /tmp/Miniforge3.sh  \
+    && $HOME/conda/condabin/conda install -y libgcc-ng python=$PYTHON_VERSION \
+    && $HOME/conda/condabin/conda install -y -c conda-forge libffi=3.4.2 \
+    && $HOME/conda/condabin/conda clean -y --all \
+    && pip install --no-cache-dir \
         flatbuffers \
         cython==0.29.32 \
         # Necessary for Dataset to work properly.
@@ -64,16 +64,16 @@ RUN sudo apt-get update -y && sudo apt-get upgrade -y \
         psutil \
     # To avoid the following error on Jenkins:
     # AttributeError: 'numpy.ufunc' object has no attribute '__module__'
-    && $HOME/anaconda3/bin/pip uninstall -y dask \ 
+    && pip uninstall -y dask \
     # We install cmake temporarily to get psutil
     && sudo apt-get autoremove -y cmake zlib1g-dev \
         # We keep g++ on GPU images, because uninstalling removes CUDA Devel tooling
-        $(if [[ "$BASE_IMAGE" == "ubuntu:focal" && "$HOSTTYPE" == "x86_64" ]]; then echo \
+        $(if [[ "$BASE_IMAGE" == "ubuntu:jammy" && "$HOSTTYPE" == "x86_64" ]]; then echo \
         g++; fi) \
     && sudo rm -rf /var/lib/apt/lists/* \
     && sudo apt-get clean \
     && (if [ "$AUTOSCALER" = "autoscaler" ]; \
-        then $HOME/anaconda3/bin/pip --no-cache-dir install \
+        then pip --no-cache-dir install \
         "redis>=3.5.0,<4.0.0" \
         "six==1.13.0" \
         "boto3==1.26.76" \

--- a/docker/ray-deps/Dockerfile
+++ b/docker/ray-deps/Dockerfile
@@ -6,7 +6,8 @@ ARG WHEEL_PATH
 ARG FIND_LINKS_PATH=".whl"
 COPY $WHEEL_PATH .
 COPY $FIND_LINKS_PATH $FIND_LINKS_PATH
-RUN $HOME/anaconda3/bin/pip --no-cache-dir install --find-links $FIND_LINKS_PATH \
+RUN pip install --upgrade pip
+RUN pip --no-cache-dir install --find-links $FIND_LINKS_PATH \
     $(basename $WHEEL_PATH)[all] \
     $(if [ "$AUTOSCALER" = "autoscaler" ]; then echo \
         "redis>=3.5.0,<4.0.0" \
@@ -22,4 +23,4 @@ RUN $HOME/anaconda3/bin/pip --no-cache-dir install --find-links $FIND_LINKS_PATH
         "azure-mgmt-network==19.0.0" \
         "azure-mgmt-resource==20.0.0" \
         "msrestazure==0.6.4"; fi) \
-    && $HOME/anaconda3/bin/pip uninstall ray -y && sudo rm $(basename $WHEEL_PATH)
+    && pip uninstall ray -y && sudo rm $(basename $WHEEL_PATH)

--- a/docker/ray-ml/Dockerfile
+++ b/docker/ray-ml/Dockerfile
@@ -19,7 +19,7 @@ RUN sudo chmod +x install-ml-docker-requirements.sh \
     && ./install-ml-docker-requirements.sh
 
 # Export installed packages
-RUN $HOME/anaconda3/bin/pip freeze > /home/ray/pip-freeze.txt
+RUN pip freeze > /home/ray/pip-freeze.txt
 
 # Make sure tfp is installed correctly and matches tf version.
 RUN python -c "import tensorflow_probability"

--- a/docker/ray-ml/install-ml-docker-requirements.sh
+++ b/docker/ray-ml/install-ml-docker-requirements.sh
@@ -12,6 +12,7 @@ sudo apt-get update \
         libosmesa6-dev \
         libglfw3 \
         patchelf \
+        python3-dev \
         unzip \
         unrar \
         zlib1g-dev

--- a/docker/ray-ml/install-ml-docker-requirements.sh
+++ b/docker/ray-ml/install-ml-docker-requirements.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# shellcheck disable=SC2139
-alias pip="$HOME/anaconda3/bin/pip"
-
 sudo apt-get update \
     && sudo apt-get install -y gcc \
         cmake \

--- a/docker/ray-worker-container/Dockerfile
+++ b/docker/ray-worker-container/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="ubuntu:21.04"
+ARG BASE_IMAGE="ubuntu:22.04"
 FROM ${BASE_IMAGE}
 # FROM directive resets ARG
 ARG BASE_IMAGE
@@ -31,24 +31,24 @@ RUN apt-get update -y && sudo apt-get upgrade -y \
         openssh-client \
         gnupg; fi) \
         unzip \
-    && wget \
-        --quiet "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${HOSTTYPE}.sh" \
-        -O /tmp/miniconda.sh \
-    && /bin/bash /tmp/miniconda.sh -b -u -p $HOME/anaconda3 \
-    && $HOME/anaconda3/bin/conda init \
-    && echo 'export PATH=$HOME/anaconda3/bin:$PATH' >> /root/.bashrc \
-    && rm /tmp/miniconda.sh \
-    && $HOME/anaconda3/bin/conda install -y \
-        libgcc python=$PYTHON_VERSION \
-    && $HOME/anaconda3/bin/conda clean -y --all \
-    && $HOME/anaconda3/bin/pip install --no-cache-dir \
+    && sudo apt install python3 pip -y \
+    && sudo ln -s /usr/bin/python3 /usr/bin/python \
+    && wget -O /tmp/Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" \
+    && bash /tmp/Miniforge3.sh -b -p "${HOME}/conda" \
+    && source "${HOME}/conda/etc/profile.d/conda.sh" \
+    && echo "export PATH=$HOME/.local/bin:$PATH" >> /home/ray/.bashrc \
+    && rm /tmp/Miniforge3.sh  \
+    && $HOME/conda/condabin/conda install -y libgcc-ng python=$PYTHON_VERSION \
+    && $HOME/conda/condabin/conda install -y -c conda-forge libffi=3.4.2 \
+    && $HOME/conda/condabin/conda clean -y --all \
+    && pip install --no-cache-dir \
         flatbuffers \
         cython==0.29.32 \
         numpy==1.15.4 \
         psutil \
     # To avoid the following error on Jenkins:
     # AttributeError: 'numpy.ufunc' object has no attribute '__module__'
-    && $HOME/anaconda3/bin/pip uninstall -y dask \
+    && pip uninstall -y dask \
     # We install cmake temporarily to get psutil
     && sudo apt-get autoremove -y cmake zlib1g-dev \
         # We keep g++ on GPU images, because uninstalling removes CUDA Devel tooling

--- a/docker/ray/Dockerfile
+++ b/docker/ray/Dockerfile
@@ -10,8 +10,8 @@ COPY requirements_compiled.txt ./
 COPY $WHEEL_PATH .
 COPY $FIND_LINKS_PATH $FIND_LINKS_PATH
 
-RUN $HOME/anaconda3/bin/pip --no-cache-dir install -c $CONSTRAINTS_FILE \
+RUN pip --no-cache-dir install -c $CONSTRAINTS_FILE \
     `basename $WHEEL_PATH`[all] \
     --find-links $FIND_LINKS_PATH && sudo rm `basename $WHEEL_PATH`
 
-RUN $HOME/anaconda3/bin/pip freeze > /home/ray/pip-freeze.txt
+RUN pip freeze > /home/ray/pip-freeze.txt


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The Ray container images use the Anaconda Python distribution, which has a restrictive license. This PR switches the Python in the various containers to use generic Python and conda-forge.

It also bumps the Ubuntu base image up to Jammy / 22.04 and updates the Ray wheel url to use Python 3.10

Happy to make updates if some of my assumptions need revising. 

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #42077 

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X] This PR is not tested :(

The build-docker script says that it is explicitly not tested, but I've built the images locally and used them for a few of my workloads without issue as a sanity check. 
