### PR TITLE
[data] fix bugs introduced by autoscaler refactor

### DIFF
--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -65,8 +65,8 @@ class DefaultAutoscaler(Autoscaler):
         elif actor_pool.current_size() >= actor_pool.max_size():
             # Do not scale up, if the actor pool is already at max size.
             return False
-        # Do not scale up, if the op still has enough resources to run.
-        if op_state._scheduling_status.under_resource_limits:
+        # Do not scale up, if the op does not have more resources.
+        if not op_state._scheduling_status.under_resource_limits:
             return False
         # Do not scale up, if the op has enough free slots for the existing inputs.
         if op_state.num_queued() <= actor_pool.num_free_task_slots():

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -34,7 +34,7 @@ def test_actor_pool_scaling():
         internal_queue_size=MagicMock(return_value=1),
     )
     op_state = MagicMock(num_queued=MagicMock(return_value=10))
-    op_scheduling_status = MagicMock(under_resource_limits=False)
+    op_scheduling_status = MagicMock(under_resource_limits=True)
     op_state._scheduling_status = op_scheduling_status
 
     @contextmanager
@@ -85,11 +85,11 @@ def test_actor_pool_scaling():
         with patch(op, "internal_queue_size", 0):
             assert_should_scale_up(False)
 
-    # Shouldn't scale up since the op is under resource limits.
+    # Shouldn't scale up since the op doesn't have enough resources.
     with patch(
         op_scheduling_status,
         "under_resource_limits",
-        True,
+        False,
         is_method=False,
     ):
         assert_should_scale_up(False)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fix following bugs introduced by #45002:
* `autoscaler.try_trigger_scaling` not called when `select_op_to_run` returns None.
* scaling up condition on `under_resource_limits`.

`python/ray/data/tests/test_streaming_integration.py::test_e2e_autoscaling_up` should pass after this fix.

## Related issue number

Closes https://github.com/ray-project/ray/issues/43481

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
