### PR TITLE
[core] handle unserializable user exception

### DIFF
--- a/doc/source/ray-core/doc_code/task_exceptions.py
+++ b/doc/source/ray-core/doc_code/task_exceptions.py
@@ -51,14 +51,14 @@ try:
     ray.get(raise_unserializable_error.remote())
 except ray.exceptions.RayTaskError as e:
     print(e)
-    # ray::raise_unserializable_error() (pid=222813, ip=172.31.5.154)
+    # ray::raise_unserializable_error() (pid=328577, ip=172.31.5.154)
     #   File "/home/ubuntu/ray/tmp~/main.py", line 25, in raise_unserializable_error
     #     raise UnserializableException
     # UnserializableException
     print(type(e.cause))
     # <class 'ray.exceptions.RayError'>
     print(e.cause)
-    # The original cause of RayTaskError (<class '__main__.UnserializableException'>) is not serializable: cannot pickle '_thread.lock' object. Overwriting the cause to RayError.
+    # The original cause of the RayTaskError (<class '__main__.UnserializableException'>) isn't serializable: cannot pickle '_thread.lock' object. Overwriting the cause to a RayError.
 
 # __unserializable_exceptions_end__
 # __catch_user_exceptions_begin__

--- a/doc/source/ray-core/doc_code/task_exceptions.py
+++ b/doc/source/ray-core/doc_code/task_exceptions.py
@@ -35,6 +35,32 @@ except ray.exceptions.RayTaskError as e:
     # Exception: the real error
 
 # __task_exceptions_end__
+# __unserializable_exceptions_begin__
+
+import threading
+
+class UnserializableException(Exception):
+    def __init__(self):
+        self.lock = threading.Lock()
+
+@ray.remote
+def raise_unserializable_error():
+    raise UnserializableException
+
+try:
+    ray.get(raise_unserializable_error.remote())
+except ray.exceptions.RayTaskError as e:
+    print(e)
+    # ray::raise_unserializable_error() (pid=222813, ip=172.31.5.154)
+    #   File "/home/ubuntu/ray/tmp~/main.py", line 25, in raise_unserializable_error
+    #     raise UnserializableException
+    # UnserializableException
+    print(type(e.cause))
+    # <class 'ray.exceptions.RayError'>
+    print(e.cause)
+    # The original cause of RayTaskError (<class '__main__.UnserializableException'>) is not serializable: cannot pickle '_thread.lock' object. Overwriting the cause to RayError.
+
+# __unserializable_exceptions_end__
 # __catch_user_exceptions_begin__
 
 class MyException(Exception):

--- a/doc/source/ray-core/fault_tolerance/tasks.rst
+++ b/doc/source/ray-core/fault_tolerance/tasks.rst
@@ -27,6 +27,13 @@ field of the ``RayTaskError``.
   :start-after: __task_exceptions_begin__
   :end-before: __task_exceptions_end__
 
+If the user's exception cannot be serialized, it would be converted to a ``RayError``:
+
+.. literalinclude:: ../doc_code/task_exceptions.py
+  :language: python
+  :start-after: __unserializable_exceptions_begin__
+  :end-before: __unserializable_exceptions_end__
+
 Example code of catching the user exception type when the exception type can be subclassed:
 
 .. literalinclude:: ../doc_code/task_exceptions.py

--- a/doc/source/ray-core/fault_tolerance/tasks.rst
+++ b/doc/source/ray-core/fault_tolerance/tasks.rst
@@ -27,7 +27,7 @@ field of the ``RayTaskError``.
   :start-after: __task_exceptions_begin__
   :end-before: __task_exceptions_end__
 
-If the user's exception cannot be serialized, it would be converted to a ``RayError``:
+If Ray can't serialize the user's exception, it converts the exception to a ``RayError``.
 
 .. literalinclude:: ../doc_code/task_exceptions.py
   :language: python

--- a/doc/source/ray-core/fault_tolerance/tasks.rst
+++ b/doc/source/ray-core/fault_tolerance/tasks.rst
@@ -27,13 +27,6 @@ field of the ``RayTaskError``.
   :start-after: __task_exceptions_begin__
   :end-before: __task_exceptions_end__
 
-If Ray can't serialize the user's exception, it converts the exception to a ``RayError``.
-
-.. literalinclude:: ../doc_code/task_exceptions.py
-  :language: python
-  :start-after: __unserializable_exceptions_begin__
-  :end-before: __unserializable_exceptions_end__
-
 Example code of catching the user exception type when the exception type can be subclassed:
 
 .. literalinclude:: ../doc_code/task_exceptions.py
@@ -47,6 +40,13 @@ Example code of accessing the user exception type when the exception type can *n
   :language: python
   :start-after: __catch_user_final_exceptions_begin__
   :end-before: __catch_user_final_exceptions_end__
+
+If Ray can't serialize the user's exception, it converts the exception to a ``RayError``.
+
+.. literalinclude:: ../doc_code/task_exceptions.py
+  :language: python
+  :start-after: __unserializable_exceptions_begin__
+  :end-before: __unserializable_exceptions_end__
 
 Use `ray list tasks` from :ref:`State API CLI <state-api-overview-ref>` to query task exit details:
 

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -138,7 +138,7 @@ class RayTaskError(RayError):
             err_msg = (
                 "The original cause of the RayTaskError"
                 f" ({self.cause.__class__}) isn't serializable: {e}."
-                " Overwriting the cause to RayError."
+                " Overwriting the cause to a RayError."
             )
             logger.warning(err_msg)
             self.cause = RayError(err_msg)

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -137,7 +137,7 @@ class RayTaskError(RayError):
         except (pickle.PicklingError, TypeError) as e:
             err_msg = (
                 "The original cause of the RayTaskError"
-                f" ({self.cause.__class__}) is not serializable: {e}."
+                f" ({self.cause.__class__}) isn't serializable: {e}."
                 " Overwriting the cause to RayError."
             )
             logger.warning(err_msg)

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -116,9 +116,6 @@ class RayTaskError(RayError):
         """Initialize a RayTaskError."""
         import ray
 
-        # BaseException implements a __reduce__ method that returns
-        # a tuple with the type and the value of self.args.
-        # https://stackoverflow.com/a/49715949/2213289
         if proctitle:
             self.proctitle = proctitle
         else:
@@ -142,6 +139,9 @@ class RayTaskError(RayError):
             logger.warning(err_msg)
             self.cause = RayError(err_msg)
 
+        # BaseException implements a __reduce__ method that returns
+        # a tuple with the type and the value of self.args.
+        # https://stackoverflow.com/a/49715949/2213289
         self.args = (function_name, traceback_str, self.cause, proctitle, pid, ip)
 
         assert traceback_str is not None

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -136,7 +136,7 @@ class RayTaskError(RayError):
             pickle.dumps(cause)
         except (pickle.PicklingError, TypeError) as e:
             err_msg = (
-                "The original cause of RayTaskError"
+                "The original cause of the RayTaskError"
                 f" ({self.cause.__class__}) is not serializable: {e}."
                 " Overwriting the cause to RayError."
             )

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -119,7 +119,6 @@ class RayTaskError(RayError):
         # BaseException implements a __reduce__ method that returns
         # a tuple with the type and the value of self.args.
         # https://stackoverflow.com/a/49715949/2213289
-        self.args = (function_name, traceback_str, cause, proctitle, pid, ip)
         if proctitle:
             self.proctitle = proctitle
         else:
@@ -142,7 +141,8 @@ class RayTaskError(RayError):
             )
             logger.warning(err_msg)
             self.cause = RayError(err_msg)
-            self.args = (function_name, traceback_str, self.cause, proctitle, pid, ip)
+
+        self.args = (function_name, traceback_str, self.cause, proctitle, pid, ip)
 
         assert traceback_str is not None
 

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -617,7 +617,7 @@ def test_unserializable_exception(ray_start_regular, propagate_logs):
 
     assert isinstance(exc_info.value, ray.exceptions.RayTaskError)
     assert isinstance(exc_info.value.cause, ray.exceptions.RayError)
-    assert "is not serializable" in str(exc_info.value.cause)
+    assert "isn't serializable" in str(exc_info.value.cause)
 
 
 def test_final_user_exception(ray_start_regular, propagate_logs, caplog):

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -3,6 +3,7 @@ import signal
 import sys
 import time
 import logging
+import threading
 
 import numpy as np
 import pytest
@@ -598,6 +599,25 @@ def test_actor_failover_with_bad_network(ray_start_cluster_head):
 
     # We should be able to get the return value of task 2 without any issue
     ray.get(obj2)
+
+
+# Previously when there is threading.Lock in the exception, it will cause
+# the serialization to fail. This test case is to cover this scenario.
+def test_unserializable_exception(ray_start_regular, propagate_logs):
+    class UnserializableException(Exception):
+        def __init__(self):
+            self.lock = threading.Lock()
+
+    @ray.remote
+    def func():
+        raise UnserializableException
+
+    with pytest.raises(ray.exceptions.RayTaskError) as exc_info:
+        ray.get(func.remote())
+
+    assert isinstance(exc_info.value, ray.exceptions.RayTaskError)
+    assert isinstance(exc_info.value.cause, ray.exceptions.RayError)
+    assert "is not serializable" in str(exc_info.value.cause)
 
 
 def test_final_user_exception(ray_start_regular, propagate_logs, caplog):

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -602,7 +602,7 @@ def test_actor_failover_with_bad_network(ray_start_cluster_head):
 
 
 # Previously when threading.Lock is in the exception, it causes
-# the serialization to fail. This test case is to cover this scenario.
+# the serialization to fail. This test case is to cover that scenario.
 def test_unserializable_exception(ray_start_regular, propagate_logs):
     class UnserializableException(Exception):
         def __init__(self):

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -601,7 +601,7 @@ def test_actor_failover_with_bad_network(ray_start_cluster_head):
     ray.get(obj2)
 
 
-# Previously when there is threading.Lock in the exception, it will cause
+# Previously when threading.Lock is in the exception, it causes
 # the serialization to fail. This test case is to cover this scenario.
 def test_unserializable_exception(ray_start_regular, propagate_logs):
     class UnserializableException(Exception):


### PR DESCRIPTION
If I run the following script, core worker would fail to serialize the RayError and crash

(credit to @alexeykudinkin )
```
from time import sleep

import ray

ray.init()

@ray.remote(num_cpus=1)
class Callee:

    def bar(self):
        from tenacity import retry, stop_after_attempt

        @retry(stop=stop_after_attempt(1))
        def failing_method():
            raise ValueError("failed")

        failing_method()


@ray.remote(num_cpus=1)
class Caller:

    def __init__(self, h):
        self.callee = h

    def foo(self):
        ref = self.callee.bar.remote()
        ray.wait([ref])


callee = Callee.remote()
caller = Caller.remote(callee)

ray.wait([caller.foo.remote()])

sleep(1800)
```

This PR will fix this.