### PR TITLE
[ci] add both async and non-async version of get_test_results

### DIFF
--- a/ci/ray_ci/automation/determine_microcheck_tests.py
+++ b/ci/ray_ci/automation/determine_microcheck_tests.py
@@ -116,6 +116,7 @@ def _get_failed_prs(test: Test, test_history_length: int) -> Set[str]:
         for result in test.get_test_results(
             limit=test_history_length,
             aws_bucket=get_global_config()["state_machine_pr_aws_bucket"],
+            use_async=True,
         )
         if result.status == ResultStatus.ERROR.value
     ]

--- a/ci/ray_ci/automation/test_determine_microcheck_tests.py
+++ b/ci/ray_ci/automation/test_determine_microcheck_tests.py
@@ -25,7 +25,9 @@ class MockTest(dict):
     def get_name(self) -> str:
         return self.get("name", "")
 
-    def get_test_results(self, limit: int, aws_bucket: str) -> List[TestResult]:
+    def get_test_results(
+        self, limit: int, aws_bucket: str, use_async: bool
+    ) -> List[TestResult]:
         return self.get("test_results", [])
 
     def persist_to_s3(self) -> None:


### PR DESCRIPTION
The async version doesn't seem to work too on windows (https://buildkite.com/ray-project/postmerge/builds/4379#018f5d33-32d2-4212-9e25-ed4ea937be3b/12248-12440). I added a non-async version on this PR, and use the async version on the automation that runs on linux only

Test:
- CI