### PR TITLE
Fix potential github action smells

### DIFF
--- a/.github/workflows/external-code-affected.yml
+++ b/.github/workflows/external-code-affected.yml
@@ -10,8 +10,8 @@ on: pull_request_target
 jobs:
   check-changes:
     permissions: write-all
-    runs-on: ubuntu-22.04
-    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/external-code-affected.yml
+++ b/.github/workflows/external-code-affected.yml
@@ -10,7 +10,8 @@ on: pull_request_target
 jobs:
   check-changes:
     permissions: write-all
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 1
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
Hey! 🙂
I want to contribute the following changes to your workflow:

- Use fixed version for runs-on argument
- Avoid jobs without timeouts

(These changes are part of a research Study at TU Delft looking at GitHub Action Smells. [Find out more](https://ceddy4395.github.io/research/gha-smells.html)

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
