### PR TITLE
[ci] fetch anyscale token when building release pipeline

### DIFF
--- a/release/ray_release/scripts/build_pipeline.py
+++ b/release/ray_release/scripts/build_pipeline.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import click
 
+from ray_release.aws import maybe_fetch_api_token
 from ray_release.buildkite.filter import filter_tests, group_tests
 from ray_release.buildkite.settings import get_pipeline_settings
 from ray_release.buildkite.step import get_step_for_test_group
@@ -69,6 +70,7 @@ def main(
         os.path.dirname(__file__), "..", "configs", global_config
     )
     init_global_config(global_config_file)
+    maybe_fetch_api_token()
     settings = get_pipeline_settings()
 
     tmpdir = None


### PR DESCRIPTION
@zcin reported that the release test init failed to run when test definition uses the `cloud_id` option: https://buildkite.com/ray-project/release/builds/14152#018f0d64-26bd-442d-a483-7cc172296486. This is because the `cloud_id` option requires anyscale api for validation, but the build_pipeline script doesn't setup for that. Add support of anyscale api in build_pipeline as well.

Test:
- CI
- Release test