### PR TITLE
[Core] Make sure dashboard agent will exit if grpc server fails

### DIFF
--- a/dashboard/agent.py
+++ b/dashboard/agent.py
@@ -85,6 +85,7 @@ class DashboardAgent:
 
     def _init_non_minimal(self):
         from ray._private.gcs_pubsub import GcsAioPublisher
+        from ray.dashboard.http_server_agent import HttpServerAgent
 
         self.aio_publisher = GcsAioPublisher(address=self.gcs_address)
 
@@ -137,12 +138,12 @@ class DashboardAgent:
         else:
             logger.info("Dashboard agent grpc address: %s:%s", grpc_ip, self.grpc_port)
 
-    async def _configure_http_server(self, modules):
-        from ray.dashboard.http_server_agent import HttpServerAgent
-
-        http_server = HttpServerAgent(self.ip, self.listen_port)
-        await http_server.start(modules)
-        return http_server
+        # If the agent is not minimal it should start the http server
+        # to communicate with the dashboard in a head node.
+        # Http server is not started in the minimal version because
+        # it requires additional dependencies that are not
+        # included in the minimal ray package.
+        self.http_server = HttpServerAgent(self.ip, self.listen_port)
 
     def _load_modules(self):
         """Load dashboard agent modules."""
@@ -183,15 +184,9 @@ class DashboardAgent:
 
         modules = self._load_modules()
 
-        # Setup http server if necessary.
-        if not self.minimal:
-            # If the agent is not minimal it should start the http server
-            # to communicate with the dashboard in a head node.
-            # Http server is not started in the minimal version because
-            # it requires additional dependencies that are not
-            # included in the minimal ray package.
+        if self.http_server:
             try:
-                self.http_server = await self._configure_http_server(modules)
+                await self.http_server.start(modules)
             except Exception:
                 # TODO(SongGuyang): Catch the exception here because there is
                 # port conflict issue which brought from static port. We should
@@ -214,6 +209,7 @@ class DashboardAgent:
         )
 
         tasks = [m.run(self.server) for m in modules]
+
         if sys.platform not in ["win32", "cygwin"]:
 
             def callback(msg):
@@ -225,13 +221,18 @@ class DashboardAgent:
                 self.log_dir, self.gcs_address, callback, loop
             )
             tasks.append(check_parent_task)
-        await asyncio.gather(*tasks)
 
         if self.server:
-            await self.server.wait_for_termination()
+            tasks.append(self.server.wait_for_termination())
         else:
-            while True:
-                await asyncio.sleep(3600)  # waits forever
+
+            async def wait_forever(self):
+                while True:
+                    await asyncio.sleep(3600)
+
+            tasks.append(wait_forever())
+
+        await asyncio.gather(*tasks)
 
         if self.http_server:
             await self.http_server.cleanup()

--- a/dashboard/modules/healthz/healthz_agent.py
+++ b/dashboard/modules/healthz/healthz_agent.py
@@ -50,4 +50,4 @@ class HealthzAgent(dashboard_utils.DashboardAgentModule):
 
     @staticmethod
     def is_minimal_module():
-        return True
+        return False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If grpc server fails, `wait_for_termination()` will raise an exception and dashboard agent should exit in this case. However, currently dashboard agent won't call `wait_for_termination()` since it's stuck at `await asyncio.gather(*tasks)` and those module tasks have infinite loop so it never has a chance to run `wait_for_termination()` and discover the failure of grpc server.  This PR makes `wait_for_termination()` part of asyncio.gather so that it runs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
