### PR TITLE
[core] Add 5s timeout to the log and err subscriber polls.

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -895,7 +895,7 @@ class Worker:
                 if self.threads_stopped.is_set():
                     return
 
-                data = subscriber.poll()
+                data = subscriber.poll(timeout=1)
                 # GCS subscriber only returns None on unavailability.
                 if data is None:
                     last_polling_batch_size = 0
@@ -2133,7 +2133,7 @@ def listen_error_messages(worker, threads_stopped):
             if threads_stopped.is_set():
                 return
 
-            _, error_data = worker.gcs_error_subscriber.poll()
+            _, error_data = worker.gcs_error_subscriber.poll(timeout=1)
             if error_data is None:
                 continue
             if error_data["job_id"] not in [


### PR DESCRIPTION
In `worker.py` we have threads to poll logs and errors from GCS. These polls are *forever* and we experienced some hang on shutdown. Changing them to a 5s timeout. This is safe because if it's timed out, `PythonGcsSubscriber::DoPoll` returns OK with empty error/log, and the python polling threads `print_logs` and `listen_error_messages` just ignores it and retries.

Also added some type annotations just for better code.