### PR TITLE
Accelerated DAG channel lock fixes

### DIFF
--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -83,11 +83,6 @@ MutableObjectManager::~MutableObjectManager() {
     (void)SetErrorInternal(object_id);
     DestroySemaphores(object_id);
   }
-  for (const auto &[_, channel] : channels_) {
-    if (channel.reading) {
-      // channel.lock->Unlock();
-    }
-  }
   channels_.clear();
   destructor_lock_.Unlock();
 }
@@ -259,17 +254,24 @@ Status MutableObjectManager::ReadAcquire(const ObjectID &object_id,
   }
   // This lock ensures that there is only one reader at a time. The lock is released in
   // `ReadRelease()`.
-  channel->lock->Lock();
+  channel->lock->lock();
   channel->reading = true;
 
   PlasmaObjectHeader::Semaphores sem;
   if (!GetSemaphores(object_id, sem)) {
     channel->reading = false;
+    channel->lock->unlock();
     return Status::IOError("Channel has not been registered (cannot get semaphores)");
   }
   int64_t version_read = 0;
-  RAY_RETURN_NOT_OK(channel->mutable_object->header->ReadAcquire(
-      sem, channel->next_version_to_read, version_read));
+  Status s = channel->mutable_object->header->ReadAcquire(
+      sem, channel->next_version_to_read, version_read);
+  if (!s.ok()) {
+    // Failed because the error bit was set on the mutable object.
+    channel->reading = false;
+    channel->lock->unlock();
+    return s;
+  }
   RAY_CHECK_GT(version_read, 0);
   channel->next_version_to_read = version_read;
 
@@ -298,20 +300,27 @@ Status MutableObjectManager::ReadRelease(const ObjectID &object_id)
   if (!channel) {
     return Status::IOError("Channel has not been registered");
   }
+  if (!channel->reading) {
+    return Status::IOError("Must call ReadAcquire() on the channel before ReadRelease()");
+  }
 
   PlasmaObjectHeader::Semaphores sem;
-  if (!GetSemaphores(object_id, sem)) {
-    return Status::IOError("Channel has not been registered (cannot get semaphores)");
+  RAY_CHECK(GetSemaphores(object_id, sem));
+  Status s =
+      channel->mutable_object->header->ReadRelease(sem, channel->next_version_to_read);
+  if (!s.ok()) {
+    // Failed because the error bit was set on the mutable object.
+    channel->reading = false;
+    channel->lock->unlock();
+    return s;
   }
-  RAY_RETURN_NOT_OK(
-      channel->mutable_object->header->ReadRelease(sem, channel->next_version_to_read));
   // The next read needs to read at least this version.
   channel->next_version_to_read++;
 
   // This lock ensures that there is only one reader at a time. The lock is acquired in
   // `ReadAcquire()`.
   channel->reading = false;
-  channel->lock->Unlock();
+  channel->lock->unlock();
   return Status::OK();
 }
 
@@ -330,6 +339,7 @@ Status MutableObjectManager::SetErrorInternal(const ObjectID &object_id) {
     channel->mutable_object->header->SetErrorUnlocked(sem);
     channel->reader_registered = false;
     channel->writer_registered = false;
+    // TODO(jhumphri): Free the channel.
   } else {
     return Status::IOError("Channel has not been registered");
   }

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -16,6 +16,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -37,7 +38,7 @@ class MutableObjectManager {
  public:
   struct Channel {
     Channel(std::unique_ptr<plasma::MutableObject> mutable_object_ptr)
-        : lock(std::make_unique<absl::Mutex>()),
+        : lock(std::make_unique<std::mutex>()),
           mutable_object(std::move(mutable_object_ptr)) {}
 
     // WriteAcquire() sets this to true. WriteRelease() sets this to false.
@@ -48,7 +49,7 @@ class MutableObjectManager {
     bool reading = false;
 
     // This mutex protects `next_version_to_read`.
-    std::unique_ptr<absl::Mutex> lock;
+    std::unique_ptr<std::mutex> lock;
     // The last version that we read. To read again, we must pass a newer
     // version than this.
     int64_t next_version_to_read = 1;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes two issues:
1. When the error bit is set on a mutable object, a reader may return from ReadAcquire() without releasing the channel lock. This will cause deadlock if another reader calls ReadAcquire() on the channel.

2. Abseil reports  a deadlock on the channel lock, though this is a false positive. Note that Abseil only tracks deadlocks when compiled with debug mode (`export RAY_DEBUG_BUILD=debug`), so this issue will not appear otherwise.
Specifically, the following occurs:
(1) Abseil sees ReadAcquire() acquire the destructor lock followed by the _input_ channel lock.
(2) When WriteAcquire() is called on the _output_ channel, Abseil sees that the thread already holds the _input_ channel lock and then the thread acquires the destructor lock.
(3) Since Abseil sees these locks acquired in the reverse order in (2), it thinks there could be a deadlock.

The deadlock check can only be disabled globally, which is undesirable, rather than for a specific lock. To resolve this issue for now, I replace absl::Mutex with std::mutex so that Abseil does not track deadlock on this lock.

A better long-term solution is to rework the synchronization model so that a lock is not held after ReadAcquire() returns.

## Related issue number

N/A

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
