### PR TITLE
[Data] Retry `RaySystemError` application errors

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -84,7 +84,8 @@ class ActorPoolMapOperator(MapOperator):
         self._ray_remote_args = self._apply_default_remote_args(self._ray_remote_args)
         self._ray_actor_task_remote_args = {}
         actor_task_errors = DataContext.get_current().actor_task_retry_on_errors
-        self._ray_actor_task_remote_args["retry_exceptions"] = actor_task_errors
+        if actor_task_errors:
+            self._ray_actor_task_remote_args["retry_exceptions"] = actor_task_errors
         _add_system_error_to_retry_exceptions(self._ray_actor_task_remote_args)
         data_context = DataContext.get_current()
         if data_context._max_num_blocks_in_streaming_gen_buffer is not None:

--- a/python/ray/data/_internal/remote_fn.py
+++ b/python/ray/data/_internal/remote_fn.py
@@ -24,13 +24,32 @@ def cached_remote_fn(fn: Any, **ray_remote_args) -> Any:
             # as needed.
             "scheduling_strategy": "DEFAULT",
             "max_retries": -1,
-            # Ray typically automatically retries system errors. However, in some cases,
-            # Ray won't retry system errors if they're raised from task code. To ensure
-            # Ray Data is fault tolerant to those errors, we need to add RaySystemError
-            # to the retry_exceptions list.
-            "retry_exceptions": [ray.exceptions.RaySystemError],
         }
-        CACHED_FUNCTIONS[fn] = ray.remote(
-            **{**default_ray_remote_args, **ray_remote_args}
-        )(fn)
+        ray_remote_args = {**default_ray_remote_args, **ray_remote_args}
+        _add_system_error_to_retry_exceptions(ray_remote_args)
+        CACHED_FUNCTIONS[fn] = ray.remote(**ray_remote_args)(fn)
     return CACHED_FUNCTIONS[fn]
+
+
+def _add_system_error_to_retry_exceptions(ray_remote_args) -> None:
+    """Modify the remote args so that Ray retries `RaySystemError`s.
+
+    Ray typically automatically retries system errors. However, in some cases, Ray won't
+    retry system errors if they're raised from task code. To ensure that Ray Data is
+    fault tolerant to those errors, we need to add `RaySystemError` to the
+    `retry_exceptions` list.
+
+    TODO: Fix this in Ray Core. See https://github.com/ray-project/ray/pull/45079.
+    """
+    retry_exceptions = ray_remote_args["retry_exceptions"]
+    assert isinstance(retry_exceptions, (list, bool))
+
+    if (
+        isinstance(retry_exceptions, list)
+        and ray.exceptions.RaySystemError not in retry_exceptions
+    ):
+        retry_exceptions.append(ray.exceptions.RaySystemError)
+    elif not retry_exceptions:
+        retry_exceptions = [ray.exceptions.RaySystemError]
+
+    ray_remote_args["retry_exceptions"] = retry_exceptions

--- a/python/ray/data/_internal/remote_fn.py
+++ b/python/ray/data/_internal/remote_fn.py
@@ -24,6 +24,11 @@ def cached_remote_fn(fn: Any, **ray_remote_args) -> Any:
             # as needed.
             "scheduling_strategy": "DEFAULT",
             "max_retries": -1,
+            # Ray typically automatically retries system errors. However, in some cases,
+            # Ray won't retry system errors if they're raised from task code. To ensure
+            # Ray Data is fault tolerant to those errors, we need to add RaySystemError
+            # to the retry_exceptions list.
+            "retry_exceptions": [ray.exceptions.RaySystemError],
         }
         CACHED_FUNCTIONS[fn] = ray.remote(
             **{**default_ray_remote_args, **ray_remote_args}

--- a/python/ray/data/_internal/remote_fn.py
+++ b/python/ray/data/_internal/remote_fn.py
@@ -41,7 +41,7 @@ def _add_system_error_to_retry_exceptions(ray_remote_args) -> None:
 
     TODO: Fix this in Ray Core. See https://github.com/ray-project/ray/pull/45079.
     """
-    retry_exceptions = ray_remote_args["retry_exceptions"]
+    retry_exceptions = ray_remote_args.get("retry_exceptions", False)
     assert isinstance(retry_exceptions, (list, bool))
 
     if (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ray typically automatically retries system errors. However, in some cases, tasks raise `RaySystemError`s and those errors aren't automatically retried. To ensure Ray Data is fault tolerant to those failures, this PR explicitly adds `RaySystemError` to the list of retried exceptions.

Note: one reason why tasks raise `RaySystemError`s is that when we shut down a node, the raylet process can die before worker processes and `ray.get()` throws an exception since it can't access plasma in raylet. A longterm solution would be to fix the shutdown order: raylet should be the last process to exit.
## Related issue number

<!-- For example: "Closes #1234" -->

Deflakes https://github.com/ray-project/ray/issues/44892

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
