### PR TITLE
[Dashboard] Fix flamegraph generation when `sudo` is not installed

### DIFF
--- a/dashboard/modules/reporter/profile_manager.py
+++ b/dashboard/modules/reporter/profile_manager.py
@@ -61,13 +61,18 @@ def _format_failed_profiler_command(cmd, profiler, stdout, stderr) -> str:
 # If we can sudo, always try that. Otherwise, py-spy will only work if the user has
 # root privileges or has configured setuid on the py-spy script.
 async def _can_passwordless_sudo() -> bool:
-    process = await asyncio.create_subprocess_exec(
-        "sudo",
-        "-n",
-        "true",
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    try:
+        process = await asyncio.create_subprocess_exec(
+            "sudo",
+            "-n",
+            "true",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        # This happens when sudo is not installed.
+        return False
+
     _, _ = await process.communicate()
     return process.returncode == 0
 

--- a/dashboard/modules/reporter/tests/test_profile_manager.py
+++ b/dashboard/modules/reporter/tests/test_profile_manager.py
@@ -7,7 +7,10 @@ from unittest.mock import patch
 
 import ray
 from ray.dashboard.tests.conftest import *  # noqa
-from ray.dashboard.modules.reporter.profile_manager import MemoryProfilingManager
+from ray.dashboard.modules.reporter.profile_manager import (
+    _can_passwordless_sudo,
+    MemoryProfilingManager,
+)
 
 
 @pytest.fixture
@@ -160,6 +163,12 @@ class TestMemoryProfiling:
         )
         assert not success, message
         assert f"process {pid} has not been profiled" in message
+
+
+@pytest.mark.asyncio
+async def test_cannot_passwordless_sudo_if_sudo_is_not_found() -> None:
+    with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError):
+        assert not await _can_passwordless_sudo()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See https://github.com/ray-project/ray/issues/44904 ; TLDR, if `sudo` is not installed, generating flamegraphs from the Ray Dashboard fails with an exception. That exception indicates that `sudo` is not available, which should put us on the "don't use `sudo`" code path.

## Related issue number

Closes #44904

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
