### PR TITLE
[ci][clean/2] add a flag to disable test state machine

### DIFF
--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -146,6 +146,9 @@ class TesterContainer(Container):
 
     @classmethod
     def move_test_state(cls, team: str, bazel_log_dir: str) -> None:
+        if get_global_config()["state_machine_disabled"]:
+            return
+
         pipeline_id = os.environ.get("BUILDKITE_PIPELINE_ID")
         branch = os.environ.get("BUILDKITE_BRANCH")
         if (

--- a/release/ray_release/configs/global_config.py
+++ b/release/ray_release/configs/global_config.py
@@ -14,6 +14,7 @@ class GlobalConfig(TypedDict):
     byod_gcp_cr: str
     state_machine_pr_aws_bucket: str
     state_machine_branch_aws_bucket: str
+    state_machine_disabled: bool
     aws2gce_credentials: str
     ci_pipeline_premerge: List[str]
     ci_pipeline_postmerge: List[str]
@@ -83,6 +84,10 @@ def _init_global_config(config_file: str):
         .get(
             "aws_bucket",
         ),
+        state_machine_disabled=config_content.get("state_machine", {}).get(
+            "disabled", 0
+        )
+        == 1,
         ci_pipeline_premerge=config_content.get("ci_pipeline", {}).get("premerge", []),
         ci_pipeline_postmerge=config_content.get("ci_pipeline", {}).get(
             "postmerge", []

--- a/release/ray_release/tests/test_global_config.py
+++ b/release/ray_release/tests/test_global_config.py
@@ -19,7 +19,11 @@ release_byod:
   aws_cr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
   gcp_cr: us-west1-docker.pkg.dev/anyscale-oss-ci
 state_machine:
-  aws_bucket: ray-ci-results
+  pr:
+    aws_bucket: ray-ci-pr-results
+  branch:
+    aws_bucket: ray-ci-results
+  disabled: 1
 credentials:
   aws2gce: release/aws2gce_iam.json
 ci_pipeline:
@@ -46,6 +50,8 @@ def test_init_global_config() -> None:
             os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
             == "/workdir/release/aws2gce_iam.json"
         )
+        assert config["state_machine_pr_aws_bucket"] == "ray-ci-pr-results"
+        assert config["state_machine_disabled"] is True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a flag to disable the test state machine in the ci global config. Upstream doesn't have many features required by the test state machine (creating github tickets, bisection, etc.) so need to disable it.

Test:
- CI