### PR TITLE
[Dashboard] Fix the filtering of the `job_id` in getTasks.

### DIFF
--- a/dashboard/client/src/service/task.ts
+++ b/dashboard/client/src/service/task.ts
@@ -5,7 +5,7 @@ import { get } from "./requestHandlers";
 export const getTasks = (jobId: string | undefined) => {
   let url = "api/v0/tasks?detail=1&limit=10000";
   if (jobId) {
-    url += `&job_id=${jobId}`;
+    url += `&filter_keys=job_id&filter_predicates=%3D&filter_values=${jobId}`;
   }
   return get<StateApiResponse<Task>>(url);
 };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The current method of passing the `job_id` while retrieving task information in the dashboard appears to be ineffective, resulting in fetching all task information every time, instead of the tasks associated with a specific job. 

The proposed fix will improve the performance of the dashboard.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
