### PR TITLE
[release-automation] More flexibility on the pipeline

### DIFF
--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -45,6 +45,7 @@ steps:
         RAYCI_SCHEDULE: "nightly"
 
   - label: "Trigger Postmerge MacOS test"
+    key: trigger-postmerge-macos
     trigger: "postmerge-macos"
     depends_on: check-commit-hash
     build:
@@ -92,6 +93,7 @@ steps:
     depends_on: check-commit-hash
 
   - label: "Trigger Release weekly test"
+    key: trigger-release-weekly
     trigger: "release"
     depends_on: block-release-weekly-test
     build:
@@ -103,6 +105,7 @@ steps:
         RELEASE_FREQUENCY: "weekly"
 
   - label: "Check Ray commit in {{matrix}} nightly images"
+    key: check-ray-commit
     if: build.branch !~ /^releases\// && build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") == "1"
     depends_on: trigger-postmerge-nightly
     allow_dependency_failure: true

--- a/.buildkite/release-automation/wheels.rayci.yml
+++ b/.buildkite/release-automation/wheels.rayci.yml
@@ -59,11 +59,6 @@ steps:
       - ./.buildkite/release-automation/verify-macos-wheels.sh arm64
 
   - block: "Upload wheels to PyPI"
-    depends_on: 
-      - validate-linux-x86-64-wheels
-      - validate-linux-arm64-wheels
-      - validate-macos-x86-64-wheels
-      - validate-macos-arm64-wheels
 
   - label: "Upload wheels to PyPI"
     key: upload-wheels-pypi

--- a/.buildkite/release-automation/wheels.rayci.yml
+++ b/.buildkite/release-automation/wheels.rayci.yml
@@ -1,6 +1,7 @@
 group: Upload & Validate wheels
 steps:
   - block: "Upload wheels from S3 to TestPyPI"
+    key: block-upload-wheels-testpypi
     depends_on: 
       - forge
 
@@ -14,10 +15,10 @@ steps:
         --commit_hash="$BUILDKITE_COMMIT"
         --pypi_env=test
 
-  - block: "Download & validate Ray wheels from TestPyPI"
+  - block: "Download & validate Ray wheels from TestPyPI Linux x86_64"
+    key: block-validate-linux-x86_64-wheels
     depends_on:
       - forge
-      - forge_arm64
 
   - label: "Linux x86_64 Python {{matrix}}"
     key: validate-linux-x86_64-wheels
@@ -30,6 +31,11 @@ steps:
       - "3.9"
       - "3.10"
       - "3.11"
+
+  - block: "Download & validate Ray wheels from TestPyPI Linux arm64"
+    key: block-validate-linux-arm64-wheels
+    depends_on:
+      - forge-arm64
 
   - label: "Linux arm64 Python {{matrix}}"
     key: validate-linux-arm64-wheels
@@ -44,6 +50,9 @@ steps:
       - "3.10"
       - "3.11"
 
+  - block: "Download & validate Ray wheels from TestPyPI Mac"
+    key: block-validate-macos-wheels
+  
   - label: "MacOS x86_64"
     key: validate-macos-x86_64-wheels
     job_env: MACOS
@@ -59,6 +68,7 @@ steps:
       - ./.buildkite/release-automation/verify-macos-wheels.sh arm64
 
   - block: "Upload wheels to PyPI"
+    key: block-upload-wheels-pypi
 
   - label: "Upload wheels to PyPI"
     key: upload-wheels-pypi

--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -82,7 +82,6 @@ def download_ray_wheels_from_s3(
     commit_hash: str,
     ray_version: str,
     directory_path: str,
-    full_platform: Optional[bool] = False,
 ) -> None:
     """
     Download Ray wheels from S3 to the given directory.
@@ -93,7 +92,8 @@ def download_ray_wheels_from_s3(
         directory_path: The directory to download the wheels to.
     """
     full_directory_path = os.path.join(bazel_workspace_dir, directory_path)
-
+    _, minor_version, _ = ray_version.split(".")
+    full_platform = True if int(minor_version) % 10 == 0 else False
     wheels = _get_wheel_names(ray_version, full_platform)
     for wheel in wheels:
         s3_key = f"releases/{ray_version}/{commit_hash}/{wheel}.whl"

--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -1,5 +1,5 @@
 import boto3
-from typing import List
+from typing import List, Optional
 import os
 
 from ci.ray_ci.utils import logger
@@ -7,12 +7,17 @@ from ci.ray_ci.utils import logger
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 
 PYTHON_VERSIONS = ["cp39-cp39", "cp310-cp310", "cp311-cp311"]
-PLATFORMS = [
+FULL_PLATFORMS = [
     "manylinux2014_x86_64",
     "manylinux2014_aarch64",
     "macosx_10_15_x86_64",
     "macosx_11_0_arm64",
     "win_amd64",
+]
+PARTIAL_PLATFORMS = [
+    "manylinux2014_x86_64",
+    "macosx_10_15_x86_64",
+    "macosx_11_0_arm64",
 ]
 RAY_TYPES = ["ray", "ray_cpp"]
 
@@ -41,11 +46,14 @@ def _check_downloaded_wheels(directory_path: str, wheels: List[str]) -> None:
     )
 
 
-def _get_wheel_names(ray_version: str) -> List[str]:
+def _get_wheel_names(
+    ray_version: str, full_platform: Optional[bool] = False
+) -> List[str]:
     """List all wheel names for the given ray version."""
     wheel_names = []
+    platforms = FULL_PLATFORMS if full_platform else PARTIAL_PLATFORMS
     for python_version in PYTHON_VERSIONS:
-        for platform in PLATFORMS:
+        for platform in platforms:
             for ray_type in RAY_TYPES:
                 wheel_name = f"{ray_type}-{ray_version}-{python_version}-{platform}"
                 wheel_names.append(wheel_name)
@@ -71,7 +79,10 @@ def download_wheel_from_s3(key: str, directory_path: str) -> None:
 
 
 def download_ray_wheels_from_s3(
-    commit_hash: str, ray_version: str, directory_path: str
+    commit_hash: str,
+    ray_version: str,
+    directory_path: str,
+    full_platform: Optional[bool] = False,
 ) -> None:
     """
     Download Ray wheels from S3 to the given directory.
@@ -83,7 +94,7 @@ def download_ray_wheels_from_s3(
     """
     full_directory_path = os.path.join(bazel_workspace_dir, directory_path)
 
-    wheels = _get_wheel_names(ray_version)
+    wheels = _get_wheel_names(ray_version, full_platform)
     for wheel in wheels:
         s3_key = f"releases/{ray_version}/{commit_hash}/{wheel}.whl"
         download_wheel_from_s3(s3_key, full_directory_path)

--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -92,7 +92,7 @@ def download_ray_wheels_from_s3(
         directory_path: The directory to download the wheels to.
     """
     full_directory_path = os.path.join(bazel_workspace_dir, directory_path)
-    _, minor_version, _ = ray_version.split(".")
+    minor_version = ray_version.split(".")[1]
     full_platform = True if int(minor_version) % 10 == 0 else False
     wheels = _get_wheel_names(ray_version, full_platform)
     for wheel in wheels:

--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -94,7 +94,7 @@ def download_ray_wheels_from_s3(
     full_directory_path = os.path.join(bazel_workspace_dir, directory_path)
     minor_version = ray_version.split(".")[1]
     full_platform = True if int(minor_version) % 10 == 0 else False
-    wheels = _get_wheel_names(ray_version, full_platform)
+    wheels = _get_wheel_names(ray_version=ray_version, full_platform=full_platform)
     for wheel in wheels:
         s3_key = f"releases/{ray_version}/{commit_hash}/{wheel}.whl"
         download_wheel_from_s3(s3_key, full_directory_path)

--- a/ci/ray_ci/automation/test_ray_wheels_lib.py
+++ b/ci/ray_ci/automation/test_ray_wheels_lib.py
@@ -165,10 +165,39 @@ def test_download_ray_wheels_from_s3(
             commit_hash=commit_hash,
             ray_version=ray_version,
             directory_path=tmp_dir,
-            full_platform=True,
         )
 
         mock_get_wheel_names.assert_called_with(ray_version, True)
+        assert mock_download_wheel.call_count == len(SAMPLE_WHEELS)
+        for i, call_args in enumerate(mock_download_wheel.call_args_list):
+            assert (
+                call_args[0][0]
+                == f"releases/{ray_version}/{commit_hash}/{SAMPLE_WHEELS[i]}.whl"
+            )
+            assert call_args[0][1] == tmp_dir
+
+        mock_check_wheels.assert_called_with(tmp_dir, SAMPLE_WHEELS)
+
+
+@mock.patch("ci.ray_ci.automation.ray_wheels_lib.download_wheel_from_s3")
+@mock.patch("ci.ray_ci.automation.ray_wheels_lib._check_downloaded_wheels")
+@mock.patch("ci.ray_ci.automation.ray_wheels_lib._get_wheel_names")
+def test_download_ray_wheels_from_s3_partial_platform(
+    mock_get_wheel_names, mock_check_wheels, mock_download_wheel
+):
+    commit_hash = "1234567"
+    ray_version = "1.1.0"
+
+    mock_get_wheel_names.return_value = SAMPLE_WHEELS
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        download_ray_wheels_from_s3(
+            commit_hash=commit_hash,
+            ray_version=ray_version,
+            directory_path=tmp_dir,
+        )
+
+        mock_get_wheel_names.assert_called_with(ray_version, False)
         assert mock_download_wheel.call_count == len(SAMPLE_WHEELS)
         for i, call_args in enumerate(mock_download_wheel.call_args_list):
             assert (

--- a/ci/ray_ci/automation/test_ray_wheels_lib.py
+++ b/ci/ray_ci/automation/test_ray_wheels_lib.py
@@ -167,7 +167,9 @@ def test_download_ray_wheels_from_s3(
             directory_path=tmp_dir,
         )
 
-        mock_get_wheel_names.assert_called_with(ray_version, True)
+        mock_get_wheel_names.assert_called_with(
+            ray_version=ray_version, full_platform=True
+        )
         assert mock_download_wheel.call_count == len(SAMPLE_WHEELS)
         for i, call_args in enumerate(mock_download_wheel.call_args_list):
             assert (
@@ -197,7 +199,9 @@ def test_download_ray_wheels_from_s3_partial_platform(
             directory_path=tmp_dir,
         )
 
-        mock_get_wheel_names.assert_called_with(ray_version, False)
+        mock_get_wheel_names.assert_called_with(
+            ray_version=ray_version, full_platform=False
+        )
         assert mock_download_wheel.call_count == len(SAMPLE_WHEELS)
         for i, call_args in enumerate(mock_download_wheel.call_args_list):
             assert (

--- a/ci/ray_ci/automation/upload_wheels_pypi.py
+++ b/ci/ray_ci/automation/upload_wheels_pypi.py
@@ -12,9 +12,7 @@ from ci.ray_ci.automation.pypi_lib import upload_wheels_to_pypi
 def main(ray_version, commit_hash, pypi_env):
     with tempfile.TemporaryDirectory() as temp_dir:
         download_ray_wheels_from_s3(
-            commit_hash=commit_hash,
-            ray_version=ray_version,
-            directory_path=temp_dir,
+            commit_hash=commit_hash, ray_version=ray_version, directory_path=temp_dir
         )
         upload_wheels_to_pypi(pypi_env=pypi_env, directory_path=temp_dir)
 

--- a/ci/ray_ci/automation/upload_wheels_pypi.py
+++ b/ci/ray_ci/automation/upload_wheels_pypi.py
@@ -10,9 +10,14 @@ from ci.ray_ci.automation.pypi_lib import upload_wheels_to_pypi
 @click.option("--commit_hash", required=True, type=str)
 @click.option("--pypi_env", required=True, type=click.Choice(["test", "prod"]))
 def main(ray_version, commit_hash, pypi_env):
+    _, minor_version, _ = ray_version.split(".")
+    full_platform = True if int(minor_version) % 10 == 0 else False
     with tempfile.TemporaryDirectory() as temp_dir:
         download_ray_wheels_from_s3(
-            commit_hash=commit_hash, ray_version=ray_version, directory_path=temp_dir
+            commit_hash=commit_hash,
+            ray_version=ray_version,
+            directory_path=temp_dir,
+            full_platform=full_platform,
         )
         upload_wheels_to_pypi(pypi_env=pypi_env, directory_path=temp_dir)
 

--- a/ci/ray_ci/automation/upload_wheels_pypi.py
+++ b/ci/ray_ci/automation/upload_wheels_pypi.py
@@ -10,14 +10,11 @@ from ci.ray_ci.automation.pypi_lib import upload_wheels_to_pypi
 @click.option("--commit_hash", required=True, type=str)
 @click.option("--pypi_env", required=True, type=click.Choice(["test", "prod"]))
 def main(ray_version, commit_hash, pypi_env):
-    _, minor_version, _ = ray_version.split(".")
-    full_platform = True if int(minor_version) % 10 == 0 else False
     with tempfile.TemporaryDirectory() as temp_dir:
         download_ray_wheels_from_s3(
             commit_hash=commit_hash,
             ray_version=ray_version,
             directory_path=temp_dir,
-            full_platform=full_platform,
         )
         upload_wheels_to_pypi(pypi_env=pypi_env, directory_path=temp_dir)
 


### PR DESCRIPTION
- Only upload `linux_x86_64`, `mac x86_64`, and `mac arm64` wheels unless it's a full platform release.
- Each of the wheel sanity check step has its own block step.
- Uploading wheels to PyPI no longer requires all sanity checks to pass. This is up for release manager to judge whether the wheels are ready.
- Add key for each of the step. This is to support automation that checks for BK job status (it's better to retrieve jobs from BK and identify with key than job label)