### PR TITLE
Improve log viewer

### DIFF
--- a/dashboard/client/src/common/MultiTabLogViewer.tsx
+++ b/dashboard/client/src/common/MultiTabLogViewer.tsx
@@ -259,9 +259,7 @@ const ApiLogViewer = ({
       path={path}
       downloadUrl={downloadUrl !== null ? downloadUrl : undefined}
       height={height}
-      onRefreshClick={() => {
-        refresh();
-      }}
+      onRefreshClick={refresh}
     />
   ) : (
     <Typography color="error">Failed to load</Typography>

--- a/dashboard/client/src/components/LogView/LogVirtualView.tsx
+++ b/dashboard/client/src/components/LogView/LogVirtualView.tsx
@@ -1,3 +1,4 @@
+import { Box } from "@mui/material";
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
 import dayjs from "dayjs";
@@ -120,24 +121,26 @@ const LogVirtualView: React.FC<LogVirtualViewProps> = ({
   const itemRenderer = ({ index, style }: { index: number; style: any }) => {
     const { i, origin } = logs[revert ? logs.length - 1 - index : index];
     return (
-      <div
+      <Box
         key={`${index}list`}
-        style={{ ...style, overflowX: "visible", whiteSpace: "pre" }}
-      >
-        <span
-          style={{
-            marginRight: 4,
+        style={style}
+        sx={{
+          overflowX: "visible",
+          whiteSpace: "pre",
+          "&::before": {
+            content: `"${i + 1}"`,
+            marginRight: 0.5,
             width: `${logs.length}`.length * 6 + 4,
             color: "#999",
             display: "inline-block",
-          }}
-        >
-          {i + 1}
-        </span>
+          },
+        }}
+      >
         {low
           .highlight(language, origin)
           .value.map((v) => value2react(v, index.toString(), keywords))}
-      </div>
+        <br />
+      </Box>
     );
   };
 

--- a/dashboard/client/src/pages/log/LogViewer.tsx
+++ b/dashboard/client/src/pages/log/LogViewer.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
-import React, { useState } from "react";
+import React, { memo, useState } from "react";
 import LogVirtualView from "../../components/LogView/LogVirtualView";
 
 const useStyles = makeStyles((theme) =>
@@ -48,119 +48,125 @@ type LogViewerProps = {
   height?: number;
 };
 
-export const LogViewer = ({
-  path,
-  log,
-  downloadUrl,
-  onRefreshClick,
-  height = 600,
-}: LogViewerProps) => {
-  const classes = useStyles();
+/**
+ * Memoized component because React-window does not work well with re-renders.
+ * If text is selected, it will get unselected if the component re-renders.
+ */
+export const LogViewer = memo(
+  ({
+    path,
+    log,
+    downloadUrl,
+    onRefreshClick,
+    height = 600,
+  }: LogViewerProps) => {
+    const classes = useStyles();
 
-  const { search, setSearch, startTime, setStart, endTime, setEnd } =
-    useLogViewer();
+    const { search, setSearch, startTime, setStart, endTime, setEnd } =
+      useLogViewer();
 
-  return (
-    <React.Fragment>
-      {log !== "Loading..." && (
-        <div>
+    return (
+      <React.Fragment>
+        {log !== "Loading..." && (
           <div>
-            <TextField
-              className={classes.search}
-              label="Keyword"
-              InputProps={{
-                onChange: ({ target: { value } }) => {
-                  setSearch({ ...search, keywords: value });
-                },
-                type: "",
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <SearchOutlined />
-                  </InputAdornment>
-                ),
-              }}
-            />
-            <TextField
-              id="datetime-local"
-              label="Start Time"
-              type="datetime-local"
-              value={startTime}
-              className={classes.search}
-              onChange={(val) => {
-                setStart(val.target.value);
-              }}
-              InputLabelProps={{
-                shrink: true,
-              }}
-            />
-            <TextField
-              label="End Time"
-              type="datetime-local"
-              value={endTime}
-              className={classes.search}
-              onChange={(val) => {
-                setEnd(val.target.value);
-              }}
-              InputLabelProps={{
-                shrink: true,
-              }}
-            />
-            <div className={classes.search}>
-              Reverse:{" "}
-              <Switch
-                checked={search?.revert}
-                onChange={(e, v) => setSearch({ ...search, revert: v })}
+            <div>
+              <TextField
+                className={classes.search}
+                label="Keyword"
+                InputProps={{
+                  onChange: ({ target: { value } }) => {
+                    setSearch({ ...search, keywords: value });
+                  },
+                  type: "",
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <SearchOutlined />
+                    </InputAdornment>
+                  ),
+                }}
               />
-              {onRefreshClick && (
+              <TextField
+                id="datetime-local"
+                label="Start Time"
+                type="datetime-local"
+                value={startTime}
+                className={classes.search}
+                onChange={(val) => {
+                  setStart(val.target.value);
+                }}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+              />
+              <TextField
+                label="End Time"
+                type="datetime-local"
+                value={endTime}
+                className={classes.search}
+                onChange={(val) => {
+                  setEnd(val.target.value);
+                }}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+              />
+              <div className={classes.search}>
+                Reverse:{" "}
+                <Switch
+                  checked={search?.revert}
+                  onChange={(e, v) => setSearch({ ...search, revert: v })}
+                />
+                {onRefreshClick && (
+                  <Button
+                    className={classes.search}
+                    variant="contained"
+                    onClick={onRefreshClick}
+                  >
+                    Refresh
+                  </Button>
+                )}
                 <Button
                   className={classes.search}
                   variant="contained"
-                  onClick={onRefreshClick}
+                  onClick={() => {
+                    setStart("");
+                    setEnd("");
+                  }}
                 >
-                  Refresh
+                  Reset Time
                 </Button>
-              )}
-              <Button
-                className={classes.search}
-                variant="contained"
-                onClick={() => {
-                  setStart("");
-                  setEnd("");
-                }}
-              >
-                Reset Time
-              </Button>
-              {downloadUrl && path && (
-                <Button
-                  variant="contained"
-                  component="a"
-                  href={downloadUrl}
-                  download={path}
-                >
-                  Download log file
-                </Button>
-              )}
+                {downloadUrl && path && (
+                  <Button
+                    variant="contained"
+                    component="a"
+                    href={downloadUrl}
+                    download={path}
+                  >
+                    Download log file
+                  </Button>
+                )}
+              </div>
             </div>
+            <LogVirtualView
+              height={height}
+              revert={search?.revert}
+              keywords={search?.keywords}
+              focusLine={Number(search?.lineNumber) || undefined}
+              fontSize={search?.fontSize || 12}
+              content={log}
+              language="prolog"
+              startTime={startTime}
+              endTime={endTime}
+            />
           </div>
-          <LogVirtualView
-            height={height}
-            revert={search?.revert}
-            keywords={search?.keywords}
-            focusLine={Number(search?.lineNumber) || undefined}
-            fontSize={search?.fontSize || 12}
-            content={log}
-            language="prolog"
-            startTime={startTime}
-            endTime={endTime}
-          />
-        </div>
-      )}
-      {log === "Loading..." && (
-        <div>
-          <br />
-          <LinearProgress />
-        </div>
-      )}
-    </React.Fragment>
-  );
-};
+        )}
+        {log === "Loading..." && (
+          <div>
+            <br />
+            <LinearProgress />
+          </div>
+        )}
+      </React.Fragment>
+    );
+  },
+);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fixes two bugs:
- When selecting text in the log viewer, a re-render of the viewer will de-select text. Even if the log viewer was not changed. Now, we will avoid re-rendering the log viewer unless the props have changed.
- When selecting text, the line numbers no longer get selected. We moved the line numbers to be pseudo-elements instead of spans.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
![Screenshot 2024-05-07 at 7 10 33 PM](https://github.com/ray-project/ray/assets/711935/54679550-cac0-419e-b838-f1fc387cc7fa)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
