### PR TITLE
Add perf metrics 2.22.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 470.708224,
+    "_dashboard_memory_usage_mb": 505.040896,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.72,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1095\t0.95GiB\tpython distributed/test_many_actors.py\n293\t0.3GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n911\t0.07GiB\tray::JobSupervisor\n612\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n451\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1157\t0.06GiB\tray::MemoryMonitorActor.run\n1232\t0.05GiB\tray::DashboardTester.run\n392\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
-    "actors_per_second": 629.465198365166,
+    "_peak_memory": 3.66,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n898\t0.97GiB\tpython distributed/test_many_actors.py\n293\t0.23GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n712\t0.07GiB\tray::JobSupervisor\n612\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n451\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n960\t0.06GiB\tray::MemoryMonitorActor.run\n1051\t0.05GiB\tray::DashboardTester.run\n392\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
+    "actors_per_second": 638.1892393086097,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 629.465198365166
+            "perf_metric_value": 638.1892393086097
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 161.266
+            "perf_metric_value": 68.347
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5216.157
+            "perf_metric_value": 2276.742
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5216.157
+            "perf_metric_value": 4468.284
         }
     ],
     "success": "1",
-    "time": 15.886501789093018
+    "time": 15.669333457946777
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 192.159744,
+    "_dashboard_memory_usage_mb": 184.631296,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.64,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t0.52GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n293\t0.18GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1192\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1461\t0.09GiB\tray::StateAPIGeneratorActor.start\n1006\t0.07GiB\tray::JobSupervisor\n450\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n448\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n603\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1317\t0.06GiB\tray::MemoryMonitorActor.run\n1407\t0.06GiB\tray::DashboardTester.run",
+    "_peak_memory": 1.65,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n293\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1140\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1345\t0.09GiB\tray::StateAPIGeneratorActor.start\n953\t0.07GiB\tray::JobSupervisor\n450\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n448\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n583\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1202\t0.06GiB\tray::MemoryMonitorActor.run\n1291\t0.06GiB\tray::DashboardTester.run",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 366.4907393960873
+            "perf_metric_value": 351.42937770172125
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.48
+            "perf_metric_value": 3.885
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 80.406
+            "perf_metric_value": 80.486
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 217.102
+            "perf_metric_value": 213.83
         }
     ],
     "success": "1",
-    "tasks_per_second": 366.4907393960873,
-    "time": 302.728581905365,
+    "tasks_per_second": 351.42937770172125,
+    "time": 302.8455219268799,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 190.68928,
+    "_dashboard_memory_usage_mb": 135.335936,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.14,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t0.93GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1018\t0.4GiB\tpython distributed/test_many_pgs.py\n293\t0.13GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n834\t0.07GiB\tray::JobSupervisor\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n611\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n451\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1143\t0.06GiB\tray::MemoryMonitorActor.run\n1234\t0.05GiB\tray::DashboardTester.run\n391\t0.04GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=",
+    "_peak_memory": 2.21,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n179\t0.95GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n969\t0.42GiB\tpython distributed/test_many_pgs.py\n294\t0.13GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n454\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n783\t0.07GiB\tray::JobSupervisor\n452\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n613\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1031\t0.06GiB\tray::MemoryMonitorActor.run\n1121\t0.05GiB\tray::DashboardTester.run\n392\t0.05GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23.470678162839302
+            "perf_metric_value": 23.57570074520289
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.272
+            "perf_metric_value": 3.411
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 42.922
+            "perf_metric_value": 13.124
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 358.309
+            "perf_metric_value": 812.483
         }
     ],
-    "pgs_per_second": 23.470678162839302,
+    "pgs_per_second": 23.57570074520289,
     "success": "1",
-    "time": 42.60635304450989
+    "time": 42.41655468940735
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1200.361472,
+    "_dashboard_memory_usage_mb": 1180.475392,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.89,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t2.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n293\t1.21GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1100\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1306\t0.08GiB\tray::StateAPIGeneratorActor.start\n1235\t0.08GiB\tray::DashboardTester.run\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n913\t0.07GiB\tray::JobSupervisor\n451\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n610\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1162\t0.06GiB\tray::MemoryMonitorActor.run",
+    "_peak_memory": 5.76,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n293\t2.1GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n178\t2.05GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n970\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1176\t0.09GiB\tray::StateAPIGeneratorActor.start\n1121\t0.08GiB\tray::DashboardTester.run\n786\t0.07GiB\tray::JobSupervisor\n450\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n448\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n604\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1048\t0.06GiB\tray::MemoryMonitorActor.run",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 592.871367164479
+            "perf_metric_value": 580.7153723158294
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 47.866
+            "perf_metric_value": 42.738
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3188.529
+            "perf_metric_value": 3207.541
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4222.657
+            "perf_metric_value": 4552.523
         }
     ],
     "success": "1",
-    "tasks_per_second": 592.871367164479,
-    "time": 316.8670651912689,
+    "tasks_per_second": 580.7153723158294,
+    "time": 317.22013998031616,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        9231.13205434199,
-        263.23898948509276
+        9062.792852859755,
+        201.88082345014254
     ],
     "1_1_actor_calls_concurrent": [
-        5207.403165869952,
-        44.363883963423724
+        5479.71996068499,
+        360.8246009353858
     ],
     "1_1_actor_calls_sync": [
-        2094.875118026067,
-        33.96019620496728
+        2096.4576697416196,
+        54.90895331226573
     ],
     "1_1_async_actor_calls_async": [
-        3679.273214565456,
-        72.42820449471026
+        3314.3892417930037,
+        132.65271504449134
     ],
     "1_1_async_actor_calls_sync": [
-        1349.154883528484,
-        21.478859920081618
+        1325.7852093012016,
+        28.80251158731383
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2441.3295492788307,
-        48.57379450168428
+        2343.1487246339175,
+        64.07964858250249
     ],
     "1_n_actor_calls_async": [
-        8687.002823855231,
-        263.0731079571473
+        8606.08018065877,
+        464.65178014068323
     ],
     "1_n_async_actor_calls_async": [
-        7616.288181387119,
-        187.30135931998024
+        7460.166048300169,
+        81.1534935797334
     ],
     "client__1_1_actor_calls_async": [
-        995.1941800794589,
-        4.386299177532235
+        907.189714069745,
+        30.09285092604243
     ],
     "client__1_1_actor_calls_concurrent": [
-        981.3610689913281,
-        9.343552920040837
+        862.2264504688716,
+        15.31700423704598
     ],
     "client__1_1_actor_calls_sync": [
-        529.2817511036485,
-        5.002896995984588
+        465.4585783069056,
+        10.3283151207103
     ],
     "client__get_calls": [
-        1102.784805636512,
-        59.49715189608496
+        1158.7613618440014,
+        15.2470079224923
     ],
     "client__put_calls": [
-        803.6907933267912,
-        28.6991879671622
+        789.0311690962432,
+        11.582638068164687
     ],
     "client__put_gigabytes": [
-        0.13000377813880426,
-        0.00045634709726433836
+        0.13155858254345548,
+        0.0006237409662319517
     ],
     "client__tasks_and_get_batch": [
-        0.8943766187635083,
-        0.034668794224519045
+        0.9229179501706766,
+        0.016042442038446857
     ],
     "client__tasks_and_put_batch": [
-        11618.996288906874,
-        99.68395835168926
+        11657.997816451738,
+        122.84381416507865
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12378.76716587138,
-        105.91623157084351
+        12873.027401685875,
+        206.74322585504657
     ],
     "multi_client_put_gigabytes": [
-        32.127583473661076,
-        3.029765850786339
+        35.8680482168819,
+        1.6837276555923617
     ],
     "multi_client_tasks_async": [
-        23246.18514733561,
-        3349.0269090731435
+        21743.557366389494,
+        766.3008688107913
     ],
     "n_n_actor_calls_async": [
-        26644.201721023048,
-        1301.4894705420318
+        27688.27595653398,
+        786.3443469102006
     ],
     "n_n_actor_calls_with_arg_async": [
-        2704.4738249461293,
-        44.69261442727767
+        2713.504279822532,
+        69.57915774978693
     ],
     "n_n_async_actor_calls_async": [
-        22642.233725461258,
-        846.0443551175905
+        23092.83239112525,
+        497.909562630626
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10556.167569431133
+            "perf_metric_value": 10269.932297010477
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5299.4573652671415
+            "perf_metric_value": 5196.004383289357
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12378.76716587138
+            "perf_metric_value": 12873.027401685875
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21.31655252094265
+            "perf_metric_value": 20.09665460590859
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.929465173212371
+            "perf_metric_value": 8.144156516407913
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 32.127583473661076
+            "perf_metric_value": 35.8680482168819
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.52171763582945
+            "perf_metric_value": 13.25584597642898
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.483630802920898
+            "perf_metric_value": 5.012190250895254
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1002.8196875307303
+            "perf_metric_value": 971.317197225919
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7813.472406257602
+            "perf_metric_value": 8194.32696391844
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23246.18514733561
+            "perf_metric_value": 21743.557366389494
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2094.875118026067
+            "perf_metric_value": 2096.4576697416196
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9231.13205434199
+            "perf_metric_value": 9062.792852859755
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5207.403165869952
+            "perf_metric_value": 5479.71996068499
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8687.002823855231
+            "perf_metric_value": 8606.08018065877
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26644.201721023048
+            "perf_metric_value": 27688.27595653398
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2704.4738249461293
+            "perf_metric_value": 2713.504279822532
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1349.154883528484
+            "perf_metric_value": 1325.7852093012016
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3679.273214565456
+            "perf_metric_value": 3314.3892417930037
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2441.3295492788307
+            "perf_metric_value": 2343.1487246339175
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7616.288181387119
+            "perf_metric_value": 7460.166048300169
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22642.233725461258
+            "perf_metric_value": 23092.83239112525
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 850.9214104369318
+            "perf_metric_value": 838.5131869401664
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1102.784805636512
+            "perf_metric_value": 1158.7613618440014
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 803.6907933267912
+            "perf_metric_value": 789.0311690962432
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13000377813880426
+            "perf_metric_value": 0.13155858254345548
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11618.996288906874
+            "perf_metric_value": 11657.997816451738
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 529.2817511036485
+            "perf_metric_value": 465.4585783069056
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 995.1941800794589
+            "perf_metric_value": 907.189714069745
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 981.3610689913281
+            "perf_metric_value": 862.2264504688716
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.8943766187635083
+            "perf_metric_value": 0.9229179501706766
         }
     ],
     "placement_group_create/removal": [
-        850.9214104369318,
-        5.605433178895902
+        838.5131869401664,
+        8.669141107798977
     ],
     "single_client_get_calls_Plasma_Store": [
-        10556.167569431133,
-        77.93663750708814
+        10269.932297010477,
+        323.15008192139106
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.52171763582945,
-        0.3330930424042106
+        13.25584597642898,
+        0.06849427287247552
     ],
     "single_client_put_calls_Plasma_Store": [
-        5299.4573652671415,
-        104.7895646656126
+        5196.004383289357,
+        39.378140465481884
     ],
     "single_client_put_gigabytes": [
-        21.31655252094265,
-        5.502507789355352
+        20.09665460590859,
+        4.950859874261046
     ],
     "single_client_tasks_and_get_batch": [
-        7.929465173212371,
-        0.27204560133861755
+        8.144156516407913,
+        0.26484235965448855
     ],
     "single_client_tasks_async": [
-        7813.472406257602,
-        464.56634150141537
+        8194.32696391844,
+        355.25438679131315
     ],
     "single_client_tasks_sync": [
-        1002.8196875307303,
-        15.63104006816665
+        971.317197225919,
+        32.73250539384329
     ],
     "single_client_wait_1k_refs": [
-        5.483630802920898,
-        0.0715962099275209
+        5.012190250895254,
+        0.17129235302778886
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 15.136383380999973,
+    "broadcast_time": 18.67043262200002,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 15.136383380999973
+            "perf_metric_value": 18.67043262200002
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.493978096000006,
-    "get_time": 23.39766470100001,
+    "args_time": 17.131764829000005,
+    "get_time": 23.237287506,
     "large_object_size": 107374182400,
-    "large_object_time": 29.229432349999968,
+    "large_object_time": 31.629831378000006,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.493978096000006
+            "perf_metric_value": 17.131764829000005
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.578864035000009
+            "perf_metric_value": 5.7444607429999905
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.39766470100001
+            "perf_metric_value": 23.237287506
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 180.797260221
+            "perf_metric_value": 188.938811406
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.229432349999968
+            "perf_metric_value": 31.629831378000006
         }
     ],
-    "queued_time": 180.797260221,
-    "returns_time": 5.578864035000009,
+    "queued_time": 188.938811406,
+    "returns_time": 5.7444607429999905,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.4795736622810365,
-    "max_iteration_time": 5.597578763961792,
-    "min_iteration_time": 0.6834812164306641,
+    "avg_iteration_time": 1.5098540854454041,
+    "max_iteration_time": 4.985053539276123,
+    "min_iteration_time": 0.6889913082122803,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4795736622810365
+            "perf_metric_value": 1.5098540854454041
         }
     ],
     "success": 1,
-    "total_time": 147.95764255523682
+    "total_time": 150.98566269874573
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 11.001468896865845
+            "perf_metric_value": 12.160747766494751
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 24.483961820602417
+            "perf_metric_value": 23.831846237182617
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 53.381308794021606
+            "perf_metric_value": 54.19231338500977
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.0290634632110596
+            "perf_metric_value": 2.171973943710327
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3010.209487915039
+            "perf_metric_value": 2976.5505974292755
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.6472558249100075
+            "perf_metric_value": 0.6098190516734817
         }
     ],
-    "stage_0_time": 11.001468896865845,
-    "stage_1_avg_iteration_time": 24.483961820602417,
-    "stage_1_max_iteration_time": 25.398903131484985,
-    "stage_1_min_iteration_time": 23.48150372505188,
-    "stage_1_time": 244.83970546722412,
-    "stage_2_avg_iteration_time": 53.381308794021606,
-    "stage_2_max_iteration_time": 54.12904739379883,
-    "stage_2_min_iteration_time": 52.89454412460327,
-    "stage_2_time": 266.9073483943939,
-    "stage_3_creation_time": 2.0290634632110596,
-    "stage_3_time": 3010.209487915039,
-    "stage_4_spread": 0.6472558249100075,
+    "stage_0_time": 12.160747766494751,
+    "stage_1_avg_iteration_time": 23.831846237182617,
+    "stage_1_max_iteration_time": 25.01764941215515,
+    "stage_1_min_iteration_time": 22.995277881622314,
+    "stage_1_time": 238.31863117218018,
+    "stage_2_avg_iteration_time": 54.19231338500977,
+    "stage_2_max_iteration_time": 54.958396911621094,
+    "stage_2_min_iteration_time": 52.179816246032715,
+    "stage_2_time": 270.96241092681885,
+    "stage_3_creation_time": 2.171973943710327,
+    "stage_3_time": 2976.5505974292755,
+    "stage_4_spread": 0.6098190516734817,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.889821163662783,
-    "avg_pg_remove_time_ms": 0.9000654909906795,
+    "avg_pg_create_time_ms": 0.8636297822809175,
+    "avg_pg_remove_time_ms": 0.9039912897897018,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.889821163662783
+            "perf_metric_value": 0.8636297822809175
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9000654909906795
+            "perf_metric_value": 0.9039912897897018
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 12.14%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 981.3610689913281 to 862.2264504688716 (12.14%) in microbenchmark.json
REGRESSION 12.06%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 529.2817511036485 to 465.4585783069056 (12.06%) in microbenchmark.json
REGRESSION 9.92%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 3679.273214565456 to 3314.3892417930037 (9.92%) in microbenchmark.json
REGRESSION 8.84%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 995.1941800794589 to 907.189714069745 (8.84%) in microbenchmark.json
REGRESSION 8.60%: single_client_wait_1k_refs (THROUGHPUT) regresses from 5.483630802920898 to 5.012190250895254 (8.60%) in microbenchmark.json
REGRESSION 6.46%: multi_client_tasks_async (THROUGHPUT) regresses from 23246.18514733561 to 21743.557366389494 (6.46%) in microbenchmark.json
REGRESSION 5.72%: single_client_put_gigabytes (THROUGHPUT) regresses from 21.31655252094265 to 20.09665460590859 (5.72%) in microbenchmark.json
REGRESSION 4.11%: tasks_per_second (THROUGHPUT) regresses from 366.4907393960873 to 351.42937770172125 (4.11%) in benchmarks/many_nodes.json
REGRESSION 4.02%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2441.3295492788307 to 2343.1487246339175 (4.02%) in microbenchmark.json
REGRESSION 3.14%: single_client_tasks_sync (THROUGHPUT) regresses from 1002.8196875307303 to 971.317197225919 (3.14%) in microbenchmark.json
REGRESSION 2.71%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10556.167569431133 to 10269.932297010477 (2.71%) in microbenchmark.json
REGRESSION 2.05%: tasks_per_second (THROUGHPUT) regresses from 592.871367164479 to 580.7153723158294 (2.05%) in benchmarks/many_tasks.json
REGRESSION 2.05%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7616.288181387119 to 7460.166048300169 (2.05%) in microbenchmark.json
REGRESSION 1.97%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.52171763582945 to 13.25584597642898 (1.97%) in microbenchmark.json
REGRESSION 1.95%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5299.4573652671415 to 5196.004383289357 (1.95%) in microbenchmark.json
REGRESSION 1.82%: client__put_calls (THROUGHPUT) regresses from 803.6907933267912 to 789.0311690962432 (1.82%) in microbenchmark.json
REGRESSION 1.82%: 1_1_actor_calls_async (THROUGHPUT) regresses from 9231.13205434199 to 9062.792852859755 (1.82%) in microbenchmark.json
REGRESSION 1.73%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1349.154883528484 to 1325.7852093012016 (1.73%) in microbenchmark.json
REGRESSION 1.46%: placement_group_create/removal (THROUGHPUT) regresses from 850.9214104369318 to 838.5131869401664 (1.46%) in microbenchmark.json
REGRESSION 0.93%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8687.002823855231 to 8606.08018065877 (0.93%) in microbenchmark.json
REGRESSION 126.75%: dashboard_p99_latency_ms (LATENCY) regresses from 358.309 to 812.483 (126.75%) in benchmarks/many_pgs.json
REGRESSION 23.35%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 15.136383380999973 to 18.67043262200002 (23.35%) in scalability/object_store.json
REGRESSION 10.54%: stage_0_time (LATENCY) regresses from 11.001468896865845 to 12.160747766494751 (10.54%) in stress_tests/stress_test_many_tasks.json
REGRESSION 8.21%: 107374182400_large_object_time (LATENCY) regresses from 29.229432349999968 to 31.629831378000006 (8.21%) in scalability/single_node.json
REGRESSION 7.81%: dashboard_p99_latency_ms (LATENCY) regresses from 4222.657 to 4552.523 (7.81%) in benchmarks/many_tasks.json
REGRESSION 7.04%: stage_3_creation_time (LATENCY) regresses from 2.0290634632110596 to 2.171973943710327 (7.04%) in stress_tests/stress_test_many_tasks.json
REGRESSION 4.50%: 1000000_queued_time (LATENCY) regresses from 180.797260221 to 188.938811406 (4.50%) in scalability/single_node.json
REGRESSION 4.25%: dashboard_p50_latency_ms (LATENCY) regresses from 3.272 to 3.411 (4.25%) in benchmarks/many_pgs.json
REGRESSION 2.97%: 3000_returns_time (LATENCY) regresses from 5.578864035000009 to 5.7444607429999905 (2.97%) in scalability/single_node.json
REGRESSION 2.05%: avg_iteration_time (LATENCY) regresses from 1.4795736622810365 to 1.5098540854454041 (2.05%) in stress_tests/stress_test_dead_actors.json
REGRESSION 1.52%: stage_2_avg_iteration_time (LATENCY) regresses from 53.381308794021606 to 54.19231338500977 (1.52%) in stress_tests/stress_test_many_tasks.json
REGRESSION 0.60%: dashboard_p95_latency_ms (LATENCY) regresses from 3188.529 to 3207.541 (0.60%) in benchmarks/many_tasks.json
REGRESSION 0.44%: avg_pg_remove_time_ms (LATENCY) regresses from 0.9000654909906795 to 0.9039912897897018 (0.44%) in stress_tests/stress_test_placement_group.json
REGRESSION 0.10%: dashboard_p95_latency_ms (LATENCY) regresses from 80.406 to 80.486 (0.10%) in benchmarks/many_nodes.json
```