### PR TITLE
[ci][bisect/0] add a function to run a single macos tests

### DIFF
--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -19,6 +19,13 @@ select_flaky_tests() {
   bazel run ci/ray_ci/automation:filter_tests -- --state_filter=flaky --prefix=darwin:
 }
 
+run_tests() {
+   # shellcheck disable=SC2046
+  bazel test --config=ci $(./ci/run/bazel_export_options) \
+      --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX \
+      --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --test_env=CI "$@"
+}
+
 run_small_and_large_flaky_tests() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures


### PR DESCRIPTION
Add a function to run a single macos tests.

My previous attempt try to optimize this process a little more, but didn't work out https://github.com/ray-project/ray/pull/44830; the macos CI is too fragile for it. I know the root cause and right fix but let's go with this solution for now.

Test:

![](https://media4.giphy.com/media/TejmLnMKgnmPInMQjV/200.gif?cid=5a38a5a2gniz5cpc84pd0n8phb2kddhesysfu4ic00jl3tqk&ep=v1_gifs_search&rid=200.gif&ct=g)