### PR TITLE
[ci] compute+store microcheck test coverage periodically

### DIFF
--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -57,3 +57,16 @@ steps:
     instance_type: small
     commands:
       - bazel run //ci/ray_ci/automation:weekly_green_metric -- --production
+
+  - label: ":robot_face: {{matrix}} microcheck test coverage"
+    tags: skip-on-premerge
+    if: build.branch == "master" && build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    instance_type: small
+    commands:
+      - bazel run //ci/ray_ci/automation:determine_microcheck_tests -- {{matrix}} 95 --production
+    matrix:
+      - "core"
+      - "serve"
+      - "data"
+      - "ml"
+      - "rllib"

--- a/ci/ray_ci/automation/determine_microcheck_tests.py
+++ b/ci/ray_ci/automation/determine_microcheck_tests.py
@@ -6,14 +6,16 @@ from ray_release.configs.global_config import get_global_config
 from ray_release.test import Test
 from ray_release.result import ResultStatus
 
-LINUX_PYTHON_TEST_PREFIX = "linux:__python"
+# The s3 prefix for the tests that run on Linux. It comes from the bazel prefix rule
+# linux:// with the character "/" replaced by "_" for s3 compatibility
+LINUX_TEST_PREFIX = "linux:__"
 
 
 @click.command()
 @click.argument("team", required=True, type=str)
 @click.argument("coverage", required=True, type=int)
 @click.option("--test-history-length", default=100, type=int)
-@click.option("--test-prefix", default=LINUX_PYTHON_TEST_PREFIX, type=str)
+@click.option("--test-prefix", default=LINUX_TEST_PREFIX, type=str)
 @click.option("--production", is_flag=True, default=False)
 def main(
     team: str,


### PR DESCRIPTION
Compute + store microcheck test coverage periodically for all OSS teams

Test:
- CI
- test build: https://buildkite.com/ray-project/postmerge/builds/4267