### PR TITLE
[ci] fix microcheck determinator script

### DIFF
--- a/ci/ray_ci/automation/determine_microcheck_step_ids.py
+++ b/ci/ray_ci/automation/determine_microcheck_step_ids.py
@@ -1,8 +1,7 @@
 import click
 
 from ci.ray_ci.utils import ci_init
-from ci.ray_ci.automation.determine_microcheck_tests import LINUX_TEST_PREFIX
-from ray_release.test import Test
+from ray_release.test import Test, LINUX_TEST_PREFIX
 
 
 @click.command()

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -47,14 +47,14 @@ bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 @click.argument("team", required=True, type=str, nargs=1)
 @click.option(
     "--workers",
-    default=1,
-    type=int,
+    default="1",
+    type=str,
     help=("Number of concurrent test jobs to run."),
 )
 @click.option(
     "--worker-id",
-    default=0,
-    type=int,
+    default="0",
+    type=str,
     help=("Index of the concurrent shard to run."),
 )
 @click.option(
@@ -180,8 +180,8 @@ bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 def main(
     targets: List[str],
     team: str,
-    workers: int,
-    worker_id: int,
+    workers: str,
+    worker_id: str,
     parallelism_per_worker: int,
     operating_system: str,
     except_tags: str,
@@ -216,8 +216,8 @@ def main(
     container = _get_container(
         team,
         operating_system,
-        workers,
-        worker_id,
+        int(workers) if workers else 1,
+        int(worker_id) if worker_id else 0,
         parallelism_per_worker,
         gpus,
         network=network,


### PR DESCRIPTION
- The current import is not reachable, use the constant from ray_release.test instead
- Also in microcheck, the worker and worker_id can be emptry string (side effect of setting BUILDKITE_PARALLELISM=1), so teach the tester to handle that properly

Test:
- CI
- microcheck run: https://buildkite.com/ray-project/microcheck/builds/22