### PR TITLE
[serve] fix documentation typo

### DIFF
--- a/doc/source/serve/advanced-guides/multi-app-container.md
+++ b/doc/source/serve/advanced-guides/multi-app-container.md
@@ -52,7 +52,7 @@ RUN curl -O https://raw.githubusercontent.com/ray-project/ray/master/doc/source/
 FROM rayproject/ray:latest-py38-cpu
 
 # Install the packages `torch` and `torchvision`, which are dependencies for the ResNet model.
-RUN torch==2.0.1 torchvision==0.15.2
+RUN pip install torch==2.0.1 torchvision==0.15.2
 RUN sudo apt-get update && sudo apt-get install curl -y
 
 # Download the source code for the ResNet application into `resnet50_example.py`.


### PR DESCRIPTION
[serve] fix documentation typo

`resnet.Dockerfile` in the "Run Multiple Applications in Different Containers" documentation page was missing the `pip install` in its RUN command.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
