### PR TITLE
Fix MutableObjectManager channel segfault

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -767,6 +767,7 @@ ray_cc_library(
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:node_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@nlohmann_json",
     ],

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -78,7 +78,7 @@ MutableObjectManager::~MutableObjectManager() {
   destructor_lock_.Lock();
 
   // Copy `semaphores_` into `tmp` because `DestroySemaphores()` mutates `semaphores_`.
-  absl::node_hash_map<ObjectID, PlasmaObjectHeader::Semaphores> tmp = semaphores_;
+  absl::flat_hash_map<ObjectID, PlasmaObjectHeader::Semaphores> tmp = semaphores_;
   for (const auto &[object_id, _] : tmp) {
     (void)SetErrorInternal(object_id);
     DestroySemaphores(object_id);

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -78,7 +78,7 @@ MutableObjectManager::~MutableObjectManager() {
   destructor_lock_.Lock();
 
   // Copy `semaphores_` into `tmp` because `DestroySemaphores()` mutates `semaphores_`.
-  absl::flat_hash_map<ObjectID, PlasmaObjectHeader::Semaphores> tmp = semaphores_;
+  absl::node_hash_map<ObjectID, PlasmaObjectHeader::Semaphores> tmp = semaphores_;
   for (const auto &[object_id, _] : tmp) {
     (void)SetErrorInternal(object_id);
     DestroySemaphores(object_id);

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/container/node_hash_map.h"
 #include "gtest/gtest_prod.h"
 #include "ray/common/buffer.h"
 #include "ray/common/ray_object.h"
@@ -202,12 +203,12 @@ class MutableObjectManager {
   // consider using RCU to avoid synchronization overhead in the common case.
   // This map holds the channels for readers and writers of mutable objects.
   absl::Mutex channel_lock_;
-  absl::flat_hash_map<ObjectID, Channel> channels_;
+  absl::node_hash_map<ObjectID, Channel> channels_;
 
   // This maps holds the semaphores for each mutable object. The semaphores are used to
   // (1) synchronize accesses to the object header and (2) synchronize readers and writers
   // of the mutable object.
-  absl::flat_hash_map<ObjectID, PlasmaObjectHeader::Semaphores> semaphores_;
+  absl::node_hash_map<ObjectID, PlasmaObjectHeader::Semaphores> semaphores_;
 
   // This lock ensures that the destructor does not start tearing down the manager and
   // freeing the memory until all readers and writers are outside the Acquire()/Release()

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -203,12 +203,15 @@ class MutableObjectManager {
   // consider using RCU to avoid synchronization overhead in the common case.
   // This map holds the channels for readers and writers of mutable objects.
   absl::Mutex channel_lock_;
+  // `channels_` requires pointer stability as one thread may hold a Channel pointer while
+  // another thread mutates `channels_`. Thus, we use absl::node_hash_map instead of
+  // absl::flat_hash_map.
   absl::node_hash_map<ObjectID, Channel> channels_;
 
   // This maps holds the semaphores for each mutable object. The semaphores are used to
   // (1) synchronize accesses to the object header and (2) synchronize readers and writers
   // of the mutable object.
-  absl::node_hash_map<ObjectID, PlasmaObjectHeader::Semaphores> semaphores_;
+  absl::flat_hash_map<ObjectID, PlasmaObjectHeader::Semaphores> semaphores_;
 
   // This lock ensures that the destructor does not start tearing down the manager and
   // freeing the memory until all readers and writers are outside the Acquire()/Release()


### PR DESCRIPTION
If one thread is holding a channel pointer while another thread attempts to register a new channel, the channel pointer could be invalidated. This is because absl::flat_hash_map does not provide pointer stability. This PR replaces absl::flat_hash_map with absl::node_hash_map, which does provider pointer stability.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See above.

## Related issue number

N/A

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
