### PR TITLE
[ci][postmerge/3] actually trigger gap builds

### DIFF
--- a/ci/ray_ci/pipeline/gap_filling_scheduler.py
+++ b/ci/ray_ci/pipeline/gap_filling_scheduler.py
@@ -93,7 +93,7 @@ class GapFillingScheduler:
             .split("\n")
         )
 
-    def _get_builds(self) -> List[Dict[str, Any]]:
+    def _get_builds(self, days_ago: int = 1) -> List[Dict[str, Any]]:
         return self.buildkite.builds().list_all_for_pipeline(
             self.buildkite_organization,
             self.buildkite_pipeline,

--- a/ci/ray_ci/pipeline/gap_filling_scheduler.py
+++ b/ci/ray_ci/pipeline/gap_filling_scheduler.py
@@ -93,7 +93,7 @@ class GapFillingScheduler:
             .split("\n")
         )
 
-    def _get_builds(self, days_ago: int = 1) -> List[Dict[str, Any]]:
+    def _get_builds(self) -> List[Dict[str, Any]]:
         return self.buildkite.builds().list_all_for_pipeline(
             self.buildkite_organization,
             self.buildkite_pipeline,

--- a/ci/ray_ci/pipeline/test_gap_filling_scheduler.py
+++ b/ci/ray_ci/pipeline/test_gap_filling_scheduler.py
@@ -91,43 +91,52 @@ def test_run(mock_get_gap_commits, mock_trigger_build):
     )
 
 
-@mock.patch("ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._init_buildkite")
-@mock.patch("ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._get_builds")
 @mock.patch("subprocess.check_output")
-def test_get_commits_between_passing_and_failing(mock_init_buildkite, mock_get_builds, mock_check_output):
+@mock.patch(
+    "ci.ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._get_latest_commits"
+)
+@mock.patch("ci.ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._get_builds")
+def test_get_gap_commits(mock_get_builds, mock_get_latest_commits, mock_check_output):
     def _mock_check_output_side_effect(cmd: str, shell: bool) -> str:
         assert cmd == "git rev-list --reverse ^111 444~"
         return b"222\n333\n"
+
     mock_get_builds.return_value = [
         {
-            "number": 2,
             "state": "passed",
             "commit": "111",
         },
         {
-            "number": 3,
             "state": "failed",
             "commit": "444",
         },
     ]
+    mock_get_latest_commits.return_value = [
+        "444",
+        "111",
+    ]
     mock_check_output.side_effect = _mock_check_output_side_effect
-    scheduler = GapFillingScheduler("org", "pipeline")
-    assert scheduler._get_gap_commits() == ["222", "333"]
+    scheduler = GapFillingScheduler("org", "pipeline", "token")
+    assert scheduler.get_gap_commits() == ["222", "333"]
 
 
-@mock.patch("ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._init_buildkite")
-@mock.patch("ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._get_gap_commits")
-@mock.patch("ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._create_build")
-def test_run(mock_init_buildkite, mock_get_gap_commits, mock_create_build):
+@mock.patch(
+    "ci.ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._trigger_build"
+)
+@mock.patch(
+    "ci.ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler.get_gap_commits"
+)
+def test_run(mock_get_gap_commits, mock_trigger_build):
     mock_get_gap_commits.return_value = ["222", "333"]
-    scheduler = GapFillingScheduler("org", "pipeline")
-    scheduler.run(dry_run=True)
-    mock_create_build.assert_not_called()
-    scheduler.run(dry_run=False)
-    mock_create_build.assert_has_calls([
-        mock.call("222"),
-        mock.call("333"),
-    ])
+    scheduler = GapFillingScheduler("org", "pipeline", "token")
+    scheduler.run()
+    mock_trigger_build.assert_has_calls(
+        [
+            mock.call("222"),
+            mock.call("333"),
+        ]
+    )
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/ci/ray_ci/pipeline/test_gap_filling_scheduler.py
+++ b/ci/ray_ci/pipeline/test_gap_filling_scheduler.py
@@ -91,5 +91,43 @@ def test_run(mock_get_gap_commits, mock_trigger_build):
     )
 
 
+@mock.patch("ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._init_buildkite")
+@mock.patch("ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._get_builds")
+@mock.patch("subprocess.check_output")
+def test_get_commits_between_passing_and_failing(mock_init_buildkite, mock_get_builds, mock_check_output):
+    def _mock_check_output_side_effect(cmd: str, shell: bool) -> str:
+        assert cmd == "git rev-list --reverse ^111 444~"
+        return b"222\n333\n"
+    mock_get_builds.return_value = [
+        {
+            "number": 2,
+            "state": "passed",
+            "commit": "111",
+        },
+        {
+            "number": 3,
+            "state": "failed",
+            "commit": "444",
+        },
+    ]
+    mock_check_output.side_effect = _mock_check_output_side_effect
+    scheduler = GapFillingScheduler("org", "pipeline")
+    assert scheduler._get_gap_commits() == ["222", "333"]
+
+
+@mock.patch("ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._init_buildkite")
+@mock.patch("ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._get_gap_commits")
+@mock.patch("ray_ci.pipeline.gap_filling_scheduler.GapFillingScheduler._create_build")
+def test_run(mock_init_buildkite, mock_get_gap_commits, mock_create_build):
+    mock_get_gap_commits.return_value = ["222", "333"]
+    scheduler = GapFillingScheduler("org", "pipeline")
+    scheduler.run(dry_run=True)
+    mock_create_build.assert_not_called()
+    scheduler.run(dry_run=False)
+    mock_create_build.assert_has_calls([
+        mock.call("222"),
+        mock.call("333"),
+    ])
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Implement the function to trigger a blocked build on postmerge

- Also cache the _get_builds function which is used repeatedly and quite expensive


Test:
- CI