### PR TITLE
[Data] Add in `local_read` option to `from_torch`

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2861,12 +2861,14 @@ def from_torch(
 
     Args:
         dataset: A `Torch Dataset`_.
+        local_read: If ``True``, perform the read as a local read.
 
     Returns:
         A :class:`~ray.data.Dataset` containing the Torch dataset samples.
     """  # noqa: E501
 
     # Files may not be accessible from all nodes, run the read task on current node.
+    ray_remote_args = {}
     if local_read:
         ray_remote_args = {
             "scheduling_strategy": NodeAffinitySchedulingStrategy(

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2875,6 +2875,10 @@ def from_torch(
                 ray.get_runtime_context().get_node_id(),
                 soft=False,
             ),
+            # The user might have initialized Ray to have num_cpus = 0 for the head
+            # node. For a local read we expect the read task to be executed on the
+            # head node, so we should set num_cpus = 0 for the task to allow it to
+            # run regardless of the user's head node configuration.
             "num_cpus": 0,
         }
     return read_datasource(

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -180,11 +180,12 @@ def test_from_tf(ray_start_regular_shared):
         tf.debugging.assert_equal(expected_label, actual_label)
 
 
-def test_from_torch(shutdown_only, tmp_path):
+@pytest.mark.parametrize("local_read", [True, False])
+def test_from_torch(shutdown_only, local_read, tmp_path):
     torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
     expected_data = list(torch_dataset)
 
-    ray_dataset = ray.data.from_torch(torch_dataset)
+    ray_dataset = ray.data.from_torch(torch_dataset, local_read=local_read)
 
     actual_data = extract_values("item", list(ray_dataset.take_all()))
     assert actual_data == expected_data


### PR DESCRIPTION
## Why are these changes needed?
Add better support for `from_torch` across local and nonlocal cluster workflows. This PR adds a new argument `local_read` which defaults to `False`. If set to `True`, `NodeAffinitySchedulingStrategy` is used and `num_cpus` is set to 0.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
