### PR TITLE
[ci] remove the RAYCI_CONTINUOUS_BUILD flag

### DIFF
--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -53,14 +53,14 @@ steps:
   # bot
   - label: ":robot_face: CI weekly green metric"
     tags: skip-on-premerge
-    if: build.branch == "master" && build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    if: build.branch == "master"
     instance_type: small
     commands:
       - bazel run //ci/ray_ci/automation:weekly_green_metric -- --production
 
   - label: ":robot_face: {{matrix}} microcheck test coverage"
     tags: skip-on-premerge
-    if: build.branch == "master" && build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    if: build.branch == "master"
     instance_type: small
     commands:
       - bazel run //ci/ray_ci/automation:determine_microcheck_tests -- {{matrix}} 95 --production

--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -27,7 +27,6 @@ steps:
       branch: "${BUILDKITE_BRANCH}"
       message: "Triggered by release-automation build #${BUILDKITE_BUILD_NUMBER}"
       env:
-        RAYCI_CONTINUOUS_BUILD: 1
         RAYCI_WEEKLY_RELEASE: 1
   
   - label: "Trigger Postmerge nightly build & test"
@@ -40,7 +39,6 @@ steps:
       branch: "${BUILDKITE_BRANCH}"
       message: "Triggered by release-automation build #${BUILDKITE_BUILD_NUMBER}"
       env:
-        RAYCI_CONTINUOUS_BUILD: 1
         RAYCI_WEEKLY_RELEASE: 1
         RAYCI_SCHEDULE: "nightly"
 

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -57,7 +57,7 @@ steps:
     depends_on: servepydantic1build
 
   - label: ":ray-serve: serve: python {{matrix.python}} tests ({{matrix.worker_id}})"
-    if: build.env("RAYCI_CONTINUOUS_BUILD") == "1" || build.pull_request.labels includes "continuous-build"
+    if: build.pull_request.labels includes "continuous-build"
     tags: 
       - serve
       - python

--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -28,7 +28,7 @@ steps:
     depends_on: windowsbuild
 
   - label: ":ray: core: :windows: cpp tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags: core_cpp
     job_env: WINDOWS
     instance_type: windows
@@ -45,7 +45,7 @@ steps:
     depends_on: windowsbuild
 
   - label: ":ray: core: :windows: python tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags: python
     job_env: WINDOWS
     instance_type: windows
@@ -63,7 +63,7 @@ steps:
     depends_on: windowsbuild
 
   - label: ":serverless: serverless: :windows: tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags: python
     job_env: WINDOWS
     instance_type: windows
@@ -80,7 +80,7 @@ steps:
     depends_on: windowsbuild
 
   - label: ":ray-serve: serve: :windows: tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags: serve
     job_env: WINDOWS
     instance_type: windows
@@ -98,7 +98,7 @@ steps:
     depends_on: windowsbuild
 
   - label: ":train: ml: :windows: tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags:
       - train
     job_env: WINDOWS
@@ -114,7 +114,7 @@ steps:
     depends_on: windowsbuild
 
   - label: "flaky :windows: tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_CONTINUOUS_BUILD") == "1"
+    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags: skip-on-premerge
     job_env: WINDOWS
     instance_type: windows


### PR DESCRIPTION
We have in flag in the past since we have a mixture of per-commit + periodic builds. Since everything is moved to periodic builds now, we don't need this flag any more.

Test:
- CI