### PR TITLE
[ci] increase time out for learning_tests_cartpole_dqn_envrunner

### DIFF
--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -51,8 +51,14 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
+        --except-tags tf_only,tf2_only,multi_gpu,learning_tests_pytorch_use_all_core
+        --test-arg --framework=torch
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
+        --only-tags learning_tests_pytorch_use_all_core
         --except-tags tf_only,tf2_only,multi_gpu
         --test-arg --framework=torch
+        --skip-ray-installation
     depends_on: rllibbuild
 
   - label: ":brain: rllib: examples"

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -187,7 +187,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_w_100_policies_appo",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "enormous",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/multi-agent-cartpole-w-100-policies-appo.py"],
@@ -285,8 +285,8 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_dqn_envrunner",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete"],
-    size = "large",
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    size = "enormous",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/dqn/cartpole_dqn_envrunner.py"],
     args = ["--dir=tuned_examples/dqn"]


### PR DESCRIPTION
The linux://rllib:learning_tests_cartpole_dqn_envrunner seems to be flaky/timedout. I increase the time out and move to test to not running in parallel with other tests.

Test:
- CI
- https://buildkite.com/ray-project/postmerge/builds/4381