### PR TITLE
[Data] Fix bug where you can't return objects and array from UDF

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -25,7 +25,7 @@ from ray.data._internal.numpy_support import (
 )
 from ray.data._internal.row import TableRow
 from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
-from ray.data._internal.util import _truncated_repr, find_partitions
+from ray.data._internal.util import find_partitions
 from ray.data.block import (
     Block,
     BlockAccessor,

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -21,7 +21,7 @@ from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.data._internal.arrow_ops import transform_polars, transform_pyarrow
 from ray.data._internal.numpy_support import (
     convert_udf_returns_to_numpy,
-    is_valid_udf_return,
+    validate_numpy_batch,
 )
 from ray.data._internal.row import TableRow
 from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
@@ -185,22 +185,14 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
     @staticmethod
     def numpy_to_block(
-        batch: Union[np.ndarray, Dict[str, np.ndarray], Dict[str, list]],
+        batch: Union[Dict[str, np.ndarray], Dict[str, list]],
     ) -> "pyarrow.Table":
         import pyarrow as pa
 
         from ray.data.extensions.tensor_extension import ArrowTensorArray
 
-        if isinstance(batch, np.ndarray):
-            batch = {TENSOR_COLUMN_NAME: batch}
-        elif not isinstance(batch, collections.abc.Mapping) or any(
-            not is_valid_udf_return(col) for col in batch.values()
-        ):
-            raise ValueError(
-                "Batch must be an ndarray or dictionary of ndarrays when converting "
-                f"a numpy batch to a block, got: {type(batch)} "
-                f"({_truncated_repr(batch)})"
-            )
+        validate_numpy_batch(batch)
+
         new_batch = {}
         for col_name, col in batch.items():
             # Coerce to np.ndarray format if possible.

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -1,4 +1,5 @@
-from typing import Any, List
+import collections
+from typing import Any, Dict, List, Union
 
 import numpy as np
 
@@ -26,6 +27,17 @@ def is_nested_list(udf_return_col: List[Any]) -> bool:
         if isinstance(e, list):
             return True
     return False
+
+
+def validate_numpy_batch(batch: Union[Dict[str, np.ndarray], Dict[str, list]]) -> None:
+    if not isinstance(batch, collections.abc.Mapping) or any(
+        not is_valid_udf_return(col) for col in batch.values()
+    ):
+        raise ValueError(
+            "Batch must be an ndarray or dictionary of ndarrays when converting "
+            f"a numpy batch to a block, got: {type(batch)} "
+            f"({_truncated_repr(batch)})"
+        )
 
 
 def convert_udf_returns_to_numpy(udf_return_col: Any) -> Any:

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -16,6 +16,10 @@ from typing import (
 import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
+from ray.data._internal.numpy_support import (
+    convert_udf_returns_to_numpy,
+    validate_numpy_batch,
+)
 from ray.data._internal.row import TableRow
 from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
 from ray.data._internal.util import find_partitions
@@ -264,6 +268,19 @@ class PandasBlockAccessor(TableBlockAccessor):
         import pyarrow
 
         return pyarrow.table(self._table)
+
+    @staticmethod
+    def numpy_to_block(
+        batch: Union[Dict[str, np.ndarray], Dict[str, list]],
+    ) -> "pandas.DataFrame":
+        validate_numpy_batch(batch)
+
+        batch = {
+            column_name: convert_udf_returns_to_numpy(column)
+            for column_name, column in batch.items()
+        }
+        block = PandasBlockBuilder._table_from_pydict(batch)
+        return block
 
     def num_rows(self) -> int:
         return self._table.shape[0]

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -365,15 +365,14 @@ class BlockAccessor:
             import pyarrow as pa
 
             from ray.data._internal.arrow_block import ArrowBlockAccessor
+            from ray.data._internal.pandas_block import PandasBlockAccessor
 
             try:
                 return ArrowBlockAccessor.numpy_to_block(batch)
             except (pa.ArrowNotImplementedError, pa.ArrowInvalid, pa.ArrowTypeError):
-                import pandas as pd
-
                 # TODO(ekl) once we support Python objects within Arrow blocks, we
                 # don't need this fallback path.
-                return pd.DataFrame(dict(batch))
+                return PandasBlockAccessor.numpy_to_block(batch)
         return batch
 
     @staticmethod

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -948,6 +948,22 @@ def test_map_batches_preserves_empty_block_format(ray_start_regular_shared):
     assert type(ray.get(block_refs[0])) == pd.DataFrame
 
 
+def test_map_with_objects_and_tensors(ray_start_regular_shared):
+    # Tests https://github.com/ray-project/ray/issues/45235
+
+    class UnsupportedType:
+        pass
+
+    def f(batch):
+        batch_size = len(batch["id"])
+        return {
+            "array": np.zeros((batch_size, 32, 32, 3)),
+            "unsupported": [UnsupportedType()] * batch_size,
+        }
+
+    ray.data.range(1).map_batches(f).materialize()
+
+
 def test_random_sample(ray_start_regular_shared):
     import math
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you try to return arbitrary objects and arrays from a UDF, Ray Data errors complaining that "per-column arrays must each be 1-dimensional." The issue is that when Ray Data falls back to pandas, it doesn't use the tensor extension type. This PR fixes the bug.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/45235

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
