### PR TITLE
add more tests for s3 url with non-ascii characters

### DIFF
--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -87,8 +87,7 @@ def test_escape_storage_uri_with_runtime_env(shutdown_only):
         assert ray.get(f.remote()) == b"baz"
 
 
-@pytest.mark.parametrize("char", ["", "fs"])
-def test_storage_uri_special(shutdown_only, char):
+def test_storage_uri_special(shutdown_only):
     # Test various non-ascii characters that can appear in a URI
     with simulate_storage("s3") as s3_uri:
         # test that ';' can be used instead of '&'

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -87,8 +87,7 @@ def test_escape_storage_uri_with_runtime_env(shutdown_only):
         assert ray.get(f.remote()) == b"baz"
 
 
-def test_storage_uri_special(shutdown_only):
-    # Test various non-ascii characters that can appear in a URI
+def test_storage_uri_semicolon(shutdown_only):
     with simulate_storage("s3") as s3_uri:
         # test that ';' can be used instead of '&'
         s3_uri.replace("&", ";")
@@ -103,19 +102,26 @@ def test_storage_uri_special(shutdown_only):
 
         assert ray.get(f.remote()) == b"baz"
 
-    # test that '$', ' ', '+' and '#' are passed through as-is
-    with simulate_storage("s3", region="$value #value +value") as s3_uri:
+
+def test_storage_uri_special(shutdown_only):
+    # Test various non-ascii characters that can appear in a URI
+    # test that '$', '+', ' ' are passed through
+    with simulate_storage("s3", region="$value+value value") as s3_uri:
         ray.init(storage=s3_uri, runtime_env={"env_vars": {"TEST_ENV": "1"}})
         client = storage.get_client("foo")
+        # url parsing: '+' becomes ' '
+        assert client.fs.region == "$value value value"
         client.put("bar", b"baz")
 
         @ray.remote
         def f():
             client = storage.get_client("foo")
-            return client.get("bar")
+            return client.get("bar").decode() + ";" + client.fs.region
 
-        assert ray.get(f.remote()) == b"baz"
+        assert ray.get(f.remote()) == "baz;$value value value"
 
+
+def test_storage_uri_unicode(shutdown_only):
     # test unicode characters in URI
     with simulate_storage("s3", region="üs-öst-2") as s3_uri:
         ray.init(storage=s3_uri, runtime_env={"env_vars": {"TEST_ENV": "1"}})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Add a test to make sure all possible s3 storage URLs are passed through to the worker properly. They appear on the command line as arguments to the `--storage` command line parameter, so may need special treatment to pass shell parsing.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #44180
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
