### PR TITLE
[Core] Add placeholder callback methods as members of RayDaskCallback

### DIFF
--- a/doc/source/ray-more-libs/dask-on-ray.rst
+++ b/doc/source/ray-more-libs/dask-on-ray.rst
@@ -271,3 +271,15 @@ execution time exceeds some user-defined threshold:
   *submitted*, not executed.
 
 This callback API is currently unstable and subject to change.
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   ray.util.dask.callbacks.RayDaskCallback
+   ray.util.dask.callbacks.RayDaskCallback._ray_presubmit
+   ray.util.dask.callbacks.RayDaskCallback._ray_postsubmit
+   ray.util.dask.callbacks.RayDaskCallback._ray_pretask
+   ray.util.dask.callbacks.RayDaskCallback._ray_posttask
+   ray.util.dask.callbacks.RayDaskCallback._ray_postsubmit_all
+   ray.util.dask.callbacks.RayDaskCallback._ray_finish

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -140,7 +140,7 @@ class RayDaskCallback(Callback):
     def _ray_posttask(self, key, result, pre_state):
         """Run after executing a Dask task within a Ray task.
 
-        This executes within a Ray worker. This callback receives the
+        This method executes within a Ray worker. This callback receives the
         return value of the _ray_pretask callback, if provided.
 
         Args:

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -83,7 +83,7 @@ class RayDaskCallback(Callback):
         """Run before submitting a Ray task.
 
         If this callback returns a non-`None` value, Ray does _not_ create 
-        created and this value will be used as the would-be task's result value.
+        a task and uses this value as the would-be task's result value.
 
         Args:
             task: A Dask task, where the first tuple item is

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -122,7 +122,7 @@ class RayDaskCallback(Callback):
     def _ray_pretask(self, key, object_refs: List[ObjectRef]):
         """Run before executing a Dask task within a Ray task.
 
-        This executes after the task has been submitted, within a Ray
+        This method executes after Ray submits the task within a Ray
         worker. The return value of this task will be passed to the
         _ray_posttask callback, if provided.
 

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -90,7 +90,7 @@ class RayDaskCallback(Callback):
                 the task function, and the remaining tuple items are
                 the task arguments, which are either the actual argument values,
                 or Dask keys into the deps dictionary whose
-                corresponding values are the argument values).
+                corresponding values are the argument values.
             key: The Dask graph key for the given task.
             deps: The dependencies of this task.
 

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -96,7 +96,7 @@ class RayDaskCallback(Callback):
 
         Returns:
             Either None, in which case Ray submits a task, or
-            a non-None value, in which case a Ray task will not be
+            a non-None value, in which case Ray task doesn't submit
             submitted and this return value will be used as the
             would-be task result value.
         """

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -82,7 +82,7 @@ class RayDaskCallback(Callback):
     def _ray_presubmit(self, task, key, deps) -> Optional[Any]:
         """Run before submitting a Ray task.
 
-        If this callback returns a non-`None` value, a Ray task will _not_ be
+        If this callback returns a non-`None` value, Ray does _not_ create 
         created and this value will be used as the would-be task's result value.
 
         Args:

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -95,7 +95,7 @@ class RayDaskCallback(Callback):
             deps: The dependencies of this task.
 
         Returns:
-            Either None, in which case a Ray task will be submitted, or
+            Either None, in which case Ray submits a task, or
             a non-None value, in which case a Ray task will not be
             submitted and this return value will be used as the
             would-be task result value.

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -108,7 +108,7 @@ class RayDaskCallback(Callback):
         Args:
             task: A Dask task, where the first tuple item is
                 the task function, and the remaining tuple items are
-                the task arguments (either the actual argument values,
+                the task arguments, which are either the actual argument values,
                 or Dask keys into the deps dictionary whose
                 corresponding values are the argument values).
             key: The Dask graph key for the given task.

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -82,7 +82,7 @@ class RayDaskCallback(Callback):
     def _ray_presubmit(self, task, key, deps) -> Optional[Any]:
         """Run before submitting a Ray task.
 
-        If this callback returns a non-`None` value, Ray does _not_ create 
+        If this callback returns a non-`None` value, Ray does _not_ create
         a task and uses this value as the would-be task's result value.
 
         Args:
@@ -113,7 +113,7 @@ class RayDaskCallback(Callback):
                 corresponding values are the argument values.
             key: The Dask graph key for the given task.
             deps: The dependencies of this task.
-            object_ref (ray.ObjectRef): The object reference for the
+            object_ref: The object reference for the
                 return value of the Ray task.
 
         """
@@ -128,7 +128,7 @@ class RayDaskCallback(Callback):
 
         Args:
             key: The Dask graph key for the Dask task.
-            object_refs (List[ray.ObjectRef]): The object references
+            object_refs: The object references
                 for the arguments of the Ray task.
 
         Returns:
@@ -155,7 +155,7 @@ class RayDaskCallback(Callback):
         """Run after Ray submits all tasks.
 
         Args:
-            object_refs (List[ray.ObjectRef]): The object references
+            object_refs: The object references
                 for the output (leaf) Ray tasks of the task graph.
             dsk: The Dask graph.
         """

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -133,7 +133,7 @@ class RayDaskCallback(Callback):
 
         Returns:
             A value that Ray passes to the corresponding
-            _ray_posttask callback, if said callback is defined.
+            _ray_posttask callback, if the callback is defined.
         """
         pass
 

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -110,7 +110,7 @@ class RayDaskCallback(Callback):
                 the task function, and the remaining tuple items are
                 the task arguments, which are either the actual argument values,
                 or Dask keys into the deps dictionary whose
-                corresponding values are the argument values).
+                corresponding values are the argument values.
             key: The Dask graph key for the given task.
             deps: The dependencies of this task.
             object_ref (ray.ObjectRef): The object reference for the

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -132,7 +132,7 @@ class RayDaskCallback(Callback):
                 for the arguments of the Ray task.
 
         Returns:
-            A value that will be passed to the corresponding
+            A value that Ray passes to the corresponding
             _ray_posttask callback, if said callback is defined.
         """
         pass

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -152,7 +152,7 @@ class RayDaskCallback(Callback):
         pass
 
     def _ray_postsubmit_all(self, object_refs: List[ObjectRef], dsk):
-        """Run after all Ray tasks have been submitted.
+        """Run after Ray submits all tasks.
 
         Args:
             object_refs (List[ray.ObjectRef]): The object references

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -1,7 +1,9 @@
 import contextlib
 
+from ray import ObjectRef
 from collections import namedtuple, defaultdict
 from datetime import datetime
+from typing import Any, List, Optional
 
 from dask.callbacks import Callback
 
@@ -48,85 +50,6 @@ class RayDaskCallback(Callback):
     ray_active = set()
 
     def __init__(self, **kwargs):
-        """
-        Ray-specific callbacks:
-            - def _ray_presubmit(task, key, deps):
-                Run before submitting a Ray task. If this callback returns a
-                non-`None` value, a Ray task will _not_ be created and this
-                value will be used as the would-be task's result value.
-
-                Args:
-                    task: A Dask task, where the first tuple item is
-                        the task function, and the remaining tuple items are
-                        the task arguments (either the actual argument values,
-                        or Dask keys into the deps dictionary whose
-                        corresponding values are the argument values).
-                    key: The Dask graph key for the given task.
-                    deps: The dependencies of this task.
-
-                Returns:
-                    Either None, in which case a Ray task will be submitted, or
-                    a non-None value, in which case a Ray task will not be
-                    submitted and this return value will be used as the
-                    would-be task result value.
-
-            - def _ray_postsubmit(task, key, deps, object_ref):
-                Run after submitting a Ray task.
-
-                Args:
-                    task: A Dask task, where the first tuple item is
-                        the task function, and the remaining tuple items are
-                        the task arguments (either the actual argument values,
-                        or Dask keys into the deps dictionary whose
-                        corresponding values are the argument values).
-                    key: The Dask graph key for the given task.
-                    deps: The dependencies of this task.
-                    object_ref (ray.ObjectRef): The object reference for the
-                        return value of the Ray task.
-
-            - def _ray_pretask(key, object_refs):
-                Run before executing a Dask task within a Ray task. This
-                executes after the task has been submitted, within a Ray
-                worker. The return value of this task will be passed to the
-                _ray_posttask callback, if provided.
-
-                Args:
-                    key: The Dask graph key for the Dask task.
-                    object_refs (List[ray.ObjectRef]): The object references
-                        for the arguments of the Ray task.
-
-                Returns:
-                    A value that will be passed to the corresponding
-                    _ray_posttask callback, if said callback is defined.
-
-            - def _ray_posttask(key, result, pre_state):
-                Run after executing a Dask task within a Ray task. This
-                executes within a Ray worker. This callback receives the return
-                value of the _ray_pretask callback, if provided.
-
-                Args:
-                    key: The Dask graph key for the Dask task.
-                    result: The task result value.
-                    pre_state: The return value of the corresponding
-                        _ray_pretask callback, if said callback is defined.
-
-            - def _ray_postsubmit_all(object_refs, dsk):
-                Run after all Ray tasks have been submitted.
-
-                Args:
-                    object_refs (List[ray.ObjectRef]): The object references
-                        for the output (leaf) Ray tasks of the task graph.
-                    dsk: The Dask graph.
-
-            - def _ray_finish(result):
-                Run after all Ray tasks have finished executing and the final
-                result has been returned.
-
-                Args:
-                    result: The final result (output) of the Dask
-                        computation, before any repackaging is done by
-                        Dask collection-specific post-compute callbacks.
-        """
         for cb in CBS:
             cb_func = kwargs.pop(cb, None)
             if cb_func is not None:
@@ -155,6 +78,99 @@ class RayDaskCallback(Callback):
     def unregister(self):
         type(self).ray_active.remove(self._ray_callback)
         super().unregister()
+
+    def _ray_presubmit(self, task, key, deps) -> Optional[Any]:
+        """Run before submitting a Ray task.
+
+        If this callback returns a non-`None` value, a Ray task will _not_ be
+        created and this value will be used as the would-be task's result value.
+
+        Args:
+            task: A Dask task, where the first tuple item is
+                the task function, and the remaining tuple items are
+                the task arguments (either the actual argument values,
+                or Dask keys into the deps dictionary whose
+                corresponding values are the argument values).
+            key: The Dask graph key for the given task.
+            deps: The dependencies of this task.
+
+        Returns:
+            Either None, in which case a Ray task will be submitted, or
+            a non-None value, in which case a Ray task will not be
+            submitted and this return value will be used as the
+            would-be task result value.
+        """
+        pass
+
+    def _ray_postsubmit(self, task, key, deps, object_ref: ObjectRef):
+        """Run after submitting a Ray task.
+
+        Args:
+            task: A Dask task, where the first tuple item is
+                the task function, and the remaining tuple items are
+                the task arguments (either the actual argument values,
+                or Dask keys into the deps dictionary whose
+                corresponding values are the argument values).
+            key: The Dask graph key for the given task.
+            deps: The dependencies of this task.
+            object_ref (ray.ObjectRef): The object reference for the
+                return value of the Ray task.
+
+        """
+        pass
+
+    def _ray_pretask(self, key, object_refs: List[ObjectRef]):
+        """Run before executing a Dask task within a Ray task.
+
+        This executes after the task has been submitted, within a Ray
+        worker. The return value of this task will be passed to the
+        _ray_posttask callback, if provided.
+
+        Args:
+            key: The Dask graph key for the Dask task.
+            object_refs (List[ray.ObjectRef]): The object references
+                for the arguments of the Ray task.
+
+        Returns:
+            A value that will be passed to the corresponding
+            _ray_posttask callback, if said callback is defined.
+        """
+        pass
+
+    def _ray_posttask(self, key, result, pre_state):
+        """Run after executing a Dask task within a Ray task.
+
+        This executes within a Ray worker. This callback receives the
+        return value of the _ray_pretask callback, if provided.
+
+        Args:
+            key: The Dask graph key for the Dask task.
+            result: The task result value.
+            pre_state: The return value of the corresponding
+                _ray_pretask callback, if said callback is defined.
+        """
+        pass
+
+    def _ray_postsubmit_all(self, object_refs: List[ObjectRef], dsk):
+        """Run after all Ray tasks have been submitted.
+
+        Args:
+            object_refs (List[ray.ObjectRef]): The object references
+                for the output (leaf) Ray tasks of the task graph.
+            dsk: The Dask graph.
+        """
+        pass
+
+    def _ray_finish(self, result):
+        """Run after all Ray tasks have finished executing and the final
+        result has been returned.
+
+        Args:
+          result: The final result (output) of the Dask
+              computation, before any repackaging is done by
+              Dask collection-specific post-compute callbacks.
+        """
+        pass
 
 
 class add_ray_callbacks:

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -163,7 +163,7 @@ class RayDaskCallback(Callback):
 
     def _ray_finish(self, result):
         """Run after Ray finishes executing all Ray tasks and returns the final
-        result has been returned.
+        result.
 
         Args:
           result: The final result (output) of the Dask

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -88,7 +88,7 @@ class RayDaskCallback(Callback):
         Args:
             task: A Dask task, where the first tuple item is
                 the task function, and the remaining tuple items are
-                the task arguments (either the actual argument values,
+                the task arguments, which are either the actual argument values,
                 or Dask keys into the deps dictionary whose
                 corresponding values are the argument values).
             key: The Dask graph key for the given task.

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -162,7 +162,7 @@ class RayDaskCallback(Callback):
         pass
 
     def _ray_finish(self, result):
-        """Run after all Ray tasks have finished executing and the final
+        """Run after Ray finishes executing all Ray tasks and returns the final
         result has been returned.
 
         Args:

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -123,7 +123,7 @@ class RayDaskCallback(Callback):
         """Run before executing a Dask task within a Ray task.
 
         This method executes after Ray submits the task within a Ray
-        worker. The return value of this task will be passed to the
+        worker. Ray passes the return value of this task to the
         _ray_posttask callback, if provided.
 
         Args:

--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -97,7 +97,7 @@ class RayDaskCallback(Callback):
         Returns:
             Either None, in which case Ray submits a task, or
             a non-None value, in which case Ray task doesn't submit
-            submitted and this return value will be used as the
+            a task and uses this return value as the
             would-be task result value.
         """
         pass


### PR DESCRIPTION
## Why are these changes needed?

This PR adds the overridable methods for `RayDaskCallback` to the base class.

Previously, the user had a few choices for instantiating a `RayDaskCallback`:

```python
RayDaskCallback(ray_presubmit=my_custom_presubmit_func)
```

or

```python
with RayDaskCallback(ray_presubmit=my_custom_presubmit_func) as cb:
    ...
```

or by subclassing:

```python
class MyCallback(RayDaskCallback):

    def _ray_presubmit(self, task, key, deps):
        ....
```

Currently the constructor for `RayDaskCallback` dynamically generates the callback methods and attaches them to the class instance upon instantiation using `setattr`. This pattern doesn't work with developer tooling including language servers, static code analysis tools, or documentation generators because these functions are generated dynamically. Additionally the documentation for dask-on-ray instructs users to use the third approach (using subclassing) rather than passing methods to the constructor. Finally, the docstring for `RayDaskCallback.__init__` currently has function signatures and pseudo-docstrings for the callback methods the user should be implementing. This docstring is itself malformed, so Sphinx mistakenly tries to interpret parts of this as references which do not exist.

At the request of @c21 I've actually implemented these functions as they appear in the docstring. Type hints are incomplete here, but match what was already in the previous docstring. I also added a summary in the dask-on-ray documentation.

## Related issue number

Unblocks #39658.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
