### PR TITLE
[ci][microcheck/4] add a command to query step ids for microcheck

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -26,6 +26,16 @@ py_binary(
 )
 
 py_binary(
+    name = "determine_microcheck_step_ids",
+    srcs = ["determine_microcheck_step_ids.py"],
+    exec_compatible_with = ["//:hermetic_python"],
+    deps = [
+        ci_require("click"),
+        "//ci/ray_ci:ray_ci_lib",
+    ],
+)
+
+py_binary(
     name = "test_db_bot",
     srcs = ["test_db_bot.py"],
     exec_compatible_with = ["//:hermetic_python"],

--- a/ci/ray_ci/automation/determine_microcheck_step_ids.py
+++ b/ci/ray_ci/automation/determine_microcheck_step_ids.py
@@ -1,14 +1,8 @@
 import click
-from typing import List, Set, Dict
 
-from ci.ray_ci.utils import logger, ci_init
-from ray_release.configs.global_config import get_global_config
+from ci.ray_ci.utils import ci_init
+from ci.ray_ci.automation.determine_microcheck_tests import LINUX_TEST_PREFIX
 from ray_release.test import Test
-from ray_release.result import ResultStatus
-
-# The s3 prefix for the tests that run on Linux. It comes from the bazel prefix rule
-# linux:// with the character "/" replaced by "_" for s3 compatibility
-LINUX_TEST_PREFIX = "linux:__"
 
 
 @click.command()
@@ -17,8 +11,8 @@ def main() -> None:
     This script determines the rayci step ids to run microcheck tests.
     """
     ci_init()
-    high_impact_tests = [
-        test for test in Test.gen_from_s3(LINUX_TEST_PREFIX) test.is_high_impact()
-    ]
-    step_ids = [test.get_test_result(limit=1)[0].rayci_step_id for test in high_impact_tests]
-    print(" ".join(step_ids))
+    print(",".join(Test.gen_high_impact_tests(LINUX_TEST_PREFIX).keys()))
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/automation/determine_microcheck_step_ids.py
+++ b/ci/ray_ci/automation/determine_microcheck_step_ids.py
@@ -1,0 +1,24 @@
+import click
+from typing import List, Set, Dict
+
+from ci.ray_ci.utils import logger, ci_init
+from ray_release.configs.global_config import get_global_config
+from ray_release.test import Test
+from ray_release.result import ResultStatus
+
+# The s3 prefix for the tests that run on Linux. It comes from the bazel prefix rule
+# linux:// with the character "/" replaced by "_" for s3 compatibility
+LINUX_TEST_PREFIX = "linux:__"
+
+
+@click.command()
+def main() -> None:
+    """
+    This script determines the rayci step ids to run microcheck tests.
+    """
+    ci_init()
+    high_impact_tests = [
+        test for test in Test.gen_from_s3(LINUX_TEST_PREFIX) test.is_high_impact()
+    ]
+    step_ids = [test.get_test_result(limit=1)[0].rayci_step_id for test in high_impact_tests]
+    print(" ".join(step_ids))

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -194,6 +194,23 @@ class Test(dict):
             for file in files
         ]
 
+    @classmethod
+    def gen_high_impact_tests(cls, prefix: str) -> Dict[str, List]:
+        """
+        Obtain the mapping from rayci step id to high impact tests with the given prefix
+        """
+        high_impact_tests = [
+            test for test in cls.gen_from_s3(prefix) if test.is_high_impact()
+        ]
+        step_id_to_tests = {}
+        for test in high_impact_tests:
+            step_id = test.get_test_results(limit=1)[0].rayci_step_id
+            if not step_id:
+                continue
+            step_id_to_tests[step_id] = step_id_to_tests.get(step_id, []) + [test]
+
+        return step_id_to_tests
+
     def is_jailed_with_open_issue(self, ray_github: Repository) -> bool:
         """
         Returns whether this test is jailed with open issue.

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -4,6 +4,7 @@ import sys
 import os
 import platform
 from unittest import mock
+from typing import List
 
 import aioboto3
 import boto3
@@ -34,6 +35,20 @@ from ray_release.test import (
 init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
 
 
+class MockTest(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get_name(self) -> str:
+        return self.get("name", "")
+
+    def get_test_results(self, limit: int) -> List[TestResult]:
+        return self.get("test_results", [])
+
+    def is_high_impact(self) -> bool:
+        return self.get(Test.KEY_IS_HIGH_IMPACT, "false") == "true"
+
+
 def _stub_test(val: dict) -> Test:
     test = Test(
         {
@@ -45,7 +60,9 @@ def _stub_test(val: dict) -> Test:
     return test
 
 
-def _stub_test_result(status: ResultStatus) -> TestResult:
+def _stub_test_result(
+    status: ResultStatus = ResultStatus.SUCCESS, rayci_step_id="123"
+) -> TestResult:
     return TestResult(
         status=status.value,
         commit="1234567890",
@@ -53,7 +70,7 @@ def _stub_test_result(status: ResultStatus) -> TestResult:
         url="url",
         timestamp=0,
         pull_request="1",
-        rayci_step_id="123",
+        rayci_step_id=rayci_step_id,
     )
 
 
@@ -314,6 +331,43 @@ def test_gen_test_results(mock_gen_test_result) -> None:
         ResultStatus.ERROR.value,
         ResultStatus.SUCCESS.value,
     ]
+
+
+@patch("ray_release.test.Test.gen_from_s3")
+def gen_high_impact_tests(mock_gen_from_s3) -> None:
+    core_test = MockTest(
+        {
+            "name": "core_test",
+            Test.KEY_IS_HIGH_IMPACT: "false",
+            "test_results": [
+                _stub_test_result(rayci_step_id="corebuild"),
+            ],
+        }
+    )
+    data_test_01 = MockTest(
+        {
+            "name": "data_test_01",
+            Test.KEY_IS_HIGH_IMPACT: "true",
+            "test_results": [
+                _stub_test_result(rayci_step_id="databuild"),
+            ],
+        }
+    )
+    data_test_02 = MockTest(
+        {
+            "name": "data_test_02",
+            Test.KEY_IS_HIGH_IMPACT: "true",
+            "test_results": [
+                _stub_test_result(rayci_step_id="databuild"),
+            ],
+        }
+    )
+
+    mock_gen_from_s3.return_value = [core_test, data_test_01, data_test_02]
+
+    assert Test.gen_high_impact_tests("linux") == {
+        "databuild": [data_test_01, data_test_02]
+    }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As title, add a command to query rayci step ids that can trigger the microcheck tests. We will use this in combination with the -select from the rayci to build the buildkite step graph for microcheck pipeline.

Test:
- CI