### PR TITLE
[ci][micro/0] add a common cpu base build for microcheck

### DIFF
--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -4,6 +4,9 @@ depends_on:
   - forge
 steps:
   #build
+  - name: onecpubuild
+    wanda: ci/docker/one.cpu.build.wanda.yaml
+
   - name: doctestbuild
     wanda: ci/docker/doctest.build.wanda.yaml
 

--- a/ci/docker/one.cpu.build.Dockerfile
+++ b/ci/docker/one.cpu.build.Dockerfile
@@ -1,0 +1,31 @@
+ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build
+FROM $DOCKER_IMAGE_BASE_BUILD
+
+# Unset dind settings; we are using the host's docker daemon.
+ENV DOCKER_TLS_CERTDIR=
+ENV DOCKER_HOST=
+ENV DOCKER_TLS_VERIFY=
+ENV DOCKER_CERT_PATH=
+
+SHELL ["/bin/bash", "-ice"]
+
+COPY . .
+
+RUN <<EOF
+#!/bin/bash
+
+set -euo pipefail
+
+DOC_TESTING=1 TRAIN_TESTING=1 TUNE_TESTING=1 DATA_PROCESSING_TESTING=1 \
+  INSTALL_HOROVOD=1 INSTALL_HDFS=1 RLLIB_TESTING=1 \
+  ./ci/env/install-dependencies.sh
+
+# serve dependencies
+git clone https://github.com/wg/wrk.git /tmp/wrk && pushd /tmp/wrk && make -j && sudo cp wrk /usr/local/bin && popd
+
+# data dependencies
+sudo apt-get purge -y mongodb*
+sudo apt-get install -y mongodb
+sudo rm -rf /var/lib/mongodb/mongod.lock
+
+EOF

--- a/ci/docker/one.cpu.build.wanda.yaml
+++ b/ci/docker/one.cpu.build.wanda.yaml
@@ -1,0 +1,25 @@
+name: "onecpubuild"
+froms: ["cr.ray.io/rayproject/oss-ci-base_build"]
+dockerfile: ci/docker/one.cpu.build.Dockerfile
+srcs:
+  - ci/env/install-dependencies.sh
+  - ci/env/install-horovod.sh
+  - ci/env/install-hdfs.sh
+  - python/requirements.txt
+  - python/requirements_compiled.txt
+  - python/requirements/test-requirements.txt
+  - python/requirements/ml/core-requirements.txt
+  - python/requirements/ml/dl-cpu-requirements.txt
+  - python/requirements/ml/dl-gpu-requirements.txt
+  - python/requirements/ml/train-requirements.txt
+  - python/requirements/ml/train-test-requirements.txt
+  - python/requirements/ml/tune-requirements.txt
+  - python/requirements/ml/tune-test-requirements.txt
+  - python/requirements/ml/data-requirements.txt
+  - python/requirements/ml/data-test-requirements.txt
+  - python/requirements/ml/rllib-requirements.txt
+  - python/requirements/ml/rllib-test-requirements.txt
+build_args:
+  - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build
+tags:
+  - cr.ray.io/rayproject/onecpubuild


### PR DESCRIPTION
Add a common base build for microcheck. This base can run cpu tests from any team (core, serve, ml, etc.). This help simplifies the build process + a bit of cost saving for microcheck (since we don't have to split tests into multiple buildkite steps).

Test:
- CI