### PR TITLE
[serve] run all serve release tests in isolated cloud

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2287,6 +2287,7 @@
   cluster:
     byod: {}
     cluster_compute: compute_tpl_single_node_32_cpu.yaml
+    cloud_id: cld_wy5a6nhazplvu32526ams61d98 
 
   run:
     timeout: 7200
@@ -2308,6 +2309,7 @@
   cluster:
     byod: {}
     cluster_compute: compute_tpl_32_cpu.yaml
+    cloud_id: cld_wy5a6nhazplvu32526ams61d98
 
   run:
     timeout: 7200
@@ -2337,6 +2339,7 @@
     byod:
       type: gpu
     cluster_compute: compute_tpl_single_node_32_cpu.yaml
+    cloud_id: cld_wy5a6nhazplvu32526ams61d98
 
   run:
     timeout: 7200
@@ -2358,6 +2361,7 @@
   cluster:
     byod: {}
     cluster_compute: compute_tpl_single_node.yaml
+    cloud_id: cld_wy5a6nhazplvu32526ams61d98
 
   run:
     timeout: 7200
@@ -2384,6 +2388,7 @@
   cluster:
     byod: {}
     cluster_compute: compute_tpl_single_node_32_cpu.yaml
+    cloud_id: cld_wy5a6nhazplvu32526ams61d98 
 
   run:
     timeout: 7200
@@ -2411,6 +2416,7 @@
     byod:
       type: gpu
     cluster_compute: compute_tpl_gpu_node.yaml
+    cloud_id: cld_wy5a6nhazplvu32526ams61d98 
 
   run:
     timeout: 7200

--- a/release/serve_tests/workloads/autoscaling_load_test.py
+++ b/release/serve_tests/workloads/autoscaling_load_test.py
@@ -42,7 +42,7 @@ def main():
         ],
     }
     compute_config = ComputeConfig(
-        cloud="anyscale_v2_default_cloud",
+        cloud="serve_release_tests_cloud",
         head_node=HeadNodeConfig(instance_type="m5.8xlarge"),
         worker_nodes=[
             WorkerNodeGroupConfig(

--- a/release/serve_tests/workloads/replica_scalability.py
+++ b/release/serve_tests/workloads/replica_scalability.py
@@ -45,7 +45,7 @@ def main(num_replicas: Optional[int], trial_length: Optional[int]):
         ],
     }
     compute_config = ComputeConfig(
-        cloud="anyscale_v2_default_cloud",
+        cloud="serve_release_tests_cloud",
         head_node=HeadNodeConfig(instance_type="m5.8xlarge"),
         worker_nodes=[
             WorkerNodeGroupConfig(


### PR DESCRIPTION
[serve] run all serve release tests in isolated cloud

Run all release test jobs, and the any services they start, in the cloud `serve_release_tests_cloud`. This provides better isolation for our release tests.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
