### PR TITLE
[Serve] fix getting attributes on stdout during Serve logging redirect

### DIFF
--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -210,10 +210,15 @@ class StreamToLogger(object):
     This comes from https://stackoverflow.com/a/36296215 directly.
     """
 
-    def __init__(self, logger, log_level):
+    def __init__(self, logger, log_level, original_object):
         self.logger = logger
         self.log_level = log_level
+        self.original_object = original_object
         self.linebuf = ""
+
+    def __getattr__(self, attr):
+        # getting attributes from the original object
+        return getattr(self.original_object, attr)
 
     @staticmethod
     def get_stacklevel():
@@ -363,8 +368,8 @@ def configure_component_logger(
     # Redirect print, stdout, and stderr to Serve logger.
     if not RAY_SERVE_LOG_TO_STDERR:
         builtins.print = redirected_print
-        sys.stdout = StreamToLogger(logger, logging.INFO)
-        sys.stderr = StreamToLogger(logger, logging.INFO)
+        sys.stdout = StreamToLogger(logger, logging.INFO, sys.stdout)
+        sys.stderr = StreamToLogger(logger, logging.INFO, sys.stderr)
 
     logger.addHandler(file_handler)
 

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 import traceback
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import ray
 from ray.serve._private.common import ServeComponentType
@@ -210,18 +210,18 @@ class StreamToLogger(object):
     This comes from https://stackoverflow.com/a/36296215 directly.
     """
 
-    def __init__(self, logger, log_level, original_object):
-        self.logger = logger
-        self.log_level = log_level
-        self.original_object = original_object
-        self.linebuf = ""
+    def __init__(self, logger: logging.Logger, log_level: int, original_object: Any):
+        self._logger = logger
+        self._log_level = log_level
+        self._original_object = original_object
+        self._linebuf = ""
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Any:
         # getting attributes from the original object
-        return getattr(self.original_object, attr)
+        return getattr(self._original_object, attr)
 
     @staticmethod
-    def get_stacklevel():
+    def get_stacklevel() -> int:
         """Rewind stack to get the stacklevel for the user code.
 
         Going from the back of the traceback and traverse until it's no longer in
@@ -236,9 +236,9 @@ class StreamToLogger(object):
                 return index
         return 1
 
-    def write(self, buf):
-        temp_linebuf = self.linebuf + buf
-        self.linebuf = ""
+    def write(self, buf: str):
+        temp_linebuf = self._linebuf + buf
+        self._linebuf = ""
         for line in temp_linebuf.splitlines(True):
             # From the io.TextIOWrapper docs:
             #   On output, if newline is None, any '\n' characters written
@@ -246,22 +246,22 @@ class StreamToLogger(object):
             # By default sys.stdout.write() expects '\n' newlines and then
             # translates them so this is still cross-platform.
             if line[-1] == "\n":
-                self.logger.log(
-                    self.log_level,
+                self._logger.log(
+                    self._log_level,
                     line.rstrip(),
                     stacklevel=self.get_stacklevel(),
                 )
             else:
-                self.linebuf += line
+                self._linebuf += line
 
     def flush(self):
-        if self.linebuf != "":
-            self.logger.log(
-                self.log_level,
-                self.linebuf.rstrip(),
+        if self._linebuf != "":
+            self._logger.log(
+                self._log_level,
+                self._linebuf.rstrip(),
                 stacklevel=self.get_stacklevel(),
             )
-        self.linebuf = ""
+        self._linebuf = ""
 
     def isatty(self) -> bool:
         return True


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are attributes on `sys.stdout` and `sys.stderr` which are not implemented on our `StreamToLogger` class. When we overrided them for redirect, it will raise `AttributeError`. This caused Ray Tune unable to get the attributes on those objects on Anyscale Services where the redirect is turned on. This PR added `__getattr__()` on the `StreamToLogger` to get the attributes on the original object so they can still be accessible. Also added a unit test for it.

## Related issue number

Closes https://github.com/ray-project/ray/issues/44779

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
