### PR TITLE
[RLlib] - Fix numerical overflow in gradient clipping for (many) large gradients

### DIFF
--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -100,6 +100,7 @@ def atanh(x: TensorType) -> TensorType:
     pass
 
 
+@PublicAPI
 def clip_gradients(
     gradients_dict: "ParamDict",
     *,

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -136,7 +136,7 @@ def clip_gradients(
         for k, v in gradients_dict.copy().items():
             if v is not None:
                 # Compute the L2-norm of the gradient tensor.
-                norm = v.norm(2)
+                norm = v.norm(2).nan_to_num(neginf=-10e8, posinf=10e8)
                 # Clip all the gradients.
                 if norm > grad_clip:
                     v.mul_(grad_clip / norm)

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -172,8 +172,11 @@ def clip_gradients(
                 f"The total norm of order {norm_type} for gradients from "
                 "`parameters` is non-finite, so it cannot be clipped. "
             )
+        # We do want the coefficient to be in between 0.0 and 1.0, therefore
+        # if the global_norm is smaller than the clip value, we use the clip value
+        # as normalization constant.
         clip_coef = grad_clip / torch.maximum(
-            torch.tensor(grad_clip), total_norm + 1e-6
+            torch.tensor(grad_clip).to(device), total_norm + 1e-6
         )
         # Note: multiplying by the clamped coef is redundant when the coef is clamped to
         # 1, but doing so avoids a `if clip_coef < 1:` conditional which can require a


### PR DESCRIPTION
## Why are these changes needed?

Large gradients and many of these could lead to numerical overflow when computing their l2-norm in `torch_utils.clip_gradients` (using the "global_norm"). This is counterproductive as a user wants to clip such gradients and instead runs into numerical overflow because of clipping gradients. 

This PR proposes small changes to turn `inf` and `neginf` values returned from norms to `10e8` and `-10e8`, respectively. This does not harm gradients themselves (if these for example were already `inf/neginf` b/c we clip gradients by multiplication and not overriding values).

## Related issue number



## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
