### PR TITLE
[Dashboard] Bumped default `REPORTER_UPDATE_INTERVAL_MS` to 5s

### DIFF
--- a/dashboard/modules/reporter/reporter_consts.py
+++ b/dashboard/modules/reporter/reporter_consts.py
@@ -3,5 +3,5 @@ import ray._private.ray_constants as ray_constants
 REPORTER_PREFIX = "RAY_REPORTER:"
 # The reporter will report its statistics this often (milliseconds).
 REPORTER_UPDATE_INTERVAL_MS = ray_constants.env_integer(
-    "REPORTER_UPDATE_INTERVAL_MS", 2500
+    "REPORTER_UPDATE_INTERVAL_MS", 5000
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To reduce the pressure induced by 

 - Relatively high-frequency of node-stats updates originated from Reporter Agent
 - Using JSON instead of Proto for payloads encoding

## Related issue number

While this change is not addressing #45191, it aims at reducing the pressure on the Dashboard Head process by reducing the frequency of updates

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
