### PR TITLE
[dashboard] Mark the decorator as `@functools.wraps`.

### DIFF
--- a/dashboard/modules/state/state_head.py
+++ b/dashboard/modules/state/state_head.py
@@ -3,6 +3,7 @@ import logging
 from dataclasses import asdict
 from datetime import datetime
 from typing import Callable, List, Tuple, Optional
+import functools
 
 import aiohttp.web
 from aiohttp.web import Response
@@ -101,6 +102,7 @@ class RateLimitedModule(ABC):
             ```
         """
 
+        @functools.wraps(func)
         async def async_wrapper(self, *args, **kwargs):
             if self.max_num_call_ >= 0 and self.num_call_ >= self.max_num_call_:
                 if self.logger_:


### PR DESCRIPTION
In `RateLimitedModule` the decorator `enforce_max_concurrent_calls` is not marked with `@functools.wraps`. This causes the dashboard metrics `ray_dashboard_api_requests_duration_seconds_count` exports all state APIs as `endpoint=async_wrapper`. This PR fixes it, and now the underlying function names are properly shown.

Before:
```
ray_dashboard_api_requests_duration_seconds_count{Component="dashboard", SessionName="session_2024-04-20_14-39-51_707028_4385", endpoint="async_wrapper", http_status="2xx", instance="127.0.0.1:44227", job="ray"}
```

After:
```
ray_dashboard_api_requests_duration_seconds_count{Component="dashboard", SessionName="session_2024-04-20_14-39-51_707028_4385", endpoint="list_actors", http_status="2xx", instance="127.0.0.1:44227", job="ray"}
```