### PR TITLE
[Data] Do not show AllToAll progress bar if the disable flag is set

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -194,26 +194,25 @@ class OpState:
         """Create progress bars at the given index (line offset in console).
 
         For AllToAllOperator, zero or more sub progress bar would be created.
-        Return the number of progress bars created for this operator.
+        Return the number of enabled progress bars created for this operator.
         """
         is_all_to_all = isinstance(self.op, AllToAllOperator)
         # Only show 1:1 ops when in verbose progress mode.
-        enabled = is_all_to_all or (
-            DataContext.get_current().enable_progress_bars and verbose_progress
+        progress_bar_enabled = DataContext.get_current().enable_progress_bars and (
+            is_all_to_all or verbose_progress
         )
         self.progress_bar = ProgressBar(
             "- " + self.op.name,
             self.op.num_outputs_total(),
             index,
-            enabled=enabled,
+            enabled=progress_bar_enabled,
         )
-        if enabled:
-            num_bars = 1
-            if is_all_to_all:
-                num_bars += self.op.initialize_sub_progress_bars(index + 1)
-        else:
-            num_bars = 0
-        return num_bars
+        num_progress_bars = 1
+        if is_all_to_all:
+            # Initialize must be called for sub progress bars, even the
+            # bars are not enabled via the DataContext.
+            num_progress_bars += self.op.initialize_sub_progress_bars(index + 1)
+        return num_progress_bars if progress_bar_enabled else 0
 
     def close_progress_bars(self):
         """Close all progress bars for this operator."""


### PR DESCRIPTION
## Why are these changes needed?

AllToAll main progress bar is shown even if progress bars are disabled.

## Related issue number

Closes #44770

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] Tested manually the visibility
