### PR TITLE
remove deprecated modules

### DIFF
--- a/python/ray/air/callbacks/comet.py
+++ b/python/ray/air/callbacks/comet.py
@@ -1,4 +1,0 @@
-from ray.air.integrations.comet import *  # noqa: F401, F403
-from ray.tune._structure_refactor import warn_structure_refactor
-
-warn_structure_refactor(__name__, "ray.air.integrations.comet")

--- a/python/ray/air/callbacks/keras.py
+++ b/python/ray/air/callbacks/keras.py
@@ -1,4 +1,0 @@
-from ray.air.integrations.keras import *  # noqa: F401, F403
-from ray.tune._structure_refactor import warn_structure_refactor
-
-warn_structure_refactor(__name__, "ray.air.integrations.keras")

--- a/python/ray/air/callbacks/mlflow.py
+++ b/python/ray/air/callbacks/mlflow.py
@@ -1,4 +1,0 @@
-from ray.air.integrations.mlflow import *  # noqa: F401, F403
-from ray.tune._structure_refactor import warn_structure_refactor
-
-warn_structure_refactor(__name__, "ray.air.integrations.mlflow")

--- a/python/ray/air/callbacks/wandb.py
+++ b/python/ray/air/callbacks/wandb.py
@@ -1,4 +1,0 @@
-from ray.air.integrations.wandb import *  # noqa: F401, F403
-from ray.tune._structure_refactor import warn_structure_refactor
-
-warn_structure_refactor(__name__, "ray.air.integrations.wandb")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/pull/36984 removed `warn_structure_refactor`, but failed to remove the `ray.air.callbacks` submodules that still rely on it. While arguably in my specific case the presence of their remainder helped me update some old code, it would be cleaner if ray failed with an ImportError, making it clear that it's an issue on the user side, rather than something that looks like it's a bug.

## Related issue number

Closes https://github.com/ray-project/ray/issues/45103

## Checks

This PR only removes no-longer-used modules, and does not add any new code.

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [-] I've run `scripts/format.sh` to lint the changes in this PR.
- [-] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [-] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [-] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [-] Unit tests
   - [-] Release tests
   - [-] This PR is not tested :(
