### PR TITLE
[serve] Fix controller recovery bug

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -100,10 +100,11 @@ class AutoscalingState:
         self._target_capacity: Optional[float] = None
         self._target_capacity_direction: Optional[TargetCapacityDirection] = None
 
-    def register(
-        self, info: DeploymentInfo, curr_target_num_replicas: Optional[int] = None
-    ) -> int:
-        """Registers an autoscaling deployment's info."""
+    def register(self, info: DeploymentInfo, curr_target_num_replicas: int) -> int:
+        """Registers an autoscaling deployment's info.
+
+        Returns the number of replicas the target should be set to.
+        """
 
         config = info.deployment_config.autoscaling_config
         if (
@@ -331,7 +332,7 @@ class AutoscalingStateManager:
         self,
         deployment_id: DeploymentID,
         info: DeploymentInfo,
-        curr_target_num_replicas: Optional[int] = None,
+        curr_target_num_replicas: int,
     ) -> int:
         """Register autoscaling deployment info."""
         assert info.deployment_config.autoscaling_config

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1301,7 +1301,9 @@ class DeploymentState:
         )
         if self._target_state.info.deployment_config.autoscaling_config:
             self._autoscaling_state_manager.register_deployment(
-                self._id, self._target_state.info
+                self._id,
+                self._target_state.info,
+                self._target_state.target_num_replicas,
             )
 
     def recover_current_state_from_replica_actor_names(

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -26,14 +26,23 @@ from ray.serve.tests.test_failure import request_with_retries
 from ray.util.state import list_actors
 
 
-def test_recover_start_from_replica_actor_names(serve_instance):
+@pytest.mark.parametrize(
+    "deployment_options",
+    [
+        {"num_replicas": 2},
+        {"autoscaling_config": {"min_replicas": 2, "max_replicas": 2}},
+    ],
+)
+def test_recover_start_from_replica_actor_names(serve_instance, deployment_options):
     """Test controller is able to recover starting -> running replicas from
     actor names.
     """
 
     # Test failed to deploy with total of 2 replicas,
     # but first constructor call fails.
-    @serve.deployment(name="recover_start_from_replica_actor_names", num_replicas=2)
+    @serve.deployment(
+        name="recover_start_from_replica_actor_names", **deployment_options
+    )
     class TransientConstructorFailureDeployment:
         def __init__(self):
             return True


### PR DESCRIPTION
[serve] Fix controller recovery bug

When controller recovers and there are autoscaling deployments whose configs don't have `initial_replicas` set, controller recover fails because of this bug.

I've fixed the bug and added a test for it.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
