### PR TITLE
[ci] pass RAYCI_WEEKLY_RELEASE to macos pipeline

### DIFF
--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -50,6 +50,8 @@ steps:
       commit: "${BUILDKITE_COMMIT}"
       branch: "${BUILDKITE_BRANCH}"
       message: "Triggered by release-automation build #${BUILDKITE_BUILD_NUMBER}"
+      env:
+        RAYCI_WEEKLY_RELEASE: 1
 
   - block: "Trigger Release nightly test"
     if: build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") != "1"


### PR DESCRIPTION
We now have periodic run vs per-commit run on macos pipeline. The periodic runs all tests while the per-commit builds the wheels only. Pass the RAYCI_WEEKLY_RELEASE flag so that the periodic run can run all tests.

Test:
![](https://media0.giphy.com/media/TejmLnMKgnmPInMQjV/200.gif?cid=5a38a5a2nbk1lk8jbd7q9og5hwibwjt7uk4yydvrxw931xor&ep=v1_gifs_search&rid=200.gif&ct=g)