### PR TITLE
[serve] track stats per stage for autoscaling release test

### DIFF
--- a/release/serve_tests/workloads/replica_scalability.py
+++ b/release/serve_tests/workloads/replica_scalability.py
@@ -126,7 +126,7 @@ def main(num_replicas: Optional[int], trial_length: Optional[int]):
         ]
         results = {
             "total_requests": stats.total_requests,
-            "history": stats.history,
+            "service_id": status.id,
             "perf_metrics": sum(
                 results_per_stage,
                 [
@@ -154,6 +154,7 @@ def main(num_replicas: Optional[int], trial_length: Optional[int]):
             ),
         }
 
+        logger.info(f"Stats history: {json.dumps(stats.history, indent=4)}")
         logger.info(f"Final aggregated metrics: {json.dumps(results, indent=4)}")
         save_test_results(results)
 


### PR DESCRIPTION
[serve] track stats per stage for autoscaling release test

The autoscaling load release test goes through 3 stages: running 10 locust users, then 50, then 100. We expect the number of replicas to autoscale in response to that. However the latencies in each of these 3 stages can differ, and we should track that.
Other small things:
* Don't save the stats history (which is a snapshot of the latencies/throughput every 10 seconds). That multiplies the amount of data that needs to be stored for each release test run, and isn't very useful. If we need to look at that data for any reason, we can go look at the job logs.
* Save the service id.

The p50, p90, p99 latencies and throughput will be stored for each stage, e.g:
```
  {
    'perf_metric_name': 'p50_latency',
    'perf_metric_value': ...,
    'perf_metric_type': 'LATENCY'
  },
  {
    'perf_metric_name': 'p90_latency',
    'perf_metric_value': ...,
    'perf_metric_type': 'LATENCY'
  },
  {
    'perf_metric_name': 'p99_latency',
    'perf_metric_value': ...,
    'perf_metric_type': 'LATENCY'
  },
  {
    'perf_metric_name': 'avg_rps',
    'perf_metric_value': ...,
    'perf_metric_type': 'THROUGHPUT'
  },
  {
    'perf_metric_name': 'stage_1_p50_latency',
    'perf_metric_value': ...,
    'perf_metric_type': 'LATENCY'
  },
  {
    'perf_metric_name': 'stage_1_p90_latency',
    'perf_metric_value': ...,
    'perf_metric_type': 'LATENCY'
  },
  {
    'perf_metric_name': 'stage_1_p99_latency',
    'perf_metric_value': ...,
    'perf_metric_type': 'LATENCY'
  },
  {
    'perf_metric_name': 'stage_1_rps',
    'perf_metric_value': ...,
    'perf_metric_type': 'THROUGHPUT'
  },
  {
    'perf_metric_name': 'stage_2_p50_latency',
    'perf_metric_value': ...,
    'perf_metric_type': 'LATENCY'
  },
  {
    'perf_metric_name': 'stage_2_p90_latency',
    'perf_metric_value': ...,
    'perf_metric_type': 'LATENCY'
  },
  {
    'perf_metric_name': 'stage_2_p99_latency',
    'perf_metric_value': ...,
    'perf_metric_type': 'LATENCY'
  },
  {
    'perf_metric_name': 'stage_2_rps',
    'perf_metric_value': ...,
    'perf_metric_type': 'THROUGHPUT'
  },
```
etc.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
