### PR TITLE
[ci] mark some rllib tests as running with all core

### DIFF
--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -63,6 +63,12 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --only-tags examples
+        --except-tags multi_gpu,gpu,examples_use_all_core 
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
+        --only-tags examples_use_all_core
+        --skip-ray-installation
         --except-tags multi_gpu,gpu 
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
     depends_on: rllibbuild

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2103,10 +2103,10 @@ py_test(
 py_test(
     name = "examples/checkpoints/checkpoint_by_custom_criteria",
     main = "examples/checkpoints/checkpoint_by_custom_criteria.py",
-    tags = ["team:rllib", "exclusive", "examples"],
-    size = "medium",
+    tags = ["team:rllib", "exclusive", "examples", "examples_use_all_core"],
+    size = "large",
     srcs = ["examples/checkpoints/checkpoint_by_custom_criteria.py"],
-    args = ["--enable-new-api-stack", "--stop-reward=150.0", "--num-cpus=9"]
+    args = ["--enable-new-api-stack", "--stop-reward=150.0", "--num-cpus=8"]
 )
 
 #@OldAPIStack
@@ -2228,7 +2228,7 @@ py_test(
 py_test(
     name = "examples/connectors/mean_std_filtering_multi_agent_ppo",
     main = "examples/connectors/mean_std_filtering.py",
-    tags = ["team:rllib", "exclusive", "examples"],
+    tags = ["team:rllib", "exclusive", "examples", "examples_use_all_core"],
     size = "large",
     srcs = ["examples/connectors/mean_std_filtering.py"],
     args = ["--enable-new-api-stack", "--num-agents=2", "--as-test", "--stop-reward=-600.0", "--framework=torch", "--algo=PPO", "--num-env-runners=5", "--num-cpus=7"]
@@ -2312,8 +2312,8 @@ py_test(
 py_test(
     name = "examples/evaluation/evaluation_parallel_to_training_multi_agent_duration_auto_torch_envrunner",
     main = "examples/evaluation/evaluation_parallel_to_training.py",
-    tags = ["team:rllib", "exclusive", "examples"],
-    size = "medium",
+    tags = ["team:rllib", "exclusive", "examples", "examples_use_all_core"],
+    size = "large",
     srcs = ["examples/evaluation/evaluation_parallel_to_training.py"],
     args = ["--enable-new-api-stack", "--num-agents=2", "--as-test", "--stop-reward=900.0", "--num-cpus=6", "--evaluation-duration=auto", "--evaluation-duration-unit=episodes"]
 )
@@ -2619,8 +2619,8 @@ py_test(
 py_test(
     name = "examples/multi_agent/custom_heuristic_policy",
     main = "examples/multi_agent/custom_heuristic_policy.py",
-    tags = ["team:rllib", "exclusive", "examples"],
-    size = "medium",
+    tags = ["team:rllib", "exclusive", "examples", "examples_use_all_core"],
+    size = "large",
     srcs = ["examples/multi_agent/custom_heuristic_policy.py"],
     args = ["--enable-new-api-stack", "--num-agents=2", "--as-test", "--framework=torch", "--stop-reward=450.0"]
 )


### PR DESCRIPTION
Talked offline with @sven1977 about some of the rllib flaky tests. He suggested to increase timed out. I also mark them as running with all core (avoid running in parallel with other tests).

Test:
- CI