### PR TITLE
[tests] Increase timeout for single_node_oom test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4011,7 +4011,7 @@
     cluster_compute: stress_tests/stress_tests_single_node_oom_compute.yaml
 
   run:
-    timeout: 500
+    timeout: 1000
     script: python stress_tests/test_parallel_tasks_memory_pressure.py --num-tasks 20
 
   variations:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This test has pretty variable run time. Increase the test timeout to avoid spurious failures.