### PR TITLE
[proof-of-concept][dashboard] One event loop per module

### DIFF
--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -200,10 +200,11 @@ class HttpServerDashboardHead:
             return response
         return await handler(request)
 
-    async def run(self, modules):
+    async def run(self, modules_to_event_loop_and_thread: dict):
         # Bind http routes of each module.
-        for c in modules:
-            dashboard_optional_utils.DashboardHeadRouteTable.bind(c)
+        for module, p in modules_to_event_loop_and_thread.items():
+            event_loop, _ = p
+            dashboard_optional_utils.DashboardHeadRouteTable.bind(module, event_loop)
 
         # Http server should be initialized after all modules loaded.
         # working_dir uploads for job submission can be up to 100MiB.


### PR DESCRIPTION
Creates 1 event loop and 1 thread for the loop, for each DashboardHeadModule. On aiohttp request, the request is offloaded to the module's loop and thread.

This is an experiment to see if we can "solve" the blocked event loop issue by splitting the module's tasks. This should *not* be needed if the code is always well written - but we need to live with non perfect code. Now, if some module blocks it only blocks itself's workloads, reducing the blast radius and giving us a good lead about which module needs more attention.

I tried it locally, it mostly works, but:

- Any call to GcsChannel and GcsAioClient fails: those things live in the "main" event loop, can't be used in other loops. Can be fixed by creating 1 Client per module.
- DataSource uses Dict which uses `asyncio.Queue()` which is not thread safe. We may need some async magic to work around this
- DataSource data is not properly locked, reads may get partial updates

