### PR TITLE
[dashboard] Remove jobInfoStub since GcsAioClient can already do that.

### DIFF
--- a/dashboard/modules/job/job_agent.py
+++ b/dashboard/modules/job/job_agent.py
@@ -27,7 +27,6 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
     def __init__(self, dashboard_agent):
         super().__init__(dashboard_agent)
         self._job_manager = None
-        self._gcs_job_info_stub = None
 
     @routes.post("/api/job_agent/jobs/")
     @optional_utils.init_ray_and_catch_exceptions()

--- a/dashboard/modules/snapshot/snapshot_head.py
+++ b/dashboard/modules/snapshot/snapshot_head.py
@@ -11,6 +11,7 @@ import aiohttp.web
 from ray.dashboard.consts import RAY_CLUSTER_ACTIVITY_HOOK
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
+from ray._private.gcs_aio_client import GcsAioClient
 from ray._private.storage import _load_class
 from ray.core.generated import gcs_service_pb2, gcs_service_pb2_grpc
 from ray.dashboard.modules.job.common import JobInfoStorageClient
@@ -78,7 +79,7 @@ class APIHead(dashboard_utils.DashboardHeadModule):
         super().__init__(dashboard_head)
         self._gcs_actor_info_stub = None
         self._dashboard_head = dashboard_head
-        self._gcs_aio_client = dashboard_head.gcs_aio_client
+        self._gcs_aio_client: GcsAioClient = dashboard_head.gcs_aio_client
         self._job_info_client = None
         # For offloading CPU intensive work.
         self._thread_pool = concurrent.futures.ThreadPoolExecutor(
@@ -183,7 +184,7 @@ class APIHead(dashboard_utils.DashboardHeadModule):
 
             num_active_drivers = 0
             latest_job_end_time = 0
-            for job_table_entry in reply.job_info_list.values():
+            for job_table_entry in reply.values():
                 is_dead = bool(job_table_entry.is_dead)
                 in_internal_namespace = job_table_entry.config.ray_namespace.startswith(
                     "_ray_internal_"

--- a/dashboard/modules/snapshot/snapshot_head.py
+++ b/dashboard/modules/snapshot/snapshot_head.py
@@ -76,7 +76,6 @@ class RayActivityResponse(BaseModel, extra=Extra.allow):
 class APIHead(dashboard_utils.DashboardHeadModule):
     def __init__(self, dashboard_head):
         super().__init__(dashboard_head)
-        self._gcs_job_info_stub = None
         self._gcs_actor_info_stub = None
         self._dashboard_head = dashboard_head
         self._gcs_aio_client = dashboard_head.gcs_aio_client
@@ -180,14 +179,11 @@ class APIHead(dashboard_utils.DashboardHeadModule):
         # This includes the _ray_internal_dashboard job that gets automatically
         # created with every cluster
         try:
-            request = gcs_service_pb2.GetAllJobInfoRequest()
-            reply = await self._gcs_job_info_stub.GetAllJobInfo(
-                request, timeout=timeout
-            )
+            reply = await self._gcs_aio_client.get_all_job_info(timeout=timeout)
 
             num_active_drivers = 0
             latest_job_end_time = 0
-            for job_table_entry in reply.job_info_list:
+            for job_table_entry in reply.job_info_list.values():
                 is_dead = bool(job_table_entry.is_dead)
                 in_internal_namespace = job_table_entry.config.ray_namespace.startswith(
                     "_ray_internal_"
@@ -235,9 +231,6 @@ class APIHead(dashboard_utils.DashboardHeadModule):
             )
 
     async def run(self, server):
-        self._gcs_job_info_stub = gcs_service_pb2_grpc.JobInfoGcsServiceStub(
-            self._dashboard_head.aiogrpc_gcs_channel
-        )
         self._gcs_actor_info_stub = gcs_service_pb2_grpc.ActorInfoGcsServiceStub(
             self._dashboard_head.aiogrpc_gcs_channel
         )

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2881,7 +2881,7 @@ cdef class GcsClient:
         return result
 
     @_auto_reconnect
-    def get_all_job_info(self, timeout=None):
+    def get_all_job_info(self, timeout=None) -> Dict[bytes, JobTableData]:
         # Ideally we should use json_format.MessageToDict(job_info),
         # but `job_info` is a cpp pb message not a python one.
         # Manually converting each and every protobuf field is out of question,


### PR DESCRIPTION
This PR removes usage of `JobInfoGcsService` in Dashboard, instead it uses GcsAioClient to talk to the GCS. No functional changes.