### PR TITLE
[CI] Fix linter installation instructions

### DIFF
--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -323,7 +323,7 @@ Dependencies for the linter (``scripts/format.sh``) can be installed with:
 
 .. code-block:: shell
 
- pip install -r python/requirements/lint-requirements.txt
+ pip install -c python/requirements_compiled.txt -r python/requirements/lint-requirements.txt
 
 Dependencies for running Ray unit tests under ``python/ray/tests`` can be installed with:
 

--- a/doc/source/ray-contribute/getting-involved.rst
+++ b/doc/source/ray-contribute/getting-involved.rst
@@ -238,7 +238,7 @@ We also have tests for code formatting and linting that need to pass before merg
 
 .. code-block:: shell
 
-  pip install -r python/requirements/lint-requirements.txt
+  pip install -c python/requirements_compiled.txt -r python/requirements/lint-requirements.txt
 
 * If developing for C++, you will need `clang-format <https://www.kernel.org/doc/html/latest/process/clang-format.html>`_ version ``12`` (download this version of Clang from `here <http://releases.llvm.org/download.html>`_)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If I install the dependencies for the linter using `pip install -r python/requirements/lint-requirements.txt`, it will install flake8 7.0.0. Then, when I run `./ci/lint/format.sh`, it gives an error stating, "Flake8 failed to load plugin ...".

<img width="1122" alt="Screenshot 2024-04-30 at 12 17 30 AM" src="https://github.com/ray-project/ray/assets/20109646/657d3b0c-dbaa-48be-8d44-a044875033a9">

I found that our CI uses `pip install -c python/requirements_compiled.txt -r python/requirements/lint-requirements.txt` instead of `pip install -r python/requirements/lint-requirements.txt` ([code](https://github.com/ray-project/ray/blob/33bde4c3345a39e99f70df6569b147bce902fcab/.buildkite/lint.rayci.yml#L14C9-L14C101)) to install flake8 3.9.1. After I used the same command as Ray CI to install flake8 3.9.1, I can run `./ci/lint/format.sh` successfully.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
