### PR TITLE
[CI][Tune] Remove duplicate new Tune output CI pipeline

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -98,16 +98,6 @@ steps:
         --except-tags soft_imports,gpu_only,rllib,multinode
     depends_on: [ "mlbuild", "forge" ]
 
-  - label: ":train: ml: tune new output tests"
-    tags: tune
-    instance_type: large
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tune/... ml 
-        --parallelism-per-worker 3
-        --except-tags soft_imports,gpu_only,rllib,multinode
-        --test-env=AIR_VERBOSITY=1
-    depends_on: [ "mlbuild", "forge" ]
-
   - label: ":train: ml: tune soft import tests"
     tags: tune
     instance_type: small


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We have a duplicate CI pipeline for the new output engine, even though it's already enabled by default. There's no need for the duplicate pipeline. This PR removes the repeated CI pipeline.

## Related issue number

Closes #44775

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
