### PR TITLE
[RLlib] Add lr-scheduling option to separate value function optimizer for APPO/IMPALA.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -163,7 +163,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_separate_losses_appo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rllib", "torch_only", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = [

--- a/rllib/algorithms/appo/appo_torch_policy.py
+++ b/rllib/algorithms/appo/appo_torch_policy.py
@@ -79,7 +79,16 @@ class APPOTorchPolicy(
             # that base.__init__ will use the make_model() call.
             VTraceOptimizer.__init__(self)
 
-        LearningRateSchedule.__init__(self, config["lr"], config["lr_schedule"])
+        lr_schedule_additional_args = []
+        if config.get("_separate_vf_optimizer"):
+            lr_schedule_additional_args = (
+                [config["_lr_vf"][0][1], config["_lr_vf"]]
+                if isinstance(config["_lr_vf"], (list, tuple))
+                else [config["_lr_vf"], None]
+            )
+        LearningRateSchedule.__init__(
+            self, config["lr"], config["lr_schedule"], *lr_schedule_additional_args
+        )
 
         TorchPolicyV2.__init__(
             self,

--- a/rllib/algorithms/impala/impala_torch_policy.py
+++ b/rllib/algorithms/impala/impala_torch_policy.py
@@ -204,7 +204,7 @@ class VTraceOptimizer:
             if self.config["opt_type"] == "adam":
                 return (
                     torch.optim.Adam(params=policy_params, lr=self.cur_lr),
-                    torch.optim.Adam(params=value_params, lr=self.config["_lr_vf"]),
+                    torch.optim.Adam(params=value_params, lr=self.cur_lr2),
                 )
             else:
                 raise NotImplementedError
@@ -246,7 +246,15 @@ class ImpalaTorchPolicy(
             VTraceOptimizer.__init__(self)
             # Need to initialize learning rate variable before calling
             # TorchPolicyV2.__init__.
-            LearningRateSchedule.__init__(self, config["lr"], config["lr_schedule"])
+            lr_schedule_additional_args = []
+            if config.get("_separate_vf_optimizer"):
+                lr_schedule_additional_args = [
+                    config["_lr_vf"][0][1],
+                    config["_lr_vf"]
+                ] if isinstance(config["_lr_vf"], list) else [config["_lr_vf"], None]
+            LearningRateSchedule.__init__(
+                self, config["lr"], config["lr_schedule"], *lr_schedule_additional_args
+            )
             EntropyCoeffSchedule.__init__(
                 self, config["entropy_coeff"], config["entropy_coeff_schedule"]
             )

--- a/rllib/algorithms/impala/impala_torch_policy.py
+++ b/rllib/algorithms/impala/impala_torch_policy.py
@@ -248,10 +248,11 @@ class ImpalaTorchPolicy(
             # TorchPolicyV2.__init__.
             lr_schedule_additional_args = []
             if config.get("_separate_vf_optimizer"):
-                lr_schedule_additional_args = [
-                    config["_lr_vf"][0][1],
-                    config["_lr_vf"]
-                ] if isinstance(config["_lr_vf"], list) else [config["_lr_vf"], None]
+                lr_schedule_additional_args = (
+                    [config["_lr_vf"][0][1], config["_lr_vf"]]
+                    if isinstance(config["_lr_vf"], (list, tuple))
+                    else [config["_lr_vf"], None]
+                )
             LearningRateSchedule.__init__(
                 self, config["lr"], config["lr_schedule"], *lr_schedule_additional_args
             )

--- a/rllib/tuned_examples/appo/cartpole-appo-separate-losses.py
+++ b/rllib/tuned_examples/appo/cartpole-appo-separate-losses.py
@@ -1,4 +1,5 @@
 from ray.rllib.algorithms.appo import APPOConfig
+from ray import tune
 
 
 stop = {
@@ -14,8 +15,8 @@ config = (
     .training(
         # APPO will produce two separate loss terms: policy loss + value function loss.
         _separate_vf_optimizer=True,
-        # Separate learning rate for the value function branch.
-        _lr_vf=0.00075,
+        # Separate learning rate (and schedule) for the value function branch.
+        _lr_vf=tune.grid_search([0.00075, [[0, 0.00075], [100000, 0.0003]]]),
         num_sgd_iter=6,
         # `vf_loss_coeff` will be ignored anyways as we use separate loss terms.
         vf_loss_coeff=0.01,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Add lr-scheduling option to separate value function optimizer for APPO/IMPALA.

Old API stack only (new API stack supports separate optimizers and learning rate (schedules) more naturally.
Setup via:
```
config.training(
    # Make sure we really have completely separate branches.
    model={
        ...
        "vf_share_layers": False,
    },
    _separate_vf_optimizer=True,
    # Separate vf learning rate.
    _lr_vf=0.00075,
    # Separate learning rate schedule.
    _lr_vf=[[0, 0.00075], [1000000, 0.00005]],
)
```

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
