### PR TITLE
[ci] store pull request number in test result

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -64,6 +64,7 @@ class TestResult:
     branch: str
     url: str
     timestamp: int
+    pull_request: str
 
     @classmethod
     def from_result(cls, result: Result):
@@ -73,6 +74,7 @@ class TestResult:
             branch=os.environ.get("BUILDKITE_BRANCH", ""),
             url=result.buildkite_url,
             timestamp=int(time.time() * 1000),
+            pull_request=os.environ.get("BUILDKITE_PULL_REQUEST", ""),
         )
 
     @classmethod
@@ -97,6 +99,7 @@ class TestResult:
             branch=result.get("branch", ""),
             url=result["url"],
             timestamp=result["timestamp"],
+            pull_request=result.get("pull_request", ""),
         )
 
     def is_failing(self) -> bool:

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -160,7 +160,7 @@ def test_is_stable() -> None:
     assert not Test(stable=False).is_stable()
 
 
-@patch.dict(os.environ, {"BUILDKITE_BRANCH": "food"})
+@patch.dict(os.environ, {"BUILDKITE_BRANCH": "food", "BUILDKITE_PULL_REQUEST": "1"})
 def test_result_from_bazel_event() -> None:
     result = TestResult.from_bazel_event(
         {
@@ -169,6 +169,7 @@ def test_result_from_bazel_event() -> None:
     )
     assert result.is_passing()
     assert result.branch == "food"
+    assert result.pull_request == "1"
     result = TestResult.from_bazel_event(
         {
             "testResult": {"status": "FAILED"},


### PR DESCRIPTION
As title, store pull request number in test result. We need this information to compute microcheck tests.

Test:
- CI