### PR TITLE
[serve] change application deploy_failed/unhealthy logs to error level

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -767,7 +767,7 @@ class ApplicationState:
             ]
             and status_msg != self._status_msg
         ):
-            logger.warning(status_msg)
+            logger.error(status_msg)
 
         self._status = status
         self._status_msg = status_msg


### PR DESCRIPTION
[serve] change application deploy_failed/unhealthy logs to error level

Currently if an application's status changes to `DEPLOY_FAILED` or `UNHEALTHY` we log the status message as `warning` level. We should log it as `error` level as that is more appropriate.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
