### PR TITLE
[ray 2.12] perf metrics

### DIFF
--- a/release/release_logs/2.11.0/benchmarks/many_actors.json
+++ b/release/release_logs/2.11.0/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 532.619264,
+    "_dashboard_memory_usage_mb": 466.80064,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.75,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1169\t0.96GiB\tpython distributed/test_many_actors.py\n266\t0.33GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n988\t0.07GiB\tray::JobSupervisor\n580\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1229\t0.06GiB\tray::MemoryMonitorActor.run\n1301\t0.05GiB\tray::DashboardTester.run\n360\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
-    "actors_per_second": 651.1938449284169,
+    "_peak_memory": 3.72,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.78GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1016\t0.96GiB\tpython distributed/test_many_actors.py\n266\t0.3GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n836\t0.07GiB\tray::JobSupervisor\n581\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1076\t0.06GiB\tray::MemoryMonitorActor.run\n1164\t0.05GiB\tray::DashboardTester.run\n360\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
+    "actors_per_second": 653.272142233422,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 651.1938449284169
+            "perf_metric_value": 653.272142233422
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 229.08
+            "perf_metric_value": 201.991
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3574.999
+            "perf_metric_value": 2575.396
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5974.341
+            "perf_metric_value": 3787.161
         }
     ],
     "success": "1",
-    "time": 15.356410503387451
+    "time": 15.30755615234375
 }

--- a/release/release_logs/2.11.0/benchmarks/many_nodes.json
+++ b/release/release_logs/2.11.0/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 185.729024,
+    "_dashboard_memory_usage_mb": 191.32416,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.63,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.52GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n849\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1049\t0.08GiB\tray::StateAPIGeneratorActor.start\n669\t0.07GiB\tray::JobSupervisor\n423\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n574\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n421\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n909\t0.06GiB\tray::MemoryMonitorActor.run\n996\t0.06GiB\tray::DashboardTester.run",
+    "_peak_memory": 1.64,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1101\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1364\t0.09GiB\tray::StateAPIGeneratorActor.start\n423\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n920\t0.07GiB\tray::JobSupervisor\n575\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n421\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1312\t0.06GiB\tray::DashboardTester.run\n1240\t0.06GiB\tray::MemoryMonitorActor.run",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 355.9888145795117
+            "perf_metric_value": 365.7446134841852
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.909
+            "perf_metric_value": 4.17
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 38.748
+            "perf_metric_value": 78.653
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 199.686
+            "perf_metric_value": 213.152
         }
     ],
     "success": "1",
-    "tasks_per_second": 355.9888145795117,
-    "time": 302.80907702445984,
+    "tasks_per_second": 365.7446134841852,
+    "time": 302.7341482639313,
     "used_cpus": 250.0
 }

--- a/release/release_logs/2.11.0/benchmarks/many_pgs.json
+++ b/release/release_logs/2.11.0/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 197.697536,
+    "_dashboard_memory_usage_mb": 130.555904,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.23,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n795\t0.42GiB\tpython distributed/test_many_pgs.py\n266\t0.16GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n615\t0.07GiB\tray::JobSupervisor\n584\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n871\t0.06GiB\tray::MemoryMonitorActor.run\n944\t0.05GiB\tray::DashboardTester.run\n364\t0.04GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=",
+    "_peak_memory": 2.18,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.93GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n920\t0.42GiB\tpython distributed/test_many_pgs.py\n266\t0.14GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n447\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n739\t0.07GiB\tray::JobSupervisor\n582\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n445\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n980\t0.06GiB\tray::MemoryMonitorActor.run\n1068\t0.05GiB\tray::DashboardTester.run\n365\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23.704540710281698
+            "perf_metric_value": 23.471191969494587
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.403
+            "perf_metric_value": 3.392
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 21.324
+            "perf_metric_value": 19.066
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 181.531
+            "perf_metric_value": 126.705
         }
     ],
-    "pgs_per_second": 23.704540710281698,
+    "pgs_per_second": 23.471191969494587,
     "success": "1",
-    "time": 42.18601036071777
+    "time": 42.60542035102844
 }

--- a/release/release_logs/2.11.0/benchmarks/many_tasks.json
+++ b/release/release_logs/2.11.0/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 686.809088,
+    "_dashboard_memory_usage_mb": 648.482816,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.06,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.34GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t1.14GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n793\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n993\t0.09GiB\tray::StateAPIGeneratorActor.start\n941\t0.08GiB\tray::DashboardTester.run\n613\t0.07GiB\tray::JobSupervisor\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n581\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n869\t0.06GiB\tray::MemoryMonitorActor.run",
+    "_peak_memory": 3.3,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n863\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n266\t0.63GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1127\t0.09GiB\tray::StateAPIGeneratorActor.start\n1073\t0.08GiB\tray::DashboardTester.run\n682\t0.07GiB\tray::JobSupervisor\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n581\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n986\t0.06GiB\tray::MemoryMonitorActor.run",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 573.1499972957042
+            "perf_metric_value": 610.9508780114498
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.656
+            "perf_metric_value": 7.373
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 15277.685
+            "perf_metric_value": 3552.838
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 26050.588
+            "perf_metric_value": 4635.591
         }
     ],
     "success": "1",
-    "tasks_per_second": 573.1499972957042,
-    "time": 317.44743967056274,
+    "tasks_per_second": 610.9508780114498,
+    "time": 316.3679280281067,
     "used_cpus": 2500.0
 }

--- a/release/release_logs/2.11.0/microbenchmark.json
+++ b/release/release_logs/2.11.0/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8920.501990632494,
-        412.48101459174575
+        8900.061966026988,
+        191.4180433077194
     ],
     "1_1_actor_calls_concurrent": [
-        5632.903374098973,
-        282.756962902867
+        5205.483996202341,
+        173.5417173511989
     ],
     "1_1_actor_calls_sync": [
-        2162.105443003009,
-        61.957193284333016
+        2055.9970223719974,
+        32.46934311676375
     ],
     "1_1_async_actor_calls_async": [
-        3431.174867943716,
-        137.00410769109666
+        3088.187256249974,
+        157.72944413924859
     ],
     "1_1_async_actor_calls_sync": [
-        1392.324666747059,
-        14.976494161304997
+        1382.8140547973987,
+        35.77823083227874
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2432.815669351221,
-        74.55740618292938
+        2411.2175991602116,
+        72.55980393195516
     ],
     "1_n_actor_calls_async": [
-        9163.099212047364,
-        289.9143389532145
+        8797.319487481269,
+        227.47595087843297
     ],
     "1_n_async_actor_calls_async": [
-        7818.901521207347,
-        163.10659158652118
+        7864.108971520267,
+        109.51908138261717
     ],
     "client__1_1_actor_calls_async": [
-        1011.3642608406338,
-        3.040692811996783
+        975.7618423482973,
+        11.087963926060809
     ],
     "client__1_1_actor_calls_concurrent": [
-        1012.6469236339258,
-        10.061992991467507
+        951.1415547703022,
+        30.97241969415422
     ],
     "client__1_1_actor_calls_sync": [
-        549.1965858848921,
-        7.027637130542828
+        523.0280053260831,
+        13.17897931512239
     ],
     "client__get_calls": [
-        1092.9690984134525,
-        53.41840043532222
+        1091.5724282284737,
+        69.90840786431814
     ],
     "client__put_calls": [
-        855.7554311772113,
-        16.895922966380912
+        835.8219066517684,
+        18.297778961703113
     ],
     "client__put_gigabytes": [
-        0.13071537488094334,
-        0.0005031585785872274
+        0.12235011485110747,
+        0.00021355763704806528
     ],
     "client__tasks_and_get_batch": [
-        0.9559718222313252,
-        0.00465116852309416
+        0.9074349140473464,
+        0.016158057500136384
     ],
     "client__tasks_and_put_batch": [
-        12023.998577597706,
-        99.31590414636526
+        10852.4324243012,
+        250.1804762248623
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12708.321183661115,
-        154.5779924095099
+        12064.308681826904,
+        139.07331263952662
     ],
     "multi_client_put_gigabytes": [
-        33.34413169862419,
-        1.6514222316948344
+        39.026311549309554,
+        1.35006350290278
     ],
     "multi_client_tasks_async": [
-        23003.327676720364,
-        1604.336939513785
+        21875.105721041346,
+        3133.1136033181197
     ],
     "n_n_actor_calls_async": [
-        28462.88330232226,
-        522.406080268322
+        28165.509673837572,
+        588.1550852646177
     ],
     "n_n_actor_calls_with_arg_async": [
-        2823.4421231666856,
-        47.7882182215245
+        2846.036342831333,
+        10.402826982801253
     ],
     "n_n_async_actor_calls_async": [
-        23555.103105727303,
-        454.6042633450258
+        22971.36788751919,
+        804.2881738869152
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9943.656629714213
+            "perf_metric_value": 10267.371114566762
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5530.230885925916
+            "perf_metric_value": 5222.55884804985
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12708.321183661115
+            "perf_metric_value": 12064.308681826904
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.822902089600902
+            "perf_metric_value": 19.613041636801512
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8.437608759394715
+            "perf_metric_value": 8.314592004219296
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 33.34413169862419
+            "perf_metric_value": 39.026311549309554
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.280849165943225
+            "perf_metric_value": 13.704970913400441
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.348733304464503
+            "perf_metric_value": 5.425389917194363
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1051.329826235638
+            "perf_metric_value": 987.9154572339097
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8191.290843342201
+            "perf_metric_value": 8175.996977132117
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23003.327676720364
+            "perf_metric_value": 21875.105721041346
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2162.105443003009
+            "perf_metric_value": 2055.9970223719974
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8920.501990632494
+            "perf_metric_value": 8900.061966026988
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5632.903374098973
+            "perf_metric_value": 5205.483996202341
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9163.099212047364
+            "perf_metric_value": 8797.319487481269
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 28462.88330232226
+            "perf_metric_value": 28165.509673837572
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2823.4421231666856
+            "perf_metric_value": 2846.036342831333
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1392.324666747059
+            "perf_metric_value": 1382.8140547973987
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3431.174867943716
+            "perf_metric_value": 3088.187256249974
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2432.815669351221
+            "perf_metric_value": 2411.2175991602116
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7818.901521207347
+            "perf_metric_value": 7864.108971520267
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23555.103105727303
+            "perf_metric_value": 22971.36788751919
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 872.5565113012652
+            "perf_metric_value": 823.8896629199388
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1092.9690984134525
+            "perf_metric_value": 1091.5724282284737
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 855.7554311772113
+            "perf_metric_value": 835.8219066517684
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13071537488094334
+            "perf_metric_value": 0.12235011485110747
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12023.998577597706
+            "perf_metric_value": 10852.4324243012
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 549.1965858848921
+            "perf_metric_value": 523.0280053260831
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1011.3642608406338
+            "perf_metric_value": 975.7618423482973
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1012.6469236339258
+            "perf_metric_value": 951.1415547703022
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9559718222313252
+            "perf_metric_value": 0.9074349140473464
         }
     ],
     "placement_group_create/removal": [
-        872.5565113012652,
-        3.735056345030286
+        823.8896629199388,
+        4.761885065253211
     ],
     "single_client_get_calls_Plasma_Store": [
-        9943.656629714213,
-        962.3335113330314
+        10267.371114566762,
+        191.11363178041842
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.280849165943225,
-        0.22802375019757148
+        13.704970913400441,
+        0.21627867671473214
     ],
     "single_client_put_calls_Plasma_Store": [
-        5530.230885925916,
-        76.2584927367091
+        5222.55884804985,
+        63.080948992722945
     ],
     "single_client_put_gigabytes": [
-        19.822902089600902,
-        5.328211428852645
+        19.613041636801512,
+        5.889826198850045
     ],
     "single_client_tasks_and_get_batch": [
-        8.437608759394715,
-        0.5956304131258263
+        8.314592004219296,
+        0.5014911979126326
     ],
     "single_client_tasks_async": [
-        8191.290843342201,
-        404.0294279813368
+        8175.996977132117,
+        382.29858495516817
     ],
     "single_client_tasks_sync": [
-        1051.329826235638,
-        6.279249879535658
+        987.9154572339097,
+        17.454435936288203
     ],
     "single_client_wait_1k_refs": [
-        5.348733304464503,
-        0.061002991236537664
+        5.425389917194363,
+        0.07281873009527651
     ]
 }

--- a/release/release_logs/2.11.0/scalability/object_store.json
+++ b/release/release_logs/2.11.0/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 14.540794130999984,
+    "broadcast_time": 16.808720801999982,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 14.540794130999984
+            "perf_metric_value": 16.808720801999982
         }
     ],
     "success": "1"

--- a/release/release_logs/2.11.0/scalability/single_node.json
+++ b/release/release_logs/2.11.0/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.036145214,
-    "get_time": 23.731508099999985,
+    "args_time": 17.686509897000008,
+    "get_time": 22.577659229999995,
     "large_object_size": 107374182400,
-    "large_object_time": 29.81586747199998,
+    "large_object_time": 29.17789060800004,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.036145214
+            "perf_metric_value": 17.686509897000008
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.704166841000003
+            "perf_metric_value": 5.479904671000014
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.731508099999985
+            "perf_metric_value": 22.577659229999995
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 183.388168655
+            "perf_metric_value": 197.709131292
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.81586747199998
+            "perf_metric_value": 29.17789060800004
         }
     ],
-    "queued_time": 183.388168655,
-    "returns_time": 5.704166841000003,
+    "queued_time": 197.709131292,
+    "returns_time": 5.479904671000014,
     "success": "1"
 }

--- a/release/release_logs/2.11.0/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.11.0/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.4924560022354125,
-    "max_iteration_time": 3.3335866928100586,
-    "min_iteration_time": 0.6611089706420898,
+    "avg_iteration_time": 1.558222110271454,
+    "max_iteration_time": 4.02335262298584,
+    "min_iteration_time": 0.6896142959594727,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4924560022354125
+            "perf_metric_value": 1.558222110271454
         }
     ],
     "success": 1,
-    "total_time": 149.2458462715149
+    "total_time": 155.82245659828186
 }

--- a/release/release_logs/2.11.0/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.11.0/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.502008199691772
+            "perf_metric_value": 10.757715463638306
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.6875333070755
+            "perf_metric_value": 26.485081911087036
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 56.80593147277832
+            "perf_metric_value": 73.74742498397828
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.057617425918579
+            "perf_metric_value": 2.1788923740386963
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3080.732224702835
+            "perf_metric_value": 3260.191632270813
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.6328428382573995
+            "perf_metric_value": 0.5319111031781492
         }
     ],
-    "stage_0_time": 12.502008199691772,
-    "stage_1_avg_iteration_time": 25.6875333070755,
-    "stage_1_max_iteration_time": 27.156538248062134,
-    "stage_1_min_iteration_time": 23.896818161010742,
-    "stage_1_time": 256.8754389286041,
-    "stage_2_avg_iteration_time": 56.80593147277832,
-    "stage_2_max_iteration_time": 58.56392431259155,
-    "stage_2_min_iteration_time": 54.59894633293152,
-    "stage_2_time": 284.0308132171631,
-    "stage_3_creation_time": 2.057617425918579,
-    "stage_3_time": 3080.732224702835,
-    "stage_4_spread": 0.6328428382573995,
+    "stage_0_time": 10.757715463638306,
+    "stage_1_avg_iteration_time": 26.485081911087036,
+    "stage_1_max_iteration_time": 27.32317543029785,
+    "stage_1_min_iteration_time": 25.39231824874878,
+    "stage_1_time": 264.85090589523315,
+    "stage_2_avg_iteration_time": 73.74742498397828,
+    "stage_2_max_iteration_time": 122.96685600280762,
+    "stage_2_min_iteration_time": 60.89244818687439,
+    "stage_2_time": 368.73850870132446,
+    "stage_3_creation_time": 2.1788923740386963,
+    "stage_3_time": 3260.191632270813,
+    "stage_4_spread": 0.5319111031781492,
     "success": 1
 }

--- a/release/release_logs/2.11.0/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.11.0/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9511960345335652,
-    "avg_pg_remove_time_ms": 0.9238805060055858,
+    "avg_pg_create_time_ms": 0.8821673768768409,
+    "avg_pg_remove_time_ms": 0.9274617132122331,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9511960345335652
+            "perf_metric_value": 0.8821673768768409
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9238805060055858
+            "perf_metric_value": 0.9274617132122331
         }
     ],
     "success": 1


### PR DESCRIPTION
Perf metrics from Thursday evening run (https://github.com/ray-project/ray/commit/7c9209fd94726de61f70b0e9ea0f624f2da8a1fd)

```
REGRESSION 10.00%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 3431.174867943716 to 3088.187256249974 (10.00%) in 2.12.0/microbenchmark.json
REGRESSION 9.74%: client__tasks_and_put_batch (THROUGHPUT) regresses from 12023.998577597706 to 10852.4324243012 (9.74%) in 2.12.0/microbenchmark.json
REGRESSION 7.59%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5632.903374098973 to 5205.483996202341 (7.59%) in 2.12.0/microbenchmark.json
REGRESSION 6.40%: client__put_gigabytes (THROUGHPUT) regresses from 0.13071537488094334 to 0.12235011485110747 (6.40%) in 2.12.0/microbenchmark.json
REGRESSION 6.07%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1012.6469236339258 to 951.1415547703022 (6.07%) in 2.12.0/microbenchmark.json
REGRESSION 6.03%: single_client_tasks_sync (THROUGHPUT) regresses from 1051.329826235638 to 987.9154572339097 (6.03%) in 2.12.0/microbenchmark.json
REGRESSION 5.58%: placement_group_create/removal (THROUGHPUT) regresses from 872.5565113012652 to 823.8896629199388 (5.58%) in 2.12.0/microbenchmark.json
REGRESSION 5.56%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5530.230885925916 to 5222.55884804985 (5.56%) in 2.12.0/microbenchmark.json
REGRESSION 5.08%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9559718222313252 to 0.9074349140473464 (5.08%) in 2.12.0/microbenchmark.json
REGRESSION 5.07%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12708.321183661115 to 12064.308681826904 (5.07%) in 2.12.0/microbenchmark.json
REGRESSION 4.91%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2162.105443003009 to 2055.9970223719974 (4.91%) in 2.12.0/microbenchmark.json
REGRESSION 4.90%: multi_client_tasks_async (THROUGHPUT) regresses from 23003.327676720364 to 21875.105721041346 (4.90%) in 2.12.0/microbenchmark.json
REGRESSION 4.76%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 549.1965858848921 to 523.0280053260831 (4.76%) in 2.12.0/microbenchmark.json
REGRESSION 3.99%: 1_n_actor_calls_async (THROUGHPUT) regresses from 9163.099212047364 to 8797.319487481269 (3.99%) in 2.12.0/microbenchmark.json
REGRESSION 3.52%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1011.3642608406338 to 975.7618423482973 (3.52%) in 2.12.0/microbenchmark.json
REGRESSION 2.48%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23555.103105727303 to 22971.36788751919 (2.48%) in 2.12.0/microbenchmark.json
REGRESSION 2.33%: client__put_calls (THROUGHPUT) regresses from 855.7554311772113 to 835.8219066517684 (2.33%) in 2.12.0/microbenchmark.json
REGRESSION 1.46%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 8.437608759394715 to 8.314592004219296 (1.46%) in 2.12.0/microbenchmark.json
REGRESSION 1.06%: single_client_put_gigabytes (THROUGHPUT) regresses from 19.822902089600902 to 19.613041636801512 (1.06%) in 2.12.0/microbenchmark.json
REGRESSION 1.04%: n_n_actor_calls_async (THROUGHPUT) regresses from 28462.88330232226 to 28165.509673837572 (1.04%) in 2.12.0/microbenchmark.json
REGRESSION 0.98%: pgs_per_second (THROUGHPUT) regresses from 23.704540710281698 to 23.471191969494587 (0.98%) in 2.12.0/benchmarks/many_pgs.json
REGRESSION 0.89%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2432.815669351221 to 2411.2175991602116 (0.89%) in 2.12.0/microbenchmark.json
REGRESSION 0.68%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1392.324666747059 to 1382.8140547973987 (0.68%) in 2.12.0/microbenchmark.json
REGRESSION 0.23%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8920.501990632494 to 8900.061966026988 (0.23%) in 2.12.0/microbenchmark.json
REGRESSION 0.19%: single_client_tasks_async (THROUGHPUT) regresses from 8191.290843342201 to 8175.996977132117 (0.19%) in 2.12.0/microbenchmark.json
REGRESSION 0.13%: client__get_calls (THROUGHPUT) regresses from 1092.9690984134525 to 1091.5724282284737 (0.13%) in 2.12.0/microbenchmark.json
REGRESSION 102.99%: dashboard_p95_latency_ms (LATENCY) regresses from 38.748 to 78.653 (102.99%) in 2.12.0/benchmarks/many_nodes.json
REGRESSION 29.82%: stage_2_avg_iteration_time (LATENCY) regresses from 56.80593147277832 to 73.74742498397828 (29.82%) in 2.12.0/stress_tests/stress_test_many_tasks.json
REGRESSION 15.60%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 14.540794130999984 to 16.808720801999982 (15.60%) in 2.12.0/scalability/object_store.json
REGRESSION 7.81%: 1000000_queued_time (LATENCY) regresses from 183.388168655 to 197.709131292 (7.81%) in 2.12.0/scalability/single_node.json
REGRESSION 6.74%: dashboard_p99_latency_ms (LATENCY) regresses from 199.686 to 213.152 (6.74%) in 2.12.0/benchmarks/many_nodes.json
REGRESSION 6.68%: dashboard_p50_latency_ms (LATENCY) regresses from 3.909 to 4.17 (6.68%) in 2.12.0/benchmarks/many_nodes.json
REGRESSION 5.89%: stage_3_creation_time (LATENCY) regresses from 2.057617425918579 to 2.1788923740386963 (5.89%) in 2.12.0/stress_tests/stress_test_many_tasks.json
REGRESSION 5.83%: stage_3_time (LATENCY) regresses from 3080.732224702835 to 3260.191632270813 (5.83%) in 2.12.0/stress_tests/stress_test_many_tasks.json
REGRESSION 4.41%: avg_iteration_time (LATENCY) regresses from 1.4924560022354125 to 1.558222110271454 (4.41%) in 2.12.0/stress_tests/stress_test_dead_actors.json
REGRESSION 3.82%: 10000_args_time (LATENCY) regresses from 17.036145214 to 17.686509897000008 (3.82%) in 2.12.0/scalability/single_node.json
REGRESSION 3.10%: stage_1_avg_iteration_time (LATENCY) regresses from 25.6875333070755 to 26.485081911087036 (3.10%) in 2.12.0/stress_tests/stress_test_many_tasks.json
REGRESSION 0.39%: avg_pg_remove_time_ms (LATENCY) regresses from 0.9238805060055858 to 0.9274617132122331 (0.39%) in 2.12.0/stress_tests/stress_test_placement_group.json
```