### PR TITLE
[Data] Remove dead `ESTIMATED_SAFE_MEMORY_FRACTION` constant

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -14,9 +14,6 @@ if TYPE_CHECKING:
 _default_context: "Optional[DataContext]" = None
 _context_lock = threading.Lock()
 
-# An estimate of what fraction of the object store a Dataset can use without too high
-# a risk of triggering spilling. This is used to generate user warnings only.
-ESTIMATED_SAFE_MEMORY_FRACTION = 0.25
 
 # We chose 128MiB for default: With streaming execution and num_cpus many concurrent
 # tasks, the memory footprint will be about 2 * num_cpus * target_max_block_size ~= RAM


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`ESTIMATED_SAFE_MEMORY_FRACTION` isn't used anywhere, so this PR removes it (it's been superseded by `ResourceManager.DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION`).
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
