### PR TITLE
[release] fix _copy_script_to_working_dir

### DIFF
--- a/release/ray_release/command_runner/job_runner.py
+++ b/release/ray_release/command_runner/job_runner.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import tempfile
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -56,11 +57,7 @@ class JobRunner(CommandRunner):
 
     def _copy_script_to_working_dir(self, script_name):
         script = os.path.join(os.path.dirname(__file__), f"_{script_name}")
-        if os.path.exists(script_name):
-            os.unlink(script_name)
-        if os.path.islink(script):
-            script = os.readlink(script)
-        os.link(script, script_name)
+        shutil.copy(script, script_name)
 
     def prepare_remote_env(self):
         self._copy_script_to_working_dir("wait_cluster.py")


### PR DESCRIPTION
The `_copy_script_to_working_dir` is used to copy test runner scripts into release test working directory, before uploading them to the cloud. Currently it attempts to symlink, however `os.link` doesn't work properly between different file system (e.g. docker mount). Use `shutil.copy` to just copy the file over instead, which also handles symlink properly.

Test:
- CI