### PR TITLE
[ci] run flaky macos twice

### DIFF
--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -314,8 +314,6 @@ if __name__ == "__main__":
                 ):
                     # Do not run on config changes
                     RAY_CI_RELEASE_TESTS_AFFECTED = 1
-                    if changed_file == "ci/ray_ci/macos/macos_ci.sh":
-                        RAY_CI_MACOS_WHEELS_AFFECTED = 1
             elif any(changed_file.startswith(prefix) for prefix in skip_prefix_list):
                 # nothing is run but linting in these cases
                 pass
@@ -325,6 +323,12 @@ if __name__ == "__main__":
             ):
                 # Linter will always be run
                 RAY_CI_TOOLS_AFFECTED = 1
+            elif (
+                changed_file == ".buildkite/macos.rayci.yml"
+                or changed_file == ".buildkite/pipeline.macos.yml"
+                or changed_file == "ci/ray_ci/macos/macos_ci.sh"
+            ):
+                RAY_CI_MACOS_WHEELS_AFFECTED = 1
             elif (
                 changed_file.startswith("ci/pipeline")
                 or changed_file.startswith("ci/build")
@@ -356,11 +360,6 @@ if __name__ == "__main__":
                 RAY_CI_DOCKER_AFFECTED = 1
                 RAY_CI_LINUX_WHEELS_AFFECTED = 1
                 RAY_CI_TOOLS_AFFECTED = 1
-            elif (
-                changed_file == ".buildkite/macos.rayci.yml"
-                or changed_file == ".buildkite/pipeline.macos.yml"
-            ):
-                RAY_CI_MACOS_WHEELS_AFFECTED = 1
             elif changed_file.startswith("ci/run") or changed_file == "ci/ci.sh":
                 RAY_CI_TOOLS_AFFECTED = 1
             elif changed_file.startswith("src/"):

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -10,6 +10,7 @@ export LC_ALL="en_US.UTF-8"
 export LANG="en_US.UTF-8"
 export BUILD="1"
 export DL="1"
+export RUN_PER_FLAKY_TEST="2"
 
 filter_out_flaky_tests() {
   bazel run ci/ray_ci/automation:filter_tests -- --state_filter=-flaky --prefix=darwin:
@@ -31,6 +32,7 @@ run_small_and_large_flaky_tests() {
   # 42 is the universal rayci exit code for test failures
   (bazel query 'attr(tags, "client_tests|small_size_python_tests|large_size_python_tests_shard_0|large_size_python_tests_shard_1|large_size_python_tests_shard_2", tests(//python/ray/tests/...))' | select_flaky_tests |
     xargs bazel test --config=ci $(./ci/run/bazel_export_options) \
+      --runs_per_test="$RUN_PER_FLAKY_TEST" \
       --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX \
       --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --test_env=CI) || exit 42
 }
@@ -39,7 +41,7 @@ run_medium_flaky_tests() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
   (bazel query 'attr(tags, "medium_size_python_tests_a_to_j|medium_size_python_tests_k_to_z", tests(//python/ray/tests/...))' | select_flaky_tests |
-    xargs bazel test --config=ci $(./ci/run/bazel_export_options) --test_env=CI) || exit 42
+    xargs bazel test --config=ci $(./ci/run/bazel_export_options) --runs_per_test="$RUN_PER_FLAKY_TEST" --test_env=CI) || exit 42
 }
 
 run_small_test() {

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -247,19 +247,19 @@ def test_get_test_results() -> None:
         json.dumps(log)
         for log in [
             {
-                "id": {"testResult": {"label": "//ray/ci:test"}},
+                "id": {"testResult": {"label": "//ray/ci:test", "run": "1"}},
                 "testResult": {"status": "FAILED"},
             },
             {
-                "id": {"testResult": {"label": "//ray/ci:reef"}},
+                "id": {"testResult": {"label": "//ray/ci:reef", "run": "1"}},
                 "testResult": {"status": "FAILED"},
             },
             {
-                "id": {"testResult": {"label": "//ray/ci:test"}},
+                "id": {"testResult": {"label": "//ray/ci:test", "run": "2"}},
                 "testResult": {"status": "FAILED"},
             },
             {
-                "id": {"testResult": {"label": "//ray/ci:test"}},
+                "id": {"testResult": {"label": "//ray/ci:test", "run": "1"}},
                 "testResult": {"status": "PASSED"},
             },
         ]
@@ -280,6 +280,11 @@ def test_get_test_results() -> None:
         assert test.get_name() == f"{platform.system().lower()}://ray/ci:test"
         assert test.get_oncall() == "manu"
         assert result.is_passing()
+
+        test, result = results[2]
+        assert test.get_name() == f"{platform.system().lower()}://ray/ci:test"
+        assert test.get_oncall() == "manu"
+        assert result.is_failing()
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -181,11 +181,12 @@ class TesterContainer(Container):
                     event = json.loads(line.decode("utf-8"))
                     if "testResult" not in event:
                         continue
+                    run_id = event["id"]["testResult"]["run"]
                     test = Test.from_bazel_event(event, team)
                     test_result = TestResult.from_bazel_event(event)
-                    # Obtain only the final test result for a given test in case
-                    # the test is retried.
-                    tests[test.get_name()] = (test, test_result)
+                    # Obtain only the final test result for a given test and run
+                    # in case the test is retried.
+                    tests[f"{run_id}-{test.get_name()}"] = (test, test_result)
 
         return list(tests.values())
 


### PR DESCRIPTION
As we're moving macos tests to period run, let's run flaky macos test twice so we have enough signals to them out of flaky state quicker.

Test:
- CI