### PR TITLE
Fix typo in function name pasre_pg_formatted_resources_to_original

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -2007,7 +2007,7 @@ def validate_node_labels(labels: Dict[str, str]):
             )
 
 
-def pasre_pg_formatted_resources_to_original(
+def parse_pg_formatted_resources_to_original(
     pg_formatted_resources: Dict[str, float]
 ) -> Dict[str, float]:
     original_resources = {}

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 import ray._private.worker
 from ray._private.client_mode_hook import client_mode_hook
-from ray._private.utils import pasre_pg_formatted_resources_to_original
+from ray._private.utils import parse_pg_formatted_resources_to_original
 from ray._raylet import TaskID
 from ray.runtime_env import RuntimeEnv
 from ray.util.annotations import Deprecated, PublicAPI
@@ -355,7 +355,7 @@ class RuntimeContext(object):
             res: sum(amt for _, amt in mapping)
             for res, mapping in resource_id_map.items()
         }
-        result = pasre_pg_formatted_resources_to_original(resource_map)
+        result = parse_pg_formatted_resources_to_original(resource_map)
         return result
 
     def get_runtime_env_string(self):

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -9,7 +9,7 @@ import pytest
 import logging
 from ray._private.utils import (
     get_or_create_event_loop,
-    pasre_pg_formatted_resources_to_original,
+    parse_pg_formatted_resources_to_original,
     try_import_each_module,
     get_current_node_cpu_model_name,
 )
@@ -81,13 +81,13 @@ def test_try_import_each_module():
             )
 
 
-def test_pasre_pg_formatted_resources():
-    out = pasre_pg_formatted_resources_to_original(
+def test_parse_pg_formatted_resources():
+    out = parse_pg_formatted_resources_to_original(
         {"CPU_group_e765be422c439de2cd263c5d9d1701000000": 1, "memory": 100}
     )
     assert out == {"CPU": 1, "memory": 100}
 
-    out = pasre_pg_formatted_resources_to_original(
+    out = parse_pg_formatted_resources_to_original(
         {
             "memory_group_4da1c24ac25bec85bc817b258b5201000000": 100.0,
             "memory_group_0_4da1c24ac25bec85bc817b258b5201000000": 100.0,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes a typo in the name of the function `pasre_pg_formatted_resources_to_original`


## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [X] This PR is not tested :(
