### PR TITLE
[Data] Add ability to not print certain logs to console

### DIFF
--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -22,6 +22,26 @@ DEFAULT_CONFIG_PATH = os.path.abspath(
 logging.addLevelName(logging.DEBUG - 1, "TRACE")
 
 
+class HiddenRecordFilter:
+    """Filters out log records with the "hide" attribute set to True.
+
+    This filter allows you to override default logging behavior. For example, if errors
+    are printed by default, and you don't want to print a specific error, you can set
+    the "hide" attribute to avoid printing the message.
+
+    .. testcode::
+
+        import logging
+        logger = logging.getLogger("ray.data.spam")
+
+        # This warning won't be printed to the console.
+        logger.warning("ham", extra={"hide": True})
+    """
+
+    def filter(self, record):
+        return not getattr(record, "hide", False)
+
+
 class SessionFileHandler(logging.Handler):
     """A handler that writes to a log file in the Ray session directory.
 

--- a/python/ray/data/_internal/logging.yaml
+++ b/python/ray/data/_internal/logging.yaml
@@ -5,6 +5,10 @@ formatters:
     ray:
         format: "%(asctime)s\t%(levelname)s %(filename)s:%(lineno)s -- %(message)s"
 
+filters:
+    console_filter:
+        (): ray.data._internal.logging.HiddenRecordFilter
+
 handlers:
     file:
         class: ray.data._internal.logging.SessionFileHandler
@@ -14,6 +18,7 @@ handlers:
         class: ray._private.log.PlainRayHandler
         formatter: ray
         level: INFO
+        filters: [console_filter]
 
 loggers:
     ray.data:

--- a/python/ray/data/exceptions.py
+++ b/python/ray/data/exceptions.py
@@ -77,11 +77,9 @@ def omit_traceback_stdout(fn: Callable) -> Callable:
                     "https://github.com/ray-project/ray/issues/new/choose"
                 )
 
-            if log_to_stdout:
-                logger.exception("Full stack trace:")
-            else:
-                logger.debug("Full stack trace:", exc_info=True)
-
+            logger.exception(
+                "Full stack trace:", exc_info=True, extra={"hide": not log_to_stdout}
+            )
             if is_user_code_exception:
                 raise e.with_traceback(None)
             else:

--- a/python/ray/data/tests/test_exceptions.py
+++ b/python/ray/data/tests/test_exceptions.py
@@ -28,7 +28,9 @@ def test_user_exception(caplog, propagate_logs, ray_start_regular_shared):
     ), caplog.records
 
     assert any(
-        record.levelno == logging.DEBUG and "Full stack trace:" in record.message
+        record.levelno == logging.ERROR
+        and "Full stack trace:" in record.message
+        and record.hide
         for record in caplog.records
     ), caplog.records
 
@@ -57,7 +59,9 @@ def test_system_exception(caplog, propagate_logs, ray_start_regular_shared):
     ), caplog.records
 
     assert any(
-        record.levelno == logging.DEBUG and "Full stack trace:" in record.message
+        record.levelno == logging.ERROR
+        and "Full stack trace:" in record.message
+        and record.hide
         for record in caplog.records
     ), caplog.records
 

--- a/python/ray/data/tests/test_logging.py
+++ b/python/ray/data/tests/test_logging.py
@@ -52,6 +52,19 @@ def test_messages_printed_to_console(
     assert "ham" in capsys.readouterr().err
 
 
+def test_hidden_messages_not_printed_to_console(
+    capsys,
+    configure_logging,
+    reset_logging,
+    propagate_logs,
+):
+    logger = logging.getLogger("ray.data.spam")
+
+    logger.info("ham", extra={"hide": True})
+
+    assert "ham" not in capsys.readouterr().err
+
+
 def test_message_format(configure_logging, reset_logging, shutdown_only):
     ray.init()
     logger = logging.getLogger("ray.data.spam")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

All info, warning, and error logs are printed to console. However, we don't want to print some errors to the console (specifically, we don't want to print full tracebacks from some UDF errors). To avoid printing these errors, we use DEBUG logs rather than WARNING logs. The issue with this approach is that it makes it harder to configuring logging for ERROR level logs.

This PR solves this issue by adding a flag to not write logs to console.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
