### PR TITLE
[ci][micro/2] determine tests for microcheck

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -1,6 +1,30 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@py_deps_buildkite//:requirements.bzl", ci_require = "requirement")
 
+py_library(
+    name = "automation",
+    srcs = glob(
+        ["*.py"],
+        exclude = [
+            "test_*.py",
+        ],
+    ),
+    visibility = ["//ci/ray_ci/automation:__subpackages__"],
+    deps = [
+        "//ci/ray_ci:ray_ci_lib",
+    ],
+)
+
+py_binary(
+    name = "determine_microcheck_tests",
+    srcs = ["determine_microcheck_tests.py"],
+    exec_compatible_with = ["//:hermetic_python"],
+    deps = [
+        ci_require("click"),
+        ":automation",
+    ],
+)
+
 py_binary(
     name = "test_db_bot",
     srcs = ["test_db_bot.py"],
@@ -172,5 +196,19 @@ py_binary(
         ":docker_tags_lib",
         ci_require("click"),
         ci_require("docker"),
+    ],
+)
+
+py_test(
+    name = "test_determine_microcheck_tests",
+    srcs = ["test_determine_microcheck_tests.py"],
+    exec_compatible_with = ["//:hermetic_python"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ci_require("pytest"),
+        ":automation",
     ],
 )

--- a/ci/ray_ci/automation/determine_microcheck_tests.py
+++ b/ci/ray_ci/automation/determine_microcheck_tests.py
@@ -1,0 +1,103 @@
+import click
+from typing import Set, Dict
+
+from ci.ray_ci.utils import logger, ci_init
+from ray_release.configs.global_config import get_global_config
+from ray_release.test import Test
+from ray_release.result import ResultStatus
+
+LINUX_PYTHON_TEST_PREFIX = "linux:__python"
+
+
+@click.command()
+@click.argument("team", required=True, type=str)
+@click.argument("coverage", required=True, type=int)
+@click.option("--test-history-length", default=100, type=int)
+@click.option("--test-prefix", default=LINUX_PYTHON_TEST_PREFIX, type=str)
+def main(team: str, coverage: int, test_history_length: int, test_prefix: str) -> None:
+    """
+    This script determines the tests that need to be run to cover a certain percentage
+    of PR failures, based on historical data
+    """
+    assert coverage > 0 and coverage <= 100, "Coverage must be between 0 and 100"
+
+    ci_init()
+    tests = [
+        test for test in Test.gen_from_s3(test_prefix) if test.get_oncall() == team
+    ]
+    logger.info(f"Analyzing {len(tests)} tests for team {team}")
+
+    test_to_prs = {
+        test.get_name(): _get_failed_prs(test, test_history_length) for test in tests
+    }
+    high_impact_tests = _get_test_with_minimal_coverage(test_to_prs, coverage)
+
+    logger.info(
+        f"To cover {coverage}% of PRs, run the following tests: {high_impact_tests}"
+    )
+
+
+def _get_test_with_minimal_coverage(
+    test_to_prs: Dict[str, Set[str]], coverage: int
+) -> Set[str]:
+    """
+    Get the minimal set of tests that cover a certain percentage of PRs
+    """
+    all_prs = set()
+    high_impact_tests = set()
+    for prs in test_to_prs.values():
+        all_prs.update(prs)
+    if not all_prs:
+        return set()
+
+    covered_prs = set()
+    covered_pr_count = 0
+    while 100 * len(covered_prs) / len(all_prs) < coverage:
+        most_impact_test = _get_most_impact_test(test_to_prs, covered_prs)
+        high_impact_tests.add(most_impact_test)
+        covered_prs.update(test_to_prs[most_impact_test])
+        assert covered_pr_count < len(covered_prs), "No progress in coverage"
+        covered_pr_count = len(covered_prs)
+
+    return high_impact_tests
+
+
+def _get_most_impact_test(
+    test_to_prs: Dict[str, Set[str]],
+    already_covered_prs: Set[str],
+) -> str:
+    """
+    Get the test that covers the most PRs, excluding the PRs that have already been
+    covered
+    """
+    most_impact_test = None
+    for test, prs in test_to_prs.items():
+        if most_impact_test is None or len(prs - already_covered_prs) > len(
+            test_to_prs[most_impact_test] - already_covered_prs
+        ):
+            most_impact_test = test
+
+    return most_impact_test
+
+
+def _get_failed_prs(test: Test, test_history_length: int) -> Set[str]:
+    """
+    Get the failed PRs for a test. Currently we use the branch name as an identifier
+    for a PR.
+
+    TODO (can): Use the PR number instead of the branch name
+    """
+    logger.info(f"Analyzing test {test.get_name()}")
+    results = [
+        result
+        for result in test.get_test_results(
+            limit=test_history_length,
+            aws_bucket=get_global_config()["state_machine_pr_aws_bucket"],
+        )
+        if result.status == ResultStatus.ERROR.value
+    ]
+    return {result.branch for result in results if result.branch}
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/automation/test_determine_microcheck_tests.py
+++ b/ci/ray_ci/automation/test_determine_microcheck_tests.py
@@ -1,0 +1,96 @@
+import sys
+from typing import List
+
+import pytest
+
+from ci.ray_ci.automation.determine_microcheck_tests import (
+    _get_failed_prs,
+    _get_test_with_minimal_coverage,
+)
+from ci.ray_ci.utils import ci_init
+from ray_release.result import ResultStatus
+from ray_release.test import TestResult
+
+ci_init()
+
+
+class MockTest:
+    def __init__(self, name: str, results: List[TestResult]):
+        self.name = name
+        self.test_results = results
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_test_results(self, limit: int, aws_bucket: str) -> List[TestResult]:
+        return self.test_results
+
+
+def stub_test_result(status: ResultStatus, branch: str) -> TestResult:
+    return TestResult(
+        status=status.value,
+        branch=branch,
+        commit="",
+        url="",
+        timestamp=0,
+        pull_request="",
+    )
+
+
+def test_get_failed_prs():
+    assert _get_failed_prs(
+        MockTest(
+            "test",
+            [
+                stub_test_result(ResultStatus.ERROR, "w00t"),
+                stub_test_result(ResultStatus.ERROR, "w00t"),
+                stub_test_result(ResultStatus.SUCCESS, "hi"),
+                stub_test_result(ResultStatus.ERROR, "f00"),
+            ],
+        ),
+        1,
+    ) == {"w00t", "f00"}
+
+
+def test_get_test_with_minimal_coverage():
+    # empty cases
+    assert _get_test_with_minimal_coverage({}, 50) == set()
+
+    # normal cases
+    test_to_prs = {
+        "test1": {"a"},
+        "test2": {"a", "b"},
+        "test3": {"c"},
+        "test4": {"d"},
+    }
+    assert _get_test_with_minimal_coverage(test_to_prs, 0) == set()
+    assert _get_test_with_minimal_coverage(test_to_prs, 50) == {"test2"}
+    assert _get_test_with_minimal_coverage(test_to_prs, 75) == {
+        "test2",
+        "test3",
+    }
+
+    # one beat all cases
+    test_to_prs = {
+        "test1": {"a"},
+        "test2": {"a", "b"},
+        "test3": {"a", "b", "c"},
+    }
+    assert _get_test_with_minimal_coverage(test_to_prs, 50) == {"test3"}
+    assert _get_test_with_minimal_coverage(test_to_prs, 75) == {"test3"}
+
+    # equal distribution cases
+    test_to_prs = {
+        "test1": {"a"},
+        "test2": {"b"},
+        "test3": {"c"},
+    }
+    assert _get_test_with_minimal_coverage(test_to_prs, 100) == {
+        "test1",
+        "test2",
+        "test3",
+    }
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -435,7 +435,7 @@ class Test(dict):
         )
 
     def get_test_results(
-        self, limit: int = 10, refresh: bool = False
+        self, limit: int = 10, refresh: bool = False, aws_bucket: str = None
     ) -> List[TestResult]:
         """
         Get test result from test object, or s3
@@ -446,9 +446,10 @@ class Test(dict):
         if self.test_results is not None and not refresh:
             return self.test_results
 
+        bucket = aws_bucket or get_read_state_machine_aws_bucket()
         s3_client = boto3.client("s3")
         pages = s3_client.get_paginator("list_objects_v2").paginate(
-            Bucket=get_read_state_machine_aws_bucket(),
+            Bucket=bucket,
             Prefix=f"{AWS_TEST_RESULT_KEY}/{self._get_s3_name(self.get_name())}-",
         )
         files = sorted(
@@ -460,7 +461,7 @@ class Test(dict):
             TestResult.from_dict(
                 json.loads(
                     s3_client.get_object(
-                        Bucket=get_read_state_machine_aws_bucket(),
+                        Bucket=bucket,
                         Key=file["Key"],
                     )
                     .get("Body")


### PR DESCRIPTION
Preliminary logic to determine tests for microcheck. It determine the minimal number of tests to run to cover a historical of X% failed PRs

Test:
- CI

> bazel run //ci/ray_ci/automation:determine_microcheck_tests -- core 90 --test-history-length 100


> [INFO 2024-04-22 21:58:20,840] determine_microcheck_tests.py: 22  Analyzing 362 tests for team core
> [INFO 2024-04-22 22:23:31,083] determine_microcheck_tests.py: 29  To cover 90% of PRs, run the following tests: {'linux://python/ray/_private:doctest', 'linux://python/ray/tests:test_task_events', 'linux://python/ray/tests:test_client_library_integration', 'linux://python/ray/tests:test_tensorflow', 'linux://python/ray/tests:test_streaming_generator', 'linux://python/ray/tests:test_chaos', 'linux://python/ray/dag:test_accelerated_dag', 'linux://python/ray/tests:test_ray_init_2', 'linux://python/ray/tests:test_gcs_ha_e2e_2', 'linux://python/ray/tests:test_runtime_env_container', 'linux://python/ray/tests:test_runtime_env_complicated', 'linux://python/ray/tests:test_gcs_ha_e2e', 'linux://python/ray/autoscaler:doctest', 'linux://python/ray/tests:test_output', 'linux://python/ray/tests:test_top_level_api', 'linux://python/ray/tests:test_placement_group_4', 'linux://python/ray/tests:test_unavailable_actors', 'linux://python/ray/tests:test_channel', 'linux://python/ray/tests:test_multi_node_3', 'linux://python/ray/dag:doctest'}