### PR TITLE
[Doc] Update Ray Summit banner colors

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -396,7 +396,7 @@ table.autosummary tr > td:first-child > p > a > code > span {
 }
 
 .bd-header-announcement {
-  color: var(--pst-color-dark);
+  color: var(--pst-color-light);
 }
 
 .bd-header-announcement::after {
@@ -404,6 +404,6 @@ table.autosummary tr > td:first-child > p > a > code > span {
 }
 
 .bd-header-announcement a {
-  color: var(--pst-color-dark);
+  color: var(--pst-color-light);
   text-decoration: underline;
 }


### PR DESCRIPTION
## Why are these changes needed?

The current black text on blue background design for the Ray Summit banner is low contrast. This PR changes the text to white.

## Related issue number

Closes #45224.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
