### PR TITLE
[core] increase GCS timeout for GetAllNodeInfo RPC

### DIFF
--- a/dashboard/modules/node/node_consts.py
+++ b/dashboard/modules/node/node_consts.py
@@ -1,3 +1,5 @@
+from ray._private.ray_constants import env_integer
+
 NODE_STATS_UPDATE_INTERVAL_SECONDS = 5
 UPDATE_NODES_INTERVAL_SECONDS = 5
 # Until the head node is registered,
@@ -8,3 +10,6 @@ FREQUENTY_UPDATE_NODES_INTERVAL_SECONDS = 0.1
 # this timeout, it will stop frequent update.
 FREQUENT_UPDATE_TIMEOUT_SECONDS = 10
 MAX_COUNT_OF_GCS_RPC_ERROR = 10
+
+# Timeout for RPCs to GCS.
+GCS_RPC_TIMEOUT_SECONDS = env_integer("RAY_DASHBOARD_GCS_RPC_TIMEOUT_SECONDS", 60)

--- a/dashboard/modules/node/node_head.py
+++ b/dashboard/modules/node/node_head.py
@@ -142,7 +142,9 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
             A dict of information about the nodes in the cluster.
         """
         request = gcs_service_pb2.GetAllNodeInfoRequest()
-        reply = await self._gcs_node_info_stub.GetAllNodeInfo(request, timeout=2)
+        reply = await self._gcs_node_info_stub.GetAllNodeInfo(
+            request, timeout=node_consts.GCS_RPC_TIMEOUT_SECONDS
+        )
         if reply.status.code == 0:
             result = {}
             for node_info in reply.node_info_list:
@@ -182,7 +184,7 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
                             node_id.encode(),
                             overwrite=True,
                             namespace=ray_constants.KV_NAMESPACE_JOB,
-                            timeout=2,
+                            timeout=node_consts.GCS_RPC_TIMEOUT_SECONDS,
                         )
                     node_id_to_ip[node_id] = ip
                     node_id_to_hostname[node_id] = hostname
@@ -201,7 +203,9 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
                             f"{node_id}"
                         )
                         agent_port = await self._gcs_aio_client.internal_kv_get(
-                            key.encode(), namespace=ray_constants.KV_NAMESPACE_DASHBOARD
+                            key.encode(),
+                            namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+                            timeout=node_consts.GCS_RPC_TIMEOUT_SECONDS,
                         )
                         if agent_port:
                             agents[node_id] = json.loads(agent_port)


### PR DESCRIPTION
Credit to: @stephanie-wang 

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

High load on the dashboard.py process could cause GetAllNodeInfoRequest RPC to GCS timeout and dead nodes not getting updated.

This will further create extra load on dashboard server. Short term fix is to increase the timeout. In long term, we need to separate system and user endpoints.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
