### PR TITLE
[ray 2.20.0] perf regressions

### DIFF
--- a/release/release_logs/2.12.0/benchmarks/many_actors.json
+++ b/release/release_logs/2.12.0/benchmarks/many_actors.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 466.80064,
+    "_dashboard_test_success": true,
+    "_peak_memory": 3.72,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.78GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1016\t0.96GiB\tpython distributed/test_many_actors.py\n266\t0.3GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n836\t0.07GiB\tray::JobSupervisor\n581\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1076\t0.06GiB\tray::MemoryMonitorActor.run\n1164\t0.05GiB\tray::DashboardTester.run\n360\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
+    "actors_per_second": 653.272142233422,
+    "num_actors": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "actors_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 653.272142233422
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 201.991
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2575.396
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3787.161
+        }
+    ],
+    "success": "1",
+    "time": 15.30755615234375
+}

--- a/release/release_logs/2.12.0/benchmarks/many_actors.json
+++ b/release/release_logs/2.12.0/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 466.80064,
+    "_dashboard_memory_usage_mb": 586.133504,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.72,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.78GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1016\t0.96GiB\tpython distributed/test_many_actors.py\n266\t0.3GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n836\t0.07GiB\tray::JobSupervisor\n581\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1076\t0.06GiB\tray::MemoryMonitorActor.run\n1164\t0.05GiB\tray::DashboardTester.run\n360\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
-    "actors_per_second": 653.272142233422,
+    "_peak_memory": 3.74,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.71GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n795\t0.9GiB\tpython distributed/test_many_actors.py\n266\t0.43GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n427\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n615\t0.07GiB\tray::JobSupervisor\n583\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n425\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n855\t0.06GiB\tray::MemoryMonitorActor.run\n943\t0.05GiB\tray::DashboardTester.run\n366\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
+    "actors_per_second": 636.4202043276684,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 653.272142233422
+            "perf_metric_value": 636.4202043276684
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 201.991
+            "perf_metric_value": 151.88
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2575.396
+            "perf_metric_value": 3121.637
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3787.161
+            "perf_metric_value": 5398.368
         }
     ],
     "success": "1",
-    "time": 15.30755615234375
+    "time": 15.712888956069946
 }

--- a/release/release_logs/2.12.0/benchmarks/many_nodes.json
+++ b/release/release_logs/2.12.0/benchmarks/many_nodes.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 196.95616,
+    "_dashboard_test_success": true,
+    "_peak_memory": 1.63,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.52GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1049\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1249\t0.08GiB\tray::StateAPIGeneratorActor.start\n423\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n868\t0.07GiB\tray::JobSupervisor\n574\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n421\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1109\t0.06GiB\tray::MemoryMonitorActor.run\n1197\t0.06GiB\tray::DashboardTester.run",
+    "num_tasks": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 352.9180225132589
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4.02
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 64.718
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 206.312
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 352.9180225132589,
+    "time": 302.8335192203522,
+    "used_cpus": 250.0
+}

--- a/release/release_logs/2.12.0/benchmarks/many_nodes.json
+++ b/release/release_logs/2.12.0/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 196.95616,
+    "_dashboard_memory_usage_mb": 189.771776,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.63,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.52GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1049\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1249\t0.08GiB\tray::StateAPIGeneratorActor.start\n423\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n868\t0.07GiB\tray::JobSupervisor\n574\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n421\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1109\t0.06GiB\tray::MemoryMonitorActor.run\n1197\t0.06GiB\tray::DashboardTester.run",
+    "_peak_memory": 1.64,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n841\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1104\t0.09GiB\tray::StateAPIGeneratorActor.start\n659\t0.07GiB\tray::JobSupervisor\n423\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n421\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n575\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1052\t0.06GiB\tray::DashboardTester.run\n964\t0.06GiB\tray::MemoryMonitorActor.run",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 352.9180225132589
+            "perf_metric_value": 354.0160266311495
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.02
+            "perf_metric_value": 4.269
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 64.718
+            "perf_metric_value": 61.618
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 206.312
+            "perf_metric_value": 216.1
         }
     ],
     "success": "1",
-    "tasks_per_second": 352.9180225132589,
-    "time": 302.8335192203522,
+    "tasks_per_second": 354.0160266311495,
+    "time": 302.8247308731079,
     "used_cpus": 250.0
 }

--- a/release/release_logs/2.12.0/benchmarks/many_pgs.json
+++ b/release/release_logs/2.12.0/benchmarks/many_pgs.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 130.555904,
+    "_dashboard_test_success": true,
+    "_peak_memory": 2.18,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.93GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n920\t0.42GiB\tpython distributed/test_many_pgs.py\n266\t0.14GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n447\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n739\t0.07GiB\tray::JobSupervisor\n582\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n445\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n980\t0.06GiB\tray::MemoryMonitorActor.run\n1068\t0.05GiB\tray::DashboardTester.run\n365\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
+    "num_pgs": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "pgs_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 23.471191969494587
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.392
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 19.066
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 126.705
+        }
+    ],
+    "pgs_per_second": 23.471191969494587,
+    "success": "1",
+    "time": 42.60542035102844
+}

--- a/release/release_logs/2.12.0/benchmarks/many_pgs.json
+++ b/release/release_logs/2.12.0/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 130.555904,
+    "_dashboard_memory_usage_mb": 161.185792,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.18,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.93GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n920\t0.42GiB\tpython distributed/test_many_pgs.py\n266\t0.14GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n447\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n739\t0.07GiB\tray::JobSupervisor\n582\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n445\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n980\t0.06GiB\tray::MemoryMonitorActor.run\n1068\t0.05GiB\tray::DashboardTester.run\n365\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
+    "_peak_memory": 2.19,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.95GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n803\t0.43GiB\tpython distributed/test_many_pgs.py\n266\t0.13GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n620\t0.07GiB\tray::JobSupervisor\n583\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n878\t0.06GiB\tray::MemoryMonitorActor.run\n951\t0.05GiB\tray::DashboardTester.run\n365\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23.471191969494587
+            "perf_metric_value": 23.144902235160945
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.392
+            "perf_metric_value": 3.32
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 19.066
+            "perf_metric_value": 41.134
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 126.705
+            "perf_metric_value": 548.637
         }
     ],
-    "pgs_per_second": 23.471191969494587,
+    "pgs_per_second": 23.144902235160945,
     "success": "1",
-    "time": 42.60542035102844
+    "time": 43.206058502197266
 }

--- a/release/release_logs/2.12.0/benchmarks/many_tasks.json
+++ b/release/release_logs/2.12.0/benchmarks/many_tasks.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 648.482816,
+    "_dashboard_test_success": true,
+    "_peak_memory": 3.3,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n863\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n266\t0.63GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1127\t0.09GiB\tray::StateAPIGeneratorActor.start\n1073\t0.08GiB\tray::DashboardTester.run\n682\t0.07GiB\tray::JobSupervisor\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n581\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n986\t0.06GiB\tray::MemoryMonitorActor.run",
+    "num_tasks": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 610.9508780114498
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2500.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 7.373
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3552.838
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4635.591
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 610.9508780114498,
+    "time": 316.3679280281067,
+    "used_cpus": 2500.0
+}

--- a/release/release_logs/2.12.0/benchmarks/many_tasks.json
+++ b/release/release_logs/2.12.0/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 648.482816,
+    "_dashboard_memory_usage_mb": 661.430272,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.3,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n863\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n266\t0.63GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1127\t0.09GiB\tray::StateAPIGeneratorActor.start\n1073\t0.08GiB\tray::DashboardTester.run\n682\t0.07GiB\tray::JobSupervisor\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n581\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n986\t0.06GiB\tray::MemoryMonitorActor.run",
+    "_peak_memory": 4.3,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.38GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t1.34GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n802\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1048\t0.08GiB\tray::StateAPIGeneratorActor.start\n996\t0.08GiB\tray::DashboardTester.run\n619\t0.07GiB\tray::JobSupervisor\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n580\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n925\t0.06GiB\tray::MemoryMonitorActor.run",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 610.9508780114498
+            "perf_metric_value": 582.3046176755182
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.373
+            "perf_metric_value": 6.47
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3552.838
+            "perf_metric_value": 16046.576
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4635.591
+            "perf_metric_value": 19529.559
         }
     ],
     "success": "1",
-    "tasks_per_second": 610.9508780114498,
-    "time": 316.3679280281067,
+    "tasks_per_second": 582.3046176755182,
+    "time": 317.1731421947479,
     "used_cpus": 2500.0
 }

--- a/release/release_logs/2.12.0/microbenchmark.json
+++ b/release/release_logs/2.12.0/microbenchmark.json
@@ -1,0 +1,283 @@
+{
+    "1_1_actor_calls_async": [
+        8900.061966026988,
+        191.4180433077194
+    ],
+    "1_1_actor_calls_concurrent": [
+        5205.483996202341,
+        173.5417173511989
+    ],
+    "1_1_actor_calls_sync": [
+        2055.9970223719974,
+        32.46934311676375
+    ],
+    "1_1_async_actor_calls_async": [
+        3088.187256249974,
+        157.72944413924859
+    ],
+    "1_1_async_actor_calls_sync": [
+        1382.8140547973987,
+        35.77823083227874
+    ],
+    "1_1_async_actor_calls_with_args_async": [
+        2411.2175991602116,
+        72.55980393195516
+    ],
+    "1_n_actor_calls_async": [
+        8797.319487481269,
+        227.47595087843297
+    ],
+    "1_n_async_actor_calls_async": [
+        7864.108971520267,
+        109.51908138261717
+    ],
+    "client__1_1_actor_calls_async": [
+        975.7618423482973,
+        11.087963926060809
+    ],
+    "client__1_1_actor_calls_concurrent": [
+        951.1415547703022,
+        30.97241969415422
+    ],
+    "client__1_1_actor_calls_sync": [
+        523.0280053260831,
+        13.17897931512239
+    ],
+    "client__get_calls": [
+        1091.5724282284737,
+        69.90840786431814
+    ],
+    "client__put_calls": [
+        835.8219066517684,
+        18.297778961703113
+    ],
+    "client__put_gigabytes": [
+        0.12235011485110747,
+        0.00021355763704806528
+    ],
+    "client__tasks_and_get_batch": [
+        0.9074349140473464,
+        0.016158057500136384
+    ],
+    "client__tasks_and_put_batch": [
+        10852.4324243012,
+        250.1804762248623
+    ],
+    "multi_client_put_calls_Plasma_Store": [
+        12064.308681826904,
+        139.07331263952662
+    ],
+    "multi_client_put_gigabytes": [
+        39.026311549309554,
+        1.35006350290278
+    ],
+    "multi_client_tasks_async": [
+        21875.105721041346,
+        3133.1136033181197
+    ],
+    "n_n_actor_calls_async": [
+        28165.509673837572,
+        588.1550852646177
+    ],
+    "n_n_actor_calls_with_arg_async": [
+        2846.036342831333,
+        10.402826982801253
+    ],
+    "n_n_async_actor_calls_async": [
+        22971.36788751919,
+        804.2881738869152
+    ],
+    "perf_metrics": [
+        {
+            "perf_metric_name": "single_client_get_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10267.371114566762
+        },
+        {
+            "perf_metric_name": "single_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5222.55884804985
+        },
+        {
+            "perf_metric_name": "multi_client_put_calls_Plasma_Store",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 12064.308681826904
+        },
+        {
+            "perf_metric_name": "single_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 19.613041636801512
+        },
+        {
+            "perf_metric_name": "single_client_tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8.314592004219296
+        },
+        {
+            "perf_metric_name": "multi_client_put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 39.026311549309554
+        },
+        {
+            "perf_metric_name": "single_client_get_object_containing_10k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 13.704970913400441
+        },
+        {
+            "perf_metric_name": "single_client_wait_1k_refs",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5.425389917194363
+        },
+        {
+            "perf_metric_name": "single_client_tasks_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 987.9154572339097
+        },
+        {
+            "perf_metric_name": "single_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8175.996977132117
+        },
+        {
+            "perf_metric_name": "multi_client_tasks_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 21875.105721041346
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2055.9970223719974
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8900.061966026988
+        },
+        {
+            "perf_metric_name": "1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 5205.483996202341
+        },
+        {
+            "perf_metric_name": "1_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 8797.319487481269
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 28165.509673837572
+        },
+        {
+            "perf_metric_name": "n_n_actor_calls_with_arg_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2846.036342831333
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1382.8140547973987
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 3088.187256249974
+        },
+        {
+            "perf_metric_name": "1_1_async_actor_calls_with_args_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2411.2175991602116
+        },
+        {
+            "perf_metric_name": "1_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 7864.108971520267
+        },
+        {
+            "perf_metric_name": "n_n_async_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 22971.36788751919
+        },
+        {
+            "perf_metric_name": "placement_group_create/removal",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 823.8896629199388
+        },
+        {
+            "perf_metric_name": "client__get_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 1091.5724282284737
+        },
+        {
+            "perf_metric_name": "client__put_calls",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 835.8219066517684
+        },
+        {
+            "perf_metric_name": "client__put_gigabytes",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.12235011485110747
+        },
+        {
+            "perf_metric_name": "client__tasks_and_put_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 10852.4324243012
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_sync",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 523.0280053260831
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_async",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 975.7618423482973
+        },
+        {
+            "perf_metric_name": "client__1_1_actor_calls_concurrent",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 951.1415547703022
+        },
+        {
+            "perf_metric_name": "client__tasks_and_get_batch",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 0.9074349140473464
+        }
+    ],
+    "placement_group_create/removal": [
+        823.8896629199388,
+        4.761885065253211
+    ],
+    "single_client_get_calls_Plasma_Store": [
+        10267.371114566762,
+        191.11363178041842
+    ],
+    "single_client_get_object_containing_10k_refs": [
+        13.704970913400441,
+        0.21627867671473214
+    ],
+    "single_client_put_calls_Plasma_Store": [
+        5222.55884804985,
+        63.080948992722945
+    ],
+    "single_client_put_gigabytes": [
+        19.613041636801512,
+        5.889826198850045
+    ],
+    "single_client_tasks_and_get_batch": [
+        8.314592004219296,
+        0.5014911979126326
+    ],
+    "single_client_tasks_async": [
+        8175.996977132117,
+        382.29858495516817
+    ],
+    "single_client_tasks_sync": [
+        987.9154572339097,
+        17.454435936288203
+    ],
+    "single_client_wait_1k_refs": [
+        5.425389917194363,
+        0.07281873009527651
+    ]
+}

--- a/release/release_logs/2.12.0/microbenchmark.json
+++ b/release/release_logs/2.12.0/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8900.061966026988,
-        191.4180433077194
+        8748.782799582932,
+        449.59513200569006
     ],
     "1_1_actor_calls_concurrent": [
-        5205.483996202341,
-        173.5417173511989
+        5331.946019829083,
+        320.4211302536989
     ],
     "1_1_actor_calls_sync": [
-        2055.9970223719974,
-        32.46934311676375
+        2112.7552826069455,
+        46.25947531390158
     ],
     "1_1_async_actor_calls_async": [
-        3088.187256249974,
-        157.72944413924859
+        3157.5281810012384,
+        98.22863116371259
     ],
     "1_1_async_actor_calls_sync": [
-        1382.8140547973987,
-        35.77823083227874
+        1341.7887372798139,
+        33.331756055952816
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2411.2175991602116,
-        72.55980393195516
+        2396.8963139443463,
+        166.4832755226004
     ],
     "1_n_actor_calls_async": [
-        8797.319487481269,
-        227.47595087843297
+        8558.218903786727,
+        335.2325317020745
     ],
     "1_n_async_actor_calls_async": [
-        7864.108971520267,
-        109.51908138261717
+        7701.7490843523765,
+        176.85412311709294
     ],
     "client__1_1_actor_calls_async": [
-        975.7618423482973,
-        11.087963926060809
+        981.3101489962544,
+        8.160759667016155
     ],
     "client__1_1_actor_calls_concurrent": [
-        951.1415547703022,
-        30.97241969415422
+        984.0363561016015,
+        6.700051344968874
     ],
     "client__1_1_actor_calls_sync": [
-        523.0280053260831,
-        13.17897931512239
+        501.2526439748014,
+        14.927831504721782
     ],
     "client__get_calls": [
-        1091.5724282284737,
-        69.90840786431814
+        984.7185148948039,
+        11.898184447451703
     ],
     "client__put_calls": [
-        835.8219066517684,
-        18.297778961703113
+        770.4735069321608,
+        4.4204997632223
     ],
     "client__put_gigabytes": [
-        0.12235011485110747,
-        0.00021355763704806528
+        0.13182480311203987,
+        0.0006594286871265931
     ],
     "client__tasks_and_get_batch": [
-        0.9074349140473464,
-        0.016158057500136384
+        0.8871100522697384,
+        0.04711087542591399
     ],
     "client__tasks_and_put_batch": [
-        10852.4324243012,
-        250.1804762248623
+        11400.628951457615,
+        96.6749337855913
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12064.308681826904,
-        139.07331263952662
+        12482.424327497527,
+        45.18434404588863
     ],
     "multi_client_put_gigabytes": [
-        39.026311549309554,
-        1.35006350290278
+        37.47472636769277,
+        3.1727284949980272
     ],
     "multi_client_tasks_async": [
-        21875.105721041346,
-        3133.1136033181197
+        22358.519928771202,
+        1160.752978756044
     ],
     "n_n_actor_calls_async": [
-        28165.509673837572,
-        588.1550852646177
+        27206.931303151337,
+        811.7575581183337
     ],
     "n_n_actor_calls_with_arg_async": [
-        2846.036342831333,
-        10.402826982801253
+        2669.9811846586795,
+        42.58209737763422
     ],
     "n_n_async_actor_calls_async": [
-        22971.36788751919,
-        804.2881738869152
+        23379.05090260775,
+        628.9522529769743
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10267.371114566762
+            "perf_metric_value": 10268.613528553546
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5222.55884804985
+            "perf_metric_value": 5141.775101569989
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12064.308681826904
+            "perf_metric_value": 12482.424327497527
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.613041636801512
+            "perf_metric_value": 18.683362618370772
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8.314592004219296
+            "perf_metric_value": 7.778792239134901
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 39.026311549309554
+            "perf_metric_value": 37.47472636769277
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.704970913400441
+            "perf_metric_value": 12.632060871624994
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.425389917194363
+            "perf_metric_value": 5.3499932380060775
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 987.9154572339097
+            "perf_metric_value": 965.8386012454489
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8175.996977132117
+            "perf_metric_value": 7993.559119696471
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21875.105721041346
+            "perf_metric_value": 22358.519928771202
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2055.9970223719974
+            "perf_metric_value": 2112.7552826069455
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8900.061966026988
+            "perf_metric_value": 8748.782799582932
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5205.483996202341
+            "perf_metric_value": 5331.946019829083
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8797.319487481269
+            "perf_metric_value": 8558.218903786727
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 28165.509673837572
+            "perf_metric_value": 27206.931303151337
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2846.036342831333
+            "perf_metric_value": 2669.9811846586795
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1382.8140547973987
+            "perf_metric_value": 1341.7887372798139
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3088.187256249974
+            "perf_metric_value": 3157.5281810012384
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2411.2175991602116
+            "perf_metric_value": 2396.8963139443463
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7864.108971520267
+            "perf_metric_value": 7701.7490843523765
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22971.36788751919
+            "perf_metric_value": 23379.05090260775
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 823.8896629199388
+            "perf_metric_value": 783.3481516266015
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1091.5724282284737
+            "perf_metric_value": 984.7185148948039
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 835.8219066517684
+            "perf_metric_value": 770.4735069321608
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.12235011485110747
+            "perf_metric_value": 0.13182480311203987
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10852.4324243012
+            "perf_metric_value": 11400.628951457615
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 523.0280053260831
+            "perf_metric_value": 501.2526439748014
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 975.7618423482973
+            "perf_metric_value": 981.3101489962544
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 951.1415547703022
+            "perf_metric_value": 984.0363561016015
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9074349140473464
+            "perf_metric_value": 0.8871100522697384
         }
     ],
     "placement_group_create/removal": [
-        823.8896629199388,
-        4.761885065253211
+        783.3481516266015,
+        12.378304647779888
     ],
     "single_client_get_calls_Plasma_Store": [
-        10267.371114566762,
-        191.11363178041842
+        10268.613528553546,
+        127.98875390202711
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.704970913400441,
-        0.21627867671473214
+        12.632060871624994,
+        0.19375733386575253
     ],
     "single_client_put_calls_Plasma_Store": [
-        5222.55884804985,
-        63.080948992722945
+        5141.775101569989,
+        39.65439583305001
     ],
     "single_client_put_gigabytes": [
-        19.613041636801512,
-        5.889826198850045
+        18.683362618370772,
+        3.887359132974222
     ],
     "single_client_tasks_and_get_batch": [
-        8.314592004219296,
-        0.5014911979126326
+        7.778792239134901,
+        0.3755120187621276
     ],
     "single_client_tasks_async": [
-        8175.996977132117,
-        382.29858495516817
+        7993.559119696471,
+        462.97661002454305
     ],
     "single_client_tasks_sync": [
-        987.9154572339097,
-        17.454435936288203
+        965.8386012454489,
+        10.246016544080797
     ],
     "single_client_wait_1k_refs": [
-        5.425389917194363,
-        0.07281873009527651
+        5.3499932380060775,
+        0.15990522801591003
     ]
 }

--- a/release/release_logs/2.12.0/scalability/object_store.json
+++ b/release/release_logs/2.12.0/scalability/object_store.json
@@ -1,0 +1,13 @@
+{
+    "broadcast_time": 16.808720801999982,
+    "num_nodes": 50,
+    "object_size": 1073741824,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 16.808720801999982
+        }
+    ],
+    "success": "1"
+}

--- a/release/release_logs/2.12.0/scalability/object_store.json
+++ b/release/release_logs/2.12.0/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 16.808720801999982,
+    "broadcast_time": 17.34891581100004,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.808720801999982
+            "perf_metric_value": 17.34891581100004
         }
     ],
     "success": "1"

--- a/release/release_logs/2.12.0/scalability/single_node.json
+++ b/release/release_logs/2.12.0/scalability/single_node.json
@@ -1,0 +1,40 @@
+{
+    "args_time": 17.686509897000008,
+    "get_time": 22.577659229999995,
+    "large_object_size": 107374182400,
+    "large_object_time": 29.17789060800004,
+    "num_args": 10000,
+    "num_get_args": 10000,
+    "num_queued": 1000000,
+    "num_returns": 3000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "10000_args_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 17.686509897000008
+        },
+        {
+            "perf_metric_name": "3000_returns_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 5.479904671000014
+        },
+        {
+            "perf_metric_name": "10000_get_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 22.577659229999995
+        },
+        {
+            "perf_metric_name": "1000000_queued_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 197.709131292
+        },
+        {
+            "perf_metric_name": "107374182400_large_object_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 29.17789060800004
+        }
+    ],
+    "queued_time": 197.709131292,
+    "returns_time": 5.479904671000014,
+    "success": "1"
+}

--- a/release/release_logs/2.12.0/scalability/single_node.json
+++ b/release/release_logs/2.12.0/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.686509897000008,
-    "get_time": 22.577659229999995,
+    "args_time": 17.267912976999995,
+    "get_time": 23.659871710999994,
     "large_object_size": 107374182400,
-    "large_object_time": 29.17789060800004,
+    "large_object_time": 30.37595573499999,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.686509897000008
+            "perf_metric_value": 17.267912976999995
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.479904671000014
+            "perf_metric_value": 5.660801429999992
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 22.577659229999995
+            "perf_metric_value": 23.659871710999994
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 197.709131292
+            "perf_metric_value": 190.11494678399998
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.17789060800004
+            "perf_metric_value": 30.37595573499999
         }
     ],
-    "queued_time": 197.709131292,
-    "returns_time": 5.479904671000014,
+    "queued_time": 190.11494678399998,
+    "returns_time": 5.660801429999992,
     "success": "1"
 }

--- a/release/release_logs/2.12.0/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.12.0/stress_tests/stress_test_dead_actors.json
@@ -1,0 +1,14 @@
+{
+    "avg_iteration_time": 1.558222110271454,
+    "max_iteration_time": 4.02335262298584,
+    "min_iteration_time": 0.6896142959594727,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 1.558222110271454
+        }
+    ],
+    "success": 1,
+    "total_time": 155.82245659828186
+}

--- a/release/release_logs/2.12.0/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.12.0/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.558222110271454,
-    "max_iteration_time": 4.02335262298584,
-    "min_iteration_time": 0.6896142959594727,
+    "avg_iteration_time": 1.4939605140686034,
+    "max_iteration_time": 9.932291746139526,
+    "min_iteration_time": 0.734281063079834,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.558222110271454
+            "perf_metric_value": 1.4939605140686034
         }
     ],
     "success": 1,
-    "total_time": 155.82245659828186
+    "total_time": 149.39628982543945
 }

--- a/release/release_logs/2.12.0/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.12.0/stress_tests/stress_test_many_tasks.json
@@ -1,0 +1,47 @@
+{
+    "perf_metrics": [
+        {
+            "perf_metric_name": "stage_0_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 10.757715463638306
+        },
+        {
+            "perf_metric_name": "stage_1_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 26.485081911087036
+        },
+        {
+            "perf_metric_name": "stage_2_avg_iteration_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 73.74742498397828
+        },
+        {
+            "perf_metric_name": "stage_3_creation_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2.1788923740386963
+        },
+        {
+            "perf_metric_name": "stage_3_time",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3260.191632270813
+        },
+        {
+            "perf_metric_name": "stage_4_spread",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.5319111031781492
+        }
+    ],
+    "stage_0_time": 10.757715463638306,
+    "stage_1_avg_iteration_time": 26.485081911087036,
+    "stage_1_max_iteration_time": 27.32317543029785,
+    "stage_1_min_iteration_time": 25.39231824874878,
+    "stage_1_time": 264.85090589523315,
+    "stage_2_avg_iteration_time": 73.74742498397828,
+    "stage_2_max_iteration_time": 122.96685600280762,
+    "stage_2_min_iteration_time": 60.89244818687439,
+    "stage_2_time": 368.73850870132446,
+    "stage_3_creation_time": 2.1788923740386963,
+    "stage_3_time": 3260.191632270813,
+    "stage_4_spread": 0.5319111031781492,
+    "success": 1
+}

--- a/release/release_logs/2.12.0/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.12.0/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.757715463638306
+            "perf_metric_value": 11.408677577972412
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 26.485081911087036
+            "perf_metric_value": 25.58948016166687
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 73.74742498397828
+            "perf_metric_value": 55.788888931274414
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.1788923740386963
+            "perf_metric_value": 1.8818552494049072
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3260.191632270813
+            "perf_metric_value": 3097.411286830902
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.5319111031781492
+            "perf_metric_value": 0.460180997609973
         }
     ],
-    "stage_0_time": 10.757715463638306,
-    "stage_1_avg_iteration_time": 26.485081911087036,
-    "stage_1_max_iteration_time": 27.32317543029785,
-    "stage_1_min_iteration_time": 25.39231824874878,
-    "stage_1_time": 264.85090589523315,
-    "stage_2_avg_iteration_time": 73.74742498397828,
-    "stage_2_max_iteration_time": 122.96685600280762,
-    "stage_2_min_iteration_time": 60.89244818687439,
-    "stage_2_time": 368.73850870132446,
-    "stage_3_creation_time": 2.1788923740386963,
-    "stage_3_time": 3260.191632270813,
-    "stage_4_spread": 0.5319111031781492,
+    "stage_0_time": 11.408677577972412,
+    "stage_1_avg_iteration_time": 25.58948016166687,
+    "stage_1_max_iteration_time": 27.471096992492676,
+    "stage_1_min_iteration_time": 24.81654191017151,
+    "stage_1_time": 255.89490818977356,
+    "stage_2_avg_iteration_time": 55.788888931274414,
+    "stage_2_max_iteration_time": 57.43562126159668,
+    "stage_2_min_iteration_time": 54.45973491668701,
+    "stage_2_time": 278.94584822654724,
+    "stage_3_creation_time": 1.8818552494049072,
+    "stage_3_time": 3097.411286830902,
+    "stage_4_spread": 0.460180997609973,
     "success": 1
 }

--- a/release/release_logs/2.12.0/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.12.0/stress_tests/stress_test_placement_group.json
@@ -1,0 +1,17 @@
+{
+    "avg_pg_create_time_ms": 0.8821673768768409,
+    "avg_pg_remove_time_ms": 0.9274617132122331,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "avg_pg_create_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.8821673768768409
+        },
+        {
+            "perf_metric_name": "avg_pg_remove_time_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 0.9274617132122331
+        }
+    ],
+    "success": 1
+}

--- a/release/release_logs/2.12.0/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.12.0/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.8821673768768409,
-    "avg_pg_remove_time_ms": 0.9274617132122331,
+    "avg_pg_create_time_ms": 0.897374594595741,
+    "avg_pg_remove_time_ms": 0.9239566561552727,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.8821673768768409
+            "perf_metric_value": 0.897374594595741
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9274617132122331
+            "perf_metric_value": 0.9239566561552727
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 9.79%: client__get_calls (THROUGHPUT) regresses from 1091.5724282284737 to 984.7185148948039 (9.79%) in 2.20.0/microbenchmark.json
REGRESSION 7.83%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.704970913400441 to 12.632060871624994 (7.83%) in 2.20.0/microbenchmark.json
REGRESSION 7.82%: client__put_calls (THROUGHPUT) regresses from 835.8219066517684 to 770.4735069321608 (7.82%) in 2.20.0/microbenchmark.json
REGRESSION 6.44%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 8.314592004219296 to 7.778792239134901 (6.44%) in 2.20.0/microbenchmark.json
REGRESSION 6.19%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2846.036342831333 to 2669.9811846586795 (6.19%) in 2.20.0/microbenchmark.json
REGRESSION 4.92%: placement_group_create/removal (THROUGHPUT) regresses from 823.8896629199388 to 783.3481516266015 (4.92%) in 2.20.0/microbenchmark.json
REGRESSION 4.74%: single_client_put_gigabytes (THROUGHPUT) regresses from 19.613041636801512 to 18.683362618370772 (4.74%) in 2.20.0/microbenchmark.json
REGRESSION 4.69%: tasks_per_second (THROUGHPUT) regresses from 610.9508780114498 to 582.3046176755182 (4.69%) in 2.20.0/benchmarks/many_tasks.json
REGRESSION 4.16%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 523.0280053260831 to 501.2526439748014 (4.16%) in 2.20.0/microbenchmark.json
REGRESSION 3.98%: multi_client_put_gigabytes (THROUGHPUT) regresses from 39.026311549309554 to 37.47472636769277 (3.98%) in 2.20.0/microbenchmark.json
REGRESSION 3.40%: n_n_actor_calls_async (THROUGHPUT) regresses from 28165.509673837572 to 27206.931303151337 (3.40%) in 2.20.0/microbenchmark.json
REGRESSION 2.97%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1382.8140547973987 to 1341.7887372798139 (2.97%) in 2.20.0/microbenchmark.json
REGRESSION 2.72%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8797.319487481269 to 8558.218903786727 (2.72%) in 2.20.0/microbenchmark.json
REGRESSION 2.58%: actors_per_second (THROUGHPUT) regresses from 653.272142233422 to 636.4202043276684 (2.58%) in 2.20.0/benchmarks/many_actors.json
REGRESSION 2.24%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9074349140473464 to 0.8871100522697384 (2.24%) in 2.20.0/microbenchmark.json
REGRESSION 2.23%: single_client_tasks_sync (THROUGHPUT) regresses from 987.9154572339097 to 965.8386012454489 (2.23%) in 2.20.0/microbenchmark.json
REGRESSION 2.23%: single_client_tasks_async (THROUGHPUT) regresses from 8175.996977132117 to 7993.559119696471 (2.23%) in 2.20.0/microbenchmark.json
REGRESSION 2.06%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7864.108971520267 to 7701.7490843523765 (2.06%) in 2.20.0/microbenchmark.json
REGRESSION 1.70%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8900.061966026988 to 8748.782799582932 (1.70%) in 2.20.0/microbenchmark.json
REGRESSION 1.55%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5222.55884804985 to 5141.775101569989 (1.55%) in 2.20.0/microbenchmark.json
REGRESSION 1.39%: pgs_per_second (THROUGHPUT) regresses from 23.471191969494587 to 23.144902235160945 (1.39%) in 2.20.0/benchmarks/many_pgs.json
REGRESSION 1.39%: single_client_wait_1k_refs (THROUGHPUT) regresses from 5.425389917194363 to 5.3499932380060775 (1.39%) in 2.20.0/microbenchmark.json
REGRESSION 0.59%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2411.2175991602116 to 2396.8963139443463 (0.59%) in 2.20.0/microbenchmark.json
REGRESSION 351.66%: dashboard_p95_latency_ms (LATENCY) regresses from 3552.838 to 16046.576 (351.66%) in 2.20.0/benchmarks/many_tasks.json
REGRESSION 333.00%: dashboard_p99_latency_ms (LATENCY) regresses from 126.705 to 548.637 (333.00%) in 2.20.0/benchmarks/many_pgs.json
REGRESSION 321.30%: dashboard_p99_latency_ms (LATENCY) regresses from 4635.591 to 19529.559 (321.30%) in 2.20.0/benchmarks/many_tasks.json
REGRESSION 115.75%: dashboard_p95_latency_ms (LATENCY) regresses from 19.066 to 41.134 (115.75%) in 2.20.0/benchmarks/many_pgs.json
REGRESSION 42.54%: dashboard_p99_latency_ms (LATENCY) regresses from 3787.161 to 5398.368 (42.54%) in 2.20.0/benchmarks/many_actors.json
REGRESSION 21.21%: dashboard_p95_latency_ms (LATENCY) regresses from 2575.396 to 3121.637 (21.21%) in 2.20.0/benchmarks/many_actors.json
REGRESSION 6.19%: dashboard_p50_latency_ms (LATENCY) regresses from 4.02 to 4.269 (6.19%) in 2.20.0/benchmarks/many_nodes.json
REGRESSION 6.05%: stage_0_time (LATENCY) regresses from 10.757715463638306 to 11.408677577972412 (6.05%) in 2.20.0/stress_tests/stress_test_many_tasks.json
REGRESSION 4.79%: 10000_get_time (LATENCY) regresses from 22.577659229999995 to 23.659871710999994 (4.79%) in 2.20.0/scalability/single_node.json
REGRESSION 4.74%: dashboard_p99_latency_ms (LATENCY) regresses from 206.312 to 216.1 (4.74%) in 2.20.0/benchmarks/many_nodes.json
REGRESSION 4.11%: 107374182400_large_object_time (LATENCY) regresses from 29.17789060800004 to 30.37595573499999 (4.11%) in 2.20.0/scalability/single_node.json
REGRESSION 3.30%: 3000_returns_time (LATENCY) regresses from 5.479904671000014 to 5.660801429999992 (3.30%) in 2.20.0/scalability/single_node.json
REGRESSION 3.21%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 16.808720801999982 to 17.34891581100004 (3.21%) in 2.20.0/scalability/object_store.json
REGRESSION 1.72%: avg_pg_create_time_ms (LATENCY) regresses from 0.8821673768768409 to 0.897374594595741 (1.72%) in 2.20.0/stress_tests/stress_test_placement_group.json
```