### PR TITLE
[ci] increase microcheck coverage to 100

### DIFF
--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -67,7 +67,7 @@ steps:
     if: build.branch == "master"
     instance_type: small
     commands:
-      - bazel run //ci/ray_ci/automation:determine_microcheck_tests -- {{matrix}} 95 --production
+      - bazel run //ci/ray_ci/automation:determine_microcheck_tests -- {{matrix}} 100 --production
     matrix:
       - "core"
       - "serve"

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -70,7 +70,9 @@ steps:
       - bazel run //ci/ray_ci/automation:determine_microcheck_tests -- {{matrix}} 100 --production
     matrix:
       - "core"
+      - "serverless"
       - "serve"
       - "data"
       - "ml"
       - "rllib"
+      - "ci"


### PR DESCRIPTION
Let start microcheck with 100% test coverage for the launch; then we can reduce it opportunistically. I plan to launch this on Weds to give folks time to rebase to a newer master base first.

Test:
- CI