### PR TITLE
[release] use bazel to run release test

### DIFF
--- a/.buildkite/release.rayci.yml
+++ b/.buildkite/release.rayci.yml
@@ -8,7 +8,7 @@ steps:
       - skip-on-premerge
       - oss
     commands:
-      - ./release/run_release_test.sh microbenchmark.aws --report 
+      - bazel run //release:run -- microbenchmark.aws --report 
         --test-definition-root /ray/release --test-collection-file release_tests.yaml
     instance_type: release
     job_env: oss-ci-base_build

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -384,6 +384,22 @@ py_test(
 # RELEASE TEST INFRA unit tests
 ####
 
+sh_binary(
+    name = "run",
+    srcs = ["run_release_test.sh"],
+    data = ["run_release_test"],
+    env = {
+        "NO_INSTALL": "1",
+        "RAY_TEST_SCRIPT": "./run_release_test",
+    }
+)
+
+py_binary(
+    name = "run_release_test",
+    srcs = ["ray_release/scripts/run_release_test.py"],
+    deps = [":ray_release"],
+)
+
 py_library(
     name = "ray_release",
     srcs = glob(
@@ -393,8 +409,7 @@ py_library(
     data = glob(["ray_release/environments/*.env"]) + [
         "ray_release/buildkite/aws_instance_types.csv",
         "ray_release/schema.json",
-        "ray_release/configs/oss_config.yaml",
-    ],
+    ] + glob(["ray_release/configs/*.yaml"]),
     imports = ["."],
     visibility = ["//visibility:public"],
     deps = [

--- a/release/ray_release/command_runner/job_runner.py
+++ b/release/ray_release/command_runner/job_runner.py
@@ -58,6 +58,8 @@ class JobRunner(CommandRunner):
         script = os.path.join(os.path.dirname(__file__), f"_{script_name}")
         if os.path.exists(script_name):
             os.unlink(script_name)
+        if os.path.islink(script):
+            script = os.readlink(script)
         os.link(script, script_name)
 
     def prepare_remote_env(self):

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -147,10 +147,11 @@ def _setup_cluster_environment(
     result: Result,
     cluster_manager: ClusterManager,
     cluster_env_id: Optional[str],
+    test_definition_root: Optional[str] = None,
 ) -> Tuple[str, int, int, int, int]:
     setup_signal_handling()
     # Load configs
-    cluster_compute = load_test_cluster_compute(test)
+    cluster_compute = load_test_cluster_compute(test, test_definition_root)
 
     if cluster_env_id:
         try:
@@ -419,6 +420,7 @@ def run_release_test(
             result,
             cluster_manager,
             cluster_env_id,
+            test_definition_root,
         )
 
         buildkite_group(":bulb: Local environment information")

--- a/release/ray_release/template.py
+++ b/release/ray_release/template.py
@@ -92,16 +92,28 @@ def render_yaml_template(template: str, env: Optional[Dict] = None):
         ) from e
 
 
-def get_cluster_env_path(test: "Test") -> str:
+def get_cluster_env_path(
+    test: "Test", test_definition_root: Optional[str] = None
+) -> str:
     working_dir = test.get("working_dir", "")
     cluster_env_file = test["cluster"]["cluster_env"]
-    return bazel_runfile("release", working_dir, cluster_env_file)
+    return (
+        os.path.join(test_definition_root, working_dir, cluster_env_file)
+        if test_definition_root
+        else bazel_runfile("release", working_dir, cluster_env_file)
+    )
 
 
-def load_test_cluster_compute(test: "Test") -> Optional[Dict]:
+def load_test_cluster_compute(
+    test: "Test", test_definition_root: Optional[str] = None
+) -> Optional[Dict]:
     cluster_compute_file = test["cluster"]["cluster_compute"]
     working_dir = test.get("working_dir", "")
-    f = bazel_runfile("release", working_dir, cluster_compute_file)
+    f = (
+        os.path.join(test_definition_root, working_dir, cluster_compute_file)
+        if test_definition_root
+        else bazel_runfile("release", working_dir, cluster_compute_file)
+    )
     env = populate_cluster_compute_variables(test)
     return load_and_render_yaml_template(f, env=env)
 

--- a/release/ray_release/tests/test_run_script.py
+++ b/release/ray_release/tests/test_run_script.py
@@ -18,7 +18,9 @@ def setup(tmpdir):
     os.environ["NO_INSTALL"] = "1"
     os.environ["NO_CLONE"] = "1"
     os.environ["NO_ARTIFACTS"] = "1"
-    os.environ["RAY_TEST_SCRIPT"] = "ray_release/tests/_test_run_release_test_sh.py"
+    os.environ[
+        "RAY_TEST_SCRIPT"
+    ] = "python ray_release/tests/_test_run_release_test_sh.py"
     os.environ["OVERRIDE_SLEEP_TIME"] = "0"
     os.environ["MAX_RETRIES"] = "3"
 
@@ -114,7 +116,7 @@ def test_repeat(setup):
 def test_parameters(setup):
     state_file, test_script = setup
 
-    os.environ["RAY_TEST_SCRIPT"] = "ray_release/tests/_test_catch_args.py"
+    os.environ["RAY_TEST_SCRIPT"] = "python ray_release/tests/_test_catch_args.py"
 
     with tempfile.TemporaryDirectory() as tmpdir:
         argv_file = os.path.join(tmpdir, "argv.json")

--- a/release/run_release_test.sh
+++ b/release/run_release_test.sh
@@ -27,7 +27,7 @@ reason() {
   echo "${REASON}"
 }
 
-RAY_TEST_SCRIPT=${RAY_TEST_SCRIPT-ray_release/scripts/run_release_test.py}
+RAY_TEST_SCRIPT=${RAY_TEST_SCRIPT-"python ray_release/scripts/run_release_test.py"}
 RELEASE_RESULTS_DIR=${RELEASE_RESULTS_DIR-/tmp/artifacts}
 BUILDKITE_MAX_RETRIES=1
 BUILDKITE_RETRY_CODE=79
@@ -93,7 +93,7 @@ while [ "$RETRY_NUM" -lt "$MAX_RETRIES" ]; do
   set +e
 
   trap _term SIGINT SIGTERM
-  python "${RAY_TEST_SCRIPT}" "$@" &
+  ${RAY_TEST_SCRIPT} "$@" &
   proc=$!
 
   wait "$proc"


### PR DESCRIPTION
Make the release test infra runnable with bazel. This also means that the package can run as a standalone installation.

Test:
- CI
- release: https://buildkite.com/ray-project/release/builds/13363