### PR TITLE
Fix flaky mutable object test

### DIFF
--- a/src/ray/object_manager/common.cc
+++ b/src/ray/object_manager/common.cc
@@ -149,6 +149,7 @@ Status PlasmaObjectHeader::ReadAcquire(Semaphores &sem,
   // Wait for the requested version (or a more recent one) to be sealed.
   while (version < version_to_read || !is_sealed) {
     RAY_CHECK_EQ(sem_post(sem.header_sem), 0);
+    sched_yield();
     RAY_RETURN_NOT_OK(TryToAcquireSemaphore(sem.header_sem));
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

mutable_object_test is currently "flaky" because the test sometimes times out in CI. This happens because there is significant contention on the header_sem semaphore in PlasmaObjectHeader::ReadAcquire() when there are many readers, due to polling.

As a temporary fix, I have the threads yield in each iteration of the loop. The correct long-term solution is to use a futex (or something similar) to avoid polling, which I will implement soon. But I want to merge this PR first to avoid blocking submission for others.

## Related issue number

Closes #44396.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
