### PR TITLE
[data] move raydp to test requirements

### DIFF
--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -7,6 +7,5 @@ crc32c==2.3
 flask_cors
 modin==0.22.2
 pandas==1.5.3
-raydp==1.7.0b20231020.dev0
 responses==0.13.4
 pymars>=0.8.3

--- a/python/requirements/ml/data-test-requirements.txt
+++ b/python/requirements/ml/data-test-requirements.txt
@@ -12,3 +12,4 @@ google-cloud-core==2.4.1
 google-cloud-bigquery-storage==2.24.0
 google-api-core==1.34.0
 webdataset
+raydp==1.7.0b20231020.dev0

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1855,7 +1855,7 @@ querystring-parser==1.2.4
     #   raydp
     #   tune-sklearn
 raydp==1.7.0b20231020.dev0
-    # via -r /ray/ci/../python/requirements/ml/data-requirements.txt
+    # via -r /ray/ci/../python/requirements/ml/data-test-requirements.txt
 recsim==0.2.4 ; sys_platform != "darwin" or platform_machine != "arm64"
     # via -r /ray/ci/../python/requirements/ml/rllib-test-requirements.txt
 redis==4.4.2


### PR DESCRIPTION
so that it won't be built inside the image. this also stops building pyspark into ray-ml images.