### PR TITLE
[serve] fix lightweight update max ongoing requests

### DIFF
--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -117,7 +117,7 @@ class DeploymentConfig(BaseModel):
     )
     max_ongoing_requests: PositiveInt = Field(
         default=DEFAULT_MAX_ONGOING_REQUESTS,
-        update_type=DeploymentOptionUpdateType.NeedsReconfigure,
+        update_type=DeploymentOptionUpdateType.NeedsActorReconfigure,
     )
     max_queued_requests: int = Field(
         default=-1,

--- a/python/ray/serve/tests/test_config_files/get_signal.py
+++ b/python/ray/serve/tests/test_config_files/get_signal.py
@@ -1,3 +1,5 @@
+import os
+
 import ray
 from ray import serve
 
@@ -7,6 +9,7 @@ class A:
     async def __call__(self):
         signal = ray.get_actor("signal123")
         await signal.wait.remote()
+        return os.getpid()
 
 
 app = A.bind()

--- a/python/ray/serve/tests/test_deployment_version.py
+++ b/python/ray/serve/tests/test_deployment_version.py
@@ -163,8 +163,10 @@ def test_max_ongoing_requests():
 
     assert v1 == v2
     assert hash(v1) == hash(v2)
+    assert not v1.requires_actor_reconfigure(v2)
     assert v1 != v3
     assert hash(v1) != hash(v3)
+    assert v1.requires_actor_reconfigure(v3)
 
 
 def test_health_check_period_s():

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -1105,7 +1105,11 @@ def test_deploy_new_config_same_code_version(
     )
     check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
 
-    if option in ["user_config", "graceful_shutdown_wait_loop_s"]:
+    if option in [
+        "user_config",
+        "graceful_shutdown_wait_loop_s",
+        "max_ongoing_requests",
+    ]:
         dsm.update()
         check_counts(ds, total=1)
         check_counts(


### PR DESCRIPTION
[serve] fix lightweight update max ongoing requests

When a lightweight update occurs for a deployment and `max_ongoing_requests` is updated, two components need to be notified:
1. Deployment handles, to know not to send more requests to a replica when it's reached its maximum
2. Replicas, to know to reject requests when it's reached its maximum

Right now we handle (1), but we don't handle (2), i.e. replicas aren't notified of the updated `max_ongoing_requests` for lightweight updates. The problem is that (1) is not strict enforcement of `max_ongoing_requests` since it relies on a cache that can be stale, so the current bug is that replicas aren't updated -> updated max is not fully enforced.

This PR fixes that, and updates a test to fully test this behavior.

Fixes https://github.com/ray-project/ray/issues/44975.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
