### PR TITLE
[core] add ray.util.concurrent.futures.RayExecutor

### DIFF
--- a/doc/source/ray-core/api/utility.rst
+++ b/doc/source/ray-core/api/utility.rst
@@ -15,7 +15,7 @@ Utility
    ray.util.accelerators.tpu.get_current_pod_worker_count
    ray.util.accelerators.tpu.get_current_pod_name
 
-   ray.util.concurrent.futures.RayExecutor
+   ray.util.concurrent.futures.ray_executor.RayExecutor
 
    ray.nodes
    ray.cluster_resources

--- a/doc/source/ray-core/api/utility.rst
+++ b/doc/source/ray-core/api/utility.rst
@@ -15,6 +15,8 @@ Utility
    ray.util.accelerators.tpu.get_current_pod_worker_count
    ray.util.accelerators.tpu.get_current_pod_name
 
+   ray.util.concurrent.futures.RayExecutor
+
    ray.nodes
    ray.cluster_resources
    ray.available_resources

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -521,6 +521,7 @@ py_test_module_list(
     "test_scheduling_2.py",
     "test_multiprocessing.py",
     "test_reference_counting.py",
+    "test_executor.py",
   ],
   size = "large",
   tags = ["exclusive", "large_size_python_tests_shard_1", "team:core"],

--- a/python/ray/tests/test_executor.py
+++ b/python/ray/tests/test_executor.py
@@ -1,0 +1,813 @@
+import os
+
+from unittest.mock import patch, call
+
+from abc import ABC, abstractmethod
+import sys
+import pytest
+from ray.util.concurrent.futures.ray_executor import (
+    RayExecutor,
+    _ActorPoolBase,
+    _AbstractActorPool,
+    _RoundRobinActorPool,
+    _RandomActorPool,
+)
+import time
+import typing as T
+from functools import partial
+from multiprocessing import Process
+
+import ray
+from ray.actor import ActorHandle
+from ray.util.state import list_actors
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    ProcessPoolExecutor,
+    TimeoutError as ConTimeoutError,
+)
+from concurrent.futures.thread import BrokenThreadPool
+from concurrent.futures import Future
+from ray.exceptions import RayTaskError, RayActorError
+
+from ray._private.worker import RayContext
+import logging
+
+
+# ProcessPoolExecutor uses pickle which can only serialize top-level functions
+def f_process1(x):
+    return len([i for i in range(x) if i % 2 == 0])
+
+
+class InitializerException(Exception):
+    pass
+
+
+class Helpers:
+    @staticmethod
+    def unsafe(exc):
+        raise exc
+
+    @staticmethod
+    def safe(_):
+        pass
+
+    @staticmethod
+    def get_actor_states(actor_pool: _ActorPoolBase):
+
+        return [
+            actor_state["state"]
+            for actor_state in list_actors()
+            if actor_state.actor_id in actor_pool.get_actor_ids()
+        ]
+
+    @staticmethod
+    def get_actor_state(actor):
+        [actor_state] = [
+            actor_state["state"]
+            for actor_state in list_actors()
+            if actor_state.actor_id == actor._ray_actor_id.hex()
+        ]
+        return actor_state
+
+    @staticmethod
+    def wait_assert(f: T.Callable[[], bool], timeout=5):
+        res = False
+        while timeout > 0:
+            if f():
+                res = True
+                break
+            else:
+                time.sleep(1)
+                timeout -= 1
+        assert res
+
+    @classmethod
+    def wait_actor_state(cls, actor_pool, state, timeout=20):
+        while timeout > 0:
+            states = cls.get_actor_states(actor_pool)
+            if not all(i == state for i in states):
+                time.sleep(1)
+                timeout -= 1
+            else:
+                break
+        if timeout == 0:
+            return False
+        else:
+            return True
+
+    @classmethod
+    def wait_actor_state_(cls, actor, expected_state, timeout=20):
+        while timeout > 0:
+            state = cls.get_actor_state(actor)
+            if state != expected_state:
+                time.sleep(1)
+                timeout -= 1
+            else:
+                break
+        if timeout == 0:
+            return False
+        else:
+            return True
+
+
+class TestIsolated:
+
+    # This class is for tests that must be run with dedicated/isolated ray
+    # instances. Individual tests are responsible for creating their own ray
+    # instances.
+    def setup_method(self):
+        assert not ray.is_initialized()
+
+    def teardown_method(self):
+        ray.shutdown()
+        while ray.is_initialized():
+            time.sleep(1)
+        assert not ray.is_initialized()
+
+
+class TestShared:
+
+    # This class if for tests that can share an existing ray instance. This
+    # speeds up tests as the instance does not need to be created and destroyed
+    # for each test.
+
+    def setup_class(self):
+        logging.warning(f"Initialising Ray instance for {self.__name__}")
+        self.address = ray.init(num_cpus=2, ignore_reinit_error=True).address_info[
+            "address"
+        ]
+        assert ray.is_initialized()
+
+    def teardown_class(self):
+        logging.warning(f"Shutting down Ray instance for {self.__name__}")
+        ray.shutdown()
+        assert not ray.is_initialized()
+
+
+class ActorPoolTests(ABC):
+    """
+    This set of tests should be executed for all implementations of `_ActorPoolBase`.
+    """
+
+    @property
+    @abstractmethod
+    def apc(self) -> type[_AbstractActorPool]:
+        ...
+
+    @property
+    @abstractmethod
+    def apt(self) -> str:
+        ...
+
+    @pytest.fixture
+    def actor_pool(self):
+        return self.apc()
+
+    def test_setting_max_tasks_per_actor(self, actor_pool):
+        assert actor_pool.max_tasks_per_actor is None
+        actor_pool.max_tasks_per_actor = 2
+        assert actor_pool.max_tasks_per_actor == 2
+        with pytest.raises(ValueError):
+            actor_pool.max_tasks_per_actor = -2
+
+    def test_setting_num_actors(self, actor_pool):
+        assert actor_pool.num_actors == 2
+        actor_pool.num_actors = 10
+        assert actor_pool.num_actors == 10
+        with pytest.raises(ValueError):
+            actor_pool.num_actors = -2
+        with pytest.raises(ValueError):
+            actor_pool.num_actors = 0
+
+    def test_setting_initializer(self, actor_pool):
+        assert actor_pool.initializer is None
+        actor_pool.initializer = lambda x: print(x)
+        with pytest.raises(TypeError):
+            actor_pool.initializer = 1
+        with pytest.raises(TypeError):
+            actor_pool.initializer = True
+
+    def test_setting_initargs(self, actor_pool):
+        assert actor_pool.initargs == ()
+        actor_pool.initargs = (1, 2)
+        assert actor_pool.initargs == (1, 2)
+        with pytest.raises(TypeError):
+            actor_pool.initargs = True
+
+    def test_submit_returns_a_future(self, actor_pool):
+        def f():
+            return 123
+
+        future = actor_pool.submit(f)
+        assert isinstance(future, Future)
+
+    def test_next_returns_pool_actor(self, actor_pool):
+        pool_actor = actor_pool.next()
+        actor = pool_actor["actor"]
+        assert isinstance(actor, ActorHandle)
+        task_count = pool_actor["task_count"]
+        assert task_count == 0
+
+    def test_get_actor_ids_returns_list_of_strings(self, actor_pool):
+        actor_ids = actor_pool.get_actor_ids()
+        assert isinstance(list, actor_ids)
+        for i in actor_ids:
+            assert isinstance(str, i)
+
+    def test_actor_pool_exit_removes_from_pool(self):
+        pool = self.apc(num_actors=1)
+        assert len(pool.pool) == 1
+        [actor] = pool.pool
+        pool._exit_actor(actor)
+        assert pool.pool == []
+        assert Helpers.wait_actor_state_(actor["actor"], "DEAD")
+
+    def test__kill_actor_called_for_actors(self, actor_pool):
+        with patch.object(actor_pool, "_kill_actor") as mock_kill_actor:
+            actor_pool.kill()
+            mock_kill_actor.assert_has_calls(
+                [call(i) for i in actor_pool.pool], any_order=True
+            )
+
+    def test__increment_task_count(self, actor_pool):
+        mock_actor = {"task_count": 0}
+        actor_pool.pool = [mock_actor]
+        actor_pool._increment_task_count(mock_actor)
+        assert mock_actor["task_count"] == 1
+
+    def test_actor_pool_kills_actors(self):
+        pool = self.apc(num_actors=2)
+        assert len(pool.pool) == 2
+
+        # wait for actors to live
+        assert Helpers.wait_actor_state(pool, "ALIVE")
+        pool.kill()
+        # wait for actors to die
+        assert Helpers.wait_actor_state(pool, "DEAD")
+
+    def test_actor_pool_kills_actors_and_does_not_wait_for_tasks_to_complete(self):
+        pool = self.apc(num_actors=2)
+
+        def f():
+            return 123
+
+        future = pool.submit(f)
+        pool.kill()
+        assert Helpers.wait_actor_state(pool, "DEAD")
+        with pytest.raises(RayActorError):
+            future.result()
+
+    def test_actor_pool_exits_actors_and_waits_for_tasks_to_complete(self):
+        pool = self.apc(num_actors=2)
+
+        def f():
+            return 123
+
+        future = pool.submit(f)
+        pool_actor = pool.pool[0]
+        actor = pool._exit_actor(pool_actor)
+        assert Helpers.wait_actor_state_(actor, "DEAD")
+        assert future.result() == 123
+
+    def test_actor_pool_replaces_expired_actors(self):
+        pool = self.apc(num_actors=1, max_tasks_per_actor=2)
+        assert len(pool.pool) == 1
+        actor_id0 = pool.pool[0]["actor"]._ray_actor_id.hex()
+        pool._replace_actor_if_max_tasks()
+        assert pool.pool[0]["actor"]._ray_actor_id.hex() == actor_id0
+        pool.pool[0]["task_count"] = 2
+        pool._replace_actor_if_max_tasks()
+        assert pool.pool[0]["actor"]._ray_actor_id.hex() != actor_id0
+
+    def test_actor_pool_replaces_actors_allowing_tasks_to_finish(self):
+        def f():
+            return 123
+
+        pool = self.apc(num_actors=1, max_tasks_per_actor=2)
+        assert len(pool.pool) == 1
+
+        assert pool.pool[0]["task_count"] == 0
+        future0 = pool.submit(f)
+        assert pool.pool[0]["task_count"] == 1
+        future1 = pool.submit(f)
+        assert pool.pool[0]["task_count"] == 2
+        actor_id01 = pool.pool[0]["actor"]._ray_actor_id.hex()
+        future2 = pool.submit(f)
+        actor_id02 = pool.pool[0]["actor"]._ray_actor_id.hex()
+        assert pool.pool[0]["task_count"] == 1
+        assert actor_id01 != actor_id02
+        assert future0.result() == 123
+        assert future1.result() == 123
+        assert future2.result() == 123
+
+    def test_actor_pool_replaces_actors_exits_gracefully(self):
+        def f():
+            return 123
+
+        pool = self.apc(num_actors=1, max_tasks_per_actor=1)
+        assert len(pool.pool) == 1
+
+        actor_id00 = pool.pool[0]["actor"]._ray_actor_id.hex()
+        future0 = pool.submit(f)
+        actor_id01 = pool.pool[0]["actor"]._ray_actor_id.hex()
+        future1 = pool.submit(f)
+        actor_id02 = pool.pool[0]["actor"]._ray_actor_id.hex()
+        assert actor_id00 == actor_id01 != actor_id02
+        assert future0.result() == 123
+        assert future1.result() == 123
+
+    def test_actor_pool_replaces_actors_exits_gracefully_in_executor(self):
+        def f():
+            return 123
+
+        with RayExecutor(
+            address=self.address,
+            max_workers=1,
+            max_tasks_per_child=1,
+            actor_pool_type=self.apt,
+        ) as ex:
+            pool = ex.actor_pool
+            assert len(pool.pool) == 1
+
+            actor_id00 = pool.pool[0]["actor"]._ray_actor_id.hex()
+            future0 = pool.submit(f)
+            actor_id01 = pool.pool[0]["actor"]._ray_actor_id.hex()
+            future1 = pool.submit(f)
+            actor_id02 = pool.pool[0]["actor"]._ray_actor_id.hex()
+            assert actor_id00 == actor_id01 != actor_id02
+            assert future0.result() == 123
+            assert future1.result() == 123
+
+
+class TestRandomActorPool(ActorPoolTests, TestShared):
+    @property
+    def apc(self) -> type[_AbstractActorPool]:
+        return _RandomActorPool
+
+    @property
+    def apt(self) -> str:
+        return "random"
+
+
+class TestRoundRobinActorPool(ActorPoolTests, TestShared):
+    @property
+    def apc(self) -> type[_AbstractActorPool]:
+        return _RoundRobinActorPool
+
+    @property
+    def apt(self) -> str:
+        return "roundrobin"
+
+    def test_actor_pool_cycles_through_actors(self):
+        pool = self.apc(num_actors=2)
+        assert len(pool.pool) == 2
+        assert pool.index == 0
+        _ = pool.next()
+        assert len(pool.pool) == 2
+        assert pool.index == 1
+        _ = pool.next()
+        assert len(pool.pool) == 2
+        assert pool.index == 0
+
+
+class TestExistingInstanceSetup(TestShared):
+    def test_actor_pool_type(self):
+        with pytest.raises(ValueError):
+            RayExecutor(address=self.address, actor_pool_type=None)
+        with pytest.raises(ValueError):
+            RayExecutor(address=self.address, actor_pool_type="my-other-type")
+
+    def test_remote_function_runs_on_specified_instance(self):
+        with RayExecutor(address=self.address) as ex:
+            result = ex.submit(lambda x: x * x, 100).result()
+            assert result == 10_000
+            assert ex._context is not None
+            assert isinstance(RayContext, ex._context)
+            assert ex._context.address_info["address"] == self.address
+
+    def test_remote_function_runs_on_specified_instance_with_map(self):
+        with RayExecutor(address=self.address) as ex:
+            futures_iter = ex.map(lambda x: x * x, [100, 100, 100])
+            for result in futures_iter:
+                assert result == 10_000
+            assert ex._context is not None
+            assert isinstance(RayContext, ex._context)
+            assert ex._context.address_info["address"] == self.address
+
+    def test_context_manager_does_not_invoke_shutdown_on_existing_instance(self):
+        with RayExecutor(address=self.address) as ex0:
+            pass
+        assert not ex0._shutdown_lock
+
+    def test_use_cluster_from_address(self):
+        with RayExecutor(address=self.address) as ex0:
+            assert not ex0._initialised_ray
+
+
+class TestSetupShutdown(TestIsolated):
+    def test_context_manager_invokes_shutdown(self):
+        with RayExecutor() as ex:
+            assert not ex._shutdown_lock
+            pass
+        assert ex._shutdown_lock
+
+    def test_context_manager_does_not_invoke_shutdown_on_existing_instance(self):
+        with RayExecutor() as ex0:
+            with RayExecutor() as ex1:
+                pass
+            assert not ex1._shutdown_lock
+        assert ex0._shutdown_lock
+
+    def test_reuse_existing_cluster(self):
+        with RayExecutor() as ex0:
+            c0 = ray.runtime_context.get_runtime_context()
+            n0 = c0.get_node_id()
+            with RayExecutor() as ex1:
+                c1 = ray.runtime_context.get_runtime_context()
+                n1 = c1.get_node_id()
+                assert n0 == n1
+                assert ex0._context is not None
+                assert ex1._context is not None
+                assert isinstance(RayContext, ex0._context)
+                assert isinstance(RayContext, ex1._context)
+                assert (
+                    ex0._context.address_info["node_id"]
+                    == ex1._context.address_info["node_id"]
+                )
+
+    def test_existing_instance_ignores_max_workers(self):
+        _ = ray.init(num_cpus=1)
+        with RayExecutor(max_workers=2):
+            assert ray.available_resources()["CPU"] == 1
+
+    def test_working_directory_must_be_supplied_for_initializer(self):
+        with pytest.raises(ValueError):
+            with RayExecutor(
+                max_workers=2,
+                initializer=Helpers.safe,
+                initargs=(InitializerException,),
+            ) as _:
+                pass
+        with RayExecutor(
+            max_workers=2,
+            initializer=Helpers.unsafe,
+            initargs=(InitializerException,),
+            runtime_env={"working_dir": "./python/ray/tests/."},
+        ) as _:
+            pass
+
+    def test_mp_context_does_nothing(self):
+        with RayExecutor(max_workers=2, mp_context="fork") as ex:
+            assert ex._mp_context == "fork"
+
+    def test_results_are_not_accessible_after_shutdown(self):
+        def f(x, y):
+            return x * y
+
+        with RayExecutor() as ex:
+            r1 = ex.map(f, [100, 100, 100], [1, 2, 3])
+        assert ex._shutdown_lock
+
+        # we run a custom timeout function otherwise ray take 180s to timeout
+        timeout_runner = Process(target=partial(list, r1))
+        timeout = 5
+        timeout_runner.start()
+        while timeout_runner.is_alive() and timeout > 0:
+            time.sleep(1)
+            timeout -= 1
+        if timeout_runner.is_alive() and timeout == 0:
+            timeout_runner.kill()
+            assert True
+        else:
+            pytest.fail("Fetching results did not timeout")
+
+    def test_cannot_submit_after_shutdown(self):
+        ex = RayExecutor()
+        ex.submit(lambda: True).result()
+        ex.shutdown()
+        with pytest.raises(RuntimeError):
+            ex.submit(lambda: True).result()
+
+    def test_can_submit_after_shutdown(self):
+        ex = RayExecutor(shutdown_ray=False)
+        ex.submit(lambda: True).result()
+        ex.shutdown()
+        try:
+            ex.submit(lambda: True).result()
+        except RuntimeError:
+            assert (
+                False
+            ), "Could not submit after calling shutdown() with shutdown_ray=False"
+        ex.shutdown_ray = True
+        ex.shutdown()
+
+    def test_cannot_map_after_shutdown(self):
+        ex = RayExecutor()
+        ex.submit(lambda: True).result()
+        ex.shutdown()
+        with pytest.raises(RuntimeError):
+            ex.submit(lambda: True).result()
+
+    def test_pending_task_is_cancelled_after_shutdown(self):
+        ex = RayExecutor()
+        f = ex.submit(lambda: True)
+        assert f._state == "PENDING"
+        ex.shutdown(cancel_futures=True)
+        assert f.cancelled()
+
+    def test_running_task_finishes_after_shutdown(self):
+        ex = RayExecutor()
+        f = ex.submit(lambda: True)
+        assert f._state == "PENDING"
+        f.set_running_or_notify_cancel()
+        assert f.running()
+        ex.shutdown(cancel_futures=True)
+        assert f._state == "FINISHED"
+
+    def test_mixed_task_states_handled_by_shutdown(self):
+        ex = RayExecutor()
+        f0 = ex.submit(lambda: True)
+        f1 = ex.submit(lambda: True)
+        assert f0._state == "PENDING"
+        assert f1._state == "PENDING"
+        f0.set_running_or_notify_cancel()
+        ex.shutdown(cancel_futures=True)
+        assert f0._state == "FINISHED"
+        assert f1.cancelled()
+
+
+class TestRunningTasks(TestIsolated):
+    def test_remote_function_runs_on_local_instance(self):
+        with RayExecutor() as ex:
+            result = ex.submit(lambda x: x * x, 100).result()
+            assert result == 10_000
+
+    def test_remote_function_runs_multiple_tasks_on_local_instance(self):
+        with RayExecutor() as ex:
+            result0 = ex.submit(lambda x: x * x, 100).result()
+            result1 = ex.submit(lambda x: x * x, 100).result()
+            assert result0 == result1 == 10_000
+
+    def test_order_retained(self):
+        def f(x, y):
+            return x * y
+
+        with RayExecutor() as ex:
+            r0 = list(ex.map(f, [100, 100, 100], [1, 2, 3]))
+        with RayExecutor(max_workers=2) as ex:
+            r1 = list(ex.map(f, [100, 100, 100], [1, 2, 3]))
+        assert r0 == r1
+
+    def test_remote_function_runs_on_local_instance_with_map(self):
+        with RayExecutor() as ex:
+            futures_iter = ex.map(lambda x: x * x, [100, 100, 100])
+            for result in futures_iter:
+                assert result == 10_000
+
+    def test_map_zips_iterables(self):
+        def f(x, y):
+            return x * y
+
+        with RayExecutor() as ex:
+            futures_iter = ex.map(f, [100, 100, 100], [1, 2, 3])
+            assert list(futures_iter) == [100, 200, 300]
+
+    def test_remote_function_map_using_max_workers(self):
+        with RayExecutor(max_workers=3) as ex:
+            assert ex.actor_pool is not None
+            pool = getattr(ex.actor_pool, "pool")
+            assert pool is not None
+            assert len(pool) == 3
+            time_start = time.monotonic()
+            _ = list(ex.map(lambda _: time.sleep(1), range(12)))
+            time_end = time.monotonic()
+            # we expect about (12*1) / 3 = 4 rounds
+            delta = time_end - time_start
+            assert delta > 3.0
+
+    def test_remote_function_max_workers_same_result(self):
+        with RayExecutor() as ex:
+            f0 = list(ex.map(lambda x: x * x, range(12)))
+        with RayExecutor(max_workers=1) as ex:
+            f1 = list(ex.map(lambda x: x * x, range(12)))
+        with RayExecutor(max_workers=3) as ex:
+            f3 = list(ex.map(lambda x: x * x, range(12)))
+        assert f0 == f1 == f3
+
+    def test_map_times_out(self):
+        def f(x):
+            time.sleep(2)
+            return x
+
+        with RayExecutor() as ex:
+            with pytest.raises(ConTimeoutError):
+                i1 = ex.map(f, [1, 2, 3], timeout=1)
+                for _ in i1:
+                    pass
+
+    def test_map_times_out_with_max_workers(self):
+        def f(x):
+            time.sleep(2)
+            return x
+
+        with RayExecutor(max_workers=2) as ex:
+            with pytest.raises(ConTimeoutError):
+                i1 = ex.map(f, [1, 2, 3], timeout=1)
+                for _ in i1:
+                    pass
+
+    def test_remote_function_runs_multiple_tasks_using_max_workers(self):
+        with RayExecutor(max_workers=2) as ex:
+            result0 = ex.submit(lambda x: x * x, 100).result()
+            result1 = ex.submit(lambda x: x * x, 100).result()
+            assert result0 == result1 == 10_000
+
+
+class TestProcessPool(TestIsolated):
+    def test_conformity_with_processpool(self):
+        def f_process0(x):
+            return len([i for i in range(x) if i % 2 == 0])
+
+        assert f_process0.__code__.co_code == f_process1.__code__.co_code
+
+        with RayExecutor() as ex:
+            ray_future = ex.submit(f_process0, 100)
+            ray_future_type = type(ray_future)
+            ray_result = ray_future.result()
+        with ProcessPoolExecutor() as ppe:
+            ppe_future = ppe.submit(f_process1, 100)
+            ppe_future_type = type(ppe_future)
+            ppe_result = ppe_future.result()
+        assert ray_future_type == ppe_future_type
+        assert ray_result == ppe_result
+
+    def test_conformity_with_processpool_map(self):
+        def f_process0(x):
+            return len([i for i in range(x) if i % 2 == 0])
+
+        assert f_process0.__code__.co_code == f_process1.__code__.co_code
+
+        with RayExecutor() as ex:
+            ray_iter = ex.map(f_process0, range(10))
+            ray_result = list(ray_iter)
+        with ProcessPoolExecutor() as ppe:
+            ppe_iter = ppe.map(f_process1, range(10))
+            ppe_result = list(ppe_iter)
+        assert hasattr(ray_iter, "__iter__")
+        assert hasattr(ray_iter, "__next__")
+        assert hasattr(ppe_iter, "__iter__")
+        assert hasattr(ppe_iter, "__next__")
+        assert isinstance(type(ppe_result), ray_result)
+        assert sorted(ray_result) == sorted(ppe_result)
+
+    def test_conformity_with_processpool_using_max_workers(self):
+        def f_process0(x):
+            return len([i for i in range(x) if i % 2 == 0])
+
+        assert f_process0.__code__.co_code == f_process1.__code__.co_code
+
+        with RayExecutor(max_workers=2) as ex:
+            ray_result = ex.submit(f_process0, 100).result()
+        with ProcessPoolExecutor(max_workers=2) as ppe:
+            ppe_result = ppe.submit(f_process1, 100).result()
+        assert isinstance(type(ppe_result), ray_result)
+        assert ray_result == ppe_result
+
+    def test_conformity_with_processpool_map_using_max_workers(self):
+        def f_process0(x):
+            return len([i for i in range(x) if i % 2 == 0])
+
+        assert f_process0.__code__.co_code == f_process1.__code__.co_code
+
+        with RayExecutor(max_workers=2) as ex:
+            ray_iter = ex.map(f_process0, range(10))
+            ray_result = list(ray_iter)
+        with ProcessPoolExecutor(max_workers=2) as ppe:
+            ppe_iter = ppe.map(f_process1, range(10))
+            ppe_result = list(ppe_iter)
+        assert hasattr(ray_iter, "__iter__")
+        assert hasattr(ray_iter, "__next__")
+        assert hasattr(ppe_iter, "__iter__")
+        assert hasattr(ppe_iter, "__next__")
+        assert isinstance(type(ppe_result), ray_result)
+        assert sorted(ray_result) == sorted(ppe_result)
+
+
+class TestThreadPool(TestIsolated):
+    def test_conformity_with_threadpool(self):
+        def f_process0(x):
+            return len([i for i in range(x) if i % 2 == 0])
+
+        assert f_process0.__code__.co_code == f_process1.__code__.co_code
+
+        with RayExecutor() as ex:
+            ray_future = ex.submit(f_process0, 100)
+            ray_future_type = type(ray_future)
+            ray_result = ray_future.result()
+        with ThreadPoolExecutor() as tpe:
+            tpe_future = tpe.submit(f_process1, 100)
+            tpe_future_type = type(tpe_future)
+            tpe_result = tpe_future.result()
+        assert ray_future_type == tpe_future_type
+        assert ray_result == tpe_result
+
+    def test_conformity_with_threadpool_map(self):
+        def f_process0(x):
+            return len([i for i in range(x) if i % 2 == 0])
+
+        assert f_process0.__code__.co_code == f_process1.__code__.co_code
+
+        with RayExecutor() as ex:
+            ray_iter = ex.map(f_process0, range(10))
+            ray_result = list(ray_iter)
+        with ThreadPoolExecutor() as tpe:
+            tpe_iter = tpe.map(f_process1, range(10))
+            tpe_result = list(tpe_iter)
+        assert hasattr(ray_iter, "__iter__")
+        assert hasattr(ray_iter, "__next__")
+        assert hasattr(tpe_iter, "__iter__")
+        assert hasattr(tpe_iter, "__next__")
+        assert isinstance(type(tpe_result), ray_result)
+        assert sorted(ray_result) == sorted(tpe_result)
+
+    def test_conformity_with_threadpool_using_max_workers(self):
+        def f_process0(x):
+            return len([i for i in range(x) if i % 2 == 0])
+
+        assert f_process0.__code__.co_code == f_process1.__code__.co_code
+
+        with RayExecutor(max_workers=2) as ex:
+            ray_future = ex.submit(f_process0, 100)
+            ray_future_type = type(ray_future)
+            ray_result = ray_future.result()
+        with ThreadPoolExecutor(max_workers=2) as tpe:
+            tpe_future = tpe.submit(f_process1, 100)
+            tpe_future_type = type(tpe_future)
+            tpe_result = tpe_future.result()
+        assert ray_future_type == tpe_future_type
+        assert ray_result == tpe_result
+
+    def test_conformity_with_threadpool_map_using_max_workers(self):
+        def f_process0(x):
+            return len([i for i in range(x) if i % 2 == 0])
+
+        assert f_process0.__code__.co_code == f_process1.__code__.co_code
+
+        with RayExecutor(max_workers=2) as ex:
+            ray_iter = ex.map(f_process0, range(10))
+            ray_result = list(ray_iter)
+        with ThreadPoolExecutor(max_workers=2) as tpe:
+            tpe_iter = tpe.map(f_process1, range(10))
+            tpe_result = list(tpe_iter)
+        assert hasattr(ray_iter, "__iter__")
+        assert hasattr(ray_iter, "__next__")
+        assert hasattr(tpe_iter, "__iter__")
+        assert hasattr(tpe_iter, "__next__")
+        assert isinstance(type(tpe_result), ray_result)
+        assert sorted(ray_result) == sorted(tpe_result)
+
+    def test_conformity_with_threadpool_initializer_initargs(self):
+
+        # this assumes that the test is executed from the root difrectory
+        assert os.path.isdir("./python/ray/tests/.")
+
+        # ----------------------------
+        with ThreadPoolExecutor(
+            max_workers=2, initializer=Helpers.safe, initargs=(InitializerException,)
+        ) as tpe:
+            tpe_iter = tpe.map(f_process1, range(10))
+            _ = list(tpe_iter)
+        with ThreadPoolExecutor(
+            max_workers=2, initializer=Helpers.unsafe, initargs=(InitializerException,)
+        ) as tpe:
+            tpe_iter = tpe.map(f_process1, range(10))
+            with pytest.raises(BrokenThreadPool):
+                _ = list(tpe_iter)
+        # ----------------------------
+
+        # ----------------------------
+        with RayExecutor(
+            max_workers=2,
+            initializer=Helpers.safe,
+            initargs=(InitializerException,),
+            runtime_env={"working_dir": "./python/ray/tests/."},
+        ) as ex:
+            ray_iter = ex.map(lambda x: x, range(10))
+            _ = list(ray_iter)
+        with RayExecutor(
+            max_workers=2,
+            initializer=Helpers.unsafe,
+            initargs=(InitializerException,),
+            runtime_env={"working_dir": "./python/ray/tests/."},
+        ) as ex:
+            ray_iter = ex.map(f_process1, range(10))
+            with pytest.raises(RayTaskError):
+                _ = list(ray_iter)
+        # ----------------------------
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/util/concurrent/futures/__init__.py
+++ b/python/ray/util/concurrent/futures/__init__.py
@@ -1,0 +1,3 @@
+from .ray_executor import RayExecutor
+
+__all__ = ["RayExecutor"]

--- a/python/ray/util/concurrent/futures/ray_executor.py
+++ b/python/ray/util/concurrent/futures/ray_executor.py
@@ -1,0 +1,651 @@
+from abc import ABC, abstractmethod
+import time
+from functools import partial
+from concurrent.futures import Executor, Future
+from concurrent.futures._base import _result_or_cancel  # type: ignore
+from typing import (
+    Any,
+    ParamSpec,
+    TYPE_CHECKING,
+    TypeVar,
+    TypedDict,
+)
+from collections.abc import Callable, Iterable, Iterator
+import random
+
+import ray
+from ray.util.annotations import PublicAPI
+import ray.exceptions
+
+
+# Typing -----------------------------------------------
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+if TYPE_CHECKING:
+    from ray._private.worker import BaseContext
+    from ray.actor import ActorHandle
+
+
+class _PoolActor(TypedDict):
+    actor: "ActorHandle"
+    task_count: int
+
+
+# ------------------------------------------------------
+
+
+class _ActorPoolBase(ABC):
+
+    """This interface defines the actor pool class of Ray actors used by
+    RayExecutor."""
+
+    @property
+    @abstractmethod
+    def max_tasks_per_actor(self) -> int | None:
+        ...
+
+    @max_tasks_per_actor.setter
+    @abstractmethod
+    def max_tasks_per_actor(self, val: int | None) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def num_actors(self) -> int:
+        ...
+
+    @num_actors.setter
+    @abstractmethod
+    def num_actors(self, val: int) -> None:
+        ...
+
+    @property
+    def initializer(self) -> Callable[..., Any] | None:
+        ...
+
+    @initializer.setter
+    @abstractmethod
+    def initializer(self, val: Callable[..., Any] | None) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def initargs(self) -> tuple[Any, ...]:
+        ...
+
+    @initargs.setter
+    @abstractmethod
+    def initargs(self, val: tuple[Any, ...]) -> None:
+        ...
+
+    @abstractmethod
+    def submit(self, fn: Callable[[], T]) -> Future[T]:
+        ...
+
+    @abstractmethod
+    def next(self) -> _PoolActor:
+        ...
+
+    @abstractmethod
+    def get_actor_ids(self) -> list[str]:
+        ...
+
+
+class _AbstractActorPool(_ActorPoolBase, ABC):
+
+    """Common actor pool methods and attributes. New actor pool types should
+    extend this. See _RandomActorPool and _RoundRobinActorPool below."""
+
+    def __init__(
+        self,
+        num_actors: int = 2,
+        initializer: Callable[..., Any] | None = None,
+        initargs: tuple[Any, ...] = (),
+        max_tasks_per_actor: int | None = None,
+    ) -> None:
+        self.max_tasks_per_actor = max_tasks_per_actor
+        self.num_actors = num_actors
+        self.initializer = initializer
+        self.initargs = initargs
+        self.pool: list[_PoolActor] = [
+            self._build_actor() for _ in range(self.num_actors)
+        ]
+        return
+
+    @abstractmethod
+    def next(self) -> _PoolActor:
+        ...
+
+    def get_actor_ids(self) -> list[str]:
+        return [i["actor"]._ray_actor_id.hex() for i in self.pool]
+
+    @property
+    def max_tasks_per_actor(self) -> int | None:
+        return self._max_tasks_per_actor
+
+    @max_tasks_per_actor.setter
+    def max_tasks_per_actor(self, val: int | None) -> None:
+        if val is not None:
+            if val < 1:
+                raise ValueError(
+                    f"max_tasks_per_child={val} was given. The argument \
+                    max_tasks_per_child must be >= 1 or None"
+                )
+        self._max_tasks_per_actor = val
+        return
+
+    @property
+    def num_actors(self) -> int:
+        return self._num_actors
+
+    @num_actors.setter
+    def num_actors(self, val: int) -> None:
+        if val < 1:
+            raise ValueError("Pool must contain at least one Actor")
+        self._num_actors = val
+        return
+
+    @property
+    def initializer(self) -> Callable[..., Any] | None:
+        return self._initializer
+
+    @initializer.setter
+    def initializer(self, val: Callable[..., Any] | None) -> None:
+        if val is not None:
+            if not callable(val):
+                raise TypeError("initializer must be callable")
+        self._initializer = val
+        return
+
+    @property
+    def initargs(self) -> tuple[Any, ...]:
+        return self._initargs
+
+    @initargs.setter
+    def initargs(self, val: tuple[Any, ...]) -> None:
+        if not isinstance(tuple, val):
+            raise TypeError("initargs must be tuple")
+        self._initargs = val
+        return
+
+    def _build_actor(self) -> _PoolActor:
+        if not ray.is_initialized():
+            raise ray.exceptions.RayError("No existing ray instance")
+
+        @ray.remote
+        class ExecutorActor:
+            def __init__(
+                self,
+                initializer: Callable[..., Any] | None = None,
+                initargs: tuple[Any, ...] = (),
+            ) -> None:
+                self.initializer = initializer
+                self.initargs = initargs
+
+            def actor_function(self, fn: Callable[[], T]) -> T:
+                if self.initializer is not None:
+                    self.initializer(*self.initargs)
+                return fn()
+
+            def exit(self) -> None:
+                ray.actor.exit_actor()
+
+        actor = ExecutorActor.options().remote(  # type: ignore[attr-defined]
+            self.initializer, self.initargs
+        )
+        return {
+            "actor": actor,
+            "task_count": 0,
+        }
+
+    def submit(self, fn: Callable[[], T]) -> Future[T]:
+        """
+        Submit a task to be executed on the actor.
+
+        Parameters
+        ----------
+        fn : Callable
+            This 0-arity function will be executed as a task on the actor.
+
+        Returns
+        -------
+        Future
+            A future representing the result of the task
+
+        """
+
+        pool_actor = self._replace_actor_if_max_tasks()
+        fut = pool_actor["actor"].actor_function.remote(fn).future()
+        self._increment_task_count(pool_actor)
+        return fut  # type: ignore
+
+    def kill(self) -> None:
+        """
+        Kill all of the actors in the pools without waiting for their tasks to complete
+        """
+        for i in self.pool:
+            self._kill_actor(i)
+        return
+
+    def _replace_actor_if_max_tasks(self) -> _PoolActor:
+        pool_actor = self.next()
+        if self.max_tasks_per_actor is not None:
+            if pool_actor["task_count"] >= self.max_tasks_per_actor:
+                self._exit_actor(pool_actor)
+                pool_actor = self._build_actor()
+                self.pool.append(pool_actor)
+        return pool_actor
+
+    def _increment_task_count(self, pool_actor: _PoolActor) -> None:
+        pool_actor["task_count"] += 1
+        return
+
+    def _kill_actor(self, pool_actor: _PoolActor) -> None:
+        ray.kill(pool_actor["actor"])
+        return
+
+    def _exit_actor(self, pool_actor: _PoolActor) -> "ActorHandle":
+        """
+        Gracefully exit the actor and allow running jobs to finish.
+        """
+        self.pool = [i for i in self.pool if i != pool_actor]
+        pool_actor["actor"].exit.remote()
+        return pool_actor["actor"]
+
+
+class _RandomActorPool(_AbstractActorPool):
+
+    """This class manages a pool of Ray actors by distributing tasks amongst
+    them in a random choice fashion. Functions are executed remotely in the
+    actor pool using submit().
+
+    ...
+
+    Attributes
+    -----------
+    num_actors : int
+        Specify the size of the actor pool to create.
+    initializer : Callable
+        A function that will be called remotely in the actor context before the
+        submitted task (for compatibility with
+        concurrent.futures.ThreadPoolExecutor).
+    initargs : tuple
+        Arguments for initializer (for compatibility with
+        concurrent.futures.ThreadPoolExecutor).
+    max_tasks_per_actor : int
+        The maximum number of tasks to be performed by an actor before it is
+        gracefully killed and replaced (for compatibility with
+        concurrent.futures.ProcessPoolExecutor).
+    """
+
+    def next(self) -> _PoolActor:
+        """
+        Get the next priority member of the actor pool
+
+        Returns
+        -------
+        _PoolActor
+            The current priority actor in the pool
+        """
+        return random.choice(self.pool)
+
+
+class _RoundRobinActorPool(_AbstractActorPool):
+
+    """This class manages a pool of Ray actors by distributing tasks amongst
+    them in a simple round-robin fashion. Functions are executed remotely in
+    the actor pool using submit().
+
+    ...
+
+    Attributes
+    -----------
+    num_actors : int
+        Specify the size of the actor pool to create.
+    initializer : Callable
+        A function that will be called remotely in the actor context before the
+        submitted task (for compatibility with
+        concurrent.futures.ThreadPoolExecutor).
+    initargs : tuple
+        Arguments for initializer (for compatibility with
+        concurrent.futures.ThreadPoolExecutor).
+    max_tasks_per_actor : int
+        The maximum number of tasks to be performed by an actor before it is
+        gracefully killed and replaced (for compatibility with
+        concurrent.futures.ProcessPoolExecutor).
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.index: int = 0
+        return
+
+    def next(self) -> _PoolActor:
+        """
+        Get the next indexed member of the actor pool
+
+        Returns
+        -------
+        _PoolActor
+            The current priority actor in the pool
+        """
+        obj = self.pool[self.index]
+        self.index += 1
+        if self.index >= len(self.pool):
+            self.index = 0
+        return obj
+
+
+@PublicAPI(stability="alpha")
+class RayExecutor(Executor):
+
+    """RayExecutor is a drop-in replacement for ProcessPoolExecutor and
+    ThreadPoolExecutor from concurrent.futures but distributes and executes
+    the specified tasks over a pool of dedicated actors belonging to a Ray
+    cluster instead of multiple processes or threads, respectively.
+
+    Attributes
+    ----------
+    max_workers : int | None
+        The number of actors to spawn. If max_workers=None, the work is
+        distributed over a number of actors equal to the number of CPU
+        resources observed by the Ray instance.
+    shutdown_ray : bool | None
+        Destroy the Ray cluster when self.shutdown() is called. If this is
+        None, RayExecutor will default to shutting down the Ray instance only
+        if it was initialised during instantiation of the current RayExecutor,
+        otherwise it will not be shutdown.
+    initializer : Callable[..., Any] | None
+        A function that will be called remotely in the actor context before the
+        submitted task (for compatibility with
+        concurrent.futures.ThreadPoolExecutor).
+    initargs : tuple[Any, ...] | None
+        Arguments for initializer (for compatibility with
+        concurrent.futures.ThreadPoolExecutor).
+    max_tasks_per_child : int | None
+        The maximum number of tasks to be performed by an actor before it is
+        gracefully killed and replaced (for compatibility with
+        concurrent.futures.ProcessPoolExecutor).
+    mp_context : Any | None
+        This is only included for compatibility with
+        concurrent.futures.ProcessPoolExecutor but is unused.
+    actor_pool_type: str | None
+        The type of actor pool to use: either 'random' (which will assign tasks
+        to randomly selected actors), or 'roundrobin' (which will simply assign
+        tasks to actors sequentially.
+    futures : list[Future[Any]]
+        Aggregated Futures from initiated tasks
+    actor_pool : _AbstractActorPool
+        A container of Actor objects over which the tasks will be distributed.
+
+    All additional keyword arguments are passed to ray.init()
+    (see https://docs.ray.io/en/latest/ray-core/package-ref.html#ray-init).
+
+    For example, this will connect to a cluster at the specified address:
+    .. testcode::
+
+        RayExecutor(address='192.168.0.123:25001')
+
+    Note: excluding an address will initialise a local Ray cluster.
+    """
+
+    futures: list[Future[Any]]
+    actor_pool: _AbstractActorPool
+
+    def __init__(
+        self,
+        max_workers: int | None = None,
+        shutdown_ray: bool | None = None,
+        initializer: Callable[..., Any] | None = None,
+        initargs: tuple[Any, ...] = (),
+        max_tasks_per_child: int | None = None,
+        mp_context: Any | None = None,
+        actor_pool_type: str = "random",
+        **kwargs: Any,
+    ):
+
+        """RayExecutor handles existing Ray instances and shutting
+        down as follows:
+
+            1. If an existing cluster is discovered in the current scope,
+            RayExecutor will simply connect to this cluster. By default, this
+            cluster will not be destroyed when RayExecutor.shutdown() is
+            called.
+
+            2. If no existing cluster is discovered in the current scope,
+            RayExecutor will instantiate a new Ray cluster instance. By
+            default, this cluster will be destroyed when RayExecutor.shutdown()
+            is called.
+
+            3. If RayExecutor.shutdown_ray is set to True or False, this will
+            override the behaviour above.
+        """
+        self._shutdown_lock: bool = False
+        self._initialised_ray: bool = (not ray.is_initialized()) and (
+            "address" not in kwargs
+        )
+        self._context: "BaseContext" = ray.init(ignore_reinit_error=True, **kwargs)
+        self.futures: list[Future[Any]] = []
+        self.shutdown_ray = shutdown_ray
+
+        # mp_context is included for API compatiblity only, it does nothing in
+        # this context
+        self._mp_context = mp_context
+
+        if max_tasks_per_child is not None:
+            if max_tasks_per_child < 1:
+                raise ValueError(
+                    f"max_tasks_per_child={max_tasks_per_child} was given. The argument \
+                    max_tasks_per_child must be >= 1 or None"
+                )
+        self.max_tasks_per_child = max_tasks_per_child
+
+        if initializer is not None:
+            runtime_env = kwargs.get("runtime_env")
+            if runtime_env is None or "working_dir" not in runtime_env:
+                raise ValueError(
+                    "working_dir must be specified in runtime_env dictionary if \
+                                 initializer function is not None so that \
+                                 it can be accessible by remote workers"
+                )
+
+        if max_workers is None:
+            max_workers = int(ray._private.state.cluster_resources()["CPU"])
+        if max_workers < 1:
+            raise ValueError(
+                f"max_workers={max_workers} as given. The argument "
+                "max_workers must be >= 1",
+            )
+        self.max_workers = max_workers
+
+        actor_pool_type_err = ValueError(
+            "actor_pool_type must be either 'random' or 'roundrobin'",
+        )
+        if not isinstance(actor_pool_type, str):
+            raise actor_pool_type_err
+        if actor_pool_type.lower() == "random":
+            self.actor_pool = _RandomActorPool(
+                num_actors=max_workers,
+                initializer=initializer,
+                initargs=initargs,
+                max_tasks_per_actor=self.max_tasks_per_child,
+            )
+        elif actor_pool_type.lower() == "roundrobin":
+            self.actor_pool = _RoundRobinActorPool(
+                num_actors=max_workers,
+                initializer=initializer,
+                initargs=initargs,
+                max_tasks_per_actor=self.max_tasks_per_child,
+            )
+        else:
+            raise actor_pool_type_err
+
+        return
+
+    def submit(
+        self, fn: Callable[P, T], /, *args: P.args, **kwargs: P.kwargs
+    ) -> Future[T]:
+        """
+        Submits a function to be executed in the actor pool with the given arguments.
+
+        Parameters
+        -----------
+        fn : Callable[]
+            A function to be executed in the actor pool as fn(*args, **kwargs)
+
+        Returns
+        -------
+        Future
+            A future representing the yet-to-be-resolved result of the
+            submitted task. Futures are also collected in self.futures.
+
+        Usage example:
+
+        .. testcode::
+
+            with RayExecutor() as ex:
+                future_0 = ex.submit(lambda x: x * x, 100)
+                future_1 = ex.submit(lambda x: x + x, 100)
+                result_0 = future_0.result()
+                result_1 = future_1.result()
+        """
+        self._check_shutdown_lock()
+        if self.actor_pool is None:
+            raise ValueError("actor_pool is not defined")
+
+        future = self.actor_pool.submit(partial(fn, *args, **kwargs))
+        self.futures.append(future)
+        return future
+
+    def map(
+        self,
+        fn: Callable[..., T],
+        *iterables: Iterable[Any],
+        timeout: float | None = None,
+        chunksize: int = 1,
+    ) -> Iterator[T]:
+        """
+        Map a function over a series of iterables. Multiple series of iterables
+        will be zipped together, and each zipped tuple will be treated as a
+        single set of arguments.
+
+        Parameters
+        ----------
+        fn : Callable[]
+            A function to be executed in the actor pool which will take as many
+            arguments as there are iterables.
+        timeout : float | None
+            The maximum number of seconds to wait for the tasks to complete. If
+            None, then there is no limit on the wait time.
+        chunksize : int
+            This has no effect and is included merely to retain compatibility
+            with concurrent.futures.Executor.
+
+        Returns
+        -------
+        Iterator
+            An iterator equivalent to: map(func, *iterables) but the calls may
+            be evaluated out-of-order.
+
+        Raises
+        ------
+            TimeoutError: If the entire result iterator could not be generated
+                before the given timeout.
+            Exception: If fn(*args) raises for any values.
+
+        Usage example 1:
+
+        .. testcode::
+
+            with RayExecutor() as ex:
+                futures = ex.map(lambda x: x * x, [100, 100, 100])
+                results = [future.result() for future in futures]
+
+        Usage example 2:
+
+        .. testcode::
+
+            def f(x, y):
+                return x * y
+
+            with RayExecutor() as ex:
+                futures_iter = ex.map(f, [100, 100, 100], [1, 2, 3])
+                assert [i for i in futures_iter] == [100, 200, 300]
+
+        """
+        self._check_shutdown_lock()
+
+        # this is unused and merely for  compatibility with concurrent.futures.Executor
+        self.chunksize = chunksize
+
+        end_time = None
+        if timeout is not None:
+            end_time = timeout + time.monotonic()
+        fs = [self.submit(fn, *args) for args in zip(*iterables)]
+
+        # from concurrent.futures.Executor.map()
+        def result_iterator() -> Iterator[T]:
+            try:
+                # reverse to keep finishing order
+                fs.reverse()
+                while fs:
+                    # Careful not to keep a reference to the popped future
+                    if end_time is None:
+                        yield _result_or_cancel(fs.pop())
+                    else:
+                        yield _result_or_cancel(fs.pop(), end_time - time.monotonic())
+            finally:
+                for future in fs:
+                    future.cancel()
+
+        return result_iterator()
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        """Clean-up the resources associated with the Executor.
+
+        It is safe to call this method several times. No other methods can be
+        called after this one.
+
+        Parameters
+        ----------
+        wait : bool
+            If True then shutdown will not return until all running futures
+            have finished executing and the resources used by the executor have
+            been reclaimed.
+        cancel_futures : bool
+            If True then shutdown will cancel all pending futures. Futures that
+            are completed or running will not be cancelled.
+        """
+
+        if self.shutdown_ray is None:
+            if self._initialised_ray:
+                self._shutdown_ray(wait, cancel_futures)
+        else:
+            if self.shutdown_ray:
+                self._shutdown_ray(wait, cancel_futures)
+
+        del self.futures
+        self.futures = []
+        return
+
+    def _shutdown_ray(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        self._shutdown_lock = True
+
+        if cancel_futures:
+            for future in self.futures:
+                _ = future.cancel()
+
+        if wait:
+            for future in self.futures:
+                if future.running():
+                    _ = future.result()
+
+        ray.shutdown()
+        return
+
+    def _check_shutdown_lock(self) -> None:
+        if self._shutdown_lock:
+            raise RuntimeError("New task submitted after shutdown() was called")
+        return


### PR DESCRIPTION
RayExecutor is a drop-in replacement for ProcessPoolExecutor and ThreadPoolExecutor from concurrent.futures but distributes and executes the specified tasks over a pool of dedicated actors belonging to a Ray cluster instead of multiple processes or threads, respectively.

## Why are these changes needed?

This change provides an easy way to use Ray for futures, allowing to scale an existing codebase that relies on them.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
