### PR TITLE
[Doc] Fix broken references in Ray Tune documentation

### DIFF
--- a/doc/source/tune/api/execution.rst
+++ b/doc/source/tune/api/execution.rst
@@ -54,3 +54,4 @@ tune.run_experiments
 
     run_experiments
     Experiment
+    TuneError

--- a/doc/source/tune/api/logging.rst
+++ b/doc/source/tune/api/logging.rst
@@ -76,6 +76,7 @@ See the :doc:`tutorial here </tune/examples/tune-wandb>`.
     :toctree: doc/
 
     ~air.integrations.wandb.WandbLoggerCallback
+    ~air.integrations.wandb.setup_wandb
 
 
 Comet Integration

--- a/doc/source/tune/api/logging.rst
+++ b/doc/source/tune/api/logging.rst
@@ -59,8 +59,10 @@ See the :doc:`tutorial here </tune/examples/tune-mlflow>`.
 
 .. autosummary::
     :nosignatures:
+    :toctree: doc/
 
-    tune.logger.mlflow.MLflowLoggerCallback
+    ~air.integrations.mlflow.MLflowLoggerCallback
+    ~air.integrations.mlflow.setup_mlflow
 
 Wandb Integration
 -----------------
@@ -71,8 +73,9 @@ See the :doc:`tutorial here </tune/examples/tune-wandb>`.
 
 .. autosummary::
     :nosignatures:
+    :toctree: doc/
 
-    tune.logger.wandb.WandbLoggerCallback
+    ~air.integrations.wandb.WandbLoggerCallback
 
 
 Comet Integration
@@ -84,8 +87,9 @@ See the :doc:`tutorial here </tune/examples/tune-comet>`.
 
 .. autosummary::
     :nosignatures:
+    :toctree: doc/
 
-    tune.logger.comet.CometLoggerCallback
+    ~air.integrations.comet.CometLoggerCallback
 
 Aim Integration
 ---------------
@@ -119,4 +123,3 @@ The non-relevant metrics (like timing stats) can be disabled on the left to show
 relevant ones (like accuracy, loss, etc.).
 
 .. image:: ../images/ray-tune-viskit.png
-

--- a/doc/source/tune/examples/tune_analyze_results.ipynb
+++ b/doc/source/tune/examples/tune_analyze_results.ipynb
@@ -479,7 +479,7 @@
             "id": "184bd3ee",
             "metadata": {},
             "source": [
-                "The last reported metrics might not contain the best accuracy each trial achieved. If we want to get maximum accuracy that each trial reported throughout its training, we can do so by using {meth}`ResultGrid.get_dataframe <ray.tune.result_grid.ResultGrid.get_dataframe>` specifying a metric and mode used to filter each trial's training history."
+                "The last reported metrics might not contain the best accuracy each trial achieved. If we want to get maximum accuracy that each trial reported throughout its training, we can do so by using {meth}`~ray.tune.ResultGrid.get_dataframe` specifying a metric and mode used to filter each trial's training history."
             ]
         },
         {

--- a/doc/source/tune/faq.rst
+++ b/doc/source/tune/faq.rst
@@ -634,7 +634,7 @@ You can configure this by setting the `RAY_CHDIR_TO_TRIAL_DIR=0` environment var
 This explicitly tells Tune to not change the working directory
 to the trial directory, giving access to paths relative to the original working directory.
 One caveat is that the working directory is now shared between workers, so the
-:meth:`ray.train.context.TrainContext.get_trial_dir`
+:meth:`train.get_context().get_trial_dir() <ray.train.context.TrainContext.get_trial_dir>`
 API should be used to get the path for saving trial-specific outputs.
 
 .. literalinclude:: doc_code/faq.py

--- a/doc/source/tune/faq.rst
+++ b/doc/source/tune/faq.rst
@@ -634,7 +634,7 @@ You can configure this by setting the `RAY_CHDIR_TO_TRIAL_DIR=0` environment var
 This explicitly tells Tune to not change the working directory
 to the trial directory, giving access to paths relative to the original working directory.
 One caveat is that the working directory is now shared between workers, so the
-:meth:`train.get_context().get_trial_dir() <ray.train.context.TrainContext.get_.get_trial_dir>`
+:meth:`ray.train.context.TrainContext.get_trial_dir`
 API should be used to get the path for saving trial-specific outputs.
 
 .. literalinclude:: doc_code/faq.py

--- a/doc/source/tune/tutorials/tune-distributed.rst
+++ b/doc/source/tune/tutorials/tune-distributed.rst
@@ -237,7 +237,7 @@ even after failure.
 Recovering From Failures
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tune automatically persists the progress of your entire experiment (a ``Tuner.fit()`` session), so if an experiment crashes or is otherwise cancelled, it can be resumed through :meth:`Tuner.restore() <ray.tune.tuner.Tuner.restore>`.
+Tune automatically persists the progress of your entire experiment (a ``Tuner.fit()`` session), so if an experiment crashes or is otherwise cancelled, it can be resumed through :meth:`~ray.tune.Tuner.restore`.
 
 .. _tune-distributed-common:
 

--- a/doc/source/tune/tutorials/tune-storage.rst
+++ b/doc/source/tune/tutorials/tune-storage.rst
@@ -212,7 +212,7 @@ you can resume it any time starting from the experiment state saved in the cloud
 There are a few options for restoring an experiment:
 ``resume_unfinished``, ``resume_errored`` and ``restart_errored``.
 Please see the documentation of
-:meth:`Tuner.restore() <ray.tune.tuner.Tuner.restore>` for more details.
+:meth:`~ray.tune.Tuner.restore` for more details.
 
 
 Advanced configuration

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -97,7 +97,7 @@ class ExportFormat:
         """Validates formats.
 
         Raises:
-            ValueError if the format is unknown.
+            ValueError: if the format is unknown.
         """
         for i in range(len(formats)):
             formats[i] = formats[i].strip().lower()
@@ -659,7 +659,7 @@ class Trial:
         Should only be called when the trial is not running.
 
         Raises:
-            ValueError if trial status is running.
+            ValueError: if trial status is running.
         """
         if self.status is Trial.RUNNING:
             raise ValueError("Cannot update resources while Trial is running.")

--- a/python/ray/tune/tuner.py
+++ b/python/ray/tune/tuner.py
@@ -391,7 +391,7 @@ class Tuner:
     def get_results(self) -> ResultGrid:
         """Get results of a hyperparameter tuning run.
 
-        This method returns the same results as :meth:`fit() <ray.tune.tuner.Tuner.fit>`
+        This method returns the same results as :meth:`~ray.tune.Tuner.fit`
         and can be used to retrieve the results after restoring a tuner without
         calling ``fit()`` again.
 


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes broken references found in the Tune documentation.

## Related issue number

Partially addresses #39658. Blocked by #45160, will mark this as ready for review once those are merged.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
