### PR TITLE
[ci][bisect/1] add bisect for linux+windows tests

### DIFF
--- a/.buildkite/bisect/bisect.rayci.yml
+++ b/.buildkite/bisect/bisect.rayci.yml
@@ -3,6 +3,7 @@ depends_on:
   - forge
 steps:
   - name: macos test
+    if: build.env("RAYCI_TEST_TYPE") != null && build.env("RAYCI_TEST_TYPE") == "macos_test"
     commands:
       - if [[ "$(buildkite-agent meta-data get test-type)" != "macos_test" ]]; then exit 0; fi
       - RAYCI_BISECT_RUN=1 ./ci/ray_ci/macos/macos_ci.sh bisect "$(buildkite-agent meta-data get test-name)" 
@@ -10,4 +11,13 @@ steps:
     mount_buildkite_agent: true
     job_env: MACOS
     instance_type: macos
+    priority: 10
+
+  - name: linux or windows test
+    if: build.env("RAYCI_TEST_TYPE") != null && (build.env("RAYCI_TEST_TYPE") == "linux_test" || build.env("RAYCI_TEST_TYPE") == "windows_test")
+    commands:
+      - if [[ "$(buildkite-agent meta-data get test-type)" != "linux_test" && "$(buildkite-agent meta-data get test-type)" != "windows_test" ]]; then exit 0; fi
+      - bazel run //ci/ray_ci/bisect:bisect_test "$(buildkite-agent meta-data get test-name)" 
+          "$(buildkite-agent meta-data get passing-commit)" "$(buildkite-agent meta-data get failing-commit)"
+    mount_buildkite_agent: true
     priority: 10

--- a/.buildkite/bisect/config.yml
+++ b/.buildkite/bisect/config.yml
@@ -10,6 +10,8 @@ runner_queues:
   macos: macos-branch
 buildkite_dirs:
   - .buildkite/bisect
+build_env_keys:
+  - RAYCI_TEST_TYPE
 env:
   BUILDKITE_BAZEL_CACHE_URL: https://bazel-cache-dev.s3.us-west-2.amazonaws.com
   RAYCI_SKIP_UPLOAD: "true"

--- a/ci/ray_ci/bisect/BUILD.bazel
+++ b/ci/ray_ci/bisect/BUILD.bazel
@@ -46,3 +46,18 @@ py_test(
         ci_require("pytest"),
     ],
 )
+
+py_test(
+    name = "test_generic_validator",
+    size = "small",
+    srcs = ["test_generic_validator.py"],
+    exec_compatible_with = ["//:hermetic_python"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":bisect",
+        ci_require("pytest"),
+    ],
+)

--- a/ci/ray_ci/bisect/bisect_test.py
+++ b/ci/ray_ci/bisect/bisect_test.py
@@ -1,19 +1,20 @@
 import click
 import json
+import os
 
 from ci.ray_ci.utils import logger, ci_init
 from ci.ray_ci.bisect.macos_validator import MacOSValidator
+from ci.ray_ci.bisect.generic_validator import GenericValidator
 from ci.ray_ci.bisect.bisector import Bisector
 from ray_release.test import (
     Test,
-    MACOS_TEST_PREFIX,
-    LINUX_TEST_PREFIX,
-    WINDOWS_TEST_PREFIX,
+    TestType,
 )
 from ray_release.test_automation.ci_state_machine import CITestStateMachine
 
 
-TEST_PREFIXES = [MACOS_TEST_PREFIX, LINUX_TEST_PREFIX, WINDOWS_TEST_PREFIX]
+# This is the directory where the ray repository is mounted in the container
+RAYCI_CHECKOUT_DIR_MOUNT = "/ray"
 
 
 @click.command()
@@ -23,11 +24,18 @@ TEST_PREFIXES = [MACOS_TEST_PREFIX, LINUX_TEST_PREFIX, WINDOWS_TEST_PREFIX]
 def main(test_name: str, passing_commit: str, failing_commit: str) -> None:
     ci_init()
     test = Test.gen_from_name(test_name)
+    if test.get_test_type() == TestType.MACOS_TEST:
+        validator = MacOSValidator()
+        git_dir = os.environ.get("RAYCI_CHECKOUT_DIR")
+    else:
+        validator = GenericValidator()
+        git_dir = RAYCI_CHECKOUT_DIR_MOUNT
     blame_commit = Bisector(
         test,
         passing_commit,
         failing_commit,
-        MacOSValidator(),
+        validator,
+        git_dir,
     ).run()
     logger.info(f"Blame revision: {blame_commit}")
     _update_test_state(test, blame_commit)

--- a/ci/ray_ci/bisect/bisector.py
+++ b/ci/ray_ci/bisect/bisector.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from typing import List, Optional
 
@@ -14,11 +13,13 @@ class Bisector:
         passing_revision: str,
         failing_revision: str,
         validator: Validator,
+        git_dir: str,
     ) -> None:
         self.test = test
         self.passing_revision = passing_revision
         self.failing_revision = failing_revision
         self.validator = validator
+        self.git_dir = git_dir
 
     def run(self) -> Optional[str]:
         """
@@ -51,7 +52,7 @@ class Bisector:
                     f"^{self.passing_revision}~",
                     self.failing_revision,
                 ],
-                cwd=os.environ["RAYCI_CHECKOUT_DIR"],
+                cwd=self.git_dir,
             )
             .decode("utf-8")
             .strip()
@@ -62,10 +63,6 @@ class Bisector:
         """
         Validate whether the test is passing or failing on the given revision
         """
-        subprocess.check_call(
-            ["git", "clean", "-df"], cwd=os.environ["RAYCI_CHECKOUT_DIR"]
-        )
-        subprocess.check_call(
-            ["git", "checkout", revision], cwd=os.environ["RAYCI_CHECKOUT_DIR"]
-        )
-        self.validator.run(self.test)
+        subprocess.check_call(["git", "clean", "-df"], cwd=self.git_dir)
+        subprocess.check_call(["git", "checkout", revision], cwd=self.git_dir)
+        self.validator.run(self.test, revision)

--- a/ci/ray_ci/bisect/generic_validator.py
+++ b/ci/ray_ci/bisect/generic_validator.py
@@ -1,0 +1,79 @@
+import time
+
+from pybuildkite.buildkite import Buildkite
+
+from ci.ray_ci.bisect.validator import Validator
+from ci.ray_ci.utils import logger
+from ray_release.test import Test
+from ray_release.aws import get_secret_token
+from ray_release.configs.global_config import get_global_config
+
+BUILDKITE_ORGANIZATION = "ray-project"
+BUILDKITE_POSTMERGE_PIPELINE = "postmerge"
+BUILDKITE_BUILD_RUNNING_STATE = [
+    "creating",
+    "scheduled",
+    "running",
+]
+BUILDKITE_BUILD_PASSING_STATE = [
+    "passed",
+    "skipped",
+]
+BUILDKITE_BUILD_FAILING_STATE = [
+    "failing",
+    "failed",
+    "blocked",
+    "canceled",
+    "canceling",
+    "not_run",
+]
+TIMEOUT = 2 * 60 * 60  # 2 hours
+WAIT = 10  # 10 seconds
+
+
+class GenericValidator(Validator):
+    def _get_buildkite(self) -> Buildkite:
+        buildkite = Buildkite()
+        buildkite.set_access_token(
+            get_secret_token(get_global_config()["ci_pipeline_buildkite_secret"]),
+        )
+
+        return buildkite
+
+    def _get_rayci_select(self, test: Test) -> str:
+        return test.get_test_results(limit=1)[0].rayci_step_id
+
+    def run(self, test: Test, revision: str) -> bool:
+        buildkite = self._get_buildkite()
+        build = buildkite.builds().create_build(
+            BUILDKITE_ORGANIZATION,
+            BUILDKITE_POSTMERGE_PIPELINE,
+            revision,
+            "master",
+            message=f"[bisection] running single test: {test.get_name()}",
+            env={
+                "RAYCI_SELECT": self._get_rayci_select(test),
+                "RAYCI_BISECT_TEST_TARGET": test.get_target(),
+            },
+        )
+        total_wait = 0
+        while True:
+            logger.info(f"... waiting for test result ...({total_wait} seconds)")
+            time.sleep(WAIT)
+            build = buildkite.builds().get_build_by_number(
+                BUILDKITE_ORGANIZATION,
+                BUILDKITE_POSTMERGE_PIPELINE,
+                build["number"],
+            )
+
+            # return build status
+            if build["state"] in BUILDKITE_BUILD_PASSING_STATE:
+                return True
+            if build["state"] in BUILDKITE_BUILD_FAILING_STATE:
+                return False
+
+            # continue waiting
+            total_wait += WAIT
+            if total_wait > TIMEOUT:
+                logger.error("Timeout")
+                return False

--- a/ci/ray_ci/bisect/macos_validator.py
+++ b/ci/ray_ci/bisect/macos_validator.py
@@ -10,7 +10,7 @@ TEST_SCRIPT = "ci/ray_ci/bisect/macos_validator.sh"
 
 
 class MacOSValidator(Validator):
-    def run(self, test: Test) -> bool:
+    def run(self, test: Test, revision: str) -> bool:
         env = os.environ.copy()
         # We need to unset PYTHONPATH to avoid conflicts with the Python from the
         # Bazel runfiles.

--- a/ci/ray_ci/bisect/test_bisector.py
+++ b/ci/ray_ci/bisect/test_bisector.py
@@ -17,10 +17,10 @@ def test_run(mock_get_revision_lists, mock_checkout_and_validate):
     mock_get_revision_lists.return_value = ["1", "2", "3", "4", "5"]
 
     # Test case 1: P P P F F
-    assert Bisector(Test(), "1", "5", MacOSValidator()).run() == "3"
+    assert Bisector(Test(), "1", "5", MacOSValidator(), "dir").run() == "3"
 
     # Test case 2: P F
-    assert Bisector(Test(), "3", "4", MacOSValidator()).run() == "3"
+    assert Bisector(Test(), "3", "4", MacOSValidator(), "dir").run() == "3"
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/bisect/test_generic_validator.py
+++ b/ci/ray_ci/bisect/test_generic_validator.py
@@ -1,0 +1,45 @@
+import time
+import sys
+import pytest
+from unittest import mock
+
+
+from ci.ray_ci.bisect.generic_validator import WAIT, GenericValidator
+from ray_release.test import Test
+
+START = time.time()
+
+
+class MockBuildkiteBuild:
+    def create_build(self, *args, **kwargs):
+        return {
+            "number": 1,
+            "state": "creating",
+        }
+
+    def get_build_by_number(self, *args, **kwargs):
+        # Simulate a build that takes 2 cycle of WAIT to pass
+        build = self.create_build()
+        if time.time() - START > 2 * WAIT:
+            build["state"] = "passed"
+        else:
+            build["state"] = "running"
+
+        return build
+
+
+class MockBuildkite:
+    def builds(self):
+        return MockBuildkiteBuild()
+
+
+@mock.patch("ci.ray_ci.bisect.generic_validator.GenericValidator._get_buildkite")
+@mock.patch("ci.ray_ci.bisect.generic_validator.GenericValidator._get_rayci_select")
+def test_run(mock_get_rayci_select, mock_get_buildkite):
+    mock_get_rayci_select.return_value = "rayci_step_id"
+    mock_get_buildkite.return_value = MockBuildkite()
+    assert GenericValidator().run(Test({"name": "test"}), "revision")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Add the LinuxValidator for bisect job, which works in the following way:
- It create a build in the postmerge pipeline with 'RAYCI_RELECT' and 'RAYCI_BISECT_TEST_TARGET' to run only the target under bisect
- Wait for the build to finish and return accordingly to the status
- Also skip recording test results on bisect run

Test:
- CI
- test:
    - bisect job: https://buildkite.com/ray-project/bisect/builds/1104#_
    - trigger single test run on postmerge: https://buildkite.com/ray-project/postmerge/builds/4353#_ 