### PR TITLE
[Data] Add support for using GPUs with `map_groups`

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -103,17 +103,9 @@ def _apply_batch_format(given_batch_format: Optional[str]) -> str:
 
 
 def _apply_batch_size(
-    given_batch_size: Optional[Union[int, Literal["default"]]], use_gpu: bool
+    given_batch_size: Optional[Union[int, Literal["default"]]]
 ) -> Optional[int]:
-    if use_gpu and (not given_batch_size or given_batch_size == "default"):
-        raise ValueError(
-            "`batch_size` must be provided to `map_batches` when requesting GPUs. "
-            "The optimal batch size depends on the model, data, and GPU used. "
-            "It is recommended to use the largest batch size that doesn't result "
-            "in your GPU device running out of memory. You can view the GPU memory "
-            "usage via the Ray dashboard."
-        )
-    elif given_batch_size == "default":
+    if given_batch_size == "default":
         return ray.data.context.DEFAULT_BATCH_SIZE
     else:
         return given_batch_size

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -559,6 +559,59 @@ class Dataset:
                 Call this method to transform one record at time.
 
         """  # noqa: E501
+        if num_gpus > 0 and (batch_size is None or batch_size == "default"):
+            raise ValueError(
+                "You must provide `batch_size` to `map_batches` when requesting GPUs. "
+                "The optimal batch size depends on the model, data, and GPU used. "
+                "We recommend using the largest batch size that doesn't result "
+                "in your GPU device running out of memory. You can view the GPU memory "
+                "usage via the Ray dashboard."
+            )
+
+        if isinstance(batch_size, int) and batch_size < 1:
+            raise ValueError("Batch size can't be negative or 0")
+
+        return self._map_batches_without_batch_size_validation(
+            fn,
+            batch_size=batch_size,
+            compute=compute,
+            batch_format=batch_format,
+            zero_copy_batch=zero_copy_batch,
+            fn_args=fn_args,
+            fn_kwargs=fn_kwargs,
+            fn_constructor_args=fn_constructor_args,
+            fn_constructor_kwargs=fn_constructor_kwargs,
+            num_cpus=num_cpus,
+            num_gpus=num_gpus,
+            concurrency=concurrency,
+            ray_remote_args_fn=ray_remote_args_fn,
+            **ray_remote_args,
+        )
+
+    def _map_batches_without_batch_size_validation(
+        self,
+        fn: UserDefinedFunction[DataBatch, DataBatch],
+        *,
+        batch_size: Union[int, None, Literal["default"]],
+        compute: Optional[ComputeStrategy],
+        batch_format: Optional[str],
+        zero_copy_batch: bool,
+        fn_args: Optional[Iterable[Any]],
+        fn_kwargs: Optional[Dict[str, Any]],
+        fn_constructor_args: Optional[Iterable[Any]],
+        fn_constructor_kwargs: Optional[Dict[str, Any]],
+        num_cpus: Optional[float],
+        num_gpus: Optional[float],
+        concurrency: Optional[Union[int, Tuple[int, int]]],
+        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]],
+        **ray_remote_args,
+    ):
+        # NOTE: The `map_groups` implementation calls `map_batches` with
+        # `batch_size=None`. The issue is that if you request GPUs with
+        # `batch_size=None`, then `map_batches` raises a value error. So, to allow users
+        # to call `map_groups` with  GPUs, we need a separate method that doesn't
+        # perform batch size validation.
+
         compute = get_compute_strategy(
             fn,
             fn_constructor_args=fn_constructor_args,
@@ -576,13 +629,9 @@ class Dataset:
 
         min_rows_per_bundled_input = None
         if batch_size is not None and batch_size != "default":
-            if batch_size < 1:
-                raise ValueError("Batch size cannot be negative or 0")
             # Enable blocks bundling when batch_size is specified by caller.
             min_rows_per_bundled_input = batch_size
-
-        use_gpu = ray_remote_args.get("num_gpus", 0) > 0
-        batch_size = _apply_batch_size(batch_size, use_gpu)
+        batch_size = _apply_batch_size(batch_size)
 
         if batch_format not in VALID_BATCH_FORMATS:
             raise ValueError(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -559,7 +559,8 @@ class Dataset:
                 Call this method to transform one record at time.
 
         """  # noqa: E501
-        if num_gpus > 0 and (batch_size is None or batch_size == "default"):
+        use_gpus = num_gpus is not None and num_gpus > 0
+        if use_gpus and (batch_size is None or batch_size == "default"):
             raise ValueError(
                 "You must provide `batch_size` to `map_batches` when requesting GPUs. "
                 "The optimal batch size depends on the model, data, and GPU used. "

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -109,6 +109,8 @@ class GroupedData:
         batch_format: Optional[str] = "default",
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
+        num_cpus: Optional[float] = None,
+        num_gpus: Optional[float] = None,
         **ray_remote_args,
     ) -> "Dataset":
         """Apply the given function to each group of records of this dataset.
@@ -162,6 +164,10 @@ class GroupedData:
                 exactly as is with no additional formatting.
             fn_args: Arguments to `fn`.
             fn_kwargs: Keyword arguments to `fn`.
+            num_cpus: The number of CPUs to reserve for each parallel map worker.
+            num_gpus: The number of GPUs to reserve for each parallel map worker. For
+                example, specify `num_gpus=1` to request 1 GPU for each parallel map
+                worker.
             ray_remote_args: Additional resource requirements to request from
                 ray (e.g., num_gpus=1 to request GPUs for the map tasks).
 
@@ -221,13 +227,20 @@ class GroupedData:
 
         # Note we set batch_size=None here, so it will use the entire block as a batch,
         # which ensures that each group will be contained within a batch in entirety.
-        return sorted_ds.map_batches(
+        return sorted_ds._map_batches_without_batch_size_validation(
             group_fn,
             batch_size=None,
             compute=compute,
             batch_format=batch_format,
+            zero_copy_batch=False,
             fn_args=fn_args,
             fn_kwargs=fn_kwargs,
+            fn_constructor_args=None,
+            fn_constructor_kwargs=None,
+            num_cpus=num_cpus,
+            num_gpus=num_gpus,
+            concurrency=None,
+            ray_remote_args_fn=None,
             **ray_remote_args,
         )
 

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -138,6 +138,17 @@ def test_groupby_errors(ray_start_regular_shared):
         ds.groupby("foo").count().show()
 
 
+def test_map_groups_with_gpus(shutdown_only):
+    ray.shutdown()
+    ray.init(num_gpus=1)
+
+    rows = (
+        ray.data.range(1).groupby("id").map_groups(lambda x: x, num_gpus=1).take_all()
+    )
+
+    assert rows == [{"id": 0}]
+
+
 def test_groupby_large_udf_returns(ray_start_regular_shared):
     # Test for https://github.com/ray-project/ray/issues/44861.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

You can't use GPUs with `map_groups`. There's no reason you shouldn't be able to do this; it was just was an issue with our implementation. This PR fixes it.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/42340

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
