### PR TITLE
[Doc][Train] Add `accelerator_type` to Ray Train user guide

### DIFF
--- a/doc/source/train/user-guides/using-gpus.rst
+++ b/doc/source/train/user-guides/using-gpus.rst
@@ -107,7 +107,7 @@ You can get a list of associated devices with :meth:`ray.train.torch.get_devices
 Setting the GPU type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Ray Train allows you to specify the accelerator type for each worker.
-This is useful if your model training has some GPU memory constraints that requires a specific type of GPU.
+This is useful if you want to use a specific accelerator type for model training.
 In a heterogeneous Ray cluster, this means that your training workers will be forced to run on the specified GPU type, 
 rather than on any arbitrary GPU node.
 
@@ -121,9 +121,9 @@ assign each worker a NVIDIA A100 GPU.
 .. testcode::
 
     ScalingConfig(
-            num_workers=1,
-            use_gpu=True,
-            accelerator_type="A100"
+        num_workers=1,
+        use_gpu=True,
+        accelerator_type="A100"
     )
 
 

--- a/doc/source/train/user-guides/using-gpus.rst
+++ b/doc/source/train/user-guides/using-gpus.rst
@@ -110,6 +110,7 @@ Ray Train allows you to specify the accelerator type for each worker.
 This is useful if your model training has some GPU memory constraints that requires a specific type of GPU.
 In a heterogeneous Ray cluster, this means that your training workers will be forced to run on the specified GPU type, 
 rather than on any arbitrary GPU node.
+
 For example, you can specify `accelerator_type="A100"` in the :class:`~ray.train.ScalingConfig` if you want to 
 assign each worker a NVIDIA A100 GPU.
 

--- a/doc/source/train/user-guides/using-gpus.rst
+++ b/doc/source/train/user-guides/using-gpus.rst
@@ -106,26 +106,21 @@ You can get a list of associated devices with :meth:`ray.train.torch.get_devices
 
 Setting the GPU type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Sometimes you might want to specify the accelerator type for a worker. For example, 
-you can specify `accelerator_type="A100"` in the `ScalingConfig` if you want to 
-assign the worker an NVIDIA A100 GPU.
+Ray Train allows you to specify the accelerator type for each worker.
+This is useful if your model training has some GPU memory constraints that requires a specific type of GPU.
+In a heterogeneous Ray cluster, this means that your training workers will be forced to run on the specified GPU type, 
+rather than on any arbitrary GPU node.
 
-You can get a list of supported `accelerator_type` from :ref:`the available accelerator types <accelerator_types>`.
+For example, you can specify `accelerator_type="A100"` in the :class:`~ray.train.ScalingConfig` if you want to 
+assign each worker a NVIDIA A100 GPU.
 Ensure that your cluster has instances with the specified accelerator type 
 or is able to autoscale to fulfill the request.
 
 .. testcode::
 
-    import torch
     from ray.train import ScalingConfig
-    from ray.train.torch import TorchTrainer, get_device
+    from ray.train.torch import TorchTrainer
 
-
-    def train_func():
-        assert torch.cuda.is_available()
-
-        device = get_device()
-        assert device == torch.device("cuda:0")
 
     trainer = TorchTrainer(
         train_func,
@@ -135,7 +130,6 @@ or is able to autoscale to fulfill the request.
             accelerator_type="A100"
         )
     )
-    trainer.fit()
 
 
 (PyTorch) Setting the communication backend 

--- a/doc/source/train/user-guides/using-gpus.rst
+++ b/doc/source/train/user-guides/using-gpus.rst
@@ -109,11 +109,11 @@ Setting the GPU type
 Ray Train allows you to specify the accelerator type for each worker.
 This is useful if you want to use a specific accelerator type for model training.
 In a heterogeneous Ray cluster, this means that your training workers will be forced to run on the specified GPU type, 
-rather than on any arbitrary GPU node.
+rather than on any arbitrary GPU node. You can get a list of supported `accelerator_type` from 
+:ref:`the available accelerator types <accelerator_types>`.
 
 For example, you can specify `accelerator_type="A100"` in the :class:`~ray.train.ScalingConfig` if you want to 
-assign each worker a NVIDIA A100 GPU. You can get a list of supported `accelerator_type` from 
-:ref:`the available accelerator types <accelerator_types>`.
+assign each worker a NVIDIA A100 GPU. 
 
 .. tip::
     Ensure that your cluster has instances with the specified accelerator type 

--- a/doc/source/train/user-guides/using-gpus.rst
+++ b/doc/source/train/user-guides/using-gpus.rst
@@ -112,7 +112,8 @@ In a heterogeneous Ray cluster, this means that your training workers will be fo
 rather than on any arbitrary GPU node.
 
 For example, you can specify `accelerator_type="A100"` in the :class:`~ray.train.ScalingConfig` if you want to 
-assign each worker a NVIDIA A100 GPU.
+assign each worker a NVIDIA A100 GPU. You can get a list of supported `accelerator_type` from 
+:ref:`the available accelerator types <accelerator_types>`.
 
 .. tip::
     Ensure that your cluster has instances with the specified accelerator type 

--- a/doc/source/train/user-guides/using-gpus.rst
+++ b/doc/source/train/user-guides/using-gpus.rst
@@ -110,25 +110,19 @@ Ray Train allows you to specify the accelerator type for each worker.
 This is useful if your model training has some GPU memory constraints that requires a specific type of GPU.
 In a heterogeneous Ray cluster, this means that your training workers will be forced to run on the specified GPU type, 
 rather than on any arbitrary GPU node.
-
 For example, you can specify `accelerator_type="A100"` in the :class:`~ray.train.ScalingConfig` if you want to 
 assign each worker a NVIDIA A100 GPU.
-Ensure that your cluster has instances with the specified accelerator type 
-or is able to autoscale to fulfill the request.
+
+.. tip::
+    Ensure that your cluster has instances with the specified accelerator type 
+    or is able to autoscale to fulfill the request.
 
 .. testcode::
 
-    from ray.train import ScalingConfig
-    from ray.train.torch import TorchTrainer
-
-
-    trainer = TorchTrainer(
-        train_func,
-        scaling_config=ScalingConfig(
+    ScalingConfig(
             num_workers=1,
             use_gpu=True,
             accelerator_type="A100"
-        )
     )
 
 

--- a/doc/source/train/user-guides/using-gpus.rst
+++ b/doc/source/train/user-guides/using-gpus.rst
@@ -104,6 +104,40 @@ You can get a list of associated devices with :meth:`ray.train.torch.get_devices
     trainer.fit()
 
 
+Setting the GPU type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sometimes you might want to specify the accelerator type for a worker. For example, 
+you can specify `accelerator_type="A100"` in the `ScalingConfig` if you want to 
+assign the worker an NVIDIA A100 GPU.
+
+You can get a list of supported `accelerator_type` from :ref:`the available accelerator types <accelerator_types>`.
+Ensure that your cluster has instances with the specified accelerator type 
+or is able to autoscale to fulfill the request.
+
+.. testcode::
+
+    import torch
+    from ray.train import ScalingConfig
+    from ray.train.torch import TorchTrainer, get_device
+
+
+    def train_func():
+        assert torch.cuda.is_available()
+
+        device = get_device()
+        assert device == torch.device("cuda:0")
+
+    trainer = TorchTrainer(
+        train_func,
+        scaling_config=ScalingConfig(
+            num_workers=1,
+            use_gpu=True,
+            accelerator_type="A100"
+        )
+    )
+    trainer.fit()
+
+
 (PyTorch) Setting the communication backend 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Our `ScalingConfig()` function supports a new argument `accelerator_type`. This PR provides a user guide with example code to showcase the usage. The generated section of the user guide is appended below:

<img width="1169" alt="Screenshot 2024-04-22 at 7 35 27 PM" src="https://github.com/ray-project/ray/assets/21209448/db84a260-4c30-4c52-8961-17f55bc60882">

## Related issue number

"Closes #44763

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
