### PR TITLE
Use arm image for macbooks

### DIFF
--- a/doc/source/cluster/kubernetes/troubleshooting/troubleshooting.md
+++ b/doc/source/cluster/kubernetes/troubleshooting/troubleshooting.md
@@ -7,6 +7,7 @@ If you don't find an answer to your question here, please don't hesitate to conn
 
 # Contents
 
+- [Use ARM-based docker images for Apple M1/M2 Macbooks](#docker-image-for-apple-macbooks) 
 - [Upgrade KubeRay](#upgrade-kuberay)
 - [Worker init container](#worker-init-container)
 - [Cluster domain](#cluster-domain)
@@ -14,6 +15,13 @@ If you don't find an answer to your question here, please don't hesitate to conn
 - [Autoscaler](#autoscaler)
 - [Other questions](#other-questions)
 
+(docker-image-for-apple-macbooks)=
+## Use ARM-based docker images for Apple M1/M2 Macbooks
+Currently Ray builds different images for different platforms. Until Ray moves to building multi-architecture images, [tracked by this Github issue](https://github.com/ray-project/ray/issues/39364), the solution here is to use platform specific docker images in the head and worker group specs of the [RayCluster config](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#image). 
+
+For e.g. just using `image: rayproject/ray:2.10.0` led to issues such as head service (`rayservice-sample-head-svc`) and Ray Serve service (`rayservice-sample-serve-svc`) for the RayService custom resource not launching in the head node and Serve applications not getting ready. The solution is to use `image: rayproject/ray:2.10.0-aarch64` instead for Apple M1/M2 Macbooks. [Link to issue details and discussion](https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1712267296145549).
+
+(upgrade-kuberay)=
 ## Upgrade KubeRay
 
 If you have issues upgrading KubeRay, refer to the [upgrade guide](#kuberay-upgrade-guide).

--- a/doc/source/cluster/kubernetes/user-guides/config.md
+++ b/doc/source/cluster/kubernetes/user-guides/config.md
@@ -171,6 +171,9 @@ the same Ray version as the CR's `spec.rayVersion`.
 If you are using a nightly or development Ray image, it is fine to specify Ray's
 latest release version under `spec.rayVersion`.
 
+For Apple M1/M2 Macbooks, please refer to [this troubleshooting doc](docker-image-for-apple-macbooks) on specifying the 
+right image.
+
 Code dependencies for a given Ray task or actor must be installed on each Ray node that
 might run the task or actor.
 To achieve this, it is simplest to use the same Ray image for the Ray head and all worker groups.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently Ray builds different images for different platforms. Until Ray moves to building multi-architecture images, [tracked by this Github issue](https://github.com/ray-project/ray/issues/39364), the solution here is to use platform specific docker images in the head and worker group specs of the [RayCluster config](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#image). 


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

Since this is not a code change, I've tested the doc changes from my IDE, the added hyperlinks work.

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
