### PR TITLE
[ci] restrict artifacts cleanup o linux only

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -8,25 +8,23 @@
 # after uploading artifacts to make sure no stale artifacts
 # remain on the node when a Buildkite runner is re-used.
 set -ex
-if [ -d "/tmp/artifacts" ]; then
-    echo "Cleaning up old artifacts before command."
-    echo "Artifact directory contents before cleanup:"
-    find /tmp/artifacts -print || true
-
-    if [ "$(ls -A /tmp/artifacts)" ]; then
-      echo "Directory not empty, cleaning up..."
-      # Need to run in docker to avoid permission issues
-      docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
-    else
-      echo "Directory already empty, no need to clean up."
-    fi
-
-    echo "Artifact directory contents after cleanup:"
-    find /tmp/artifacts -print || true
-fi
 
 echo "Creating artifact directory..."
 if [[ "${OSTYPE}" == linux* ]]; then
+  if [[ -d "/tmp/artifacts" ]]; then
+      echo "Cleaning up old artifacts before command."
+      echo "Artifact directory contents before cleanup:"
+      find /tmp/artifacts -print || true
+
+      if [[ "$(ls -A /tmp/artifacts)" ]]; then
+        echo "Directory not empty, cleaning up..."
+        # Need to run in docker to avoid permission issues
+        docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'rm -rf /artifact-mount/*; rm -rf /artifact-mount/.[!.]*' || true
+      else
+        echo "Directory already empty, no need to clean up."
+      fi
+  fi
+
   docker run --rm -v /tmp/artifacts:/artifact-mount alpine:latest /bin/sh -c 'chown -R 2000 /artifact-mount/' || true
 elif [[ "${OSTYPE}" == msys ]]; then
   if [[ -d "/c/tmp/artifacts" ]]; then


### PR DESCRIPTION
in pre-command. otherwise, macos and windows can also trigger those, and lead to things like "docker command not found"
