### PR TITLE
[ci] run flaky tests twice

### DIFF
--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -8,6 +8,7 @@ from unittest import mock
 from typing import List, Optional
 
 from ci.ray_ci.linux_tester_container import LinuxTesterContainer
+from ci.ray_ci.tester_container import RUN_PER_FLAKY_TEST
 from ci.ray_ci.utils import chunk_into_n, ci_init
 from ci.ray_ci.container import _DOCKER_ECR_REPO, _RAYCI_BUILD_ID
 from ray_release.configs.global_config import get_global_config
@@ -116,13 +117,15 @@ def test_run_tests_in_docker() -> None:
             "bazel test --jobs=1 --config=ci $(./ci/run/bazel_export_options) "
             "--config=ci-debug --test_env v=k --test_arg flag t1 t2" in input_str
         )
+        assert f"--runs_per_test {RUN_PER_FLAKY_TEST} " not in input_str
 
         LinuxTesterContainer("team")._run_tests_in_docker(
-            ["t1", "t2"], [], "/tmp", ["v=k"]
+            ["t1", "t2"], [], "/tmp", ["v=k"], run_flaky_tests=True
         )
         input_str = inputs[-1]
         assert "--env BUILDKITE_BUILD_URL" in input_str
         assert "--gpus" not in input_str
+        assert f"--runs_per_test {RUN_PER_FLAKY_TEST} " in input_str
 
 
 def test_run_script_in_docker() -> None:
@@ -199,6 +202,7 @@ def test_run_tests() -> None:
         bazel_log_dir: str,
         test_envs: List[str],
         test_arg: Optional[str] = None,
+        run_flaky_tests: Optional[bool] = False,
     ) -> MockPopen:
         return MockPopen(test_targets)
 

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -241,7 +241,11 @@ def main(
         or os.environ.get("RAYCI_MICROCHECK_RUN") == "1",
     )
     success = container.run_tests(
-        team, test_targets, test_arg, is_bisect_run=bisect_run_test_target is not None
+        team,
+        test_targets,
+        test_arg,
+        is_bisect_run=bisect_run_test_target is not None,
+        run_flaky_tests=run_flaky_tests,
     )
     sys.exit(0 if success else 42)
 

--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -16,6 +16,9 @@ from ray_release.test_automation.ci_state_machine import CITestStateMachine
 from ray_release.configs.global_config import get_global_config
 
 
+RUN_PER_FLAKY_TEST = 2
+
+
 class TesterContainer(Container):
     """
     A wrapper for running tests in ray ci docker container
@@ -73,6 +76,7 @@ class TesterContainer(Container):
         test_targets: List[str],
         test_arg: Optional[str] = None,
         is_bisect_run: bool = False,
+        run_flaky_tests: bool = False,
     ) -> bool:
         """
         Run tests parallelly in docker.  Return whether all tests pass.
@@ -96,7 +100,12 @@ class TesterContainer(Container):
         bazel_log_dir_host, bazel_log_dir_container = self._create_bazel_log_mount()
         runs = [
             self._run_tests_in_docker(
-                chunks[i], gpu_ids[i], bazel_log_dir_host, self.test_envs, test_arg
+                chunks[i],
+                gpu_ids[i],
+                bazel_log_dir_host,
+                self.test_envs,
+                test_arg,
+                run_flaky_tests,
             )
             for i in range(len(chunks))
         ]
@@ -211,6 +220,7 @@ class TesterContainer(Container):
         bazel_log_dir_host: str,
         test_envs: List[str],
         test_arg: Optional[str] = None,
+        run_flaky_tests: bool = False,
     ) -> subprocess.Popen:
         logger.info("Running tests: %s", test_targets)
         commands = [
@@ -245,6 +255,8 @@ class TesterContainer(Container):
             test_cmd += f"--test_env {env} "
         if test_arg:
             test_cmd += f"--test_arg {test_arg} "
+        if run_flaky_tests:
+            test_cmd += f"--runs_per_test {RUN_PER_FLAKY_TEST} "
         test_cmd += f"{' '.join(test_targets)}"
         commands.append(test_cmd)
         return subprocess.Popen(


### PR DESCRIPTION
As we move linux + windows test to periodic run, let's run flaky tests twice, similar to what we do for macosx. This will allow the state machine to have enough signals to move flaky tests around quick enough.

Test:
- CI
- postmerge: https://buildkite.com/ray-project/postmerge/builds/4380