### PR TITLE
[ci] sandbox macos pip environments

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -545,7 +545,7 @@ install_dependencies() {
     "${SCRIPT_DIR}"/install-hdfs.sh
   fi
 
-  if [ "${MINIMAL_INSTALL-}" != "1" ]; then
+  if [[ "${MINIMAL_INSTALL-}" != "1" && "${SKIP_REQUIREMENT_PACKAGES-}" != "1" ]]; then
     install_pip_packages
   fi
 

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -320,6 +320,12 @@ if __name__ == "__main__":
                 # nothing is run but linting in these cases
                 pass
             elif (
+                changed_file == ".buildkite/macos.rayci.yml"
+                or changed_file == "ci/ray_ci/macos/macos_ci.sh"
+                or changed_file == "ci/ray_ci/macos/macos_ci_test.sh"
+            ):
+                RAY_CI_MACOS_WHEELS_AFFECTED = 1
+            elif (
                 changed_file.startswith("ci/lint")
                 or changed_file == ".buildkite/lint.rayci.yml"
             ):
@@ -356,11 +362,6 @@ if __name__ == "__main__":
                 RAY_CI_DOCKER_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_TOOLS_AFFECTED = 1
-            elif (
-                changed_file == ".buildkite/macos.rayci.yml"
-                or changed_file == ".buildkite/pipeline.macos.yml"
-            ):
-                RAY_CI_MACOS_WHEELS_AFFECTED = 1
             elif changed_file.startswith("ci/run") or changed_file == "ci/ci.sh":
                 RAY_CI_TOOLS_AFFECTED = 1
             elif changed_file.startswith("src/"):

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -23,63 +23,53 @@ run_small_and_large_flaky_tests() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
   (bazel query 'attr(tags, "client_tests|small_size_python_tests|large_size_python_tests_shard_0|large_size_python_tests_shard_1|large_size_python_tests_shard_2", tests(//python/ray/tests/...))' | select_flaky_tests |
-    xargs bazel test --config=ci $(./ci/run/bazel_export_options) \
-      --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX \
-      --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --test_env=CI) || exit 42
+    xargs ./ci/ray_ci/macos/macos_ci_test.sh) || exit 42
 }
 
 run_medium_flaky_tests() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
   (bazel query 'attr(tags, "medium_size_python_tests_a_to_j|medium_size_python_tests_k_to_z", tests(//python/ray/tests/...))' | select_flaky_tests |
-    xargs bazel test --config=ci $(./ci/run/bazel_export_options) --test_env=CI) || exit 42
+    xargs ./ci/ray_ci/macos/macos_ci_test.sh) || exit 42
 }
 
 run_small_test() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
   (bazel query 'attr(tags, "client_tests|small_size_python_tests", tests(//python/ray/tests/...))' | filter_out_flaky_tests |
-    xargs bazel test --config=ci $(./ci/run/bazel_export_options) \
-      --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX \
-      --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --test_env=CI) || exit 42
+    xargs ./ci/ray_ci/macos/macos_ci_test.sh) || exit 42
 }
 
 run_medium_a_j_test() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
   (bazel query 'attr(tags, "medium_size_python_tests_a_to_j", tests(//python/ray/tests/...))' | filter_out_flaky_tests |
-    xargs bazel test --config=ci $(./ci/run/bazel_export_options) --test_env=CI) || exit 42
+    xargs ./ci/ray_ci/macos/macos_ci_test.sh) || exit 42
 }
 
 run_medium_k_z_test() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
   (bazel query 'attr(tags, "medium_size_python_tests_k_to_z", tests(//python/ray/tests/...))' | filter_out_flaky_tests |
-    xargs bazel test --config=ci $(./ci/run/bazel_export_options) --test_env=CI) || exit 42
+    xargs ./ci/ray_ci/macos/macos_ci_test.sh) || exit 42
 }
 
 run_large_test() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
   (bazel query 'attr(tags, "large_size_python_tests_shard_'"${BUILDKITE_PARALLEL_JOB}"'", tests(//python/ray/tests/...))' | filter_out_flaky_tests |
-    xargs bazel test --config=ci $(./ci/run/bazel_export_options) \
-      --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX --test_env=CONDA_DEFAULT_ENV \
-      --test_env=CONDA_PROMPT_MODIFIER --test_env=CI) || exit 42
+    xargs ./ci/ray_ci/macos/macos_ci_test.sh) || exit 42
 }
 
 run_core_dashboard_test() {
-  TORCH_VERSION=1.9.0 ./ci/env/install-dependencies.sh
-  # Use --dynamic_mode=off until MacOS CI runs on Big Sur or newer. Otherwise there are problems with running tests
-  # with dynamic linking.
-  # shellcheck disable=SC2046
-  # 42 is the universal rayci exit code for test failures
-  (bazel test --config=ci --dynamic_mode=off \
-    --test_env=CI $(./ci/run/bazel_export_options) --build_tests_only \
-    --test_tag_filters=-post_wheel_build -- \
+  (./ci/ray_ci/macos/macos_ci_test.sh --test_tag_filters=-post_wheel_build \
     //:all python/ray/dashboard/... -python/ray/serve/... -rllib/...) || exit 42
 }
 
 run_ray_cpp_and_java() {
+  # build ray
+  ./ci/ci.sh build
+
   # clang-format is needed by java/test.sh
   # 42 is the universal rayci exit code for test failures
   pip install clang-format==12.0.1
@@ -90,9 +80,8 @@ run_ray_cpp_and_java() {
 _prelude() {
   rm -rf /tmp/bazel_event_logs
   (which bazel && bazel clean) || true;
-  . ./ci/ci.sh init && source ~/.zshenv
+  SKIP_REQUIREMENT_PACKAGES=1 . ./ci/ci.sh init && source ~/.zshenv
   source ~/.zshrc
-  ./ci/ci.sh build
   ./ci/env/env_info.sh
 }
 

--- a/ci/ray_ci/macos/macos_ci_test.sh
+++ b/ci/ray_ci/macos/macos_ci_test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -ex
+
+export CI="true"
+export PYTHON="3.9"
+export RAY_USE_RANDOM_PORTS="1"
+export RAY_DEFAULT_BUILD="1"
+export LC_ALL="en_US.UTF-8"
+export LANG="en_US.UTF-8"
+export BUILD="1"
+export DL="1"
+
+_cleanup() {
+  conda deactivate
+  conda remove -n rayci-"$RAYCI_BUILD_ID" --all -y
+}
+
+trap _cleanup EXIT
+
+source ~/.zshrc
+conda create -n rayci-"$RAYCI_BUILD_ID" -y python="$PYTHON"
+conda activate rayci-"$RAYCI_BUILD_ID"
+
+# install dependencies
+pip install -U --ignore-installed \
+  -c python/requirements_compiled.txt \
+  -r python/requirements.txt \
+  -r python/requirements/test-requirements.txt \
+  -r python/requirements/ml/dl-cpu-requirements.txt
+
+# install ray
+. ./ci/ci.sh build
+
+# run test
+# shellcheck disable=SC2046
+bazel test --config=ci --dynamic_mode=off \
+  --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE \
+  --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX --test_env=CONDA_DEFAULT_ENV \
+  --test_env=CONDA_PROMPT_MODIFIER --test_env=CI $(./ci/run/bazel_export_options) "$@"


### PR DESCRIPTION
The weirdness state of macos pool actually comes from https://github.com/ray-project/ray/commit/ecb4ec021f0fafc66acce65ae7d2f03e73a65a3c. There seems to be a bug? in pip that it can leave the environment not usable when trying to upgrade a package. For example `pip install -U scipy` will attempt to delete the existing version of scipy and somehow leave the environment in an unusable state.

A proper solution is probably to sandbox all macos runs using conda environment and clean them up between runs.

Test:
- CI