### PR TITLE
[rllib] add werkzeug as explicit dependency

### DIFF
--- a/release/ray_release/byod/byod_rllib_test.sh
+++ b/release/ray_release/byod/byod_rllib_test.sh
@@ -10,6 +10,7 @@ pip3 install https://ray-ci-deps-wheels.s3.us-west-2.amazonaws.com/AutoROM.accep
 git clone https://github.com/ray-project/rl-experiments.git
 unzip rl-experiments/halfcheetah-sac/2022-12-17/halfcheetah_1500_mean_reward_sac.zip -d ~/.
 pip3 uninstall -y minigrid
+pip3 install werkzeug==2.3.8
 
 # not strictly necessary, but makes debugging easier
 git clone https://github.com/ray-project/ray.git


### PR DESCRIPTION
to handle cases where it is not installed inside the base image
