### PR TITLE
Fix incorrect use of ssh port forward option.

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -349,7 +349,7 @@ class SSHCommandRunner(CommandRunnerInterface):
                         cf.bold(local),
                         cf.bold(remote),
                     )  # todo: msg
-                    ssh += ["-L", "{}:localhost:{}".format(remote, local)]
+                    ssh += ["-L", "{}:localhost:{}".format(local, remote)]
 
         final_cmd = (
             ssh


### PR DESCRIPTION
This fixes the order of ports, making the port option (-p) of "ray dashboard" command actually work.

If you cannot merge this as-is, feel free to make the trivial change yourself.