### PR TITLE
[RLlib] Make RLlib learner support custom resources

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -181,10 +181,12 @@ except ImportError:
                         {"GPU": cf.num_learner_workers * cf.num_gpus_per_learner_worker}
                     ]
                 elif cf.custom_resources_per_learner_worker:
-                    learner_bundles = {
-                        key: cf.num_learner_workers * value
-                        for key, value in cf.custom_resources_per_learner_worker.items()
-                    }
+                    learner_bundles = [
+                        {
+                            k: cf.num_learner_workers * v
+                            for k, v in cf.custom_resources_per_learner_worker.items()
+                        }
+                    ]
                 elif cf.num_cpus_per_learner_worker:
                     learner_bundles = [
                         {

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -180,6 +180,11 @@ except ImportError:
                     learner_bundles = [
                         {"GPU": cf.num_learner_workers * cf.num_gpus_per_learner_worker}
                     ]
+                elif cf.custom_resources_per_learner_worker:
+                    learner_bundles = {
+                        key: cf.num_learner_workers * value
+                        for key, value in cf.custom_resources_per_learner_worker.items()
+                    }
                 elif cf.num_cpus_per_learner_worker:
                     learner_bundles = [
                         {
@@ -196,6 +201,7 @@ except ImportError:
                             cf.num_cpus_per_learner_worker, cf.num_cpus_for_local_worker
                         ),
                         "GPU": cf.num_gpus_per_learner_worker,
+                        **cf.custom_resources_per_learner_worker,
                     }
                 ]
             return learner_bundles
@@ -2505,6 +2511,7 @@ class Algorithm(Trainable, AlgorithmBase):
             driver = {
                 "CPU": cf.num_cpus_for_local_worker,
                 "GPU": 0 if cf._fake_gpus else cf.num_gpus,
+                **cf.custom_resources,
             }
 
         # resources for remote rollout env samplers

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -146,13 +146,22 @@ class LearnerGroup:
             #  https://github.com/ray-project/ray/issues/35409 for more details.
             num_cpus_per_worker = (
                 self.config.num_cpus_per_learner_worker
-                if not self.config.num_gpus_per_learner_worker
+                if (
+                    not self.config.num_gpus_per_learner_worker
+                    and not sum(
+                        self.config.custom_resources_per_learner_worker.values()
+                    )
+                )
                 else 0
             )
             num_gpus_per_worker = self.config.num_gpus_per_learner_worker
+            custom_resources_per_worker = (
+                self.config.custom_resources_per_learner_worker
+            )
             resources_per_worker = {
                 "CPU": num_cpus_per_worker,
                 "GPU": num_gpus_per_worker,
+                **custom_resources_per_worker,
             }
 
             backend_executor = BackendExecutor(

--- a/rllib/tests/test_custom_resource.py
+++ b/rllib/tests/test_custom_resource.py
@@ -34,6 +34,90 @@ def test_custom_resource(algorithm):
     ).fit()
 
 
+@pytest.mark.parametrize("algorithm", ["PPO", "IMPALA"])
+def test_algorithm_custom_resource(algorithm):
+    if ray.is_initialized:
+        ray.shutdown()
+
+    ray.init(
+        resources={"custom_resource": 1},
+        include_dashboard=False,
+    )
+
+    config = (
+        get_trainable_cls(algorithm)
+        .get_default_config()
+        .environment("CartPole-v1")
+        .framework("torch")
+        .rollouts(num_rollout_workers=1)
+        .resources(num_gpus=0, custom_resources={"custom_resource": 0.01})
+    )
+    stop = {"training_iteration": 1}
+
+    tune.Tuner(
+        algorithm,
+        param_space=config,
+        run_config=air.RunConfig(stop=stop, verbose=0),
+        tune_config=tune.TuneConfig(num_samples=1),
+    ).fit()
+
+
+@pytest.mark.parametrize("algorithm", ["PPO", "IMPALA"])
+def test_learner_custom_resource(algorithm):
+    if ray.is_initialized:
+        ray.shutdown()
+
+    ray.init(
+        resources={"custom_resource": 1},
+        include_dashboard=False,
+    )
+
+    config = (
+        get_trainable_cls(algorithm)
+        .get_default_config()
+        .environment("CartPole-v1")
+        .framework("torch")
+        .rollouts(num_rollout_workers=1)
+        .resources(num_gpus=0, custom_resources_per_learner_worker={"custom_resource": 0.01})
+        .experimental(_enable_new_api_stack=True)
+    )
+    stop = {"training_iteration": 1}
+
+    tune.Tuner(
+        algorithm,
+        param_space=config,
+        run_config=air.RunConfig(stop=stop, verbose=0),
+        tune_config=tune.TuneConfig(num_samples=1),
+    ).fit()
+
+
+def test_custom_resource_type():
+    # CPU/GPU should not be specified in custom resources api
+    algorithm = "PPO"
+
+    config = (
+        get_trainable_cls(algorithm)
+        .get_default_config()
+        .environment("CartPole-v1")
+        .framework("torch")
+        .rollouts(num_rollout_workers=1)
+        .resources(num_gpus=0, custom_resources_per_learner_worker={"CPU": 1})
+        .experimental(_enable_new_api_stack=True)
+    )
+    
+    stop = {"training_iteration": 1}
+
+    with pytest.raises(ValueError) as exc_info:
+        tune.Tuner(
+            algorithm,
+            param_space=config,
+            run_config=air.RunConfig(stop=stop, verbose=0),
+            tune_config=tune.TuneConfig(num_samples=1),
+        ).fit()
+    
+    assert "Use the `num_cpus_per_learner_worker` " in str(exc_info.value)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, RLlib learner does not support scheduling custom resources, users can only use GPUs to accelerate training. This feature will enable users to build RLlib algorithms on third-party accelerators.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
