### PR TITLE
[Serve] update serve build multi app doc

### DIFF
--- a/doc/source/serve/multi-app.md
+++ b/doc/source/serve/multi-app.md
@@ -38,7 +38,7 @@ Copy this code to a file named `text_translator.py`.
 Generate a multi-application config file that contains both of these two applications and save it to `config.yaml`.
 
 ```
-serve build --multi-app image_classifier:app text_translator:app -o config.yaml
+serve build image_classifier:app text_translator:app -o config.yaml
 ```
 
 This generates the following config:
@@ -53,21 +53,27 @@ grpc_options:
   port: 9000
   grpc_servicer_functions: []
 
-applications:
-- name: app1
-  route_prefix: /classify
-  import_path: image_classifier:app
-  runtime_env: {}
-  deployments:
-  - name: downloader
-  - name: ImageClassifier
+logging_config:
+  encoding: JSON
+  log_level: INFO
+  logs_dir: null
+  enable_access_log: true
 
-- name: app2
-  route_prefix: /translate
-  import_path: text_translator:app
-  runtime_env: {}
-  deployments:
-  - name: Translator
+applications:
+  - name: app1
+    route_prefix: /classify
+    import_path: image_classifier:app
+    runtime_env: {}
+    deployments:
+      - name: downloader
+      - name: ImageClassifier
+
+  - name: app2
+    route_prefix: /translate
+    import_path: text_translator:app
+    runtime_env: {}
+    deployments:
+      - name: Translator
 ```
 
 :::{note} 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A user reported the `--multi-app` flag doesn't work. This option is already deprecated from the previous migration work and by default the command will generate multi-app config. This PR updated the docs on example command and the resulting config. This seems to be the only place that's still mentioning `--multi-app`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
