### PR TITLE
[Data] Adding in default behavior to false for creating dirs on s3 writes

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -122,6 +122,10 @@ DEFAULT_BATCH_SIZE = 1024
 # streaming generator backpressure.
 DEFAULT_MAX_NUM_BLOCKS_IN_STREAMING_GEN_BUFFER = 2
 
+# Default value for whether or not to try to create directories for write
+# calls if the URI is an S3 URI.
+DEFAULT_S3_TRY_CREATE_DIR = False
+
 
 def _execution_options_factory() -> "ExecutionOptions":
     # Lazily import to avoid circular dependencies.
@@ -216,6 +220,8 @@ class DataContext:
             always written to the Ray Data log file.
         print_on_execution_start: If ``True``, print execution information when
             execution starts.
+        s3_try_create_dir: If ``True``, try to create directories on S3 when a write
+            call is made with a S3 URI.
     """
 
     target_max_block_size: int = DEFAULT_TARGET_MAX_BLOCK_SIZE
@@ -260,6 +266,7 @@ class DataContext:
         DEFAULT_LOG_INTERNAL_STACK_TRACE_TO_STDOUT
     )
     print_on_execution_start: bool = True
+    s3_try_create_dir: bool = DEFAULT_S3_TRY_CREATE_DIR
 
     def __post_init__(self):
         # The additonal ray remote args that should be added to

--- a/python/ray/data/datasource/file_datasink.py
+++ b/python/ray/data/datasource/file_datasink.py
@@ -96,9 +96,16 @@ class _FileDatasink(Datasink):
         from pyarrow.fs import FileType
 
         # We should skip creating directories in s3 unless the user specifically
-        # overrides this behavior. PyArrow's s3fs implementation might collide
-        # with restrictive IAM permissions and skipping the create_dir call will
-        # prevent some of these errors.
+        # overrides this behavior. PyArrow's s3fs implementation for create_dir
+        # will attempt to check if the parent directory exists before trying to
+        # create the directory (with recursive=True it will try to do this to
+        # all of the directories until the root of the bucket). An IAM Policy that
+        # restricts access to a subset of prefixes within the bucket might cause
+        # the creation of the directory to fail even if the permissions should
+        # allow the data can be written to the specified path. For example if a
+        # a policy only allows users to write blobs prefixed with s3://bucket/foo
+        # a call to create_dir for s3://bucket/foo/bar will fail even though it
+        # should not.
         parsed_uri = urlparse(self.path)
         is_s3_uri = parsed_uri.scheme == "s3"
         skip_create_dir_for_s3 = (

--- a/python/ray/data/datasource/file_datasink.py
+++ b/python/ray/data/datasource/file_datasink.py
@@ -95,13 +95,15 @@ class _FileDatasink(Datasink):
         """
         from pyarrow.fs import FileType
 
-        # We should skip creating directories in s3 unless the user specifically 
+        # We should skip creating directories in s3 unless the user specifically
         # overrides this behavior. PyArrow's s3fs implementation might collide
-        # with restrictive IAM permissions and skipping the create_dir call will 
-        # prevent some of these errors.  
+        # with restrictive IAM permissions and skipping the create_dir call will
+        # prevent some of these errors.
         parsed_uri = urlparse(self.path)
         is_s3_uri = parsed_uri.scheme == "s3"
-        skip_create_dir_for_s3 = is_s3_uri and not DataContext.get_current().s3_try_create_dir
+        skip_create_dir_for_s3 = (
+            is_s3_uri and not DataContext.get_current().s3_try_create_dir
+        )
 
         if self.try_create_dir and not skip_create_dir_for_s3:
             if self.filesystem.get_file_info(self.path).type is FileType.NotFound:

--- a/python/ray/data/datasource/file_datasink.py
+++ b/python/ray/data/datasource/file_datasink.py
@@ -1,6 +1,7 @@
 import logging
 import posixpath
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+from urllib.parse import urlparse
 
 from ray._private.utils import _add_creatable_buckets_param_if_s3_uri
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
@@ -94,7 +95,15 @@ class _FileDatasink(Datasink):
         """
         from pyarrow.fs import FileType
 
-        if self.try_create_dir:
+        # We should skip creating directories in s3 unless the user specifically 
+        # overrides this behavior. PyArrow's s3fs implementation might collide
+        # with restrictive IAM permissions and skipping the create_dir call will 
+        # prevent some of these errors.  
+        parsed_uri = urlparse(self.path)
+        is_s3_uri = parsed_uri.scheme == "s3"
+        skip_create_dir_for_s3 = is_s3_uri and not DataContext.get_current().s3_try_create_dir
+
+        if self.try_create_dir and not skip_create_dir_for_s3:
             if self.filesystem.get_file_info(self.path).type is FileType.NotFound:
                 # Arrow's S3FileSystem doesn't allow creating buckets by default, so we
                 # add a query arg enabling bucket creation if an S3 URI is provided.


### PR DESCRIPTION
## Why are these changes needed?
We should skip creating directories in s3 unless the user specifically overrides this behavior. PyArrow's s3fs implementation might collide with restrictive IAM permissions and skipping the create_dir call will prevent some of these errors.  

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
