### PR TITLE
[KubeRay][Docs] Clarify KubeRay v1 API guarantees

### DIFF
--- a/doc/source/cluster/kubernetes/references.md
+++ b/doc/source/cluster/kubernetes/references.md
@@ -10,8 +10,13 @@ refer to the [API reference][APIReference].
 ## KubeRay API compatibility and guarantees
 
 v1 APIs in the KubeRay project are stable and suitable for production environments.
-While KubeRay maintainers strive to maintain backward compatibility, they reserve the right to deprecate API fields.
-They will clearly communicate the deprecation status, and may remove the APIs after a minimum of two minor releases.
-This policy allows for the necessary evolution of the API while providing a reasonable transition period for users.
+Fields in the v1 APIs will never be removed to maintain compatibility.
+Future major versions of the API (i.e. v2) may have breaking changes and fields removed from v1.
+
+However, KubeRay maintainers preserve the right to mark fields as deprecated and remove
+functionality associated with deprecated fields after a minimum of two minor releases.
+In addition, some definitions of the API may see small changes in behavior. For example,
+the definition of a "ready" or "unhealthy" RayCluster could change to better handle new
+failure scenarios.
 
 [APIReference]: https://ray-project.github.io/kuberay/reference/api/


### PR DESCRIPTION
## Why are these changes needed?

This is a follow-up to https://github.com/ray-project/ray/pull/43281 to clarify that v1 fields will never be removed to preserve compatibility, but they can be deprecated. Also clarifies that some definitions and behavior of fields can change to better handle new failure scenarios 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
