### PR TITLE
[tune] Fix PB2 scheduler error resulting from trying to sort by `Trial` objects

### DIFF
--- a/python/ray/tune/schedulers/pb2.py
+++ b/python/ray/tune/schedulers/pb2.py
@@ -239,7 +239,7 @@ def _explore(
         new_T = df[df["Trial"] == str(base)].iloc[-1, :]["Time"]
         new_Reward = df[df["Trial"] == str(base)].iloc[-1, :].Reward
 
-        lst = [[old] + [new_T] + values + [new_Reward]]
+        lst = [[str(old)] + [new_T] + values + [new_Reward]]
         cols = ["Trial", "Time"] + list(bounds) + ["Reward"]
         new_entry = pd.DataFrame(lst, columns=cols)
 


### PR DESCRIPTION
## Why are these changes needed?

Very minor change solving a bug for the PB2 scheduler in tune: The dataframe storing the Trials should have its first column being of string type ([for instance, here](https://github.com/ray-project/ray/blob/5ab90889150505a426bb269a4ec5f33a994f1944/python/ray/tune/schedulers/pb2.py#L450)); However, in one case, it is stored as a `Trial` type instead, leading to a comparison error when the dataframe is sorted (which e.g. happens by default in the `groupby` operations)

## Related issue number

Closes #37638.
(I believe this may also close #14187 although it's an older issue)

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [X] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [] Unit tests
   - [] Release tests
   - [X] This PR is not tested :( 
