### PR TITLE
[Data][Train] Allow manually setting resource limits for training jobs

### DIFF
--- a/python/ray/air/tests/test_new_dataset_config.py
+++ b/python/ray/air/tests/test_new_dataset_config.py
@@ -313,13 +313,11 @@ def _run_data_config_resource_test(data_config):
                 train_ds = train.get_dataset_shard("train")
                 new_execution_options = train_ds._base_dataset.context.execution_options
                 if original_execution_options.is_resource_limits_default():
-                    # If the original resource limits are default, the new resource limits
-                    # should be the default as well.
+                    # If the original resource limits are default, the new resource
+                    # limits should be the default as well.
                     # And the new exclude_resources should be the resources used by
                     # Train + user-defined exclude_resources.
-                    assert (
-                        new_execution_options.resource_limits.is_resource_limits_default()
-                    )
+                    assert new_execution_options.is_resource_limits_default()
                     exclude_resources = new_execution_options.exclude_resources
                     assert (
                         exclude_resources.cpu

--- a/python/ray/air/tests/test_new_dataset_config.py
+++ b/python/ray/air/tests/test_new_dataset_config.py
@@ -7,7 +7,10 @@ import pytest
 import ray
 from ray import train
 from ray.data import DataIterator
-from ray.data._internal.execution.interfaces.execution_options import ExecutionOptions
+from ray.data._internal.execution.interfaces.execution_options import (
+    ExecutionOptions,
+    ExecutionResources,
+)
 from ray.tests.conftest import *  # noqa
 from ray.train import DataConfig, ScalingConfig
 from ray.train.data_parallel_trainer import DataParallelTrainer
@@ -290,8 +293,7 @@ def test_materialized_preprocessing(ray_start_4_cpus):
     test.fit()
 
 
-def test_data_config_default_resource_limits(shutdown_only):
-    """Test that DataConfig should exclude training resources from Data."""
+def _run_data_config_resource_test(data_config):
     cluster_cpus, cluster_gpus = 20, 10
     num_workers = 2
     # Resources used by training workers.
@@ -301,8 +303,7 @@ def test_data_config_default_resource_limits(shutdown_only):
     num_train_cpus = num_workers * cpus_per_worker + default_trainer_cpus
     num_train_gpus = num_workers * gpus_per_worker + default_trainer_gpus
 
-    init_exclude_cpus = 2
-    init_exclude_gpus = 1
+    original_execution_options = data_config._execution_options
 
     ray.init(num_cpus=cluster_cpus, num_gpus=cluster_gpus)
 
@@ -310,17 +311,40 @@ def test_data_config_default_resource_limits(shutdown_only):
         def __init__(self, **kwargs):
             def train_loop_fn():
                 train_ds = train.get_dataset_shard("train")
-                exclude_resources = (
-                    train_ds._base_dataset.context.execution_options.exclude_resources
-                )
-                assert exclude_resources.cpu == num_train_cpus + init_exclude_cpus
-                assert exclude_resources.gpu == num_train_gpus + init_exclude_gpus
+                new_execution_options = train_ds._base_dataset.context.execution_options
+                if original_execution_options.is_resource_limits_default():
+                    # If the original resource limits are default, the new resource limits
+                    # should be the default as well.
+                    # And the new exclude_resources should be the resources used by
+                    # Train + user-defined exclude_resources.
+                    assert (
+                        new_execution_options.resource_limits.is_resource_limits_default()
+                    )
+                    exclude_resources = new_execution_options.exclude_resources
+                    assert (
+                        exclude_resources.cpu
+                        == num_train_cpus
+                        + original_execution_options.exclude_resources.cpu
+                    )
+                    assert (
+                        exclude_resources.gpu
+                        == num_train_gpus
+                        + original_execution_options.exclude_resources.gpu
+                    )
+                else:
+                    # If the original resource limits are not default, the new resource
+                    # limits should be the same as the original ones.
+                    # And the new exclude_resources should be zero.
+                    assert (
+                        new_execution_options.resource_limits
+                        == original_execution_options.resource_limits
+                    )
+                    assert (
+                        new_execution_options.exclude_resources
+                        == ExecutionResources.zero()
+                    )
 
             kwargs.pop("scaling_config", None)
-
-            execution_options = ExecutionOptions()
-            execution_options.exclude_resources.cpu = init_exclude_cpus
-            execution_options.exclude_resources.gpu = init_exclude_gpus
 
             super().__init__(
                 train_loop_per_worker=train_loop_fn,
@@ -333,12 +357,32 @@ def test_data_config_default_resource_limits(shutdown_only):
                     },
                 ),
                 datasets={"train": ray.data.range(10)},
-                dataset_config=DataConfig(execution_options=execution_options),
+                dataset_config=data_config,
                 **kwargs,
             )
 
     trainer = MyTrainer()
     trainer.fit()
+
+
+def test_data_config_default_resource_limits(shutdown_only):
+    """Test that DataConfig should exclude training resources from Data."""
+    execution_options = ExecutionOptions()
+    execution_options.exclude_resources.cpu = 2
+    execution_options.exclude_resources.gpu = 1
+    data_config = DataConfig(execution_options=execution_options)
+
+    _run_data_config_resource_test(data_config)
+
+
+def test_data_config_manual_resource_limits(shutdown_only):
+    """Test manually setting resource limits in DataConfig."""
+    execution_options = ExecutionOptions()
+    execution_options.resource_limits.cpu = 10
+    execution_options.resource_limits.gpu = 5
+    data_config = DataConfig(execution_options=execution_options)
+
+    _run_data_config_resource_test(data_config)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -273,10 +273,6 @@ class ExecutionOptions:
         """Returns True if resource_limits is the default value."""
         return self._resource_limits == ExecutionResources.for_limits()
 
-    def is_exlude_resources_default(self):
-        """Returns True if exclude_resources is the default value."""
-        return self.exclude_resources == ExecutionResources.zero()
-
     def validate(self) -> None:
         """Validate the options."""
         for attr in ["cpu", "gpu", "object_store_memory"]:

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -269,6 +269,14 @@ class ExecutionOptions:
             object_store_memory=value._object_store_memory,
         )
 
+    def is_resource_limits_default(self):
+        """Returns True if resource_limits is the default value."""
+        return self._resource_limits == ExecutionResources.for_limits()
+
+    def is_exlude_resources_default(self):
+        """Returns True if exclude_resources is the default value."""
+        return self.exclude_resources == ExecutionResources.zero()
+
     def validate(self) -> None:
         """Validate the options."""
         for attr in ["cpu", "gpu", "object_store_memory"]:

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -91,17 +91,23 @@ class DataConfig:
             worker_node_ids if self._execution_options.locality_with_output else None
         )
         for name, ds in datasets.items():
-            ds = ds.copy(ds)
-            ds.context.execution_options = copy.deepcopy(self._execution_options)
+            execution_options = copy.deepcopy(self._execution_options)
 
-            # Add training-reserved resources to Data's exclude_resources.
-            ds.context.execution_options.exclude_resources = (
-                ds.context.execution_options.exclude_resources.add(
-                    ExecutionResources(
-                        cpu=self._num_train_cpus, gpu=self._num_train_gpus
+            if (
+                execution_options.is_resource_limits_default()
+                and execution_options.is_exlude_resources_default()
+            ):
+                # If "resource_limits" and "exclude_resources" are not overriden by the
+                # user, add training-reserved resources to Data's exclude_resources.
+                execution_options.exclude_resources = (
+                    ds.context.execution_options.exclude_resources.add(
+                        ExecutionResources(
+                            cpu=self._num_train_cpus, gpu=self._num_train_gpus
+                        )
                     )
                 )
-            )
+            ds = ds.copy(ds)
+            ds.context.execution_options = execution_options
 
             if name in datasets_to_split:
                 for i, split in enumerate(

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -93,12 +93,9 @@ class DataConfig:
         for name, ds in datasets.items():
             execution_options = copy.deepcopy(self._execution_options)
 
-            if (
-                execution_options.is_resource_limits_default()
-                and execution_options.is_exlude_resources_default()
-            ):
-                # If "resource_limits" and "exclude_resources" are not overriden by the
-                # user, add training-reserved resources to Data's exclude_resources.
+            if execution_options.is_resource_limits_default():
+                # If "resource_limits" is not overriden by the user,
+                # add training-reserved resources to Data's exclude_resources.
                 execution_options.exclude_resources = (
                     ds.context.execution_options.exclude_resources.add(
                         ExecutionResources(

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -97,12 +97,13 @@ class DataConfig:
                 # If "resource_limits" is not overriden by the user,
                 # add training-reserved resources to Data's exclude_resources.
                 execution_options.exclude_resources = (
-                    ds.context.execution_options.exclude_resources.add(
+                    execution_options.exclude_resources.add(
                         ExecutionResources(
                             cpu=self._num_train_cpus, gpu=self._num_train_gpus
                         )
                     )
                 )
+
             ds = ds.copy(ds)
             ds.context.execution_options = execution_options
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously it's not possible to manually set data resource limits for training jobs. 
Because we automatically set "exclude_resources" for training jobs, and "exclude_resources" and "resource_limits" cannot be both set. 

This PR fixes this issue by not automatically setting "exclude_resources" when "resource_limits" are already set by the user

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
