### PR TITLE
Fix sem_unlink() error check in MutableObjectManager

### DIFF
--- a/src/ray/object_manager/plasma/test/mutable_object_test.cc
+++ b/src/ray/object_manager/plasma/test/mutable_object_test.cc
@@ -643,6 +643,9 @@ TEST(MutableObjectTest, TestMutableObjectManagerDestruct) {
     ASSERT_TRUE(
         manager2.RegisterChannel(object_id, std::move(object2), /*reader=*/false).ok());
   }
+  // The purpose of this test is to ensure that neither the MutableObjectManager instance
+  // destructor crashes when the two instances go out of scope below at the end of this
+  // function.
 }
 
 #endif  // defined(__APPLE__) || defined(__linux__)

--- a/src/ray/object_manager/plasma/test/mutable_object_test.cc
+++ b/src/ray/object_manager/plasma/test/mutable_object_test.cc
@@ -615,6 +615,36 @@ TEST(MutableObjectTest, TestReadMultipleAcquireDuringFailure) {
   }
 }
 
+// Tests that MutableObjectManager instances destruct properly when there are multiple
+// instances.
+// The core worker and the raylet each have their own MutableObjectManager instance, and
+// when both a reader and a writer are on the same machine, the reader and writer will
+// each register the same object with separate MutableObjectManager instances. Thus, we
+// must ensure that the object and its associated metadata (such as the semaphores) are
+// destructed the proper number of times.
+TEST(MutableObjectTest, TestMutableObjectManagerDestruct) {
+  MutableObjectManager manager1;
+  MutableObjectManager manager2;
+  ObjectID object_id = ObjectID::FromRandom();
+  std::string unique_name;
+
+  {
+    std::unique_ptr<plasma::MutableObject> object1 = MakeObject();
+    object1->header->Init();
+    unique_name = std::string(object1->header->unique_name);
+    ASSERT_TRUE(
+        manager1.RegisterChannel(object_id, std::move(object1), /*reader=*/true).ok());
+  }
+  {
+    std::unique_ptr<plasma::MutableObject> object2 = MakeObject();
+    object2->header->Init();
+    memset(object2->header->unique_name, 0, sizeof(object2->header->unique_name));
+    memcpy(object2->header->unique_name, unique_name.c_str(), unique_name.size());
+    ASSERT_TRUE(
+        manager2.RegisterChannel(object_id, std::move(object2), /*reader=*/false).ok());
+  }
+}
+
 #endif  // defined(__APPLE__) || defined(__linux__)
 
 }  // namespace experimental


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This fixes #45061.

The core worker and the raylet each have their own MutableObjectManager instance, and when both a reader and a writer are on the same machine, the reader and writer will each register the same object with separate MutableObjectManager instances. Thus, when the second instance is destructed, it will call sem_unlink() on the same two semaphores. As the two semaphores have already been unlinked by the first instance, the sem_unlink() calls in the second instance will both fail with ENOENT.

Prior to this PR, we checked that *all* calls to sem_unlink() return 0, which is incorrect.

## Related issue number

Closes #45061 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
