### PR TITLE
[ci] Adds promethesus latencies for ray_dashboard_api_requests_duration_seconds_bucket for the Ray Core Tests.

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1140,6 +1140,25 @@ def fetch_prometheus_metrics(prom_addresses: List[str]) -> Dict[str, List[Any]]:
     return samples_by_name
 
 
+def query_prometheus(promethesus_host: str, query: str):
+    """Query promethesus for the metric.
+
+    Returns: json dict of the query result.
+    Raises: Exception on failure to get, or ImportError in minimal tests.
+    """
+    import requests
+
+    url = f"{promethesus_host}/api/v1/query"
+
+    response = requests.get(url, params={"query": query})
+    response.raise_for_status()
+
+    results = response.json()
+    if results["status"] != "success":
+        raise Exception("Failed to fetch data")
+    return results
+
+
 def raw_metrics(info: RayContext) -> Dict[str, List[Any]]:
     """Return prometheus metrics from a RayContext
 

--- a/release/benchmarks/distributed/dashboard_test.py
+++ b/release/benchmarks/distributed/dashboard_test.py
@@ -206,7 +206,10 @@ def query_promthesus_dashboard_api_requests_duration_seconds(
         quantile_str = str(quantile)
         ret[quantile_str] = {}
 
-        query = f"histogram_quantile(0.{quantile}, sum(rate({metric}[{window}])) by (le, endpoint))"
+        query = (
+            f"histogram_quantile(0.{quantile}, sum(rate({metric}[{window}]))"
+            " by (le, endpoint))"
+        )
         results = query_prometheus(promethesus_host, query)
         for result in results["data"]["result"]:
             endpoint = result["metric"]["endpoint"]
@@ -227,7 +230,7 @@ def update_release_test_result_for_dashboard_api_requests_duration_seconds(
         release_result["_dashboard_api_requests_duration_seconds_test_success"] = False
         return
 
-    print(f"====== Print ray_dashboard_api_requests_duration_seconds_bucket ======")
+    print("====== Print ray_dashboard_api_requests_duration_seconds_bucket ======")
     pprint(test_result)
 
     if "perf_metrics" not in release_result:
@@ -238,7 +241,9 @@ def update_release_test_result_for_dashboard_api_requests_duration_seconds(
         p_str = f"p{quantile_str}"  # "95" -> "p95"
         p_results = [
             {
-                "perf_metric_name": f"dashboard_api_requests_{endpoint}_{p_str}_latency_s",
+                "perf_metric_name": (
+                    f"dashboard_api_requests_{endpoint}_{p_str}_latency_s"
+                ),
                 "perf_metric_value": value,
                 "perf_metric_type": "LATENCY",
             }

--- a/release/benchmarks/distributed/many_nodes_tests/actor_test.py
+++ b/release/benchmarks/distributed/many_nodes_tests/actor_test.py
@@ -93,7 +93,10 @@ def main():
     args, unknown = parse_script_args()
     args.total_actors.sort()
 
-    from distributed.dashboard_test import DashboardTestAtScale
+    from distributed.dashboard_test import (
+        DashboardTestAtScale,
+        update_release_test_result_for_dashboard_api_requests_duration_seconds,
+    )
 
     addr = ray.init(address="auto")
     dashboard_test = DashboardTestAtScale(addr)
@@ -120,6 +123,7 @@ def main():
         ]
         result["perf_metrics"] = perf
         dashboard_test.update_release_test_result(result)
+        update_release_test_result_for_dashboard_api_requests_duration_seconds(result)
 
         print(f"Writing data into file: {os.environ['TEST_OUTPUT_JSON']}")
         json.dump(result, out_file)

--- a/release/benchmarks/distributed/test_many_actors.py
+++ b/release/benchmarks/distributed/test_many_actors.py
@@ -4,7 +4,10 @@ import ray._private.test_utils as test_utils
 import time
 import tqdm
 
-from dashboard_test import DashboardTestAtScale
+from dashboard_test import (
+    DashboardTestAtScale,
+    update_release_test_result_for_dashboard_api_requests_duration_seconds,
+)
 from ray._private.state_api_test_utils import summarize_worker_startup_time
 
 is_smoke_test = True
@@ -86,4 +89,5 @@ if not is_smoke_test:
         }
     ]
 dashboard_test.update_release_test_result(results)
+update_release_test_result_for_dashboard_api_requests_duration_seconds(results)
 test_utils.safe_write_to_results_json(results)

--- a/release/benchmarks/distributed/test_many_pgs.py
+++ b/release/benchmarks/distributed/test_many_pgs.py
@@ -3,7 +3,10 @@ import ray
 import ray._private.test_utils as test_utils
 from ray.util.placement_group import placement_group, remove_placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
-from dashboard_test import DashboardTestAtScale
+from dashboard_test import (
+    DashboardTestAtScale,
+    update_release_test_result_for_dashboard_api_requests_duration_seconds,
+)
 import time
 import tqdm
 
@@ -116,4 +119,6 @@ if not is_smoke_test:
         }
     ]
 dashboard_test.update_release_test_result(results)
+update_release_test_result_for_dashboard_api_requests_duration_seconds(results)
+
 test_utils.safe_write_to_results_json(results)

--- a/release/benchmarks/distributed/test_many_tasks.py
+++ b/release/benchmarks/distributed/test_many_tasks.py
@@ -5,7 +5,10 @@ import time
 import tqdm
 
 from ray.util.state import summarize_tasks
-from dashboard_test import DashboardTestAtScale
+from dashboard_test import (
+    DashboardTestAtScale,
+    update_release_test_result_for_dashboard_api_requests_duration_seconds,
+)
 from ray._private.state_api_test_utils import (
     StateAPICallSpec,
     periodic_invoke_state_apis_with_actor,
@@ -130,6 +133,7 @@ def test(num_tasks):
     }
 
     dashboard_test.update_release_test_result(results)
+    update_release_test_result_for_dashboard_api_requests_duration_seconds(results)
     test_utils.safe_write_to_results_json(results)
 
 


### PR DESCRIPTION
Example output, notice `dashboard_api_requests_*` metrics.

```
{
    "actors_per_second": 18.262386303767595,
    "num_actors": 100,
    "time": 5.475735664367676,
    "success": "1",
    "_peak_memory": 30.04,
    "_peak_process_memory": "<redacted>",
    "_dashboard_test_success": true,
    "perf_metrics": [
        {
            "perf_metric_name": "dashboard_p50_latency_ms",
            "perf_metric_value": 4.351,
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_p95_latency_ms",
            "perf_metric_value": 54.054,
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_p99_latency_ms",
            "perf_metric_value": 127.724,
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_async_wrapper_p50_latency_s",
            "perf_metric_value": "0.09226190476190477",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_all_actors[cache ttl=2, max_size=128]_p50_latency_s",
            "perf_metric_value": "0.0025",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_all_nodes[cache ttl=2, max_size=128]_p50_latency_s",
            "perf_metric_value": "0.0025",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_cluster_status_p50_latency_s",
            "perf_metric_value": "0.0025",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_event[cache ttl=2, max_size=128]_p50_latency_s",
            "perf_metric_value": "0.0025",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_index_p50_latency_s",
            "perf_metric_value": "0.0025",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_list_jobs_p50_latency_s",
            "perf_metric_value": "0.0025",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_prometheus_health_p50_latency_s",
            "perf_metric_value": "0.0025",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_async_wrapper_p95_latency_s",
            "perf_metric_value": "0.22455357142857144",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_all_actors[cache ttl=2, max_size=128]_p95_latency_s",
            "perf_metric_value": "0.00475",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_all_nodes[cache ttl=2, max_size=128]_p95_latency_s",
            "perf_metric_value": "0.00475",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_cluster_status_p95_latency_s",
            "perf_metric_value": "0.00475",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_event[cache ttl=2, max_size=128]_p95_latency_s",
            "perf_metric_value": "0.00475",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_index_p95_latency_s",
            "perf_metric_value": "0.00475",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_list_jobs_p95_latency_s",
            "perf_metric_value": "0.00475",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_prometheus_health_p95_latency_s",
            "perf_metric_value": "0.00475",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_async_wrapper_p99_latency_s",
            "perf_metric_value": "0.2449107142857143",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_all_actors[cache ttl=2, max_size=128]_p99_latency_s",
            "perf_metric_value": "0.00495",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_all_nodes[cache ttl=2, max_size=128]_p99_latency_s",
            "perf_metric_value": "0.00495",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_cluster_status_p99_latency_s",
            "perf_metric_value": "0.00495",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_event[cache ttl=2, max_size=128]_p99_latency_s",
            "perf_metric_value": "0.00495",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_get_index_p99_latency_s",
            "perf_metric_value": "0.00495",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_list_jobs_p99_latency_s",
            "perf_metric_value": "0.00495",
            "perf_metric_type": "LATENCY"
        },
        {
            "perf_metric_name": "dashboard_api_requests_prometheus_health_p99_latency_s",
            "perf_metric_value": "0.00495",
            "perf_metric_type": "LATENCY"
        }
    ],
    "_dashboard_memory_usage_mb": 98.254848,
    "_dashboard_api_requests_duration_seconds_test_success": true
}
```