### PR TITLE
[Doc] Fix broken references in serve documentation

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -14,9 +14,7 @@ sphinxcontrib-redoc==1.6.0
 sphinx-remove-toctrees==0.0.3
 sphinx_design==0.5.0
 pydata-sphinx-theme==0.14.1
-# Supporrt v1 pydantic schema.
-# https://autodoc-pydantic.readthedocs.io/en/stable/users/faq.html#migration-guide-from-v1-to-v2
-autodoc_pydantic==1.9.0
+autodoc_pydantic==2.2.0
 
 pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3
 

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -99,6 +99,7 @@ See the [model composition guide](serve-model-composition) for how to update cod
    serve.get_deployment_handle
    serve.grpc_util.RayServegRPCContext
    serve.exceptions.BackPressureError
+   serve.exceptions.RayServeException
 ```
 
 (serve-cli)=

--- a/doc/source/serve/http-guide.md
+++ b/doc/source/serve/http-guide.md
@@ -60,7 +60,7 @@ When the request is cancelled, a cancellation error is raised inside the `Snorin
 (serve-fastapi-http)=
 ## FastAPI HTTP Deployments
 
-If you want to define more complex HTTP handling logic, Serve integrates with [FastAPI](https://fastapi.tiangolo.com/). This allows you to define a Serve deployment using the {mod}`@serve.ingress <ray.serve.api.ingress>` decorator that wraps a FastAPI app with its full range of features. The most basic example of this is shown below, but for more details on all that FastAPI has to offer such as variable routes, automatic type validation, dependency injection (e.g., for database connections), and more, please check out [their documentation](https://fastapi.tiangolo.com/).
+If you want to define more complex HTTP handling logic, Serve integrates with [FastAPI](https://fastapi.tiangolo.com/). This allows you to define a Serve deployment using the {mod}`@serve.ingress <ray.serve.ingress>` decorator that wraps a FastAPI app with its full range of features. The most basic example of this is shown below, but for more details on all that FastAPI has to offer such as variable routes, automatic type validation, dependency injection (e.g., for database connections), and more, please check out [their documentation](https://fastapi.tiangolo.com/).
 
 :::{note}
 A Serve application that's integrated with FastAPI still respects the `route_prefix` set through Serve. The routes are that registered through the FastAPI `app` object are layered on top of the route prefix. For instance, if your Serve application has `route_prefix = /my_app` and you decorate a method with `@app.get("/fetch_data")`, then you can call that method by sending a GET request to the path `/my_app/fetch_data`.

--- a/doc/source/serve/key-concepts.md
+++ b/doc/source/serve/key-concepts.md
@@ -11,7 +11,7 @@ A deployment contains business logic or an ML model to handle incoming requests 
 At runtime, a deployment consists of a number of *replicas*, which are individual copies of the class or function that are started in separate Ray Actors (processes).
 The number of replicas can be scaled up or down (or even autoscaled) to match the incoming request load.
 
-To define a deployment, use the {mod}`@serve.deployment <ray.serve.api.deployment>` decorator on a Python class (or function for simple use cases).
+To define a deployment, use the {mod}`@serve.deployment <ray.serve.deployment>` decorator on a Python class (or function for simple use cases).
 Then, `bind` the deployment with optional arguments to the constructor to define an [application](serve-key-concepts-application).
 Finally, deploy the resulting application using `serve.run` (or the equivalent `serve run` CLI command, see [Development Workflow](serve-dev-workflow) for details).
 


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes broken links in Serve documentation in preparation for turning on Sphinx's nitpicky mode.

## Related issue number

Partially addresses #39658.

Note: The version increase of `autodoc_pydantic` is needed to support `@root_validator`-decorated pydantic models, and is made possible by #40451.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
