### PR TITLE
[Core] Pass node_id to default_worker

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -247,24 +247,25 @@ class Node:
             # Get socket names from the configuration.
             self._plasma_store_socket_name = ray_params.plasma_store_socket_name
             self._raylet_socket_name = ray_params.raylet_socket_name
-
-            # Get the address info of the processes to connect to
-            # from Redis or GCS.
-            node_info = ray._private.services.get_node_to_connect_for_driver(
-                self.gcs_address,
-                self._raylet_ip_address,
-            )
-            self._node_id = node_info["node_id"]
+            self._node_id = ray_params.node_id
 
             # If user does not provide the socket name, get it from Redis.
             if (
                 self._plasma_store_socket_name is None
                 or self._raylet_socket_name is None
                 or self._ray_params.node_manager_port is None
+                or self._node_id is None
             ):
+                # Get the address info of the processes to connect to
+                # from Redis or GCS.
+                node_info = ray._private.services.get_node_to_connect_for_driver(
+                    self.gcs_address,
+                    self._raylet_ip_address,
+                )
                 self._plasma_store_socket_name = node_info["object_store_socket_name"]
                 self._raylet_socket_name = node_info["raylet_socket_name"]
                 self._ray_params.node_manager_port = node_info["node_manager_port"]
+                self._node_id = node_info["node_id"]
         else:
             # If the user specified a socket name, use it.
             self._plasma_store_socket_name = self._prepare_socket_file(

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -192,6 +192,7 @@ class RayParams:
         session_name: Optional[str] = None,
         webui: Optional[str] = None,
         cluster_id: Optional[str] = None,
+        node_id: Optional[str] = None,
     ):
         self.redis_address = redis_address
         self.gcs_address = gcs_address
@@ -254,6 +255,7 @@ class RayParams:
         self.labels = labels
         self._check_usage()
         self.cluster_id = cluster_id
+        self.node_id = node_id
 
         # Set the internal config options for object reconstruction.
         if enable_object_reconstruction:

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -24,6 +24,12 @@ parser.add_argument(
     help="the auto-generated ID of the cluster",
 )
 parser.add_argument(
+    "--node-id",
+    required=True,
+    type=str,
+    help="the auto-generated ID of the node",
+)
+parser.add_argument(
     "--node-ip-address",
     required=True,
     type=str,
@@ -217,6 +223,7 @@ if __name__ == "__main__":
         session_name=args.session_name,
         webui=args.webui,
         cluster_id=args.cluster_id,
+        node_id=args.node_id,
     )
     node = ray._private.node.Node(
         ray_params,

--- a/python/ray/tests/test_object_spilling_3.py
+++ b/python/ray/tests/test_object_spilling_3.py
@@ -278,7 +278,6 @@ def test_spill_dir_cleanup_on_node_removal(fs_only_object_spilling_config):
 
     ids = ray.get(run_workload.remote())
     node2_id = node2.node_id
-    assert not is_dir_empty(temp_folder, node2_id)
 
     # Kill node 2
     cluster.remove_node(node2)

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1648,7 +1648,7 @@ const std::vector<std::string> &WorkerPool::LookupWorkerDynamicOptions(
   return kNoDynamicOptions;
 }
 
-const NodeID WorkerPool::GetNodeID() const { return node_id_; }
+const NodeID &WorkerPool::GetNodeID() const { return node_id_; }
 
 }  // namespace raylet
 

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -337,6 +337,7 @@ WorkerPool::BuildProcessCommandArgs(const Language &language,
                                   std::to_string(worker_startup_token_counter_));
     worker_command_args.push_back("--worker-launch-time-ms=" +
                                   std::to_string(current_sys_time_ms()));
+    worker_command_args.push_back("--node-id=" + node_id_.Hex());
   } else if (language == Language::CPP) {
     worker_command_args.push_back("--startup_token=" +
                                   std::to_string(worker_startup_token_counter_));

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1648,6 +1648,8 @@ const std::vector<std::string> &WorkerPool::LookupWorkerDynamicOptions(
   return kNoDynamicOptions;
 }
 
+const NodeID WorkerPool::GetNodeID() const { return node_id_; }
+
 }  // namespace raylet
 
 }  // namespace ray

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -392,6 +392,9 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// reasonable size.
   void TryKillingIdleWorkers();
 
+  /// Get the NodeID of this worker pool.
+  const NodeID GetNodeID() const;
+
  protected:
   void update_worker_startup_token_counter();
 

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -392,9 +392,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// reasonable size.
   void TryKillingIdleWorkers();
 
-  /// Get the NodeID of this worker pool.
-  const NodeID GetNodeID() const;
-
  protected:
   void update_worker_startup_token_counter();
 
@@ -763,6 +760,9 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   int64_t process_failed_rate_limited_ = 0;
   int64_t process_failed_pending_registration_ = 0;
   int64_t process_failed_runtime_env_setup_failed_ = 0;
+
+  /// Get the NodeID of this worker pool.
+  const NodeID &GetNodeID() const;
 
   friend class WorkerPoolTest;
   friend class WorkerPoolDriverRegisteredTest;

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -392,6 +392,9 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// reasonable size.
   void TryKillingIdleWorkers();
 
+  /// Get the NodeID of this worker pool.
+  const NodeID &GetNodeID() const;
+
  protected:
   void update_worker_startup_token_counter();
 
@@ -760,9 +763,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   int64_t process_failed_rate_limited_ = 0;
   int64_t process_failed_pending_registration_ = 0;
   int64_t process_failed_runtime_env_setup_failed_ = 0;
-
-  /// Get the NodeID of this worker pool.
-  const NodeID &GetNodeID() const;
 
   friend class WorkerPoolTest;
   friend class WorkerPoolDriverRegisteredTest;

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -479,25 +479,6 @@ class WorkerPoolTest : public ::testing::Test {
     ASSERT_EQ(worker_pool_->NumWorkersStarting(), expected_worker_process_count);
   }
 
-  void TestNodeIDArgInWorkerCommand() {
-    WorkerPool::State state;
-    auto [worker_command_args, env] = worker_pool_->BuildProcessCommandArgs(
-        Language::PYTHON, nullptr, rpc::WorkerType::WORKER, JOB_ID, {}, 0, "{}", state);
-
-    std::ostringstream stringStream;
-    stringStream << "--node-id=" << worker_pool_->GetNodeID();
-    std::string expected_node_id_arg = stringStream.str();
-
-    bool node_id_arg_found = false;
-    for (const auto &arg : worker_command_args) {
-      if (arg.find(expected_node_id_arg) != std::string::npos) {
-        node_id_arg_found = true;
-        break;
-      }
-    }
-    ASSERT_TRUE(node_id_arg_found);
-  }
-
   absl::flat_hash_map<WorkerID, std::shared_ptr<MockWorkerClient>>
       mock_worker_rpc_clients_;
 
@@ -704,6 +685,29 @@ TEST_F(WorkerPoolDriverRegisteredTest, PopWorkerSyncsOfMultipleLanguages) {
   worker_pool_->PushWorker(java_worker);
   // Check that the Java worker will be popped now for Java task
   ASSERT_EQ(worker_pool_->PopWorkerSync(java_task_spec), java_worker);
+}
+
+TEST_F(WorkerPoolDriverRegisteredTest, StartWorkerWithNodeIdArg) {
+  auto task_id = TaskID::FromRandom(JOB_ID);
+  TaskSpecification task_spec = ExampleTaskSpec(
+      ActorID::Nil(), Language::PYTHON, JOB_ID, ActorID::Nil(), {}, task_id);
+  ASSERT_NE(worker_pool_->PopWorkerSync(task_spec), nullptr);
+  const auto real_command =
+      worker_pool_->GetWorkerCommand(worker_pool_->LastStartedWorkerProcess());
+
+  std::ostringstream stringStream;
+  stringStream << "--node-id=" << worker_pool_->GetNodeID();
+  std::string expected_node_id_arg = stringStream.str();
+
+  bool node_id_arg_found = false;
+  for (const auto &arg : real_command) {
+    std::cout << arg << std::endl;
+    if (arg.find(expected_node_id_arg) != std::string::npos) {
+      node_id_arg_found = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(node_id_arg_found);
 }
 
 TEST_F(WorkerPoolDriverRegisteredTest, StartWorkerWithDynamicOptionsCommand) {
@@ -2028,8 +2032,6 @@ TEST_F(WorkerPoolTest, RegisterFirstJavaDriverCallbackImmediately) {
   RAY_CHECK_OK(worker_pool_->RegisterDriver(driver, rpc::JobConfig(), callback));
   ASSERT_TRUE(callback_called);
 }
-
-TEST_F(WorkerPoolTest, NodeIDArgInWorkerCommand) { TestNodeIDArgInWorkerCommand(); }
 
 }  // namespace raylet
 

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -481,15 +481,8 @@ class WorkerPoolTest : public ::testing::Test {
 
   void TestNodeIDArgInWorkerCommand() {
     WorkerPool::State state;
-    auto [worker_command_args, env] =
-        worker_pool_->BuildProcessCommandArgs(Language::PYTHON,
-                                              nullptr,
-                                              rpc::WorkerType::WORKER,
-                                              JOB_ID,
-                                              {},
-                                              0,
-                                              "{}",
-                                              state);
+    auto [worker_command_args, env] = worker_pool_->BuildProcessCommandArgs(
+        Language::PYTHON, nullptr, rpc::WorkerType::WORKER, JOB_ID, {}, 0, "{}", state);
 
     std::ostringstream stringStream;
     stringStream << "--node-id=" << worker_pool_->GetNodeID();

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -701,7 +701,6 @@ TEST_F(WorkerPoolDriverRegisteredTest, StartWorkerWithNodeIdArg) {
 
   bool node_id_arg_found = false;
   for (const auto &arg : real_command) {
-    std::cout << arg << std::endl;
     if (arg.find(expected_node_id_arg) != std::string::npos) {
       node_id_arg_found = true;
       break;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In #44487 , node_id is obtained from an RPC call, which is extra overhead. In this change, we pass down node_id from raylet when default workers are created to avoid such overhead. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Related to #44487

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
