### PR TITLE
[Data] Store Ray Data logs in special subdirectory

### DIFF
--- a/doc/source/data/examples/huggingface_vit_batch_prediction.ipynb
+++ b/doc/source/data/examples/huggingface_vit_batch_prediction.ipynb
@@ -148,7 +148,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-03-13 11:15:48,780\tINFO streaming_executor.py:115 -- Starting execution of Dataset. Full log are in /tmp/ray/session_2024-03-13_10-32-07_109388_95283/logs/ray-data\n",
+      "2024-03-13 11:15:48,780\tINFO streaming_executor.py:115 -- Starting execution of Dataset. Full logs are in /tmp/ray/session_2024-03-13_10-32-07_109388_95283/logs/ray-data\n",
       "2024-03-13 11:15:48,780\tINFO streaming_executor.py:116 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[ReadImage] -> LimitOperator[limit=10]\n",
       "\n"
      ]

--- a/doc/source/data/examples/huggingface_vit_batch_prediction.ipynb
+++ b/doc/source/data/examples/huggingface_vit_batch_prediction.ipynb
@@ -148,7 +148,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-03-13 11:15:48,780\tINFO streaming_executor.py:115 -- Starting execution of Dataset. Full log is in /tmp/ray/session_2024-03-13_10-32-07_109388_95283/logs/ray-data.log\n",
+      "2024-03-13 11:15:48,780\tINFO streaming_executor.py:115 -- Starting execution of Dataset. Full log are in /tmp/ray/session_2024-03-13_10-32-07_109388_95283/logs/ray-data\n",
       "2024-03-13 11:15:48,780\tINFO streaming_executor.py:116 -- Execution plan of Dataset: InputDataBuffer[Input] -> TaskPoolMapOperator[ReadImage] -> LimitOperator[limit=10]\n",
       "\n"
      ]

--- a/doc/source/data/inspecting-data.rst
+++ b/doc/source/data/inspecting-data.rst
@@ -150,7 +150,7 @@ Inspecting execution statistics
 
 Ray Data calculates statistics during execution for each operator, such as wall clock time and memory usage.
 
-To view stats about your :class:`Datasets <ray.data.Dataset>`, call :meth:`Dataset.stats() <ray.data.Dataset.stats>` on an executed dataset. The stats are also persisted under `/tmp/ray/session_*/logs/ray-data.log`.
+To view stats about your :class:`Datasets <ray.data.Dataset>`, call :meth:`Dataset.stats() <ray.data.Dataset.stats>` on an executed dataset. The stats are also persisted under `/tmp/ray/session_*/logs/ray-data/ray-data.log`.
 For more on how to read this output, see :ref:`Monitoring Your Workload with the Ray Data Dashboard <monitoring-your-workload>`.
 
 .. testcode::

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -106,7 +106,7 @@ When an operator completes, the metrics for that operator are also logged.
    Operator InputDataBuffer[Input] -> TaskPoolMapOperator[ReadRange->MapBatches(<lambda>)] completed. Operator Metrics:
    {'num_inputs_received': 20, 'bytes_inputs_received': 46440, 'num_task_inputs_processed': 20, 'bytes_task_inputs_processed': 46440, 'num_task_outputs_generated': 20, 'bytes_task_outputs_generated': 800, 'rows_task_outputs_generated': 100, 'num_outputs_taken': 20, 'bytes_outputs_taken': 800, 'num_outputs_of_finished_tasks': 20, 'bytes_outputs_of_finished_tasks': 800, 'num_tasks_submitted': 20, 'num_tasks_running': 0, 'num_tasks_have_outputs': 20, 'num_tasks_finished': 20, 'obj_store_mem_freed': 46440, 'obj_store_mem_spilled': 0, 'block_generation_time': 1.191296085, 'cpu_usage': 0, 'gpu_usage': 0, 'ray_remote_args': {'num_cpus': 1, 'scheduling_strategy': 'SPREAD'}}
 
-This log file can be found locally at `/tmp/ray/{SESSION_NAME}/logs/ray-data.log`. It can also be found on the Ray Dashboard under the head node's logs in the :ref:`Logs view <dash-logs-view>`.
+This log file can be found locally at `/tmp/ray/{SESSION_NAME}/logs/ray-data/ray-data.log`. It can also be found on the Ray Dashboard under the head node's logs in the :ref:`Logs view <dash-logs-view>`.
 
 .. _ray-data-stats:
 

--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -97,4 +97,4 @@ def get_log_directory() -> Optional[str]:
         return None
 
     session_dir = global_node.get_session_dir_path()
-    return os.path.join(session_dir, "logs")
+    return os.path.join(session_dir, "logs", "ray-data")

--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -58,6 +58,8 @@ class SessionFileHandler(logging.Handler):
         if log_directory is None:
             return
 
+        os.makedirs(log_directory, exist_ok=True)
+
         self._path = os.path.join(log_directory, self._filename)
         self._handler = logging.FileHandler(self._path)
         if self._formatter is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, Ray Data stores logs in the `{session_directory}/logs` directory along with all other Ray logs. This PR changes the behavior so Ray Data stores log in a dedicated `{session_directory}/logs/ray-data` directory. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
