### PR TITLE
[serve] reduce remote calls for get handle APIs

### DIFF
--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -409,36 +409,31 @@ class ServeControllerClient:
     def get_handle(
         self,
         deployment_name: str,
-        app_name: Optional[str] = "default",
-        missing_ok: Optional[bool] = False,
+        app_name: Optional[str] = SERVE_DEFAULT_APP_NAME,
+        check_exists: bool = True,
     ) -> DeploymentHandle:
         """Construct a handle for the specified deployment.
 
         Args:
             deployment_name: Deployment name.
             app_name: Application name.
-            missing_ok: If true, then Serve won't check the deployment
-                is registered. False by default.
+            check_exists: If False, then Serve won't check the deployment
+                is registered. True by default.
 
         Returns:
             DeploymentHandle
         """
         from ray.serve.context import _get_internal_replica_context
 
-        cache_key = (deployment_name, app_name, missing_ok)
+        deployment_id = DeploymentID(name=deployment_name, app_name=app_name)
+        cache_key = (deployment_name, app_name, check_exists)
         if cache_key in self.handle_cache:
             return self.handle_cache[cache_key]
 
-        all_deployments = ray.get(self._controller.list_deployment_ids.remote())
-        if (
-            not missing_ok
-            and DeploymentID(name=deployment_name, app_name=app_name)
-            not in all_deployments
-        ):
-            raise KeyError(
-                f"Deployment '{deployment_name}' in application '{app_name}' does not "
-                "exist."
-            )
+        if check_exists:
+            all_deployments = ray.get(self._controller.list_deployment_ids.remote())
+            if deployment_id not in all_deployments:
+                raise KeyError(f"{deployment_id} does not exist.")
 
         if _get_internal_replica_context() is not None:
             handle = DeploymentHandle(

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -535,7 +535,7 @@ def _run(
         # deploy_application returns; the application state manager will
         # need another reconcile iteration to create it.
         client._wait_for_deployment_created(ingress.name, name)
-        handle = client.get_handle(ingress.name, name, missing_ok=True)
+        handle = client.get_handle(ingress.name, name, check_exists=False)
         return handle
 
 
@@ -829,13 +829,16 @@ def get_app_handle(name: str) -> DeploymentHandle:
         raise RayServeException(f"Application '{name}' does not exist.")
 
     ServeUsageTag.SERVE_GET_APP_HANDLE_API_USED.record("1")
-    return client.get_handle(ingress, name)
+    # There is no need to check if the deployment exists since the
+    # deployment name was just fetched from the controller
+    return client.get_handle(ingress, name, check_exists=False)
 
 
 @DeveloperAPI
 def get_deployment_handle(
     deployment_name: str,
     app_name: Optional[str] = None,
+    _check_exists: bool = True,
     _record_telemetry: bool = True,
 ) -> DeploymentHandle:
     """Get a handle to a deployment by name.
@@ -926,4 +929,4 @@ def get_deployment_handle(
     if _record_telemetry:
         ServeUsageTag.SERVE_GET_DEPLOYMENT_HANDLE_API_USED.record("1")
 
-    return client.get_handle(deployment_name, app_name)
+    return client.get_handle(deployment_name, app_name, check_exists=_check_exists)

--- a/python/ray/serve/tests/test_regression.py
+++ b/python/ray/serve/tests/test_regression.py
@@ -163,7 +163,7 @@ def test_handle_cache_out_of_scope(serve_instance):
     assert len(handle_cache) == initial_num_cached + 1
 
     def sender_where_handle_goes_out_of_scope():
-        f = _get_global_client().get_handle("f", "app", missing_ok=True)
+        f = _get_global_client().get_handle("f", "app", check_exists=False)
         assert f is handle
         assert f.remote().result() == "hi"
 


### PR DESCRIPTION
[serve] reduce remote calls for get handle APIs

This PR makes two changes to the get handle APIs:
1. First, it optimizes `serve.get_app_handle`, which made two separate calls to the controller: one to get the ingress deployment name for the specified application, and one to check if the deployment exists. This is unnecessary and can be squashed into one call; in other words the second call doesn't need to be made.
2. `serve.get_deployment_handle` makes one call to the controller to check if the specified deployment exists. This remains the default behavior, but this PR adds a private flag `_check_exists` which can be set to False if the user wants to bypass that check for performance reasons.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
