### PR TITLE
[Serve] Use signal actor to test request timeout behavior

### DIFF
--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -206,22 +206,20 @@ def test_streaming_request_already_sent_and_timed_out(ray_instance, shutdown_ser
     Verify that streaming requests are timed out even if some chunks have already
     been sent.
     """
+    signal_actor = SignalActor.remote()
 
     @serve.deployment(graceful_shutdown_timeout_s=0, max_ongoing_requests=1)
-    class SleepForNSeconds:
-        def __init__(self, sleep_s: int):
-            self.sleep_s = sleep_s
-
-        def generate_numbers(self) -> Generator[str, None, None]:
+    class BlockOnSecondChunk:
+        async def generate_numbers(self) -> Generator[str, None, None]:
             for i in range(2):
                 yield f"generated {i}"
-                time.sleep(self.sleep_s)
+                await signal_actor.wait.remote()
 
         def __call__(self, request: Request) -> StreamingResponse:
             gen = self.generate_numbers()
             return StreamingResponse(gen, status_code=200, media_type="text/plain")
 
-    serve.run(SleepForNSeconds.bind(0.11))  # 0.11s > 0.1s timeout
+    serve.run(BlockOnSecondChunk.bind())
 
     r = requests.get("http://localhost:8000", stream=True)
     iterator = r.iter_content(chunk_size=None, decode_unicode=True)

--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import sys
-import time
 from typing import Generator, Set
 
 import pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test was previously relying on timing to see the behavior and can be flaky. Update the test to use signal actor to ensure the chunk will be blocked until needed. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
