### PR TITLE
[spark] Fix GPUs per spark worker node calculation

### DIFF
--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -1056,10 +1056,7 @@ def _setup_ray_cluster_internal(
         )
 
         num_cpus_spark_worker = _get_cpu_cores()
-        if num_spark_task_gpus == 0:
-            num_gpus_spark_worker = 0
-        else:
-            num_gpus_spark_worker = _get_num_physical_gpus()
+        num_gpus_spark_worker = _get_num_physical_gpus()
         total_mem_bytes = _get_spark_worker_total_physical_memory()
 
         return (

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -1065,7 +1065,11 @@ def _setup_ray_cluster_internal(
             total_mem_bytes,
         )
 
-    (num_cpus_spark_worker, num_gpus_spark_worker, spark_worker_mem_bytes,) = (
+    (
+        num_cpus_spark_worker,
+        num_gpus_spark_worker,
+        spark_worker_mem_bytes,
+    ) = (
         spark.sparkContext.parallelize([1], 1)
         .map(_get_spark_worker_resources)
         .collect()[0]

--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -1065,11 +1065,7 @@ def _setup_ray_cluster_internal(
             total_mem_bytes,
         )
 
-    (
-        num_cpus_spark_worker,
-        num_gpus_spark_worker,
-        spark_worker_mem_bytes,
-    ) = (
+    (num_cpus_spark_worker, num_gpus_spark_worker, spark_worker_mem_bytes,) = (
         spark.sparkContext.parallelize([1], 1)
         .map(_get_spark_worker_resources)
         .collect()[0]

--- a/python/ray/util/spark/utils.py
+++ b/python/ray/util/spark/utils.py
@@ -382,9 +382,9 @@ def _get_local_ray_node_slots(
         if num_gpus_per_node > num_gpus:
             raise ValueError(
                 "gpu number per Ray worker node should be <= spark worker node "
-                "GPU number, you set cpu number per Ray worker node to "
-                f"{num_cpus_per_node} but spark worker node CPU core number "
-                f"is {num_cpus}."
+                "GPU number, you set GPU devices number per Ray worker node to "
+                f"{num_gpus_per_node} but spark worker node GPU devices number "
+                f"is {num_gpus}."
             )
         if num_ray_node_slots > num_gpus // num_gpus_per_node:
             num_ray_node_slots = num_gpus // num_gpus_per_node

--- a/python/ray/util/spark/utils.py
+++ b/python/ray/util/spark/utils.py
@@ -357,10 +357,14 @@ def _get_num_physical_gpus():
             text=True,
             capture_output=True,
         )
-    except Exception as e:
-        raise RuntimeError(
+    except Exception:
+        _logger.warning(
             "Running command `nvidia-smi` for inferring GPU devices list failed."
-        ) from e
+        )
+        _logger.debug(
+            "'nvidia-smi --query-gpu=name --format=csv,noheader' command execution failed.",
+            exc_info=True,
+        )
     return len(completed_proc.stdout.strip().split("\n"))
 
 

--- a/python/ray/util/spark/utils.py
+++ b/python/ray/util/spark/utils.py
@@ -357,6 +357,7 @@ def _get_num_physical_gpus():
             text=True,
             capture_output=True,
         )
+        return len(completed_proc.stdout.strip().split("\n"))
     except Exception:
         _logger.warning(
             "Running command `nvidia-smi` for inferring GPU devices list failed."
@@ -365,7 +366,7 @@ def _get_num_physical_gpus():
             "'nvidia-smi --query-gpu=name --format=csv,noheader' command execution failed.",
             exc_info=True,
         )
-    return len(completed_proc.stdout.strip().split("\n"))
+        return 0
 
 
 def _get_local_ray_node_slots(

--- a/python/ray/util/spark/utils.py
+++ b/python/ray/util/spark/utils.py
@@ -363,7 +363,8 @@ def _get_num_physical_gpus():
             "Running command `nvidia-smi` for inferring GPU devices list failed."
         )
         _logger.debug(
-            "'nvidia-smi --query-gpu=name --format=csv,noheader' command execution failed.",
+            "'nvidia-smi --query-gpu=name --format=csv,noheader' command execution "
+            "failed.",
             exc_info=True,
         )
         return 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fix GPUs per spark worker node calculation:

In current master code, if `spark.task.resource.gpu.amount` is set to `0`, "GPUs per spark worker node" variable is set to `0` , but the value "GPUs per spark worker node"  should not be affected by `spark.task.resource.gpu.amount`. In many cases, users set `spark.task.resource.gpu.amount` to `0` to avoid spark SQL jobs using GPU, but the spark cluster worker nodes still have GPU devices.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
