### PR TITLE
[train] Setup xgboost `CommunicatorContext` automatically

### DIFF
--- a/python/ray/train/xgboost/config.py
+++ b/python/ray/train/xgboost/config.py
@@ -1,9 +1,11 @@
 import json
 import logging
 import os
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 from xgboost import RabitTracker
+from xgboost.collective import CommunicatorContext
 
 import ray
 from ray.train._internal.worker_group import WorkerGroup
@@ -30,6 +32,13 @@ class XGBoostConfig(BackendConfig):
     """
 
     xgboost_communicator: str = "rabit"
+
+    @property
+    def train_func_context(self):
+        @contextmanager
+        def collective_communication_context():
+            with CommunicatorContext():
+                yield
 
     @property
     def backend_cls(self):

--- a/python/ray/train/xgboost/config.py
+++ b/python/ray/train/xgboost/config.py
@@ -40,6 +40,8 @@ class XGBoostConfig(BackendConfig):
             with CommunicatorContext():
                 yield
 
+        return collective_communication_context
+
     @property
     def backend_cls(self):
         if self.xgboost_communicator == "rabit":

--- a/python/ray/train/xgboost/v2.py
+++ b/python/ray/train/xgboost/v2.py
@@ -26,8 +26,6 @@ class XGBoostTrainer(DataParallelTrainer):
         from ray.train.xgboost.v2 import XGBoostTrainer
 
         def train_fn_per_worker(config: dict):
-            from xgboost.collective import CommunicatorContext
-
             # (Optional) Add logic to resume training state from a checkpoint.
             # ray.train.get_checkpoint()
 
@@ -53,17 +51,16 @@ class XGBoostTrainer(DataParallelTrainer):
                 "max_depth": 2,
             }
 
-            # 2. Do distributed data-parallel training with the `CommunicatorContext`.
+            # 2. Do distributed data-parallel training.
             # Ray Train sets up the necessary coordinator processes and
             # environment variables for your workers to communicate with each other.
-            with CommunicatorContext():
-                bst = xgboost.train(
-                    params,
-                    dtrain=dtrain,
-                    evals=[(deval, "validation")],
-                    num_boost_round=10,
-                    callbacks=[RayTrainReportCallback()],
-                )
+            bst = xgboost.train(
+                params,
+                dtrain=dtrain,
+                evals=[(deval, "validation")],
+                num_boost_round=10,
+                callbacks=[RayTrainReportCallback()],
+            )
 
         train_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
         eval_ds = ray.data.from_items([{"x": x, "y": x + 1} for x in range(16)])

--- a/python/ray/train/xgboost/xgboost_trainer.py
+++ b/python/ray/train/xgboost/xgboost_trainer.py
@@ -23,8 +23,6 @@ def _xgboost_train_fn_per_worker(
     dataset_keys: set,
     xgboost_train_kwargs: dict,
 ):
-    from xgboost.collective import CommunicatorContext
-
     checkpoint = ray.train.get_checkpoint()
     starting_model = None
     remaining_iters = num_boost_round
@@ -60,17 +58,16 @@ def _xgboost_train_fn_per_worker(
         eval_X, eval_y = eval_df.drop(label_column, axis=1), eval_df[label_column]
         evals.append((xgboost.DMatrix(eval_X, label=eval_y), eval_name))
 
-    with CommunicatorContext():
-        evals_result = {}
-        xgboost.train(
-            config,
-            dtrain=dtrain,
-            evals=evals,
-            evals_result=evals_result,
-            num_boost_round=remaining_iters,
-            xgb_model=starting_model,
-            **xgboost_train_kwargs,
-        )
+    evals_result = {}
+    xgboost.train(
+        config,
+        dtrain=dtrain,
+        evals=evals,
+        evals_result=evals_result,
+        num_boost_round=remaining_iters,
+        xgb_model=starting_model,
+        **xgboost_train_kwargs,
+    )
 
 
 @PublicAPI(stability="beta")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR uses the recently added `Backend(train_func_context)` configuration to automatically set up the xgboost `CommunicatorContext` for users so they don't have to call it manually in their training code. Users do not need to change their single worker code as much.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
