### PR TITLE
[GCS] Fixed GCS pub-sub channel-types to be explicitly mapped to either capped/uncapped channels

### DIFF
--- a/src/ray/pubsub/publisher.cc
+++ b/src/ray/pubsub/publisher.cc
@@ -232,11 +232,22 @@ bool SubscriptionIndex::CheckNoLeaks() const {
 std::unique_ptr<EntityState> SubscriptionIndex::CreateEntityState() {
   switch (channel_type_) {
   case rpc::ChannelType::RAY_ERROR_INFO_CHANNEL:
-  case rpc::ChannelType::RAY_LOG_CHANNEL: {
+  case rpc::ChannelType::RAY_LOG_CHANNEL:
+  case rpc::ChannelType::RAY_NODE_RESOURCE_USAGE_CHANNEL:
     return std::make_unique<CappedEntityState>();
-  }
-  default:
+
+  case rpc::ChannelType::WORKER_OBJECT_EVICTION:
+  case rpc::ChannelType::WORKER_REF_REMOVED_CHANNEL:
+  case rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL:
+  case rpc::ChannelType::GCS_ACTOR_CHANNEL:
+  case rpc::ChannelType::GCS_JOB_CHANNEL:
+  case rpc::ChannelType::GCS_NODE_INFO_CHANNEL:
+  case rpc::ChannelType::GCS_WORKER_DELTA_CHANNEL:
     return std::make_unique<BasicEntityState>();
+
+  default:
+    RAY_LOG(FATAL) << "Unexpected channel type: " << rpc::ChannelType_Name(channel_type_);
+    return nullptr;
   }
 }
 


### PR DESCRIPTION
## Changes

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Currently, `RAY_NODE_RESOURCE_USAGE_CHANNEL` channel in GCS pub-sub is not mapped to a capped channel that could potentially lead to GCS OOMs.

This change explicitly maps every channel-type to corresponding capped/uncapped channel, throwing an exception in case of the channel-type not being mapped appropriately.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
