### PR TITLE
grid_search resolution code optimization

### DIFF
--- a/python/ray/tune/search/variant_generator.py
+++ b/python/ray/tune/search/variant_generator.py
@@ -425,8 +425,12 @@ def _grid_search_generator(
         yield unresolved_spec
         return
 
+    # a skeleton is easier to deep-copy than the full spec
+    unresolved_spec_skeleton = copy.deepcopy(unresolved_spec)
+    for path, _ in grid_vars:
+        assign_value(unresolved_spec_skeleton, path, None)
     while value_indices[-1] < len(grid_vars[-1][1]):
-        spec = copy.deepcopy(unresolved_spec)
+        spec = copy.deepcopy(unresolved_spec_skeleton)
         for i, (path, values) in enumerate(grid_vars):
             assign_value(spec, path, values[value_indices[i]])
         yield spec


### PR DESCRIPTION
A small Python code optimization to significantly speed up `grid_search` resolution. 

Instead of deep-copying the whole unresolved spec for every resolved spec, we can create a skeleton spec, filled with None in place of grid variables, and deep-copy that every time. The fix involves a handful of line changes in one location.

I checked that the slow implementation is still present in the latest release.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current grid resolution takes upwards of 1 minute on a Ryzen 7 7600X for grid_search generation for grids larger than 10k elements. Ray does not start the trials before generating the entire grid and the behavior, resulting from slow grid resolution, appears like ray has hung (as the trials are not starting) - this is confusing.

## Related issue number

N/A

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(