### PR TITLE
[serve] autoscaling release test deflake and debugging

### DIFF
--- a/release/serve_tests/workloads/resnet_50.py
+++ b/release/serve_tests/workloads/resnet_50.py
@@ -33,8 +33,16 @@ class Model:
 
     async def __call__(self, request: starlette.requests.Request) -> str:
         uri = (await request.json())["uri"]
+
         try:
             image_bytes = requests.get(uri).content
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ChunkedEncodingError,
+        ):
+            return
+
+        try:
             image = Image.open(BytesIO(image_bytes)).convert("RGB")
         except PIL.UnidentifiedImageError:
             return


### PR DESCRIPTION
[serve] autoscaling release test deflake and debugging

Deflake release test. From the logs sometimes the http request to get the image fails with connection reset error. For those few occasions we can just return.
Also seeing some 504 errors but need more visibility, so this also adds better tracking for failed requests.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
