### PR TITLE
[dashboard][perf] Add Version to all Ray metrics

### DIFF
--- a/dashboard/consts.py
+++ b/dashboard/consts.py
@@ -69,7 +69,7 @@ DEFAULT_JOB_START_TIMEOUT_SECONDS = 60 * 15
 RAY_JOB_START_TIMEOUT_SECONDS_ENV_VAR = "RAY_JOB_START_TIMEOUT_SECONDS"
 # Port that dashboard prometheus metrics will be exported to
 DASHBOARD_METRIC_PORT = env_integer("DASHBOARD_METRIC_PORT", 44227)
-COMPONENT_METRICS_TAG_KEYS = ["ip", "pid", "Component", "SessionName"]
+COMPONENT_METRICS_TAG_KEYS = ["ip", "pid", "Version", "Component", "SessionName"]
 # Dashboard metrics are tracked separately at the dashboard. TODO(sang): Support GCS.
 AVAILABLE_COMPONENT_NAMES_FOR_METRICS = {
     "workers",

--- a/dashboard/dashboard_metrics.py
+++ b/dashboard/dashboard_metrics.py
@@ -53,7 +53,7 @@ try:
             self.metrics_request_duration = Histogram(
                 "dashboard_api_requests_duration_seconds",
                 "Total duration in seconds per endpoint",
-                ("endpoint", "http_status", "SessionName", "Component"),
+                ("endpoint", "http_status", "Version", "SessionName", "Component"),
                 unit="seconds",
                 namespace="ray",
                 registry=self.registry,
@@ -62,7 +62,14 @@ try:
             self.metrics_request_count = Counter(
                 "dashboard_api_requests_count",
                 "Total requests count per endpoint",
-                ("method", "endpoint", "http_status", "SessionName", "Component"),
+                (
+                    "method",
+                    "endpoint",
+                    "http_status",
+                    "Version",
+                    "SessionName",
+                    "Component",
+                ),
                 unit="requests",
                 namespace="ray",
                 registry=self.registry,

--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -10,6 +10,7 @@ from math import floor
 
 from packaging.version import Version
 
+import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
@@ -179,6 +180,7 @@ class HttpServerDashboardHead:
                 self.metrics.metrics_request_duration.labels(
                     endpoint=handler.__name__,
                     http_status=status_tag,
+                    Version=ray.__version__,
                     SessionName=self._session_name,
                     Component="dashboard",
                 ).observe(resp_time)
@@ -186,6 +188,7 @@ class HttpServerDashboardHead:
                     method=request.method,
                     endpoint=handler.__name__,
                     http_status=status_tag,
+                    Version=ray.__version__,
                     SessionName=self._session_name,
                     Component="dashboard",
                 ).inc()

--- a/dashboard/modules/metrics/metrics_head.py
+++ b/dashboard/modules/metrics/metrics_head.py
@@ -3,12 +3,11 @@ import aiohttp
 import logging
 import os
 import shutil
-
 from typing import Optional
-
 import psutil
-
 from urllib.parse import quote
+
+import ray
 from ray.dashboard.modules.metrics.grafana_dashboard_factory import (
     generate_default_grafana_dashboard,
     generate_serve_grafana_dashboard,
@@ -309,12 +308,14 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
         self._dashboard_head.metrics.metrics_dashboard_cpu.labels(
             ip=self._ip,
             pid=self._pid,
+            Version=ray.__version__,
             Component=self._component,
             SessionName=self._session_name,
         ).set(float(self._dashboard_proc.cpu_percent()))
         self._dashboard_head.metrics.metrics_dashboard_mem.labels(
             ip=self._ip,
             pid=self._pid,
+            Version=ray.__version__,
             Component=self._component,
             SessionName=self._session_name,
         ).set(float(self._dashboard_proc.memory_full_info().uss) / 1.0e6)

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -819,7 +819,7 @@ class ReporterAgent(
                 total_uss += float(mem_full_info.uss) / 1.0e6
             total_num_fds += int(stat.get("num_fds", 0))
 
-        tags = {"ip": self._ip, "Component": component_name}
+        tags = {"ip": self._ip, "Component": component_name, "Version": ray.__version__}
         if pid:
             tags["pid"] = pid
 

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -77,127 +77,151 @@ METRICS_GAUGES = {
         "node_cpu_utilization",
         "Total CPU usage on a ray node",
         "percentage",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_cpu_count": Gauge(
         "node_cpu_count",
         "Total CPUs available on a ray node",
         "cores",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_mem_used": Gauge(
-        "node_mem_used", "Memory usage on a ray node", "bytes", ["ip", "SessionName"]
+        "node_mem_used",
+        "Memory usage on a ray node",
+        "bytes",
+        ["ip", "Version", "SessionName"],
     ),
     "node_mem_available": Gauge(
         "node_mem_available",
         "Memory available on a ray node",
         "bytes",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_mem_total": Gauge(
-        "node_mem_total", "Total memory on a ray node", "bytes", ["ip", "SessionName"]
+        "node_mem_total",
+        "Total memory on a ray node",
+        "bytes",
+        ["ip", "Version", "SessionName"],
     ),
     "node_mem_shared_bytes": Gauge(
         "node_mem_shared_bytes",
         "Total shared memory usage on a ray node",
         "bytes",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_gpus_available": Gauge(
         "node_gpus_available",
         "Total GPUs available on a ray node",
         "percentage",
-        ["ip", "SessionName", "GpuDeviceName", "GpuIndex"],
+        ["ip", "Version", "SessionName", "GpuDeviceName", "GpuIndex"],
     ),
     "node_gpus_utilization": Gauge(
         "node_gpus_utilization",
         "Total GPUs usage on a ray node",
         "percentage",
-        ["ip", "SessionName", "GpuDeviceName", "GpuIndex"],
+        ["ip", "Version", "SessionName", "GpuDeviceName", "GpuIndex"],
     ),
     "node_gram_used": Gauge(
         "node_gram_used",
         "Total GPU RAM usage on a ray node",
         "bytes",
-        ["ip", "SessionName", "GpuDeviceName", "GpuIndex"],
+        ["ip", "Version", "SessionName", "GpuDeviceName", "GpuIndex"],
     ),
     "node_gram_available": Gauge(
         "node_gram_available",
         "Total GPU RAM available on a ray node",
         "bytes",
-        ["ip", "SessionName", "GpuDeviceName", "GpuIndex"],
+        ["ip", "Version", "SessionName", "GpuDeviceName", "GpuIndex"],
     ),
     "node_disk_io_read": Gauge(
-        "node_disk_io_read", "Total read from disk", "bytes", ["ip", "SessionName"]
+        "node_disk_io_read",
+        "Total read from disk",
+        "bytes",
+        ["ip", "Version", "SessionName"],
     ),
     "node_disk_io_write": Gauge(
-        "node_disk_io_write", "Total written to disk", "bytes", ["ip", "SessionName"]
+        "node_disk_io_write",
+        "Total written to disk",
+        "bytes",
+        ["ip", "Version", "SessionName"],
     ),
     "node_disk_io_read_count": Gauge(
         "node_disk_io_read_count",
         "Total read ops from disk",
         "io",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_disk_io_write_count": Gauge(
         "node_disk_io_write_count",
         "Total write ops to disk",
         "io",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_disk_io_read_speed": Gauge(
-        "node_disk_io_read_speed", "Disk read speed", "bytes/sec", ["ip", "SessionName"]
+        "node_disk_io_read_speed",
+        "Disk read speed",
+        "bytes/sec",
+        ["ip", "Version", "SessionName"],
     ),
     "node_disk_io_write_speed": Gauge(
         "node_disk_io_write_speed",
         "Disk write speed",
         "bytes/sec",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_disk_read_iops": Gauge(
-        "node_disk_read_iops", "Disk read iops", "iops", ["ip", "SessionName"]
+        "node_disk_read_iops",
+        "Disk read iops",
+        "iops",
+        ["ip", "Version", "SessionName"],
     ),
     "node_disk_write_iops": Gauge(
-        "node_disk_write_iops", "Disk write iops", "iops", ["ip", "SessionName"]
+        "node_disk_write_iops",
+        "Disk write iops",
+        "iops",
+        ["ip", "Version", "SessionName"],
     ),
     "node_disk_usage": Gauge(
         "node_disk_usage",
         "Total disk usage (bytes) on a ray node",
         "bytes",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_disk_free": Gauge(
         "node_disk_free",
         "Total disk free (bytes) on a ray node",
         "bytes",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_disk_utilization_percentage": Gauge(
         "node_disk_utilization_percentage",
         "Total disk utilization (percentage) on a ray node",
         "percentage",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_network_sent": Gauge(
-        "node_network_sent", "Total network sent", "bytes", ["ip", "SessionName"]
+        "node_network_sent",
+        "Total network sent",
+        "bytes",
+        ["ip", "Version", "SessionName"],
     ),
     "node_network_received": Gauge(
         "node_network_received",
         "Total network received",
         "bytes",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_network_send_speed": Gauge(
         "node_network_send_speed",
         "Network send speed",
         "bytes/sec",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "node_network_receive_speed": Gauge(
         "node_network_receive_speed",
         "Network receive speed",
         "bytes/sec",
-        ["ip", "SessionName"],
+        ["ip", "Version", "SessionName"],
     ),
     "component_cpu_percentage": Gauge(
         "component_cpu_percentage",
@@ -234,19 +258,19 @@ METRICS_GAUGES = {
         "cluster_active_nodes",
         "Active nodes on the cluster",
         "count",
-        ["node_type", "SessionName"],
+        ["node_type", "Version", "SessionName"],
     ),
     "cluster_failed_nodes": Gauge(
         "cluster_failed_nodes",
         "Failed nodes on the cluster",
         "count",
-        ["node_type", "SessionName"],
+        ["node_type", "Version", "SessionName"],
     ),
     "cluster_pending_nodes": Gauge(
         "cluster_pending_nodes",
         "Pending nodes on the cluster",
         "count",
-        ["node_type", "SessionName"],
+        ["node_type", "Version", "SessionName"],
     ),
 }
 
@@ -819,7 +843,7 @@ class ReporterAgent(
                 total_uss += float(mem_full_info.uss) / 1.0e6
             total_num_fds += int(stat.get("num_fds", 0))
 
-        tags = {"ip": self._ip, "Component": component_name, "Version": ray.__version__}
+        tags = {"ip": self._ip, "Component": component_name}
         if pid:
             tags["pid"] = pid
 
@@ -1209,7 +1233,10 @@ class ReporterAgent(
                     records_reported = self._record_stats(stats, cluster_stats)
                     self._metrics_agent.record_and_export(
                         records_reported,
-                        global_tags={"SessionName": self._session_name},
+                        global_tags={
+                            "Version": ray.__version__,
+                            "SessionName": self._session_name,
+                        },
                     )
                     self._metrics_agent.clean_all_dead_worker_metrics()
                 await publisher.publish_resource_usage(self._key, jsonify_asdict(stats))

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -302,6 +302,7 @@ def test_metrics_export_end_to_end(_setup_cluster_for_test):
                 assert sample.labels["SessionName"] == session_name
             if sample.name in _DASHBOARD_METRICS:
                 assert sample.labels["SessionName"] == session_name
+                assert sample.labels["Version"] == ray.__version__, sample
 
         # Make sure the numeric values are correct
         test_counter_sample = [m for m in metric_samples if "test_counter" in m.name][0]
@@ -400,6 +401,7 @@ def test_metrics_export_node_metrics(shutdown_only):
         for metric in _NODE_COMPONENT_METRICS:
             samples = avail_metrics[metric]
             for sample in samples:
+                assert sample.labels["Version"] == ray.__version__
                 components.add(sample.labels["Component"])
         assert components == {"raylet", "agent", "ray::IDLE"}
 

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -298,11 +298,10 @@ def test_metrics_export_end_to_end(_setup_cluster_for_test):
             assert metric in metric_names, f"metric {metric} not in {metric_names}"
 
         for sample in metric_samples:
-            if sample.name in _METRICS:
-                assert sample.labels["SessionName"] == session_name
-            if sample.name in _DASHBOARD_METRICS:
-                assert sample.labels["SessionName"] == session_name
-                assert sample.labels["Version"] == ray.__version__, sample
+            # All Ray metrics have label "Version" and "SessionName".
+            if sample.name in _METRICS or sample.name in _DASHBOARD_METRICS:
+                assert sample.labels.get("Version") == ray.__version__, sample
+                assert sample.labels["SessionName"] == session_name, sample
 
         # Make sure the numeric values are correct
         test_counter_sample = [m for m in metric_samples if "test_counter" in m.name][0]
@@ -401,7 +400,6 @@ def test_metrics_export_node_metrics(shutdown_only):
         for metric in _NODE_COMPONENT_METRICS:
             samples = avail_metrics[metric]
             for sample in samples:
-                assert sample.labels["Version"] == ray.__version__
                 components.add(sample.labels["Component"])
         assert components == {"raylet", "agent", "ray::IDLE"}
 


### PR DESCRIPTION
Many Ray metrics have `Version` label, for example all metrics exported by Ray core C++ codebase, including [GCS](https://github.com/ray-project/ray/blob/71935134065d70eec0d60537b2ac159c3a4f8b53/src/ray/gcs/gcs_server/gcs_server_main.cc#L76), [Raylet](https://github.com/ray-project/ray/blob/8870e9dd9aa5570de729bb833b427354999f4475/src/ray/raylet/main.cc#L366) and [Core Worker](https://github.com/ray-project/ray/blob/8870e9dd9aa5570de729bb833b427354999f4475/src/ray/core_worker/core_worker_process.cc#L119). However, Python-generated metrics do not yet have the Version label.

This PR adds the label to all Ray metrics generated by the reporter_agent.py and dashboard API server. The label is useful for them because we can compare performance numbers between Ray versions.