### PR TITLE
[release-automation] Stop adding temporary conda bin into PATH

### DIFF
--- a/.buildkite/release-automation/verify-macos-wheels.sh
+++ b/.buildkite/release-automation/verify-macos-wheels.sh
@@ -68,8 +68,6 @@ _clean_up() {
 # Create tmp directory unique for the run
 TMP_DIR="$(mktemp -d "$HOME/tmp.XXXXXXXXXX")"
 mkdir -p "$TMP_DIR/bin"
-# Add bin dir to the path.
-export PATH="$TMP_DIR/bin:$PATH"
 
 trap _clean_up EXIT
 

--- a/.buildkite/release-automation/verify-macos-wheels.sh
+++ b/.buildkite/release-automation/verify-macos-wheels.sh
@@ -39,9 +39,6 @@ install_miniconda() {
     bash "$TMP_DIR/miniconda3/miniconda.sh" -b -u -p "$TMP_DIR/miniconda3"
     rm -rf "$TMP_DIR/miniconda3/miniconda.sh"
 
-    # Add miniconda3 to the PATH to use `conda` command.
-    export PATH="$TMP_DIR/miniconda3/bin:$PATH"
-
     # Initialize conda. This replaces calling `conda init bash`.
     # Conda init command requires a shell restart which should not be done on BK.
     source "$TMP_DIR/miniconda3/etc/profile.d/conda.sh"


### PR DESCRIPTION
The script that verifies macos wheels installs `miniconda3` into a temporary directory, then exports its binary path `$TMP_DIR/miniconda3/bin` into `PATH`. This caused a problem when a new conda environment is created and activated, this path goes before the environment's bin path: https://buildkite.com/ray-project/release-automation/builds/384#018eedf8-6486-41ab-889c-2f8db37e57bd/39-286

^ In this log where I `echo $PATH` after activating the conda environment `rayio_3.9`, you can see that `/Users/ec2-user/tmp.PyjQ7FlK9E/miniconda3/envs/rayio_3.9/bin` is supposed to be the first in `$PATH`, but it's `/Users/ec2-user/tmp.PyjQ7FlK9E/miniconda3/bin` instead. This led the environment to use `python` and `pip` from the default miniconda installation which is on 3.8 version: https://buildkite.com/ray-project/release-automation/builds/384#018eedf8-6486-41ab-889c-2f8db37e57bd/39-268

I ran the job again without exporting and it shows that the right python and pip version from the environment was used: https://buildkite.com/ray-project/release-automation/builds/387#018eee3e-6b83-40a0-9a1b-e8164426f3e3/32-256
along with the env path being first in `$PATH`: https://buildkite.com/ray-project/release-automation/builds/387#018eee3e-6b83-40a0-9a1b-e8164426f3e3/32-274
The step was able to find the right distribution from `ray` on testpypi. It only failed because the commit was not right which is expected.