### PR TITLE
[Serve] Allow methods to pass type `@serve.batch` type hint

### DIFF
--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -447,7 +447,7 @@ def _validate_batch_wait_timeout_s(batch_wait_timeout_s):
 
 T = TypeVar("T")
 R = TypeVar("R")
-F = TypeVar("F", bound=Callable[[List[T]], List[R]])
+F = TypeVar("F", Callable[[List[T]], List[R]], Callable[[Any, List[T]], List[R]])
 G = TypeVar("G", bound=Callable[[T], R])
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Without this change, `mypy` raises a type warning when decorating methods with `@serve.batch`:

<img width="504" alt="Screenshot 2024-04-26 at 5 14 00 PM" src="https://github.com/ray-project/ray/assets/92341594/fd535d23-2a41-4f62-bb38-5f41a8bf53d5">

With this change, `mypy` no longer raises a type warning for methods:

<img width="505" alt="Screenshot 2024-04-26 at 5 14 35 PM" src="https://github.com/ray-project/ray/assets/92341594/b14c4167-30e9-417e-a920-d694629b8038">

We should be aware that functions with an extra parameter before the input list will now pass the type check. This allows users to define a method outside a class and then assign it to a class:

<img width="329" alt="Screenshot 2024-04-26 at 5 17 30 PM" src="https://github.com/ray-project/ray/assets/92341594/54043cf3-677a-48b8-a83b-10bec2ee6053">

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - This change relies on existing tests.
