### PR TITLE
[ci][bisect/0] add test-type to the bisect pipeline

### DIFF
--- a/release/ray_release/test_automation/release_state_machine.py
+++ b/release/ray_release/test_automation/release_state_machine.py
@@ -132,6 +132,7 @@ class ReleaseTestStateMachine(TestStateMachine):
                 "failing-commit": failing_commit,
                 "concurrency": "3",
                 "run-per-commit": "1",
+                "test-type": "release-test",
             },
         )
         self.test[Test.KEY_BISECT_BUILD_NUMBER] = build["number"]


### PR DESCRIPTION
Add test-type as an input to the bisect pipeline. This will allow us to run different bisect step depending on test type as an input.

Test:
- CI