### PR TITLE
[serve] Improve telemetry tests and fix get deployment handle telemetry

### DIFF
--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -6,6 +6,7 @@ import pickle
 import socket
 import time
 from abc import ABC, abstractmethod
+from functools import partial
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type
 
 import grpc
@@ -160,7 +161,7 @@ class GenericProxy(ABC):
         self.route_info: Dict[str, DeploymentID] = dict()
 
         self.proxy_router = proxy_router_class(
-            serve.get_deployment_handle, self.protocol
+            partial(serve.get_deployment_handle, _record_telemetry=False), self.protocol
         )
         self.request_counter = metrics.Counter(
             f"serve_num_{self.protocol.lower()}_requests",

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -836,6 +836,7 @@ def get_app_handle(name: str) -> DeploymentHandle:
 def get_deployment_handle(
     deployment_name: str,
     app_name: Optional[str] = None,
+    _record_telemetry: bool = True,
 ) -> DeploymentHandle:
     """Get a handle to a deployment by name.
 
@@ -922,5 +923,7 @@ def get_deployment_handle(
         else:
             app_name = internal_replica_context.app_name
 
-    ServeUsageTag.SERVE_GET_DEPLOYMENT_HANDLE_API_USED.record("1")
+    if _record_telemetry:
+        ServeUsageTag.SERVE_GET_DEPLOYMENT_HANDLE_API_USED.record("1")
+
     return client.get_handle(deployment_name, app_name)

--- a/python/ray/serve/tests/test_telemetry.py
+++ b/python/ray/serve/tests/test_telemetry.py
@@ -13,13 +13,7 @@ from ray._private.test_utils import wait_for_condition
 from ray._private.usage.usage_lib import get_extra_usage_tags_to_report
 from ray.serve._private.common import ApplicationStatus
 from ray.serve._private.constants import SERVE_MULTIPLEXED_MODEL_ID
-from ray.serve._private.test_utils import (
-    TELEMETRY_ROUTE_PREFIX,
-    TelemetryStorage,
-    check_ray_started,
-    receiver_app,
-    start_telemetry_app,
-)
+from ray.serve._private.test_utils import check_apps_running, check_telemetry
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve.context import _get_global_client
 from ray.serve.schema import ServeDeploySchema
@@ -30,14 +24,7 @@ def test_fastapi_detected(manage_ray_with_telemetry):
     Check that FastAPI is detected by telemetry.
     """
 
-    subprocess.check_output(["ray", "start", "--head"])
-    wait_for_condition(check_ray_started, timeout=5)
-
-    storage_handle = start_telemetry_app()
-
-    wait_for_condition(
-        lambda: ray.get(storage_handle.get_reports_received.remote()) > 0, timeout=5
-    )
+    storage_handle = manage_ray_with_telemetry
 
     # Check that telemetry related to FastAPI app is not set
     def check_report_before_fastapi():
@@ -110,34 +97,13 @@ def test_rest_api(manage_ray_with_telemetry, tmp_dir):
     Check that telemetry works with REST API.
     """
 
-    subprocess.check_output(["ray", "start", "--head"])
-    wait_for_condition(check_ray_started, timeout=5)
-
-    storage = TelemetryStorage.remote()
-
-    serve.run(
-        receiver_app,
-        name="telemetry",
-        route_prefix=TELEMETRY_ROUTE_PREFIX,
-    )
-
-    wait_for_condition(
-        lambda: ray.get(storage.get_reports_received.remote()) > 1, timeout=15
-    )
+    storage = manage_ray_with_telemetry
 
     # Check that REST API telemetry is not set
-    report = ray.get(storage.get_report.remote())
-    assert ServeUsageTag.REST_API_VERSION.get_value_from_report(report) is None
-
-    serve.delete(name="telemetry", _blocking=True)
+    check_telemetry(ServeUsageTag.REST_API_VERSION, expected=None)
 
     config = {
         "applications": [
-            {
-                "name": "receiver_app",
-                "import_path": "ray.serve._private.test_utils.receiver_app",
-                "route_prefix": TELEMETRY_ROUTE_PREFIX,
-            },
             {
                 "name": "stub_app",
                 "import_path": "ray.serve.tests.test_telemetry.stub_app",
@@ -153,16 +119,7 @@ def test_rest_api(manage_ray_with_telemetry, tmp_dir):
 
     client = _get_global_client()
     # Make sure the applications are RUNNING.
-    wait_for_condition(
-        lambda: serve.status().applications["receiver_app"].status
-        == ApplicationStatus.RUNNING,
-        timeout=15,
-    )
-    wait_for_condition(
-        lambda: serve.status().applications["stub_app"].status
-        == ApplicationStatus.RUNNING,
-        timeout=15,
-    )
+    wait_for_condition(check_apps_running, apps=["stub_app"], timeout=15)
 
     current_num_reports = ray.get(storage.get_reports_received.remote())
 
@@ -189,15 +146,7 @@ def test_rest_api(manage_ray_with_telemetry, tmp_dir):
     assert ServeUsageTag.DAG_DRIVER_USED.get_value_from_report(report) is None
 
     # Check that app deletions are tracked.
-    new_config = {
-        "applications": [
-            {
-                "name": "receiver_app",
-                "import_path": "ray.serve._private.test_utils.receiver_app",
-                "route_prefix": TELEMETRY_ROUTE_PREFIX,
-            },
-        ]
-    }
+    new_config = {"applications": []}
 
     with open(config_file_path, "w+") as f:
         yaml.safe_dump(new_config, f)
@@ -241,9 +190,9 @@ tester = Tester.bind()
 def test_lightweight_config_options(
     manage_ray_with_telemetry, lightweight_option, value, new_value
 ):
-    """
-    Check that lightweight config options are detected by telemetry.
-    """
+    """Check that lightweight config options are detected by telemetry."""
+
+    storage = manage_ray_with_telemetry
 
     lightweight_tagkeys = {
         "num_replicas": ServeUsageTag.NUM_REPLICAS_LIGHTWEIGHT_UPDATED,
@@ -251,33 +200,11 @@ def test_lightweight_config_options(
         "autoscaling_config": ServeUsageTag.AUTOSCALING_CONFIG_LIGHTWEIGHT_UPDATED,
     }
 
-    subprocess.check_output(["ray", "start", "--head"])
-    wait_for_condition(check_ray_started, timeout=5)
-    storage = TelemetryStorage.remote()
-
-    serve.run(
-        receiver_app,
-        name="telemetry",
-        route_prefix=TELEMETRY_ROUTE_PREFIX,
-    )
-
-    wait_for_condition(
-        lambda: ray.get(storage.get_reports_received.remote()) > 1, timeout=15
-    )
-
     # Check that REST API telemetry is not set
-    report = ray.get(storage.get_report.remote())
-    assert ServeUsageTag.REST_API_VERSION.get_value_from_report(report) is None
-
-    serve.delete(name="telemetry", _blocking=True)
+    check_telemetry(ServeUsageTag.REST_API_VERSION, expected=None)
 
     config = {
         "applications": [
-            {
-                "name": "receiver_app",
-                "import_path": "ray.serve._private.test_utils.receiver_app",
-                "route_prefix": TELEMETRY_ROUTE_PREFIX,
-            },
             {
                 "name": "test_app",
                 "import_path": "ray.serve.tests.test_telemetry.tester",
@@ -285,22 +212,12 @@ def test_lightweight_config_options(
             },
         ]
     }
-    config["applications"][1]["deployments"][0][lightweight_option] = value
+    config["applications"][0]["deployments"][0][lightweight_option] = value
 
     # Deploy first config
-    serve.start()
     client = _get_global_client()
     client.deploy_apps(ServeDeploySchema(**config))
-    wait_for_condition(
-        lambda: serve.status().applications["receiver_app"].status
-        == ApplicationStatus.RUNNING,
-        timeout=15,
-    )
-    wait_for_condition(
-        lambda: serve.status().applications["test_app"].status
-        == ApplicationStatus.RUNNING,
-        timeout=15,
-    )
+    wait_for_condition(check_apps_running, apps=["test_app"], timeout=15)
 
     current_num_reports = ray.get(storage.get_reports_received.remote())
 
@@ -317,25 +234,15 @@ def test_lightweight_config_options(
         assert tagkey.get_value_from_report(report) is None
 
     # Change config and deploy again
-    config["applications"][1]["deployments"][0][lightweight_option] = new_value
+    config["applications"][0]["deployments"][0][lightweight_option] = new_value
     client.deploy_apps(ServeDeploySchema(**config))
-    wait_for_condition(
-        lambda: serve.status().applications["receiver_app"].status
-        == ApplicationStatus.RUNNING,
-        timeout=15,
-    )
-    wait_for_condition(
-        lambda: serve.status().applications["test_app"].status
-        == ApplicationStatus.RUNNING,
-        timeout=15,
-    )
+    wait_for_condition(check_apps_running, apps=["test_app"], timeout=15)
 
     # Check again
     wait_for_condition(
-        lambda: lightweight_tagkeys[lightweight_option].get_value_from_report(
-            ray.get(storage.get_report.remote())
-        )
-        == "True",
+        check_telemetry,
+        tag=lightweight_tagkeys[lightweight_option],
+        expected="True",
         timeout=5,
     )
     report = ray.get(storage.get_report.remote())
@@ -350,19 +257,7 @@ def test_lightweight_config_options(
 def test_handle_apis_detected(manage_ray_with_telemetry, call_in_deployment):
     """Check that the various handles are detected correctly by telemetry."""
 
-    subprocess.check_output(["ray", "start", "--head"])
-    wait_for_condition(check_ray_started, timeout=5)
-
-    storage_handle = start_telemetry_app()
-    wait_for_condition(
-        lambda: ray.get(storage_handle.get_reports_received.remote()) > 0, timeout=5
-    )
-
-    report = ray.get(storage_handle.get_report.remote())
-    print(report["extra_usage_tags"])
-    assert (
-        ServeUsageTag.DEPLOYMENT_HANDLE_API_USED.get_value_from_report(report) is None
-    )
+    check_telemetry(ServeUsageTag.DEPLOYMENT_HANDLE_API_USED, expected=None)
 
     @serve.deployment
     class Downstream:
@@ -388,37 +283,17 @@ def test_handle_apis_detected(manage_ray_with_telemetry, call_in_deployment):
 
     assert result == "ok"
 
-    def check_telemetry():
-        report = ray.get(storage_handle.get_report.remote())
-        print(report["extra_usage_tags"])
-        assert (
-            ServeUsageTag.DEPLOYMENT_HANDLE_API_USED.get_value_from_report(report)
-            == "1"
-        )
-        return True
-
-    wait_for_condition(check_telemetry)
+    wait_for_condition(
+        check_telemetry, tag=ServeUsageTag.DEPLOYMENT_HANDLE_API_USED, expected="1"
+    )
 
 
 @pytest.mark.parametrize("mode", ["http", "outside_deployment", "inside_deployment"])
 def test_deployment_handle_to_obj_ref_detected(manage_ray_with_telemetry, mode):
     """Check that the handle to_object_ref API is detected correctly by telemetry."""
 
-    subprocess.check_output(["ray", "start", "--head"])
-    wait_for_condition(check_ray_started, timeout=5)
-
-    storage_handle = start_telemetry_app()
-    wait_for_condition(
-        lambda: ray.get(storage_handle.get_reports_received.remote()) > 0, timeout=5
-    )
-
-    report = ray.get(storage_handle.get_report.remote())
-    print(report["extra_usage_tags"])
-    assert (
-        ServeUsageTag.DEPLOYMENT_HANDLE_TO_OBJECT_REF_API_USED.get_value_from_report(
-            report
-        )
-        is None
+    check_telemetry(
+        ServeUsageTag.DEPLOYMENT_HANDLE_TO_OBJECT_REF_API_USED, expected=None
     )
 
     @serve.deployment
@@ -450,30 +325,22 @@ def test_deployment_handle_to_obj_ref_detected(manage_ray_with_telemetry, mode):
 
     assert result == "ok"
 
-    def check_telemetry(tag_should_be_set: bool):
-        report = ray.get(storage_handle.get_report.remote())
-        print(report["extra_usage_tags"])
-        tag = ServeUsageTag.DEPLOYMENT_HANDLE_TO_OBJECT_REF_API_USED
-        if tag_should_be_set:
-            assert tag.get_value_from_report(report) == "1"
-        else:
-            assert tag.get_value_from_report(report) is None
-
-        return True
-
     if mode == "http":
         for _ in range(20):
-            check_telemetry(tag_should_be_set=False)
+            check_telemetry(
+                ServeUsageTag.DEPLOYMENT_HANDLE_TO_OBJECT_REF_API_USED, expected=None
+            )
             time.sleep(0.1)
     else:
-        wait_for_condition(check_telemetry, tag_should_be_set=True)
+        wait_for_condition(
+            check_telemetry,
+            tag=ServeUsageTag.DEPLOYMENT_HANDLE_TO_OBJECT_REF_API_USED,
+            expected="1",
+        )
 
 
 def test_multiplexed_detect(manage_ray_with_telemetry):
     """Check that multiplexed api is detected by telemetry."""
-
-    subprocess.check_output(["ray", "start", "--head"])
-    wait_for_condition(check_ray_started, timeout=5)
 
     @serve.deployment
     class Model:
@@ -487,37 +354,16 @@ def test_multiplexed_detect(manage_ray_with_telemetry):
             return tag
 
     serve.run(Model.bind(), name="app", route_prefix="/app")
+    wait_for_condition(check_apps_running, apps=["app"])
 
-    storage_handle = start_telemetry_app()
-    wait_for_condition(
-        lambda: ray.get(storage_handle.get_reports_received.remote()) > 0, timeout=5
-    )
-    report = ray.get(storage_handle.get_report.remote())
-    assert ServeUsageTag.MULTIPLEXED_API_USED.get_value_from_report(report) is None
-
-    client = _get_global_client()
-    wait_for_condition(
-        lambda: client.get_serve_status("app").app_status.status
-        == ApplicationStatus.RUNNING,
-        timeout=15,
-    )
-
-    wait_for_condition(
-        lambda: ray.get(storage_handle.get_reports_received.remote()) > 0, timeout=5
-    )
+    check_telemetry(ServeUsageTag.MULTIPLEXED_API_USED, expected=None)
 
     headers = {SERVE_MULTIPLEXED_MODEL_ID: "1"}
     resp = requests.get("http://localhost:8000/app", headers=headers)
     assert resp.status_code == 200
 
     wait_for_condition(
-        lambda: int(
-            ServeUsageTag.MULTIPLEXED_API_USED.get_value_from_report(
-                ray.get(storage_handle.get_report.remote())
-            )
-        )
-        == 1,
-        timeout=5,
+        check_telemetry, tag=ServeUsageTag.MULTIPLEXED_API_USED, expected="1"
     )
 
 

--- a/python/ray/serve/tests/test_telemetry_2.py
+++ b/python/ray/serve/tests/test_telemetry_2.py
@@ -1,33 +1,20 @@
-import subprocess
 import sys
 import time
 
 import pytest
 
-import ray
 from ray import serve
 from ray._private.test_utils import wait_for_condition
-from ray.serve._private.test_utils import (
-    check_ray_started,
-    check_telemetry_not_recorded,
-    check_telemetry_recorded,
-    start_telemetry_app,
-)
+from ray.serve._private.test_utils import check_telemetry
+from ray.serve._private.usage import ServeUsageTag
 
 
 @pytest.mark.parametrize("location", ["driver", "deployment", None])
 def test_status_api_detected(manage_ray_with_telemetry, location):
     """Check that serve.status is detected correctly by telemetry."""
 
-    subprocess.check_output(["ray", "start", "--head"])
-    wait_for_condition(check_ray_started, timeout=5)
-
-    storage_handle = start_telemetry_app()
-    wait_for_condition(
-        lambda: ray.get(storage_handle.get_reports_received.remote()) > 0, timeout=5
-    )
     # Check telemetry is not recorded before test starts
-    check_telemetry_not_recorded(storage_handle, "serve_status_api_used")
+    check_telemetry(ServeUsageTag.SERVE_STATUS_API_USED, expected=None)
 
     @serve.deployment
     class Model:
@@ -42,14 +29,11 @@ def test_status_api_detected(manage_ray_with_telemetry, location):
             serve.status()
 
         wait_for_condition(
-            check_telemetry_recorded,
-            storage_handle=storage_handle,
-            key="serve_status_api_used",
-            expected_value="1",
+            check_telemetry, tag=ServeUsageTag.SERVE_STATUS_API_USED, expected="1"
         )
     else:
         for _ in range(3):
-            check_telemetry_not_recorded(storage_handle, "serve_status_api_used")
+            check_telemetry(ServeUsageTag.SERVE_STATUS_API_USED, expected=None)
             time.sleep(1)
 
 
@@ -57,15 +41,8 @@ def test_status_api_detected(manage_ray_with_telemetry, location):
 def test_get_app_handle_api_detected(manage_ray_with_telemetry, location):
     """Check that serve.get_app_handle is detected correctly by telemetry."""
 
-    subprocess.check_output(["ray", "start", "--head"])
-    wait_for_condition(check_ray_started, timeout=5)
-
-    storage_handle = start_telemetry_app()
-    wait_for_condition(
-        lambda: ray.get(storage_handle.get_reports_received.remote()) > 0, timeout=5
-    )
     # Check telemetry is not recorded before test starts
-    check_telemetry_not_recorded(storage_handle, "serve_get_app_handle_api_used")
+    check_telemetry(ServeUsageTag.SERVE_GET_APP_HANDLE_API_USED, expected=None)
 
     @serve.deployment
     class Model:
@@ -80,16 +57,13 @@ def test_get_app_handle_api_detected(manage_ray_with_telemetry, location):
             serve.get_app_handle("telemetry")
 
         wait_for_condition(
-            check_telemetry_recorded,
-            storage_handle=storage_handle,
-            key="serve_get_app_handle_api_used",
-            expected_value="1",
+            check_telemetry,
+            tag=ServeUsageTag.SERVE_GET_APP_HANDLE_API_USED,
+            expected="1",
         )
     else:
         for _ in range(3):
-            check_telemetry_not_recorded(
-                storage_handle, "serve_get_app_handle_api_used"
-            )
+            check_telemetry(ServeUsageTag.SERVE_GET_APP_HANDLE_API_USED, expected=None)
             time.sleep(1)
 
 
@@ -97,15 +71,7 @@ def test_get_app_handle_api_detected(manage_ray_with_telemetry, location):
 def test_get_deployment_handle_api_detected(manage_ray_with_telemetry, location):
     """Check that serve.get_deployment_handle is detected correctly by telemetry."""
 
-    subprocess.check_output(["ray", "start", "--head"])
-    wait_for_condition(check_ray_started, timeout=5)
-
-    storage_handle = start_telemetry_app()
-    wait_for_condition(
-        lambda: ray.get(storage_handle.get_reports_received.remote()) > 0, timeout=5
-    )
-    # Check telemetry is not recorded before test starts
-    check_telemetry_not_recorded(storage_handle, "serve_get_deployment_handle_api_used")
+    check_telemetry(ServeUsageTag.SERVE_GET_DEPLOYMENT_HANDLE_API_USED, expected=None)
 
     @serve.deployment
     class Model:
@@ -120,15 +86,14 @@ def test_get_deployment_handle_api_detected(manage_ray_with_telemetry, location)
             serve.get_deployment_handle("TelemetryReceiver", "telemetry")
 
         wait_for_condition(
-            check_telemetry_recorded,
-            storage_handle=storage_handle,
-            key="serve_get_deployment_handle_api_used",
-            expected_value="1",
+            check_telemetry,
+            tag=ServeUsageTag.SERVE_GET_DEPLOYMENT_HANDLE_API_USED,
+            expected="1",
         )
     else:
         for _ in range(3):
-            check_telemetry_not_recorded(
-                storage_handle, "serve_get_deployment_handle_api_used"
+            check_telemetry(
+                ServeUsageTag.SERVE_GET_DEPLOYMENT_HANDLE_API_USED, expected=None
             )
             time.sleep(1)
 


### PR DESCRIPTION
[serve] Improve telemetry tests and fix get deployment handle telemetry

1. Improved telemetry tests.
2. Fixes `SERVE_GET_DEPLOYMENT_HANDLE_API_USED` telemetry, which was always recorded because we use it in proxy.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/ray-project/ray/pull/44736).
* #44609
* __->__ #44736