### PR TITLE
[release-automation] Separate postmerge trigger step to nightly & test

### DIFF
--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -18,6 +18,20 @@ steps:
       - bash .buildkite/release-automation/check-commit-hash.sh
 
   - label: "Trigger Postmerge test"
+    if: build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") != "1"
+    trigger: "postmerge"
+    key: trigger-postmerge
+    depends_on: check-commit-hash
+    build:
+      commit: "${BUILDKITE_COMMIT}"
+      branch: "${BUILDKITE_BRANCH}"
+      message: "Triggered by release-automation build #${BUILDKITE_BUILD_NUMBER}"
+      env:
+        RAYCI_CONTINUOUS_BUILD: 1
+        RAYCI_WEEKLY_RELEASE: 1
+  
+  - label: "Trigger Postmerge nightly build & test"
+    if: build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") == "1"
     trigger: "postmerge"
     key: trigger-postmerge
     depends_on: check-commit-hash


### PR DESCRIPTION
- We control whether postmerge builds and uploads nightly image by the `RAYCI_SCHEDULE`. Other than nightly scheduled runs, we don't need to build nightly image and only run tests.
- This is to separate the 2 cases into 1 step for daily runs & other manual runs and 1 step for scheduled nightly run so we don't build extra nightly images when it's not supposed to.