### PR TITLE
[Data] Don't raise batch size error if `num_gpus=0`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -566,9 +566,8 @@ class Dataset:
             # Enable blocks bundling when batch_size is specified by caller.
             min_rows_per_bundled_input = batch_size
 
-        batch_size = _apply_batch_size(
-            batch_size, use_gpu="num_gpus" in ray_remote_args
-        )
+        use_gpu = ray_remote_args.get("num_gpus", 0) > 0
+        batch_size = _apply_batch_size(batch_size, use_gpu)
 
         if batch_format not in VALID_BATCH_FORMATS:
             raise ValueError(

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -232,6 +232,8 @@ def test_strict_require_batch_size_for_gpu():
     with pytest.raises(ValueError):
         ds.map_batches(lambda x: x, num_gpus=1)
 
+    ds.map_batches(lambda x: x, num_gpus=0)
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ray Data raises an error if you use GPUs and don't specify a batch size. However, if you specify `num_gpus=0`, you still get an error. This PR corrects this confusing behavior.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/45201

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
