### PR TITLE
empty_block without format will cause return unexcept block type

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -310,7 +310,7 @@ class BlocksToBatchesMapTransformFn(MapTransformFn):
         if first is None:
             return []
         blocks = itertools.chain([first], block_iter)
-        empty_block = BlockAccessor.for_block(first).builder().build()
+        empty_block = BlockAccessor.for_block(first).to_batch_format(self._batch_format)
         # Don't hold the first block in memory, so we reset the reference.
         first = None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
if dataset.map_batches set batch_format, when input is empty, the return format maybe different with batch_format， they will cause dataset blocks type is not same , when in sort method will cause error

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/44536
case `ray.data.from_items(range(10), override_num_blocks=10).map_batches(lambda v: {'item':[]} if v['item'][0] < 4 else v,batch_format='numpy').map_batches(lambda v:v,batch_format='pandas').sort('item').show()`

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
