### PR TITLE
[ci] add a gpu build for core

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -6,6 +6,18 @@ steps:
   # builds
   - name: corebuild
     wanda: ci/docker/core.build.py39.wanda.yaml
+    env:
+      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_build
+      IMAGE_TO: corebuild
+      RAYCI_IS_GPU_BUILD: "false"
+
+  - name: coregpubuild
+    wanda: ci/docker/core.build.py39.wanda.yaml
+    depends_on: oss-ci-base_gpu
+    env:
+      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_gpu
+      IMAGE_TO: coregpubuild
+      RAYCI_IS_GPU_BUILD: "true"
 
   - name: corebuild-multipy
     label: "wanda: corebuild-py{{matrix}}"

--- a/ci/docker/core.build.Dockerfile
+++ b/ci/docker/core.build.Dockerfile
@@ -1,6 +1,8 @@
 ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build
 FROM $DOCKER_IMAGE_BASE_BUILD
 
+ARG RAYCI_IS_GPU_BUILD=false
+
 # Unset dind settings; we are using the host's docker daemon.
 ENV DOCKER_TLS_CERTDIR=
 ENV DOCKER_HOST=
@@ -11,8 +13,19 @@ SHELL ["/bin/bash", "-ice"]
 
 COPY . .
 
-RUN pip install -U --ignore-installed  \
+RUN <<EOF
+#!/bin/bash
+
+set -euo pipefail
+
+pip install -U --ignore-installed  \
   -c python/requirements_compiled.txt \
   -r python/requirements.txt \
   -r python/requirements/test-requirements.txt \
   -r python/requirements/ml/dl-cpu-requirements.txt
+
+if [[ "$RAYCI_IS_GPU_BUILD" == "true" ]]; then
+  pip install -Ur ./python/requirements/ml/dl-gpu-requirements.txt
+fi
+
+EOF

--- a/ci/docker/core.build.py39.wanda.yaml
+++ b/ci/docker/core.build.py39.wanda.yaml
@@ -1,10 +1,14 @@
-name: "corebuild"
-froms: ["cr.ray.io/rayproject/oss-ci-base_build"]
+name: "$IMAGE_TO"
+froms: ["$IMAGE_FROM"]
 dockerfile: ci/docker/core.build.Dockerfile
 srcs:
   - python/requirements.txt
   - python/requirements_compiled.txt
   - python/requirements/test-requirements.txt
   - python/requirements/ml/dl-cpu-requirements.txt
+  - python/requirements/ml/dl-gpu-requirements.txt
+build_args:
+  - DOCKER_IMAGE_BASE_BUILD=$IMAGE_FROM
+  - RAYCI_IS_GPU_BUILD
 tags:
-  - cr.ray.io/rayproject/corebuild
+  - cr.ray.io/rayproject/$IMAGE_TO


### PR DESCRIPTION
Add a gpu build for core to run multi-gpu tests. This is requested by core team since they are adding a few gpu tests for core DAG work.

Test:
- CI