### PR TITLE
[ci] remove hermetic_python from scheduler

### DIFF
--- a/ci/ray_ci/pipeline/BUILD.bazel
+++ b/ci/ray_ci/pipeline/BUILD.bazel
@@ -5,7 +5,6 @@ py_binary(
     name="scheduler",
     srcs = ["scheduler.py"],
     deps = [":pipeline"],
-    exec_compatible_with = ["//:hermetic_python"],
 )
 
 py_library(


### PR DESCRIPTION
bazel doesn't package the python interpreter during `bazel build`, I detailed the errors upstream

Test:
- CI