### PR TITLE
Add descriptive error message when deployment name not found

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1236,14 +1236,13 @@ def override_deployment_info(
             options["max_ongoing_requests"] = options.get("max_ongoing_requests")
 
         deployment_name = options["name"]
-        try:
-            info = deployment_infos[deployment_name]
-        except KeyError:
-            raise RayServeException(
-                f"Deployment '{deployment_name}' for application "
-                f"'{app_name}' does not exist. Available: "
-                f"{list(deployment_infos.keys())}"
+        if deployment_name not in deployment_infos:
+            raise ValueError(
+                f"Deployment '{deployment_name}' does not exist. "
+                f"Available: {list(deployment_infos.keys())}"
             )
+
+        info = deployment_infos[deployment_name]
         original_options = info.deployment_config.dict()
         original_options["user_configured_option_names"].update(set(options))
 

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1236,12 +1236,14 @@ def override_deployment_info(
             options["max_ongoing_requests"] = options.get("max_ongoing_requests")
 
         deployment_name = options["name"]
-        if deployment_name not in deployment_infos:
-            raise ValueError(
-                f"Got config override for nonexistent deployment '{deployment_name}'"
+        try:
+            info = deployment_infos[deployment_name]
+        except KeyError:
+            raise RayServeException(
+                f"Deployment '{deployment_name}' for application "
+                f"'{app_name}' does not exist. Available: "
+                f"{list(deployment_infos.keys())}"
             )
-
-        info = deployment_infos[deployment_name]
         original_options = info.deployment_config.dict()
         original_options["user_configured_option_names"].update(set(options))
 

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -1056,10 +1056,12 @@ def test_deploy_nonexistent_deployment(client: ServeControllerClient):
     def check_app_message():
         details = ray.get(client._controller.get_serve_instance_details.remote())
         # The error message should be descriptive
-        # e.g. no deployment "x" in application "y"
+        # e.g. no deployment "x" in application "y", available deployments: "z"
+        message = details["applications"]["random1"]["message"]
         return (
-            "application" in details["applications"]["random1"]["message"]
-            and "deployment" in details["applications"]["random1"]["message"]
+            "Deployment" in message
+            and "Available" in message
+            and "application" in message
         )
 
     wait_for_condition(check_app_message)

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -1160,7 +1160,7 @@ def test_redeploy_old_config_after_failed_deployment(
     else:
         # Set config for a nonexistent deployment
         new_app_config["deployments"] = [{"name": "nonexistent", "num_replicas": 1}]
-        err_msg = "nonexistent deployment 'nonexistent'"
+        err_msg = "Deployment 'nonexistent' does not exist."
     client.deploy_apps(ServeDeploySchema(**{"applications": [new_app_config]}))
 
     def check_deploy_failed(message):

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -1309,6 +1309,22 @@ class TestOverrideDeploymentInfo:
             == "s3://B"
         )
 
+    def test_non_existent_deployment(self, info):
+        """Test error is raised when attempting to override a non-existent deployment."""
+        config = ServeApplicationSchema(
+            name="default",
+            import_path="test.import.path",
+            deployments=[
+                DeploymentSchema(
+                    name="A",
+                    num_replicas=3,
+                )
+            ],
+        )
+
+        with pytest.raises(ValueError, match="Deployment 'NonExistentDeployment' does not exist. Available:"):
+            override_deployment_info({"NonExistentDeployment": info}, config)
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -1309,26 +1309,6 @@ class TestOverrideDeploymentInfo:
             == "s3://B"
         )
 
-    def test_non_existent_deployment(self, info):
-        """Test error is raised when attempting to override a non-existent deployment."""
-        non_existent_name = "NonExistentDeployment"
-        config = ServeApplicationSchema(
-            name="default",
-            import_path="test.import.path",
-            deployments=[
-                DeploymentSchema(
-                    name=non_existent_name,
-                    num_replicas=3,
-                )
-            ],
-        )
-
-        with pytest.raises(
-            ValueError,
-            match=f"Deployment '{non_existent_name}' does not exist. Available:",
-        ):
-            override_deployment_info({"A": info}, config)
-
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -1311,12 +1311,13 @@ class TestOverrideDeploymentInfo:
 
     def test_non_existent_deployment(self, info):
         """Test error is raised when attempting to override a non-existent deployment."""
+        non_existent_name = "NonExistentDeployment"
         config = ServeApplicationSchema(
             name="default",
             import_path="test.import.path",
             deployments=[
                 DeploymentSchema(
-                    name="A",
+                    name=non_existent_name,
                     num_replicas=3,
                 )
             ],
@@ -1324,9 +1325,9 @@ class TestOverrideDeploymentInfo:
 
         with pytest.raises(
             ValueError,
-            match="Deployment 'NonExistentDeployment' does not exist. Available:",
+            match=f"Deployment '{non_existent_name}' does not exist. Available:",
         ):
-            override_deployment_info({"NonExistentDeployment": info}, config)
+            override_deployment_info({"A": info}, config)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -1322,7 +1322,10 @@ class TestOverrideDeploymentInfo:
             ],
         )
 
-        with pytest.raises(ValueError, match="Deployment 'NonExistentDeployment' does not exist. Available:"):
+        with pytest.raises(
+            ValueError,
+            match="Deployment 'NonExistentDeployment' does not exist. Available:",
+        ):
             override_deployment_info({"NonExistentDeployment": info}, config)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If the named deployment isn't found in a Ray serve instance, it's difficult to troubleshoot the names of deployments that are available. This error lists the known ones out in the error message instead.

For example, we now can see:

```
ray.serve.exceptions.RayServeException: Deployment 'capitalizer' for application 'capitalizer' 
does not exist. Available: ['Capitalizer', 'Uncapitalizer', 'CapitalizerEndpoint']
```

vs. previously:

```
(ServeController pid=99265)   File ... error in override_deployment_info
(ServeController pid=99265)     info = deployment_infos[deployment_name]
(ServeController pid=99265)            ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
(ServeController pid=99265) KeyError: 'capitalizer'
```


## Related issue number

<!-- For example: "Closes #1234" -->

(N/A)

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] ~~I've included any doc changes needed for https://docs.ray.io/en/master/.~~
    - [ ] ~~I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.~~
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
