### PR TITLE
[ci] upload macos test results on premerge

### DIFF
--- a/.buildkite/macos/macos.rayci.yml
+++ b/.buildkite/macos/macos.rayci.yml
@@ -5,6 +5,7 @@ steps:
   - block: "run macos tests"
     if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b"
 
+  # build
   - label: ":tapioca: build: :mac: wheels and jars (x86_64)"
     if: build.env("BUILDKITE_PIPELINE_ID") != "0189e759-8c96-4302-b6b5-b4274406bf89"
     tags:
@@ -25,6 +26,7 @@ steps:
     commands:
       - ./ci/ray_ci/macos/macos_ci_build.sh build_aarch64
 
+  # test
   - label: ":ray: core: :mac: small & client tests"
     if: build.env("BUILDKITE_PIPELINE_ID") != "0189e759-8c96-4302-b6b5-b4274406bf89"
     tags:

--- a/ci/ray_ci/automation/test_db_bot.py
+++ b/ci/ray_ci/automation/test_db_bot.py
@@ -12,16 +12,25 @@ from ray_release.configs.global_config import get_global_config
 @click.argument("bazel_log_dir", required=True, type=str)
 def main(team: str, bazel_log_dir: str) -> None:
     ci_init()
+    pipeline = os.environ.get("BUILDKITE_PIPELINE_ID")
+    postmerge_pipelines = get_global_config()["ci_pipeline_postmerge"]
+    premerge_pipelines = get_global_config()["ci_pipeline_premerge"]
 
-    if os.environ.get("BUILDKITE_BRANCH") != "master":
-        logger.info("Skip upload test results. We only upload on master branch.")
+    if pipeline not in postmerge_pipelines + premerge_pipelines:
+        logger.info(
+            "Skip upload test results. "
+            "We only upload on premerge or postmerge pipeline."
+        )
         return
 
     if (
-        os.environ.get("BUILDKITE_PIPELINE_ID")
-        not in get_global_config()["ci_pipeline_postmerge"]
+        pipeline in postmerge_pipelines
+        and os.environ.get("BUILDKITE_BRANCH") != "master"
     ):
-        logger.info("Skip upload test results. We only upload on postmerge pipeline.")
+        logger.info(
+            "Skip upload test results. "
+            "We only upload on the master branch on postmerge pipeline."
+        )
         return
 
     TesterContainer.upload_test_results(team, bazel_log_dir)


### PR DESCRIPTION
The `test_db_bot` is used to upload test results on macos. This PR allows this bot to run on premerge, or master branch of postmerge. 

Test:
- CI