### PR TITLE
[cherry-pick; RLlib] Fix running w/ exactly 1 GPU on new API stack.

### DIFF
--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -383,7 +383,7 @@ class LearnerGroup:
                 # In the multi-agent case AND `minibatch_size` AND num_workers > 1, we
                 # compute a max iteration counter such that the different Learners will
                 # not go through a different number of iterations.
-                min_total_mini_batches = None
+                min_total_mini_batches = 0
                 if (
                     isinstance(episodes[0], MultiAgentEpisode)
                     and minibatch_size


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Cherry picks [this fix here](https://github.com/ray-project/ray/pull/44664) into 2.11. Broken since 4 days ago [by this PR](https://github.com/ray-project/ray/pull/44420).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
