### PR TITLE
[Data] Make `name` a required argument for `AggregateFn`

### DIFF
--- a/python/ray/data/aggregate/_aggregate.py
+++ b/python/ray/data/aggregate/_aggregate.py
@@ -70,9 +70,9 @@ class AggregateFn:
 
         self.init = init
         self.merge = merge
+        self.name = name
         self.accumulate_block = accumulate_block
         self.finalize = finalize
-        self.name = name
 
     def _validate(self, schema: Optional[Union[type, "pa.lib.Schema"]]) -> None:
         """Raise an error if this cannot be applied to the given schema."""

--- a/python/ray/data/aggregate/_aggregate.py
+++ b/python/ray/data/aggregate/_aggregate.py
@@ -30,6 +30,8 @@ class AggregateFn:
             For example, an empty accumulator for a sum would be 0.
         merge: This may be called multiple times, each time to merge
             two accumulators into one.
+        name: The name of the aggregation. This will be used as the column name
+            in the output Dataset.
         accumulate_row: This is called once per row of the same group.
             This combines the accumulator and the row, returns the updated
             accumulator. Exactly one of accumulate_row and accumulate_block must
@@ -41,18 +43,16 @@ class AggregateFn:
             accumulate_block must be provided.
         finalize: This is called once to compute the final aggregation
             result from the fully merged accumulator.
-        name: The name of the aggregation. This will be used as the output
-            column name in the case of Arrow dataset.
     """
 
     def __init__(
         self,
         init: Callable[[KeyType], AggType],
         merge: Callable[[AggType, AggType], AggType],
+        name: str,
         accumulate_row: Callable[[AggType, T], AggType] = None,
         accumulate_block: Callable[[AggType, Block], AggType] = None,
         finalize: Callable[[AggType], U] = lambda a: a,
-        name: Optional[str] = None,
     ):
         if (accumulate_row is None and accumulate_block is None) or (
             accumulate_row is not None and accumulate_block is not None

--- a/python/ray/data/aggregate/_aggregate.py
+++ b/python/ray/data/aggregate/_aggregate.py
@@ -68,6 +68,9 @@ class AggregateFn:
                     a = accumulate_row(a, r)
                 return a
 
+        if not isinstance(name, str):
+            raise TypeError("`name` must be provided.")
+
         self.init = init
         self.merge = merge
         self.name = name


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, `name` is an optional arg for `AggregateFn`, which can cause errors when the user defines a custom `AggregateFn` without a name. For example, [here](https://github.com/ray-project/ray/blob/master/python/ray/data/_internal/pandas_block.py#L582) we will get an empty row due to the `AggregateFn.name` not being set.

This PR makes the `name` parameter required for `AggregateFn`, which resolves the issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
