### PR TITLE
[Core] Use GCS cluster id as the usage stats reported session id

### DIFF
--- a/dashboard/modules/usage_stats/usage_stats_head.py
+++ b/dashboard/modules/usage_stats/usage_stats_head.py
@@ -126,6 +126,7 @@ class UsageStatsHead(dashboard_utils.DashboardHeadModule):
                 self.total_failed,
                 self.seq_no,
                 self._dashboard_head.gcs_client.address,
+                self._dashboard_head.gcs_client.cluster_id.hex(),
             )
 
             error = None

--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -690,9 +690,7 @@ def test_usage_lib_cluster_metadata_generation(
             ray.experimental.internal_kv.internal_kv_get_gcs_client()
         )
         # Remove fields that are dynamically changed.
-        assert meta.pop("session_id")
         assert meta.pop("session_start_timestamp_ms")
-        assert cluster_metadata.pop("session_id")
         assert cluster_metadata.pop("session_start_timestamp_ms")
         assert meta == cluster_metadata
 
@@ -1064,6 +1062,7 @@ provider:
             2,
             2,
             ray.worker.global_worker.gcs_client.address,
+            ray.worker.global_worker.gcs_client.cluster_id.hex(),
         )
         validate(instance=asdict(d), schema=schema)
 
@@ -1122,7 +1121,7 @@ provider:
         usage_stats_server = start_usage_stats_server
 
         cluster = ray_start_cluster
-        cluster.add_node(num_cpus=3)
+        node = cluster.add_node(num_cpus=3)
         if os.environ.get("RAY_MINIMAL") != "1":
             from ray import train  # noqa: F401
             from ray.rllib.algorithms.ppo import PPO  # noqa: F401
@@ -1170,6 +1169,7 @@ provider:
             )
 
         assert payload["source"] == "OSS"
+        assert payload["session_id"] == node.cluster_id.hex()
         assert payload["cloud_provider"] == "aws"
         assert payload["min_workers"] is None
         assert payload["max_workers"] == 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
After #36517, each Ray cluster has a unique ClusterID and this PR reuses this cluster id as the session id for usage stats report instead of generating a new id.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
