### PR TITLE
[ci][microcheck/6] disable automerge on pullrequest updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -126,3 +126,5 @@
 /release/ray_release @ray-project/ray-ci-reviewers
 
 /.github/ISSUE_TEMPLATE/ @ericl @stephanie-wang @scv119 @pcmoritz
+
+/.github/workflows/ @ray-project/ray-ci-reviewers

--- a/.github/workflows/on_pull_request_synchronized.yml
+++ b/.github/workflows/on_pull_request_synchronized.yml
@@ -1,0 +1,44 @@
+name: Pull request synchronized
+on:
+  pull_request_target:
+    types:
+      - synchronize
+jobs:
+  disable-automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const prQuery = `query PullRequest($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pullRequestNumber) {
+                  id
+                  autoMergeRequest {
+                    enabledAt
+                  }
+                }
+              }
+            }`;
+            const prVariables = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pullRequestNumber: context.issue.number
+            }
+            const prResult = await github.graphql(prQuery, prVariables)
+            if (!prResult.repository.pullRequest.autoMergeRequest) {
+              console.log('Auto merge is not enabled')
+              return
+            }
+            const automergeQuery = `mutation DisablePullRequestAutoMerge($pullRequestId: ID!) {
+              disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) {
+                pullRequest {
+                  id
+                }
+              }
+            }`;
+            const automergeVariables = {
+              pullRequestId: prResult.repository.pullRequest.id
+            }
+            const result = await github.graphql(automergeQuery, automergeVariables)
+            console.log(result)


### PR DESCRIPTION
Add a github workflow to disable automerge on pull request updates. I tested that it works in another test repo: https://github.com/anyscale/reef-dev/pull/56

Also add reef to be the owner for .github/workflow

Test:
- CI