### PR TITLE
[ci] migrate reef test to use test_in_docker

### DIFF
--- a/.buildkite/cicd.rayci.yml
+++ b/.buildkite/cicd.rayci.yml
@@ -1,17 +1,14 @@
-group: CI/CD infra
-depends_on:
-  - forge
+group: reef tests
 steps:
-  - label: "CI/CD: ray_ci tooling"
-    key: ray-ci-tooling-tests
+  - label: ":coral: reef: ci+release tooling tests"
+    key: reef-tests
     commands:
-      # TODO(aslonnie): wrap this in a script, and upload test telemetry.
-      - bazel test --test_tag_filters=ci_unit //ci/ray_ci/...
+      - bazel run //ci/ray_ci:test_in_docker -- //ci/ray_ci/... //release/... ci
+          --only-tags=release_unit,ci_unit
+          --parallelism-per-worker 2
+          --build-name oss-ci-base_test
+          --build-type skip
     instance_type: small
-
-  - label: "CI/CD: release test infra"
-    key: ray-release-infra-tests
-    commands:
-      # TODO(aslonnie): wrap this in a script, and upload test telemetry.
-      - bazel test --test_tag_filters=release_unit //release/...
-    instance_type: small
+    depends_on:
+      - oss-ci-base_test
+      - forge

--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -23,6 +23,11 @@ if [[ "$BUILDKITE_PIPELINE_ID" == "0189942e-0876-4b8f-80a4-617f988ec59b" ]]; the
   echo "build --remote_upload_local_results=false" >> ~/.bazelrc
 fi
 
+if [[ "$BUILD_TYPE" == "skip" ]]; then
+  echo "Skipping build"
+  exit 0
+fi
+
 (
   cd dashboard/client
   npm ci


### PR DESCRIPTION
Migrate reef tests to use test_in_docker so that they can be included in microcheck. This PR also:
- Add a BUILD_TYPE=skip to skip building ray in test_in_docker
- Make the ci.tests.yaml file (that one declares flaky tests per team) optional. I'll working towards deprecating them.

Test:
- CI