### PR TITLE
[serve] change cloud that release test services run in

### DIFF
--- a/release/serve_tests/workloads/autoscaling_load_test.py
+++ b/release/serve_tests/workloads/autoscaling_load_test.py
@@ -42,7 +42,7 @@ def main():
         ],
     }
     compute_config = ComputeConfig(
-        cloud="anyscale_v2_default_cloud",
+        cloud="serve_release_tests_cloud",
         head_node=HeadNodeConfig(instance_type="m5.8xlarge"),
         worker_nodes=[
             WorkerNodeGroupConfig(

--- a/release/serve_tests/workloads/replica_scalability.py
+++ b/release/serve_tests/workloads/replica_scalability.py
@@ -45,7 +45,7 @@ def main(num_replicas: Optional[int], trial_length: Optional[int]):
         ],
     }
     compute_config = ComputeConfig(
-        cloud="anyscale_v2_default_cloud",
+        cloud="serve_release_tests_cloud",
         head_node=HeadNodeConfig(instance_type="m5.8xlarge"),
         worker_nodes=[
             WorkerNodeGroupConfig(


### PR DESCRIPTION
[serve] change cloud that release test services run in

Change to use a more isolated `serve_release_tests_cloud`.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
