### PR TITLE
[dashboard][perf] Move Job package uploading to another thread.

### DIFF
--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -161,7 +161,6 @@ class DashboardHead:
             self.http_port,
             self.http_port_retries,
             self.gcs_address,
-            self.gcs_client,
             self.session_name,
             self.metrics,
         )

--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -15,7 +15,6 @@ import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray._private.utils import get_or_create_event_loop
-from ray._raylet import GcsClient
 from ray.dashboard.dashboard_metrics import DashboardPrometheusMetrics
 
 # All third-party dependencies that are not included in the minimal Ray
@@ -60,7 +59,6 @@ class HttpServerDashboardHead:
         http_port: int,
         http_port_retries: int,
         gcs_address: str,
-        gcs_client: GcsClient,
         session_name: str,
         metrics: DashboardPrometheusMetrics,
     ):
@@ -68,7 +66,6 @@ class HttpServerDashboardHead:
         self.http_host = http_host
         self.http_port = http_port
         self.http_port_retries = http_port_retries
-        self.gcs_client = gcs_client
         self.head_node_ip = gcs_address.split(":")[0]
         self.metrics = metrics
         self._session_name = session_name

--- a/dashboard/modules/job/job_head.py
+++ b/dashboard/modules/job/job_head.py
@@ -4,7 +4,8 @@ import json
 import logging
 import traceback
 from random import sample
-from typing import Iterator, Optional
+from typing import AsyncIterator, Optional
+from concurrent.futures import ThreadPoolExecutor
 
 import aiohttp.web
 from aiohttp.web import Request, Response
@@ -113,7 +114,7 @@ class JobAgentSubmissionClient:
             else:
                 await self._raise_error(resp)
 
-    async def tail_job_logs(self, job_id: str) -> Iterator[str]:
+    async def tail_job_logs(self, job_id: str) -> AsyncIterator[str]:
         """Get an iterator that follows the logs of a job."""
         ws = await self._session.ws_connect(
             f"{self._agent_address}/api/job_agent/jobs/{job_id}/logs/tail"
@@ -159,6 +160,9 @@ class JobHead(dashboard_utils.DashboardHeadModule):
         super().__init__(dashboard_head)
         self._dashboard_head = dashboard_head
         self._job_info_client = None
+        self._upload_package_thread_pool_executor = ThreadPoolExecutor(
+            thread_name_prefix="job_head.upload_package"
+        )
 
         # It contains all `JobAgentSubmissionClient` that
         # `JobHead` has ever used, and will not be deleted
@@ -261,7 +265,10 @@ class JobHead(dashboard_utils.DashboardHeadModule):
         )
         logger.info(f"Uploading package {package_uri} to the GCS.")
         try:
-            upload_package_to_gcs(package_uri, await req.read())
+            data = await req.read()
+            await self._upload_package_thread_pool_executor.submit(
+                upload_package_to_gcs, package_uri, data
+            )
         except Exception:
             return Response(
                 text=traceback.format_exc(),

--- a/dashboard/modules/job/job_head.py
+++ b/dashboard/modules/job/job_head.py
@@ -21,6 +21,7 @@ from ray._private.runtime_env.packaging import (
     pin_runtime_env_uri,
     upload_package_to_gcs,
 )
+from ray._private.utils import get_or_create_event_loop
 from ray.dashboard.modules.job.common import (
     JobDeleteResponse,
     http_uri_components_to_uri,
@@ -266,8 +267,11 @@ class JobHead(dashboard_utils.DashboardHeadModule):
         logger.info(f"Uploading package {package_uri} to the GCS.")
         try:
             data = await req.read()
-            await self._upload_package_thread_pool_executor.submit(
-                upload_package_to_gcs, package_uri, data
+            await get_or_create_event_loop().run_in_executor(
+                self._upload_package_thread_pool_executor,
+                upload_package_to_gcs,
+                package_uri,
+                data,
             )
         except Exception:
             return Response(


### PR DESCRIPTION
Package uploading is a CPU intensive work in Dashboard, where it collects the whole 500 MiB working_dir and uploads it to the GCS. It can take 30s to do so - during which the Dashboard event loop is blocking.

This PR moves the uploading to another thread. This avoids event loop blocking.

This PR also removes a dead reference to gcs_client in http_server_head.py.