### PR TITLE
[serve] Prevent ASGI `receive()` from hanging on disconnects

### DIFF
--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -228,7 +228,14 @@ class ASGIReceiveProxy:
         self._disconnect_message = None
 
     def _get_default_disconnect_message(self) -> Message:
-        """Return the appropriate disconnect message based on the connection type."""
+        """Return the appropriate disconnect message based on the connection type.
+
+        HTTP ASGI spec:
+            https://asgi.readthedocs.io/en/latest/specs/www.html#disconnect-receive-event
+
+        WS ASGI spec:
+            https://asgi.readthedocs.io/en/latest/specs/www.html#disconnect-receive-event-ws
+        """
         if self._type == "websocket":
             return {
                 "type": "websocket.disconnect",

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -269,6 +269,7 @@ class ASGIReceiveProxy:
                 message = self._get_default_disconnect_message()
                 self._queue.put_nowait(message)
                 self._disconnect_message = message
+                return
             except Exception as e:
                 # Raise unexpected exceptions in the next `__call__`.
                 self._queue.put_nowait(e)

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -217,13 +217,26 @@ class ASGIReceiveProxy:
 
     def __init__(
         self,
+        scope: Scope,
         request_id: str,
         receive_asgi_messages: Callable[[str], Awaitable[bytes]],
     ):
+        self._type = scope["type"]  # Either 'http' or 'websocket'.
         self._queue = asyncio.Queue()
         self._request_id = request_id
         self._receive_asgi_messages = receive_asgi_messages
         self._disconnect_message = None
+
+    def _get_default_disconnect_message(self) -> Message:
+        """Return the appropriate disconnect message based on the connection type."""
+        if self._type == "websocket":
+            return {
+                "type": "websocket.disconnect",
+                # 1005 is the default disconnect code according to the ASGI spec.
+                "code": 1005,
+            }
+        else:
+            return {"type": "http.disconnect"}
 
     async def fetch_until_disconnect(self):
         """Fetch messages repeatedly until a disconnect message is received.
@@ -244,9 +257,11 @@ class ASGIReceiveProxy:
                         return
             except KeyError:
                 # KeyError can be raised if the request is no longer active in the proxy
-                # (e.g., the user disconnects). This is expected behavior and we should
+                # (i.e., the user disconnects). This is expected behavior and we should
                 # not log an error: https://github.com/ray-project/ray/issues/43290.
-                return
+                message = self._get_default_disconnect_message()
+                self._queue.put_nowait(message)
+                self._disconnect_message = message
             except Exception as e:
                 # Raise unexpected exceptions in the next `__call__`.
                 self._queue.put_nowait(e)

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -107,6 +107,11 @@ RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S = (
 # of the performance optimizations to make troubleshooting easier
 RAY_SERVE_DEBUG_MODE = bool(os.environ.get("RAY_SERVE_DEBUG_MODE", 0))
 
+RAY_SERVE_ASGI_RECEIVE_QUEUE_GRACE_PERIOD_S = float(
+    os.environ.get("RAY_SERVE_ASGI_RECEIVE_QUEUE_GRACE_PERIOD_S", "10.0")
+)
+
+
 if os.environ.get("SERVE_REQUEST_PROCESSING_TIMEOUT_S") is not None:
     logger.warning(
         "The `SERVE_REQUEST_PROCESSING_TIMEOUT_S` environment variable has "
@@ -151,6 +156,7 @@ class GenericProxy(ABC):
             self.request_timeout_s = None
 
         self._node_id = node_id
+        self._event_loop = get_or_create_event_loop()
 
         # Flipped to `True` once the route table has been updated at least once.
         # Health checks will not pass until the route table is populated.
@@ -944,7 +950,7 @@ class HTTPProxy(GenericProxy):
         # actor to receive the messages.
         receive_queue = MessageQueue()
         self.asgi_receive_queues[request_id] = receive_queue
-        proxy_asgi_receive_task = get_or_create_event_loop().create_task(
+        proxy_asgi_receive_task = self._event_loop.create_task(
             self.proxy_asgi_receive(proxy_request.receive, receive_queue)
         )
 
@@ -1075,7 +1081,15 @@ class HTTPProxy(GenericProxy):
                         is_error=True,
                     )
 
-            del self.asgi_receive_queues[request_id]
+            # Clean up the created ASGI receive queue after a grace period.
+            # The grace period is provided because the replica code may still be running
+            # in the case of a disconnect.
+            # TODO(edoakes): move to a push-based model to avoid these edge cases.
+            self._event_loop.call_later(
+                RAY_SERVE_ASGI_RECEIVE_QUEUE_GRACE_PERIOD_S,
+                self.asgi_receive_queues.pop,
+                request_id,
+            )
 
         # The status code should always be set.
         assert status is not None

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -942,7 +942,9 @@ class UserCallableWrapper:
 
         The returned `receive_task` should be cancelled when the user method exits.
         """
+        scope = pickle.loads(request.pickled_asgi_scope)
         receive = ASGIReceiveProxy(
+            scope,
             request_metadata.request_id,
             request.receive_asgi_messages,
         )
@@ -950,7 +952,7 @@ class UserCallableWrapper:
             receive.fetch_until_disconnect()
         )
         asgi_args = ASGIArgs(
-            scope=pickle.loads(request.pickled_asgi_scope),
+            scope=scope,
             receive=receive,
             send=generator_result_callback,
         )

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -351,6 +351,8 @@ class ReplicaActor:
         try:
             self._metrics_manager.inc_num_ongoing_requests()
             yield
+        except asyncio.CancelledError as e:
+            user_exception = e
         except Exception as e:
             user_exception = e
             logger.error(f"Request failed:\n{e}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See https://github.com/ray-project/ray/issues/44644 for the user-reported issue.

In https://github.com/ray-project/ray/pull/43713, I changed the behavior of the ASGI `receive` interface to not raise an exception but rather silently hang if the request was not present in the proxy. This was done under the assumption that the code calling `receive` would be subsequently cancelled anyways. However, this assumption was faulty for a few reasons:

- The user may ignore the `CancelledError` but still want to fetch `ASGI` messages.
- Cancellation is best-effort. Specifically, because we are currently using the `run_coroutine_threadsafe` / `concurrent.futures.Executor` interface, there is no way to guarantee that either the scheduling task is cancelled or the resulting object ref is cancelled. In rare cases, neither may happen (see https://github.com/python/cpython/issues/105836).

This PR mitigates the issue by returning an appropriate `disconnect` ASGI message when the proxy no longer has the request in scope.

Note that this is not a perfect solution: we may still drop the messages _prior_ to the disconnect (e.g., the body of the HTTP request) if the replica does not fetch them prior to the client disconnecting.

- Note that this is not a regression from the current behavior and should only happen in practice if the client disconnects very quickly after initiating the request.
- As a follow-up, we should rework this codepath to something more robust. For example we could use a push-based model where the proxy instead pushes messages eagerly to the replica (this was originally very difficult to implement but should be possible now).

TODO before merging:

- [x] Manually verify the fix using the reproduction script in the issue.

## Related issue number

Closes https://github.com/ray-project/ray/issues/44644

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
