### PR TITLE
[ci][bisect/0] pipeline for bisect

### DIFF
--- a/.buildkite/bisect/_forge.rayci.yml
+++ b/.buildkite/bisect/_forge.rayci.yml
@@ -1,0 +1,4 @@
+group: forge
+steps:
+  - name: forge
+    wanda: ci/docker/forge.wanda.yaml

--- a/.buildkite/bisect/bisect.rayci.yml
+++ b/.buildkite/bisect/bisect.rayci.yml
@@ -1,0 +1,7 @@
+group: bisect
+depends_on: 
+  - forge
+steps:
+  - name: release test
+    commands:
+      - ./ci/ray_ci/bisect/release_test_bisect.sh

--- a/.buildkite/bisect/config.yml
+++ b/.buildkite/bisect/config.yml
@@ -1,0 +1,22 @@
+name: ray-bisect
+artifacts_bucket: ray-ci-artifact-branch-public
+ci_temp: s3://ray-ci-artifact-branch-public/ci-temp/
+ci_work_repo: 029272617770.dkr.ecr.us-west-2.amazonaws.com/rayproject/citemp
+forge_prefix: cr.ray.io/rayproject/
+builder_queues:
+  builder: builder_queue_branch
+runner_queues:
+  default: runner_queue_small_branch
+buildkite_dirs:
+  - .buildkite/bisect
+env:
+  BUILDKITE_BAZEL_CACHE_URL: https://bazel-cache-dev.s3.us-west-2.amazonaws.com
+  RAYCI_SKIP_UPLOAD: "true"
+  # the following will be replaced by the actual values in the bisect pipeline
+  RAYCI_BISECT_TEST_NAME: __RAYCI_BISECT_TEST_NAME__
+  RAYCI_BISECT_PASSING_COMMIT: __RAYCI_BISECT_PASSING_COMMIT__
+  RAYCI_BISECT_FAILING_COMMIT: __RAYCI_BISECT_FAILING_COMMIT__
+  RAYCI_BISECT_CONCURRENCY: __RAYCI_BISECT_CONCURRENCY__
+  RAYCI_BISECT_RUN_PER_COMMIT: __RAYCI_BISECT_RUN_PER_COMMIT__
+hook_env_keys:
+  - RAYCI_CHECKOUT_DIR

--- a/ci/ray_ci/bisect/release_test_bisect.sh
+++ b/ci/ray_ci/bisect/release_test_bisect.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eux
+
+# set up the release and bisect infra environment
+bash release/gcloud_docker_login.sh release/aws2gce_iam.json 
+export PATH="$(pwd)/google-cloud-sdk/bin:$PATH"
+
+# running bisect
+export BUILDKITE_MAX_RETRIES=0
+pip install -e release/
+cd release 
+python ray_release/scripts/ray_bisect.py "$RAYCI_BISECT_TEST_NAME" \
+  "$RAYCI_BISECT_PASSING_COMMIT" "$RAYCI_BISECT_FAILING_COMMIT" \
+  --concurrency "$RAYCI_BISECT_CONCURRENCY" \
+  --run-per-commit "$RAYCI_BISECT_RUN_PER_COMMIT"

--- a/release/ray_release/scripts/ray_bisect.py
+++ b/release/ray_release/scripts/ray_bisect.py
@@ -239,7 +239,10 @@ def _obtain_test_result(
     return outcomes
 
 
-def _get_test(test_name: str, test_collection_file: Tuple[str]) -> Test:
+def _get_test(
+    test_name: str,
+    test_collection_file: Tuple[str],
+) -> Test:
     test_collection = read_and_validate_release_test_collection(
         test_collection_file or ["release/release_tests.yaml"],
     )


### PR DESCRIPTION
Move the buildkite bisect definition to ray repo. This will allow me to reuse this pipeline for macos test and other type of test bisecting.

Test: https://buildkite.com/ray-project/bisect/builds/1002