### PR TITLE
[serve] prevent growing memory in replica autoscaling metrics

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2178,11 +2178,7 @@ class DeploymentState:
                 self._replicas.add(ReplicaState.STOPPING, replica)
             else:
                 logger.info(f"{replica.replica_id} is stopped.")
-                # NOTE(zcin): We need to remove the replica from in-memory metrics store
-                # here instead of _stop_replica because the replica will continue to
-                # send metrics while it's still alive.
-                if replica.replica_id in self.replica_average_ongoing_requests:
-                    del self.replica_average_ongoing_requests[replica.replica_id]
+                self._autoscaling_state_manager.on_replica_stopped(replica.replica_id)
 
     def _choose_pending_migration_replicas_to_stop(
         self,

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -41,6 +41,9 @@ from ray.util import metrics
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
+QUEUED_REQUESTS_KEY = "queued"
+
+
 class RouterMetricsManager:
     """Manages metrics for the router."""
 
@@ -260,7 +263,7 @@ class RouterMetricsManager:
     def _add_autoscaling_metrics_point(self):
         timestamp = time.time()
         self.metrics_store.add_metrics_point(
-            {"queued": self.num_queued_requests}, timestamp
+            {QUEUED_REQUESTS_KEY: self.num_queued_requests}, timestamp
         )
         if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
             self.metrics_store.add_metrics_point(


### PR DESCRIPTION
[serve] prevent growing memory in replica autoscaling metrics

In the https://github.com/ray-project/ray/pull/44638 refactor, the code that prevents the dict of replica autoscaling metrics living in the controller from growing in memory over time (as replicas upscale/downscale) was missed and didn't get ported over. This PR patches that.

I also added to the unit test `test_basic_autoscaling` to make sure dead replicas are removed from the in-memory dict of replica metrics.

(The ugly list of changes in `test_deployment_state` is from moving 5 autoscaling unit tests into a class `TestAutoscaling`. I didn't change anything else except for adding to `test_basic_autoscaling`.)


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
