### PR TITLE
avoid merge errors when blocks contain different type

### DIFF
--- a/python/ray/data/_internal/delegating_block_builder.py
+++ b/python/ray/data/_internal/delegating_block_builder.py
@@ -54,7 +54,8 @@ class DelegatingBlockBuilder(BlockBuilder):
         from ray.data._internal.pandas_block import PandasBlockBuilder
 
         # TODO see BlockAccessor.batch_to_block, fallback maybe cause dataset refs
-        # both pandas and arrow exist. like issue https://github.com/ray-project/ray/issues/45236
+        # both pandas and arrow exist. like issue
+        # https://github.com/ray-project/ray/issues/45236
         # Added judgments and conversions to avoid errors when blocks merge
         block = accessor.to_block()
         if isinstance(block, pd.DataFrame):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

example:
```
ds = ray.data.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", np.nan]}))
ds.repartition(2)
```
wil get `# <class 'pyarrow.lib.Table'>, <class 'pandas.core.frame.DataFrame'>`
because in blockaccess, fallback maybe arise， like `["a", "b", np.nan]` cannot cover to arrow will raise exception cause fallback, and then return pandas
![image](https://github.com/ray-project/ray/assets/49055103/e931af66-f266-48cb-939a-7fde74be7beb)

when use this code 
```
def my_fn(batch):
    return batch
a = ds.repartition(2).map_batches(my_fn,).to_pandas()
```
will finally cause `# <class 'pyarrow.lib.Table'>, <class 'pandas.core.frame.DataFrame'>` merge in to_pandas method, it will raise exception.

**In short, I solved the problem that merging two blocks of a dataset will throw an exception when there are two formats of pandas arrow in the blocks.**


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/45236

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
