### PR TITLE
[rllib] remove installing pytorch in release test setup

### DIFF
--- a/release/ray_release/byod/byod_rllib_test.sh
+++ b/release/ray_release/byod/byod_rllib_test.sh
@@ -10,7 +10,6 @@ pip3 install https://ray-ci-deps-wheels.s3.us-west-2.amazonaws.com/AutoROM.accep
 git clone https://github.com/ray-project/rl-experiments.git
 unzip rl-experiments/halfcheetah-sac/2022-12-17/halfcheetah_1500_mean_reward_sac.zip -d ~/.
 pip3 uninstall -y minigrid
-pip3 install torch==2.0.0+cu118 torchvision==0.15.1+cu118 --index-url https://download.pytorch.org/whl/cu118
 
 # not strictly necessary, but makes debugging easier
 git clone https://github.com/ray-project/ray.git


### PR DESCRIPTION
these packages should be already included in ray-ml image building

reinstalling it actually might cause issues / conflicts.