### PR TITLE
[ci] merge two flaky mac jobs into one

### DIFF
--- a/.buildkite/macos/macos.rayci.yml
+++ b/.buildkite/macos/macos.rayci.yml
@@ -104,7 +104,7 @@ steps:
     commands:
       - RAY_INSTALL_JAVA=1 ./ci/ray_ci/macos/macos_ci.sh run_ray_cpp_and_java
 
-  - label: ":ray: core: :mac: small & large flaky tests"
+  - label: ":ray: core: :mac: flaky tests"
     if: build.env("BUILDKITE_PIPELINE_ID") != "0189e759-8c96-4302-b6b5-b4274406bf89"
     tags:
       - core_cpp
@@ -116,18 +116,4 @@ steps:
     instance_type: macos
     soft_fail: true
     commands:
-      - ./ci/ray_ci/macos/macos_ci.sh run_small_and_large_flaky_tests
-
-  - label: ":ray: core: :mac: medium flaky tests"
-    if: build.env("BUILDKITE_PIPELINE_ID") != "0189e759-8c96-4302-b6b5-b4274406bf89"
-    tags:
-      - core_cpp
-      - python
-      - macos_wheels
-      - oss
-      - skip_on_premerge
-    job_env: MACOS
-    instance_type: macos
-    soft_fail: true
-    commands:
-      - ./ci/ray_ci/macos/macos_ci.sh run_medium_flaky_tests
+      - ./ci/ray_ci/macos/macos_ci.sh run_flaky_tests

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -27,21 +27,14 @@ run_tests() {
       --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --test_env=CI "$@"
 }
 
-run_small_and_large_flaky_tests() {
+run_flaky_tests() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
-  (bazel query 'attr(tags, "client_tests|small_size_python_tests|large_size_python_tests_shard_0|large_size_python_tests_shard_1|large_size_python_tests_shard_2", tests(//python/ray/tests/...))' | select_flaky_tests |
+  (bazel query 'attr(tags, "client_tests|small_size_python_tests|large_size_python_tests_shard_0|large_size_python_tests_shard_1|large_size_python_tests_shard_2|medium_size_python_tests_a_to_j|medium_size_python_tests_k_to_z", tests(//python/ray/tests/...))' | select_flaky_tests |
     xargs bazel test --config=ci $(./ci/run/bazel_export_options) \
       --runs_per_test="$RUN_PER_FLAKY_TEST" \
       --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX \
       --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --test_env=CI) || exit 42
-}
-
-run_medium_flaky_tests() {
-  # shellcheck disable=SC2046
-  # 42 is the universal rayci exit code for test failures
-  (bazel query 'attr(tags, "medium_size_python_tests_a_to_j|medium_size_python_tests_k_to_z", tests(//python/ray/tests/...))' | select_flaky_tests |
-    xargs bazel test --config=ci $(./ci/run/bazel_export_options) --runs_per_test="$RUN_PER_FLAKY_TEST" --test_env=CI) || exit 42
 }
 
 run_small_test() {


### PR DESCRIPTION
Merge two flaky mac jobs into one. The bootstraper (installing dependencies, build ray, etc.) for each mac job pretty expensive so let's merge as much as we can to save machine cycle.

Test:
- CI
- https://buildkite.com/ray-project/premerge/builds/26053#018f7338-b0de-4565-a7d2-48135fff49c9