### PR TITLE
[ci] fix fetch_release_logs for master release

### DIFF
--- a/release/release_logs/fetch_release_logs.py
+++ b/release/release_logs/fetch_release_logs.py
@@ -199,13 +199,17 @@ def write_results(log_dir: Path, fetched_results: Dict[str, Any]) -> None:
 
 @click.command()
 @click.argument("version", required=True)
-def main(version: str):
+@click.argument("commit", required=True)
+@click.argument("branch", required=True)
+def main(version: str, commit: str, branch: str):
     log_dir = Path(__file__).parent.joinpath(version)
-    branch = f"releases/{version}"
 
     bk = get_buildkite_api()
     build_dict_list = bk.builds().list_all_for_pipeline(
-        organization=BUILDKITE_ORGANIZATION, pipeline=BUILDKITE_PIPELINE, branch=branch
+        organization=BUILDKITE_ORGANIZATION,
+        pipeline=BUILDKITE_PIPELINE,
+        branch=branch,
+        commit=commit,
     )
     fetched_results = get_results_from_build_collection(bk, build_dict_list)
     write_results(log_dir, fetched_results)


### PR DESCRIPTION
Fix the `fetch_release_logs` to download the logs from a commit from a master branch. This will still download to the directory of the ray version under release.

Test:
- run it locally