### PR TITLE
[ray 2.21.0] perf regression

### DIFF
--- a/release/release_logs/2.20.0/benchmarks/many_actors.json
+++ b/release/release_logs/2.20.0/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 586.133504,
+    "_dashboard_memory_usage_mb": 470.708224,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.74,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.71GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n795\t0.9GiB\tpython distributed/test_many_actors.py\n266\t0.43GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n427\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n615\t0.07GiB\tray::JobSupervisor\n583\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n425\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n855\t0.06GiB\tray::MemoryMonitorActor.run\n943\t0.05GiB\tray::DashboardTester.run\n366\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
-    "actors_per_second": 636.4202043276684,
+    "_peak_memory": 3.72,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1095\t0.95GiB\tpython distributed/test_many_actors.py\n293\t0.3GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n911\t0.07GiB\tray::JobSupervisor\n612\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n451\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1157\t0.06GiB\tray::MemoryMonitorActor.run\n1232\t0.05GiB\tray::DashboardTester.run\n392\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
+    "actors_per_second": 629.465198365166,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 636.4202043276684
+            "perf_metric_value": 629.465198365166
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 151.88
+            "perf_metric_value": 161.266
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3121.637
+            "perf_metric_value": 5216.157
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5398.368
+            "perf_metric_value": 5216.157
         }
     ],
     "success": "1",
-    "time": 15.712888956069946
+    "time": 15.886501789093018
 }

--- a/release/release_logs/2.20.0/benchmarks/many_nodes.json
+++ b/release/release_logs/2.20.0/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 189.771776,
+    "_dashboard_memory_usage_mb": 192.159744,
     "_dashboard_test_success": true,
     "_peak_memory": 1.64,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n841\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1104\t0.09GiB\tray::StateAPIGeneratorActor.start\n659\t0.07GiB\tray::JobSupervisor\n423\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n421\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n575\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1052\t0.06GiB\tray::DashboardTester.run\n964\t0.06GiB\tray::MemoryMonitorActor.run",
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t0.52GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n293\t0.18GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1192\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1461\t0.09GiB\tray::StateAPIGeneratorActor.start\n1006\t0.07GiB\tray::JobSupervisor\n450\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n448\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n603\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1317\t0.06GiB\tray::MemoryMonitorActor.run\n1407\t0.06GiB\tray::DashboardTester.run",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 354.0160266311495
+            "perf_metric_value": 366.4907393960873
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.269
+            "perf_metric_value": 4.48
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 61.618
+            "perf_metric_value": 80.406
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 216.1
+            "perf_metric_value": 217.102
         }
     ],
     "success": "1",
-    "tasks_per_second": 354.0160266311495,
-    "time": 302.8247308731079,
+    "tasks_per_second": 366.4907393960873,
+    "time": 302.728581905365,
     "used_cpus": 250.0
 }

--- a/release/release_logs/2.20.0/benchmarks/many_pgs.json
+++ b/release/release_logs/2.20.0/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 161.185792,
+    "_dashboard_memory_usage_mb": 190.68928,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.19,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t0.95GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n803\t0.43GiB\tpython distributed/test_many_pgs.py\n266\t0.13GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n620\t0.07GiB\tray::JobSupervisor\n583\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n878\t0.06GiB\tray::MemoryMonitorActor.run\n951\t0.05GiB\tray::DashboardTester.run\n365\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
+    "_peak_memory": 2.14,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t0.93GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1018\t0.4GiB\tpython distributed/test_many_pgs.py\n293\t0.13GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n834\t0.07GiB\tray::JobSupervisor\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n611\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n451\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1143\t0.06GiB\tray::MemoryMonitorActor.run\n1234\t0.05GiB\tray::DashboardTester.run\n391\t0.04GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23.144902235160945
+            "perf_metric_value": 23.470678162839302
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.32
+            "perf_metric_value": 3.272
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 41.134
+            "perf_metric_value": 42.922
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 548.637
+            "perf_metric_value": 358.309
         }
     ],
-    "pgs_per_second": 23.144902235160945,
+    "pgs_per_second": 23.470678162839302,
     "success": "1",
-    "time": 43.206058502197266
+    "time": 42.60635304450989
 }

--- a/release/release_logs/2.20.0/benchmarks/many_tasks.json
+++ b/release/release_logs/2.20.0/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 661.430272,
+    "_dashboard_memory_usage_mb": 1200.361472,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.3,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n151\t1.38GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n266\t1.34GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n802\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1048\t0.08GiB\tray::StateAPIGeneratorActor.start\n996\t0.08GiB\tray::DashboardTester.run\n619\t0.07GiB\tray::JobSupervisor\n426\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n580\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n424\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n925\t0.06GiB\tray::MemoryMonitorActor.run",
+    "_peak_memory": 4.89,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t2.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n293\t1.21GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1100\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1306\t0.08GiB\tray::StateAPIGeneratorActor.start\n1235\t0.08GiB\tray::DashboardTester.run\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n913\t0.07GiB\tray::JobSupervisor\n451\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n610\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1162\t0.06GiB\tray::MemoryMonitorActor.run",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 582.3046176755182
+            "perf_metric_value": 592.871367164479
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.47
+            "perf_metric_value": 47.866
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16046.576
+            "perf_metric_value": 3188.529
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 19529.559
+            "perf_metric_value": 4222.657
         }
     ],
     "success": "1",
-    "tasks_per_second": 582.3046176755182,
-    "time": 317.1731421947479,
+    "tasks_per_second": 592.871367164479,
+    "time": 316.8670651912689,
     "used_cpus": 2500.0
 }

--- a/release/release_logs/2.20.0/microbenchmark.json
+++ b/release/release_logs/2.20.0/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8748.782799582932,
-        449.59513200569006
+        9231.13205434199,
+        263.23898948509276
     ],
     "1_1_actor_calls_concurrent": [
-        5331.946019829083,
-        320.4211302536989
+        5207.403165869952,
+        44.363883963423724
     ],
     "1_1_actor_calls_sync": [
-        2112.7552826069455,
-        46.25947531390158
+        2094.875118026067,
+        33.96019620496728
     ],
     "1_1_async_actor_calls_async": [
-        3157.5281810012384,
-        98.22863116371259
+        3679.273214565456,
+        72.42820449471026
     ],
     "1_1_async_actor_calls_sync": [
-        1341.7887372798139,
-        33.331756055952816
+        1349.154883528484,
+        21.478859920081618
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2396.8963139443463,
-        166.4832755226004
+        2441.3295492788307,
+        48.57379450168428
     ],
     "1_n_actor_calls_async": [
-        8558.218903786727,
-        335.2325317020745
+        8687.002823855231,
+        263.0731079571473
     ],
     "1_n_async_actor_calls_async": [
-        7701.7490843523765,
-        176.85412311709294
+        7616.288181387119,
+        187.30135931998024
     ],
     "client__1_1_actor_calls_async": [
-        981.3101489962544,
-        8.160759667016155
+        995.1941800794589,
+        4.386299177532235
     ],
     "client__1_1_actor_calls_concurrent": [
-        984.0363561016015,
-        6.700051344968874
+        981.3610689913281,
+        9.343552920040837
     ],
     "client__1_1_actor_calls_sync": [
-        501.2526439748014,
-        14.927831504721782
+        529.2817511036485,
+        5.002896995984588
     ],
     "client__get_calls": [
-        984.7185148948039,
-        11.898184447451703
+        1102.784805636512,
+        59.49715189608496
     ],
     "client__put_calls": [
-        770.4735069321608,
-        4.4204997632223
+        803.6907933267912,
+        28.6991879671622
     ],
     "client__put_gigabytes": [
-        0.13182480311203987,
-        0.0006594286871265931
+        0.13000377813880426,
+        0.00045634709726433836
     ],
     "client__tasks_and_get_batch": [
-        0.8871100522697384,
-        0.04711087542591399
+        0.8943766187635083,
+        0.034668794224519045
     ],
     "client__tasks_and_put_batch": [
-        11400.628951457615,
-        96.6749337855913
+        11618.996288906874,
+        99.68395835168926
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12482.424327497527,
-        45.18434404588863
+        12378.76716587138,
+        105.91623157084351
     ],
     "multi_client_put_gigabytes": [
-        37.47472636769277,
-        3.1727284949980272
+        32.127583473661076,
+        3.029765850786339
     ],
     "multi_client_tasks_async": [
-        22358.519928771202,
-        1160.752978756044
+        23246.18514733561,
+        3349.0269090731435
     ],
     "n_n_actor_calls_async": [
-        27206.931303151337,
-        811.7575581183337
+        26644.201721023048,
+        1301.4894705420318
     ],
     "n_n_actor_calls_with_arg_async": [
-        2669.9811846586795,
-        42.58209737763422
+        2704.4738249461293,
+        44.69261442727767
     ],
     "n_n_async_actor_calls_async": [
-        23379.05090260775,
-        628.9522529769743
+        22642.233725461258,
+        846.0443551175905
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10268.613528553546
+            "perf_metric_value": 10556.167569431133
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5141.775101569989
+            "perf_metric_value": 5299.4573652671415
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12482.424327497527
+            "perf_metric_value": 12378.76716587138
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.683362618370772
+            "perf_metric_value": 21.31655252094265
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.778792239134901
+            "perf_metric_value": 7.929465173212371
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 37.47472636769277
+            "perf_metric_value": 32.127583473661076
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.632060871624994
+            "perf_metric_value": 13.52171763582945
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.3499932380060775
+            "perf_metric_value": 5.483630802920898
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 965.8386012454489
+            "perf_metric_value": 1002.8196875307303
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7993.559119696471
+            "perf_metric_value": 7813.472406257602
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22358.519928771202
+            "perf_metric_value": 23246.18514733561
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2112.7552826069455
+            "perf_metric_value": 2094.875118026067
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8748.782799582932
+            "perf_metric_value": 9231.13205434199
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5331.946019829083
+            "perf_metric_value": 5207.403165869952
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8558.218903786727
+            "perf_metric_value": 8687.002823855231
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27206.931303151337
+            "perf_metric_value": 26644.201721023048
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2669.9811846586795
+            "perf_metric_value": 2704.4738249461293
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1341.7887372798139
+            "perf_metric_value": 1349.154883528484
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3157.5281810012384
+            "perf_metric_value": 3679.273214565456
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2396.8963139443463
+            "perf_metric_value": 2441.3295492788307
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7701.7490843523765
+            "perf_metric_value": 7616.288181387119
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23379.05090260775
+            "perf_metric_value": 22642.233725461258
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 783.3481516266015
+            "perf_metric_value": 850.9214104369318
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 984.7185148948039
+            "perf_metric_value": 1102.784805636512
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 770.4735069321608
+            "perf_metric_value": 803.6907933267912
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13182480311203987
+            "perf_metric_value": 0.13000377813880426
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11400.628951457615
+            "perf_metric_value": 11618.996288906874
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 501.2526439748014
+            "perf_metric_value": 529.2817511036485
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 981.3101489962544
+            "perf_metric_value": 995.1941800794589
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 984.0363561016015
+            "perf_metric_value": 981.3610689913281
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.8871100522697384
+            "perf_metric_value": 0.8943766187635083
         }
     ],
     "placement_group_create/removal": [
-        783.3481516266015,
-        12.378304647779888
+        850.9214104369318,
+        5.605433178895902
     ],
     "single_client_get_calls_Plasma_Store": [
-        10268.613528553546,
-        127.98875390202711
+        10556.167569431133,
+        77.93663750708814
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.632060871624994,
-        0.19375733386575253
+        13.52171763582945,
+        0.3330930424042106
     ],
     "single_client_put_calls_Plasma_Store": [
-        5141.775101569989,
-        39.65439583305001
+        5299.4573652671415,
+        104.7895646656126
     ],
     "single_client_put_gigabytes": [
-        18.683362618370772,
-        3.887359132974222
+        21.31655252094265,
+        5.502507789355352
     ],
     "single_client_tasks_and_get_batch": [
-        7.778792239134901,
-        0.3755120187621276
+        7.929465173212371,
+        0.27204560133861755
     ],
     "single_client_tasks_async": [
-        7993.559119696471,
-        462.97661002454305
+        7813.472406257602,
+        464.56634150141537
     ],
     "single_client_tasks_sync": [
-        965.8386012454489,
-        10.246016544080797
+        1002.8196875307303,
+        15.63104006816665
     ],
     "single_client_wait_1k_refs": [
-        5.3499932380060775,
-        0.15990522801591003
+        5.483630802920898,
+        0.0715962099275209
     ]
 }

--- a/release/release_logs/2.20.0/scalability/object_store.json
+++ b/release/release_logs/2.20.0/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 17.34891581100004,
+    "broadcast_time": 15.136383380999973,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.34891581100004
+            "perf_metric_value": 15.136383380999973
         }
     ],
     "success": "1"

--- a/release/release_logs/2.20.0/scalability/single_node.json
+++ b/release/release_logs/2.20.0/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.267912976999995,
-    "get_time": 23.659871710999994,
+    "args_time": 17.493978096000006,
+    "get_time": 23.39766470100001,
     "large_object_size": 107374182400,
-    "large_object_time": 30.37595573499999,
+    "large_object_time": 29.229432349999968,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.267912976999995
+            "perf_metric_value": 17.493978096000006
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.660801429999992
+            "perf_metric_value": 5.578864035000009
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.659871710999994
+            "perf_metric_value": 23.39766470100001
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 190.11494678399998
+            "perf_metric_value": 180.797260221
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.37595573499999
+            "perf_metric_value": 29.229432349999968
         }
     ],
-    "queued_time": 190.11494678399998,
-    "returns_time": 5.660801429999992,
+    "queued_time": 180.797260221,
+    "returns_time": 5.578864035000009,
     "success": "1"
 }

--- a/release/release_logs/2.20.0/stress_tests/stress_test_dead_actors.json
+++ b/release/release_logs/2.20.0/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.4939605140686034,
-    "max_iteration_time": 9.932291746139526,
-    "min_iteration_time": 0.734281063079834,
+    "avg_iteration_time": 1.4795736622810365,
+    "max_iteration_time": 5.597578763961792,
+    "min_iteration_time": 0.6834812164306641,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4939605140686034
+            "perf_metric_value": 1.4795736622810365
         }
     ],
     "success": 1,
-    "total_time": 149.39628982543945
+    "total_time": 147.95764255523682
 }

--- a/release/release_logs/2.20.0/stress_tests/stress_test_many_tasks.json
+++ b/release/release_logs/2.20.0/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 11.408677577972412
+            "perf_metric_value": 11.001468896865845
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.58948016166687
+            "perf_metric_value": 24.483961820602417
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 55.788888931274414
+            "perf_metric_value": 53.381308794021606
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.8818552494049072
+            "perf_metric_value": 2.0290634632110596
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3097.411286830902
+            "perf_metric_value": 3010.209487915039
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.460180997609973
+            "perf_metric_value": 0.6472558249100075
         }
     ],
-    "stage_0_time": 11.408677577972412,
-    "stage_1_avg_iteration_time": 25.58948016166687,
-    "stage_1_max_iteration_time": 27.471096992492676,
-    "stage_1_min_iteration_time": 24.81654191017151,
-    "stage_1_time": 255.89490818977356,
-    "stage_2_avg_iteration_time": 55.788888931274414,
-    "stage_2_max_iteration_time": 57.43562126159668,
-    "stage_2_min_iteration_time": 54.45973491668701,
-    "stage_2_time": 278.94584822654724,
-    "stage_3_creation_time": 1.8818552494049072,
-    "stage_3_time": 3097.411286830902,
-    "stage_4_spread": 0.460180997609973,
+    "stage_0_time": 11.001468896865845,
+    "stage_1_avg_iteration_time": 24.483961820602417,
+    "stage_1_max_iteration_time": 25.398903131484985,
+    "stage_1_min_iteration_time": 23.48150372505188,
+    "stage_1_time": 244.83970546722412,
+    "stage_2_avg_iteration_time": 53.381308794021606,
+    "stage_2_max_iteration_time": 54.12904739379883,
+    "stage_2_min_iteration_time": 52.89454412460327,
+    "stage_2_time": 266.9073483943939,
+    "stage_3_creation_time": 2.0290634632110596,
+    "stage_3_time": 3010.209487915039,
+    "stage_4_spread": 0.6472558249100075,
     "success": 1
 }

--- a/release/release_logs/2.20.0/stress_tests/stress_test_placement_group.json
+++ b/release/release_logs/2.20.0/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.897374594595741,
-    "avg_pg_remove_time_ms": 0.9239566561552727,
+    "avg_pg_create_time_ms": 0.889821163662783,
+    "avg_pg_remove_time_ms": 0.9000654909906795,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.897374594595741
+            "perf_metric_value": 0.889821163662783
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9239566561552727
+            "perf_metric_value": 0.9000654909906795
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 14.27%: multi_client_put_gigabytes (THROUGHPUT) regresses from 37.47472636769277 to 32.127583473661076 (14.27%) in 2.21.0/microbenchmark.json
REGRESSION 3.15%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23379.05090260775 to 22642.233725461258 (3.15%) in 2.21.0/microbenchmark.json
REGRESSION 2.34%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5331.946019829083 to 5207.403165869952 (2.34%) in 2.21.0/microbenchmark.json
REGRESSION 2.25%: single_client_tasks_async (THROUGHPUT) regresses from 7993.559119696471 to 7813.472406257602 (2.25%) in 2.21.0/microbenchmark.json
REGRESSION 2.07%: n_n_actor_calls_async (THROUGHPUT) regresses from 27206.931303151337 to 26644.201721023048 (2.07%) in 2.21.0/microbenchmark.json
REGRESSION 1.38%: client__put_gigabytes (THROUGHPUT) regresses from 0.13182480311203987 to 0.13000377813880426 (1.38%) in 2.21.0/microbenchmark.json
REGRESSION 1.11%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7701.7490843523765 to 7616.288181387119 (1.11%) in 2.21.0/microbenchmark.json
REGRESSION 1.09%: actors_per_second (THROUGHPUT) regresses from 636.4202043276684 to 629.465198365166 (1.09%) in 2.21.0/benchmarks/many_actors.json
REGRESSION 0.85%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2112.7552826069455 to 2094.875118026067 (0.85%) in 2.21.0/microbenchmark.json
REGRESSION 0.83%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12482.424327497527 to 12378.76716587138 (0.83%) in 2.21.0/microbenchmark.json
REGRESSION 0.27%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 984.0363561016015 to 981.3610689913281 (0.27%) in 2.21.0/microbenchmark.json
REGRESSION 639.81%: dashboard_p50_latency_ms (LATENCY) regresses from 6.47 to 47.866 (639.81%) in 2.21.0/benchmarks/many_tasks.json
REGRESSION 67.10%: dashboard_p95_latency_ms (LATENCY) regresses from 3121.637 to 5216.157 (67.10%) in 2.21.0/benchmarks/many_actors.json
REGRESSION 40.65%: stage_4_spread (LATENCY) regresses from 0.460180997609973 to 0.6472558249100075 (40.65%) in 2.21.0/stress_tests/stress_test_many_tasks.json
REGRESSION 30.49%: dashboard_p95_latency_ms (LATENCY) regresses from 61.618 to 80.406 (30.49%) in 2.21.0/benchmarks/many_nodes.json
REGRESSION 7.82%: stage_3_creation_time (LATENCY) regresses from 1.8818552494049072 to 2.0290634632110596 (7.82%) in 2.21.0/stress_tests/stress_test_many_tasks.json
REGRESSION 6.18%: dashboard_p50_latency_ms (LATENCY) regresses from 151.88 to 161.266 (6.18%) in 2.21.0/benchmarks/many_actors.json
REGRESSION 4.94%: dashboard_p50_latency_ms (LATENCY) regresses from 4.269 to 4.48 (4.94%) in 2.21.0/benchmarks/many_nodes.json
REGRESSION 4.35%: dashboard_p95_latency_ms (LATENCY) regresses from 41.134 to 42.922 (4.35%) in 2.21.0/benchmarks/many_pgs.json
REGRESSION 1.31%: 10000_args_time (LATENCY) regresses from 17.267912976999995 to 17.493978096000006 (1.31%) in 2.21.0/scalability/single_node.json
REGRESSION 0.46%: dashboard_p99_latency_ms (LATENCY) regresses from 216.1 to 217.102 (0.46%) in 2.21.0/benchmarks/many_nodes.json
```