### PR TITLE
[Serve] Remove replicas from scheduler when receiving an `ActorDiedError`

### DIFF
--- a/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
@@ -17,7 +17,7 @@ from typing import (
     Tuple,
 )
 
-from ray.exceptions import ActorDiedError
+from ray.exceptions import ActorDiedError, ActorUnavailableError
 from ray.serve._private.common import (
     DeploymentID,
     ReplicaID,
@@ -526,6 +526,12 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                     for id_set in self._colocated_replica_ids.values():
                         id_set.discard(replica.replica_id)
                     msg += " This replica will no longer be considered for requests."
+                elif isinstance(t.exception(), ActorUnavailableError):
+                    msg = (
+                        "Failed to fetch queue length for "
+                        f"{replica.replica_id}. Replica is temporarily "
+                        "unavailable."
+                    )
 
                 logger.warning(msg)
             else:

--- a/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
@@ -17,7 +17,7 @@ from typing import (
     Tuple,
 )
 
-from ray.exceptions import RayActorError
+from ray.exceptions import ActorDiedError
 from ray.serve._private.common import (
     DeploymentID,
     ReplicaID,
@@ -517,7 +517,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                 # If we get a RayActorError, it means the replica actor has died. This
                 # is not recoverable (the controller will start a new replica in its
                 # place), so we should no longer consider it for requests.
-                if isinstance(t.exception(), RayActorError):
+                if isinstance(t.exception(), ActorDiedError):
                     self._replicas.pop(replica.replica_id, None)
                     self._replica_id_set.discard(replica.replica_id)
                     for id_set in self._colocated_replica_ids.values():

--- a/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
@@ -514,9 +514,12 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                     "Failed to fetch queue length for "
                     f"{replica.replica_id}: '{t.exception()}'"
                 )
-                # If we get a RayActorError, it means the replica actor has died. This
+                # If we get an ActorDiedError, the replica actor has died. This
                 # is not recoverable (the controller will start a new replica in its
                 # place), so we should no longer consider it for requests.
+                # We do not catch RayActorError here because that error can be
+                # raised even when a replica is temporarily unavailable.
+                # See https://github.com/ray-project/ray/issues/44185 for details.
                 if isinstance(t.exception(), ActorDiedError):
                     self._replicas.pop(replica.replica_id, None)
                     self._replica_id_set.discard(replica.replica_id)

--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -89,6 +89,7 @@ class FakeReplicaWrapper(ReplicaWrapper):
         self._has_queue_len_response.set()
 
     async def get_queue_len(self, *, deadline_s: float) -> int:
+        self.num_get_queue_len_calls += 1
         self.queue_len_deadline_history.append(deadline_s)
         try:
             while not self._has_queue_len_response.is_set():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change makes the `PowerOfTwoChoicesReplicaScheduler` stop routing to a replica when it receives an `ActorDiedError`.

**Context:** Currently, the scheduler stops routing to a replica when it receives a `RayActorError`. However, `RayActorError` can also be raised when there's network instability in the cluster, which leads to issues like #44185. #44212 recently introduced the `ActorDiedError` subclass, which only gets raised if the actor has died.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #44185.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds tests to `test_pow_2_replica_scheduler.py`.
   - [ ] Release tests
   - [ ] This PR is not tested :(
