### PR TITLE
[Train] Add Schema for Train Run and Train Worker

### DIFF
--- a/python/ray/train/_internal/schema.py
+++ b/python/ray/train/_internal/schema.py
@@ -1,0 +1,46 @@
+from typing import List, Optional
+
+from ray._private.pydantic_compat import BaseModel, Field
+from ray.util.annotations import DeveloperAPI
+
+
+@DeveloperAPI
+class TrainWorkerInfo(BaseModel):
+    """Metadata of a Ray Train worker."""
+
+    actor_id: str = Field(description="Actor ID of the worker.")
+    world_rank: int = Field(description="World rank.")
+    local_rank: int = Field(description="Local rank.")
+    node_rank: int = Field(description="Node rank.")
+    gpu_ids: Optional[List[str]] = Field(
+        description="A list of GPU ids allocated to that worker."
+    )
+    node_id: Optional[str] = Field(
+        description="ID of the node that the worker is running on."
+    )
+    node_ip: Optional[str] = Field(
+        description="IP address of the node that the worker is running on."
+    )
+    pid: Optional[str] = Field(description="PID of the worker.")
+
+
+@DeveloperAPI
+class TrainRunInfo(BaseModel):
+    """Metadata for a Ray Train run and information about its workers."""
+
+    name: str = Field(description="The name of the Train run.")
+    id: str = Field(description="The unique identifier for each Train run.")
+    job_id: str = Field(description="Ray Job ID.")
+    trial_name: str = Field(
+        description=(
+            "Trial name. It should be different among different Train runs, "
+            "except for those that are restored from checkpoints."
+        )
+    )
+    trainer_actor_id: str = Field(description="Actor Id of the Trainer.")
+    workers: List[TrainWorkerInfo] = Field(
+        description="A List of Train workers sorted by global ranks."
+    )
+    dataset_ids: Optional[List[str]] = Field(
+        description="A List of dataset ids for this Train run."
+    )

--- a/python/ray/train/_internal/schema.py
+++ b/python/ray/train/_internal/schema.py
@@ -12,31 +12,29 @@ class TrainWorkerInfo(BaseModel):
     world_rank: int = Field(description="World rank.")
     local_rank: int = Field(description="Local rank.")
     node_rank: int = Field(description="Node rank.")
+    node_id: str = Field(description="ID of the node that the worker is running on.")
+    node_ip: str = Field(
+        description="IP address of the node that the worker is running on."
+    )
+    pid: str = Field(description="PID of the worker.")
     gpu_ids: Optional[List[str]] = Field(
         description="A list of GPU ids allocated to that worker."
     )
-    node_id: Optional[str] = Field(
-        description="ID of the node that the worker is running on."
-    )
-    node_ip: Optional[str] = Field(
-        description="IP address of the node that the worker is running on."
-    )
-    pid: Optional[str] = Field(description="PID of the worker.")
 
 
 @DeveloperAPI
 class TrainRunInfo(BaseModel):
     """Metadata for a Ray Train run and information about its workers."""
 
-    name: str = Field(description="The name of the Train run.")
     id: str = Field(description="The unique identifier for each Train run.")
-    job_id: str = Field(description="Ray Job ID.")
-    trial_name: str = Field(
+    name: str = Field(description="The name of the Train run.")
+    trial_name: Optional[str] = Field(
         description=(
             "Trial name. It should be different among different Train runs, "
             "except for those that are restored from checkpoints."
         )
     )
+    job_id: str = Field(description="The Ray Job ID.")
     trainer_actor_id: str = Field(description="Actor Id of the Trainer.")
     workers: List[TrainWorkerInfo] = Field(
         description="A List of Train workers sorted by global ranks."

--- a/python/ray/train/lightning/_lightning_utils.py
+++ b/python/ray/train/lightning/_lightning_utils.py
@@ -26,7 +26,6 @@ def import_lightning():  # noqa: F402
 pl = import_lightning()
 
 _LIGHTNING_GREATER_EQUAL_2_0 = Version(pl.__version__) >= Version("2.0.0")
-_LIGHTNING_LESS_THAN_2_1 = Version(pl.__version__) < Version("2.1.0")
 _TORCH_GREATER_EQUAL_1_12 = Version(torch.__version__) >= Version("1.12.0")
 _TORCH_FSDP_AVAILABLE = _TORCH_GREATER_EQUAL_1_12 and torch.distributed.is_available()
 
@@ -107,14 +106,7 @@ class RayFSDPStrategy(FSDPStrategy):  # noqa: F821
         """Gathers the full state dict to rank 0 on CPU."""
         assert self.model is not None, "Failed to get the state dict for a None model!"
 
-        # Lightning < 2.1 lacks FSDP sharding_strategy support.
-        # (PR: https://github.com/Lightning-AI/pytorch-lightning/pull/18087).
-        # We need this patch logic to enable FSDP checkpointing between 2.0 and 2.1.
-        if (
-            _TORCH_FSDP_AVAILABLE
-            and _LIGHTNING_GREATER_EQUAL_2_0
-            and _LIGHTNING_LESS_THAN_2_1
-        ):
+        if _LIGHTNING_GREATER_EQUAL_2_0 and _TORCH_FSDP_AVAILABLE:
             with FullyShardedDataParallel.state_dict_type(
                 module=self.model,
                 state_dict_type=StateDictType.FULL_STATE_DICT,

--- a/python/ray/train/lightning/_lightning_utils.py
+++ b/python/ray/train/lightning/_lightning_utils.py
@@ -26,6 +26,7 @@ def import_lightning():  # noqa: F402
 pl = import_lightning()
 
 _LIGHTNING_GREATER_EQUAL_2_0 = Version(pl.__version__) >= Version("2.0.0")
+_LIGHTNING_LESS_THAN_2_1 = Version(pl.__version__) < Version("2.1.0")
 _TORCH_GREATER_EQUAL_1_12 = Version(torch.__version__) >= Version("1.12.0")
 _TORCH_FSDP_AVAILABLE = _TORCH_GREATER_EQUAL_1_12 and torch.distributed.is_available()
 
@@ -106,7 +107,14 @@ class RayFSDPStrategy(FSDPStrategy):  # noqa: F821
         """Gathers the full state dict to rank 0 on CPU."""
         assert self.model is not None, "Failed to get the state dict for a None model!"
 
-        if _LIGHTNING_GREATER_EQUAL_2_0 and _TORCH_FSDP_AVAILABLE:
+        # Lightning < 2.1 lacks FSDP sharding_strategy support.
+        # (PR: https://github.com/Lightning-AI/pytorch-lightning/pull/18087).
+        # We need this patch logic to enable FSDP checkpointing between 2.0 and 2.1.
+        if (
+            _TORCH_FSDP_AVAILABLE
+            and _LIGHTNING_GREATER_EQUAL_2_0
+            and _LIGHTNING_LESS_THAN_2_1
+        ):
             with FullyShardedDataParallel.state_dict_type(
                 module=self.model,
                 state_dict_type=StateDictType.FULL_STATE_DICT,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This is the pydantic schema for the metadata of a Train Run. Each Trainer will construct and send the `TrainRunInfo` object to Ray Train dashboard for observability.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
