### PR TITLE
[ci] skip the failing cpp tests on mac

### DIFF
--- a/.buildkite/macos/macos.rayci.yml
+++ b/.buildkite/macos/macos.rayci.yml
@@ -98,7 +98,6 @@ steps:
       - oss
     job_env: MACOS
     instance_type: macos
-    soft_fail: true
     commands:
       - RAY_INSTALL_JAVA=1 ./ci/ray_ci/macos/macos_ci.sh run_ray_cpp_and_java
 

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -302,10 +302,12 @@ test_cpp() {
     --test_arg=--ray_redis_password="1234"
   bazel test --test_output=all //cpp:test_python_call_cpp
 
-  # run the cpp example
-  rm -rf ray-template
-  ray cpp --generate-bazel-project-template-to ray-template
-  pushd ray-template && bash run.sh
+  # run the cpp example, currently does not work on mac
+  if [[ "${OSTYPE}" != darwin* ]]; then
+    rm -rf ray-template
+    ray cpp --generate-bazel-project-template-to ray-template
+    pushd ray-template && bash run.sh
+  fi
 }
 
 test_wheels() {


### PR DESCRIPTION
Skip the current failing cpp tests on mac so that it can pass. It currently soft-fails, hinders other errors, etc.

Test:
- https://buildkite.com/ray-project/premerge/builds/25983#018f69fc-44dc-4329-b5af-0dcfdd59d74b