### PR TITLE
[RLlib] Cleanup `ActorManager` and `WorkerSet`: Make all `mark_healthy`/`healthy_only` method args `True` by default.

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -790,7 +790,6 @@ class Algorithm(Trainable, AlgorithmBase):
                 )
                 self.workers.foreach_worker(
                     lambda w: w.set_is_policy_to_train(policies_to_train),
-                    healthy_only=True,
                 )
 
             # Sync the weights from the learner group to the rollout workers.
@@ -1255,10 +1254,9 @@ class Algorithm(Trainable, AlgorithmBase):
                     func=functools.partial(
                         _env_runner_remote, num=_num, round=_round, iter=algo_iteration
                     ),
-                    healthy_only=True,
                 )
                 results = self.evaluation_workers.fetch_ready_async_reqs(
-                    mark_healthy=True, return_obj_refs=False, timeout_seconds=0.01
+                    return_obj_refs=False, timeout_seconds=0.01
                 )
                 for wid, (env_s, ag_s, metrics, iter) in results:
                     if iter != self.iteration:
@@ -1270,10 +1268,9 @@ class Algorithm(Trainable, AlgorithmBase):
             else:
                 self.evaluation_workers.foreach_worker_async(
                     func=lambda w: (w.sample(), w.get_metrics(), algo_iteration),
-                    healthy_only=True,
                 )
                 results = self.evaluation_workers.fetch_ready_async_reqs(
-                    mark_healthy=True, return_obj_refs=False, timeout_seconds=0.01
+                    return_obj_refs=False, timeout_seconds=0.01
                 )
                 for wid, (batch, metrics, iter) in results:
                     if iter != self.iteration:
@@ -1398,10 +1395,9 @@ class Algorithm(Trainable, AlgorithmBase):
                     func=functools.partial(
                         _env_runner_remote, num=_num, round=_round, iter=algo_iteration
                     ),
-                    healthy_only=True,
                 )
                 results = self.evaluation_workers.fetch_ready_async_reqs(
-                    mark_healthy=True, return_obj_refs=False, timeout_seconds=0.01
+                    return_obj_refs=False, timeout_seconds=0.01
                 )
                 # Make sure we properly time out if we have not received any results
                 # for more than `time_out` seconds.
@@ -1443,7 +1439,7 @@ class Algorithm(Trainable, AlgorithmBase):
                     remote_worker_ids=selected_eval_worker_ids,
                 )
                 results = self.evaluation_workers.fetch_ready_async_reqs(
-                    mark_healthy=True, return_obj_refs=False, timeout_seconds=0.01
+                    return_obj_refs=False, timeout_seconds=0.01
                 )
                 # Make sure we properly time out if we have not received any results
                 # for more than `time_out` seconds.
@@ -1530,16 +1526,16 @@ class Algorithm(Trainable, AlgorithmBase):
     @OverrideToImplementCustomLogic
     @DeveloperAPI
     def restore_workers(self, workers: WorkerSet) -> None:
-        """Try syncing previously failed and restarted workers with local, if necessary.
+        """Try bringing back unhealthy EnvRunners and - if successful - sync with local.
 
         Algorithms that use custom EnvRunners may override this method to
-        disable default, and create custom restoration logics. Note that "restoring"
+        disable the default, and create custom restoration logics. Note that "restoring"
         does not include the actual restarting process, but merely what should happen
         after such a restart of a (previously failed) worker.
 
         Args:
-            workers: The WorkerSet to restore. This may be Rollout or Evaluation
-                workers.
+            workers: The WorkerSet to restore. This may be the training or the
+                evaluation WorkerSet.
         """
         # If `workers` is None, or
         # 1. `workers` (WorkerSet) does not have a local worker, and
@@ -1576,9 +1572,7 @@ class Algorithm(Trainable, AlgorithmBase):
                 remote_worker_ids=restored,
                 # Don't update the local_worker, b/c it's the one we are synching from.
                 local_worker=False,
-                timeout_seconds=self.config.worker_restore_timeout_s,
-                # Bring back actor after successful state syncing.
-                mark_healthy=True,
+                timeout_seconds=self.config.env_runner_restore_timeout_s,
             )
 
             # Fire the callback for re-created workers.
@@ -2274,7 +2268,7 @@ class Algorithm(Trainable, AlgorithmBase):
             )
 
         # Update all EnvRunner workers.
-        self.workers.foreach_worker(fn, local_worker=True, healthy_only=True)
+        self.workers.foreach_worker(fn, local_worker=True)
 
         # Update each Learner's `policies_to_train` information, but only
         # if the arg is explicitly provided here.
@@ -2287,11 +2281,7 @@ class Algorithm(Trainable, AlgorithmBase):
 
         # Update the evaluation worker set's workers, if required.
         if evaluation_workers and self.evaluation_workers is not None:
-            self.evaluation_workers.foreach_worker(
-                fn,
-                local_worker=True,
-                healthy_only=True,
-            )
+            self.evaluation_workers.foreach_worker(fn, local_worker=True)
 
     @OldAPIStack
     def export_policy_model(
@@ -2896,7 +2886,6 @@ class Algorithm(Trainable, AlgorithmBase):
             self.workers.foreach_worker(
                 lambda w: w.set_state(ray.get(remote_state_ref)),
                 local_worker=False,
-                healthy_only=False,
             )
             if self.evaluation_workers:
                 # Avoid `state` being pickled into the remote function below.
@@ -2910,10 +2899,8 @@ class Algorithm(Trainable, AlgorithmBase):
 
                 # If evaluation workers are used, also restore the policies
                 # there in case they are used for evaluation purpose.
-                self.evaluation_workers.foreach_worker(
-                    _setup_eval_worker,
-                    healthy_only=False,
-                )
+                self.evaluation_workers.foreach_worker(_setup_eval_worker)
+
         # If necessary, restore replay data as well.
         if self.local_replay_buffer is not None:
             # TODO: Experimental functionality: Restore contents of replay
@@ -3304,7 +3291,7 @@ class Algorithm(Trainable, AlgorithmBase):
 
         # Collect the evaluation results.
         eval_results = self.evaluation_workers.fetch_ready_async_reqs(
-            mark_healthy=True, return_obj_refs=False, timeout_seconds=time_out
+            return_obj_refs=False, timeout_seconds=time_out
         )
         for wid, (batch, metrics, iter) in eval_results:
             # Skip results from an older iteration.

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -502,7 +502,7 @@ class AlgorithmConfig(_Config):
         self.delay_between_env_runner_restarts_s = 60.0
         self.restart_failed_sub_environments = False
         self.num_consecutive_env_runner_failures_tolerance = 100
-        self.env_runner_health_probe_timeout_s = 60
+        self.env_runner_health_probe_timeout_s = 30
         self.env_runner_restore_timeout_s = 1800
 
         # `self.rl_module()`
@@ -2742,9 +2742,11 @@ class AlgorithmConfig(_Config):
                 failures, the EnvRunner itself is NOT affected and won't throw any
                 errors as the flawed sub-environment is silently restarted under the
                 hood.
-            env_runner_health_probe_timeout_s: Max amount of time we should spend
-                waiting for health probe calls to finish. Health pings are very cheap,
-                so the default is 1 minute.
+            env_runner_health_probe_timeout_s: Max amount of time in seconds, we should
+                spend waiting for EnvRunner health probe calls
+                (`EnvRunner.ping.remote()`) to respond. Health pings are very cheap,
+                however, we perform the health check via a blocking `ray.get()`, so the
+                default value should not be too long.
             env_runner_restore_timeout_s: Max amount of time we should wait to restore
                 states on recovered EnvRunner actors. Default is 30 mins.
 

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -755,7 +755,6 @@ class Impala(Algorithm):
         if self._aggregator_actor_manager:
             self._aggregator_actor_manager.probe_unhealthy_actors(
                 timeout_seconds=self.config.env_runner_health_probe_timeout_s,
-                mark_healthy=True,
             )
 
         if self.config._enable_new_api_stack:
@@ -909,10 +908,7 @@ class Impala(Algorithm):
             # local worker. Otherwise just return an empty list.
             if self.workers.num_healthy_remote_workers() > 0:
                 # Perform asynchronous sampling on all (remote) rollout workers.
-                self.workers.foreach_worker_async(
-                    lambda worker: worker.sample(),
-                    healthy_only=True,
-                )
+                self.workers.foreach_worker_async(lambda worker: worker.sample())
                 sample_batches: List[
                     Tuple[int, ObjectRef]
                 ] = self.workers.fetch_ready_async_reqs(

--- a/rllib/algorithms/tests/test_worker_failures.py
+++ b/rllib/algorithms/tests/test_worker_failures.py
@@ -307,9 +307,6 @@ class TestWorkerFailures(unittest.TestCase):
                     "evaluation": True,
                 },
             }
-
-        print(config)
-
         algo = config.build()
         algo.train()
 

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -101,7 +101,6 @@ def synchronous_parallel_sample(
                     else (lambda w: (w.sample(), w.get_metrics()))
                 ),
                 local_worker=False,
-                healthy_only=True,
                 timeout_seconds=sample_timeout_s,
             )
             # Nothing was returned (maybe all workers are stalling) or no healthy

--- a/rllib/utils/actor_manager.py
+++ b/rllib/utils/actor_manager.py
@@ -443,7 +443,7 @@ class FaultTolerantActorManager:
         tags: List[str],
         timeout_seconds: int = None,
         return_obj_refs: bool = False,
-        mark_healthy: bool = False,
+        mark_healthy: bool = True,
     ) -> Tuple[List[ray.ObjectRef], RemoteCallResults]:
         """Try fetching results from remote actor calls.
 
@@ -508,8 +508,10 @@ class FaultTolerantActorManager:
                 remote_results.add_result(actor_id, ResultOrError(error=e), tag)
 
                 # Mark the actor as unhealthy.
-                # TODO(jungong): Using RayError here to preserve historical behavior.
-                #  It may very likely be better to use RayActorError here.
+                # TODO (sven): Using RayError here to preserve historical behavior.
+                #  It may be better to use (RayActorError, RayTaskError) here, but it's
+                #  not 100% clear to me yet. For example, if an env crashes within a
+                #  EnvRunner, Ray seems to throw a RayTaskError, not RayActorError.
                 if isinstance(e, RayError):
                     # Take this actor out of service and wait for Ray Core to
                     # restore it.
@@ -519,8 +521,9 @@ class FaultTolerantActorManager:
                             f"{str(e)}"
                         )
                     self.set_actor_state(actor_id, healthy=False)
+                # ActorManager should not handle other RayErrors or application level
+                # errors.
                 else:
-                    # ActorManager should not handle application level errors.
                     pass
 
         return ready, remote_results
@@ -564,31 +567,39 @@ class FaultTolerantActorManager:
         self,
         func: Union[Callable[[Any], Any], List[Callable[[Any], Any]]],
         *,
-        healthy_only=True,
+        healthy_only: bool = True,
         remote_actor_ids: List[int] = None,
-        timeout_seconds=None,
+        timeout_seconds: Optional[float] = None,
         return_obj_refs: bool = False,
-        mark_healthy: bool = False,
+        mark_healthy: bool = True,
     ) -> RemoteCallResults:
         """Calls the given function with each actor instance as arg.
 
-        Automatically mark actors unhealthy if they fail to respond.
+        Automatically marks actors unhealthy if they crash during the remote call.
 
         Args:
             func: A single, or a list of Callables, that get applied on the list
                 of specified remote actors.
-            healthy_only: If True, applies func on known healthy actors only.
+            healthy_only: If True, applies `func` only to actors currently tagged
+                "healthy", otherwise to all actors. If `healthy_only=False` and
+                `mark_healthy=True`, will send `func` to all actors and mark those
+                actors "healthy" that respond to the request within `timeout_seconds`
+                and are currently tagged as "unhealthy".
             remote_actor_ids: Apply func on a selected set of remote actors.
-            timeout_seconds: Ray.get() timeout. Default is None.
-                Setting this to 0.0 effectively makes all the
-                remote calls fire-and-forget, while setting timeout_seconds to None
-                make them synchronous calls.
+            timeout_seconds: Ray.get() timeout in seconds. Default is None, which will
+                block until all remote results have been received. Setting this to 0.0
+                makes all the remote calls fire-and-forget, while setting this to
+                None make them synchronous calls.
             return_obj_refs: whether to return ObjectRef instead of actual results.
                 Note, for fault tolerance reasons, these returned ObjectRefs should
                 never be resolved with ray.get() outside of the context of this manager.
-            mark_healthy: whether to mark certain actors healthy based on the results
-                of these remote calls. Useful, for example, to make sure actors
-                do not come back without proper state restoration.
+            mark_healthy: Whether to mark all those actors healthy again that are
+                currently marked unhealthy AND that returned results from the remote
+                call (within the given `timeout_seconds`).
+                Note that actors are NOT set unhealthy, if they simply time out
+                (only if they return a RayActorError).
+                Also not that this setting is ignored if `healthy_only=True` (b/c this
+                setting only affects actors that are currently tagged as unhealthy).
 
         Returns:
             The list of return values of all calls to `func(actor)`. The values may be
@@ -625,7 +636,7 @@ class FaultTolerantActorManager:
         func: Union[Callable[[Any], Any], List[Callable[[Any], Any]]],
         tag: str = None,
         *,
-        healthy_only=True,
+        healthy_only: bool = True,
         remote_actor_ids: List[int] = None,
     ) -> int:
         """Calls given functions against each actors without waiting for results.
@@ -634,7 +645,12 @@ class FaultTolerantActorManager:
             func: A single, or a list of Callables, that get applied on the list
                 of specified remote actors.
             tag: A tag to identify the results from this async call.
-            healthy_only: If True, applies func on known healthy actors only.
+            healthy_only: If True, applies `func` only to actors currently tagged
+                "healthy", otherwise to all actors. If `healthy_only=False` and
+                later, `self.fetch_ready_async_reqs()` is called with
+                `mark_healthy=True`, will send `func` to all actors and mark those
+                actors "healthy" that respond to the request within `timeout_seconds`
+                and are currently tagged as "unhealthy".
             remote_actor_ids: Apply func on a selected set of remote actors.
                 Note, for fault tolerance reasons, these returned ObjectRefs should
                 never be resolved with ray.get() outside of the context of this manager.
@@ -744,7 +760,7 @@ class FaultTolerantActorManager:
         tags: Union[str, List[str]] = (),
         timeout_seconds: Union[None, int] = 0,
         return_obj_refs: bool = False,
-        mark_healthy: bool = False,
+        mark_healthy: bool = True,
     ) -> RemoteCallResults:
         """Get results from outstanding async requests that are ready.
 
@@ -758,9 +774,17 @@ class FaultTolerantActorManager:
                 already ready).
             tags: A tag or a list of tags to identify the results from this async call.
             return_obj_refs: Whether to return ObjectRef instead of actual results.
-            mark_healthy: whether to mark certain actors healthy based on the results
-                of these remote calls. Useful, for example, to make sure actors
-                do not come back without proper state restoration.
+            mark_healthy: Whether to mark all those actors healthy again that are
+                currently marked unhealthy AND that returned results from the remote
+                call (within the given `timeout_seconds`).
+                Note that actors are NOT set to unhealthy, if they simply time out,
+                meaning take a longer time to fulfil the remote request. We only ever
+                mark an actor unhealthy, if they raise a RayActorError inside the remote
+                request.
+                Also note that this settings is ignored if the preceding
+                `foreach_actor_async()` call used the `healthy_only=True` argument (b/c
+                `mark_healthy` only affects actors that are currently tagged as
+                unhealthy).
 
         Returns:
             A list of return values of all calls to `func(actor)` that are ready.
@@ -791,19 +815,29 @@ class FaultTolerantActorManager:
     @DeveloperAPI
     def probe_unhealthy_actors(
         self,
-        timeout_seconds: Optional[int] = None,
-        mark_healthy: bool = False,
+        timeout_seconds: Optional[float] = None,
+        mark_healthy: bool = True,
     ) -> List[int]:
         """Ping all unhealthy actors to try bringing them back.
 
         Args:
-            timeout_seconds: Timeout to avoid pinging hanging workers indefinitely.
-            mark_healthy: Whether to mark actors healthy if they respond to the ping.
+            timeout_seconds: Timeout in seconds (to avoid pinging hanging workers
+                indefinitely).
+            mark_healthy: Whether to mark all those actors healthy again that are
+                currently marked unhealthy AND that respond to the `ping` remote request
+                (within the given `timeout_seconds`).
+                Note that actors are NOT set to unhealthy, if they simply time out,
+                meaning take a longer time to fulfil the remote request. We only ever
+                mark and actor unhealthy, if they return a RayActorError from the remote
+                request.
+                Also note that this settings is ignored if `healthy_only=True` (b/c this
+                setting only affects actors that are currently tagged as unhealthy).
 
         Returns:
-            A list of actor IDs that were restored by the `ping` AND those actors that
-            were previously restored via other remote requests. The cached set of
-            such previously restored actors will be erased in this call.
+            A list of actor IDs that were restored by the `ping.remote()` call PLUS
+            those actors that were previously restored via other remote requests.
+            The cached set of such previously restored actors will be erased in this
+            call.
         """
         # Collect recently restored actors (from `self._fetch_result` calls other than
         # the one triggered here via the `ping`).

--- a/rllib/utils/tests/test_actor_manager.py
+++ b/rllib/utils/tests/test_actor_manager.py
@@ -165,7 +165,7 @@ class TestActorManager(unittest.TestCase):
 
         results1 = []
         for _ in range(10):
-            manager.probe_unhealthy_actors(mark_healthy=True)
+            manager.probe_unhealthy_actors()
             results1.extend(
                 manager.foreach_actor(lambda w: w.call(), timeout_seconds=0)
             )
@@ -230,7 +230,7 @@ class TestActorManager(unittest.TestCase):
 
         results = []
         for _ in range(10):
-            manager.probe_unhealthy_actors(mark_healthy=True)
+            manager.probe_unhealthy_actors()
             results.extend(manager.foreach_actor(lambda w: w.call()))
             # Wait for actors to recover.
             wait_for_restore()
@@ -251,9 +251,9 @@ class TestActorManager(unittest.TestCase):
 
         # Wait for actors to recover.
         wait_for_restore()
-        manager.probe_unhealthy_actors()
+        manager.probe_unhealthy_actors(mark_healthy=False)
 
-        # Restored actors are not marked healthy if we just do probing.
+        # Restored actors were not marked healthy (`mark_healthy=False` above).
         # Only 2 healthy actors.
         self.assertEqual(manager.num_healthy_actors(), 2)
 
@@ -355,7 +355,7 @@ class TestActorManager(unittest.TestCase):
         manager.set_actor_state(2, False)
 
         # These actors are actually healthy.
-        manager.probe_unhealthy_actors(mark_healthy=True)
+        manager.probe_unhealthy_actors()
         # Both actors are now healthy.
         self.assertEqual(len(manager.healthy_actor_ids()), 4)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Cleanup `ActorManager` and `WorkerSet`: Make all `mark_healthy`/`healthy_only` method args `True` by default.

Also renamed `WorkerSet.__actor_manager` not super-private anymore (super-privates make it impossible to debug properly!).

Reasoning:
The default behavior of a `WorkerSet.foreach_...` call should be:
* Only send requests to healthy workers by default. This will avoid having to wait up to the full `timeout` (sometimes a minute) for workers that we already know are NOT healthy.
* `mark_healthy` should always be True anyways! If any worker that is being sent q request - for whatever reason - then responds properly, we should mark it healthy, unless there is a good reason NOT to do so.
* Once an iteration, Algorithm will try to restore all currently marked "unhealthy" workers via its `restore_workers` API. This method will send a special "ping" request to all unhealthy (only) workers (with a now shortened timeout of 30sec (before 60s)) and mark them healthy, if they respond well.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
