### PR TITLE
[GCS] Add `total_resources` to reduce communication overhead for aggregating alive resources

### DIFF
--- a/python/ray/_private/gcs_utils.py
+++ b/python/ray/_private/gcs_utils.py
@@ -9,6 +9,7 @@ from ray.core.generated.common_pb2 import ErrorType, JobConfig
 from ray.core.generated.gcs_pb2 import (
     ActorTableData,
     AvailableResources,
+    TotalResources,
     ErrorTableData,
     GcsEntry,
     GcsNodeInfo,
@@ -32,6 +33,7 @@ __all__ = [
     "ActorTableData",
     "GcsNodeInfo",
     "AvailableResources",
+    "TotalResources",
     "JobTableData",
     "JobConfig",
     "ErrorTableData",

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -741,7 +741,7 @@ class GlobalState:
 
     def _live_node_ids(self):
         """Returns a set of node IDs corresponding to nodes still alive."""
-        return {node_id for node_id in self.total_resources_per_node().keys()}
+        return set(self.total_resources_per_node().keys())
 
     def available_resources_per_node(self):
         """Returns a dictionary mapping node id to avaiable resources."""

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -1023,6 +1023,7 @@ def available_resources_per_node():
 
     return state.available_resources_per_node()
 
+
 @DeveloperAPI
 def total_resources_per_node():
     """Get the current total resources of each live node.

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -1023,6 +1023,18 @@ def available_resources_per_node():
 
     return state.available_resources_per_node()
 
+@DeveloperAPI
+def total_resources_per_node():
+    """Get the current total resources of each live node.
+
+    Note that this information can grow stale as tasks start and finish.
+
+    Returns:
+        A dictionary mapping node hex id to total resources dictionary.
+    """
+
+    return state.total_resources_per_node()
+
 
 def update_worker_debugger_port(worker_id, debugger_port):
     """Update the debugger port of a worker.

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -763,7 +763,8 @@ class GlobalState:
 
         return available_resources_by_id
 
-    def total_resources_per_node(self):
+    # returns a dict that maps node_id(hex string) to a dict of {resource_id: capacity}
+    def total_resources_per_node(self) -> Dict[str, Dict[str, int]]:
         self._check_connected()
         total_resources_by_node = {}
 

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -347,8 +347,7 @@ class Cluster:
         """
         start_time = time.time()
         while time.time() - start_time < timeout:
-            clients = self.global_state.node_table()
-            live_clients = [client for client in clients if client["Alive"]]
+            live_clients = self.global_state._live_node_ids()
 
             expected = len(self.list_all_nodes())
             if len(live_clients) == expected:

--- a/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
@@ -815,14 +815,13 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
 
 
 def _get_num_cpus_per_node_map() -> Dict[str, int]:
-    nodes = ray.nodes()
+    total_resources_by_node = ray.state.total_resources_per_node()
     # Map from per-node resource name to number of CPUs available on that
     # node.
     num_cpus_per_node_map = {}
-    for node in nodes:
-        resources = node["Resources"]
+    for node_id, resources in total_resources_by_node.items():
         num_cpus = int(resources.get("CPU", 0))
         if num_cpus == 0:
             continue
-        num_cpus_per_node_map[node["NodeID"]] = num_cpus
+        num_cpus_per_node_map[node_id] = num_cpus
     return num_cpus_per_node_map

--- a/python/ray/includes/global_state_accessor.pxd
+++ b/python/ray/includes/global_state_accessor.pxd
@@ -33,6 +33,7 @@ cdef extern from "ray/gcs/gcs_client/global_state_accessor.h" nogil:
         CJobID GetNextJobID()
         c_vector[c_string] GetAllNodeInfo()
         c_vector[c_string] GetAllAvailableResources()
+        c_vector[c_string] GetAllTotalResources()
         unordered_map[CNodeID, c_int64_t] GetDrainingNodes()
         c_vector[c_string] GetAllTaskEvents()
         unique_ptr[c_string] GetObjectInfo(const CObjectID &object_id)

--- a/python/ray/includes/global_state_accessor.pxi
+++ b/python/ray/includes/global_state_accessor.pxi
@@ -124,6 +124,12 @@ cdef class GlobalStateAccessor:
             result = self.inner.get().GetAllAvailableResources()
         return result
 
+    def get_all_total_resources(self):
+        cdef c_vector[c_string] result
+        with nogil:
+            result = self.inner.get().GetAllTotalResources()
+        return result
+
     def get_task_events(self):
         cdef c_vector[c_string] result
         with nogil:

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -70,8 +70,9 @@ def test_available_resources_per_node(ray_start_cluster_head):
         assert available_resources_per_node[head_node_id]["CPU"] == 1
         assert available_resources_per_node[worker_node_id]["CPU"] == 2
         assert available_resources_per_node[worker_node_id].get("worker", 0) == 0
+        return True
 
-    wait_for_condition(lambda: available_resources_per_node_check1)
+    wait_for_condition(available_resources_per_node_check1)
 
     cluster.remove_node(worker_node)
     cluster.wait_for_nodes()
@@ -81,8 +82,9 @@ def test_available_resources_per_node(ray_start_cluster_head):
         available_resources_per_node = ray._private.state.available_resources_per_node()
         assert len(available_resources_per_node) == 1
         assert available_resources_per_node[head_node_id]["CPU"] == 1
+        return True
 
-    wait_for_condition(lambda: available_resources_per_node_check2)
+    wait_for_condition(available_resources_per_node_check2)
 
 
 def test_total_resources_per_node(ray_start_cluster_head):
@@ -110,8 +112,9 @@ def test_total_resources_per_node(ray_start_cluster_head):
         assert total_resources_per_node[head_node_id]["CPU"] == 1
         assert total_resources_per_node[worker_node_id]["CPU"] == 3
         assert total_resources_per_node[worker_node_id].get("worker", 0) == 1
+        return True
 
-    wait_for_condition(lambda: total_resources_per_node_check1)
+    wait_for_condition(total_resources_per_node_check1)
 
     cluster.remove_node(worker_node)
     cluster.wait_for_nodes()
@@ -121,8 +124,9 @@ def test_total_resources_per_node(ray_start_cluster_head):
         total_resources_per_node = ray._private.state.total_resources_per_node()
         assert len(total_resources_per_node) == 1
         assert total_resources_per_node[head_node_id]["CPU"] == 1
+        return True
 
-    wait_for_condition(lambda: total_resources_per_node_check2)
+    wait_for_condition(total_resources_per_node_check2)
 
 
 def test_add_remove_cluster_resources(ray_start_cluster_head):

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -85,6 +85,46 @@ def test_available_resources_per_node(ray_start_cluster_head):
     wait_for_condition(lambda: available_resources_per_node_check2)
 
 
+def test_total_resources_per_node(ray_start_cluster_head):
+    cluster = ray_start_cluster_head
+
+    @ray.remote
+    def get_node_id():
+        return ray.get_runtime_context().get_node_id()
+
+    head_node_id = ray.get(get_node_id.remote())
+
+    worker_node = cluster.add_node(num_cpus=3, resources={"worker": 1})
+
+    @ray.remote(num_cpus=1, resources={"worker": 1})
+    class Actor:
+        def ping(self):
+            return ray.get_runtime_context().get_node_id()
+
+    actor = Actor.remote()
+    worker_node_id = ray.get(actor.ping.remote())
+
+    def total_resources_per_node_check1():
+        total_resources_per_node = ray._private.state.total_resources_per_node()
+        assert len(total_resources_per_node) == 2
+        assert total_resources_per_node[head_node_id]["CPU"] == 1
+        assert total_resources_per_node[worker_node_id]["CPU"] == 3
+        assert total_resources_per_node[worker_node_id].get("worker", 0) == 1
+
+    wait_for_condition(lambda: total_resources_per_node_check1)
+
+    cluster.remove_node(worker_node)
+    cluster.wait_for_nodes()
+
+    def total_resources_per_node_check2():
+        # Make sure worker node is not returned
+        total_resources_per_node = ray._private.state.total_resources_per_node()
+        assert len(total_resources_per_node) == 1
+        assert total_resources_per_node[head_node_id]["CPU"] == 1
+
+    wait_for_condition(lambda: total_resources_per_node_check2)
+
+
 def test_add_remove_cluster_resources(ray_start_cluster_head):
     """Tests that Global State API is consistent with actual cluster."""
     cluster = ray_start_cluster_head

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -737,6 +737,19 @@ Status NodeResourceInfoAccessor::AsyncGetAllAvailableResources(
   return Status::OK();
 }
 
+Status NodeResourceInfoAccessor::AsyncGetAllTotalResources(
+    const MultiItemCallback<rpc::TotalResources> &callback) {
+  rpc::GetAllTotalResourcesRequest request;
+  client_impl_->GetGcsRpcClient().GetAllTotalResources(
+      request,
+      [callback](const Status &status, const rpc::GetAllTotalResourcesReply &reply) {
+        callback(status, VectorFromProtobuf(reply.resources_list()));
+        RAY_LOG(DEBUG) << "Finished getting total resources of all nodes, status = "
+                       << status;
+      });
+  return Status::OK();
+}
+
 Status NodeResourceInfoAccessor::AsyncGetDrainingNodes(
     const ItemCallback<std::unordered_map<NodeID, int64_t>> &callback) {
   rpc::GetDrainingNodesRequest request;

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -459,6 +459,13 @@ class NodeResourceInfoAccessor {
   virtual Status AsyncGetAllAvailableResources(
       const MultiItemCallback<rpc::AvailableResources> &callback);
 
+  /// Get total resources of all nodes from GCS asynchronously.
+  ///
+  /// \param callback Callback that will be called after lookup finishes.
+  /// \return Status
+  virtual Status AsyncGetAllTotalResources(
+      const MultiItemCallback<rpc::TotalResources> &callback);
+
   /// Get draining nodes from GCS asynchronously.
   ///
   /// \param callback Callback that will be called after lookup finishes.

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -118,6 +118,19 @@ std::vector<std::string> GlobalStateAccessor::GetAllAvailableResources() {
   return available_resources;
 }
 
+std::vector<std::string> GlobalStateAccessor::GetAllTotalResources() {
+  std::vector<std::string> total_resources;
+  std::promise<bool> promise;
+  {
+    absl::ReaderMutexLock lock(&mutex_);
+    RAY_CHECK_OK(gcs_client_->NodeResources().AsyncGetAllTotalResources(
+        TransformForMultiItemCallback<rpc::TotalResources>(total_resources,
+                                                               promise)));
+  }
+  promise.get_future().get();
+  return total_resources;
+}
+
 std::unordered_map<NodeID, int64_t> GlobalStateAccessor::GetDrainingNodes() {
   std::promise<std::unordered_map<NodeID, int64_t>> promise;
   {

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -124,8 +124,7 @@ std::vector<std::string> GlobalStateAccessor::GetAllTotalResources() {
   {
     absl::ReaderMutexLock lock(&mutex_);
     RAY_CHECK_OK(gcs_client_->NodeResources().AsyncGetAllTotalResources(
-        TransformForMultiItemCallback<rpc::TotalResources>(total_resources,
-                                                               promise)));
+        TransformForMultiItemCallback<rpc::TotalResources>(total_resources, promise)));
   }
   promise.get_future().get();
   return total_resources;

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -73,6 +73,14 @@ class GlobalStateAccessor {
   /// deserialized with protobuf function.
   std::vector<std::string> GetAllAvailableResources() ABSL_LOCKS_EXCLUDED(mutex_);
 
+  /// Get total resources of all nodes.
+  ///
+  /// \return total resources of all nodes. To support multi-language, we serialize
+  /// each TotalResources and return the serialized string. Where used, it needs to be
+  /// deserialized with protobuf function.
+  std::vector<std::string> GetAllTotalResources() ABSL_LOCKS_EXCLUDED(mutex_);
+
+
   /// Get draining nodes.
   ///
   /// \return Draining node id to draining deadline.

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -80,7 +80,6 @@ class GlobalStateAccessor {
   /// deserialized with protobuf function.
   std::vector<std::string> GetAllTotalResources() ABSL_LOCKS_EXCLUDED(mutex_);
 
-
   /// Get draining nodes.
   ///
   /// \return Draining node id to draining deadline.

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -188,7 +188,8 @@ TEST_P(GlobalStateAccessorTest, TestGetAllTotalResources) {
 
   // Assert get total resources right.
   std::vector<rpc::TotalResources> all_total_resources;
-  for(const auto &string_of_total_resources_by_node_id : global_state_->GetAllTotalResources()){
+  for (const auto &string_of_total_resources_by_node_id :
+       global_state_->GetAllTotalResources()) {
     rpc::TotalResources total_resources_by_node_id;
     total_resources_by_node_id.ParseFromString(string_of_total_resources_by_node_id);
     all_total_resources.push_back(total_resources_by_node_id);

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -172,6 +172,33 @@ TEST_P(GlobalStateAccessorTest, TestNodeTable) {
   }
 }
 
+TEST_P(GlobalStateAccessorTest, TestGetAllTotalResources) {
+  ASSERT_EQ(global_state_->GetAllTotalResources().size(), 0);
+
+  // Register node
+  auto node_table_data = Mocker::GenNodeInfo();
+  node_table_data->mutable_resources_total()->insert({"CPU", 1});
+  node_table_data->mutable_resources_total()->insert({"GPU", 10});
+
+  std::promise<bool> promise;
+  RAY_CHECK_OK(gcs_client_->Nodes().AsyncRegister(
+      *node_table_data, [&promise](Status status) { promise.set_value(status.ok()); }));
+  WaitReady(promise.get_future(), timeout_ms_);
+  ASSERT_EQ(global_state_->GetAllNodeInfo().size(), 1);
+
+  // Assert get total resources right.
+  std::vector<rpc::TotalResources> all_total_resources;
+  for(const auto &string_of_total_resources_by_node_id : global_state_->GetAllTotalResources()){
+    rpc::TotalResources total_resources_by_node_id;
+    total_resources_by_node_id.ParseFromString(string_of_total_resources_by_node_id);
+    all_total_resources.push_back(total_resources_by_node_id);
+  }
+  ASSERT_EQ(all_total_resources.size(), 1);
+  ASSERT_EQ(all_total_resources[0].resources_total_size(), 2);
+  ASSERT_EQ((*all_total_resources[0].mutable_resources_total())["CPU"], 1.0);
+  ASSERT_EQ((*all_total_resources[0].mutable_resources_total())["GPU"], 10.0);
+}
+
 TEST_P(GlobalStateAccessorTest, TestGetAllResourceUsage) {
   std::unique_ptr<std::string> resources = global_state_->GetAllResourceUsage();
   rpc::ResourceUsageBatchData resource_usage_batch_data;

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -79,6 +79,13 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
       rpc::GetAllAvailableResourcesReply *reply,
       rpc::SendReplyCallback send_reply_callback) override;
 
+  /// Handle get total resources of all nodes.
+  /// Autoscaler-specific RPC called from Python.
+  void HandleGetAllTotalResources(
+      rpc::GetAllTotalResourcesRequest request,
+      rpc::GetAllTotalResourcesReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override;
+
   /// Handle get ids of draining nodes.
   /// Autoscaler-specific RPC called from Python.
   void HandleGetDrainingNodes(rpc::GetDrainingNodesRequest request,
@@ -185,7 +192,8 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
     GET_ALL_AVAILABLE_RESOURCES_REQUEST = 1,
     REPORT_RESOURCE_USAGE_REQUEST = 2,
     GET_ALL_RESOURCE_USAGE_REQUEST = 3,
-    CountType_MAX = 4,
+    GET_All_TOTAL_RESOURCES_REQUEST = 4,
+    CountType_MAX = 5,
   };
   uint64_t counts_[CountType::CountType_MAX] = {0};
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -81,10 +81,9 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
 
   /// Handle get total resources of all nodes.
   /// Autoscaler-specific RPC called from Python.
-  void HandleGetAllTotalResources(
-      rpc::GetAllTotalResourcesRequest request,
-      rpc::GetAllTotalResourcesReply *reply,
-      rpc::SendReplyCallback send_reply_callback) override;
+  void HandleGetAllTotalResources(rpc::GetAllTotalResourcesRequest request,
+                                  rpc::GetAllTotalResourcesReply *reply,
+                                  rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle get ids of draining nodes.
   /// Autoscaler-specific RPC called from Python.

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -295,6 +295,13 @@ message AvailableResources {
   map<string, double> resources_available = 2;
 }
 
+message TotalResources {
+  // Node id.
+  bytes node_id = 1;
+  // Resource capacity currently total on this node manager.
+  map<string, double> resources_total = 2;
+}
+
 // A snapshot of the state of a node.
 message NodeSnapshot {
   // The idle state of a node.

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -238,6 +238,13 @@ message GetAllAvailableResourcesReply {
   repeated AvailableResources resources_list = 2;
 }
 
+message GetAllTotalResourcesRequest {}
+
+message GetAllTotalResourcesReply {
+  GcsStatus status = 1;
+  repeated TotalResources resources_list = 2;
+}
+
 message ReportWorkerFailureRequest {
   WorkerTableData worker_failure = 1;
 }
@@ -654,6 +661,9 @@ service NodeResourceInfoGcsService {
   // Get available resources of all nodes.
   rpc GetAllAvailableResources(GetAllAvailableResourcesRequest)
       returns (GetAllAvailableResourcesReply);
+  // Get total resources of all nodes.
+  rpc GetAllTotalResources(GetAllTotalResourcesRequest)
+      returns (GetAllTotalResourcesReply);
   // Get resource usage of all nodes from GCS Service.
   rpc GetAllResourceUsage(GetAllResourceUsageRequest) returns (GetAllResourceUsageReply);
   // Get ids of draining nodes.

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -362,6 +362,12 @@ class GcsRpcClient {
                              node_resource_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
+  /// Get total resources of all nodes from the GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD(NodeResourceInfoGcsService,
+                             GetAllTotalResources,
+                             node_resource_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
   VOID_GCS_RPC_CLIENT_METHOD(NodeResourceInfoGcsService,
                              GetDrainingNodes,
                              node_resource_info_grpc_client_,

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -369,6 +369,11 @@ class NodeResourceInfoGcsServiceHandler {
       rpc::GetAllAvailableResourcesReply *reply,
       rpc::SendReplyCallback send_reply_callback) = 0;
 
+  virtual void HandleGetAllTotalResources(
+      rpc::GetAllTotalResourcesRequest request,
+      rpc::GetAllTotalResourcesReply *reply,
+      rpc::SendReplyCallback send_reply_callback) = 0;
+
   virtual void HandleGetDrainingNodes(rpc::GetDrainingNodesRequest request,
                                       rpc::GetDrainingNodesReply *reply,
                                       rpc::SendReplyCallback send_reply_callback) = 0;
@@ -396,6 +401,7 @@ class NodeResourceInfoGrpcService : public GrpcService {
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
       const ClusterID &cluster_id) override {
     NODE_RESOURCE_INFO_SERVICE_RPC_HANDLER(GetAllAvailableResources);
+    NODE_RESOURCE_INFO_SERVICE_RPC_HANDLER(GetAllTotalResources);
     NODE_RESOURCE_INFO_SERVICE_RPC_HANDLER(GetDrainingNodes);
     NODE_RESOURCE_INFO_SERVICE_RPC_HANDLER(GetAllResourceUsage);
   }

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -369,10 +369,9 @@ class NodeResourceInfoGcsServiceHandler {
       rpc::GetAllAvailableResourcesReply *reply,
       rpc::SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleGetAllTotalResources(
-      rpc::GetAllTotalResourcesRequest request,
-      rpc::GetAllTotalResourcesReply *reply,
-      rpc::SendReplyCallback send_reply_callback) = 0;
+  virtual void HandleGetAllTotalResources(rpc::GetAllTotalResourcesRequest request,
+                                          rpc::GetAllTotalResourcesReply *reply,
+                                          rpc::SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleGetDrainingNodes(rpc::GetDrainingNodesRequest request,
                                       rpc::GetDrainingNodesReply *reply,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, when Ray need to collect total resources of all alive nodes, such as selecting executable operators in Ray data, it first retrieve the `node_table` which includes dead nodes, then filter out the alive resources. Due to the redundant information in the node_table, this process incurs significant overhead. When using Ray 2.9, @Bye-legumes @nemo9cby and I observed close to 80MB/s of communication overhead while running multiple Ray data jobs in a 100-node cluster.

[This PR](https://github.com/ray-project/ray/pull/42817#issue-2106794703) addresses this problem by adding `GLOBAL_LIMITS_UPDATE_INTERVAL_S` to reduce the refresh frequency of cluster resources in Ray data. However, reducing redundant information can further decrease communication overhead and improve the scalability.

To achieve this, we introduce a new `TotalResources` object for aggregating total alive resources to reduce the network overhead of `cluster_resources` API. The reduction is shown below.

<img width="602" alt="image" src="https://github.com/ray-project/ray/assets/58834787/29cd6ba5-0fdd-4f91-9aac-fd9a4bcf941a">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
