### PR TITLE
[RLlib] - Fixes bug with dependent search space in Tune using `train_batch_size_per_learner` in PPO

### DIFF
--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -334,7 +334,7 @@ class PPOConfig(AlgorithmConfig):
         elif self._enable_new_api_stack:
             mbs = self.mini_batch_size_per_learner or self.sgd_minibatch_size
             tbs = self.train_batch_size_per_learner or self.train_batch_size
-            if mbs > tbs:
+            if isinstance(mbs, int) and isinstance(tbs, int) and mbs > tbs:
                 raise ValueError(
                     f"`mini_batch_size_per_learner` ({mbs}) must be <= "
                     f"`train_batch_size_per_learner` ({tbs}). In PPO, the train batch"


### PR DESCRIPTION


## Why are these changes needed?

Because we were validating the relation between `mini_batch_size_per_learner` and `train_batch_size_per_learner` using the latter in a Tune dependent search space led to an error and made it basically impossible to use this argument in a search space. This PR fixes this bug.

## Related issue number



## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
