### PR TITLE
[ci] add RAYCI_FULL_PLATFORM_RELEASE to build full platform

### DIFF
--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -27,7 +27,8 @@ steps:
       branch: "${BUILDKITE_BRANCH}"
       message: "Triggered by release-automation build #${BUILDKITE_BUILD_NUMBER}"
       env:
-        RAYCI_WEEKLY_RELEASE: 1
+        RAYCI_RELEASE: 1
+        RAYCI_FULL_PLATFORM_RELEASE: "${RAYCI_FULL_PLATFORM_RELEASE}"
   
   - label: "Trigger Postmerge nightly build & test"
     if: build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") == "1"
@@ -39,7 +40,7 @@ steps:
       branch: "${BUILDKITE_BRANCH}"
       message: "Triggered by release-automation build #${BUILDKITE_BUILD_NUMBER}"
       env:
-        RAYCI_WEEKLY_RELEASE: 1
+        RAYCI_RELEASE: 1
         RAYCI_SCHEDULE: "nightly"
 
   - label: "Trigger Postmerge MacOS test"
@@ -51,7 +52,7 @@ steps:
       branch: "${BUILDKITE_BRANCH}"
       message: "Triggered by release-automation build #${BUILDKITE_BUILD_NUMBER}"
       env:
-        RAYCI_WEEKLY_RELEASE: 1
+        RAYCI_RELEASE: 1
 
   - block: "Trigger Release nightly test"
     if: build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") != "1"

--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -3,7 +3,7 @@ sort_key: "~windows"
 steps:
   # block on premerge and weekly release
   - block: "run windows tests"
-    if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("RAYCI_WEEKLY_RELEASE") == "1"
+    if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b" || (build.env("RAYCI_RELEASE") == "1" && build.env("RAYCI_FULL_PLATFORM_RELEASE") != "1")
 
   - name: windowsbuild
     wanda: ci/docker/windows.build.wanda.yaml


### PR DESCRIPTION
Add `RAYCI_FULL_PLATFORM_RELEASE` so we can create a run from release-automation to build full platform. I also change `RAYCI_WEEKLY_RELEASE` to `RAYCI_RELEASE` (since `RAYCI_FULL_PLATFORM_WEEKLY_RELEASE` is too long).

Test:
- CI