### PR TITLE
[serve] add script for comparing perf metrics

### DIFF
--- a/release/serve_tests/release_utils.py
+++ b/release/serve_tests/release_utils.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+import click
+import json
+import logging
+import requests
+from typing import Dict, Optional
+
+logger = logging.getLogger(__file__)
+logging.basicConfig(level=logging.INFO)
+
+
+@click.group()
+def cli():
+    pass
+
+
+def load_metrics(file_path: str) -> Dict[str, float]:
+    with open(file_path) as f:
+        report = json.load(f)
+        if "perf_metrics" in report:
+            # Input file is the TEST_OUTPUT_JSON (e.g. /tmp/release_test_out.json)
+            # that is written to directly from running `python workloads/abc.py`
+            results = report
+        elif "results" in report:
+            # Input file is either downloaded from the buildkite job artifacts
+            # or from file uploaded to AWS
+            results = report["results"]
+        else:
+            raise RuntimeError(f"Invalid results file {file_path}")
+
+        return {
+            perf_metric["perf_metric_name"]: perf_metric["perf_metric_value"]
+            for perf_metric in results["perf_metrics"]
+        }
+
+
+@cli.command(
+    help=(
+        "Print a table that compares the performance metric results from two runs of "
+        "the same release test."
+    )
+)
+@click.argument("results_file1")
+@click.argument("results_file2")
+def compare_perf(results_file1: str, results_file2: str):
+    metrics1 = load_metrics(results_file1)
+    metrics2 = load_metrics(results_file2)
+
+    print("|metric                        |results 1      |results 2      |%change   |")
+    print("|------------------------------|---------------|---------------|----------|")
+    for key in metrics1:
+        if key in metrics2:
+            change = metrics2[key] / metrics1[key] - 1
+            percent_change = str(round(100 * change, 2))
+
+            metric1 = str(round(metrics1[key], 2))
+            metric2 = str(round(metrics2[key], 2))
+
+            print(f"|{key.ljust(30)}", end="")
+            print(f"|{metric1.ljust(15)}", end="")
+            print(f"|{metric2.ljust(15)}", end="")
+            print(f"|{percent_change.ljust(10)}|")
+
+
+@cli.command(
+    help=(
+        "Fetch the results from the most recent nightly run of the specified release "
+        "test within the past 30 days."
+    )
+)
+@click.argument("test_name")
+@click.option(
+    "--output-path",
+    "-o",
+    type=str,
+    default=None,
+    help="Output file to write results to",
+)
+def fetch_nightly(test_name: str, output_path: Optional[str]):
+    auth_header = {
+        "Authorization": "Bearer bkua_6474b2bfb20dd78d44b83f197d12cb7921583ed7"
+    }
+
+    # Get job ID of the most recent run that passed on master
+    # Builds returned from buildkite rest api are sorted from newest to
+    # oldest already
+    builds = requests.get(
+        (
+            "https://api.buildkite.com/v2/organizations/ray-project/pipelines/release/"
+            "builds"
+        ),
+        headers=auth_header,
+        params={"branch": "master"},
+    ).json()
+    build_number = None
+    job_id = None
+    for build in builds:
+        for job in build["jobs"]:
+            job_name = job.get("name")
+            if (
+                job_name
+                and job_name.startswith(test_name)
+                and job.get("state") == "passed"
+            ):
+                build_number = build["number"]
+                job_id = job["id"]
+
+        if job_id:
+            logger.info(
+                f"Found latest release run on master with build #{build_number} and "
+                f"job ID {job_id}."
+            )
+            break
+
+    if job_id is None:
+        raise RuntimeError(
+            f"Did not find any successful runs of the release test {test_name} on "
+            "master in the past 30 days."
+        )
+
+    # Get results file from Job ID
+    artifacts = requests.get(
+        (
+            "https://api.buildkite.com/v2/organizations/ray-project/pipelines/release/"
+            f"builds/{build_number}/jobs/{job_id}/artifacts"
+        ),
+        headers=auth_header,
+    ).json()
+    results = None
+    for artifact in artifacts:
+        if artifact.get("filename") == "result.json":
+            results = requests.get(artifact["download_url"], headers=auth_header).json()
+            results = results["results"]
+
+    if results is None:
+        raise RuntimeError(f"Did not find results file for buildkite job {job_id}")
+
+    if output_path:
+        with open(output_path, "w+") as f:
+            json.dump(results, f)
+    else:
+        print(json.dumps(results, indent=4))
+
+
+if __name__ == "__main__":
+    cli()

--- a/release/serve_tests/workloads/anyscale_service_utils.py
+++ b/release/serve_tests/workloads/anyscale_service_utils.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 import logging
 import os
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from anyscale import service
 from anyscale.service.models import ServiceState
@@ -32,6 +32,7 @@ def start_service(
     compute_config: ComputeConfig,
     applications: List[Dict],
     add_unique_suffix: bool = True,
+    cluster_env: Optional[str] = None,
 ):
     """Starts an Anyscale Service with the specified configs.
 
@@ -46,7 +47,7 @@ def start_service(
             service name.
     """
 
-    cluster_env = os.environ.get("ANYSCALE_JOB_CLUSTER_ENV_NAME", None)
+    cluster_env = cluster_env or os.environ.get("ANYSCALE_JOB_CLUSTER_ENV_NAME", None)
     if add_unique_suffix:
         ray_commit = (
             ray.__commit__[:8] if ray.__commit__ != "{{RAY_COMMIT_SHA}}" else "nocommit"

--- a/release/serve_tests/workloads/autoscaling_load_test.py
+++ b/release/serve_tests/workloads/autoscaling_load_test.py
@@ -3,8 +3,10 @@
 Benchmark test.
 """
 
+import click
 import json
 import logging
+from typing import Optional
 
 from anyscale import service
 from anyscale.compute_config.models import (
@@ -31,7 +33,10 @@ logging.basicConfig(level=logging.INFO)
 URI = "https://serve-resnet-benchmark-data.s3.us-west-1.amazonaws.com/000000000019.jpeg"
 
 
-def main():
+@click.command()
+@click.option("--output-path", "-o", type=str, default=None)
+@click.option("--cluster-env", type=str, default=None)
+def main(output_path: Optional[str], cluster_env: Optional[str]):
     resnet_application = {
         "import_path": "resnet_50:app",
         "deployments": [
@@ -60,6 +65,7 @@ def main():
         "autoscaling-load-test",
         compute_config=compute_config,
         applications=[resnet_application],
+        cluster_env=cluster_env,
     ) as service_name:
         ray.init(address="auto")
         status = service.status(name=service_name)
@@ -131,7 +137,7 @@ def main():
         }
         logger.info(f"Stats history: {json.dumps(stats.history, indent=4)}")
         logger.info(f"Final aggregated metrics: {json.dumps(results, indent=4)}")
-        save_test_results(results)
+        save_test_results(results, output_path=output_path)
 
 
 if __name__ == "__main__":

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -9,6 +9,7 @@ Throughput benchmarks:
     Calculate the average throughput achieved on 10 batches of requests.
 """
 import asyncio
+import click
 from functools import partial
 import json
 import logging
@@ -16,7 +17,7 @@ import logging
 import grpc
 import pandas as pd
 import requests
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from ray import serve
 from ray.serve._private.benchmarks.common import (
@@ -102,7 +103,7 @@ def convert_latencies_to_perf_metrics(name: str, latencies: pd.Series) -> List[D
     ]
 
 
-async def main():
+async def _main(output_path: Optional[str]):
     # Start and configure Serve
     serve.start(
         grpc_options=gRPCOptions(
@@ -198,8 +199,14 @@ async def main():
 
     logging.info(f"Perf metrics:\n {json.dumps(perf_metrics, indent=4)}")
     results = {"perf_metrics": perf_metrics}
-    save_test_results(results)
+    save_test_results(results, output_path=output_path)
+
+
+@click.command()
+@click.option("--output-path", "-o", type=str, default=None)
+def main(output_path: Optional[str]):
+    asyncio.run(_main(output_path))
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
+++ b/release/serve_tests/workloads/multi_deployment_1k_noop_replica.py
@@ -175,10 +175,7 @@ def main(
     logger.info("Final aggregated metrics: ")
     for key, val in aggregated_metrics.items():
         logger.info(f"{key}: {val}")
-    save_test_results(
-        aggregated_metrics,
-        default_output_file="/tmp/multi_deployment_1k_noop_replica.json",
-    )
+    save_test_results(aggregated_metrics)
 
 
 if __name__ == "__main__":

--- a/release/serve_tests/workloads/replica_scalability.py
+++ b/release/serve_tests/workloads/replica_scalability.py
@@ -27,7 +27,14 @@ DEFAULT_FULL_TEST_TRIAL_LENGTH_S = 60
 @click.command()
 @click.option("--num-replicas", type=int, default=DEFAULT_FULL_TEST_NUM_REPLICA)
 @click.option("--trial-length", type=int, default=DEFAULT_FULL_TEST_TRIAL_LENGTH_S)
-def main(num_replicas: Optional[int], trial_length: Optional[int]):
+@click.option("--output-path", "-o", type=str, default=None)
+@click.option("--cluster-env", type=str, default=None)
+def main(
+    num_replicas: Optional[int],
+    trial_length: Optional[int],
+    output_path: Optional[str],
+    cluster_env: Optional[str],
+):
     noop_1k_application = {
         "name": "default",
         "import_path": "noop:app",
@@ -83,6 +90,7 @@ def main(num_replicas: Optional[int], trial_length: Optional[int]):
         service_name="replica-scalability",
         compute_config=compute_config,
         applications=[noop_1k_application],
+        cluster_env=cluster_env,
     ) as service_name:
         ray.init("auto")
         status = service.status(name=service_name)
@@ -156,7 +164,7 @@ def main(num_replicas: Optional[int], trial_length: Optional[int]):
 
         logger.info(f"Stats history: {json.dumps(stats.history, indent=4)}")
         logger.info(f"Final aggregated metrics: {json.dumps(results, indent=4)}")
-        save_test_results(results)
+        save_test_results(results, output_path=output_path)
 
 
 if __name__ == "__main__":

--- a/release/serve_tests/workloads/serve_micro_benchmark.py
+++ b/release/serve_tests/workloads/serve_micro_benchmark.py
@@ -25,7 +25,7 @@ async def main():
 
     result_json = await benchmark_main()
     logger.info(result_json)
-    save_test_results(result_json, default_output_file="/tmp/micro_benchmark.json")
+    save_test_results(result_json)
 
 
 if __name__ == "__main__":

--- a/release/serve_tests/workloads/serve_resnet_benchmark.py
+++ b/release/serve_tests/workloads/serve_resnet_benchmark.py
@@ -199,10 +199,7 @@ def main(gpu_env: Optional[bool], smoke_run: Optional[bool]):
             }
             print(throughput_mean_tps, model_inference_latency_mean)
 
-        save_test_results(
-            {test_name: result},
-            default_output_file="/tmp/serve_resent_benchmark.json",
-        )
+        save_test_results({test_name: result})
 
 
 if __name__ == "__main__":

--- a/release/serve_tests/workloads/serve_test_utils.py
+++ b/release/serve_tests/workloads/serve_test_utils.py
@@ -10,9 +10,12 @@ from collections import defaultdict
 
 from serve_test_cluster_utils import NUM_CPU_PER_NODE
 from subprocess import PIPE
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 logger = logging.getLogger(__file__)
+
+
+DEFAULT_RELEASE_OUTPUT_PATH = "/tmp/release_test_out.json"
 
 
 def is_smoke_test():
@@ -335,7 +338,12 @@ def run_wrk_on_all_nodes(
     return all_metrics, all_wrk_stdout
 
 
-def save_test_results(final_result, default_output_file="/tmp/release_test_out.json"):
-    test_output_json = os.environ.get("TEST_OUTPUT_JSON", default_output_file)
-    with open(test_output_json, "wt") as f:
-        json.dump(final_result, f)
+def save_test_results(
+    test_results: Dict,
+    output_path: Optional[str] = None,
+):
+    results_file_path = output_path or os.environ.get(
+        "TEST_OUTPUT_JSON", DEFAULT_RELEASE_OUTPUT_PATH
+    )
+    with open(results_file_path, "wt") as f:
+        json.dump(test_results, f)


### PR DESCRIPTION
[serve] add script for comparing perf metrics

Add script that can:
* output the comparison between the performance metrics from two release test output files.
* fetch release test results from latest nightly run on master

Usage:
```
./release_utils.py compare-perf RESULTS_FILE1 RESULTS_FILE2
```

Example output:
```
|metric                        |results 1      |results 2      |%change   |
|------------------------------|---------------|---------------|----------|
|http_p50_latency              |11.08          |11.63          |4.9       |
|http_p90_latency              |17.24          |17.71          |2.75      |
|http_p95_latency              |19.19          |20.12          |4.87      |
|http_p99_latency              |22.7           |25.29          |11.44     |
|http_1mb_p50_latency          |11.82          |12.78          |8.12      |
|http_1mb_p90_latency          |18.78          |19.59          |4.32      |
|http_1mb_p95_latency          |21.55          |22.79          |5.75      |
|http_1mb_p99_latency          |32.36          |26.53          |-18.0     |
|http_10mb_p50_latency         |17.57          |18.04          |2.65      |
|http_10mb_p90_latency         |25.32          |26.31          |3.88      |
|http_10mb_p95_latency         |28.41          |30.15          |6.14      |
|http_10mb_p99_latency         |35.19          |37.68          |7.08      |
|http_avg_rps                  |204.2          |195.04         |-4.49     |
|http_throughput_std           |10.59          |10.05          |-5.1      |
|grpc_p50_latency              |7.97           |8.84           |11.03     |
|grpc_p90_latency              |12.89          |16.0           |24.14     |
|grpc_p95_latency              |15.1           |19.05          |26.21     |
|grpc_p99_latency              |21.11          |25.19          |19.3      |
|grpc_1mb_p50_latency          |17.65          |19.92          |12.85     |
|grpc_1mb_p90_latency          |24.59          |28.3           |15.1      |
|grpc_1mb_p95_latency          |27.62          |32.11          |16.27     |
|grpc_1mb_p99_latency          |34.33          |40.01          |16.57     |
|grpc_10mb_p50_latency         |142.4          |153.89         |8.07      |
|grpc_10mb_p90_latency         |171.29         |196.54         |14.74     |
|grpc_10mb_p95_latency         |180.63         |208.3          |15.32     |
|grpc_10mb_p99_latency         |203.08         |228.68         |12.61     |
|grpc_avg_rps                  |203.35         |211.01         |3.77      |
|grpc_throughput_std           |11.9           |18.37          |54.37     |
|handle_p50_latency            |4.89           |4.08           |-16.52    |
|handle_p90_latency            |8.33           |7.07           |-15.17    |
|handle_p95_latency            |10.29          |8.81           |-14.38    |
|handle_p99_latency            |14.3           |11.08          |-22.5     |
|handle_1mb_p50_latency        |11.58          |10.91          |-5.85     |
|handle_1mb_p90_latency        |17.04          |16.73          |-1.86     |
|handle_1mb_p95_latency        |19.41          |18.97          |-2.29     |
|handle_1mb_p99_latency        |22.92          |26.54          |15.78     |
|handle_10mb_p50_latency       |65.54          |67.52          |3.02      |
|handle_10mb_p90_latency       |83.53          |84.07          |0.65      |
|handle_10mb_p95_latency       |90.7           |93.42          |3.0       |
|handle_10mb_p99_latency       |106.93         |104.65         |-2.13     |
|handle_avg_rps                |394.57         |404.85         |2.61      |
|handle_throughput_std         |22.09          |23.86          |8.01      |
```

The output can also be directly copy-pasted into a github PR and it will be formatted as a human-readable table. e.g. the above becomes:

|metric                        |results 1      |results 2      |%change   |
|------------------------------|---------------|---------------|----------|
|http_p50_latency              |11.08          |11.63          |4.9       |
|http_p90_latency              |17.24          |17.71          |2.75      |
|http_p95_latency              |19.19          |20.12          |4.87      |
|http_p99_latency              |22.7           |25.29          |11.44     |
|http_1mb_p50_latency          |11.82          |12.78          |8.12      |
|http_1mb_p90_latency          |18.78          |19.59          |4.32      |
|http_1mb_p95_latency          |21.55          |22.79          |5.75      |
|http_1mb_p99_latency          |32.36          |26.53          |-18.0     |
|http_10mb_p50_latency         |17.57          |18.04          |2.65      |
|http_10mb_p90_latency         |25.32          |26.31          |3.88      |
|http_10mb_p95_latency         |28.41          |30.15          |6.14      |
|http_10mb_p99_latency         |35.19          |37.68          |7.08      |
|http_avg_rps                  |204.2          |195.04         |-4.49     |
|http_throughput_std           |10.59          |10.05          |-5.1      |
|grpc_p50_latency              |7.97           |8.84           |11.03     |
|grpc_p90_latency              |12.89          |16.0           |24.14     |
|grpc_p95_latency              |15.1           |19.05          |26.21     |
|grpc_p99_latency              |21.11          |25.19          |19.3      |
|grpc_1mb_p50_latency          |17.65          |19.92          |12.85     |
|grpc_1mb_p90_latency          |24.59          |28.3           |15.1      |
|grpc_1mb_p95_latency          |27.62          |32.11          |16.27     |
|grpc_1mb_p99_latency          |34.33          |40.01          |16.57     |
|grpc_10mb_p50_latency         |142.4          |153.89         |8.07      |
|grpc_10mb_p90_latency         |171.29         |196.54         |14.74     |
|grpc_10mb_p95_latency         |180.63         |208.3          |15.32     |
|grpc_10mb_p99_latency         |203.08         |228.68         |12.61     |
|grpc_avg_rps                  |203.35         |211.01         |3.77      |
|grpc_throughput_std           |11.9           |18.37          |54.37     |
|handle_p50_latency            |4.89           |4.08           |-16.52    |
|handle_p90_latency            |8.33           |7.07           |-15.17    |
|handle_p95_latency            |10.29          |8.81           |-14.38    |
|handle_p99_latency            |14.3           |11.08          |-22.5     |
|handle_1mb_p50_latency        |11.58          |10.91          |-5.85     |
|handle_1mb_p90_latency        |17.04          |16.73          |-1.86     |
|handle_1mb_p95_latency        |19.41          |18.97          |-2.29     |
|handle_1mb_p99_latency        |22.92          |26.54          |15.78     |
|handle_10mb_p50_latency       |65.54          |67.52          |3.02      |
|handle_10mb_p90_latency       |83.53          |84.07          |0.65      |
|handle_10mb_p95_latency       |90.7           |93.42          |3.0       |
|handle_10mb_p99_latency       |106.93         |104.65         |-2.13     |
|handle_avg_rps                |394.57         |404.85         |2.61      |
|handle_throughput_std         |22.09          |23.86          |8.01      |

Example usage:
```
./release_utils.py fetch-nightly TEST_NAME -o OUTPUT_PATH
```

I also added options to the release tests `microbenchmarks.py`, `autoscaling_load_test.py`, and `replica_scalability.py` so that they can be more easily run locally, and the release test output can be saved to a filepath of your choice with `-o output_path`. This can be helpful if we want to quickly run the microbenchmarks locally in the future and compare against some other results.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
