### PR TITLE
[Serve] Documentation and typing fixes for `serve.run(..., route_prefix=False)`

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -568,7 +568,7 @@ def run(
         route_prefix: Route prefix for HTTP requests. Defaults to '/'.
             If `None` is passed, the application will not be exposed over HTTP
             (this may be useful if you only want the application to be exposed via
-            gRPC or a `DeploymentHandle`.
+            gRPC or a `DeploymentHandle`).
         logging_config: Application logging config. If provided, the config will
             be applied to all deployments which doesn't have logging config.
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -546,7 +546,7 @@ def run(
     target: Application,
     blocking: bool = False,
     name: str = SERVE_DEFAULT_APP_NAME,
-    route_prefix: str = DEFAULT.VALUE,
+    route_prefix: Optional[str] = DEFAULT.VALUE,
     logging_config: Optional[Union[Dict, LoggingConfig]] = None,
 ) -> DeploymentHandle:
     """Run an application and return a handle to its ingress deployment.
@@ -565,9 +565,11 @@ def run(
             will loop and log status until Ctrl-C'd.
         name: Application name. If not provided, this will be the only
             application running on the cluster (it will delete all others).
-        route_prefix: Route prefix for HTTP requests. If not provided, it will use
-            route_prefix of the ingress deployment. If specified neither as an argument
-            nor in the ingress deployment, the route prefix will default to '/'.
+        route_prefix: Route prefix for HTTP requests. If not provided, it will use the
+            `route_prefix` of the application's ingress deployment.
+            If specified neither as an argument nor in the ingress deployment,
+            the route prefix will default to '/'.
+            If `None`, the application will not be exposed over HTTP.
         logging_config: Application logging config. If provided, the config will
             be applied to all deployments which doesn't have logging config.
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -565,15 +565,10 @@ def run(
             will loop and log status until Ctrl-C'd.
         name: Application name. If not provided, this will be the only
             application running on the cluster (it will delete all others).
-        route_prefix: Route prefix for HTTP requests. If not provided, it will use the
-            `route_prefix` of the application's ingress deployment.
-            If specified neither as an argument nor in the ingress deployment,
-            the route prefix will default to '/'.
-            If `None`, the application will not be exposed over HTTP
-            (this may be useful if you only want the application to be usable
-            via other methods like
-            [gRPC](serve-set-up-grpc-service) or
-            `serve.get_app_handle()`).
+        route_prefix: Route prefix for HTTP requests. Defaults to '/'.
+            If `None` is passed, the application will not be exposed over HTTP
+            (this may be useful if you only want the application to be exposed via
+            gRPC or a `DeploymentHandle`.
         logging_config: Application logging config. If provided, the config will
             be applied to all deployments which doesn't have logging config.
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -569,7 +569,11 @@ def run(
             `route_prefix` of the application's ingress deployment.
             If specified neither as an argument nor in the ingress deployment,
             the route prefix will default to '/'.
-            If `None`, the application will not be exposed over HTTP.
+            If `None`, the application will not be exposed over HTTP
+            (this may be useful if you only want the application to be usable
+            via other methods like
+            [gRPC](serve-set-up-grpc-service) or
+            `serve.get_app_handle()`).
         logging_config: Application logging config. If provided, the config will
             be applied to all deployments which doesn't have logging config.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In #44809 I thought that `route_prefix` didn't support being set to `None` to disable HTTP ingress because the type was `str`, and the docs didn't mention that this was supported (except indirectly in other places which I didn't know about until searching for them as part of this PR). It turns out this feature is already well-supported throughout the controller and proxy, it just wasn't fully documented in the public API, so this PR fixes that.

## Related issue number

Closes #44809

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
