### PR TITLE
[RLlib] Performance booster (cache in- and out-) specs RLModule; MetricsLogger speedups, avoid NestedDict, etc..

### DIFF
--- a/rllib/algorithms/impala/tests/test_impala_off_policyness.py
+++ b/rllib/algorithms/impala/tests/test_impala_off_policyness.py
@@ -32,7 +32,7 @@ class TestIMPALAOffPolicyNess(unittest.TestCase):
         num_aggregation_workers_options = [0, 1]
 
         for num_aggregation_workers in num_aggregation_workers_options:
-            for _ in framework_iterator(config, frameworks=("tf2", "torch")):
+            for _ in framework_iterator(config, frameworks=("torch", "tf2")):
 
                 # We have to set exploration_config here manually because setting
                 # it through config.env_runners() only deepupdates it

--- a/rllib/connectors/module_to_env/get_actions.py
+++ b/rllib/connectors/module_to_env/get_actions.py
@@ -49,7 +49,6 @@ class GetActions(ConnectorV2):
 
         # ACTION_DIST_INPUTS field returned by `forward_exploration|inference()` ->
         # Create a new action distribution object.
-        action_dist = None
         if Columns.ACTION_DIST_INPUTS in data:
             if explore:
                 action_dist_class = sa_rl_module.get_exploration_action_dist_cls()

--- a/rllib/core/models/specs/checker.py
+++ b/rllib/core/models/specs/checker.py
@@ -266,6 +266,7 @@ def check_input_specs(
                 initial_exception
                 or not cache
                 or func.__name__ not in self.__checked_input_specs_cache__
+                or filter
             ):
                 if hasattr(self, input_specs):
                     spec = getattr(self, input_specs)

--- a/rllib/core/models/specs/checker.py
+++ b/rllib/core/models/specs/checker.py
@@ -168,7 +168,7 @@ def _validate(
 
 
 @DeveloperAPI(stability="alpha")
-def check_input_specs(
+def XYZ_check_input_specs(
     input_specs: str,
     *,
     only_check_on_retry: bool = True,
@@ -263,28 +263,28 @@ def check_input_specs(
 
             # If the function was not executed successfully yet, we check specs
             checked_data = input_data
-            if input_specs:
-                if hasattr(self, input_specs):
-                    spec = getattr(self, input_specs)
-                else:
-                    raise SpecCheckingError(
-                        f"object {self} has no attribute {input_specs}."
-                    )
+            #if input_specs:
+            #    if hasattr(self, input_specs):
+            #        spec = getattr(self, input_specs)
+            #    else:
+            #        raise SpecCheckingError(
+            #            f"object {self} has no attribute {input_specs}."
+            #        )
 
-                if spec is not None:
-                    spec = convert_to_canonical_format(spec)
-                    checked_data = _validate(
-                        cls_instance=self,
-                        method=func,
-                        data=input_data,
-                        spec=spec,
-                        filter=filter,
-                        tag="input",
-                    )
+                #if spec is not None:
+                #    spec = convert_to_canonical_format(spec)
+                #    checked_data = _validate(
+                #        cls_instance=self,
+                #        method=func,
+                #        data=input_data,
+                #        spec=spec,
+                #        filter=filter,
+                #        tag="input",
+                #    )
 
-                    if filter and isinstance(checked_data, NestedDict):
-                        # filtering should happen regardless of cache
-                        checked_data = checked_data.filter(spec)
+                #    if filter and isinstance(checked_data, NestedDict):
+                #        # filtering should happen regardless of cache
+                #        checked_data = checked_data.filter(spec)
 
             # If we have encountered an exception from calling `func` already,
             # we raise it again here and don't need to call func again.
@@ -300,7 +300,7 @@ def check_input_specs(
 
 
 @DeveloperAPI(stability="alpha")
-def check_output_specs(
+def XYZ_check_output_specs(
     output_specs: str,
     *,
     cache: bool = False,

--- a/rllib/core/models/specs/tests/test_spec_dict.py
+++ b/rllib/core/models/specs/tests/test_spec_dict.py
@@ -163,12 +163,16 @@ class TestSpecDict(unittest.TestCase):
             def spec_with_type_and_tensor_leaves(self):
                 return {"a": TypeClass1, "b": TensorSpec("b, h", h=3, framework="np")}
 
-            @check_input_specs("nested_key_spec", only_check_on_retry=False)
+            @check_input_specs(
+                "nested_key_spec",
+                only_check_on_retry=False,
+                cache=False,
+            )
             def forward_nested_key(self, input_dict):
                 return input_dict
 
             @check_input_specs(
-                "dict_key_spec_with_none_leaves", only_check_on_retry=False
+                "dict_key_spec_with_none_leaves", only_check_on_retry=False, cache=False
             )
             def forward_dict_key_with_none_leaves(self, input_dict):
                 return input_dict

--- a/rllib/core/models/torch/base.py
+++ b/rllib/core/models/torch/base.py
@@ -9,8 +9,8 @@ from ray.rllib.core.models.configs import ModelConfig
 from ray.rllib.core.models.specs.checker import (
     is_input_decorated,
     is_output_decorated,
-    #check_input_specs,
-    #check_output_specs,
+    check_input_specs,
+    check_output_specs,
 )
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_torch
@@ -70,26 +70,26 @@ class TorchModel(nn.Module, Model, abc.ABC):
         Model.__init__(self, config)
 
         # Raise errors if forward method is not decorated to check input specs.
-        #if not is_input_decorated(self.forward):
-        #    raise ValueError(
-        #        f"`{type(self).__name__}.forward()` not decorated with input "
-        #        f"specification. Decorate it with @check_input_specs() to define a "
-        #        f"specification and resolve this Error. If you don't want to check "
-        #        f"anything, you can use an empty spec."
-        #    )
+        if not is_input_decorated(self.forward):
+            raise ValueError(
+                f"`{type(self).__name__}.forward()` not decorated with input "
+                f"specification. Decorate it with @check_input_specs() to define a "
+                f"specification and resolve this Error. If you don't want to check "
+                f"anything, you can use an empty spec."
+            )
 
-        #if is_output_decorated(self.forward):
-        #    if log_once("torch_model_forward_output_decorated"):
-        #        logger.warning(
-        #            f"`{type(self).__name__}.forward()` decorated with output "
-        #            f"specification. This is not recommended for torch models "
-        #            f"that are used with torch.compile() because it breaks "
-        #            f"torch dynamo's graph. This can lead lead to slower execution."
-        #            f"Remove @check_output_specs() from the forward() method to "
-        #            f"resolve this."
-        #        )
+        if is_output_decorated(self.forward):
+            if log_once("torch_model_forward_output_decorated"):
+                logger.warning(
+                    f"`{type(self).__name__}.forward()` decorated with output "
+                    f"specification. This is not recommended for torch models "
+                    f"that are used with torch.compile() because it breaks "
+                    f"torch dynamo's graph. This can lead lead to slower execution."
+                    f"Remove @check_output_specs() from the forward() method to "
+                    f"resolve this."
+                )
 
-    #@check_input_specs("input_specs")
+    @check_input_specs("input_specs")
     def forward(
         self, inputs: Union[dict, TensorType], **kwargs
     ) -> Union[dict, TensorType]:
@@ -108,14 +108,14 @@ class TorchModel(nn.Module, Model, abc.ABC):
         # When `always_check_shapes` is set, we always check input and output specs.
         # Note that we check the input specs twice because we need the following
         # check to always check the input specs.
-        #if self.config.always_check_shapes:
+        if self.config.always_check_shapes:
 
-        #    @check_input_specs("input_specs", only_check_on_retry=False)
-        #    @check_output_specs("output_specs")
-        #    def checked_forward(self, input_data, **kwargs):
-        #        return self._forward(input_data, **kwargs)
+            @check_input_specs("input_specs", only_check_on_retry=False)
+            @check_output_specs("output_specs")
+            def checked_forward(self, input_data, **kwargs):
+                return self._forward(input_data, **kwargs)
 
-        #    return checked_forward(self, inputs, **kwargs)
+            return checked_forward(self, inputs, **kwargs)
 
         return self._forward(inputs, **kwargs)
 

--- a/rllib/core/models/torch/base.py
+++ b/rllib/core/models/torch/base.py
@@ -9,8 +9,8 @@ from ray.rllib.core.models.configs import ModelConfig
 from ray.rllib.core.models.specs.checker import (
     is_input_decorated,
     is_output_decorated,
-    check_input_specs,
-    check_output_specs,
+    #check_input_specs,
+    #check_output_specs,
 )
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_torch
@@ -70,26 +70,26 @@ class TorchModel(nn.Module, Model, abc.ABC):
         Model.__init__(self, config)
 
         # Raise errors if forward method is not decorated to check input specs.
-        if not is_input_decorated(self.forward):
-            raise ValueError(
-                f"`{type(self).__name__}.forward()` not decorated with input "
-                f"specification. Decorate it with @check_input_specs() to define a "
-                f"specification and resolve this Error. If you don't want to check "
-                f"anything, you can use an empty spec."
-            )
+        #if not is_input_decorated(self.forward):
+        #    raise ValueError(
+        #        f"`{type(self).__name__}.forward()` not decorated with input "
+        #        f"specification. Decorate it with @check_input_specs() to define a "
+        #        f"specification and resolve this Error. If you don't want to check "
+        #        f"anything, you can use an empty spec."
+        #    )
 
-        if is_output_decorated(self.forward):
-            if log_once("torch_model_forward_output_decorated"):
-                logger.warning(
-                    f"`{type(self).__name__}.forward()` decorated with output "
-                    f"specification. This is not recommended for torch models "
-                    f"that are used with torch.compile() because it breaks "
-                    f"torch dynamo's graph. This can lead lead to slower execution."
-                    f"Remove @check_output_specs() from the forward() method to "
-                    f"resolve this."
-                )
+        #if is_output_decorated(self.forward):
+        #    if log_once("torch_model_forward_output_decorated"):
+        #        logger.warning(
+        #            f"`{type(self).__name__}.forward()` decorated with output "
+        #            f"specification. This is not recommended for torch models "
+        #            f"that are used with torch.compile() because it breaks "
+        #            f"torch dynamo's graph. This can lead lead to slower execution."
+        #            f"Remove @check_output_specs() from the forward() method to "
+        #            f"resolve this."
+        #        )
 
-    @check_input_specs("input_specs")
+    #@check_input_specs("input_specs")
     def forward(
         self, inputs: Union[dict, TensorType], **kwargs
     ) -> Union[dict, TensorType]:
@@ -108,14 +108,14 @@ class TorchModel(nn.Module, Model, abc.ABC):
         # When `always_check_shapes` is set, we always check input and output specs.
         # Note that we check the input specs twice because we need the following
         # check to always check the input specs.
-        if self.config.always_check_shapes:
+        #if self.config.always_check_shapes:
 
-            @check_input_specs("input_specs", only_check_on_retry=False)
-            @check_output_specs("output_specs")
-            def checked_forward(self, input_data, **kwargs):
-                return self._forward(input_data, **kwargs)
+        #    @check_input_specs("input_specs", only_check_on_retry=False)
+        #    @check_output_specs("output_specs")
+        #    def checked_forward(self, input_data, **kwargs):
+        #        return self._forward(input_data, **kwargs)
 
-            return checked_forward(self, inputs, **kwargs)
+        #    return checked_forward(self, inputs, **kwargs)
 
         return self._forward(inputs, **kwargs)
 

--- a/rllib/core/rl_module/rl_module.py
+++ b/rllib/core/rl_module/rl_module.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Mapping, Any, TYPE_CHECKING, Optional, Type, Dict, Union
 
 import gymnasium as gym
-import tree
+import tree  # pip install dm_tree
 
 if TYPE_CHECKING:
     from ray.rllib.core.rl_module.marl_module import (
@@ -19,11 +19,11 @@ import ray
 from ray.rllib.core import DEFAULT_MODULE_ID
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.models.specs.typing import SpecType
-#from ray.rllib.core.models.specs.checker import (
-#    check_input_specs,
-#    check_output_specs,
-#    convert_to_canonical_format,
-#)
+from ray.rllib.core.models.specs.checker import (
+    check_input_specs,
+    check_output_specs,
+    convert_to_canonical_format,
+)
 from ray.rllib.models.distributions import Distribution
 from ray.rllib.policy.policy import get_gym_space_from_struct_of_tensors
 from ray.rllib.policy.sample_batch import SampleBatch
@@ -410,45 +410,45 @@ class RLModule(abc.ABC):
         self.setup()
         self._is_setup = True
 
-    #def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs):
         # Automatically add a __post_init__ method to all subclasses of RLModule.
         # This method is called after the __init__ method of the subclass.
-    #    def init_decorator(previous_init):
-    #        def new_init(self, *args, **kwargs):
-    #            previous_init(self, *args, **kwargs)
-    #            if type(self) is cls:
-    #                self.__post_init__()
+        def init_decorator(previous_init):
+            def new_init(self, *args, **kwargs):
+                previous_init(self, *args, **kwargs)
+                if type(self) is cls:
+                    self.__post_init__()
 
-    #        return new_init
+            return new_init
 
-    #    cls.__init__ = init_decorator(cls.__init__)
+        cls.__init__ = init_decorator(cls.__init__)
 
-    #def __post_init__(self):
-    #    """Called automatically after the __init__ method of the subclass.
+    def __post_init__(self):
+        """Called automatically after the __init__ method of the subclass.
 
-    #    The module first calls the __init__ method of the subclass, With in the
-    #    __init__ you should call the super().__init__ method. Then after the __init__
-    #    method of the subclass is called, the __post_init__ method is called.
+        The module first calls the __init__ method of the subclass, With in the
+        __init__ you should call the super().__init__ method. Then after the __init__
+        method of the subclass is called, the __post_init__ method is called.
 
-    #    This is a good place to do any initialization that requires access to the
-    #    subclass's attributes.
-    #    """
-    #    self._input_specs_train = convert_to_canonical_format(self.input_specs_train())
-    #    self._output_specs_train = convert_to_canonical_format(
-    #        self.output_specs_train()
-    #    )
-    #    self._input_specs_exploration = convert_to_canonical_format(
-    #        self.input_specs_exploration()
-    #    )
-    #    self._output_specs_exploration = convert_to_canonical_format(
-    #        self.output_specs_exploration()
-    #    )
-    #    self._input_specs_inference = convert_to_canonical_format(
-    #        self.input_specs_inference()
-    #    )
-    #    self._output_specs_inference = convert_to_canonical_format(
-    #        self.output_specs_inference()
-    #    )
+        This is a good place to do any initialization that requires access to the
+        subclass's attributes.
+        """
+        self._input_specs_train = convert_to_canonical_format(self.input_specs_train())
+        self._output_specs_train = convert_to_canonical_format(
+            self.output_specs_train()
+        )
+        self._input_specs_exploration = convert_to_canonical_format(
+            self.input_specs_exploration()
+        )
+        self._output_specs_exploration = convert_to_canonical_format(
+            self.output_specs_exploration()
+        )
+        self._input_specs_inference = convert_to_canonical_format(
+            self.input_specs_inference()
+        )
+        self._output_specs_inference = convert_to_canonical_format(
+            self.output_specs_inference()
+        )
 
     @OverrideToImplementCustomLogic
     def setup(self):
@@ -633,8 +633,8 @@ class RLModule(abc.ABC):
         """Returns the default input specs."""
         return [Columns.OBS]
 
-    #@check_input_specs("_input_specs_inference")
-    #@check_output_specs("_output_specs_inference")
+    @check_input_specs("_input_specs_inference")
+    @check_output_specs("_output_specs_inference")
     def forward_inference(self, batch: SampleBatchType, **kwargs) -> Mapping[str, Any]:
         """Forward-pass during evaluation, called from the sampler.
 
@@ -656,8 +656,8 @@ class RLModule(abc.ABC):
     def _forward_inference(self, batch: NestedDict, **kwargs) -> Mapping[str, Any]:
         """Forward-pass during evaluation. See forward_inference for details."""
 
-    #@check_input_specs("_input_specs_exploration")
-    #@check_output_specs("_output_specs_exploration")
+    @check_input_specs("_input_specs_exploration")
+    @check_output_specs("_output_specs_exploration")
     def forward_exploration(
         self, batch: SampleBatchType, **kwargs
     ) -> Mapping[str, Any]:
@@ -681,8 +681,8 @@ class RLModule(abc.ABC):
     def _forward_exploration(self, batch: NestedDict, **kwargs) -> Mapping[str, Any]:
         """Forward-pass during exploration. See forward_exploration for details."""
 
-    #@check_input_specs("_input_specs_train")
-    #@check_output_specs("_output_specs_train")
+    @check_input_specs("_input_specs_train")
+    @check_output_specs("_output_specs_train")
     def forward_train(self, batch: SampleBatchType, **kwargs) -> Mapping[str, Any]:
         """Forward-pass during training called from the learner. This method should
         not be overriden. Instead, override the _forward_train method.

--- a/rllib/core/rl_module/rl_module.py
+++ b/rllib/core/rl_module/rl_module.py
@@ -19,11 +19,11 @@ import ray
 from ray.rllib.core import DEFAULT_MODULE_ID
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.models.specs.typing import SpecType
-from ray.rllib.core.models.specs.checker import (
-    check_input_specs,
-    check_output_specs,
-    convert_to_canonical_format,
-)
+#from ray.rllib.core.models.specs.checker import (
+#    check_input_specs,
+#    check_output_specs,
+#    convert_to_canonical_format,
+#)
 from ray.rllib.models.distributions import Distribution
 from ray.rllib.policy.policy import get_gym_space_from_struct_of_tensors
 from ray.rllib.policy.sample_batch import SampleBatch
@@ -410,45 +410,45 @@ class RLModule(abc.ABC):
         self.setup()
         self._is_setup = True
 
-    def __init_subclass__(cls, **kwargs):
+    #def __init_subclass__(cls, **kwargs):
         # Automatically add a __post_init__ method to all subclasses of RLModule.
         # This method is called after the __init__ method of the subclass.
-        def init_decorator(previous_init):
-            def new_init(self, *args, **kwargs):
-                previous_init(self, *args, **kwargs)
-                if type(self) is cls:
-                    self.__post_init__()
+    #    def init_decorator(previous_init):
+    #        def new_init(self, *args, **kwargs):
+    #            previous_init(self, *args, **kwargs)
+    #            if type(self) is cls:
+    #                self.__post_init__()
 
-            return new_init
+    #        return new_init
 
-        cls.__init__ = init_decorator(cls.__init__)
+    #    cls.__init__ = init_decorator(cls.__init__)
 
-    def __post_init__(self):
-        """Called automatically after the __init__ method of the subclass.
+    #def __post_init__(self):
+    #    """Called automatically after the __init__ method of the subclass.
 
-        The module first calls the __init__ method of the subclass, With in the
-        __init__ you should call the super().__init__ method. Then after the __init__
-        method of the subclass is called, the __post_init__ method is called.
+    #    The module first calls the __init__ method of the subclass, With in the
+    #    __init__ you should call the super().__init__ method. Then after the __init__
+    #    method of the subclass is called, the __post_init__ method is called.
 
-        This is a good place to do any initialization that requires access to the
-        subclass's attributes.
-        """
-        self._input_specs_train = convert_to_canonical_format(self.input_specs_train())
-        self._output_specs_train = convert_to_canonical_format(
-            self.output_specs_train()
-        )
-        self._input_specs_exploration = convert_to_canonical_format(
-            self.input_specs_exploration()
-        )
-        self._output_specs_exploration = convert_to_canonical_format(
-            self.output_specs_exploration()
-        )
-        self._input_specs_inference = convert_to_canonical_format(
-            self.input_specs_inference()
-        )
-        self._output_specs_inference = convert_to_canonical_format(
-            self.output_specs_inference()
-        )
+    #    This is a good place to do any initialization that requires access to the
+    #    subclass's attributes.
+    #    """
+    #    self._input_specs_train = convert_to_canonical_format(self.input_specs_train())
+    #    self._output_specs_train = convert_to_canonical_format(
+    #        self.output_specs_train()
+    #    )
+    #    self._input_specs_exploration = convert_to_canonical_format(
+    #        self.input_specs_exploration()
+    #    )
+    #    self._output_specs_exploration = convert_to_canonical_format(
+    #        self.output_specs_exploration()
+    #    )
+    #    self._input_specs_inference = convert_to_canonical_format(
+    #        self.input_specs_inference()
+    #    )
+    #    self._output_specs_inference = convert_to_canonical_format(
+    #        self.output_specs_inference()
+    #    )
 
     @OverrideToImplementCustomLogic
     def setup(self):
@@ -633,8 +633,8 @@ class RLModule(abc.ABC):
         """Returns the default input specs."""
         return [Columns.OBS]
 
-    @check_input_specs("_input_specs_inference")
-    @check_output_specs("_output_specs_inference")
+    #@check_input_specs("_input_specs_inference")
+    #@check_output_specs("_output_specs_inference")
     def forward_inference(self, batch: SampleBatchType, **kwargs) -> Mapping[str, Any]:
         """Forward-pass during evaluation, called from the sampler.
 
@@ -656,8 +656,8 @@ class RLModule(abc.ABC):
     def _forward_inference(self, batch: NestedDict, **kwargs) -> Mapping[str, Any]:
         """Forward-pass during evaluation. See forward_inference for details."""
 
-    @check_input_specs("_input_specs_exploration")
-    @check_output_specs("_output_specs_exploration")
+    #@check_input_specs("_input_specs_exploration")
+    #@check_output_specs("_output_specs_exploration")
     def forward_exploration(
         self, batch: SampleBatchType, **kwargs
     ) -> Mapping[str, Any]:
@@ -681,8 +681,8 @@ class RLModule(abc.ABC):
     def _forward_exploration(self, batch: NestedDict, **kwargs) -> Mapping[str, Any]:
         """Forward-pass during exploration. See forward_exploration for details."""
 
-    @check_input_specs("_input_specs_train")
-    @check_output_specs("_output_specs_train")
+    #@check_input_specs("_input_specs_train")
+    #@check_output_specs("_output_specs_train")
     def forward_train(self, batch: SampleBatchType, **kwargs) -> Mapping[str, Any]:
         """Forward-pass during training called from the learner. This method should
         not be overriden. Instead, override the _forward_train method.

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -813,29 +813,34 @@ class MultiAgentEnvRunner(EnvRunner):
         )
 
     def _increase_sampled_metrics(self, num_steps, next_obs, episode):
-        self.metrics.log_dict(
-            {
-                NUM_ENV_STEPS_SAMPLED: num_steps,
-                # TODO (sven): obs is not-vectorized. Support vectorized MA envs.
-                NUM_AGENT_STEPS_SAMPLED: {str(aid): 1 for aid in next_obs},
-                NUM_MODULE_STEPS_SAMPLED: {
-                    episode.module_for(aid): 1 for aid in next_obs
-                },
-            },
-            reduce="sum",
-            clear_on_reduce=True,
+        self.metrics.log_value(
+            NUM_ENV_STEPS_SAMPLED, num_steps, reduce="sum", clear_on_reduce=True
         )
-        self.metrics.log_dict(
-            {
-                NUM_ENV_STEPS_SAMPLED_LIFETIME: num_steps,
-                # TODO (sven): obs is not-vectorized. Support vectorized MA envs.
-                NUM_AGENT_STEPS_SAMPLED_LIFETIME: {str(aid): 1 for aid in next_obs},
-                NUM_MODULE_STEPS_SAMPLED_LIFETIME: {
-                    episode.module_for(aid): 1 for aid in next_obs
-                },
-            },
-            reduce="sum",
-        )
+        self.metrics.log_value(NUM_ENV_STEPS_SAMPLED_LIFETIME, num_steps, reduce="sum")
+        # TODO (sven): obs is not-vectorized. Support vectorized MA envs.
+        for aid in next_obs:
+            self.metrics.log_value(
+                (NUM_AGENT_STEPS_SAMPLED, str(aid)),
+                1,
+                reduce="sum",
+                clear_on_reduce=True,
+            )
+            self.metrics.log_value(
+                (NUM_AGENT_STEPS_SAMPLED_LIFETIME, str(aid)),
+                1,
+                reduce="sum",
+            )
+            self.metrics.log_value(
+                (NUM_MODULE_STEPS_SAMPLED, episode.module_for(aid)),
+                1,
+                reduce="sum",
+                clear_on_reduce=True,
+            )
+            self.metrics.log_value(
+                (NUM_MODULE_STEPS_SAMPLED_LIFETIME, episode.module_for(aid)),
+                1,
+                reduce="sum",
+            )
         return num_steps
 
     def _log_episode_metrics(self, length, ret, sec, agents=None, modules=None):

--- a/rllib/utils/metrics/metrics_logger.py
+++ b/rllib/utils/metrics/metrics_logger.py
@@ -281,45 +281,6 @@ class MetricsLogger:
                 clear_on_reduce=clear_on_reduce,
             )
 
-            # _clear_on_reduce = clear_on_reduce
-
-            # No reduction (continue appending to list) AND no window.
-            # -> We'll force-reset our values upon `reduce()`.
-            # if reduce is None and (window is None or window == float("inf")):
-            #    _clear_on_reduce = True
-
-            # _has_extended_key = self._key_in_stats(extended_key)
-
-            # if not isinstance(stat_or_value, Stats):
-            #    self._check_tensor(extended_key, stat_or_value)
-
-            #    # `self` already has this key path -> Use c'tor options from self's
-            #    # Stats.
-            #    if _has_extended_key:
-            #        stat_or_value = Stats.similar_to(
-            #            self._get_key(extended_key), init_value=stat_or_value
-            #        )
-            #    else:
-            #        stat_or_value = Stats(
-            #            stat_or_value,
-            #            reduce=reduce,
-            #            window=window,
-            #            ema_coeff=ema_coeff,
-            #            clear_on_reduce=_clear_on_reduce,
-            #        )
-
-            # Merge incoming Stats into existing one (as a next timestep on top of
-            # existing data).
-            # if _has_extended_key:
-            #    self._get_key(extended_key).merge_on_time_axis(stat_or_value)
-            # Use incoming Stats object's values, but create a new Stats object (around
-            # these values) to not mess with the original Stats object.
-            # else:
-            #    self._set_key(
-            #        extended_key,
-            #        Stats.similar_to(stat_or_value, init_value=stat_or_value.values),
-            #    )
-
         tree.map_structure_with_path(_map, stats_dict)
 
     def log_n_dicts(
@@ -390,9 +351,6 @@ class MetricsLogger:
                         ema_coeff=ema_coeff,
                         clear_on_reduce=clear_on_reduce,
                     )
-                # `key` not in self yet -> Create an empty Stats entry under that key.
-                if not self._key_in_stats(extended_key):
-                    self._set_key(extended_key, Stats.similar_to(stat_or_value))
 
                 # Create a new Stats object to merge everything into as parallel,
                 # equally weighted Stats.
@@ -409,9 +367,14 @@ class MetricsLogger:
             if len(more_stats) > 0:
                 base_stats.merge_in_parallel(*more_stats)
 
-            # Finally, merge `base_stats` into self's entry on time axis, meaning
-            # give the incoming values priority over already existing ones.
-            self._get_key(extended_key).merge_on_time_axis(base_stats)
+            # `key` not in self yet -> Store merged stats under the new key.
+            if not self._key_in_stats(extended_key):
+                self._set_key(extended_key, base_stats)
+            # `key` already exists in `self` -> Merge `base_stats` into self's entry
+            # on time axis, meaning give the incoming values priority over already
+            # existing ones.
+            else:
+                self._get_key(extended_key).merge_on_time_axis(base_stats)
 
     def log_time(
         self,
@@ -457,13 +420,6 @@ class MetricsLogger:
                 in which the internal values list would otherwise grow indefinitely,
                 for example if reduce is None and there is no `window` provided.
         """
-        if self.tensor_mode:
-            raise RuntimeError(
-                "`MetricsLogger.log_time()` cannot be called in tensor-mode! Make sure "
-                "to deactivate tensor-mode first (`MetricsLogger."
-                "deactivate_tensor_mode()`), before calling this method."
-            )
-
         # No reduction (continue appending to list) AND no window.
         # -> We'll force-reset our values upon `reduce()`.
         if reduce is None and (window is None or window == float("inf")):
@@ -801,7 +757,7 @@ class MetricsLogger:
             self._tensor_keys.add(key)
 
     def _key_in_stats(self, flat_key, stats=None):
-        flat_key = force_tuple(flat_key)
+        flat_key = force_tuple(tree.flatten(flat_key))
         _dict = stats if stats is not None else self.stats
         for key in flat_key:
             if key not in _dict:
@@ -810,14 +766,14 @@ class MetricsLogger:
         return True
 
     def _get_key(self, flat_key, stats=None):
-        flat_key = force_tuple(flat_key)
+        flat_key = force_tuple(tree.flatten(flat_key))
         _dict = stats if stats is not None else self.stats
         for key in flat_key:
             _dict = _dict[key]
         return _dict
 
     def _set_key(self, flat_key, stats):
-        flat_key = force_tuple(flat_key)
+        flat_key = force_tuple(tree.flatten(flat_key))
         _dict = self.stats
         for i, key in enumerate(flat_key):
             if i == len(flat_key) - 1:

--- a/rllib/utils/metrics/metrics_logger.py
+++ b/rllib/utils/metrics/metrics_logger.py
@@ -6,7 +6,6 @@ import tree  # pip install dm_tree
 from ray.rllib.utils import force_tuple
 from ray.rllib.utils.metrics.stats import Stats
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
-from ray.rllib.utils.nested_dict import NestedDict
 from ray.util.annotations import PublicAPI
 
 _, tf, _ = try_import_tf()
@@ -50,7 +49,7 @@ class MetricsLogger:
 
     def __init__(self):
         """Initializes a MetricsLogger instance."""
-        self.stats = NestedDict()
+        self.stats = {}
         self._tensor_mode = False
         self._tensor_keys = set()
 
@@ -166,20 +165,23 @@ class MetricsLogger:
 
         self._check_tensor(key, value)
 
-        if key not in self.stats:
-            self.stats[key] = Stats(
-                value,
-                reduce=reduce,
-                window=window,
-                ema_coeff=ema_coeff,
-                clear_on_reduce=clear_on_reduce,
+        if not self._key_in_stats(key):
+            self._set_key(
+                key,
+                Stats(
+                    value,
+                    reduce=reduce,
+                    window=window,
+                    ema_coeff=ema_coeff,
+                    clear_on_reduce=clear_on_reduce,
+                ),
             )
         # If value itself is a stat, we merge it on time axis into `self`.
         elif isinstance(value, Stats):
-            self.stats[key].merge_on_time_axis(value)
+            self._get_key(key).merge_on_time_axis(value)
         # Otherwise, we just push the value into `self`.
         else:
-            self.stats[key].push(value)
+            self._get_key(key).push(value)
 
     def log_dict(
         self,
@@ -265,44 +267,60 @@ class MetricsLogger:
                 in which the internal values list would otherwise grow indefinitely,
                 for example if reduce is None and there is no `window` provided.
         """
-        stats_dict = NestedDict(stats_dict)
         prefix_key = force_tuple(key)
 
-        for key, stat_or_value in stats_dict.items():
-            extended_key = prefix_key + key
+        def _map(path, stat_or_value):
+            extended_key = prefix_key + force_tuple(path)
+
+            self.log_value(
+                extended_key,
+                stat_or_value,
+                reduce=reduce,
+                window=window,
+                ema_coeff=ema_coeff,
+                clear_on_reduce=clear_on_reduce,
+            )
+
+            # _clear_on_reduce = clear_on_reduce
+
             # No reduction (continue appending to list) AND no window.
             # -> We'll force-reset our values upon `reduce()`.
-            if reduce is None and (window is None or window == float("inf")):
-                clear_on_reduce = True
+            # if reduce is None and (window is None or window == float("inf")):
+            #    _clear_on_reduce = True
 
-            if not isinstance(stat_or_value, Stats):
-                self._check_tensor(extended_key, stat_or_value)
+            # _has_extended_key = self._key_in_stats(extended_key)
 
-                # `self` already has this key path -> Use c'tor options from self's
-                # Stats.
-                if extended_key in self.stats:
-                    stat_or_value = Stats.similar_to(
-                        self.stats[extended_key], init_value=stat_or_value
-                    )
-                else:
-                    stat_or_value = Stats(
-                        stat_or_value,
-                        reduce=reduce,
-                        window=window,
-                        ema_coeff=ema_coeff,
-                        clear_on_reduce=clear_on_reduce,
-                    )
+            # if not isinstance(stat_or_value, Stats):
+            #    self._check_tensor(extended_key, stat_or_value)
+
+            #    # `self` already has this key path -> Use c'tor options from self's
+            #    # Stats.
+            #    if _has_extended_key:
+            #        stat_or_value = Stats.similar_to(
+            #            self._get_key(extended_key), init_value=stat_or_value
+            #        )
+            #    else:
+            #        stat_or_value = Stats(
+            #            stat_or_value,
+            #            reduce=reduce,
+            #            window=window,
+            #            ema_coeff=ema_coeff,
+            #            clear_on_reduce=_clear_on_reduce,
+            #        )
 
             # Merge incoming Stats into existing one (as a next timestep on top of
             # existing data).
-            if extended_key in self.stats:
-                self.stats[extended_key].merge_on_time_axis(stat_or_value)
+            # if _has_extended_key:
+            #    self._get_key(extended_key).merge_on_time_axis(stat_or_value)
             # Use incoming Stats object's values, but create a new Stats object (around
             # these values) to not mess with the original Stats object.
-            else:
-                self.stats[extended_key] = Stats.similar_to(
-                    stat_or_value, init_value=stat_or_value.values
-                )
+            # else:
+            #    self._set_key(
+            #        extended_key,
+            #        Stats.similar_to(stat_or_value, init_value=stat_or_value.values),
+            #    )
+
+        tree.map_structure_with_path(_map, stats_dict)
 
     def log_n_dicts(
         self,
@@ -340,22 +358,25 @@ class MetricsLogger:
                 in which the internal values list would otherwise grow indefinitely,
                 for example if reduce is None and there is no `window` provided.
         """
-        stats_dicts = [NestedDict(s) for s in stats_dicts]
         prefix_key = force_tuple(key)
 
         all_keys = set()
-        for s in stats_dicts:
-            all_keys |= set(s.keys())
+        for stats_dict in stats_dicts:
+            tree.map_structure_with_path(
+                lambda path, _: all_keys.add(force_tuple(path)),
+                stats_dict,
+            )
+
+        # No reduction (continue appending to list) AND no window.
+        # -> We'll force-reset our values upon `reduce()`.
+        if reduce is None and (window is None or window == float("inf")):
+            clear_on_reduce = True
 
         for key in all_keys:
             extended_key = prefix_key + key
-
-            # No reduction (continue appending to list) AND no window.
-            # -> We'll force-reset our values upon `reduce()`.
-            if reduce is None and (window is None or window == float("inf")):
-                clear_on_reduce = True
-
-            available_stats = [s[key] for s in stats_dicts if key in s]
+            available_stats = [
+                self._get_key(key, s) for s in stats_dicts if self._key_in_stats(key, s)
+            ]
             base_stats = None
             more_stats = []
             for i, stat_or_value in enumerate(available_stats):
@@ -370,8 +391,8 @@ class MetricsLogger:
                         clear_on_reduce=clear_on_reduce,
                     )
                 # `key` not in self yet -> Create an empty Stats entry under that key.
-                if extended_key not in self.stats:
-                    self.stats[extended_key] = Stats.similar_to(stat_or_value)
+                if not self._key_in_stats(extended_key):
+                    self._set_key(extended_key, Stats.similar_to(stat_or_value))
 
                 # Create a new Stats object to merge everything into as parallel,
                 # equally weighted Stats.
@@ -390,7 +411,7 @@ class MetricsLogger:
 
             # Finally, merge `base_stats` into self's entry on time axis, meaning
             # give the incoming values priority over already existing ones.
-            self.stats[extended_key].merge_on_time_axis(base_stats)
+            self._get_key(extended_key).merge_on_time_axis(base_stats)
 
     def log_time(
         self,
@@ -448,7 +469,7 @@ class MetricsLogger:
         if reduce is None and (window is None or window == float("inf")):
             clear_on_reduce = True
 
-        if key not in self.stats:
+        if not self._key_in_stats(key):
             # TODO (sven): Figure out how to best implement an additional throughput
             #  measurement.
             # measure_throughput = None
@@ -456,27 +477,30 @@ class MetricsLogger:
             #    measure_throughput = True
             #    throughput_key = throughput_key or (key + "_throughput_per_s")
 
-            self.stats[key] = Stats(
-                reduce=reduce,
-                window=window,
-                ema_coeff=ema_coeff,
-                clear_on_reduce=clear_on_reduce,
-                # on_exit=(
-                #    lambda stats: (
-                #        self.log_value(
-                #            throughput_key,
-                #            self.peek(throughput_key_of_unit_count),
-                #            reduce=reduce,
-                #            window=window,
-                #            ema_coeff=ema_coeff,
-                #            clear_on_reduce=clear_on_reduce,
-                #        )
-                #    ),
-                # ),
+            self._set_key(
+                key,
+                Stats(
+                    reduce=reduce,
+                    window=window,
+                    ema_coeff=ema_coeff,
+                    clear_on_reduce=clear_on_reduce,
+                    # on_exit=(
+                    #    lambda stats: (
+                    #        self.log_value(
+                    #            throughput_key,
+                    #            self.peek(throughput_key_of_unit_count),
+                    #            reduce=reduce,
+                    #            window=window,
+                    #            ema_coeff=ema_coeff,
+                    #            clear_on_reduce=clear_on_reduce,
+                    #        )
+                    #    ),
+                    # ),
+                ),
             )
 
         # Return the Stats object, so a `with` clause can enter and exit it.
-        return self.stats[key]
+        return self._get_key(key)
 
     def activate_tensor_mode(self):
         """Switches to tensor-mode, in which in-graph tensors can be logged.
@@ -499,7 +523,7 @@ class MetricsLogger:
         assert self.tensor_mode
         self._tensor_mode = False
         # Return all logged tensors (logged during the tensor-mode phase).
-        ret = {key: self.stats[key].peek() for key in self._tensor_keys}
+        ret = {key: self._get_key(key).peek() for key in self._tensor_keys}
         # Clear out logged tensor keys.
         self._tensor_keys.clear()
         return ret
@@ -507,8 +531,8 @@ class MetricsLogger:
     def tensors_to_numpy(self, tensor_metrics):
         """Converts all previously logged and returned tensors back to numpy values."""
         for key, value in tensor_metrics.items():
-            assert key in self.stats
-            self.stats[key].numpy(value)
+            assert self._key_in_stats(key)
+            self._get_key(key).numpy(value)
 
     @property
     def tensor_mode(self):
@@ -568,15 +592,11 @@ class MetricsLogger:
             KeyError: If `key` cannot be found AND `default` is not provided.
         """
         # Use default value, b/c `key` cannot be found in our stats.
-        if key not in self.stats and default is not None:
+        if not self._key_in_stats(key) and default is not None:
             return default
 
         # Create a reduced view of the requested sub-structure or leaf (Stats object).
-        ret = tree.map_structure(lambda s: s.peek(), self.stats[key])
-
-        # `key` only reached to a deeper NestedDict -> Have to convert to dict.
-        if isinstance(ret, NestedDict):
-            return ret.asdict()
+        ret = tree.map_structure(lambda s: s.peek(), self._get_key(key))
 
         # Otherwise, return the reduced Stats' (peek) value.
         return ret
@@ -628,8 +648,8 @@ class MetricsLogger:
                 Note that this is only applied if `key` does not exist in `self` yet.
         """
         # Key already in self -> Erase internal values list with [`value`].
-        if key in self.stats:
-            self.stats[key].values = [value]
+        if self._key_in_stats(key):
+            self._get_key(key).values = [value]
         # Key cannot be found in `self` -> Simply log as a (new) value.
         else:
             self.log_value(
@@ -712,7 +732,6 @@ class MetricsLogger:
             # We execute similarly useful merging strategies for other reduce settings,
             # such as EMA, max/min/sum-reducing, etc..
             end_result = downstream_logger.reduce(return_stats_obj=False)
-
             check(end_result, {"a": 2.5})
 
         Args:
@@ -732,25 +751,18 @@ class MetricsLogger:
         """
         # Create a shallow copy of `self.stats` in case we need to reset some of our
         # stats due to this `reduce()` call (and the Stat having self.clear_on_reduce
-        # set to True).
+        # set to True). In case we clear the Stats upon `reduce`, we get returned a
+        # new empty `Stats` object from `stat.reduce()` with the same settings as
+        # existing one and can now re-assign it to `self.stats[key]` (while we return
+        # from this method the properly reduced, but not cleared/emptied new `Stats`).
         if key is not None:
-            stats_to_return = self.stats[key].copy()
+            stats_to_return = self._get_key(key).copy()
+            self._set_key(
+                key, tree.map_structure(lambda s: s.reduce(), stats_to_return)
+            )
         else:
             stats_to_return = self.stats.copy()
-
-        # Reduce all stats according to each of their reduce-settings.
-        for sub_key, stat in stats_to_return.items():
-            # In case we clear the Stats upon `reduce`, we get returned a new empty
-            # `Stats` object from `stat.reduce()` with the same settings as existing one
-            # and can now re-assign it to `self.stats[key]` (while we return from this
-            # method the properly reduced, but not cleared/emptied new `Stats`).
-            if key is not None:
-                self.stats[key][sub_key] = stat.reduce()
-            else:
-                self.stats[sub_key] = stat.reduce()
-
-        # Return reduced values as dict (not NestedDict).
-        stats_to_return = stats_to_return.asdict()
+            self.stats = tree.map_structure(lambda s: s.reduce(), stats_to_return)
 
         if return_stats_obj:
             return stats_to_return
@@ -763,9 +775,14 @@ class MetricsLogger:
         Note that the state is merely the combination of all states of the individual
         `Stats` objects stored under `self.stats`.
         """
-        return {
-            "stats": {key: stat.get_state() for key, stat in self.stats.items()},
-        }
+        stats_dict = {}
+
+        def _map(path, stats):
+            stats_dict[force_tuple(path)] = stats.get_state()
+
+        tree.map_structure_with_path(_map, self.stats)
+
+        return {"stats": stats_dict}
 
     def set_state(self, state: Dict[str, Any]) -> None:
         """Sets the state of `self` to the given `state`.
@@ -773,12 +790,8 @@ class MetricsLogger:
         Args:
             state: The state to set `self` to.
         """
-        self.stats = NestedDict(
-            {
-                key: Stats.from_state(stat_state)
-                for key, stat_state in state["stats"].items()
-            }
-        )
+        for flat_key, stats_state in state["stats"].items():
+            self._set_key(flat_key, Stats.from_state(stats_state))
 
     def _check_tensor(self, key, value) -> None:
         # `value` is a tensor -> Log it in our keys set.
@@ -786,3 +799,31 @@ class MetricsLogger:
             (torch and torch.is_tensor(value)) or (tf and tf.is_tensor(value))
         ):
             self._tensor_keys.add(key)
+
+    def _key_in_stats(self, flat_key, stats=None):
+        flat_key = force_tuple(flat_key)
+        _dict = stats if stats is not None else self.stats
+        for key in flat_key:
+            if key not in _dict:
+                return False
+            _dict = _dict[key]
+        return True
+
+    def _get_key(self, flat_key, stats=None):
+        flat_key = force_tuple(flat_key)
+        _dict = stats if stats is not None else self.stats
+        for key in flat_key:
+            _dict = _dict[key]
+        return _dict
+
+    def _set_key(self, flat_key, stats):
+        flat_key = force_tuple(flat_key)
+        _dict = self.stats
+        for i, key in enumerate(flat_key):
+            if key not in _dict:
+                if i == len(flat_key) - 1:
+                    _dict[key] = stats
+                    return
+                else:
+                    _dict[key] = {}
+            _dict = _dict[key]

--- a/rllib/utils/metrics/metrics_logger.py
+++ b/rllib/utils/metrics/metrics_logger.py
@@ -270,7 +270,7 @@ class MetricsLogger:
         prefix_key = force_tuple(key)
 
         def _map(path, stat_or_value):
-            extended_key = prefix_key + force_tuple(path)
+            extended_key = prefix_key + force_tuple(tree.flatten(path))
 
             self.log_value(
                 extended_key,
@@ -820,10 +820,9 @@ class MetricsLogger:
         flat_key = force_tuple(flat_key)
         _dict = self.stats
         for i, key in enumerate(flat_key):
+            if i == len(flat_key) - 1:
+                _dict[key] = stats
+                return
             if key not in _dict:
-                if i == len(flat_key) - 1:
-                    _dict[key] = stats
-                    return
-                else:
-                    _dict[key] = {}
+                _dict[key] = {}
             _dict = _dict[key]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Performance booster:
* Cache all RLModule checking (in- and output);
* MetricsLogger speedups;
* avoid NestedDict;
* Only create OneHotCategorlcal when really needed.

Speedup measured:

```
from ray.rllib.algorithms.impala import ImpalaConfig
from ray.rllib.env.single_agent_env_runner import SingleAgentEnvRunner
from timeit import timeit

config = (
    ImpalaConfig()
    .api_stack(
        enable_rl_module_and_learner=True,
        enable_env_runner_and_connector_v2=True,
    )
    .env_runners(create_env_on_local_worker=True)
    .environment("CartPole-v1")
    .rl_module(
        model_config_dict={
            "vf_share_layers": True,
            "uses_new_env_runners": True,
        }
    )
)

print(timeit(
    stmt="env_runner.sample(); env_runner.get_metrics()",
    setup="env_runner = SingleAgentEnvRunner(config=config)",
    number=500,
    globals={"config": config, "SingleAgentEnvRunner": SingleAgentEnvRunner},
))
```

With this PR:
6.4 sec

W/o this PR:
10.7 sec


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

