### PR TITLE
[ci] remove //python/ray/data:test_streaming_integration from flaky list

### DIFF
--- a/ci/ray_ci/data.tests.yml
+++ b/ci/ray_ci/data.tests.yml
@@ -1,2 +1,1 @@
-flaky_tests:
-  - //python/ray/data:test_streaming_integration
+flaky_tests: []


### PR DESCRIPTION
Remove this test from flaky list. We break it previously because it is here. The test is not flaky, and also automation handles flaky tests nowadays.

Test:
- CI