### PR TITLE
[Logs] Streamlining log-tailing sequence

### DIFF
--- a/dashboard/modules/job/tests/test_utils.py
+++ b/dashboard/modules/job/tests/test_utils.py
@@ -162,31 +162,19 @@ class TestIterLine:
 
         f = open(tmp, "w")
 
-        # Write a single line that is over 60000 characters,
-        # check we get it in batches of 20000
+        # Write a single line that is 60k characters
         f.write(f"{'1234567890' * 6000}\n")
+        # Write a 4 lines that are 10k characters each
+        for _ in range(4):
+            f.write(f"{'1234567890' * 500}\n")
         f.flush()
 
-        assert next(it) == ["1234567890" * 2000]
-        assert next(it) == ["1234567890" * 2000]
-        assert next(it) == ["1234567890" * 2000]
-        assert next(it) == ["\n"]
-        assert next(it) is None
-
-        # Write a 10 lines where last line is over 20000 characters,
-        # check we get it in batches of 20000
-        for i in range(9):
-            f.write(f"{i}\n")
-        f.write(f"{'1234567890' * 2000}\n")
-        f.flush()
-
-        first_nine_lines = [f"{i}\n" for i in range(9)]
-        first_nine_lines_length = sum(len(line) for line in first_nine_lines)
-        assert next(it) == first_nine_lines + [
-            f"{'1234567890' * 2000}"[0:-first_nine_lines_length]
-        ]
-        # Remainder of last line
-        assert next(it) == [f"{'1234567890' * 2000}"[-first_nine_lines_length:] + "\n"]
+        # First line will come in a batch of its own
+        assert next(it) == [f"{'1234567890' * 6000}\n"]
+        # Other 4 lines will be batched together
+        assert next(it) == [
+            f"{'1234567890' * 500}\n",
+        ] * 4
         assert next(it) is None
 
     def test_delete_file(self):

--- a/dashboard/modules/job/tests/test_utils.py
+++ b/dashboard/modules/job/tests/test_utils.py
@@ -172,9 +172,13 @@ class TestIterLine:
         # First line will come in a batch of its own
         assert next(it) == [f"{'1234567890' * 6000}\n"]
         # Other 4 lines will be batched together
-        assert next(it) == [
-            f"{'1234567890' * 500}\n",
-        ] * 4
+        assert (
+            next(it)
+            == [
+                f"{'1234567890' * 500}\n",
+            ]
+            * 4
+        )
         assert next(it) is None
 
     def test_delete_file(self):

--- a/dashboard/modules/job/utils.py
+++ b/dashboard/modules/job/utils.py
@@ -79,11 +79,6 @@ def file_tail_iterator(path: str) -> Iterator[Optional[List[str]]]:
         curr_line = None
 
         while True:
-            if curr_line is None:
-                # Only read the next line in the file
-                # if there's no remaining "curr_line" to process
-                curr_line = f.readline()
-
             # We want to flush current chunk in following cases:
             #   - We accumulated 10 lines
             #   - We accumulated at least MAX_CHUNK_CHAR_LENGTH total chars
@@ -99,7 +94,9 @@ def file_tail_iterator(path: str) -> Iterator[Optional[List[str]]]:
 
                 lines = []
                 chunk_char_count = 0
-                curr_line = None
+
+            # Read next line
+            curr_line = f.readline()
 
             # `readline` will return
             #   - '' for EOF
@@ -108,11 +105,9 @@ def file_tail_iterator(path: str) -> Iterator[Optional[List[str]]]:
                 # Add line to current chunk
                 lines.append(curr_line)
                 chunk_char_count += len(curr_line)
-                curr_line = None
             else:
                 # If EOF is reached sleep for 1s before continuing
                 time.sleep(1)
-                curr_line = None
 
 
 async def parse_and_validate_request(

--- a/dashboard/modules/job/utils.py
+++ b/dashboard/modules/job/utils.py
@@ -70,7 +70,7 @@ def file_tail_iterator(path: str) -> Iterator[Optional[List[str]]]:
         logger.debug(f"Path {path} doesn't exist yet.")
         yield None
 
-    EOF = ''
+    EOF = ""
 
     with open(path, "r") as f:
         lines = []
@@ -88,7 +88,11 @@ def file_tail_iterator(path: str) -> Iterator[Optional[List[str]]]:
             #   - We accumulated 10 lines
             #   - We accumulated at least MAX_CHUNK_CHAR_LENGTH total chars
             #   - We reached EOF
-            if len(lines) >= 10 or chunk_char_count > MAX_CHUNK_CHAR_LENGTH or curr_line == EOF:
+            if (
+                len(lines) >= 10
+                or chunk_char_count > MAX_CHUNK_CHAR_LENGTH
+                or curr_line == EOF
+            ):
                 # Too many lines, return 10 lines in this chunk, and then
                 # continue reading the file.
                 yield lines or None

--- a/dashboard/modules/job/utils.py
+++ b/dashboard/modules/job/utils.py
@@ -2,6 +2,7 @@ import dataclasses
 import logging
 import os
 import re
+import time
 import traceback
 from dataclasses import dataclass
 from typing import Iterator, List, Optional, Any, Dict, Tuple, Union
@@ -69,44 +70,44 @@ def file_tail_iterator(path: str) -> Iterator[Optional[List[str]]]:
         logger.debug(f"Path {path} doesn't exist yet.")
         yield None
 
+    EOF = ''
+
     with open(path, "r") as f:
         lines = []
+
         chunk_char_count = 0
         curr_line = None
+
         while True:
             if curr_line is None:
                 # Only read the next line in the file
                 # if there's no remaining "curr_line" to process
                 curr_line = f.readline()
-            new_chunk_char_count = chunk_char_count + len(curr_line)
-            if new_chunk_char_count > MAX_CHUNK_CHAR_LENGTH:
-                # Too many characters, return 20000 in this chunk, and then
-                # continue loop with remaining characters in curr_line
-                truncated_line = curr_line[0 : MAX_CHUNK_CHAR_LENGTH - chunk_char_count]
-                lines.append(truncated_line)
-                # Set remainder of current line to process next
-                curr_line = curr_line[MAX_CHUNK_CHAR_LENGTH - chunk_char_count :]
-                yield lines or None
-                lines = []
-                chunk_char_count = 0
-            elif len(lines) >= 9:
+
+            # We want to flush current chunk in following cases:
+            #   - We accumulated 10 lines
+            #   - We accumulated at least MAX_CHUNK_CHAR_LENGTH total chars
+            #   - We reached EOF
+            if len(lines) >= 10 or chunk_char_count > MAX_CHUNK_CHAR_LENGTH or curr_line == EOF:
                 # Too many lines, return 10 lines in this chunk, and then
                 # continue reading the file.
-                lines.append(curr_line)
                 yield lines or None
+
                 lines = []
                 chunk_char_count = 0
                 curr_line = None
-            elif curr_line:
+
+            # `readline` will return
+            #   - '' for EOF
+            #   - '\n' for an empty line in the file
+            if curr_line != EOF:
                 # Add line to current chunk
                 lines.append(curr_line)
-                chunk_char_count = new_chunk_char_count
+                chunk_char_count += len(curr_line)
                 curr_line = None
             else:
-                # readline() returns empty string when there's no new line.
-                yield lines or None
-                lines = []
-                chunk_char_count = 0
+                # If EOF is reached sleep for 1s before continuing
+                time.sleep(1)
                 curr_line = None
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Changes
---

Revisited log-tailing sequence to
 - Get it streamlined and simplified
 - Avoid busy-looping when reached EOF (instead doing 1s sleeps)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Addresses https://github.com/ray-project/ray/issues/44659

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
