### PR TITLE
[spark] Fix Ray-on-Spark ray child process shebang issue

### DIFF
--- a/python/ray/util/spark/start_ray_node.py
+++ b/python/ray/util/spark/start_ray_node.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     # using the temp directory.
     fcntl.flock(lock_fd, fcntl.LOCK_SH)
     process = subprocess.Popen(
-        ["python", shutil.which(ray_cli_cmd), "start", *arg_list],
+        [sys.executable, shutil.which(ray_cli_cmd), "start", *arg_list],
         text=True,
     )
 

--- a/python/ray/util/spark/start_ray_node.py
+++ b/python/ray/util/spark/start_ray_node.py
@@ -63,6 +63,12 @@ if __name__ == "__main__":
     # using the temp directory.
     fcntl.flock(lock_fd, fcntl.LOCK_SH)
     process = subprocess.Popen(
+        # 'ray start ...' command uses python that is set by
+        # Shebang #! ..., the Shebang line is hardcoded in ray script,
+        # it can't be changed to other python executable path.
+        # to enforce using current python executable,
+        # turn the subprocess command to
+        # '`sys.executable` `which ray` start ...'
         [sys.executable, shutil.which(ray_cli_cmd), "start", *arg_list],
         text=True,
     )

--- a/python/ray/util/spark/start_ray_node.py
+++ b/python/ray/util/spark/start_ray_node.py
@@ -62,7 +62,10 @@ if __name__ == "__main__":
     # same temp directory, adding a shared lock representing current ray node is
     # using the temp directory.
     fcntl.flock(lock_fd, fcntl.LOCK_SH)
-    process = subprocess.Popen([ray_cli_cmd, "start", *arg_list], text=True)
+    process = subprocess.Popen(
+        ["python", shutil.which(ray_cli_cmd), "start", *arg_list],
+        text=True,
+    )
 
     def try_clean_temp_dir_at_exit():
         try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fix Ray-on-Spark ray child process shebang issue:

Ray CLI script Shebang is hardcoded to a fixed python binary program,
but our Databricks allow user to create python environment layer on top of base python environment. Then Ray tasks can't use python packages installed in user cusomized python environment layer.

This PR addresses the issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [X] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
