### PR TITLE
[ci] reduce rllib example test parallelism

### DIFF
--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -61,7 +61,7 @@ steps:
     instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 2
         --only-tags examples
         --except-tags multi_gpu,gpu,examples_use_all_core 
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1


### PR DESCRIPTION
The rllib example tests are getting more flaky than usual. Reduce parallelism to see if it helps. Many of these tests are asking for 4 cpus: https://github.com/ray-project/ray/blob/master/rllib/BUILD#L2232

Test:
- CI