### PR TITLE
Fix wrong returns in multi agent partially returned episodes

### DIFF
--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -621,7 +621,7 @@ class MultiAgentEnvRunner(EnvRunner):
                     episode_return += return_eps2
                     episode_duration_s += eps2.get_duration_s()
                     for sa_eps in eps2.agent_episodes.values():
-                        agent_episode_returns[str(sa_eps.agent_id)] += return_eps2
+                        agent_episode_returns[str(sa_eps.agent_id)] += eps2.get_agent_return(sa_eps.agent_id)
                         module_episode_returns[sa_eps.module_id] += return_eps2
                 del self._ongoing_episodes_for_metrics[eps.id_]
 

--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -1806,6 +1806,36 @@ class MultiAgentEpisode:
             env_steps=self.env_t - self.env_t_started,
         )
 
+    def get_agent_return(
+        self,
+        agent_id,
+        include_hanging_rewards: bool = False,
+    ) -> float:
+        """Returns single agent return.
+
+        Args:
+            agent_id: id of the agent
+            include_hanging_rewards: Whether we should also consider
+                hanging rewards wehn calculating the overall return. Agents might
+                have received partial rewards, i.e. rewards without an
+                observation. These are stored in the "hanging" caches (begin and end)
+                for each agent and added up until the next observation is received by
+                that agent.
+
+        Returns:
+            The a single agents' returns (maybe including the hanging
+            rewards per agent).
+        """
+        env_return = self.agent_episodes[agent_id].get_return() if agent_id in self.agent_episodes else 0.0
+
+        if include_hanging_rewards:
+            if agent_id in self._hanging_rewards_begin:
+                env_return += self._hanging_rewards_begin[agent_id]
+            if agent_id in self._hanging_rewards_end:
+                env_return += self._hanging_rewards_end[agent_id]
+
+        return env_return
+
     def get_return(
         self,
         include_hanging_rewards: bool = False,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There is a bug in the way returns are calculated when a episode has partially returned chucks. In that situation instead of using the previously cached returns of the current agent, it uses the sum of rewards of all agents.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
