### PR TITLE
[ci][micro/3] persist high impact test information

### DIFF
--- a/ci/ray_ci/automation/determine_microcheck_tests.py
+++ b/ci/ray_ci/automation/determine_microcheck_tests.py
@@ -15,7 +15,13 @@ LINUX_PYTHON_TEST_PREFIX = "linux:__python"
 @click.option("--test-history-length", default=100, type=int)
 @click.option("--test-prefix", default=LINUX_PYTHON_TEST_PREFIX, type=str)
 @click.option("--production", is_flag=True, default=False)
-def main(team: str, coverage: int, test_history_length: int, test_prefix: str, production: bool) -> None:
+def main(
+    team: str,
+    coverage: int,
+    test_history_length: int,
+    test_prefix: str,
+    production: bool,
+) -> None:
     """
     This script determines the tests that need to be run to cover a certain percentage
     of PR failures, based on historical data
@@ -42,8 +48,13 @@ def main(team: str, coverage: int, test_history_length: int, test_prefix: str, p
 
 def _update_high_impact_tests(tests: List[Test], high_impact_tests: Set[str]) -> None:
     for test in tests:
-        test[Test.KEY_IS_HIGH_IMPACT] = 'true' if test.get_name() in high_impact_tests else 'false'
-        logger.info(f"Mark test {test.get_name()} as high impact: {test[Test.KEY_IS_HIGH_IMPACT]}")
+        test_name = test.get_name()
+        test[Test.KEY_IS_HIGH_IMPACT] = (
+            "true" if test_name in high_impact_tests else "false"
+        )
+        logger.info(
+            f"Mark test {test_name} as high impact: {test[Test.KEY_IS_HIGH_IMPACT]}"
+        )
         test.persist_to_s3()
 
 

--- a/ci/ray_ci/automation/determine_microcheck_tests.py
+++ b/ci/ray_ci/automation/determine_microcheck_tests.py
@@ -1,5 +1,5 @@
 import click
-from typing import Set, Dict
+from typing import List, Set, Dict
 
 from ci.ray_ci.utils import logger, ci_init
 from ray_release.configs.global_config import get_global_config
@@ -14,7 +14,8 @@ LINUX_PYTHON_TEST_PREFIX = "linux:__python"
 @click.argument("coverage", required=True, type=int)
 @click.option("--test-history-length", default=100, type=int)
 @click.option("--test-prefix", default=LINUX_PYTHON_TEST_PREFIX, type=str)
-def main(team: str, coverage: int, test_history_length: int, test_prefix: str) -> None:
+@click.option("--production", is_flag=True, default=False)
+def main(team: str, coverage: int, test_history_length: int, test_prefix: str, production: bool) -> None:
     """
     This script determines the tests that need to be run to cover a certain percentage
     of PR failures, based on historical data
@@ -31,10 +32,19 @@ def main(team: str, coverage: int, test_history_length: int, test_prefix: str) -
         test.get_name(): _get_failed_prs(test, test_history_length) for test in tests
     }
     high_impact_tests = _get_test_with_minimal_coverage(test_to_prs, coverage)
+    if production:
+        _update_high_impact_tests(tests, high_impact_tests)
 
     logger.info(
         f"To cover {coverage}% of PRs, run the following tests: {high_impact_tests}"
     )
+
+
+def _update_high_impact_tests(tests: List[Test], high_impact_tests: Set[str]) -> None:
+    for test in tests:
+        test[Test.KEY_IS_HIGH_IMPACT] = 'true' if test.get_name() in high_impact_tests else 'false'
+        logger.info(f"Mark test {test.get_name()} as high impact: {test[Test.KEY_IS_HIGH_IMPACT]}")
+        test.persist_to_s3()
 
 
 def _get_test_with_minimal_coverage(

--- a/ci/ray_ci/automation/test_determine_microcheck_tests.py
+++ b/ci/ray_ci/automation/test_determine_microcheck_tests.py
@@ -1,4 +1,5 @@
 import sys
+import json
 from typing import List
 
 import pytest
@@ -6,24 +7,29 @@ import pytest
 from ci.ray_ci.automation.determine_microcheck_tests import (
     _get_failed_prs,
     _get_test_with_minimal_coverage,
+    _update_high_impact_tests,
 )
 from ci.ray_ci.utils import ci_init
 from ray_release.result import ResultStatus
-from ray_release.test import TestResult
+from ray_release.test import TestResult, Test
 
 ci_init()
 
+DB = {}
 
-class MockTest:
-    def __init__(self, name: str, results: List[TestResult]):
-        self.name = name
-        self.test_results = results
+
+class MockTest(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def get_name(self) -> str:
-        return self.name
+        return self.get("name", "")
 
     def get_test_results(self, limit: int, aws_bucket: str) -> List[TestResult]:
-        return self.test_results
+        return self.get("test_results", [])
+
+    def persist_to_s3(self) -> None:
+        DB[self["name"]] = json.dumps(self)
 
 
 def stub_test_result(status: ResultStatus, branch: str) -> TestResult:
@@ -37,16 +43,38 @@ def stub_test_result(status: ResultStatus, branch: str) -> TestResult:
     )
 
 
+def test_update_high_impact_tests():
+    tests = [
+        MockTest(
+            {
+                "name": "good_test",
+                Test.KEY_IS_HIGH_IMPACT: "false",
+            }
+        ),
+        MockTest(
+            {
+                "name": "bad_test",
+                Test.KEY_IS_HIGH_IMPACT: "false",
+            }
+        ),
+    ]
+    _update_high_impact_tests(tests, {"good_test"})
+    assert json.loads(DB["good_test"])[Test.KEY_IS_HIGH_IMPACT] == "true"
+    assert json.loads(DB["bad_test"])[Test.KEY_IS_HIGH_IMPACT] == "false"
+
+
 def test_get_failed_prs():
     assert _get_failed_prs(
         MockTest(
-            "test",
-            [
-                stub_test_result(ResultStatus.ERROR, "w00t"),
-                stub_test_result(ResultStatus.ERROR, "w00t"),
-                stub_test_result(ResultStatus.SUCCESS, "hi"),
-                stub_test_result(ResultStatus.ERROR, "f00"),
-            ],
+            {
+                "name": "test",
+                "test_results": [
+                    stub_test_result(ResultStatus.ERROR, "w00t"),
+                    stub_test_result(ResultStatus.ERROR, "w00t"),
+                    stub_test_result(ResultStatus.SUCCESS, "hi"),
+                    stub_test_result(ResultStatus.ERROR, "f00"),
+                ],
+            }
         ),
         1,
     ) == {"w00t", "f00"}

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -134,6 +134,8 @@ class Test(dict):
     KEY_GITHUB_ISSUE_NUMBER = "github_issue_number"
     KEY_BISECT_BUILD_NUMBER = "bisect_build_number"
     KEY_BISECT_BLAMED_COMMIT = "bisect_blamed_commit"
+    # a test is high impact if it catches regressions frequently
+    KEY_IS_HIGH_IMPACT = "is_high_impact"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -217,6 +219,11 @@ class Test(dict):
         Returns whether this test is running on a BYOD cluster.
         """
         return self["cluster"].get("byod") is not None
+
+    def get_is_high_impact(self) -> bool:
+        # a test is high impact if it catches regressions frequently, this field is
+        # populated by the determine_microcheck_tests.py script
+        self.get(self.KEY_IS_HIGH_IMPACT, None) == "true"
 
     def get_test_type(self) -> TestType:
         test_name = self.get_name()

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -220,10 +220,10 @@ class Test(dict):
         """
         return self["cluster"].get("byod") is not None
 
-    def get_is_high_impact(self) -> bool:
+    def is_high_impact(self) -> bool:
         # a test is high impact if it catches regressions frequently, this field is
         # populated by the determine_microcheck_tests.py script
-        self.get(self.KEY_IS_HIGH_IMPACT, None) == "true"
+        return self.get(self.KEY_IS_HIGH_IMPACT, None) == "true"
 
     def get_test_type(self) -> TestType:
         test_name = self.get_name()

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -254,5 +254,15 @@ def test_get_s3_name() -> None:
     assert Test._get_s3_name("linux://python/ray/test") == "linux:__python_ray_test"
 
 
+def test_is_high_impact() -> None:
+    assert _stub_test(
+        {"name": "test", Test.KEY_IS_HIGH_IMPACT: "true"}
+    ).is_high_impact()
+    assert not _stub_test(
+        {"name": "test", Test.KEY_IS_HIGH_IMPACT: "false"}
+    ).is_high_impact()
+    assert not _stub_test({"name": "test"}).is_high_impact()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Add a 'is_high_impact' field for test object, and persist this information once we finish analyze its impact.

A test is high impact if it often catches regressions on PRs.

Test:
- CI