### PR TITLE
[release] add 2.11.0 performance metrics

### DIFF
--- a/release/release_logs/2.11.0/benchmarks/many_actors.json
+++ b/release/release_logs/2.11.0/benchmarks/many_actors.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 532.619264,
+    "_dashboard_test_success": true,
+    "_peak_memory": 3.75,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1169\t0.96GiB\tpython distributed/test_many_actors.py\n266\t0.33GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n988\t0.07GiB\tray::JobSupervisor\n580\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1229\t0.06GiB\tray::MemoryMonitorActor.run\n1301\t0.05GiB\tray::DashboardTester.run\n360\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
+    "actors_per_second": 651.1938449284169,
+    "num_actors": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "actors_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 651.1938449284169
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 229.08
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3574.999
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 5974.341
+        }
+    ],
+    "success": "1",
+    "time": 15.356410503387451
+}

--- a/release/release_logs/2.11.0/benchmarks/many_nodes.json
+++ b/release/release_logs/2.11.0/benchmarks/many_nodes.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 185.729024,
+    "_dashboard_test_success": true,
+    "_peak_memory": 1.63,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.52GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n849\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1049\t0.08GiB\tray::StateAPIGeneratorActor.start\n669\t0.07GiB\tray::JobSupervisor\n423\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n574\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n421\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n909\t0.06GiB\tray::MemoryMonitorActor.run\n996\t0.06GiB\tray::DashboardTester.run",
+    "num_tasks": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 355.9888145795117
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.909
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 38.748
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 199.686
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 355.9888145795117,
+    "time": 302.80907702445984,
+    "used_cpus": 250.0
+}

--- a/release/release_logs/2.11.0/benchmarks/many_pgs.json
+++ b/release/release_logs/2.11.0/benchmarks/many_pgs.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 197.697536,
+    "_dashboard_test_success": true,
+    "_peak_memory": 2.23,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n795\t0.42GiB\tpython distributed/test_many_pgs.py\n266\t0.16GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n615\t0.07GiB\tray::JobSupervisor\n584\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n871\t0.06GiB\tray::MemoryMonitorActor.run\n944\t0.05GiB\tray::DashboardTester.run\n364\t0.04GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=",
+    "num_pgs": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "pgs_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 23.704540710281698
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.403
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 21.324
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 181.531
+        }
+    ],
+    "pgs_per_second": 23.704540710281698,
+    "success": "1",
+    "time": 42.18601036071777
+}

--- a/release/release_logs/2.11.0/benchmarks/many_tasks.json
+++ b/release/release_logs/2.11.0/benchmarks/many_tasks.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 686.809088,
+    "_dashboard_test_success": true,
+    "_peak_memory": 4.06,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.34GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t1.14GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n793\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n993\t0.09GiB\tray::StateAPIGeneratorActor.start\n941\t0.08GiB\tray::DashboardTester.run\n613\t0.07GiB\tray::JobSupervisor\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n581\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n869\t0.06GiB\tray::MemoryMonitorActor.run",
+    "num_tasks": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 573.1499972957042
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2500.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 7.656
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 15277.685
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 26050.588
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 573.1499972957042,
+    "time": 317.44743967056274,
+    "used_cpus": 2500.0
+}

--- a/release/release_logs/2.11.0/microbenchmark.json
+++ b/release/release_logs/2.11.0/microbenchmark.json
@@ -1,0 +1,283 @@
+{
+    "1_1_actor_calls_async": [
+        8920.501990632494,
+        412.48101459174575
+    ],
+    "1_1_actor_calls_concurrent": [
+        5632.903374098973,
+        282.756962902867
+    ],
+    "1_1_actor_calls_sync": [
+        2162.105443003009,
+        61.957193284333016
+    ],
+    "1_1_async_actor_calls_async": [
+        3431.174867943716,
+        137.00410769109666
+    ],
+    "1_1_async_actor_calls_sync": [
+        1392.324666747059,
+        14.976494161304997
+    ],
+    "1_1_async_actor_calls_with_args_async": [
+        2432.815669351221,
+        74.55740618292938
+    ],
+    "1_n_actor_calls_async": [
+        9163.099212047364,
+        289.9143389532145
+    ],
+    "1_n_async_actor_calls_async": [
+        7818.901521207347,
+        163.10659158652118
+    ],
+    "client__1_1_actor_calls_async": [
+        1011.3642608406338,
+        3.040692811996783
+    ],
+    "client__1_1_actor_calls_concurrent": [
+        1012.6469236339258,
+        10.061992991467507
+    ],
+    "client__1_1_actor_calls_sync": [
+        549.1965858848921,
+        7.027637130542828
+    ],
+    "client__get_calls": [
+        1092.9690984134525,
+        53.41840043532222
+    ],
+    "client__put_calls": [
+        855.7554311772113,
+        16.895922966380912
+    ],
+    "client__put_gigabytes": [
+        0.13071537488094334,
+        0.0005031585785872274
+    ],
+    "client__tasks_and_get_batch": [
+        0.9559718222313252,
+        0.00465116852309416
+    ],
+    "client__tasks_and_put_batch": [
+        12023.998577597706,
+        99.31590414636526
+    ],
+    "multi_client_put_calls_Plasma_Store": [
+        12708.321183661115,
+        154.5779924095099
+    ],
+    "multi_client_put_gigabytes": [
+        33.34413169862419,
+        1.6514222316948344
+    ],
+    "multi_client_tasks_async": [
+        23003.327676720364,
+        1604.336939513785
+    ],
+    "n_n_actor_calls_async": [
+        28462.88330232226,
+        522.406080268322
+    ],
+    "n_n_actor_calls_with_arg_async": [
+        2823.4421231666856,
+        47.7882182215245
+    ],
+    "n_n_async_actor_calls_async": [
+        23555.103105727303,
+        454.6042633450258
+    ],
+    "perf_metrics": [
+        {
+            "perf_metric_name": "single_client_get_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 9943.656629714213
+        },
+        {
+            "perf_metric_name": "single_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5530.230885925916
+        },
+        {
+            "perf_metric_name": "multi_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 12708.321183661115
+        },
+        {
+            "perf_metric_name": "single_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 19.822902089600902
+        },
+        {
+            "perf_metric_name": "single_client_tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8.437608759394715
+        },
+        {
+            "perf_metric_name": "multi_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 33.34413169862419
+        },
+        {
+            "perf_metric_name": "single_client_get_object_containing_10k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 13.280849165943225
+        },
+        {
+            "perf_metric_name": "single_client_wait_1k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5.348733304464503
+        },
+        {
+            "perf_metric_name": "single_client_tasks_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1051.329826235638
+        },
+        {
+            "perf_metric_name": "single_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8191.290843342201
+        },
+        {
+            "perf_metric_name": "multi_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 23003.327676720364
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2162.105443003009
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8920.501990632494
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5632.903374098973
+        },
+        {
+            "perf_metric_name": "1_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 9163.099212047364
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 28462.88330232226
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_with_arg_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2823.4421231666856
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1392.324666747059
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 3431.174867943716
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_with_args_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2432.815669351221
+        },
+        {
+            "perf_metric_name": "1_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 7818.901521207347
+        },
+        {
+            "perf_metric_name": "n_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 23555.103105727303
+        },
+        {
+            "perf_metric_name": "placement_group_create/removal",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 872.5565113012652
+        },
+        {
+            "perf_metric_name": "client__get_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1092.9690984134525
+        },
+        {
+            "perf_metric_name": "client__put_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 855.7554311772113
+        },
+        {
+            "perf_metric_name": "client__put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.13071537488094334
+        },
+        {
+            "perf_metric_name": "client__tasks_and_put_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 12023.998577597706
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 549.1965858848921
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1011.3642608406338
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1012.6469236339258
+        },
+        {
+            "perf_metric_name": "client__tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.9559718222313252
+        }
+    ],
+    "placement_group_create/removal": [
+        872.5565113012652,
+        3.735056345030286
+    ],
+    "single_client_get_calls_Plasma_Store": [
+        9943.656629714213,
+        962.3335113330314
+    ],
+    "single_client_get_object_containing_10k_refs": [
+        13.280849165943225,
+        0.22802375019757148
+    ],
+    "single_client_put_calls_Plasma_Store": [
+        5530.230885925916,
+        76.2584927367091
+    ],
+    "single_client_put_gigabytes": [
+        19.822902089600902,
+        5.328211428852645
+    ],
+    "single_client_tasks_and_get_batch": [
+        8.437608759394715,
+        0.5956304131258263
+    ],
+    "single_client_tasks_async": [
+        8191.290843342201,
+        404.0294279813368
+    ],
+    "single_client_tasks_sync": [
+        1051.329826235638,
+        6.279249879535658
+    ],
+    "single_client_wait_1k_refs": [
+        5.348733304464503,
+        0.061002991236537664
+    ]
+}

--- a/release/release_logs/2.11.0/scalability/object_store.json
+++ b/release/release_logs/2.11.0/scalability/object_store.json
@@ -1,0 +1,13 @@
+{
+    "broadcast_time": 14.540794130999984,
+    "num_nodes": 50,
+    "object_size": 1073741824,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 14.540794130999984
+        }
+    ],
+    "success": "1"
+}

--- a/release/release_logs/2.11.0/scalability/single_node.json
+++ b/release/release_logs/2.11.0/scalability/single_node.json
@@ -1,0 +1,40 @@
+{
+    "args_time": 17.036145214,
+    "get_time": 23.731508099999985,
+    "large_object_size": 107374182400,
+    "large_object_time": 29.81586747199998,
+    "num_args": 10000,
+    "num_get_args": 10000,
+    "num_queued": 1000000,
+    "num_returns": 3000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "10000_args_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 17.036145214
+        },
+        {
+            "perf_metric_name": "3000_returns_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 5.704166841000003
+        },
+        {
+            "perf_metric_name": "10000_get_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 23.731508099999985
+        },
+        {
+            "perf_metric_name": "1000000_queued_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 183.388168655
+        },
+        {
+            "perf_metric_name": "107374182400_large_object_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 29.81586747199998
+        }
+    ],
+    "queued_time": 183.388168655,
+    "returns_time": 5.704166841000003,
+    "success": "1"
+}

--- a/release/release_logs/2.11.0/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.11.0/stress_tests/stress_test_dead_actors.json
@@ -1,0 +1,14 @@
+{
+    "avg_iteration_time": 1.4924560022354125,
+    "max_iteration_time": 3.3335866928100586,
+    "min_iteration_time": 0.6611089706420898,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1.4924560022354125
+        }
+    ],
+    "success": 1,
+    "total_time": 149.2458462715149
+}

--- a/release/release_logs/2.11.0/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.11.0/stress_tests/stress_test_many_tasks.json
@@ -1,0 +1,47 @@
+{
+    "perf_metrics": [
+        {
+            "perf_metric_name": "stage_0_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 12.502008199691772
+        },
+        {
+            "perf_metric_name": "stage_1_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 25.6875333070755
+        },
+        {
+            "perf_metric_name": "stage_2_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 56.80593147277832
+        },
+        {
+            "perf_metric_name": "stage_3_creation_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2.057617425918579
+        },
+        {
+            "perf_metric_name": "stage_3_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3080.732224702835
+        },
+        {
+            "perf_metric_name": "stage_4_spread",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.6328428382573995
+        }
+    ],
+    "stage_0_time": 12.502008199691772,
+    "stage_1_avg_iteration_time": 25.6875333070755,
+    "stage_1_max_iteration_time": 27.156538248062134,
+    "stage_1_min_iteration_time": 23.896818161010742,
+    "stage_1_time": 256.8754389286041,
+    "stage_2_avg_iteration_time": 56.80593147277832,
+    "stage_2_max_iteration_time": 58.56392431259155,
+    "stage_2_min_iteration_time": 54.59894633293152,
+    "stage_2_time": 284.0308132171631,
+    "stage_3_creation_time": 2.057617425918579,
+    "stage_3_time": 3080.732224702835,
+    "stage_4_spread": 0.6328428382573995,
+    "success": 1
+}

--- a/release/release_logs/2.11.0/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.11.0/stress_tests/stress_test_placement_group.json
@@ -1,0 +1,17 @@
+{
+    "avg_pg_create_time_ms": 0.9511960345335652,
+    "avg_pg_remove_time_ms": 0.9238805060055858,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_pg_create_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.9511960345335652
+        },
+        {
+            "perf_metric_name": "avg_pg_remove_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.9238805060055858
+        }
+    ],
+    "success": 1
+}


### PR DESCRIPTION
Add 2.11.0 performance metrics. Generated by

````
python release/release_logs/fetch_release_logs.py 2.11.0 b15802c2328898bb5da63a156f7b56b134868d1d master
````