### PR TITLE
[Core] Improve logging during accelerator auto-detection

### DIFF
--- a/python/ray/_private/accelerators/__init__.py
+++ b/python/ray/_private/accelerators/__init__.py
@@ -33,6 +33,7 @@ def get_all_accelerator_resource_names() -> Set[str]:
 
 def get_accelerator_manager_for_resource(
     resource_name: str,
+    is_user_specified_resource: bool = False,
 ) -> Optional[AcceleratorManager]:
     """Get the corresponding accelerator manager for the given
     accelerator resource name
@@ -40,9 +41,18 @@ def get_accelerator_manager_for_resource(
     E.g., TPUAcceleratorManager is returned if resource name is "TPU"
     """
     try:
-        return get_accelerator_manager_for_resource._resource_name_to_accelerator_manager.get(  # noqa: E501
+        accelerator_manager = get_accelerator_manager_for_resource._resource_name_to_accelerator_manager.get(  # noqa: E501
             resource_name, None
         )
+        if is_user_specified_resource:
+            # GPU handling
+            if resource_name == "GPU":
+                AMDGPUAcceleratorManager.set_user_specified_resource(True)
+                IntelGPUAcceleratorManager.set_user_specified_resource(True)
+                NvidiaGPUAcceleratorManager.set_user_specified_resource(True)
+            else:
+                accelerator_manager.set_user_specified_resource(True)
+        return accelerator_manager
     except AttributeError:
         # Lazy initialization.
         resource_name_to_accelerator_manager = {

--- a/python/ray/_private/accelerators/accelerator.py
+++ b/python/ray/_private/accelerators/accelerator.py
@@ -6,6 +6,14 @@ class AcceleratorManager(ABC):
     """This class contains all the functions needed for supporting
     an accelerator family in Ray."""
 
+    _is_user_specified_resource = False
+
+    @classmethod
+    def set_user_specified_resource(cls, value=True):
+        """Set the flag to indicate that the accelerator resource is user specified."""
+        cls._is_user_specified_resource = value
+
+
     @staticmethod
     @abstractmethod
     def get_resource_name() -> str:

--- a/python/ray/_private/accelerators/accelerator.py
+++ b/python/ray/_private/accelerators/accelerator.py
@@ -13,7 +13,6 @@ class AcceleratorManager(ABC):
         """Set the flag to indicate that the accelerator resource is user specified."""
         cls._is_user_specified_resource = value
 
-
     @staticmethod
     @abstractmethod
     def get_resource_name() -> str:

--- a/python/ray/_private/accelerators/amd_gpu.py
+++ b/python/ray/_private/accelerators/amd_gpu.py
@@ -72,8 +72,8 @@ class AMDGPUAcceleratorManager(AcceleratorManager):
             except Exception as e:
                 if AMDGPUAcceleratorManager._is_user_specified_resource:
                     logger.debug(
-                        f"AMD ran into the following error"
-                        "while getting number of GPUs: {e},"
+                        "AMD ran into the following error"
+                        f"while getting number of GPUs: {e},"
                         "you can ignore this message if you are"
                         "not using AMD GPUs."
                     )

--- a/python/ray/_private/accelerators/amd_gpu.py
+++ b/python/ray/_private/accelerators/amd_gpu.py
@@ -71,10 +71,12 @@ class AMDGPUAcceleratorManager(AcceleratorManager):
                 )
             except Exception as e:
                 if AMDGPUAcceleratorManager._is_user_specified_resource:
-                    logger.debug(f"AMD ran into the following error"
-                                 "while getting number of GPUs: {e},"
-                                 "you can ignore this message if you are"
-                                 "not using AMD GPUs.")
+                    logger.debug(
+                        f"AMD ran into the following error"
+                        "while getting number of GPUs: {e},"
+                        "you can ignore this message if you are"
+                        "not using AMD GPUs."
+                    )
         return num_gpus
 
     @staticmethod

--- a/python/ray/_private/accelerators/amd_gpu.py
+++ b/python/ray/_private/accelerators/amd_gpu.py
@@ -27,6 +27,8 @@ amd_product_dict = {
 class AMDGPUAcceleratorManager(AcceleratorManager):
     """AMD GPU accelerators."""
 
+    _is_user_specified_resource = False
+
     @staticmethod
     def get_resource_name() -> str:
         return "GPU"
@@ -67,8 +69,12 @@ class AMDGPUAcceleratorManager(AcceleratorManager):
                     )
                     - 1
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                if AMDGPUAcceleratorManager._is_user_specified_resource:
+                    logger.debug(f"AMD ran into the following error"
+                                 "while getting number of GPUs: {e},"
+                                 "you can ignore this message if you are"
+                                 "not using AMD GPUs.")
         return num_gpus
 
     @staticmethod

--- a/python/ray/_private/accelerators/hpu.py
+++ b/python/ray/_private/accelerators/hpu.py
@@ -26,6 +26,8 @@ HPU_PACKAGE_AVAILABLE = is_package_present("habana_frameworks")
 class HPUAcceleratorManager(AcceleratorManager):
     """Intel Habana(HPU) accelerators."""
 
+    _is_user_specified_resource = False
+
     @staticmethod
     def get_resource_name() -> str:
         return "HPU"
@@ -63,6 +65,11 @@ class HPUAcceleratorManager(AcceleratorManager):
                 logging.info("HPU devices not available")
                 return 0
         else:
+            if HPUAcceleratorManager._is_user_specified_resource:
+                logger.debug(
+                    "Intel Habana support requires the 'habana_frameworks' package,"
+                    "which is not installed."
+                )
             return 0
 
     @staticmethod

--- a/python/ray/_private/accelerators/intel_gpu.py
+++ b/python/ray/_private/accelerators/intel_gpu.py
@@ -49,8 +49,10 @@ class IntelGPUAcceleratorManager(AcceleratorManager):
             import dpctl
         except ImportError as e:
             if IntelGPUAcceleratorManager._is_user_specified_resource:
-                logger.warning("Intel GPU support requires the 'dpctl' package," 
-                            "which is not installed.")
+                logger.warning(
+                    "Intel GPU support requires the 'dpctl' package,"
+                    "which is not installed."
+                )
             dpctl = None
         if dpctl is None:
             return 0
@@ -62,9 +64,11 @@ class IntelGPUAcceleratorManager(AcceleratorManager):
             num_gpus = context.device_count
         except Exception as e:
             if IntelGPUAcceleratorManager._is_user_specified_resource:
-                logger.debug(f"Intel GPU ran into the following error while"
-                            "getting number of GPUs: {e},"
-                            "you can ignore this message if you are not using Intel GPUs.")
+                logger.debug(
+                    f"Intel GPU ran into the following error while"
+                    "getting number of GPUs: {e},"
+                    "you can ignore this message if you are not using Intel GPUs."
+                )
                 num_gpus = 0
         return num_gpus
 

--- a/python/ray/_private/accelerators/intel_gpu.py
+++ b/python/ray/_private/accelerators/intel_gpu.py
@@ -47,9 +47,9 @@ class IntelGPUAcceleratorManager(AcceleratorManager):
     def get_current_node_num_accelerators() -> int:
         try:
             import dpctl
-        except ImportError as e:
+        except ImportError:
             if IntelGPUAcceleratorManager._is_user_specified_resource:
-                logger.warning(
+                logger.debug(
                     "Intel GPU support requires the 'dpctl' package,"
                     "which is not installed."
                 )
@@ -65,8 +65,8 @@ class IntelGPUAcceleratorManager(AcceleratorManager):
         except Exception as e:
             if IntelGPUAcceleratorManager._is_user_specified_resource:
                 logger.debug(
-                    f"Intel GPU ran into the following error while"
-                    "getting number of GPUs: {e},"
+                    "Intel GPU ran into the following error while"
+                    f"getting number of GPUs: {e},"
                     "you can ignore this message if you are not using Intel GPUs."
                 )
                 num_gpus = 0

--- a/python/ray/_private/accelerators/neuron.py
+++ b/python/ray/_private/accelerators/neuron.py
@@ -31,6 +31,8 @@ AWS_NEURON_INSTANCE_MAP = {
 class NeuronAcceleratorManager(AcceleratorManager):
     """AWS Inferentia and Trainium accelerators."""
 
+    _is_user_specified_resource = False
+
     @staticmethod
     def get_resource_name() -> str:
         return "neuron_cores"
@@ -73,6 +75,11 @@ class NeuronAcceleratorManager(AcceleratorManager):
                 neuron_devices = json.loads(result.stdout)
                 for neuron_device in neuron_devices:
                     nc_count += neuron_device.get("nc_count", 0)
+        else:
+            if NeuronAcceleratorManager._is_user_specified_resource:
+                logger.debug(
+                    "Neuron accelerator path not found."
+                )
         return nc_count
 
     @staticmethod

--- a/python/ray/_private/accelerators/neuron.py
+++ b/python/ray/_private/accelerators/neuron.py
@@ -77,9 +77,7 @@ class NeuronAcceleratorManager(AcceleratorManager):
                     nc_count += neuron_device.get("nc_count", 0)
         else:
             if NeuronAcceleratorManager._is_user_specified_resource:
-                logger.debug(
-                    "Neuron accelerator path not found."
-                )
+                logger.debug("Neuron accelerator path not found.")
         return nc_count
 
     @staticmethod

--- a/python/ray/_private/accelerators/npu.py
+++ b/python/ray/_private/accelerators/npu.py
@@ -16,6 +16,8 @@ NOSET_ASCEND_RT_VISIBLE_DEVICES_ENV_VAR = (
 class NPUAcceleratorManager(AcceleratorManager):
     """Ascend NPU accelerators."""
 
+    _is_user_specified_resource = False
+
     @staticmethod
     def get_resource_name() -> str:
         return "NPU"
@@ -63,7 +65,8 @@ class NPUAcceleratorManager(AcceleratorManager):
             npu_files = glob.glob("/dev/davinci?")
             return len(npu_files)
         except Exception as e:
-            logger.debug("Failed to detect number of NPUs: %s", e)
+            if NPUAcceleratorManager._is_user_specified_resource:
+                logger.debug("Failed to detect number of NPUs: %s", e)
         return 0
 
     @staticmethod

--- a/python/ray/_private/accelerators/nvidia_gpu.py
+++ b/python/ray/_private/accelerators/nvidia_gpu.py
@@ -64,9 +64,11 @@ class NvidiaGPUAcceleratorManager(AcceleratorManager):
             pynvml.nvmlInit()
         except pynvml.NVMLError as e:
             if NvidiaGPUAcceleratorManager._is_user_specified_resource:
-                logger.debug(f"NVIDIA GPU runs into error: {e}"
-                             "while initializing pynvml."
-                             "You can ignore this message if you are not using NVIDIA GPUs.")
+                logger.debug(
+                    f"NVIDIA GPU runs into error: {e}"
+                    "while initializing pynvml."
+                    "You can ignore this message if you are not using NVIDIA GPUs."
+                )
             return None  # pynvml init failed
         device_count = pynvml.nvmlDeviceGetCount()
         cuda_device_type = None

--- a/python/ray/_private/accelerators/nvidia_gpu.py
+++ b/python/ray/_private/accelerators/nvidia_gpu.py
@@ -18,6 +18,8 @@ NVIDIA_GPU_NAME_PATTERN = re.compile(r"\w+\s+([A-Z0-9]+)")
 class NvidiaGPUAcceleratorManager(AcceleratorManager):
     """Nvidia GPU accelerators."""
 
+    _is_user_specified_resource = False
+
     @staticmethod
     def get_resource_name() -> str:
         return "GPU"
@@ -60,7 +62,11 @@ class NvidiaGPUAcceleratorManager(AcceleratorManager):
 
         try:
             pynvml.nvmlInit()
-        except pynvml.NVMLError:
+        except pynvml.NVMLError as e:
+            if NvidiaGPUAcceleratorManager._is_user_specified_resource:
+                logger.debug(f"NVIDIA GPU runs into error: {e}"
+                             "while initializing pynvml."
+                             "You can ignore this message if you are not using NVIDIA GPUs.")
             return None  # pynvml init failed
         device_count = pynvml.nvmlDeviceGetCount()
         cuda_device_type = None

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -75,6 +75,8 @@ def _get_tpu_metadata(key: str) -> Optional[str]:
 class TPUAcceleratorManager(AcceleratorManager):
     """Google TPU accelerators."""
 
+    _is_user_specified_resource = False
+
     @staticmethod
     def get_resource_name() -> str:
         return "TPU"
@@ -116,7 +118,8 @@ class TPUAcceleratorManager(AcceleratorManager):
             numeric_entries = [int(entry) for entry in vfio_entries if entry.isdigit()]
             return len(numeric_entries)
         except FileNotFoundError as e:
-            logger.debug("Failed to detect number of TPUs: %s", e)
+            if TPUAcceleratorManager._is_user_specified_resource:
+                logger.debug("Failed to detect number of TPUs: %s", e)
             return 0
 
     @staticmethod

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -192,7 +192,7 @@ class ResourceSpec(
             # Check that the number of accelerators that the raylet wants doesn't
             # exceed the amount allowed by visible accelerator ids.
             if num_accelerators is not None and visible_accelerator_ids is None:
-                raise ValueError(
+                logger.debug(
                     f"Attempting to start raylet with {num_accelerators} "
                     f"{accelerator_resource_name}, but "
                     f"{accelerator_manager.get_visible_accelerator_ids_env_var()} "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR improves the user experience during accelerator auto-detection. Currently errors from accelerator autodetection are suppressed. With the changes in this PR, if a user specifies accelerator(s) as part of available resources (for example, `ray.init(num_gpus=3)`), and that resource encounters errors during auto-detection, an error message will be logged. 

I also added an additional check in `resource_spec.py`  which adds an entry to logger if raylet wants a certain number of accelerators but visible accelerator id is `None`. 

## Related issue number

Closes #43328 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
