### PR TITLE
[ci] mac dashboard flaky test jobs

### DIFF
--- a/.buildkite/macos/macos.rayci.yml
+++ b/.buildkite/macos/macos.rayci.yml
@@ -102,7 +102,7 @@ steps:
     commands:
       - RAY_INSTALL_JAVA=1 ./ci/ray_ci/macos/macos_ci.sh run_ray_cpp_and_java
 
-  - label: ":ray: core: :mac: small & large flaky tests"
+  - label: ":ray: core: :mac: python flaky tests"
     if: build.env("BUILDKITE_PIPELINE_ID") != "0189e759-8c96-4302-b6b5-b4274406bf89"
     tags:
       - core_cpp
@@ -114,9 +114,9 @@ steps:
     instance_type: macos
     soft_fail: true
     commands:
-      - ./ci/ray_ci/macos/macos_ci.sh run_small_and_large_flaky_tests
+      - ./ci/ray_ci/macos/macos_ci.sh run_python_flaky_tests
 
-  - label: ":ray: core: :mac: medium flaky tests"
+  - label: ":ray: core: :mac: core and dashboard flaky tests"
     if: build.env("BUILDKITE_PIPELINE_ID") != "0189e759-8c96-4302-b6b5-b4274406bf89"
     tags:
       - core_cpp
@@ -128,4 +128,4 @@ steps:
     instance_type: macos
     soft_fail: true
     commands:
-      - ./ci/ray_ci/macos/macos_ci.sh run_medium_flaky_tests
+      - ./ci/ray_ci/macos/macos_ci.sh run_core_dashboard_flaky_test

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -27,21 +27,26 @@ run_tests() {
       --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --test_env=CI "$@"
 }
 
-run_small_and_large_flaky_tests() {
+run_python_flaky_tests() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
-  (bazel query 'attr(tags, "client_tests|small_size_python_tests|large_size_python_tests_shard_0|large_size_python_tests_shard_1|large_size_python_tests_shard_2", tests(//python/ray/tests/...))' | select_flaky_tests |
+  (bazel query 'attr(tags, "client_tests|small_size_python_tests|medium_size_python_tests_a_to_j|medium_size_python_tests_k_to_z|large_size_python_tests_shard_0|large_size_python_tests_shard_1|large_size_python_tests_shard_2", tests(//python/ray/tests/...))' | select_flaky_tests |
     xargs bazel test --config=ci $(./ci/run/bazel_export_options) \
       --runs_per_test="$RUN_PER_FLAKY_TEST" \
       --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX \
       --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --test_env=CI) || exit 42
 }
 
-run_medium_flaky_tests() {
+run_core_dashboard_flaky_test() {
+  TORCH_VERSION=1.9.0 ./ci/env/install-dependencies.sh
+  # Use --dynamic_mode=off until MacOS CI runs on Big Sur or newer. Otherwise there are problems with running tests
+  # with dynamic linking.
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
-  (bazel query 'attr(tags, "medium_size_python_tests_a_to_j|medium_size_python_tests_k_to_z", tests(//python/ray/tests/...))' | select_flaky_tests |
-    xargs bazel test --config=ci $(./ci/run/bazel_export_options) --runs_per_test="$RUN_PER_FLAKY_TEST" --test_env=CI) || exit 42
+  (bazel cquery '(tests(//python/ray/dashboard/...) union tests(//:all)) except (tests(//python/ray/serve/...) union tests(//rllib/...))' | awk '{print $1;}' | select_flaky_tests |
+    xargs bazel test --config=ci --dynamic_mode=off \
+      --test_env=CI $(./ci/run/bazel_export_options) --build_tests_only \
+      --test_tag_filters=-post_wheel_build) || exit 42
 }
 
 run_small_test() {
@@ -82,10 +87,10 @@ run_core_dashboard_test() {
   # with dynamic linking.
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
-  (bazel test --config=ci --dynamic_mode=off \
-    --test_env=CI $(./ci/run/bazel_export_options) --build_tests_only \
-    --test_tag_filters=-post_wheel_build -- \
-    //:all python/ray/dashboard/... -python/ray/serve/... -rllib/...) || exit 42
+  (bazel cquery '(tests(//python/ray/dashboard/...) union tests(//:all)) except (tests(//python/ray/serve/...) union tests(//rllib/...))' | awk '{print $1;}' | filter_out_flaky_tests |
+    xargs bazel test --config=ci --dynamic_mode=off \
+      --test_env=CI $(./ci/run/bazel_export_options) --build_tests_only \
+      --test_tag_filters=-post_wheel_build) || exit 42
 }
 
 run_ray_cpp_and_java() {


### PR DESCRIPTION
- Add flaky job for mac dashboard test
- Merge the flaky small, medium and large job into one

Note that I use `bazel cquery` instead of `bazel query` as `cquery` is platform awareness.

Test:
- CI (https://buildkite.com/ray-project/premerge/builds/25495#018f403d-68fe-4674-a8b1-5b9a62bc246a)