### PR TITLE
[Doc] Remove Unnecessary option

### DIFF
--- a/doc/source/cluster/configure-manage-dashboard.md
+++ b/doc/source/cluster/configure-manage-dashboard.md
@@ -77,7 +77,7 @@ Follow the [instructions](kuberay-ingress) to set up ingress to access Ray Dashb
 You can also view the dashboard from outside the Kubernetes cluster by using port-forwarding:
 
 ```shell
-$ kubectl port-forward --address 0.0.0.0 service/${RAYCLUSTER_NAME}-head-svc 8265:8265 
+$ kubectl port-forward service/${RAYCLUSTER_NAME}-head-svc 8265:8265 
 # Visit ${YOUR_IP}:8265 for the Dashboard (e.g. 127.0.0.1:8265 or ${YOUR_VM_IP}:8265)
 ```
 

--- a/doc/source/cluster/kubernetes/examples/gpu-training-example.md
+++ b/doc/source/cluster/kubernetes/examples/gpu-training-example.md
@@ -49,7 +49,7 @@ helm install kuberay-operator kuberay/kuberay-operator --version 1.0.0
 kubectl apply -f https://raw.githubusercontent.com/ray-project/ray/master/doc/source/cluster/kubernetes/configs/ray-cluster.gpu.yaml
 
 # Set up port-forwarding
-kubectl port-forward --address 0.0.0.0 services/raycluster-head-svc 8265:8265
+kubectl port-forward services/raycluster-head-svc 8265:8265
 
 # Step 3: Run the PyTorch image training benchmark.
 # Install Ray if needed
@@ -122,7 +122,7 @@ helm install kuberay-operator kuberay/kuberay-operator --version 1.0.0
 kubectl apply -f https://raw.githubusercontent.com/ray-project/ray/master/doc/source/cluster/kubernetes/configs/ray-cluster.gpu.yaml
 
 # port forwarding
-kubectl port-forward --address 0.0.0.0 services/raycluster-head-svc 8265:8265
+kubectl port-forward services/raycluster-head-svc 8265:8265
 
 # Test cluster (optional)
 ray job submit --address http://localhost:8265 -- python -c "import ray; ray.init(); print(ray.cluster_resources())"

--- a/doc/source/cluster/kubernetes/examples/ml-example.md
+++ b/doc/source/cluster/kubernetes/examples/ml-example.md
@@ -99,7 +99,7 @@ See the {ref}`networking notes <kuberay-networking>` for production use-cases.
 
 ```shell
 # Run the following blocking command in a separate shell.
-kubectl port-forward --address 0.0.0.0 service/raycluster-xgboost-benchmark-head-svc 8265:8265
+kubectl port-forward service/raycluster-xgboost-benchmark-head-svc 8265:8265
 ```
 
 ### Submit the workload.

--- a/doc/source/cluster/kubernetes/getting-started/raycluster-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycluster-quick-start.md
@@ -123,7 +123,7 @@ Now that we have the name of the service, we can use port-forwarding to access t
 
 ```sh
 # Execute this in a separate shell.
-kubectl port-forward --address 0.0.0.0 service/raycluster-kuberay-head-svc 8265:8265
+kubectl port-forward service/raycluster-kuberay-head-svc 8265:8265
 
 # Visit ${YOUR_IP}:8265 in your browser for the Dashboard (e.g. 127.0.0.1:8265)
 ```

--- a/doc/source/cluster/kubernetes/getting-started/rayservice-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/rayservice-quick-start.md
@@ -87,7 +87,7 @@ When the Ray Serve applications are healthy and ready, KubeRay creates a head se
 ```sh
 # (1) Forward the dashboard port to localhost.
 # (2) Check the Serve page in the Ray dashboard at http://localhost:8265/#/serve.
-kubectl port-forward svc/rayservice-sample-head-svc --address 0.0.0.0 8265:8265
+kubectl port-forward svc/rayservice-sample-head-svc 8265:8265
 ```
 
 * Refer to [rayservice-troubleshooting.md](kuberay-raysvc-troubleshoot) for more details on RayService observability.

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.md
@@ -66,7 +66,7 @@ kubectl get pod -l ray.io/node-type=head
 # raycluster-kuberay-head-btwc2   1/1     Running   0          63s
 
 # Wait until all Ray Pods are running and forward the port of the Prometheus metrics endpoint in a new terminal.
-kubectl port-forward --address 0.0.0.0 ${RAYCLUSTER_HEAD_POD} 8080:8080
+kubectl port-forward ${RAYCLUSTER_HEAD_POD} 8080:8080
 curl localhost:8080
 
 # Example output (Prometheus metrics format):
@@ -301,7 +301,7 @@ spec:
 ## Step 9: Access Prometheus Web UI
 ```sh
 # Forward the port of Prometheus Web UI in the Prometheus server Pod.
-kubectl port-forward --address 0.0.0.0 prometheus-prometheus-kube-prometheus-prometheus-0 -n prometheus-system 9090:9090
+kubectl port-forward prometheus-prometheus-kube-prometheus-prometheus-0 -n prometheus-system 9090:9090
 ```
 
 - Go to `${YOUR_IP}:9090/targets` (e.g. `127.0.0.1:9090/targets`). You should be able to see:
@@ -322,7 +322,7 @@ kubectl port-forward --address 0.0.0.0 prometheus-prometheus-kube-prometheus-pro
 
 ```sh
 # Forward the port of Grafana
-kubectl port-forward --address 0.0.0.0 deployment/prometheus-grafana -n prometheus-system 3000:3000
+kubectl port-forward deployment/prometheus-grafana -n prometheus-system 3000:3000
 # Note: You need to update `RAY_GRAFANA_IFRAME_HOST` if you expose Grafana to a different port.
 
 # Check ${YOUR_IP}:3000/login for the Grafana login page (e.g. 127.0.0.1:3000/login).
@@ -351,7 +351,7 @@ Refer to [this Grafana document](https://grafana.com/tutorials/run-grafana-behin
 ## Step 11: Embed Grafana panels in Ray Dashboard
 
 ```sh
-kubectl port-forward --address 0.0.0.0 svc/raycluster-embed-grafana-head-svc 8265:8265
+kubectl port-forward svc/raycluster-embed-grafana-head-svc 8265:8265
 # Visit http://127.0.0.1:8265/#/metrics in your browser.
 ```
 

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/pyspy.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/pyspy.md
@@ -42,7 +42,7 @@ kubectl apply -f ray-cluster.py-spy.yaml
 ### Step 4: Forward the dashboard port
 
 ```bash
-kubectl port-forward --address 0.0.0.0 svc/raycluster-py-spy-head-svc 8265:8265
+kubectl port-forward svc/raycluster-py-spy-head-svc 8265:8265
 ```
 
 ### Step 5: Run a sample job within the head Pod

--- a/doc/source/cluster/kubernetes/troubleshooting/rayservice-troubleshooting.md
+++ b/doc/source/cluster/kubernetes/troubleshooting/rayservice-troubleshooting.md
@@ -36,7 +36,7 @@ kubectl exec -it $RAY_POD -n $YOUR_NAMESPACE -- bash
 ### Method 4: Check Dashboard
 
 ```bash
-kubectl port-forward $RAY_POD -n $YOUR_NAMESPACE --address 0.0.0.0 8265:8265
+kubectl port-forward $RAY_POD -n $YOUR_NAMESPACE 8265:8265
 # Check $YOUR_IP:8265 in your browser
 ```
 

--- a/doc/source/cluster/kubernetes/user-guides/observability.md
+++ b/doc/source/cluster/kubernetes/user-guides/observability.md
@@ -43,7 +43,7 @@ kubectl exec -it $RAY_POD -n $YOUR_NAMESPACE -- bash
 
 ```bash
 export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -o custom-columns=POD:metadata.name --no-headers)
-kubectl port-forward $RAY_POD -n $YOUR_NAMESPACE --address 0.0.0.0 8265:8265
+kubectl port-forward $RAY_POD -n $YOUR_NAMESPACE 8265:8265
 # Check $YOUR_IP:8265 in your browser to access the dashboard.
 # For most cases, 127.0.0.1:8265 or localhost:8265 should work.
 ```

--- a/doc/source/cluster/kubernetes/user-guides/pod-security.md
+++ b/doc/source/cluster/kubernetes/user-guides/pod-security.md
@@ -113,7 +113,7 @@ kubectl apply -n pod-security -f ray-cluster.pod-security.yaml
 docker exec kind-control-plane cat /var/log/kubernetes/kube-apiserver-audit.log
 
 # Forward the dashboard port
-kubectl port-forward --address 0.0.0.0 svc/raycluster-pod-security-head-svc -n pod-security 8265:8265
+kubectl port-forward svc/raycluster-pod-security-head-svc -n pod-security 8265:8265
 
 # Log in to the head Pod
 kubectl exec -it -n pod-security ${YOUR_HEAD_POD} -- bash

--- a/doc/source/cluster/kubernetes/user-guides/rayserve-dev-doc.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayserve-dev-doc.md
@@ -77,7 +77,7 @@ serve run mobilenet.mobilenet:app
 
 ```sh
 # (On your local machine) Forward the serve port of the head Pod
-kubectl port-forward --address 0.0.0.0 $HEAD_POD 8000
+kubectl port-forward $HEAD_POD 8000
 
 # Clone the repository on your local machine
 git clone https://github.com/ray-project/serve_config_examples.git

--- a/doc/source/cluster/kubernetes/user-guides/rayservice-high-availability.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice-high-availability.md
@@ -57,7 +57,7 @@ Thus, the `rayservice-ha-serve-svc` service in the previous step has 3 endpoints
 
 ```sh
 # Port forward the Ray Dashboard.
-kubectl port-forward --address 0.0.0.0 svc/rayservice-ha-head-svc 8265:8265
+kubectl port-forward svc/rayservice-ha-head-svc 8265:8265
 # Visit ${YOUR_IP}:8265 in your browser for the Dashboard (e.g. 127.0.0.1:8265)
 # Check:
 # (1) Both head and worker nodes have HTTPProxyActors.

--- a/doc/source/cluster/kubernetes/user-guides/rayservice.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice.md
@@ -153,7 +153,7 @@ kubectl describe rayservices rayservice-sample
 # Step 5.2: Check the Serve applications in the Ray dashboard.
 # (1) Forward the dashboard port to localhost.
 # (2) Check the Serve page in the Ray dashboard at http://localhost:8265/#/serve.
-kubectl port-forward svc/rayservice-sample-head-svc --address 0.0.0.0 8265:8265
+kubectl port-forward svc/rayservice-sample-head-svc 8265:8265
 ```
 
 * See [rayservice-troubleshooting.md](kuberay-raysvc-troubleshoot) for more details on RayService observability.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The purpose of this PR is to simplify and clarify the usage of the `kubectl port-forward` command. The original documentation included the `--address 0.0.0.0` option, which is used to specify forwarding the port to all available IP addresses. 
However, this is often unnecessary since `kubectl port-forward` defaults to forwarding the port to the local host. 
From [Kubernetes document](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_port-forward/#options):

> --address strings     Default: "localhost"
Addresses to listen on (comma separated). Only accepts IP addresses or localhost as a value. When localhost is supplied, kubectl will try to bind on both 127.0.0.1 and ::1 and will fail if neither of these addresses are available to bind.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
