### PR TITLE
[Core] Make sure dashboard will exit if grpc server fails

### DIFF
--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -367,8 +367,11 @@ class DashboardHead:
             DataOrganizer.purge(),
             DataOrganizer.organize(),
         ]
-        await asyncio.gather(*concurrent_tasks, *(m.run(self.server) for m in modules))
-        await self.server.wait_for_termination()
+        await asyncio.gather(
+            *concurrent_tasks,
+            *(m.run(self.server) for m in modules),
+            self.server.wait_for_termination(),
+        )
 
         if self.http_server:
             await self.http_server.cleanup()

--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -367,11 +367,11 @@ class DashboardHead:
             DataOrganizer.purge(),
             DataOrganizer.organize(),
         ]
-        await asyncio.gather(
-            *concurrent_tasks,
-            *(m.run(self.server) for m in modules),
-            self.server.wait_for_termination(),
-        )
+        for m in modules:
+            concurrent_tasks.append(m.run(self.server))
+        if self.server:
+            concurrent_tasks.append(self.server.wait_for_termination())
+        await asyncio.gather(*concurrent_tasks)
 
         if self.http_server:
             await self.http_server.cleanup()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Same reason as #44899: currently `grpc_server.wait_for_termination` never run since the previous gather contains tasks that have infinite loop.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
