### PR TITLE
[Serve] fix control+c after `serve run` doesn't shutdown serve components

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -588,11 +588,11 @@ def run(
             while True:
                 # Block, letting Ray print logs to the terminal.
                 time.sleep(10)
-        except KeyboardInterrupt as e:
+        except KeyboardInterrupt:
             logger.warning("Got KeyboardInterrupt, exiting...")
             # We need to re-raise KeyboardInterrupt, so serve components can be shutdown
             # from the main script.
-            raise e
+            raise
     return handle
 
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -588,8 +588,11 @@ def run(
             while True:
                 # Block, letting Ray print logs to the terminal.
                 time.sleep(10)
-        except KeyboardInterrupt:
+        except KeyboardInterrupt as e:
             logger.warning("Got KeyboardInterrupt, exiting...")
+            # We need to re-raise KeyboardInterrupt, so serve components can be shutdown
+            # from the main script.
+            raise e
     return handle
 
 

--- a/python/ray/serve/tests/test_cli_2.py
+++ b/python/ray/serve/tests/test_cli_2.py
@@ -964,5 +964,22 @@ def test_serve_run_mount_to_correct_deployment_route_prefix(ray_start_stop):
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
+def test_control_c_shutdown_serve_components(ray_start_stop):
+    """Test ctrl+c after `serve run` shuts down serve components."""
+
+    p = subprocess.Popen(["serve", "run", "ray.serve.tests.test_cli_2.echo_app"])
+
+    wait_for_condition(check_app_running, app_name=SERVE_DEFAULT_APP_NAME)
+    assert ping_endpoint("/") == "hello"
+    p.send_signal(signal.SIGINT)  # Equivalent to ctrl-C
+    p.wait()
+
+    status_response = subprocess.check_output(["serve", "status"])
+    status = yaml.safe_load(status_response)
+    assert False, status
+    assert status == {"applications": {}, "proxies": {}, "target_capacity": None}
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Added a test to ensure this is captured and fix it. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
