### PR TITLE
[RLlib] Metrics do-over 06: Remove `render_images`/`with_render_images` from MAEps and -runner and deprecate `env_render` config option.

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -4175,16 +4175,15 @@ class AlgorithmConfig(_Config):
                 "script for more information: "
                 "https://github.com/ray-project/ray/blob/master/rllib/examples/curriculum/curriculum_learning.py",  # noqa
             )
-        # `render_env` will be deprecated
-        # TODO (sven): Uncomment once example is translated to new API stack.
-        # if self._enable_new_api_stack and self.render_env is not False:
-        #    deprecation_warning(
-        #        old="AlgorithmConfig.render_env",
-        #        help="The `render_env` setting is not supported on the new API stack! "
-        #        "Take a look at the new rendering example here for how to create
-        #        videos of your envs and send them to WandB: "
-        #        "https://github.com/ray-project/ray/blob/master/rllib/examples/envs/env_rendering_and_recording.py",  # noqa
-        #    )
+        # `render_env` is deprecated on new API stack.
+        if self.enable_env_runner_and_connector_v2 and self.render_env is not False:
+            deprecation_warning(
+                old="AlgorithmConfig.render_env",
+                help="The `render_env` setting is not supported on the new API stack! "
+                "In order to log videos to WandB (or other loggers), take a look at "
+                "this example here: "
+                "https://github.com/ray-project/ray/blob/master/rllib/examples/envs/env_rendering_and_recording.py",  # noqa
+            )
 
         if self.preprocessor_pref not in ["rllib", "deepmind", None]:
             raise ValueError(

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -105,7 +105,6 @@ class MultiAgentEnvRunner(EnvRunner):
         explore: bool = None,
         random_actions: bool = False,
         force_reset: bool = False,
-        with_render_data: bool = False,
     ) -> List[MultiAgentEpisode]:
         """Runs and returns a sample (n timesteps or m episodes) on the env(s).
 
@@ -127,8 +126,6 @@ class MultiAgentEnvRunner(EnvRunner):
                 sampling. Useful if you would like to collect a clean slate of new
                 episodes via this call. Note that when sampling n episodes
                 (`num_episodes != None`), this is fixed to True.
-            with_render_data: If True, will call `render()` on the environment and
-                collect returned images.
 
         Returns:
             A list of `MultiAgentEpisode` instances, carrying the sampled data.
@@ -161,7 +158,6 @@ class MultiAgentEnvRunner(EnvRunner):
                 num_episodes=num_episodes,
                 explore=explore,
                 random_actions=random_actions,
-                with_render_data=with_render_data,
             )
 
         # Make the `on_sample_end` callback.
@@ -190,9 +186,6 @@ class MultiAgentEnvRunner(EnvRunner):
             random_actions: boolean. If actions should be sampled from the action
                 space. In default mode (i.e. `False`) we sample actions frokm the
                 policy.
-            with_render_data: If render data from the environment should be collected.
-                This is only available when sampling episodes, i.e. `num_episodes` is
-                not `None`.
 
         Returns:
             `Lists of `MultiAgentEpisode` instances, carrying the collected sample data.
@@ -403,7 +396,6 @@ class MultiAgentEnvRunner(EnvRunner):
         num_episodes: int,
         explore: bool,
         random_actions: bool = False,
-        with_render_data: bool = False,
     ) -> List[MultiAgentEpisode]:
         """Helper method to run n episodes.
 
@@ -426,13 +418,8 @@ class MultiAgentEnvRunner(EnvRunner):
             "agent_to_module_mapping_fn": self.config.policy_mapping_fn,
         }
 
-        # Initialize image rendering if needed.
-        render_image = None
-        if with_render_data:
-            render_image = self.env.render()
-
         # Set initial obs and infos in the episodes.
-        _episode.add_env_reset(observations=obs, infos=infos, render_image=render_image)
+        _episode.add_env_reset(observations=obs, infos=infos)
         self._make_on_episode_callback("on_episode_start", _episode)
 
         # Loop over episodes.
@@ -501,10 +488,6 @@ class MultiAgentEnvRunner(EnvRunner):
             )
             ts += self._increase_sampled_metrics(self.num_envs, obs, _episode)
 
-            # Add render data if needed.
-            if with_render_data:
-                render_image = self.env.render()
-
             # TODO (sven): This simple approach to re-map `to_env` from a
             #  dict[col, List[MADict]] to a dict[agentID, MADict] would not work for
             #  a vectorized env.
@@ -525,7 +508,6 @@ class MultiAgentEnvRunner(EnvRunner):
                 terminateds=terminateds,
                 truncateds=truncateds,
                 extra_model_outputs=extra_model_outputs,
-                render_image=render_image,
             )
 
             # Make `on_episode_step` callback before finalizing the episode.

--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -15,7 +15,6 @@ from typing import (
 import uuid
 
 import gymnasium as gym
-import numpy as np
 
 from ray.rllib.env.single_agent_episode import SingleAgentEpisode
 from ray.rllib.env.utils.infinite_lookback_buffer import InfiniteLookbackBuffer
@@ -73,7 +72,6 @@ class MultiAgentEpisode:
         rewards: Optional[List[MultiAgentDict]] = None,
         terminateds: Union[MultiAgentDict, bool] = False,
         truncateds: Union[MultiAgentDict, bool] = False,
-        render_images: Optional[List[np.ndarray]] = None,
         extra_model_outputs: Optional[List[MultiAgentDict]] = None,
         env_t_started: Optional[int] = None,
         agent_t_started: Optional[Dict[AgentID, int]] = None,
@@ -125,8 +123,6 @@ class MultiAgentEpisode:
                 truncated. A special __all__ key in these dicts indicates, whether the
                 episode is truncated for all agents.
                 The default is `False`, i.e. the episode has not been truncated.
-            render_images: A list of RGB uint8 images from rendering
-                the multi-agent environment.
             extra_model_outputs: A list of dictionaries mapping agent IDs to their
                 corresponding extra model outputs. Each of these "outputs" is a dict
                 mapping keys (str) to model output values, for example for
@@ -267,17 +263,6 @@ class MultiAgentEpisode:
             len_lookback_buffer=len_lookback_buffer,
         )
 
-        # TODO (sven): Remove this in favor of logging render images from an env inside
-        #  custom callbacks and using a to-be-designed metrics logger. Render images
-        #  from the env should NOT be stored in an episode (b/c they have nothing to do
-        #  with the data to be learned from, which should be the only thing an episode
-        #  has to be concerned with).
-        # RGB uint8 images from rendering the env.
-        assert render_images is None or observations is not None
-        self.render_images: Union[List[np.ndarray], List[object]] = (
-            [] if render_images is None else render_images
-        )
-
         # Keep timer stats on deltas between steps.
         self._start_time = None
         self._last_step_time = None
@@ -290,7 +275,6 @@ class MultiAgentEpisode:
         *,
         observations: MultiAgentDict,
         infos: Optional[MultiAgentDict] = None,
-        render_image: Optional[np.ndarray] = None,
     ) -> None:
         """Stores initial observation.
 
@@ -302,19 +286,12 @@ class MultiAgentEpisode:
                 the agent IDs in `infos` must be a subset of those in `observations`
                 meaning it would not be allowed to have an agent with an info dict,
                 but not with an observation.
-            render_image: A (global) RGB uint8 image from rendering the environment
-                (for all agents).
         """
         assert not self.is_done
         # Assume that this episode is completely empty and has not stepped yet.
         # Leave self.env_t (and self.env_t_started) at 0.
         assert self.env_t == self.env_t_started == 0
         infos = infos or {}
-
-        # Note that we store the render images into the `MultiAgentEpisode`
-        # instead into each `SingleAgentEpisode`.
-        if render_image is not None:
-            self.render_images.append(render_image)
 
         # Note, all agents will have an initial observation, some may have an initial
         # info dict as well.
@@ -352,7 +329,6 @@ class MultiAgentEpisode:
         *,
         terminateds: Optional[MultiAgentDict] = None,
         truncateds: Optional[MultiAgentDict] = None,
-        render_image: Optional[np.ndarray] = None,
         extra_model_outputs: Optional[MultiAgentDict] = None,
     ) -> None:
         """Adds a timestep to the episode.
@@ -378,7 +354,6 @@ class MultiAgentEpisode:
                 indicating, whether the environment has been truncated for them.
                 A special `__all__` key indicates that the episode is `truncated` for
                 all agent IDs.
-            render_image: An RGB uint8 image from rendering the environment.
             extra_model_outputs: A dictionary mapping agent IDs to their
                 corresponding specific model outputs (also in a dictionary; e.g.
                 `vf_preds` for PPO).
@@ -413,11 +388,6 @@ class MultiAgentEpisode:
         # this episode as terminated.
         if all(aid in set(agents_done) for aid in self.agent_ids):
             self.is_terminated = True
-
-        # Note that we store the render images into the `MultiAgentEpisode`
-        # instead of storing them into each `SingleAgentEpisode`.
-        if render_image is not None:
-            self.render_images.append(render_image)
 
         # For all agents that are not stepping in this env step, but that are not done
         # yet -> Add a skip tag to their env- to agent-step mappings.
@@ -1727,7 +1697,6 @@ class MultiAgentEpisode:
                     for agent_id, agent_eps in self.agent_episodes.items()
                 }.items()
             ),
-            "render_images": self.render_images,
             "_start_time": self._start_time,
             "_last_step_time": self._last_step_time,
         }
@@ -1775,7 +1744,6 @@ class MultiAgentEpisode:
             agent_id: SingleAgentEpisode.from_state(agent_state)
             for agent_id, agent_state in state["agent_episodes"]
         }
-        episode.render_images = state["render_images"]
         episode._start_time = state["_start_time"]
         episode._last_step_time = state["_last_step_time"]
 

--- a/rllib/env/tests/test_multi_agent_episode.py
+++ b/rllib/env/tests/test_multi_agent_episode.py
@@ -3366,7 +3366,6 @@ class TestMultiAgentEpisode(unittest.TestCase):
         )
         for agent_id, agent_eps in episode_2.agent_episodes.items():
             self.assertEqual(agent_eps.id_, episode.agent_episodes[agent_id].id_)
-        check(episode_2.render_images, episode.render_images)
         check(episode_2._start_time, episode._start_time)
         check(episode_2._last_step_time, episode._last_step_time)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Metrics do-over 06:
* Remove `render_images`/`with_render_images` from MAEps and MAEnvRunner
* deprecate `render_env` algo config option (in favor of new WandB and MetricsLogger based examples).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
