### PR TITLE
[ci] pass RAYCI_BISECT_RUN=1 to bisect run

### DIFF
--- a/.buildkite/bisect/bisect.rayci.yml
+++ b/.buildkite/bisect/bisect.rayci.yml
@@ -5,7 +5,7 @@ steps:
   - name: macos test
     commands:
       - if [[ "$(buildkite-agent meta-data get test-type)" != "macos_test" ]]; then exit 0; fi
-      - ./ci/ray_ci/macos/macos_ci.sh bisect "$(buildkite-agent meta-data get test-name)" 
+      - RAYCI_BISECT_RUN=1 ./ci/ray_ci/macos/macos_ci.sh bisect "$(buildkite-agent meta-data get test-name)" 
           "$(buildkite-agent meta-data get passing-commit)" "$(buildkite-agent meta-data get failing-commit)"
     mount_buildkite_agent: true
     job_env: MACOS


### PR DESCRIPTION
As title, when this en variable is set, macos_ci.sh will not upload bazel test results into test db (https://github.com/ray-project/ray/blob/master/ci/ray_ci/macos/macos_ci.sh#L118). We need this set otherwise, bisect will upload its test run results to test db and pollute the data. Check https://github.com/ray-project/ray/issues/44729#issuecomment-2079950082, it commented the blame PR and then set the test to PASSING

Test:

![](https://media0.giphy.com/media/TejmLnMKgnmPInMQjV/200.gif?cid=5a38a5a22klnjal5u4nuzuaidiller3rdlk0o74diqr5wjtx&ep=v1_gifs_search&rid=200.gif&ct=g)
