### PR TITLE
[ci] add windows + serve tests back to postmerge

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -57,7 +57,7 @@ steps:
     depends_on: servepydantic1build
 
   - label: ":ray-serve: serve: python {{matrix.python}} tests ({{matrix.worker_id}})"
-    if: build.pull_request.labels includes "continuous-build"
+    if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89"
     tags: 
       - serve
       - python

--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -28,7 +28,6 @@ steps:
     depends_on: windowsbuild
 
   - label: ":ray: core: :windows: cpp tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags: core_cpp
     job_env: WINDOWS
     instance_type: windows
@@ -45,7 +44,6 @@ steps:
     depends_on: windowsbuild
 
   - label: ":ray: core: :windows: python tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags: python
     job_env: WINDOWS
     instance_type: windows
@@ -63,7 +61,6 @@ steps:
     depends_on: windowsbuild
 
   - label: ":serverless: serverless: :windows: tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags: python
     job_env: WINDOWS
     instance_type: windows
@@ -80,7 +77,6 @@ steps:
     depends_on: windowsbuild
 
   - label: ":ray-serve: serve: :windows: tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags: serve
     job_env: WINDOWS
     instance_type: windows
@@ -98,7 +94,6 @@ steps:
     depends_on: windowsbuild
 
   - label: ":train: ml: :windows: tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags:
       - train
     job_env: WINDOWS
@@ -114,7 +109,6 @@ steps:
     depends_on: windowsbuild
 
   - label: "flaky :windows: tests"
-    if: pipeline.id == "0189942e-0876-4b8f-80a4-617f988ec59b"
     tags: skip-on-premerge
     job_env: WINDOWS
     instance_type: windows


### PR DESCRIPTION
https://github.com/ray-project/ray/commit/e87a4b09d12918a35a014e747e67203d6ece2145#diff-feeb08c6318643fd49b0bf41b7755104dc400e1c58cb2f782bd7cf35292a993e mistakenly removes some of the buildkite steps from postmerge (because it's the || condition)
- remove the `pipeline_id==premerge_pipeline_id` conditions on windows (it is now run on both premerge+postmerge with blocking)
- add `pipeline_id==postmerge_pipeline_id` conditions to python 3.11 serve tests

Test:
- CI
- check that they build on postmerge: https://buildkite.com/ray-project/postmerge/builds/4399