### PR TITLE
[release] package run_release_test.sh

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -386,12 +386,21 @@ py_test(
 
 sh_binary(
     name = "run",
-    srcs = ["run_release_test.sh"],
+    srcs = ["run_release_test_sh"],
     data = ["run_release_test"],
     env = {
         "NO_INSTALL": "1",
         "RAY_TEST_SCRIPT": "./run_release_test",
     }
+)
+
+genrule(
+    name = "run_release_test_sh",
+    srcs = ["run_release_test.sh"],
+    outs = ["run.sh"],
+    cmd = """
+        cat $(location run_release_test.sh) > $@
+    """,
 )
 
 py_binary(


### PR DESCRIPTION
In order to package the run_release_test binary properly, the run_release_test.sh needs to be copied over. This doesn't really matter for 'bazel run' but 'bazel build' need this.

Test:
- CI
- release test run: https://buildkite.com/ray-project/postmerge/builds/4012