### PR TITLE
[Core] fix schedule resource utilization bug

### DIFF
--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -62,9 +62,12 @@ NodeResources ResourceMapToNodeResources(
 
 float NodeResources::CalculateCriticalResourceUtilization() const {
   float highest = 0;
-  for (const auto &i : {CPU, MEM, OBJECT_STORE_MEM}) {
+  std::size_t zero_count = 0;
+  auto resource_types = {CPU, MEM, OBJECT_STORE_MEM};
+  for (const auto &i : resource_types) {
     const auto &total = this->total.Get(ResourceID(i));
     if (total == 0) {
+      zero_count++;
       continue;
     }
     auto available = this->available.Get(ResourceID(i)).Double();
@@ -82,7 +85,7 @@ float NodeResources::CalculateCriticalResourceUtilization() const {
       highest = utilization;
     }
   }
-  return highest;
+  return resource_types.size() == zero_count ? 1.0 :  highest;
 }
 
 bool NodeResources::IsAvailable(const ResourceRequest &resource_request,

--- a/src/ray/raylet/scheduling/policy/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/scheduling_policy_test.cc
@@ -263,6 +263,18 @@ TEST_F(SchedulingPolicyTest, CriticalResourceUtilizationDefinitionTest) {
         .Set(ResourceID::ObjectStoreMemory(), 100);
     ASSERT_EQ(resources.CalculateCriticalResourceUtilization(), 0.75);
   }
+  
+  {
+    //  0 total resource
+    NodeResources resources;
+    resources.available.Set(ResourceID::CPU(), 0)
+        .Set(ResourceID::Memory(), 0)
+        .Set(ResourceID::ObjectStoreMemory(), 0);
+    resources.total.Set(ResourceID::CPU(), 0)
+        .Set(ResourceID::Memory(), 0)
+        .Set(ResourceID::ObjectStoreMemory(), 0);
+    ASSERT_EQ(resources.CalculateCriticalResourceUtilization(), 1.0);
+  }
 }
 
 TEST_F(SchedulingPolicyTest, AvailableTruncationTest) {


### PR DESCRIPTION
Node scheduler resource utilization calculations may result in the scheduler running on a node with no resources #44696

@jjyao 

## Why are these changes needed?

when a node's all resource total equals 0, the CalculateCriticalResourceUtilization function will get result of 0, that cause the node to be scheduled

## Related issue number

open #44696

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
