### PR TITLE
[Docs][Kuberay] Update Ray version and sample config files for Grafana

### DIFF
--- a/doc/source/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.md
@@ -340,7 +340,7 @@ Refer to [this Grafana document](https://grafana.com/tutorials/run-grafana-behin
   * Click "Import".
   * Click "Upload JSON file".
   * Choose a JSON file.
-    * Case 1: If you are using Ray 2.9.0, you can use [the sample config files in GitHub repository](https://github.com/ray-project/kuberay/tree/master/config/grafana) The file names have a pattern of `xxx_grafana_dashboard.json`.
+    * Case 1: If you are using Ray 2.9.0, you can use [the sample config files in GitHub repository](https://github.com/ray-project/kuberay/tree/master/config/grafana). The file names have a pattern of `xxx_grafana_dashboard.json`.
     * Case 2: Otherwise, you should import the JSON files from `/tmp/ray/session_latest/metrics/grafana/dashboards/` in the head Pod. You can use `kubectl cp` to copy the files from the head Pod to your local machine.
   * Click "Import".
 

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.md
@@ -340,8 +340,8 @@ Refer to [this Grafana document](https://grafana.com/tutorials/run-grafana-behin
   * Click "Import".
   * Click "Upload JSON file".
   * Choose a JSON file.
-    * Case 1: If you are using Ray 2.5.0, you can use [config/grafana/default_grafana_dashboard.json](https://github.com/ray-project/kuberay/blob/master/config/grafana/default_grafana_dashboard.json).
-    * Case 2: Otherwise, you should import the `default_grafana_dashboard.json` file from `/tmp/ray/session_latest/metrics/grafana/dashboards/` in the head Pod. You can use `kubectl cp` to copy the file from the head Pod to your local machine.
+    * Case 1: If you are using Ray 2.9.0, you can use [the sample config files in GitHub repository](https://github.com/ray-project/kuberay/tree/master/config/grafana) The file names have a pattern of `xxx_grafana_dashboard.json`.
+    * Case 2: Otherwise, you should import the JSON files from `/tmp/ray/session_latest/metrics/grafana/dashboards/` in the head Pod. You can use `kubectl cp` to copy the files from the head Pod to your local machine.
   * Click "Import".
 
 * TODO: Note that importing the dashboard manually is not ideal. We should find a way to import the dashboard automatically.


### PR DESCRIPTION
## Why are these changes needed?

The documentation in KubeRay integration with Grafana is out of date.

Changes:
- Update Ray version from 2.5.0 to 2.9.0
- Update the config files from single config file to multiple config files under the `config/grafana` directory in the kuberay repo.

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
