### PR TITLE
Accelerated DAG test_channel fix

### DIFF
--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -88,7 +88,9 @@ def test_errors(ray_start_regular):
     @ray.remote
     class Actor:
         def make_chan(self, do_write=True):
-            self.chan = ray_channel.Channel(None, [None], 1000)
+            self.chan = ray_channel.Channel(
+                ray.get_runtime_context().current_actor, [None], 1000
+            )
             if do_write:
                 self.chan.write(b"hello")
             return self.chan


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This fixes a test crash for test_errors in test_channel.py. The actor is the writer rather than the driver, so the actor handle must be passed to the channel constructor.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
