### PR TITLE
[RLlib] Add debug setting for running `training_step` inside a thread (similar to `evaluate_parallel_to_training`, but even w/o any eval going on).

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -817,7 +817,13 @@ class Algorithm(Trainable, AlgorithmBase):
         eval_results: ResultDict = {}
 
         # Parallel eval + training: Kick off evaluation-loop and parallel train() call.
-        if evaluate_this_iter and self.config.evaluation_parallel_to_training:
+        if (
+            self.config._run_training_always_in_thread
+            or (
+                evaluate_this_iter
+                and self.config.evaluation_parallel_to_training
+            )
+        ):
             (
                 train_results,
                 eval_results,
@@ -3091,12 +3097,16 @@ class Algorithm(Trainable, AlgorithmBase):
             parallel_train_future = executor.submit(
                 lambda: self._run_one_training_iteration()
             )
-            # Pass the train_future into `self._run_one_evaluation()` to allow it
-            # to run exactly as long as the training iteration takes in case
-            # evaluation_duration=auto.
-            evaluation_results = self._run_one_evaluation(
-                parallel_train_future=parallel_train_future
-            )
+            evaluation_results = {}
+            # If the debug setting _run_training_always_in_thread is used, do NOT
+            # evaluate, no matter what the settings are,
+            if not self.config._run_training_always_in_thread:
+                # Pass the train_future into `self._run_one_evaluation()` to allow it
+                # to run exactly as long as the training iteration takes in case
+                # evaluation_duration=auto.
+                evaluation_results = self._run_one_evaluation(
+                    parallel_train_future=parallel_train_future
+                )
             # Collect the training results from the future.
             train_results, train_iter_ctx = parallel_train_future.result()
 

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -817,12 +817,8 @@ class Algorithm(Trainable, AlgorithmBase):
         eval_results: ResultDict = {}
 
         # Parallel eval + training: Kick off evaluation-loop and parallel train() call.
-        if (
-            self.config._run_training_always_in_thread
-            or (
-                evaluate_this_iter
-                and self.config.evaluation_parallel_to_training
-            )
+        if self.config._run_training_always_in_thread or (
+            evaluate_this_iter and self.config.evaluation_parallel_to_training
         ):
             (
                 train_results,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Add debug setting for running `training_step` inside a thread (similar to `evaluate_parallel_to_training`, but even w/o any eval going on).

**Why do we need this setting?**
We will remove this setting in the near future again, but it'll help us pin down a complex, production-only memory leak that is possibly connected to the `evaluate_parallel_to_training=True` setting, in which we run the `training_step` calls inside a thread (and the evaluation calls in the main thread). We are also not sure whether RLlib itself is the reason for the leak, but with the help of this PR, will be able to narrow down things further.


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
