### PR TITLE
[RLlib] Fix overflow error b/c of int division in `Filter` updates.

### DIFF
--- a/rllib/utils/filter.py
+++ b/rllib/utils/filter.py
@@ -118,8 +118,8 @@ class RunningStat:
             )
 
     def update(self, other):
-        n1 = self.num_pushes
-        n2 = other.num_pushes
+        n1 = float(self.num_pushes)
+        n2 = float(other.num_pushes)
         n = n1 + n2
         if n == 0:
             # Avoid divide by zero, which creates nans


### PR DESCRIPTION
## Why are these changes needed?

`Filter.update` raised multiple times error due to overflow errors using integers in division/multiplication. This PR fixes this by converting the integers before multiplication/division takes place to floats.

## Related issue number



## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
