### PR TITLE
[RLlib] Make deprecated AlgorithmConfig properties NOT error out when written to (just warn).

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -4434,8 +4434,9 @@ class AlgorithmConfig(_Config):
         deprecation_warning(
             old="AlgorithmConfig.num_rollout_workers",
             new="AlgorithmConfig.num_env_runners",
-            error=True,
+            error=False,
         )
+        self.num_env_runners = value
 
     @property
     @Deprecated(new="AlgorithmConfig.num_envs_per_env_runner", error=False)
@@ -4447,8 +4448,9 @@ class AlgorithmConfig(_Config):
         deprecation_warning(
             old="AlgorithmConfig.num_envs_per_worker",
             new="AlgorithmConfig.num_envs_per_env_runner",
-            error=True,
+            error=False,
         )
+        self.num_envs_per_env_runner = value
 
     @property
     @Deprecated(new="AlgorithmConfig.ignore_env_runner_failures", error=False)
@@ -4460,8 +4462,9 @@ class AlgorithmConfig(_Config):
         deprecation_warning(
             old="AlgorithmConfig.ignore_worker_failures",
             new="AlgorithmConfig.ignore_env_runner_failures",
-            error=True,
+            error=False,
         )
+        self.ignore_env_runner_failures = value
 
     @property
     @Deprecated(new="AlgorithmConfig.recreate_failed_env_runners", error=False)
@@ -4473,8 +4476,9 @@ class AlgorithmConfig(_Config):
         deprecation_warning(
             old="AlgorithmConfig.recreate_failed_workers",
             new="AlgorithmConfig.recreate_failed_env_runners",
-            error=True,
+            error=False,
         )
+        self.recreate_failed_env_runners = value
 
     @property
     @Deprecated(new="AlgorithmConfig.max_num_env_runner_restarts", error=False)
@@ -4486,8 +4490,9 @@ class AlgorithmConfig(_Config):
         deprecation_warning(
             old="AlgorithmConfig.max_num_worker_restarts",
             new="AlgorithmConfig.max_num_env_runner_restarts",
-            error=True,
+            error=False,
         )
+        self.max_num_env_runner_restarts = value
 
     @property
     @Deprecated(new="AlgorithmConfig.delay_between_env_runner_restarts_s", error=False)
@@ -4499,8 +4504,9 @@ class AlgorithmConfig(_Config):
         deprecation_warning(
             old="AlgorithmConfig.delay_between_worker_restarts_s",
             new="AlgorithmConfig.delay_between_env_runner_restarts_s",
-            error=True,
+            error=False,
         )
+        self.delay_between_env_runner_restarts_s = value
 
     @property
     @Deprecated(
@@ -4514,8 +4520,9 @@ class AlgorithmConfig(_Config):
         deprecation_warning(
             old="AlgorithmConfig.num_consecutive_worker_failures_tolerance",
             new="AlgorithmConfig.num_consecutive_env_runner_failures_tolerance",
-            error=True,
+            error=False,
         )
+        self.num_consecutive_env_runner_failures_tolerance = value
 
     @property
     @Deprecated(new="AlgorithmConfig.env_runner_health_probe_timeout_s", error=False)
@@ -4527,8 +4534,9 @@ class AlgorithmConfig(_Config):
         deprecation_warning(
             old="AlgorithmConfig.worker_health_probe_timeout_s",
             new="AlgorithmConfig.env_runner_health_probe_timeout_s",
-            error=True,
+            error=False,
         )
+        self.env_runner_health_probe_timeout_s = value
 
     @property
     @Deprecated(new="AlgorithmConfig.env_runner_restore_timeout_s", error=False)
@@ -4540,8 +4548,9 @@ class AlgorithmConfig(_Config):
         deprecation_warning(
             old="AlgorithmConfig.worker_restore_timeout_s",
             new="AlgorithmConfig.env_runner_restore_timeout_s",
-            error=True,
+            error=False,
         )
+        self.env_runner_restore_timeout_s = value
 
     @property
     @Deprecated(
@@ -4556,8 +4565,9 @@ class AlgorithmConfig(_Config):
         deprecation_warning(
             old="AlgorithmConfig.validate_workers_after_construction",
             new="AlgorithmConfig.validate_env_runners_after_construction",
-            error=True,
+            error=False,
         )
+        self.validate_env_runners_after_construction = value
 
 
 class TorchCompileWhatToCompile(str, Enum):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Make deprecated AlgorithmConfig properties NOT error out when written to (just warn and assign values to new property names).
Reasoning: We want to avoid old checkpoints to become unusable due to the old configs stored in these checkpoints not working anymore.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
