### PR TITLE
[Data] Clarify deprecated `Datasource` docstrings

### DIFF
--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -16,19 +16,18 @@ class Datasource:
 
     @Deprecated
     def create_reader(self, **read_args) -> "Reader":
-        """Return a Reader for the given read arguments.
-
-        The reader object will be responsible for querying the read metadata, and
-        generating the actual read tasks to retrieve the data blocks upon request.
-
-        Args:
-            read_args: Additional kwargs to pass to the datasource impl.
+        """
+        Deprecated: Implement :meth:`Datasource.get_read_tasks` and
+        :meth:`Datasource.estimate_inmemory_data_size` instead.
         """
         return _LegacyDatasourceReader(self, **read_args)
 
     @Deprecated
     def prepare_read(self, parallelism: int, **read_args) -> List["ReadTask"]:
-        """Deprecated: Please implement create_reader() instead."""
+        """
+        Deprecated: Implement :meth:`Datasource.get_read_tasks` and
+        :meth:`Datasource.estimate_inmemory_data_size` instead.
+        """
         raise NotImplementedError
 
     def get_name(self) -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `prepare_read` docstring instructs the user to implement `create_reader` instead, but `create_reader` is deprecated. This PR clarifies that in both cases the user should implement `get_read_tasks` and `estimated_in_memory_data_size`.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
