### PR TITLE
Fix MutableObjectManager compile error on Windows

### DIFF
--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -411,7 +411,11 @@ Status MutableObjectManager::SetError(const ObjectID &object_id) {
   return Status::NotImplemented("Not supported on Windows.");
 }
 
-Status MutableObjectManager::SetError() {
+Status MutableObjectManager::SetErrorInternal(const ObjectID &object_id) {
+  return Status::NotImplemented("Not supported on Windows.");
+}
+
+Status MutableObjectManager::SetErrorAll() {
   return Status::NotImplemented("Not supported on Windows.");
 }
 

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -157,7 +157,6 @@ class MutableObjectManager {
   ///
   /// \param[in] object_id The ID of the object.
   Status SetError(const ObjectID &object_id);
-  Status SetErrorInternal(const ObjectID &object_id);
 
   /// Sets the error bit on all channels, causing all future readers and writers to raise
   /// an error on acquire.
@@ -184,6 +183,11 @@ class MutableObjectManager {
   // Closes, unlinks, and destroys the named semaphores for the object. Note that the
   // destructor calls this method for all remaining objects.
   void DestroySemaphores(const ObjectID &object_id);
+
+  // Internal method used to set the error bit on `object_id`. The destructor lock must be
+  // held before calling this method.
+  Status SetErrorInternal(const ObjectID &object_id)
+      ABSL_SHARED_LOCKS_REQUIRED(destructor_lock_);
 
   FRIEND_TEST(MutableObjectTest, TestBasic);
   FRIEND_TEST(MutableObjectTest, TestMultipleReaders);


### PR DESCRIPTION
There were some issues with function definitions on Windows that this PR fixes. I also made style improvements to related code.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There were some issues with function definitions on Windows that this PR fixes. I also made style improvements to related code.

## Related issue number

N/A

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
