### PR TITLE
[ci] persist rayci step id to test result

### DIFF
--- a/ci/ray_ci/automation/test_determine_microcheck_tests.py
+++ b/ci/ray_ci/automation/test_determine_microcheck_tests.py
@@ -40,6 +40,7 @@ def stub_test_result(status: ResultStatus, branch: str) -> TestResult:
         url="",
         timestamp=0,
         pull_request="",
+        rayci_step_id="",
     )
 
 

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -89,6 +89,7 @@ class TestResult:
     url: str
     timestamp: int
     pull_request: str
+    rayci_step_id: str
 
     @classmethod
     def from_result(cls, result: Result):
@@ -99,6 +100,7 @@ class TestResult:
             url=result.buildkite_url,
             timestamp=int(time.time() * 1000),
             pull_request=os.environ.get("BUILDKITE_PULL_REQUEST", ""),
+            rayci_step_id=os.environ.get("RAYCI_STEP_ID", ""),
         )
 
     @classmethod
@@ -124,6 +126,7 @@ class TestResult:
             url=result["url"],
             timestamp=result["timestamp"],
             pull_request=result.get("pull_request", ""),
+            rayci_step_id=result.get("rayci_step_id", ""),
         )
 
     def is_failing(self) -> bool:

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -53,6 +53,7 @@ def _stub_test_result(status: ResultStatus) -> TestResult:
         url="url",
         timestamp=0,
         pull_request="1",
+        rayci_step_id="123",
     )
 
 
@@ -179,7 +180,14 @@ def test_is_stable() -> None:
     assert not Test(stable=False).is_stable()
 
 
-@patch.dict(os.environ, {"BUILDKITE_BRANCH": "food", "BUILDKITE_PULL_REQUEST": "1"})
+@patch.dict(
+    os.environ,
+    {
+        "BUILDKITE_BRANCH": "food",
+        "BUILDKITE_PULL_REQUEST": "1",
+        "RAYCI_STEP_ID": "g4_s5",
+    },
+)
 def test_result_from_bazel_event() -> None:
     result = TestResult.from_bazel_event(
         {
@@ -189,6 +197,7 @@ def test_result_from_bazel_event() -> None:
     assert result.is_passing()
     assert result.branch == "food"
     assert result.pull_request == "1"
+    assert result.rayci_step_id == "g4_s5"
     result = TestResult.from_bazel_event(
         {
             "testResult": {"status": "FAILED"},


### PR DESCRIPTION
Persist rayci step id to test result. RAYCI_STEP_ID is the unique identifier of the buildkite test job definition.

Test:
- CI