### PR TITLE
[ci] remove python 3.11 constraint for a couple of packages

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -144,12 +144,6 @@ compile_pip_dependencies() {
   # pip install will complain about irresolvable constraints.
   sed -i -E 's/==([\.0-9]+)\+[^\b]*cpu/==\1/g' "${WORKSPACE_DIR}/python/$TARGET"
 
-  # Add python_version < 3.11 to scikit-image, scipy, networkx
-  # as they need more recent versions in python 3.11.
-  # These will be automatically resolved. Remove as
-  # soon as we resolve to versions of scikit-image that are built for py311.
-  sed -i -E 's/((scikit-image|scipy|networkx)==[\.0-9]+\b)/\1 ; python_version < "3.11"/g' "${WORKSPACE_DIR}/python/$TARGET"
-
   cat "${WORKSPACE_DIR}/python/$TARGET"
 
   if [ "$HAS_TORCH" -eq 0 ]; then

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1189,7 +1189,7 @@ netifaces==0.11.0
     # via
     #   hpbandster
     #   raydp
-networkx==3.2.1 ; python_version < "3.11"
+networkx==3.2.1
     # via
     #   cfn-lint
     #   hyperopt
@@ -1968,7 +1968,7 @@ safetensors==0.4.1
     #   transformers
 sarif-om==1.0.4
     # via cfn-lint
-scikit-image==0.21.0 ; python_version < "3.11"
+scikit-image==0.21.0
     # via -r /ray/ci/../python/requirements.txt
 scikit-learn==1.3.2
     # via
@@ -1982,7 +1982,7 @@ scikit-learn==1.3.2
     #   pymars
     #   torch-geometric
     #   tune-sklearn
-scipy==1.11.4 ; python_version < "3.11"
+scipy==1.11.4
     # via
     #   -r /ray/ci/../python/requirements.txt
     #   ax-platform


### PR DESCRIPTION
Remove python 3.11 constraint from a few packages. We don't need these any more since we are using 3.11 compatible packages now. Update the compiled file as generated from buildkite.

Test:
- CI