### PR TITLE
[RLlib] - Fix APPO RLModule inference-only problems.

### DIFF
--- a/rllib/algorithms/appo/appo_rl_module.py
+++ b/rllib/algorithms/appo/appo_rl_module.py
@@ -1,0 +1,31 @@
+"""
+This file holds framework-agnostic components for APPO's RLModules.
+"""
+
+import abc
+
+from ray.rllib.algorithms.ppo.ppo_rl_module import PPORLModule
+from ray.rllib.utils.annotations import ExperimentalAPI
+
+# TODO (simon): Write a light-weight version of this class for the `TFRLModule`
+
+
+@ExperimentalAPI
+class APPORLModule(PPORLModule, abc.ABC):
+    def setup(self):
+        super().setup()
+
+        # If the module is not for inference only, set up the target networks.
+        if not self.inference_only:
+            catalog = self.config.get_catalog()
+            # Old pi and old encoder are the "target networks" that are used for
+            # the stabilization of the updates of the current pi and encoder.
+            self.old_pi = catalog.build_pi_head(framework=self.framework)
+            self.old_encoder = catalog.build_actor_critic_encoder(
+                framework=self.framework
+            )
+            self.old_pi.load_state_dict(self.pi.state_dict())
+            self.old_encoder.load_state_dict(self.encoder.state_dict())
+            # We do not train the targets.
+            self.old_pi.requires_grad_(False)
+            self.old_encoder.requires_grad_(False)

--- a/rllib/algorithms/appo/appo_rl_module.py
+++ b/rllib/algorithms/appo/appo_rl_module.py
@@ -24,8 +24,3 @@ class APPORLModule(PPORLModule, abc.ABC):
             self.old_encoder = catalog.build_actor_critic_encoder(
                 framework=self.framework
             )
-            self.old_pi.load_state_dict(self.pi.state_dict())
-            self.old_encoder.load_state_dict(self.encoder.state_dict())
-            # We do not train the targets.
-            self.old_pi.requires_grad_(False)
-            self.old_encoder.requires_grad_(False)

--- a/rllib/algorithms/appo/tf/appo_tf_rl_module.py
+++ b/rllib/algorithms/appo/tf/appo_tf_rl_module.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from ray.rllib.algorithms.appo.appo import OLD_ACTION_DIST_LOGITS_KEY
+from ray.rllib.algorithms.appo.appo_rl_module import APPORLModule
 from ray.rllib.algorithms.ppo.tf.ppo_tf_rl_module import PPOTfRLModule
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.models.base import ACTOR
@@ -15,19 +16,7 @@ from ray.rllib.utils.nested_dict import NestedDict
 _, tf, _ = try_import_tf()
 
 
-class APPOTfRLModule(PPOTfRLModule, RLModuleWithTargetNetworksInterface):
-    def setup(self):
-        super().setup()
-        catalog = self.config.get_catalog()
-        # old pi and old encoder are the "target networks" that are used for
-        # the stabilization of the updates of the current pi and encoder.
-        self.old_pi = catalog.build_pi_head(framework=self.framework)
-        self.old_encoder = catalog.build_actor_critic_encoder(framework=self.framework)
-        self.old_pi.set_weights(self.pi.get_weights())
-        self.old_encoder.set_weights(self.encoder.get_weights())
-        self.old_pi.trainable = False
-        self.old_encoder.trainable = False
-
+class APPOTfRLModule(PPOTfRLModule, RLModuleWithTargetNetworksInterface, APPORLModule):
     @override(RLModuleWithTargetNetworksInterface)
     def get_target_network_pairs(self):
         return [(self.old_pi, self.pi), (self.old_encoder, self.encoder)]

--- a/rllib/algorithms/appo/tf/appo_tf_rl_module.py
+++ b/rllib/algorithms/appo/tf/appo_tf_rl_module.py
@@ -17,6 +17,17 @@ _, tf, _ = try_import_tf()
 
 
 class APPOTfRLModule(PPOTfRLModule, RLModuleWithTargetNetworksInterface, APPORLModule):
+    @override(PPOTfRLModule)
+    def setup(self):
+        super().setup()
+
+        # If the module is not for inference only, set up the target networks.
+        if not self.inference_only:
+            self.old_pi.set_weights(self.pi.get_weights())
+            self.old_encoder.set_weights(self.encoder.get_weights())
+            self.old_pi.trainable = False
+            self.old_encoder.trainable = False
+
     @override(RLModuleWithTargetNetworksInterface)
     def get_target_network_pairs(self):
         return [(self.old_pi, self.pi), (self.old_encoder, self.encoder)]

--- a/rllib/algorithms/appo/torch/appo_torch_rl_module.py
+++ b/rllib/algorithms/appo/torch/appo_torch_rl_module.py
@@ -18,6 +18,18 @@ from ray.rllib.utils.nested_dict import NestedDict
 class APPOTorchRLModule(
     PPOTorchRLModule, RLModuleWithTargetNetworksInterface, APPORLModule
 ):
+    @override(PPOTorchRLModule)
+    def setup(self):
+        super().setup()
+
+        # If the module is not for inference only, update the target networks.
+        if not self.inference_only:
+            self.old_pi.load_state_dict(self.pi.state_dict())
+            self.old_encoder.load_state_dict(self.encoder.state_dict())
+            # We do not train the targets.
+            self.old_pi.requires_grad_(False)
+            self.old_encoder.requires_grad_(False)
+
     @override(RLModuleWithTargetNetworksInterface)
     def get_target_network_pairs(self):
         return [(self.old_pi, self.pi), (self.old_encoder, self.encoder)]

--- a/rllib/algorithms/appo/torch/appo_torch_rl_module.py
+++ b/rllib/algorithms/appo/torch/appo_torch_rl_module.py
@@ -44,12 +44,6 @@ class APPOTorchRLModule(
 
     @override(PPOTorchRLModule)
     def _forward_train(self, batch: NestedDict):
-        if self.inference_only:
-            raise RuntimeError(
-                "Trying to train a module that is not a learner module. Set the "
-                "flag `inference_only=False` when building the module."
-            )
-
         outs = super()._forward_train(batch)
         old_pi_inputs_encoded = self.old_encoder(batch)[ENCODER_OUT][ACTOR]
         old_action_dist_logits = self.old_pi(old_pi_inputs_encoded)

--- a/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
+++ b/rllib/algorithms/ppo/torch/ppo_torch_rl_module.py
@@ -141,7 +141,9 @@ class PPOTorchRLModule(TorchRLModule, PPORLModule):
         # Note, these keys are only known to the learner module. Furthermore,
         # we want this to be run once during setup and not for each worker.
         self._inference_only_state_dict_keys["unexpected_keys"] = [
-            name for name in state_dict if "vf" in name or "critic_encoder" in name
+            name
+            for name in state_dict
+            if "vf" in name or name.startswith("encoder.critic_encoder")
         ]
         # Do we use a separate encoder for the actor and critic?
         # if not self.config.model_config_dict.get("vf_share_layers", True):
@@ -153,7 +155,7 @@ class PPOTorchRLModule(TorchRLModule, PPORLModule):
             self._inference_only_state_dict_keys["expected_keys"] = {
                 name: name.replace("actor_encoder", "encoder")
                 for name in state_dict
-                if "actor_encoder" in name
+                if name.startswith("encoder.actor_encoder")
             }
 
     @override(TorchRLModule)


### PR DESCRIPTION
## Why are these changes needed?

The APPO algorithm could not deal with `inference-only`, yet. This change does enable `inference-only` modules for APPO. In addition to the `_inference_only_state_dict_keys` from PPO, APPO needs to remove the target networks when in inference. 

For this to work properly a parent `RLModule` is needed that triggers the building of the `_inference_only_state_dict_keys`. Due to inheritance from the PPO module polymorphism did not work out of the box b/c this parent was missing. This parent is added to APPO in this PR as well, named `APPORLModule`. 


## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
