### PR TITLE
[Rllib] Add a package dependency to the rendering example to keeps users from running into errors.

### DIFF
--- a/python/requirements/ml/rllib-test-requirements.txt
+++ b/python/requirements/ml/rllib-test-requirements.txt
@@ -41,3 +41,6 @@ open-spiel==1.4
 # Requires libtorrent which is unavailable for arm64
 autorom[accept-rom-license]; platform_machine != "arm64"
 h5py==3.10.0
+
+# Requirements for rendering.
+moviepy

--- a/rllib/examples/envs/env_rendering_and_recording.py
+++ b/rllib/examples/envs/env_rendering_and_recording.py
@@ -19,7 +19,9 @@ How to run this script
 --wandb-run-name=[optional: WandB run name within --wandb-project]`
 
 In order to see the actual videos, you need to have a WandB account and provide your
-API key and a project name on the command line (see above).
+API key and a project name on the command line (see above). To log the videos in WandB
+you need to have the `wandb` and `moviepy` packages installed (`pip install wandb
+moviepy`).
 
 Use the `--env` flag to control, which Atari env is used. Note that this example
 only works with Atari envs.


### PR DESCRIPTION

## Why are these changes needed?

To make the `env_rendering_and_recording.py` example run, `wandb` and `moviepy` have to be installed. While `wandb` is a standard package for most Ray users, `moviepy` is not. Noting this shortly in the description of the example keeps users from running into errors on first try.

## Related issue number



## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
