### PR TITLE
[Core] Deflake test_unavailable_actors

### DIFF
--- a/python/ray/tests/test_unavailable_actors.py
+++ b/python/ray/tests/test_unavailable_actors.py
@@ -64,6 +64,41 @@ def sigkill_actor(actor):
     print(f"killing actor {actor}'s process {pid}")
     os.kill(pid, signal.SIGKILL)
 
+@pytest.mark.parametrize(
+    "caller",
+    ["actor", "task", "driver"],
+)
+def test_generators_early_stop_unavailable(ray_start_regular, caller):
+    """
+    For a streaming generator, if a connection break happens, *some* elements may still
+    yield because they are received prior to the break. Then, two things can happen:
+    - an early StopIteration, if `next(gen)` is called.
+    - a ActorUnavailableError, if `ray.get(obj_ref)` is called.
+    """
+
+    def body():
+        a = Counter.remote()
+        pid = ray.get(a.getpid.remote())
+        total = 2000000
+        break_at = 5
+        gen = a.gen_iota.remote(total)
+        obj_refs = []
+        i = 0
+        for obj_ref in gen:
+            obj_refs.append(obj_ref)
+            if i == break_at:
+                print(f"breaking conns at {i}")
+                close_common_connections(pid)
+            i += 1
+        # StopIteration happened before `total` elements reached.
+        # On my laptop, 11120 elements are collected.
+        print(f"collected {len(obj_refs)} elements")
+        assert len(obj_refs) < total
+        with pytest.raises(ActorUnavailableError):
+            ray.get(obj_refs)
+
+    call_from(body, caller)
+
 
 @pytest.mark.parametrize(
     "caller",

--- a/python/ray/tests/test_unavailable_actors.py
+++ b/python/ray/tests/test_unavailable_actors.py
@@ -19,6 +19,7 @@ def ray_start_regular_with_patch_with_patch(ray_start_regular_with_patch):
     we invoke gRPC `grpc::ClientContext::TryCancel` but the thread still hangs in
     `poll`. We will investigate more on it, e.g. to add a timeout; before that we skip
     the logging.
+    https://github.com/ray-project/ray/issues/44836
     """
     address = ray_start_regular_with_patch["address"]
     if sys.platform == "win32":

--- a/python/ray/tests/test_unavailable_actors.py
+++ b/python/ray/tests/test_unavailable_actors.py
@@ -136,10 +136,12 @@ def test_actor_unavailable_conn_broken(ray_start_regular_with_patch, caller):
         assert ray.get(a.slow_increment.remote(2, 0.1)) == 2
         pid = ray.get(a.getpid.remote())
         task = a.slow_increment.remote(3, 5)
+        # Wait for the task to start.
+        time.sleep(0.5)
         # Break the grpc connection from this process to the actor process. The
         # next `ray.get` call should fail with ActorUnavailableError.
         close_common_connections(pid)
-        with pytest.raises(ActorUnavailableError, match="GrpcUnavailable"):
+        with pytest.raises(ActorUnavailableError, match="Grpc"):
             ray.get(task)
         # Since the remote() call happens *before* the break, the actor did receive the
         # request, so the side effects are observable, and the actor recovered.
@@ -152,7 +154,7 @@ def test_actor_unavailable_conn_broken(ray_start_regular_with_patch, caller):
         # itself won't raise an error.
         close_common_connections(pid)
         task2 = a.slow_increment.remote(5, 0.1)
-        with pytest.raises(ActorUnavailableError, match="GrpcUnavailable"):
+        with pytest.raises(ActorUnavailableError, match="Grpc"):
             ray.get(task2)
         assert ray.get(a.read.remote()) == 9
 
@@ -259,7 +261,7 @@ def test_unavailable_then_actor_error(ray_start_regular_with_patch):
     # calls get ActorUnavailableError.
     sigkill_actor(a)
 
-    with pytest.raises(ActorUnavailableError, match="GrpcUnavailable"):
+    with pytest.raises(ActorUnavailableError, match="Grpc"):
         print(ray.get(a.ping.remote("unavailable")))
     # When the actor is restarting, any method call raises ActorUnavailableError.
     with pytest.raises(ActorUnavailableError, match="The actor is restarting"):


### PR DESCRIPTION
The test_unavailable_actors.py test is flaky in MacOS and breaks in Windows. This has something to do with our gRPC config: when there are connection breaks sometimes our grpc call cancellation no longer works. This is being solved in https://github.com/ray-project/ray/pull/44837, but to unblock the master branch we first stop creating those hanging logger threads.