### PR TITLE
[Docker] Downgrade tensorflow version from `2.15.1` to `2.14.0` to be compatible with `cuda==118` in ML docker image.

### DIFF
--- a/ci/build/build-docker-images.py
+++ b/ci/build/build-docker-images.py
@@ -67,7 +67,7 @@ CUDA_FULL = {
 # If changing the CUDA version in the below line, you should also change the base Docker
 # image being used in ~/ci/docker/Dockerfile.base.gpu to match the same image being used
 # here.
-ML_CUDA_VERSION = "cu118"
+ML_CUDA_VERSION = "cu121"
 
 DEFAULT_PYTHON_VERSION = "py38"
 

--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
+FROM nvidia/cuda:12.1.0-cudnn8-devel-ubuntu20.04
 
 ARG REMOTE_CACHE_URL
 ARG BUILDKITE_PULL_REQUEST

--- a/ci/docker/base.gpu.py39.wanda.yaml
+++ b/ci/docker/base.gpu.py39.wanda.yaml
@@ -5,7 +5,7 @@
 # TODO(can-anyscale): migrate all jobs to use the multi-py version
 
 name: "oss-ci-base_gpu"
-froms: ["nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04"]
+froms: ["nvidia/cuda:12.1.0-cudnn8-devel-ubuntu20.04"]
 dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc

--- a/ci/docker/base.gpu.wanda.yaml
+++ b/ci/docker/base.gpu.wanda.yaml
@@ -1,5 +1,5 @@
 name: "oss-ci-base_gpu-py$PYTHON"
-froms: ["nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04"]
+froms: ["nvidia/cuda:12.1.0-cudnn8-devel-ubuntu20.04"]
 dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc

--- a/python/requirements/ml/dl-cpu-requirements.txt
+++ b/python/requirements/ml/dl-cpu-requirements.txt
@@ -1,9 +1,9 @@
 # These requirements are used for the CI and CPU-only Docker images so we install CPU only versions of torch.
 # For GPU Docker images, you should install dl-gpu-requirements.txt afterwards.
 
-tensorflow==2.14.0; sys_platform != 'darwin' or platform_machine != 'arm64'
-tensorflow-macos==2.14.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-tensorflow-probability==0.22.0
+tensorflow==2.15.1; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.15.1; sys_platform == 'darwin' and platform_machine == 'arm64'
+tensorflow-probability==0.23.0
 tensorflow-io-gcs-filesystem==0.31.0
 tensorflow-datasets
 array-record==0.5.0; sys_platform != 'darwin' and platform_system != "Windows"
@@ -15,14 +15,15 @@ etils==1.3.0
 --extra-index-url https://download.pytorch.org/whl/cpu  # for CPU versions of torch, torchvision
 --find-links https://data.pyg.org/whl/torch-1.13.0+cpu.html  # for CPU versions of torch-scatter, torch-sparse, torch-cluster, torch-spline-conv
 --find-links https://data.pyg.org/whl/torch-2.0.1+cpu.html  # for CPU versions of torch-scatter, torch-sparse, torch-cluster, torch-spline-conv
+--find-links https://data.pyg.org/whl/torch-2.1.0+cpu.html  # for CPU versions of torch-scatter, torch-sparse, torch-cluster, torch-spline-conv
 
-torch==2.0.1
+torch==2.1.0
 torchmetrics==0.10.3
-torchtext==0.15.2
-torchvision==0.15.2
+torchtext==0.16.0
+torchvision==0.16.0
 
-torch-scatter==2.1.1
-torch-sparse==0.6.17
-torch-cluster==1.6.1
+torch-scatter==2.1.2
+torch-sparse==0.6.18
+torch-cluster==1.6.2
 torch-spline-conv==1.2.2
-torch-geometric==2.3.1
+torch-geometric==2.5.0

--- a/python/requirements/ml/dl-cpu-requirements.txt
+++ b/python/requirements/ml/dl-cpu-requirements.txt
@@ -1,9 +1,9 @@
 # These requirements are used for the CI and CPU-only Docker images so we install CPU only versions of torch.
 # For GPU Docker images, you should install dl-gpu-requirements.txt afterwards.
 
-tensorflow==2.15.1; sys_platform != 'darwin' or platform_machine != 'arm64'
-tensorflow-macos==2.15.1; sys_platform == 'darwin' and platform_machine == 'arm64'
-tensorflow-probability==0.23.0
+tensorflow==2.14.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.14.0; sys_platform == 'darwin' and platform_machine == 'arm64'
+tensorflow-probability==0.22.0
 tensorflow-io-gcs-filesystem==0.31.0
 tensorflow-datasets
 array-record==0.5.0; sys_platform != 'darwin' and platform_system != "Windows"

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -2,7 +2,7 @@
 
 tensorflow==2.14.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.14.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-tensorflow-probability==0.23.0
+tensorflow-probability==0.22.0
 tensorflow-datasets
 
 --extra-index-url https://download.pytorch.org/whl/cu118  # for GPU versions of torch, torchvision

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -1,16 +1,16 @@
 # If you make changes below this line, please also make the corresponding changes to `dl-cpu-requirements.txt`!
 
-tensorflow==2.14.0; sys_platform != 'darwin' or platform_machine != 'arm64'
-tensorflow-macos==2.14.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-tensorflow-probability==0.22.0
+tensorflow==2.15.1; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.15.1; sys_platform == 'darwin' and platform_machine == 'arm64'
+tensorflow-probability==0.23.0
 tensorflow-datasets
 
---extra-index-url https://download.pytorch.org/whl/cu118  # for GPU versions of torch, torchvision
---find-links https://data.pyg.org/whl/torch-2.0.1+cu118.html  # for GPU versions of torch-scatter, torch-sparse, torch-cluster, torch-spline-conv
+--extra-index-url https://download.pytorch.org/whl/cu121  # for GPU versions of torch, torchvision
+--find-links https://data.pyg.org/whl/torch-2.1.0+cu121.html  # for GPU versions of torch-scatter, torch-sparse, torch-cluster, torch-spline-conv
 # specifying explicit plus-notation below so pip overwrites the existing cpu verisons
-torch==2.0.1+cu118
-torchvision==0.15.2+cu118
-torch-scatter==2.1.1+pt20cu118
-torch-sparse==0.6.17+pt20cu118
-torch-cluster==1.6.1+pt20cu118
-torch-spline-conv==1.2.2+pt20cu118
+torch==2.1.0+cu121
+torchvision==0.16.0+cu121
+torch-scatter==2.1.2+pt21cu121
+torch-sparse==0.6.18+pt21cu121
+torch-cluster==1.6.2+pt21cu121
+torch-spline-conv==1.2.2+pt21cu121

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -1,7 +1,7 @@
 # If you make changes below this line, please also make the corresponding changes to `dl-cpu-requirements.txt`!
 
-tensorflow==2.15.1; sys_platform != 'darwin' or platform_machine != 'arm64'
-tensorflow-macos==2.15.1; sys_platform == 'darwin' and platform_machine == 'arm64'
+tensorflow==2.14.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.14.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow-probability==0.23.0
 tensorflow-datasets
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The docker image image cannot correctly import `tensorflow`. `tensorflow==2.15.1` relies on `nvcc==12.2`. To fix this importing error, a quick solution is to downgrade tf to `tensorflow==2.14.0`. `tensorflow==2.14.0` relies on `nvcc==11.8`, which is the latest version of `nvcc` that is tested against both `tf` and `torch` stable versions.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
