### PR TITLE
Fix typo in ray status output

### DIFF
--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -685,7 +685,7 @@ Status PythonCheckGcsHealth(const std::string &gcs_address,
       is_healthy = false;
       std::ostringstream ss;
       ss << "Ray cluster at " << gcs_address << ":" << gcs_port << " has version "
-         << reply.ray_version() << ", but this process"
+         << reply.ray_version() << ", but this process "
          << "is running Ray version " << ray_version << ".";
       return Status::Invalid(ss.str());
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
before
```text
RuntimeError: System error: Ray cluster at 10.218.163.85:6379 has version 2.10.0, but this processis running Ray version 2.9.2.
```
after 
```text
RuntimeError: System error: Ray cluster at 10.218.163.85:6379 has version 2.10.0, but this process is running Ray version 2.9.2.
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
