### PR TITLE
[ci][microcheck/7] trigger premerge with 'go' label pull request

### DIFF
--- a/.github/workflows/on_pull_request_synchronized.yml
+++ b/.github/workflows/on_pull_request_synchronized.yml
@@ -4,6 +4,18 @@ on:
     types:
       - synchronize
 jobs:
+  trigger-premerge:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'go')
+    steps:
+      - uses: buildkite/trigger-pipeline-action@v2.2.0
+        with:
+          buildkite_api_access_token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}
+          pipeline: "ray-project/premerge"
+          branch: ${{ github.event.pull_request.head.ref }}
+          commit: ${{ github.event.pull_request.head.sha }}
+          pull_request_base_branch: ${{ github.event.pull_request.base.ref }}
+
   disable-automerge:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Trigger premerge when a pull request with the 'go' label is updated. With this change, we should turn off the premerge trigger from buildkite, and lave the job to github workflow.

Test:
- CI