### PR TITLE
[release-automation] Not checking Ray commit for release branch

### DIFF
--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -89,6 +89,7 @@ steps:
         RELEASE_FREQUENCY: "weekly"
 
   - label: "Check Ray commit in {{matrix}} nightly images"
+    if: build.branch !~ /^releases\//
     depends_on: trigger-postmerge
     allow_dependency_failure: true
     job_env: forge


### PR DESCRIPTION
- Only run step when branch doesn't start with `releases/`