### PR TITLE
[Core] ray.init(logging_format) argument is ignored

### DIFF
--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -25,6 +25,11 @@ def setup_logger(
 ):
     """Setup default logging for ray."""
     logger = logging.getLogger("ray")
+    if logging_format:
+        # Overwrite the formatters for all default handlers.
+        formatter = logging.Formatter(logging_format)
+        for handler in logger.handlers:
+            handler.setFormatter(formatter)
     if type(logging_level) is str:
         logging_level = logging.getLevelName(logging_level.upper())
     logger.setLevel(logging_level)

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -459,6 +459,13 @@ assert set(log_component_names).isdisjoint(set(paths)), paths
         # unique ID suffix.
         assert f"({component}" in stderr, stderr
 
+def test_custom_logging_format(shutdown_only):
+    script = """
+import ray
+ray.init(logging_format='custom logging format - %(message)s')
+"""
+    stderr = run_string_as_driver(script)
+    assert "custom logging format - " in stderr
 
 def test_segfault_stack_trace(ray_start_cluster, capsys):
     @ray.remote

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -459,6 +459,7 @@ assert set(log_component_names).isdisjoint(set(paths)), paths
         # unique ID suffix.
         assert f"({component}" in stderr, stderr
 
+
 def test_custom_logging_format(shutdown_only):
     script = """
 import ray
@@ -466,6 +467,7 @@ ray.init(logging_format='custom logging format - %(message)s')
 """
     stderr = run_string_as_driver(script)
     assert "custom logging format - " in stderr
+
 
 def test_segfault_stack_trace(ray_start_cluster, capsys):
     @ray.remote


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#32741 accidentally removes the `logging_format` parameter from the `setup_logging` function. This PR overwrites the formatters for all default handlers.

## Related issue number

Closes #44713 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
<img width="1066" alt="Screenshot 2024-04-29 at 12 43 30 PM" src="https://github.com/ray-project/ray/assets/20109646/60f15a49-58f8-4046-8560-3d9ef8ceefb3">


