### PR TITLE
[ci] add reef team as code ownership of ray_ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,8 +42,9 @@
 /ci/lint/format.sh @richardliaw @ericl @edoakes
 
 # Docker image and build scripts.
-/ci/build/build-docker-images.py @ray-project/ray-core @aslonnie @can-anyscale
-/ci/docker @aslonnie @can-anyscale
+/ci/build/build-docker-images.py @ray-project/ray-core @ray-project/ray-ci
+/ci/docker @ray-project/ray-ci
+/ci/ray_ci @ray-project/ray-ci
 
 # Python worker.
 #/python/ray/ @ray-project/ray-core


### PR DESCRIPTION
Add reef team as code ownership of ci/ray_ci

Test:

![](https://media4.giphy.com/media/TejmLnMKgnmPInMQjV/200.gif?cid=5a38a5a2kjwmjxdf5qsmi7eklaa32xclb4qiwsfubci68zbj&ep=v1_gifs_search&rid=200.gif&ct=g)