### PR TITLE
[Doc] Fix broken references in rllib documentation

### DIFF
--- a/doc/source/rllib/package_ref/algorithm.rst
+++ b/doc/source/rllib/package_ref/algorithm.rst
@@ -149,6 +149,8 @@ Constructor
     :toctree: doc/
 
     ~Algorithm
+    ~Algorithm.setup
+    ~Algorithm.get_default_config
 
 Inference and Evaluation
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -196,4 +198,3 @@ Multi Agent
 
     ~Algorithm.add_policy
     ~Algorithm.remove_policy
-

--- a/doc/source/rllib/package_ref/evaluation.rst
+++ b/doc/source/rllib/package_ref/evaluation.rst
@@ -145,6 +145,17 @@ Miscellaneous
 
 .. _workerset-reference-docs:
 
+EnvRunner API
+-------------
+
+.. currentmodule:: ray.rllib.env.env_runner
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   EnvRunner
+
 EnvRunnerGroup API
 ------------------
 

--- a/doc/source/rllib/package_ref/models.rst
+++ b/doc/source/rllib/package_ref/models.rst
@@ -48,6 +48,7 @@ Acessing variables
 
     ~modelv2.ModelV2.variables
     ~modelv2.ModelV2.trainable_variables
+    ~distributions.Distribution
 
 Customization
 --------------

--- a/doc/source/rllib/rllib-catalogs.rst
+++ b/doc/source/rllib/rllib-catalogs.rst
@@ -110,7 +110,7 @@ Since we mostly build RLModules out of :py:class:`~ray.rllib.core.models.base.En
 For example, the PPOCatalog will output Encoders that output a latent vector and two Heads that take this latent vector as input.
 (That's why Catalogs have a ``latent_dims`` attribute). Heads and distributions behave accordingly.
 Whenever you create a Catalog, the decision tree is executed to find suitable configs for models and classes for distributions.
-By default this happens in :py:meth:`~ray.rllib.core.models.catalog.Catalog.get_encoder_config` and :py:meth:`~ray.rllib.core.models.catalog.Catalog._get_dist_cls_from_action_space`.
+By default this happens in :py:meth:`~ray.rllib.core.models.catalog.Catalog._get_encoder_config` and :py:meth:`~ray.rllib.core.models.catalog.Catalog._get_dist_cls_from_action_space`.
 Whenever you build a model, the config is turned into a model.
 Distributions are instantiated per forward pass of an `RLModule` and are therefore not built.
 

--- a/doc/source/rllib/rllib-rlmodule.rst
+++ b/doc/source/rllib/rllib-rlmodule.rst
@@ -138,11 +138,11 @@ RLlib implements the following abstract framework specific base classes:
 
 The minimum requirement is for sub-classes of :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` is to implement the following methods:
 
-- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule._forward_train`: Forward pass for training.
+- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule.forward_train`: Forward pass for training.
 
-- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule._forward_inference`: Forward pass for inference.
+- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule.forward_inference`: Forward pass for inference.
 
-- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule._forward_exploration`: Forward pass for exploration.
+- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule.forward_exploration`: Forward pass for exploration.
 
 For your custom :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule.forward_exploration` and :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule.forward_inference`
 methods, you must return a dictionary that either contains the key "actions" and/or the key "action_dist_inputs".
@@ -183,13 +183,13 @@ Commonly used distribution implementations can be found under ``ray.rllib.models
             class MyRLModule(TorchRLModule):
                 ...
 
-                def _forward_inference(self, batch):
+                def forward_inference(self, batch):
                     ...
                     return {
                         "actions": ...  # actions will be used as-is
                     }
 
-                def _forward_exploration(self, batch):
+                def forward_exploration(self, batch):
                     ...
                     return {
                         "actions": ...  # actions will be used as-is (no sampling step!)
@@ -208,7 +208,7 @@ Commonly used distribution implementations can be found under ``ray.rllib.models
             class MyRLModule(TorchRLModule):
                 ...
 
-                def _forward_inference(self, batch):
+                def forward_inference(self, batch):
                     ...
                     return {
                         # RLlib will:
@@ -218,7 +218,7 @@ Commonly used distribution implementations can be found under ``ray.rllib.models
                         "action_dist_inputs": ...
                     }
 
-                def _forward_exploration(self, batch):
+                def forward_exploration(self, batch):
                     ...
                     return {
                         # RLlib will:
@@ -365,9 +365,8 @@ There are two possible ways to extend existing RL Modules:
             )
 
         A concrete example: If you want to replace the default encoder that RLlib builds for torch, PPO and a given observation space,
-        you can override :py:class:`~ray.rllib.algorithms.ppo.torch.ppo_torch_rl_module.PPOTorchRLModule`'s
-        :py:meth:`~ray.rllib.algorithms.ppo.torch.ppo_torch_rl_module.PPOTorchRLModule.__init__` to create your custom
-        encoder instead of the default one. We do this in the following example.
+        you can override the `__init__` method on the :py:class:`~ray.rllib.algorithms.ppo.torch.ppo_torch_rl_module.PPOTorchRLModule`
+        class to create your custom encoder instead of the default one. We do this in the following example.
 
         .. literalinclude:: ../../../rllib/examples/rl_modules/classes/mobilenet_rlm.py
                 :language: python
@@ -575,8 +574,8 @@ See `Writing Custom Single Agent RL Modules`_ for more details on how to impleme
                     # specify an action distribution class here
                     ...
 
-                def _forward_inference(self, batch):
+                def forward_inference(self, batch):
                     ...
 
-                def _forward_exploration(self, batch):
+                def forward_exploration(self, batch):
                     ...

--- a/doc/source/rllib/rllib-rlmodule.rst
+++ b/doc/source/rllib/rllib-rlmodule.rst
@@ -577,5 +577,5 @@ See `Writing Custom Single Agent RL Modules`_ for more details on how to impleme
                 def _forward_inference(self, batch):
                     ...
 
-                def forward_exploration(self, batch):
+                def _forward_exploration(self, batch):
                     ...

--- a/doc/source/rllib/rllib-rlmodule.rst
+++ b/doc/source/rllib/rllib-rlmodule.rst
@@ -138,11 +138,11 @@ RLlib implements the following abstract framework specific base classes:
 
 The minimum requirement is for sub-classes of :py:class:`~ray.rllib.core.rl_module.rl_module.RLModule` is to implement the following methods:
 
-- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule.forward_train`: Forward pass for training.
+- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule._forward_train`: Forward pass for training.
 
-- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule.forward_inference`: Forward pass for inference.
+- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule._forward_inference`: Forward pass for inference.
 
-- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule.forward_exploration`: Forward pass for exploration.
+- :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule._forward_exploration`: Forward pass for exploration.
 
 For your custom :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule.forward_exploration` and :py:meth:`~ray.rllib.core.rl_module.rl_module.RLModule.forward_inference`
 methods, you must return a dictionary that either contains the key "actions" and/or the key "action_dist_inputs".
@@ -183,13 +183,13 @@ Commonly used distribution implementations can be found under ``ray.rllib.models
             class MyRLModule(TorchRLModule):
                 ...
 
-                def forward_inference(self, batch):
+                def _forward_inference(self, batch):
                     ...
                     return {
                         "actions": ...  # actions will be used as-is
                     }
 
-                def forward_exploration(self, batch):
+                def _forward_exploration(self, batch):
                     ...
                     return {
                         "actions": ...  # actions will be used as-is (no sampling step!)
@@ -208,7 +208,7 @@ Commonly used distribution implementations can be found under ``ray.rllib.models
             class MyRLModule(TorchRLModule):
                 ...
 
-                def forward_inference(self, batch):
+                def _forward_inference(self, batch):
                     ...
                     return {
                         # RLlib will:
@@ -218,7 +218,7 @@ Commonly used distribution implementations can be found under ``ray.rllib.models
                         "action_dist_inputs": ...
                     }
 
-                def forward_exploration(self, batch):
+                def _forward_exploration(self, batch):
                     ...
                     return {
                         # RLlib will:
@@ -574,7 +574,7 @@ See `Writing Custom Single Agent RL Modules`_ for more details on how to impleme
                     # specify an action distribution class here
                     ...
 
-                def forward_inference(self, batch):
+                def _forward_inference(self, batch):
                     ...
 
                 def forward_exploration(self, batch):

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -2332,7 +2332,7 @@ class Algorithm(Trainable, AlgorithmBase):
                 will raise a KeyError.
 
         Raises:
-            KeyError if `policy_id` cannot be found in this Algorithm.
+            KeyError: if `policy_id` cannot be found in this Algorithm.
 
         .. testcode::
 
@@ -2779,7 +2779,7 @@ class Algorithm(Trainable, AlgorithmBase):
             env_context: The EnvContext to configure the environment.
 
         Raises:
-            Exception in case something is wrong with the given environment.
+            Exception: in case something is wrong with the given environment.
         """
         pass
 

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -230,8 +230,8 @@ class AlgorithmConfig(_Config):
 
         Raises:
             KeyError: In case a non-existing property name (kwargs key) is being
-            passed in. Valid property names are taken from a default AlgorithmConfig
-            object of `cls`.
+                passed in. Valid property names are taken from a default
+                AlgorithmConfig object of `cls`.
         """
         default_config = cls()
         config_overrides = {}
@@ -3418,7 +3418,7 @@ class AlgorithmConfig(_Config):
 
         Raises:
             ValueError: If there is a mismatch between user provided
-            `rollout_fragment_length` and `total_train_batch_size`.
+                `rollout_fragment_length` and `total_train_batch_size`.
         """
         if (
             self.rollout_fragment_length != "auto"

--- a/rllib/core/rl_module/marl_module.py
+++ b/rllib/core/rl_module/marl_module.py
@@ -155,8 +155,8 @@ class MultiAgentRLModule(RLModule):
 
         Raises:
             ValueError: If the module ID already exists and override is False.
-            Warnings are raised if the module id is not valid according to the logic of
-            validate_policy_id().
+                Warnings are raised if the module id is not valid according to the
+                logic of ``validate_policy_id()``.
         """
         validate_policy_id(module_id)
         if module_id in self._rl_modules and not override:

--- a/rllib/core/rl_module/rl_module.py
+++ b/rllib/core/rl_module/rl_module.py
@@ -357,11 +357,11 @@ class RLModule(abc.ABC):
         config: The config for the RLModule.
 
     Abstract Methods:
-        :py:meth:`~_forward_train`: Forward pass during training.
+        ``~_forward_train``: Forward pass during training.
 
-        :py:meth:`~_forward_exploration`: Forward pass during training for exploration.
+        ``~_forward_exploration``: Forward pass during training for exploration.
 
-        :py:meth:`~_forward_inference`: Forward pass during inference.
+        ``~_forward_inference``: Forward pass during inference.
 
 
     Note:

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -726,7 +726,7 @@ class EnvRunnerGroup:
 
         Raises:
             RayError: If any of the constructed remote workers is not up and running
-            properly.
+                properly.
         """
         old_num_workers = self._worker_manager.num_actors()
         new_workers = [

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -1202,7 +1202,7 @@ class Policy(metaclass=ABCMeta):
 
         Raises:
             ValueError: If a native DL-framework based model (e.g. a keras Model)
-            cannot be saved to disk for various reasons.
+                cannot be saved to disk for various reasons.
         """
         raise NotImplementedError
 

--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -971,7 +971,7 @@ class TorchPolicyV2(Policy):
 
         Raises:
             AssertionError: If the `stats_name` cannot be found in any one
-            of the tower's `tower_stats` dicts.
+                of the tower's `tower_stats` dicts.
         """
         data = []
         for model in self.model_gpu_towers:


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes a number of broken references in RLlib documentation.

## Related issue number

Partially addresses #39658.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
