### PR TITLE
[RLlib] Provide more constants for common result dict keys, e.g. `EPISODE_RETURN_MEAN`.

### DIFF
--- a/rllib/README.rst
+++ b/rllib/README.rst
@@ -173,7 +173,7 @@ Quick First Experiment
     # we can expect to reach an optimal episode reward of 0.0.
     for i in range(1):
         results = algo.train()
-        print(f"Iter: {i}; avg. return={results['env_runner_results/episode_return_mean']}")
+        print(f"Iter: {i}; avg. return={results['env_runners/episode_return_mean']}")
 
 .. testoutput::
     :options: +MOCK

--- a/rllib/README.rst
+++ b/rllib/README.rst
@@ -173,7 +173,7 @@ Quick First Experiment
     # we can expect to reach an optimal episode reward of 0.0.
     for i in range(1):
         results = algo.train()
-        print(f"Iter: {i}; avg. reward={results['episode_reward_mean']}")
+        print(f"Iter: {i}; avg. return={results['env_runner_results/episode_return_mean']}")
 
 .. testoutput::
     :options: +MOCK

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -647,7 +647,7 @@ class Algorithm(Trainable, AlgorithmBase):
             default_policy_class=self.get_default_policy_class(self.config),
             config=self.config,
             num_workers=self.config.num_env_runners,
-            local_worker=True,
+            local_env_runner=True,
             logdir=self.logdir,
         )
 

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -92,6 +92,9 @@ from ray.rllib.utils.metrics import (
     ALL_MODULES,
     ENV_RUNNER_RESULTS,
     ENV_RUNNER_SAMPLING_TIMER,
+    EPISODE_RETURN_MAX,
+    EPISODE_RETURN_MEAN,
+    EPISODE_RETURN_MIN,
     EVALUATION_ITERATION_TIMER,
     EVALUATION_RESULTS,
     FAULT_TOLERANCE_STATS,
@@ -540,13 +543,13 @@ class Algorithm(Trainable, AlgorithmBase):
         self.evaluation_metrics = {
             # TODO: Don't dump sampler results into top-level.
             "evaluation": {
-                "episode_reward_max": np.nan,
-                "episode_reward_min": np.nan,
-                "episode_reward_mean": np.nan,
-                "sampler_results": {
-                    "episode_reward_max": np.nan,
-                    "episode_reward_min": np.nan,
-                    "episode_reward_mean": np.nan,
+                EPISODE_RETURN_MAX: np.nan,
+                EPISODE_RETURN_MIN: np.nan,
+                EPISODE_RETURN_MEAN: np.nan,
+                ENV_RUNNER_RESULTS: {
+                    EPISODE_RETURN_MAX: np.nan,
+                    EPISODE_RETURN_MIN: np.nan,
+                    EPISODE_RETURN_MEAN: np.nan,
                 },
             },
         }
@@ -3339,7 +3342,7 @@ class Algorithm(Trainable, AlgorithmBase):
 
         # Warn if results are empty, it could be that this is because the eval timesteps
         # are not enough to run through one full episode.
-        if eval_results["sampler_results"][NUM_EPISODES] == 0:
+        if eval_results[ENV_RUNNER_RESULTS][NUM_EPISODES] == 0:
             logger.warning(
                 "This evaluation iteration resulted in an empty set of episode summary "
                 "results! It's possible that your configured duration timesteps are not"
@@ -3481,7 +3484,7 @@ class Algorithm(Trainable, AlgorithmBase):
             self.config.keep_per_episode_custom_metrics,
         )
         # TODO: Don't dump sampler results into top-level.
-        results.update(results["sampler_results"])
+        results.update(results[ENV_RUNNER_RESULTS])
 
         results["num_healthy_workers"] = self.workers.num_healthy_remote_workers()
         results["num_in_flight_async_reqs"] = self.workers.num_in_flight_async_reqs()

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -31,6 +31,7 @@ from typing import (
 import tree  # pip install dm_tree
 
 import ray
+from ray.air.constants import TRAINING_ITERATION
 from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray.actor import ActorHandle
 from ray.train import Checkpoint
@@ -2876,7 +2877,7 @@ class Algorithm(Trainable, AlgorithmBase):
             state["counters"] = self._counters
 
         # Save current `training_iteration`.
-        state["training_iteration"] = self.training_iteration
+        state[TRAINING_ITERATION] = self.training_iteration
 
         return state
 
@@ -2949,8 +2950,8 @@ class Algorithm(Trainable, AlgorithmBase):
         if "counters" in state:
             self._counters = state["counters"]
 
-        if "training_iteration" in state:
-            self._iteration = state["training_iteration"]
+        if TRAINING_ITERATION in state:
+            self._iteration = state[TRAINING_ITERATION]
 
     @staticmethod
     def _checkpoint_info_to_algorithm_state(

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -2141,7 +2141,7 @@ class AlgorithmConfig(_Config):
                 it wastes no extra time for evaluation - causes the evaluation results
                 to lag one iteration behind the rest of the training results. This is
                 important when picking a good checkpoint. For example, if iteration 42
-                reports a good evaluation `episode_reward_mean`, be aware that these
+                reports a good evaluation `episode_return_mean`, be aware that these
                 results were achieved on the weights trained in iteration 41, so you
                 should probably pick the iteration 41 checkpoint instead.
             evaluation_force_reset_envs_before_iteration: Whether all environments

--- a/rllib/algorithms/bc/tests/test_bc.py
+++ b/rllib/algorithms/bc/tests/test_bc.py
@@ -4,6 +4,10 @@ import unittest
 
 import ray
 import ray.rllib.algorithms.bc as bc
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import (
     check_compute_single_action,
     check_train_results,
@@ -77,11 +81,11 @@ class TestBC(unittest.TestCase):
                         if eval_results:
                             print(
                                 "iter={} R={}".format(
-                                    i, eval_results["episode_reward_mean"]
+                                    i, eval_results[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]
                                 )
                             )
                             # Learn until good reward is reached in the actual env.
-                            if eval_results["episode_reward_mean"] > min_reward:
+                            if eval_results[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"] > min_reward:
                                 print("learnt!")
                                 learnt = True
                                 break

--- a/rllib/algorithms/bc/tests/test_bc.py
+++ b/rllib/algorithms/bc/tests/test_bc.py
@@ -81,11 +81,19 @@ class TestBC(unittest.TestCase):
                         if eval_results:
                             print(
                                 "iter={} R={}".format(
-                                    i, eval_results[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]
+                                    i,
+                                    eval_results[
+                                        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
+                                    ],
                                 )
                             )
                             # Learn until good reward is reached in the actual env.
-                            if eval_results[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"] > min_reward:
+                            if (
+                                eval_results[
+                                    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
+                                ]
+                                > min_reward
+                            ):
                                 print("learnt!")
                                 learnt = True
                                 break

--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
 import gymnasium as gym
 import numpy as np
 
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.core.rl_module.rl_module import RLModule
 from ray.rllib.env.base_env import BaseEnv
 from ray.rllib.env.env_context import EnvContext
@@ -832,5 +833,5 @@ class RE3UpdateCallbacks(DefaultCallbacks):
     def on_train_result(self, *, result: dict, algorithm=None, **kwargs) -> None:
         # TODO(gjoliver): Remove explicit _step tracking and pass
         #  Algorithm._iteration as a parameter to on_learn_on_batch() call.
-        RE3UpdateCallbacks._step = result["training_iteration"]
+        RE3UpdateCallbacks._step = result[TRAINING_ITERATION]
         super().on_train_result(algorithm=algorithm, result=result, **kwargs)

--- a/rllib/algorithms/cql/tests/test_cql.py
+++ b/rllib/algorithms/cql/tests/test_cql.py
@@ -6,6 +6,10 @@ import unittest
 import ray
 from ray.rllib.algorithms import cql
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import (
     check_compute_single_action,
     check_train_results,
@@ -80,7 +84,8 @@ class TestCQL(unittest.TestCase):
                 print(results)
                 eval_results = results["evaluation"]
                 print(
-                    f"iter={algo.iteration} " f"R={eval_results['episode_reward_mean']}"
+                    f"iter={algo.iteration} "
+                    f"R={eval_results[ENV_RUNNER_RESULTS + '/' + EPISODE_RETURN_MEAN]}"
                 )
             check_compute_single_action(algo)
 

--- a/rllib/algorithms/cql/tests/test_cql.py
+++ b/rllib/algorithms/cql/tests/test_cql.py
@@ -85,7 +85,7 @@ class TestCQL(unittest.TestCase):
                 eval_results = results["evaluation"]
                 print(
                     f"iter={algo.iteration} "
-                    f"R={eval_results[ENV_RUNNER_RESULTS + '/' + EPISODE_RETURN_MEAN]}"
+                    f"R={eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]}"
                 )
             check_compute_single_action(algo)
 

--- a/rllib/algorithms/marwil/tests/test_marwil.py
+++ b/rllib/algorithms/marwil/tests/test_marwil.py
@@ -79,10 +79,15 @@ class TestMARWIL(unittest.TestCase):
                 eval_results = results.get("evaluation")
                 if eval_results:
                     print(
-                        "iter={} R={} ".format(i, eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN])
+                        "iter={} R={} ".format(
+                            i, eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
+                        )
                     )
                     # Learn until some reward is reached on an actual live env.
-                    if eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] > min_reward:
+                    if (
+                        eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
+                        > min_reward
+                    ):
                         print("learnt!")
                         learnt = True
                         break

--- a/rllib/algorithms/marwil/tests/test_marwil.py
+++ b/rllib/algorithms/marwil/tests/test_marwil.py
@@ -10,6 +10,10 @@ from ray.rllib.algorithms.marwil.marwil_torch_policy import MARWILTorchPolicy
 from ray.rllib.evaluation.postprocessing import compute_advantages
 from ray.rllib.offline import JsonReader
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import (
     check,
     check_compute_single_action,
@@ -75,10 +79,10 @@ class TestMARWIL(unittest.TestCase):
                 eval_results = results.get("evaluation")
                 if eval_results:
                     print(
-                        "iter={} R={} ".format(i, eval_results["episode_reward_mean"])
+                        "iter={} R={} ".format(i, eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN])
                     )
                     # Learn until some reward is reached on an actual live env.
-                    if eval_results["episode_reward_mean"] > min_reward:
+                    if eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] > min_reward:
                         print("learnt!")
                         learnt = True
                         break

--- a/rllib/algorithms/tests/test_algorithm.py
+++ b/rllib/algorithms/tests/test_algorithm.py
@@ -336,7 +336,10 @@ class TestAlgorithm(unittest.TestCase):
             config.create_env_on_local_worker = True
             algo_w_env_on_local_worker = config.build()
             results = algo_w_env_on_local_worker.evaluate()
-            assert ENV_RUNNER_RESULTS in results and EPISODE_RETURN_MEAN in results[ENV_RUNNER_RESULTS]
+            assert (
+                ENV_RUNNER_RESULTS in results
+                and EPISODE_RETURN_MEAN in results[ENV_RUNNER_RESULTS]
+            )
             algo_w_env_on_local_worker.stop()
             config.create_env_on_local_worker = False
 

--- a/rllib/algorithms/tests/test_algorithm.py
+++ b/rllib/algorithms/tests/test_algorithm.py
@@ -14,6 +14,10 @@ from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
 from ray.rllib.examples.evaluation.evaluation_parallel_to_training import (
     AssertEvalCallback,
 )
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.metrics.learner_info import LEARNER_INFO
 from ray.rllib.utils.test_utils import check, framework_iterator
 
@@ -268,7 +272,8 @@ class TestAlgorithm(unittest.TestCase):
             self.assertTrue("evaluation" in r1)
             self.assertFalse("evaluation" in r2)
             self.assertTrue("evaluation" in r3)
-            self.assertTrue("episode_reward_mean" in r1["evaluation"])
+            self.assertTrue(ENV_RUNNER_RESULTS in r1["evaluation"])
+            self.assertTrue(EPISODE_RETURN_MEAN in r1["evaluation"][ENV_RUNNER_RESULTS])
             self.assertNotEqual(r1["evaluation"], r3["evaluation"])
 
     def test_evaluation_option_always_attach_eval_metrics(self):
@@ -331,7 +336,7 @@ class TestAlgorithm(unittest.TestCase):
             config.create_env_on_local_worker = True
             algo_w_env_on_local_worker = config.build()
             results = algo_w_env_on_local_worker.evaluate()
-            assert "episode_reward_mean" in results
+            assert ENV_RUNNER_RESULTS in results and EPISODE_RETURN_MEAN in results[ENV_RUNNER_RESULTS]
             algo_w_env_on_local_worker.stop()
             config.create_env_on_local_worker = False
 

--- a/rllib/algorithms/tests/test_worker_failures.py
+++ b/rllib/algorithms/tests/test_worker_failures.py
@@ -862,7 +862,11 @@ class TestWorkerFailures(unittest.TestCase):
         )
         algo = config.build()
         results = algo.train()
-        self.assertTrue(np.isnan(results["evaluation_results"]["episode_return_mean"]))
+        self.assertTrue(
+            np.isnan(
+                results[EVALUATION_RESULTS][ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/rllib/algorithms/tests/test_worker_failures.py
+++ b/rllib/algorithms/tests/test_worker_failures.py
@@ -15,6 +15,11 @@ from ray.rllib.env.multi_agent_env import make_multi_agent
 from ray.rllib.env.multi_agent_env_runner import MultiAgentEnvRunner
 from ray.rllib.env.single_agent_env_runner import SingleAgentEnvRunner
 from ray.rllib.examples.envs.classes.random_env import RandomEnv
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+)
 from ray.tune.registry import register_env
 
 

--- a/rllib/benchmarks/torch_compile/run_ppo_with_inference_bm.py
+++ b/rllib/benchmarks/torch_compile/run_ppo_with_inference_bm.py
@@ -1,6 +1,7 @@
 import argparse
 
 from ray import tune, air
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.ppo import PPOConfig
 
 # Note:
@@ -72,7 +73,7 @@ def main(pargs):
     tuner = tune.Tuner(
         "PPO",
         run_config=air.RunConfig(
-            stop={"training_iteration": 1 if pargs.smoke_test else pargs.num_iters},
+            stop={TRAINING_ITERATION: 1 if pargs.smoke_test else pargs.num_iters},
         ),
         param_space=config,
     )

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -17,6 +17,13 @@ from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
 from ray.rllib.env.utils import _gym_env_creator
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.metrics import (
+    EPISODE_DURATION_SEC_MEAN,
+    EPISODE_LEN_MAX,
+    EPISODE_LEN_MEAN,
+    EPISODE_LEN_MIN,
+    EPISODE_RETURN_MAX,
+    EPISODE_RETURN_MEAN,
+    EPISODE_RETURN_MIN,
     NUM_AGENT_STEPS_SAMPLED,
     NUM_AGENT_STEPS_SAMPLED_LIFETIME,
     NUM_ENV_STEPS_SAMPLED,

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -847,9 +847,9 @@ class MultiAgentEnvRunner(EnvRunner):
         # Log general episode metrics.
         self.metrics.log_dict(
             {
-                "episode_len_mean": length,
-                "episode_return_mean": ret,
-                "episode_duration_sec_mean": sec,
+                EPISODE_LEN_MEAN: length,
+                EPISODE_RETURN_MEAN: ret,
+                EPISODE_DURATION_SEC_MEAN: sec,
                 **(
                     {
                         # Per-agent returns.
@@ -868,15 +868,15 @@ class MultiAgentEnvRunner(EnvRunner):
         # For some metrics, log min/max as well.
         self.metrics.log_dict(
             {
-                "episode_len_min": length,
-                "episode_return_min": ret,
+                EPISODE_LEN_MIN: length,
+                EPISODE_RETURN_MIN: ret,
             },
             reduce="min",
         )
         self.metrics.log_dict(
             {
-                "episode_len_max": length,
-                "episode_return_max": ret,
+                EPISODE_LEN_MAX: length,
+                EPISODE_RETURN_MAX: ret,
             },
             reduce="max",
         )

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -19,6 +19,13 @@ from ray.rllib.env.utils import _gym_env_creator
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.metrics import (
+    EPISODE_DURATION_SEC_MEAN,
+    EPISODE_LEN_MAX,
+    EPISODE_LEN_MEAN,
+    EPISODE_LEN_MIN,
+    EPISODE_RETURN_MAX,
+    EPISODE_RETURN_MEAN,
+    EPISODE_RETURN_MIN,
     NUM_AGENT_STEPS_SAMPLED,
     NUM_AGENT_STEPS_SAMPLED_LIFETIME,
     NUM_ENV_STEPS_SAMPLED,

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -777,9 +777,9 @@ class SingleAgentEnvRunner(EnvRunner):
         # To mimick the old API stack behavior, we'll use `window` here for
         # these particular stats (instead of the default EMA).
         win = self.config.metrics_num_episodes_for_smoothing
-        self.metrics.log_value("episode_len_mean", length, window=win)
-        self.metrics.log_value("episode_return_mean", ret, window=win)
-        self.metrics.log_value("episode_duration_sec_mean", sec, window=win)
+        self.metrics.log_value(EPISODE_LEN_MEAN, length, window=win)
+        self.metrics.log_value(EPISODE_RETURN_MEAN, ret, window=win)
+        self.metrics.log_value(EPISODE_DURATION_SEC_MEAN, sec, window=win)
         # Per-agent returns.
         self.metrics.log_value(
             ("agent_episode_returns_mean", DEFAULT_AGENT_ID), ret, window=win
@@ -790,7 +790,7 @@ class SingleAgentEnvRunner(EnvRunner):
         )
 
         # For some metrics, log min/max as well.
-        self.metrics.log_value("episode_len_min", length, reduce="min")
-        self.metrics.log_value("episode_return_min", ret, reduce="min")
-        self.metrics.log_value("episode_len_max", length, reduce="max")
-        self.metrics.log_value("episode_return_max", ret, reduce="max")
+        self.metrics.log_value(EPISODE_LEN_MIN, length, reduce="min")
+        self.metrics.log_value(EPISODE_RETURN_MIN, ret, reduce="min")
+        self.metrics.log_value(EPISODE_LEN_MAX, length, reduce="max")
+        self.metrics.log_value(EPISODE_RETURN_MAX, ret, reduce="max")

--- a/rllib/env/tests/test_multi_agent_env.py
+++ b/rllib/env/tests/test_multi_agent_env.py
@@ -606,8 +606,8 @@ class TestMultiAgentEnv(unittest.TestCase):
             print(
                 "Iteration {}, reward {}, timesteps {}".format(
                     i,
-                    result[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"],
-                    result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"],
+                    result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN],
+                    result[NUM_ENV_STEPS_SAMPLED_LIFETIME],
                 )
             )
         algo.stop()
@@ -629,7 +629,7 @@ class TestMultiAgentEnv(unittest.TestCase):
                 "Iteration {}, reward {}, timesteps {}".format(
                     i,
                     result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN],
-                    result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"],
+                    result[NUM_ENV_STEPS_SAMPLED_LIFETIME],
                 )
             )
         algo.stop()
@@ -828,7 +828,7 @@ class TestMultiAgentEnv(unittest.TestCase):
                 "Iteration {}, reward {}, timesteps {}".format(
                     i,
                     result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN],
-                    result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"],
+                    result[NUM_ENV_STEPS_SAMPLED_LIFETIME],
                 )
             )
             if result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] >= 50 * n:
@@ -874,7 +874,7 @@ class TestMultiAgentEnv(unittest.TestCase):
                 "Iteration {}, reward {}, timesteps {}".format(
                     i,
                     result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN],
-                    result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"],
+                    result[NUM_ENV_STEPS_SAMPLED_LIFETIME],
                 )
             )
         self.assertTrue(

--- a/rllib/env/tests/test_multi_agent_env.py
+++ b/rllib/env/tests/test_multi_agent_env.py
@@ -627,7 +627,9 @@ class TestMultiAgentEnv(unittest.TestCase):
             result = algo.train()
             print(
                 "Iteration {}, reward {}, timesteps {}".format(
-                    i, result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
+                    i,
+                    result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN],
+                    result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"],
                 )
             )
         algo.stop()
@@ -689,7 +691,7 @@ class TestMultiAgentEnv(unittest.TestCase):
                 episodes=None,
                 explore=True,
                 timestep=None,
-                **kwargs
+                **kwargs,
             ):
                 obs_shape = (len(obs_batch),)
                 actions = np.zeros(obs_shape, dtype=np.int32)
@@ -824,7 +826,9 @@ class TestMultiAgentEnv(unittest.TestCase):
             result = algo.train()
             print(
                 "Iteration {}, reward {}, timesteps {}".format(
-                    i, result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
+                    i,
+                    result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN],
+                    result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"],
                 )
             )
             if result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] >= 50 * n:
@@ -868,7 +872,9 @@ class TestMultiAgentEnv(unittest.TestCase):
             result = algo.train()
             print(
                 "Iteration {}, reward {}, timesteps {}".format(
-                    i, result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
+                    i,
+                    result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN],
+                    result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"],
                 )
             )
         self.assertTrue(

--- a/rllib/env/tests/test_multi_agent_env.py
+++ b/rllib/env/tests/test_multi_agent_env.py
@@ -26,6 +26,11 @@ from ray.rllib.policy.sample_batch import (
     convert_ma_batch_to_sample_batch,
 )
 from ray.rllib.tests.test_nested_observation_spaces import NestedMultiAgentEnv
+from ray.rllib.utils.metrics import (
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.numpy import one_hot
 from ray.rllib.utils.test_utils import check
 
@@ -600,7 +605,9 @@ class TestMultiAgentEnv(unittest.TestCase):
             result = algo.train()
             print(
                 "Iteration {}, reward {}, timesteps {}".format(
-                    i, result["episode_reward_mean"], result["timesteps_total"]
+                    i,
+                    result[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"],
+                    result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"],
                 )
             )
         algo.stop()
@@ -620,7 +627,7 @@ class TestMultiAgentEnv(unittest.TestCase):
             result = algo.train()
             print(
                 "Iteration {}, reward {}, timesteps {}".format(
-                    i, result["episode_reward_mean"], result["timesteps_total"]
+                    i, result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
                 )
             )
         algo.stop()
@@ -817,10 +824,10 @@ class TestMultiAgentEnv(unittest.TestCase):
             result = algo.train()
             print(
                 "Iteration {}, reward {}, timesteps {}".format(
-                    i, result["episode_reward_mean"], result["timesteps_total"]
+                    i, result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
                 )
             )
-            if result["episode_reward_mean"] >= 50 * n:
+            if result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] >= 50 * n:
                 algo.stop()
                 return
         raise Exception("failed to improve reward")
@@ -861,7 +868,7 @@ class TestMultiAgentEnv(unittest.TestCase):
             result = algo.train()
             print(
                 "Iteration {}, reward {}, timesteps {}".format(
-                    i, result["episode_reward_mean"], result["timesteps_total"]
+                    i, result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
                 )
             )
         self.assertTrue(

--- a/rllib/evaluate.py
+++ b/rllib/evaluate.py
@@ -11,13 +11,18 @@ import typer
 
 import ray
 import ray.cloudpickle as cloudpickle
+from ray.rllib.common import CLIArguments as cli
 from ray.rllib.env import MultiAgentEnv
 from ray.rllib.env.base_env import _DUMMY_AGENT_ID
 from ray.rllib.env.env_context import EnvContext
 from ray.rllib.env.env_runner_group import EnvRunnerGroup
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_LEN_MEAN,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.spaces.space_utils import flatten_to_single_ndarray
-from ray.rllib.common import CLIArguments as cli
 from ray.train._checkpoint import Checkpoint
 from ray.train._internal.session import _TrainingResult
 from ray.tune.utils import merge_dicts

--- a/rllib/evaluate.py
+++ b/rllib/evaluate.py
@@ -326,11 +326,11 @@ def rollout(
             # Increase time-step and episode counters.
             eps = agent.config["evaluation_duration"]
             episodes += eps
-            steps += eps * eval_result["episode_len_mean"]
+            steps += eps * eval_result[ENV_RUNNER_RESULTS][EPISODE_LEN_MEAN]
             # Print out results and continue.
             print(
                 "Episode #{}: reward: {}".format(
-                    episodes, eval_result["episode_return_mean"]
+                    episodes, eval_result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
                 )
             )
             saver.end_rollout()

--- a/rllib/evaluation/tests/test_rollout_worker.py
+++ b/rllib/evaluation/tests/test_rollout_worker.py
@@ -38,7 +38,6 @@ from ray.rllib.utils.annotations import override
 from ray.rllib.utils.metrics import (
     NUM_AGENT_STEPS_SAMPLED,
     NUM_AGENT_STEPS_TRAINED,
-    ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
 )
 from ray.rllib.utils.test_utils import check, framework_iterator
@@ -496,11 +495,11 @@ class TestRolloutWorker(unittest.TestCase):
         # Shows different behavior when connector is on/off.
         if config.enable_connectors:
             # episode_return_mean shows the correct clipped value.
-            self.assertEqual(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], 10)
+            self.assertEqual(result[EPISODE_RETURN_MEAN], 10)
         else:
             # episode_return_mean shows the unclipped raw value
             # when connector is off, and old env_runner v1 is used.
-            self.assertEqual(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], 1000)
+            self.assertEqual(result[EPISODE_RETURN_MEAN], 1000)
         ev.stop()
 
         # Clipping in certain range (-2.0, 2.0).
@@ -539,7 +538,7 @@ class TestRolloutWorker(unittest.TestCase):
         )
         self.assertEqual(max(sample["rewards"]), 100)
         result2 = collect_metrics(ws2, [])
-        self.assertEqual(result2[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], 1000)
+        self.assertEqual(result2[EPISODE_RETURN_MEAN], 1000)
         ev2.stop()
 
     def test_metrics(self):
@@ -569,7 +568,7 @@ class TestRolloutWorker(unittest.TestCase):
         ray.get(remote_ev.sample.remote())
         result = collect_metrics(ws)
         self.assertEqual(result["episodes_this_iter"], 20)
-        self.assertEqual(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], 10)
+        self.assertEqual(result[EPISODE_RETURN_MEAN], 10)
         ev.stop()
 
     def test_auto_vectorization(self):

--- a/rllib/evaluation/tests/test_rollout_worker.py
+++ b/rllib/evaluation/tests/test_rollout_worker.py
@@ -35,7 +35,12 @@ from ray.rllib.policy.sample_batch import (
     convert_ma_batch_to_sample_batch,
 )
 from ray.rllib.utils.annotations import override
-from ray.rllib.utils.metrics import NUM_AGENT_STEPS_SAMPLED, NUM_AGENT_STEPS_TRAINED
+from ray.rllib.utils.metrics import (
+    NUM_AGENT_STEPS_SAMPLED,
+    NUM_AGENT_STEPS_TRAINED,
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import check, framework_iterator
 from ray.tune.registry import register_env
 
@@ -490,12 +495,12 @@ class TestRolloutWorker(unittest.TestCase):
         result = collect_metrics(ws, [])
         # Shows different behavior when connector is on/off.
         if config.enable_connectors:
-            # episode_reward_mean shows the correct clipped value.
-            self.assertEqual(result["episode_reward_mean"], 10)
+            # episode_return_mean shows the correct clipped value.
+            self.assertEqual(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], 10)
         else:
-            # episode_reward_mean shows the unclipped raw value
+            # episode_return_mean shows the unclipped raw value
             # when connector is off, and old env_runner v1 is used.
-            self.assertEqual(result["episode_reward_mean"], 1000)
+            self.assertEqual(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], 1000)
         ev.stop()
 
         # Clipping in certain range (-2.0, 2.0).
@@ -534,7 +539,7 @@ class TestRolloutWorker(unittest.TestCase):
         )
         self.assertEqual(max(sample["rewards"]), 100)
         result2 = collect_metrics(ws2, [])
-        self.assertEqual(result2["episode_reward_mean"], 1000)
+        self.assertEqual(result2[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], 1000)
         ev2.stop()
 
     def test_metrics(self):
@@ -564,7 +569,7 @@ class TestRolloutWorker(unittest.TestCase):
         ray.get(remote_ev.sample.remote())
         result = collect_metrics(ws)
         self.assertEqual(result["episodes_this_iter"], 20)
-        self.assertEqual(result["episode_reward_mean"], 10)
+        self.assertEqual(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN], 10)
         ev.stop()
 
     def test_auto_vectorization(self):

--- a/rllib/evaluation/tests/test_trajectory_view_api.py
+++ b/rllib/evaluation/tests/test_trajectory_view_api.py
@@ -22,6 +22,7 @@ from ray.rllib.policy.sample_batch import (
 )
 from ray.rllib.policy.view_requirement import ViewRequirement
 from ray.rllib.utils.annotations import override
+from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
 from ray.rllib.utils.test_utils import framework_iterator, check
 
 
@@ -222,7 +223,7 @@ class TestTrajectoryViewAPI(unittest.TestCase):
             sample = rw.sample()
             assert sample.count == algo.config.get_rollout_fragment_length()
             results = algo.train()
-            assert results["timesteps_total"] == config["train_batch_size"]
+            assert results[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] == config["train_batch_size"]
             algo.stop()
 
     def test_traj_view_next_action(self):
@@ -352,7 +353,7 @@ class TestTrajectoryViewAPI(unittest.TestCase):
         results = None
         for i in range(num_iterations):
             results = algo.train()
-        self.assertEqual(results["agent_timesteps_total"], results["timesteps_total"])
+        self.assertEqual(results["agent_timesteps_total"], results[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"])
         self.assertEqual(
             results["num_env_steps_trained"] * num_agents,
             results["num_agent_steps_trained"],

--- a/rllib/evaluation/tests/test_trajectory_view_api.py
+++ b/rllib/evaluation/tests/test_trajectory_view_api.py
@@ -223,7 +223,10 @@ class TestTrajectoryViewAPI(unittest.TestCase):
             sample = rw.sample()
             assert sample.count == algo.config.get_rollout_fragment_length()
             results = algo.train()
-            assert results[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] == config["train_batch_size"]
+            assert (
+                results[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
+                == config["train_batch_size"]
+            )
             algo.stop()
 
     def test_traj_view_next_action(self):
@@ -353,7 +356,10 @@ class TestTrajectoryViewAPI(unittest.TestCase):
         results = None
         for i in range(num_iterations):
             results = algo.train()
-        self.assertEqual(results["agent_timesteps_total"], results[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"])
+        self.assertEqual(
+            results["agent_timesteps_total"],
+            results[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"],
+        )
         self.assertEqual(
             results["num_env_steps_trained"] * num_agents,
             results["num_agent_steps_trained"],

--- a/rllib/examples/_docs/rllib_on_rllib_readme.py
+++ b/rllib/examples/_docs/rllib_on_rllib_readme.py
@@ -1,5 +1,9 @@
 import gymnasium as gym
 from ray.rllib.algorithms.ppo import PPOConfig
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 
 
 # Define your problem using python and Farama-Foundation's gymnasium API:
@@ -69,7 +73,7 @@ algo = config.build()
 # we can expect to reach an optimal episode reward of 0.0.
 for i in range(5):
     results = algo.train()
-    print(f"Iter: {i}; avg. reward={results['episode_reward_mean']}")
+    print(f"Iter: {i}; avg. reward={results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]}")
 
 # Perform inference (action computations) based on given env observations.
 # Note that we are using a slightly simpler env here (-3.0 to 3.0, instead

--- a/rllib/examples/_old_api_stack/complex_struct_space.py
+++ b/rllib/examples/_old_api_stack/complex_struct_space.py
@@ -46,9 +46,7 @@ if __name__ == "__main__":
         .resources(num_gpus=int(os.environ.get("RLLIB_NUM_GPUS", "0")))
     )
 
-    stop = {
-        "num_env_steps_sampled_lifetime": 1,
-    }
+    stop = {NUM_ENV_STEPS_SAMPLED_LIFETIME: 1}
 
     tuner = tune.Tuner(
         "PPO",

--- a/rllib/examples/_old_api_stack/complex_struct_space.py
+++ b/rllib/examples/_old_api_stack/complex_struct_space.py
@@ -19,6 +19,7 @@ from ray.rllib.examples._old_api_stack.models.simple_rpg_model import (
     CustomTorchRPGModel,
     CustomTFRPGModel,
 )
+from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
 
 parser = argparse.ArgumentParser()
 parser.add_argument(

--- a/rllib/examples/_old_api_stack/connectors/self_play_with_policy_checkpoint.py
+++ b/rllib/examples/_old_api_stack/connectors/self_play_with_policy_checkpoint.py
@@ -18,6 +18,11 @@ from ray.rllib.examples._old_api_stack.connectors.prepare_checkpoint import (
     create_open_spiel_checkpoint,
 )
 from ray.rllib.policy.policy import Policy
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+    NUM_EPISODES,
+)
 from ray.tune import CLIReporter, register_env
 
 
@@ -117,10 +122,10 @@ def main(checkpoint_dir):
                 metric_columns={
                     "training_iteration": "iter",
                     "time_total_s": "time_total_s",
-                    "num_env_steps_sampled_lifetime": "ts",
-                    "env_runner_results/num_episodes": "train_episodes",
+                    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": "ts",
+                    f"{ENV_RUNNER_RESULTS}/{NUM_EPISODES}": "train_episodes",
                     (
-                        "env_runner_results/module_episode_returns_mean/" "main"
+                        f"{ENV_RUNNER_RESULTS}/module_episode_returns_mean/" "main"
                     ): "reward_main",
                 },
                 sort_by_metric=True,

--- a/rllib/examples/_old_api_stack/connectors/self_play_with_policy_checkpoint.py
+++ b/rllib/examples/_old_api_stack/connectors/self_play_with_policy_checkpoint.py
@@ -10,6 +10,7 @@ import tempfile
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.algorithms.sac import SACConfig
 from ray.rllib.env.utils import try_import_pyspiel

--- a/rllib/examples/_old_api_stack/connectors/self_play_with_policy_checkpoint.py
+++ b/rllib/examples/_old_api_stack/connectors/self_play_with_policy_checkpoint.py
@@ -103,9 +103,7 @@ def main(checkpoint_dir):
         )
     )
 
-    stop = {
-        "training_iteration": args.train_iteration,
-    }
+    stop = {TRAINING_ITERATION: args.train_iteration}
 
     # Train the "main" policy to play really well using self-play.
     tuner = tune.Tuner(
@@ -120,7 +118,7 @@ def main(checkpoint_dir):
             verbose=2,
             progress_reporter=CLIReporter(
                 metric_columns={
-                    "training_iteration": "iter",
+                    TRAINING_ITERATION: "iter",
                     "time_total_s": "time_total_s",
                     f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": "ts",
                     f"{ENV_RUNNER_RESULTS}/{NUM_EPISODES}": "train_episodes",

--- a/rllib/examples/_old_api_stack/custom_keras_model.py
+++ b/rllib/examples/_old_api_stack/custom_keras_model.py
@@ -14,6 +14,10 @@ from ray.rllib.models.tf.tf_modelv2 import TFModelV2
 from ray.rllib.models.tf.visionnet import VisionNetwork as MyVisionNetwork
 from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
 from ray.rllib.utils.framework import try_import_tf
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.metrics.learner_info import LEARNER_INFO, LEARNER_STATS_KEY
 from ray.tune.registry import get_trainable_cls
 
@@ -142,7 +146,7 @@ if __name__ == "__main__":
         )
 
     stop = {
-        "env_runner_results/episode_return_mean": args.stop,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop,
     }
 
     tuner = tune.Tuner(

--- a/rllib/examples/_old_api_stack/parametric_actions_cartpole.py
+++ b/rllib/examples/_old_api_stack/parametric_actions_cartpole.py
@@ -27,6 +27,11 @@ from ray.rllib.examples._old_api_stack.models.parametric_actions_model import (
     TorchParametricActionsModel,
 )
 from ray.rllib.models import ModelCatalog
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.registry import register_env
 
@@ -96,8 +101,8 @@ if __name__ == "__main__":
 
     stop = {
         "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": args.stop_timesteps,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     results = tune.Tuner(

--- a/rllib/examples/_old_api_stack/parametric_actions_cartpole.py
+++ b/rllib/examples/_old_api_stack/parametric_actions_cartpole.py
@@ -19,6 +19,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.examples.envs.classes.parametric_actions_cartpole import (
     ParametricActionsCartPole,
 )
@@ -100,7 +101,7 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
+        TRAINING_ITERATION: args.stop_iters,
         f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }

--- a/rllib/examples/_old_api_stack/parametric_actions_cartpole.py
+++ b/rllib/examples/_old_api_stack/parametric_actions_cartpole.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
             "num_workers": 0,
             "framework": args.framework,
         },
-        **cfg
+        **cfg,
     )
 
     stop = {

--- a/rllib/examples/_old_api_stack/parametric_actions_cartpole_embeddings_learnt_by_model.py
+++ b/rllib/examples/_old_api_stack/parametric_actions_cartpole_embeddings_learnt_by_model.py
@@ -26,6 +26,10 @@ from ray.rllib.examples._old_api_stack.models.parametric_actions_model import (
     ParametricActionsModelThatLearnsEmbeddings,
 )
 from ray.rllib.models import ModelCatalog
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.registry import register_env
 
@@ -83,7 +87,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     results = tune.Tuner(

--- a/rllib/examples/_old_api_stack/parametric_actions_cartpole_embeddings_learnt_by_model.py
+++ b/rllib/examples/_old_api_stack/parametric_actions_cartpole_embeddings_learnt_by_model.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
             "framework": args.framework,
             "action_mask_key": "valid_avail_actions_mask",
         },
-        **cfg
+        **cfg,
     )
 
     stop = {

--- a/rllib/examples/_old_api_stack/parametric_actions_cartpole_embeddings_learnt_by_model.py
+++ b/rllib/examples/_old_api_stack/parametric_actions_cartpole_embeddings_learnt_by_model.py
@@ -19,6 +19,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.examples.envs.classes.parametric_actions_cartpole import (
     ParametricActionsCartPoleNoEmbeddings,
 )
@@ -85,8 +86,8 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/_old_api_stack/parametric_actions_cartpole_embeddings_learnt_by_model.py
+++ b/rllib/examples/_old_api_stack/parametric_actions_cartpole_embeddings_learnt_by_model.py
@@ -30,6 +30,7 @@ from ray.rllib.models import ModelCatalog
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.registry import register_env

--- a/rllib/examples/_old_api_stack/remote_base_env_with_custom_api.py
+++ b/rllib/examples/_old_api_stack/remote_base_env_with_custom_api.py
@@ -12,6 +12,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.env.apis.task_settable_env import TaskSettableEnv
 from ray.rllib.utils.metrics import (
@@ -135,8 +136,8 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/_old_api_stack/remote_base_env_with_custom_api.py
+++ b/rllib/examples/_old_api_stack/remote_base_env_with_custom_api.py
@@ -14,6 +14,10 @@ import ray
 from ray import air, tune
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.env.apis.task_settable_env import TaskSettableEnv
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.registry import get_trainable_cls
 
@@ -91,7 +95,7 @@ class TaskSettingCallback(DefaultCallbacks):
 
     def on_train_result(self, *, algorithm, result: dict, **kwargs) -> None:
         """Curriculum learning as seen in Ray docs"""
-        if result["episode_reward_mean"] > 0.0:
+        if result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] > 0.0:
             phase = 0
         else:
             phase = 1
@@ -133,7 +137,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     results = tune.Tuner(

--- a/rllib/examples/_old_api_stack/remote_base_env_with_custom_api.py
+++ b/rllib/examples/_old_api_stack/remote_base_env_with_custom_api.py
@@ -18,6 +18,7 @@ from ray.rllib.env.apis.task_settable_env import TaskSettableEnv
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.registry import get_trainable_cls

--- a/rllib/examples/_old_api_stack/remote_envs_with_inference_done_on_main_node.py
+++ b/rllib/examples/_old_api_stack/remote_envs_with_inference_done_on_main_node.py
@@ -19,6 +19,11 @@ from ray.rllib.algorithms.ppo import PPO, PPOConfig
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.utils.annotations import override
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.rllib.utils.typing import PartialAlgorithmConfigDict
 from ray.tune import PlacementGroupFactory
@@ -154,8 +159,8 @@ if __name__ == "__main__":
             print(pretty_print(result))
             # Stop training if the target train steps or reward are reached.
             if (
-                result["timesteps_total"] >= args.stop_timesteps
-                or result["episode_reward_mean"] >= args.stop_reward
+                result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] >= args.stop_timesteps
+                or result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] >= args.stop_reward
             ):
                 break
 
@@ -164,7 +169,7 @@ if __name__ == "__main__":
         stop = {
             "training_iteration": args.stop_iters,
             "num_env_steps_sampled_lifetime": args.stop_timesteps,
-            "env_runner_results/episode_return_mean": args.stop_reward,
+            f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
         }
 
         results = tune.Tuner(

--- a/rllib/examples/_old_api_stack/remote_envs_with_inference_done_on_main_node.py
+++ b/rllib/examples/_old_api_stack/remote_envs_with_inference_done_on_main_node.py
@@ -15,6 +15,7 @@ from typing import Union
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.ppo import PPO, PPOConfig
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
@@ -167,8 +168,8 @@ if __name__ == "__main__":
     # Run with Tune for auto env and algorithm creation and TensorBoard.
     else:
         stop = {
-            "training_iteration": args.stop_iters,
-            "num_env_steps_sampled_lifetime": args.stop_timesteps,
+            TRAINING_ITERATION: args.stop_iters,
+            NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
             f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
         }
 

--- a/rllib/examples/_old_api_stack/sb2rllib_rllib_example.py
+++ b/rllib/examples/_old_api_stack/sb2rllib_rllib_example.py
@@ -8,6 +8,7 @@ Run example: python sb2rllib_rllib_example.py
 import gymnasium as gym
 from ray import tune, air
 import ray.rllib.algorithms.ppo as ppo
+from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
 
 # settings used for both stable baselines and rllib
 env_name = "CartPole-v1"

--- a/rllib/examples/_old_api_stack/sb2rllib_rllib_example.py
+++ b/rllib/examples/_old_api_stack/sb2rllib_rllib_example.py
@@ -19,7 +19,7 @@ save_dir = "saved_models"
 analysis = tune.Tuner(
     "PPO",
     run_config=air.RunConfig(
-        stop={"num_env_steps_sampled_lifetime": train_steps},
+        stop={NUM_ENV_STEPS_SAMPLED_LIFETIME: train_steps},
         local_dir=save_dir,
         checkpoint_config=air.CheckpointConfig(
             checkpoint_at_end=True,

--- a/rllib/examples/algorithms/custom_training_step_on_and_off_policy_combined.py
+++ b/rllib/examples/algorithms/custom_training_step_on_and_off_policy_combined.py
@@ -28,6 +28,8 @@ from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
 from ray.rllib.policy.sample_batch import MultiAgentBatch, concat_samples
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
     NUM_AGENT_STEPS_SAMPLED,
     NUM_ENV_STEPS_SAMPLED,
     NUM_TARGET_UPDATES,
@@ -205,7 +207,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     results = tune.Tuner(

--- a/rllib/examples/algorithms/custom_training_step_on_and_off_policy_combined.py
+++ b/rllib/examples/algorithms/custom_training_step_on_and_off_policy_combined.py
@@ -10,6 +10,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.algorithms.dqn.dqn import DQNConfig
@@ -32,6 +33,7 @@ from ray.rllib.utils.metrics import (
     EPISODE_RETURN_MEAN,
     NUM_AGENT_STEPS_SAMPLED,
     NUM_ENV_STEPS_SAMPLED,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
     NUM_TARGET_UPDATES,
     LAST_TARGET_UPDATE_TS,
 )
@@ -205,8 +207,8 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/autoregressive_action_dist.py
+++ b/rllib/examples/autoregressive_action_dist.py
@@ -53,6 +53,7 @@ from ray.rllib.models import ModelCatalog
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.logger import pretty_print

--- a/rllib/examples/autoregressive_action_dist.py
+++ b/rllib/examples/autoregressive_action_dist.py
@@ -40,6 +40,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.examples.envs.classes.correlated_actions_env import CorrelatedActionsEnv
 from ray.rllib.examples._old_api_stack.models.autoregressive_action_model import (
     AutoregressiveActionModel,

--- a/rllib/examples/autoregressive_action_dist.py
+++ b/rllib/examples/autoregressive_action_dist.py
@@ -164,8 +164,8 @@ if __name__ == "__main__":
 
     # use stop conditions passed via CLI (or defaults)
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/autoregressive_action_dist.py
+++ b/rllib/examples/autoregressive_action_dist.py
@@ -50,6 +50,10 @@ from ray.rllib.examples._old_api_stack.models.autoregressive_action_dist import 
     TorchBinaryAutoregressiveDistribution,
 )
 from ray.rllib.models import ModelCatalog
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.logger import pretty_print
 from ray.tune.registry import get_trainable_cls
@@ -161,7 +165,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     # manual training loop using PPO without ``Tuner.fit()``.
@@ -178,8 +182,8 @@ if __name__ == "__main__":
             print(pretty_print(result))
             # stop training if the target train steps or reward are reached
             if (
-                result["timesteps_total"] >= args.stop_timesteps
-                or result["episode_reward_mean"] >= args.stop_reward
+                result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] >= args.stop_timesteps
+                or result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] >= args.stop_reward
             ):
                 break
 

--- a/rllib/examples/cartpole_lstm.py
+++ b/rllib/examples/cartpole_lstm.py
@@ -5,6 +5,10 @@ import argparse
 import os
 
 from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.registry import get_trainable_cls
 
@@ -70,7 +74,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     tuner = tune.Tuner(

--- a/rllib/examples/cartpole_lstm.py
+++ b/rllib/examples/cartpole_lstm.py
@@ -4,10 +4,12 @@
 import argparse
 import os
 
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.registry import get_trainable_cls

--- a/rllib/examples/cartpole_lstm.py
+++ b/rllib/examples/cartpole_lstm.py
@@ -72,8 +72,8 @@ if __name__ == "__main__":
         config.training(vf_loss_coeff=0.01)
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/centralized_critic.py
+++ b/rllib/examples/centralized_critic.py
@@ -27,6 +27,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.ppo.ppo import PPO, PPOConfig
 from ray.rllib.algorithms.ppo.ppo_tf_policy import (
     PPOTF1Policy,
@@ -46,6 +47,7 @@ from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.test_utils import check_learning_achieved

--- a/rllib/examples/centralized_critic.py
+++ b/rllib/examples/centralized_critic.py
@@ -300,8 +300,8 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/centralized_critic.py
+++ b/rllib/examples/centralized_critic.py
@@ -43,6 +43,10 @@ from ray.rllib.models import ModelCatalog
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.rllib.utils.tf_utils import explained_variance, make_tf_callable
@@ -298,7 +302,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     tuner = tune.Tuner(

--- a/rllib/examples/centralized_critic_2.py
+++ b/rllib/examples/centralized_critic_2.py
@@ -154,8 +154,8 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/centralized_critic_2.py
+++ b/rllib/examples/centralized_critic_2.py
@@ -23,6 +23,7 @@ import argparse
 import os
 
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.examples._old_api_stack.models.centralized_critic_models import (
@@ -35,6 +36,7 @@ from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.test_utils import check_learning_achieved
 

--- a/rllib/examples/centralized_critic_2.py
+++ b/rllib/examples/centralized_critic_2.py
@@ -32,6 +32,10 @@ from ray.rllib.examples._old_api_stack.models.centralized_critic_models import (
 from ray.rllib.examples.envs.classes.two_step_game import TwoStepGame
 from ray.rllib.models import ModelCatalog
 from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 
 parser = argparse.ArgumentParser()
@@ -152,7 +156,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     tuner = tune.Tuner(

--- a/rllib/examples/centralized_critic_2.py
+++ b/rllib/examples/centralized_critic_2.py
@@ -74,7 +74,7 @@ class FillInActions(DefaultCallbacks):
         policies,
         postprocessed_batch,
         original_batches,
-        **kwargs
+        **kwargs,
     ):
         to_update = postprocessed_batch[SampleBatch.CUR_OBS]
         other_id = 1 if agent_id == 0 else 0

--- a/rllib/examples/checkpoints/checkpoint_by_custom_criteria.py
+++ b/rllib/examples/checkpoints/checkpoint_by_custom_criteria.py
@@ -58,9 +58,11 @@ rates used here:
 """
 
 from ray import tune
+from ray.rllib.core import DEFAULT_MODULE_ID
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    LEARNER_RESULTS,
 )
 from ray.rllib.utils.test_utils import (
     add_rllib_example_script_args,
@@ -124,7 +126,7 @@ if __name__ == "__main__":
     # Get the best checkpoints from the trial, based on different metrics.
     # Checkpoint with the lowest policy loss value:
     if args.enable_new_api_stack:
-        policy_loss_key = "learner_results/default_policy/policy_loss"
+        policy_loss_key = f"{LEARNER_RESULTS}/{DEFAULT_MODULE_ID}/policy_loss"
     else:
         policy_loss_key = "info/learner/default_policy/learner_stats/policy_loss"
     best_result = results.get_best_result(metric=policy_loss_key, mode="min")
@@ -134,7 +136,7 @@ if __name__ == "__main__":
 
     # Checkpoint with the highest value-function loss:
     if args.enable_new_api_stack:
-        vf_loss_key = "learner_results/default_policy/vf_loss"
+        vf_loss_key = f"{LEARNER_RESULTS}/{DEFAULT_MODULE_ID}/vf_loss"
     else:
         vf_loss_key = "info/learner/default_policy/learner_stats/vf_loss"
     best_result = results.get_best_result(metric=vf_loss_key, mode="max")

--- a/rllib/examples/checkpoints/checkpoint_by_custom_criteria.py
+++ b/rllib/examples/checkpoints/checkpoint_by_custom_criteria.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     # iterations with each other, respectively.
     # Setting scope to "avg" will compare (using `mode`=min|max) the average
     # values over the entire run.
-    metric = "env_runner_results/num_episodes"
+    metric = "env_runners/num_episodes"
     # notice here `scope` is `all`, meaning for each trial,
     # all results (not just the last one) will be examined.
     best_result = results.get_best_result(metric=metric, mode="min", scope="all")

--- a/rllib/examples/checkpoints/checkpoint_by_custom_criteria.py
+++ b/rllib/examples/checkpoints/checkpoint_by_custom_criteria.py
@@ -58,6 +58,10 @@ rates used here:
 """
 
 from ray import tune
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import (
     add_rllib_example_script_args,
     run_rllib_example_script_experiment,
@@ -102,7 +106,7 @@ if __name__ == "__main__":
     best_result = results.get_best_result(metric=metric, mode="min", scope="all")
     value_best_metric = best_result.metrics_dataframe[metric].min()
     best_return_best = best_result.metrics_dataframe[
-        "env_runner_results/episode_return_mean"
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
     ].max()
     print(
         f"Best trial was the one with lr={best_result.metrics['config']['lr']}. "

--- a/rllib/examples/checkpoints/restore_1_of_n_agents_from_checkpoint.py
+++ b/rllib/examples/checkpoints/restore_1_of_n_agents_from_checkpoint.py
@@ -20,6 +20,10 @@ from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
 from ray.rllib.policy.policy import Policy
 from ray.rllib.utils.framework import try_import_tf
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 
 tf1, tf, tfv = try_import_tf()
@@ -109,7 +113,7 @@ if __name__ == "__main__":
 
     # Start our actual experiment.
     stop = {
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
         "training_iteration": args.stop_iters,
     }

--- a/rllib/examples/checkpoints/restore_1_of_n_agents_from_checkpoint.py
+++ b/rllib/examples/checkpoints/restore_1_of_n_agents_from_checkpoint.py
@@ -12,8 +12,8 @@ import os
 import random
 
 import ray
-from ray import air
-from ray import tune
+from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.algorithms.ppo import PPOConfig
@@ -23,6 +23,7 @@ from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.test_utils import check_learning_achieved
 

--- a/rllib/examples/checkpoints/restore_1_of_n_agents_from_checkpoint.py
+++ b/rllib/examples/checkpoints/restore_1_of_n_agents_from_checkpoint.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         "PPO",
         param_space=config.to_dict(),
         run_config=air.RunConfig(
-            stop={"training_iteration": args.pre_training_iters},
+            stop={TRAINING_ITERATION: args.pre_training_iters},
             verbose=1,
             checkpoint_config=air.CheckpointConfig(
                 checkpoint_frequency=1, checkpoint_at_end=True
@@ -114,8 +114,8 @@ if __name__ == "__main__":
     # Start our actual experiment.
     stop = {
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "training_iteration": args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
     }
 
     class RestoreWeightsCallback(DefaultCallbacks):

--- a/rllib/examples/connectors/mean_std_filtering.py
+++ b/rllib/examples/connectors/mean_std_filtering.py
@@ -1,6 +1,13 @@
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.connectors.env_to_module.mean_std_filter import MeanStdFilter
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentPendulum
 from ray.rllib.utils.framework import try_import_torch
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.rllib.utils.test_utils import (
     add_rllib_example_script_args,
     run_rllib_example_script_experiment,
@@ -102,7 +109,9 @@ if __name__ == "__main__":
 
     stop = {
         TRAINING_ITERATION: args.stop_iters,
-        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
+        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": (
+            args.stop_reward
+        ),
         NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
     }
     run_rllib_example_script_experiment(config, args, stop=stop)

--- a/rllib/examples/connectors/mean_std_filtering.py
+++ b/rllib/examples/connectors/mean_std_filtering.py
@@ -101,8 +101,8 @@ if __name__ == "__main__":
         )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "evaluation_results/env_runner_results/episode_return_mean": args.stop_reward,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
     }
     run_rllib_example_script_experiment(config, args, stop=stop)

--- a/rllib/examples/curriculum/curriculum_learning.py
+++ b/rllib/examples/curriculum/curriculum_learning.py
@@ -163,7 +163,7 @@ class EnvTaskCallback(DefaultCallbacks):
         # to a more difficult task (if possible). If we already mastered the most
         # difficult task, we publish our victory in the result dict.
         result["task_solved"] = 0.0
-        current_return = result[ENV_RUNNER_RESULTS]["episode_return_mean"]
+        current_return = result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
         if current_return > args.upgrade_task_threshold:
             if current_task < 2:
                 new_task = current_task + 1
@@ -225,13 +225,13 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
+        TRAINING_ITERATION: args.stop_iters,
         # Reward directly does not matter to us as we would like to continue
         # after the policy reaches a return of ~1.0 on the 0-task (easiest).
         # But we DO want to stop, once the entire task is learned (policy achieves
         # return of 1.0 on the most difficult task=2).
         "task_solved": 1.0,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
     }
 
     run_rllib_example_script_experiment(

--- a/rllib/examples/curriculum/curriculum_learning.py
+++ b/rllib/examples/curriculum/curriculum_learning.py
@@ -56,6 +56,7 @@ Policy NOT using the curriculum (trying to solve the hardest task right away):
 """
 from functools import partial
 
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.connectors.env_to_module import (
@@ -63,7 +64,11 @@ from ray.rllib.connectors.env_to_module import (
     FlattenObservations,
     WriteObservationsToEpisodes,
 )
-from ray.rllib.utils.metrics import ENV_RUNNER_RESULTS
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.rllib.utils.test_utils import (
     add_rllib_example_script_args,
     run_rllib_example_script_experiment,

--- a/rllib/examples/custom_metrics_and_callbacks.py
+++ b/rllib/examples/custom_metrics_and_callbacks.py
@@ -197,9 +197,7 @@ if __name__ == "__main__":
     tuner = tune.Tuner(
         "PPO",
         run_config=air.RunConfig(
-            stop={
-                "training_iteration": args.stop_iters,
-            },
+            stop={TRAINING_ITERATION: args.stop_iters},
         ),
         param_space=config,
     )

--- a/rllib/examples/custom_metrics_and_callbacks.py
+++ b/rllib/examples/custom_metrics_and_callbacks.py
@@ -17,6 +17,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.env import BaseEnv

--- a/rllib/examples/custom_model_loss_and_metrics.py
+++ b/rllib/examples/custom_model_loss_and_metrics.py
@@ -87,9 +87,7 @@ if __name__ == "__main__":
         .resources(num_gpus=int(os.environ.get("RLLIB_NUM_GPUS", "0")))
     )
 
-    stop = {
-        "training_iteration": args.stop_iters,
-    }
+    stop = {TRAINING_ITERATION: args.stop_iters}
 
     tuner = tune.Tuner(
         args.run,

--- a/rllib/examples/custom_model_loss_and_metrics.py
+++ b/rllib/examples/custom_model_loss_and_metrics.py
@@ -21,6 +21,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.core import DEFAULT_MODULE_ID
 from ray.rllib.examples._old_api_stack.models.custom_loss_model import (
     CustomLossModel,

--- a/rllib/examples/custom_recurrent_rnn_tokenizer.py
+++ b/rllib/examples/custom_recurrent_rnn_tokenizer.py
@@ -14,6 +14,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.tune.registry import register_env
 from ray.rllib.examples.envs.classes.repeat_after_me_env import RepeatAfterMeEnv
 from ray.rllib.examples.envs.classes.repeat_initial_obs_env import RepeatInitialObsEnv
@@ -31,6 +32,7 @@ from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.rllib.core.models.configs import ModelConfig

--- a/rllib/examples/custom_recurrent_rnn_tokenizer.py
+++ b/rllib/examples/custom_recurrent_rnn_tokenizer.py
@@ -189,8 +189,8 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/custom_recurrent_rnn_tokenizer.py
+++ b/rllib/examples/custom_recurrent_rnn_tokenizer.py
@@ -28,6 +28,10 @@ from ray.rllib.core.models.tf.base import TfModel
 from ray.rllib.algorithms.ppo.ppo import PPOConfig
 from ray.rllib.algorithms.ppo.ppo_catalog import PPOCatalog
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.rllib.core.models.configs import ModelConfig
 
@@ -187,7 +191,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     tuner = tune.Tuner(

--- a/rllib/examples/debugging/deterministic_training.py
+++ b/rllib/examples/debugging/deterministic_training.py
@@ -63,9 +63,7 @@ if __name__ == "__main__":
         # Simplify to run this example script faster.
         config.training(sgd_minibatch_size=10, num_sgd_iter=5)
 
-    stop = {
-        "training_iteration": args.stop_iters,
-    }
+    stop = {TRAINING_ITERATION: args.stop_iters}
 
     results1 = tune.Tuner(
         args.run,

--- a/rllib/examples/debugging/deterministic_training.py
+++ b/rllib/examples/debugging/deterministic_training.py
@@ -8,6 +8,7 @@ import argparse
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.core import DEFAULT_MODULE_ID
 from ray.rllib.examples.envs.classes.env_using_remote_actor import (
     CartPoleWithRemoteParamServer,

--- a/rllib/examples/envs/external_envs/cartpole_server.py
+++ b/rllib/examples/envs/external_envs/cartpole_server.py
@@ -31,6 +31,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.env.policy_server_input import PolicyServerInput
 from ray.rllib.examples.custom_metrics_and_callbacks import MyCallbacks
 from ray.rllib.utils.metrics import (

--- a/rllib/examples/envs/external_envs/cartpole_server.py
+++ b/rllib/examples/envs/external_envs/cartpole_server.py
@@ -271,8 +271,8 @@ if __name__ == "__main__":
         print("Ignoring restore even if previous checkpoint is provided...")
 
         stop = {
-            "training_iteration": args.stop_iters,
-            "num_env_steps_sampled_lifetime": args.stop_timesteps,
+            TRAINING_ITERATION: args.stop_iters,
+            NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
             f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
         }
 

--- a/rllib/examples/envs/external_envs/cartpole_server.py
+++ b/rllib/examples/envs/external_envs/cartpole_server.py
@@ -33,6 +33,11 @@ import ray
 from ray import air, tune
 from ray.rllib.env.policy_server_input import PolicyServerInput
 from ray.rllib.examples.custom_metrics_and_callbacks import MyCallbacks
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.tune.logger import pretty_print
 from ray.tune.registry import get_trainable_cls
 
@@ -253,11 +258,11 @@ if __name__ == "__main__":
             with open(checkpoint_path, "w") as f:
                 f.write(checkpoint.path)
             if (
-                results["episode_reward_mean"] >= args.stop_reward
+                results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] >= args.stop_reward
                 or ts >= args.stop_timesteps
             ):
                 break
-            ts += results["timesteps_total"]
+            ts += results[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
 
         algo.stop()
 
@@ -268,7 +273,7 @@ if __name__ == "__main__":
         stop = {
             "training_iteration": args.stop_iters,
             "num_env_steps_sampled_lifetime": args.stop_timesteps,
-            "env_runner_results/episode_return_mean": args.stop_reward,
+            f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
         }
 
         tune.Tuner(

--- a/rllib/examples/envs/greyscale_env.py
+++ b/rllib/examples/envs/greyscale_env.py
@@ -23,11 +23,13 @@ from supersuit import (
     resize_v1,
 )
 
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.env import PettingZooEnv
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.tune.registry import register_env
 from ray import tune

--- a/rllib/examples/envs/greyscale_env.py
+++ b/rllib/examples/envs/greyscale_env.py
@@ -25,6 +25,10 @@ from supersuit import (
 
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.env import PettingZooEnv
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.tune.registry import register_env
 from ray import tune
 from ray import air
@@ -113,7 +117,7 @@ tune.Tuner(
         stop={
             "training_iteration": args.stop_iters,
             "num_env_steps_sampled_lifetime": args.stop_timesteps,
-            "env_runner_results/episode_return_mean": args.stop_reward,
+            f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
         },
         verbose=2,
     ),

--- a/rllib/examples/envs/greyscale_env.py
+++ b/rllib/examples/envs/greyscale_env.py
@@ -115,8 +115,8 @@ tune.Tuner(
     param_space=config.to_dict(),
     run_config=air.RunConfig(
         stop={
-            "training_iteration": args.stop_iters,
-            "num_env_steps_sampled_lifetime": args.stop_timesteps,
+            TRAINING_ITERATION: args.stop_iters,
+            NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
             f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
         },
         verbose=2,

--- a/rllib/examples/envs/unity3d_env_local.py
+++ b/rllib/examples/envs/unity3d_env_local.py
@@ -30,6 +30,10 @@ import ray
 from ray import air, tune
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.env.wrappers.unity3d_env import Unity3DEnv
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 
 parser = argparse.ArgumentParser()
@@ -183,7 +187,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     # Run the experiment.

--- a/rllib/examples/envs/unity3d_env_local.py
+++ b/rllib/examples/envs/unity3d_env_local.py
@@ -28,11 +28,13 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.env.wrappers.unity3d_env import Unity3DEnv
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.test_utils import check_learning_achieved
 

--- a/rllib/examples/envs/unity3d_env_local.py
+++ b/rllib/examples/envs/unity3d_env_local.py
@@ -185,8 +185,8 @@ if __name__ == "__main__":
         config.training(model={"use_attention": True})
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/evaluation/custom_evaluation.py
+++ b/rllib/examples/evaluation/custom_evaluation.py
@@ -201,7 +201,7 @@ if __name__ == "__main__":
     stop = {
         TRAINING_ITERATION: args.stop_iters,
         f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": (
-            args.stop_reward,
+            args.stop_reward
         ),
         NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
     }

--- a/rllib/examples/evaluation/custom_evaluation.py
+++ b/rllib/examples/evaluation/custom_evaluation.py
@@ -63,6 +63,7 @@ Training iteration 1 -> evaluation round 2
 |          26.1973 | 16000 | 0.872034 |            13.7966 |
 +------------------+-------+----------+--------------------+
 """
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.env.env_runner_group import EnvRunnerGroup
@@ -71,6 +72,7 @@ from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EVALUATION_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.test_utils import (
     add_rllib_example_script_args,
@@ -198,7 +200,9 @@ if __name__ == "__main__":
 
     stop = {
         TRAINING_ITERATION: args.stop_iters,
-        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
+        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": (
+            args.stop_reward,
+        ),
         NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
     }
 

--- a/rllib/examples/evaluation/custom_evaluation.py
+++ b/rllib/examples/evaluation/custom_evaluation.py
@@ -67,7 +67,11 @@ from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.env.env_runner_group import EnvRunnerGroup
 from ray.rllib.examples.envs.classes.simple_corridor import SimpleCorridor
-from ray.rllib.utils.metrics import ENV_RUNNER_RESULTS, EVALUATION_RESULTS
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EVALUATION_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import (
     add_rllib_example_script_args,
     run_rllib_example_script_experiment,
@@ -193,9 +197,9 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "evaluation_results/env_runner_results/episode_return_mean": args.stop_reward,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
     }
 
     run_rllib_example_script_experiment(
@@ -203,7 +207,7 @@ if __name__ == "__main__":
         args,
         stop=stop,
         success_metric={
-            "evaluation_results/env_runner_results/episode_return_mean": (
+            f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": (
                 args.stop_reward
             ),
         },

--- a/rllib/examples/evaluation/evaluation_parallel_to_training.py
+++ b/rllib/examples/evaluation/evaluation_parallel_to_training.py
@@ -68,6 +68,7 @@ the experiment takes considerably longer (~70sec vs ~80sec):
 """
 from typing import Optional
 
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
@@ -264,7 +265,9 @@ if __name__ == "__main__":
 
     stop = {
         TRAINING_ITERATION: args.stop_iters,
-        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
+        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": (
+            args.stop_reward
+        ),
         f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": args.stop_timesteps,
     }
 

--- a/rllib/examples/evaluation/evaluation_parallel_to_training.py
+++ b/rllib/examples/evaluation/evaluation_parallel_to_training.py
@@ -139,9 +139,9 @@ class AssertEvalCallback(DefaultCallbacks):
         # (old API stack: "evaluation").
         eval_results = result.get(EVALUATION_RESULTS, result.get("evaluation", {}))
         # In there, there is a sub-key: ENV_RUNNER_RESULTS
-        # (old API stack: "sampler_results")
+        # (old API stack: "env_runners")
         eval_env_runner_results = eval_results.get(
-            ENV_RUNNER_RESULTS, eval_results.get("sampler_results")
+            ENV_RUNNER_RESULTS, eval_results.get(ENV_RUNNER_RESULTS)
         )
         # Make sure we always run exactly the given evaluation duration,
         # no matter what the other settings are (such as

--- a/rllib/examples/evaluation/evaluation_parallel_to_training.py
+++ b/rllib/examples/evaluation/evaluation_parallel_to_training.py
@@ -73,9 +73,11 @@ from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
     EVALUATION_RESULTS,
     NUM_EPISODES,
     NUM_ENV_STEPS_SAMPLED,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.metrics.metrics_logger import MetricsLogger
 from ray.rllib.utils.test_utils import (
@@ -191,13 +193,11 @@ class AssertEvalCallback(DefaultCallbacks):
                     "Number of run evaluation timesteps: "
                     f"{num_timesteps_reported} (ok)!"
                 )
-        # Expect at least evaluation_results/env_runner_results to be always available.
+        # Expect at least evaluation/env_runners to be always available.
         elif algorithm.config.always_attach_evaluation_results and (
             not eval_env_runner_results
         ):
-            raise KeyError(
-                "`evaluation_results->env_runner_results` not found in result dict!"
-            )
+            raise KeyError("`evaluation->env_runners` not found in result dict!")
 
 
 if __name__ == "__main__":
@@ -263,9 +263,9 @@ if __name__ == "__main__":
         )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "evaluation_results/env_runner_results/episode_return_mean": args.stop_reward,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": args.stop_timesteps,
     }
 
     run_rllib_example_script_experiment(
@@ -273,7 +273,7 @@ if __name__ == "__main__":
         args,
         stop=stop,
         success_metric={
-            "evaluation_results/env_runner_results/episode_return_mean": (
+            f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": (
                 args.stop_reward
             ),
         },

--- a/rllib/examples/evaluation/evaluation_parallel_to_training.py
+++ b/rllib/examples/evaluation/evaluation_parallel_to_training.py
@@ -140,12 +140,9 @@ class AssertEvalCallback(DefaultCallbacks):
     ):
         # The eval results can be found inside the main `result` dict
         # (old API stack: "evaluation").
-        eval_results = result.get(EVALUATION_RESULTS, result.get("evaluation", {}))
-        # In there, there is a sub-key: ENV_RUNNER_RESULTS
-        # (old API stack: "env_runners")
-        eval_env_runner_results = eval_results.get(
-            ENV_RUNNER_RESULTS, eval_results.get(ENV_RUNNER_RESULTS)
-        )
+        eval_results = result.get(EVALUATION_RESULTS, {})
+        # In there, there is a sub-key: ENV_RUNNER_RESULTS.
+        eval_env_runner_results = eval_results.get(ENV_RUNNER_RESULTS)
         # Make sure we always run exactly the given evaluation duration,
         # no matter what the other settings are (such as
         # `evaluation_num_env_runners` or `evaluation_parallel_to_training`).
@@ -268,7 +265,7 @@ if __name__ == "__main__":
         f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": (
             args.stop_reward
         ),
-        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": args.stop_timesteps,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
     }
 
     run_rllib_example_script_experiment(

--- a/rllib/examples/gpus/fractional_gpus.py
+++ b/rllib/examples/gpus/fractional_gpus.py
@@ -111,8 +111,8 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/gpus/fractional_gpus.py
+++ b/rllib/examples/gpus/fractional_gpus.py
@@ -15,6 +15,10 @@ import ray
 from ray import air, tune
 from ray.rllib.examples.envs.classes.gpu_requiring_env import GPURequiringEnv
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.registry import get_trainable_cls
 
@@ -109,7 +113,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     # Note: The above GPU settings should also work in case you are not

--- a/rllib/examples/gpus/fractional_gpus.py
+++ b/rllib/examples/gpus/fractional_gpus.py
@@ -13,11 +13,13 @@ import argparse
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.examples.envs.classes.gpu_requiring_env import GPURequiringEnv
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.test_utils import check_learning_achieved
 from ray.tune.registry import get_trainable_cls

--- a/rllib/examples/hierarchical/hierarchical_training.py
+++ b/rllib/examples/hierarchical/hierarchical_training.py
@@ -36,6 +36,10 @@ from ray.rllib.examples.envs.classes.windy_maze_env import (
     WindyMazeEnv,
     HierarchicalWindyMazeEnv,
 )
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.rllib.utils.test_utils import check_learning_achieved
 
 parser = argparse.ArgumentParser()
@@ -76,7 +80,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     if args.flat:

--- a/rllib/examples/hierarchical/hierarchical_training.py
+++ b/rllib/examples/hierarchical/hierarchical_training.py
@@ -31,6 +31,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.examples.envs.classes.windy_maze_env import (
     WindyMazeEnv,
@@ -39,6 +40,7 @@ from ray.rllib.examples.envs.classes.windy_maze_env import (
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.rllib.utils.test_utils import check_learning_achieved
 

--- a/rllib/examples/hierarchical/hierarchical_training.py
+++ b/rllib/examples/hierarchical/hierarchical_training.py
@@ -78,8 +78,8 @@ if __name__ == "__main__":
     ray.init(local_mode=args.local_mode)
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/inference/policy_inference_after_training.py
+++ b/rllib/examples/inference/policy_inference_after_training.py
@@ -11,10 +11,12 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.tune.registry import get_trainable_cls
 

--- a/rllib/examples/inference/policy_inference_after_training.py
+++ b/rllib/examples/inference/policy_inference_after_training.py
@@ -12,6 +12,10 @@ import os
 import ray
 from ray import air, tune
 from ray.rllib.algorithms.algorithm import Algorithm
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.tune.registry import get_trainable_cls
 
 parser = argparse.ArgumentParser()
@@ -74,7 +78,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     print("Training policy until desired reward/timesteps/iterations. ...")

--- a/rllib/examples/inference/policy_inference_after_training.py
+++ b/rllib/examples/inference/policy_inference_after_training.py
@@ -76,8 +76,8 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/inference/policy_inference_after_training_with_attention.py
+++ b/rllib/examples/inference/policy_inference_after_training_with_attention.py
@@ -102,8 +102,8 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/inference/policy_inference_after_training_with_attention.py
+++ b/rllib/examples/inference/policy_inference_after_training_with_attention.py
@@ -12,10 +12,12 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.tune.registry import get_trainable_cls
 

--- a/rllib/examples/inference/policy_inference_after_training_with_attention.py
+++ b/rllib/examples/inference/policy_inference_after_training_with_attention.py
@@ -13,6 +13,10 @@ import os
 import ray
 from ray import air, tune
 from ray.rllib.algorithms.algorithm import Algorithm
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.tune.registry import get_trainable_cls
 
 parser = argparse.ArgumentParser()
@@ -100,7 +104,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     print("Training policy until desired reward/timesteps/iterations. ...")

--- a/rllib/examples/inference/policy_inference_after_training_with_lstm.py
+++ b/rllib/examples/inference/policy_inference_after_training_with_lstm.py
@@ -95,8 +95,8 @@ if __name__ == "__main__":
     )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 

--- a/rllib/examples/inference/policy_inference_after_training_with_lstm.py
+++ b/rllib/examples/inference/policy_inference_after_training_with_lstm.py
@@ -12,10 +12,12 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.tune.registry import get_trainable_cls
 

--- a/rllib/examples/inference/policy_inference_after_training_with_lstm.py
+++ b/rllib/examples/inference/policy_inference_after_training_with_lstm.py
@@ -13,6 +13,10 @@ import os
 import ray
 from ray import air, tune
 from ray.rllib.algorithms.algorithm import Algorithm
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.tune.registry import get_trainable_cls
 
 parser = argparse.ArgumentParser()
@@ -93,7 +97,7 @@ if __name__ == "__main__":
     stop = {
         "training_iteration": args.stop_iters,
         "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "env_runner_results/episode_return_mean": args.stop_reward,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
     }
 
     print("Training policy until desired reward/timesteps/iterations. ...")

--- a/rllib/examples/learners/ppo_load_rl_modules.py
+++ b/rllib/examples/learners/ppo_load_rl_modules.py
@@ -5,6 +5,7 @@ import tempfile
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.algorithms.ppo.ppo_catalog import PPOCatalog
 from ray.rllib.algorithms.ppo.tf.ppo_tf_rl_module import PPOTfRLModule

--- a/rllib/examples/learners/ppo_load_rl_modules.py
+++ b/rllib/examples/learners/ppo_load_rl_modules.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         "PPO",
         param_space=config.to_dict(),
         run_config=air.RunConfig(
-            stop={"training_iteration": 1},
+            stop={TRAINING_ITERATION: 1},
             failure_config=air.FailureConfig(fail_fast="raise"),
         ),
     )

--- a/rllib/examples/learners/ppo_tuner.py
+++ b/rllib/examples/learners/ppo_tuner.py
@@ -2,6 +2,7 @@ import argparse
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.ppo import PPOConfig
 
 RESOURCE_CONFIG = {

--- a/rllib/examples/learners/ppo_tuner.py
+++ b/rllib/examples/learners/ppo_tuner.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         "PPO",
         param_space=config.to_dict(),
         run_config=air.RunConfig(
-            stop={"training_iteration": 1},
+            stop={TRAINING_ITERATION: 1},
             failure_config=air.FailureConfig(fail_fast="raise"),
         ),
     )

--- a/rllib/examples/learners/train_w_bc_finetune_w_ppo.py
+++ b/rllib/examples/learners/train_w_bc_finetune_w_ppo.py
@@ -11,6 +11,7 @@ from typing import Mapping
 
 import ray
 from ray import tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.train import RunConfig, FailureConfig
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.algorithms.ppo.torch.ppo_torch_rl_module import PPOTorchRLModule

--- a/rllib/examples/learners/train_w_bc_finetune_w_ppo.py
+++ b/rllib/examples/learners/train_w_bc_finetune_w_ppo.py
@@ -129,7 +129,7 @@ def train_ppo_agent_from_checkpointed_module(
         "PPO",
         param_space=config.to_dict(),
         run_config=RunConfig(
-            stop={"training_iteration": 20},
+            stop={TRAINING_ITERATION: 20},
             failure_config=FailureConfig(fail_fast="raise"),
             verbose=2,
         ),

--- a/rllib/examples/multi_agent/rock_paper_scissors_heuristic_vs_learned.py
+++ b/rllib/examples/multi_agent/rock_paper_scissors_heuristic_vs_learned.py
@@ -32,6 +32,7 @@ import random
 import gymnasium as gym
 from pettingzoo.classic import rps_v2
 
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.connectors.env_to_module import (
     AddObservationsFromEpisodesToBatch,
     FlattenObservations,
@@ -40,6 +41,10 @@ from ray.rllib.connectors.env_to_module import (
 from ray.rllib.core.rl_module.marl_module import MultiAgentRLModuleSpec
 from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
 from ray.rllib.env.wrappers.pettingzoo_env import ParallelPettingZooEnv
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.rllib.utils.test_utils import (
     add_rllib_example_script_args,
     run_rllib_example_script_experiment,
@@ -135,9 +140,9 @@ if __name__ == "__main__":
 
     # Make `args.stop_reward` "point" to the reward of the learned policy.
     stop = {
-        "training_iteration": args.stop_iters,
-        "env_runner_results/module_episode_returns_mean/learned": args.stop_reward,
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
+        f"{ENV_RUNNER_RESULTS}/module_episode_returns_mean/learned": args.stop_reward,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
     }
 
     run_rllib_example_script_experiment(
@@ -145,6 +150,8 @@ if __name__ == "__main__":
         args,
         stop=stop,
         success_metric={
-            "env_runner_results/module_episode_returns_mean/learned": args.stop_reward,
+            f"{ENV_RUNNER_RESULTS}/module_episode_returns_mean/learned": (
+                args.stop_reward
+            ),
         },
     )

--- a/rllib/examples/multi_agent/self_play_league_based_with_open_spiel.py
+++ b/rllib/examples/multi_agent/self_play_league_based_with_open_spiel.py
@@ -34,6 +34,7 @@ import functools
 import numpy as np
 
 import ray
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.core.rl_module.marl_module import MultiAgentRLModuleSpec
 from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
 from ray.rllib.env.utils import try_import_pyspiel, try_import_open_spiel
@@ -46,6 +47,7 @@ from ray.rllib.examples.multi_agent.utils import (
 from ray.rllib.examples._old_api_stack.policy.random_policy import RandomPolicy
 from ray.rllib.examples.rl_modules.classes.random_rlm import RandomRLModule
 from ray.rllib.policy.policy import PolicySpec
+from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
 from ray.rllib.utils.test_utils import (
     add_rllib_example_script_args,
     run_rllib_example_script_experiment,
@@ -217,8 +219,8 @@ if __name__ == "__main__":
     results = None
     if not args.from_checkpoint:
         stop = {
-            "num_env_steps_sampled_lifetime": args.stop_timesteps,
-            "training_iteration": args.stop_iters,
+            NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
+            TRAINING_ITERATION: args.stop_iters,
             "league_size": args.min_league_size,
         }
         results = run_rllib_example_script_experiment(config, args, stop=stop)

--- a/rllib/examples/multi_agent/self_play_with_open_spiel.py
+++ b/rllib/examples/multi_agent/self_play_with_open_spiel.py
@@ -35,6 +35,7 @@ from ray.rllib.examples.multi_agent.utils import (
 )
 from ray.rllib.examples._old_api_stack.policy.random_policy import RandomPolicy
 from ray.rllib.policy.policy import PolicySpec
+from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
 from ray.rllib.utils.test_utils import (
     add_rllib_example_script_args,
     run_rllib_example_script_experiment,

--- a/rllib/examples/multi_agent/self_play_with_open_spiel.py
+++ b/rllib/examples/multi_agent/self_play_with_open_spiel.py
@@ -22,6 +22,7 @@ import functools
 
 import numpy as np
 
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
 from ray.rllib.core.rl_module.marl_module import MultiAgentRLModuleSpec
 from ray.rllib.env.utils import try_import_pyspiel, try_import_open_spiel
@@ -179,8 +180,8 @@ if __name__ == "__main__":
         config.training(num_sgd_iter=20)
 
     stop = {
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "training_iteration": args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
         "league_size": args.min_league_size,
     }
 

--- a/rllib/examples/multi_agent/two_algorithms.py
+++ b/rllib/examples/multi_agent/two_algorithms.py
@@ -23,6 +23,10 @@ from ray.rllib.algorithms.ppo import (
     PPOTorchPolicy,
 )
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.tune.logger import pretty_print
 from ray.tune.registry import register_env
 
@@ -173,8 +177,8 @@ if __name__ == "__main__":
         # Test passed gracefully.
         if (
             args.as_test
-            and result_dqn["episode_reward_mean"] > args.stop_reward
-            and result_ppo["episode_reward_mean"] > args.stop_reward
+            and result_dqn[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] > args.stop_reward
+            and result_ppo[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] > args.stop_reward
         ):
             print("test passed (both agents above requested reward)")
             quit(0)

--- a/rllib/examples/offline_rl/custom_input_api.py
+++ b/rllib/examples/offline_rl/custom_input_api.py
@@ -18,6 +18,11 @@ import os
 import ray
 from ray import air, tune
 from ray.rllib.offline import JsonReader, ShuffledInput, IOContext, InputReader
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+)
 from ray.tune.registry import get_trainable_cls, register_input
 
 parser = argparse.ArgumentParser()
@@ -118,8 +123,8 @@ if __name__ == "__main__":
         )
 
     stop = {
-        "training_iteration": args.stop_iters,
-        "evaluation_results/env_runner_results/episode_return_mean": -600,
+        TRAINING_ITERATION: args.stop_iters,
+        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -600,
     }
 
     tuner = tune.Tuner(

--- a/rllib/examples/offline_rl/custom_input_api.py
+++ b/rllib/examples/offline_rl/custom_input_api.py
@@ -17,6 +17,7 @@ import os
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.offline import JsonReader, ShuffledInput, IOContext, InputReader
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,

--- a/rllib/examples/offline_rl/offline_rl.py
+++ b/rllib/examples/offline_rl/offline_rl.py
@@ -113,7 +113,9 @@ if __name__ == "__main__":
         print(f"Iter {i}")
         eval_results = cql_algorithm.train().get("evaluation")
         if eval_results:
-            print("... R={}".format(eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]))
+            print(
+                "... R={}".format(eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN])
+            )
             # Learn until some reward is reached on an actual live env.
             if eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] >= min_reward:
                 # Test passed gracefully.

--- a/rllib/examples/offline_rl/offline_rl.py
+++ b/rllib/examples/offline_rl/offline_rl.py
@@ -24,9 +24,13 @@ import numpy as np
 
 from ray.rllib.policy.sample_batch import convert_ma_batch_to_sample_batch
 from ray.rllib.algorithms import cql as cql
-from ray.rllib.utils.framework import try_import_torch
 from ray.rllib.execution.rollout_ops import (
     synchronous_parallel_sample,
+)
+from ray.rllib.utils.framework import try_import_torch
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
 )
 
 torch, _ = try_import_torch()
@@ -109,9 +113,9 @@ if __name__ == "__main__":
         print(f"Iter {i}")
         eval_results = cql_algorithm.train().get("evaluation")
         if eval_results:
-            print("... R={}".format(eval_results["episode_reward_mean"]))
+            print("... R={}".format(eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]))
             # Learn until some reward is reached on an actual live env.
-            if eval_results["episode_reward_mean"] >= min_reward:
+            if eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] >= min_reward:
                 # Test passed gracefully.
                 if args.as_test:
                     print("Test passed after {} iterations.".format(i))

--- a/rllib/examples/ray_tune/custom_experiment.py
+++ b/rllib/examples/ray_tune/custom_experiment.py
@@ -44,6 +44,7 @@ import numpy as np
 from ray import train, tune
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.utils.framework import try_import_torch
+from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
 
 torch, _ = try_import_torch()
 

--- a/rllib/examples/ray_tune/custom_experiment.py
+++ b/rllib/examples/ray_tune/custom_experiment.py
@@ -69,7 +69,7 @@ def my_experiment(config: Dict):
         # Add the phase to the result dict.
         train_results["phase"] = 1
         train.report(train_results)
-        phase_high_lr_time = train_results["num_env_steps_sampled_lifetime"]
+        phase_high_lr_time = train_results[NUM_ENV_STEPS_SAMPLED_LIFETIME]
     checkpoint_training_high_lr = algo_high_lr.save()
     algo_high_lr.stop()
 
@@ -83,7 +83,7 @@ def my_experiment(config: Dict):
         # Add the phase to the result dict.
         train_results["phase"] = 2
         # keep time moving forward
-        train_results["num_env_steps_sampled_lifetime"] += phase_high_lr_time
+        train_results[NUM_ENV_STEPS_SAMPLED_LIFETIME] += phase_high_lr_time
         train.report(train_results)
 
     checkpoint_training_low_lr = algo_low_lr.save()

--- a/rllib/examples/ray_tune/custom_logger.py
+++ b/rllib/examples/ray_tune/custom_logger.py
@@ -70,7 +70,7 @@ class MyPrintLogger(Logger):
 
     def on_result(self, result: dict):
         # Define, what should happen on receiving a `result` (dict).
-        mean_return = result["env_runner_results"]["episode_return_mean"]
+        mean_return = result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
         pi_loss = result["learner_results"]["default_policy"]["policy_loss"]
         print(f"{self.prefix} " f"Avg-return: {mean_return} " f"pi-loss: {pi_loss}")
 

--- a/rllib/examples/ray_tune/custom_logger.py
+++ b/rllib/examples/ray_tune/custom_logger.py
@@ -52,9 +52,11 @@ Closing
 
 from ray import air, tune
 from ray.rllib.algorithms.ppo import PPOConfig
+from ray.rllib.core import DEFAULT_MODULE_ID
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    LEARNER_RESULTS,
 )
 from ray.tune.logger import Logger, LegacyLoggerCallback
 
@@ -71,7 +73,7 @@ class MyPrintLogger(Logger):
     def on_result(self, result: dict):
         # Define, what should happen on receiving a `result` (dict).
         mean_return = result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
-        pi_loss = result["learner_results"]["default_policy"]["policy_loss"]
+        pi_loss = result[LEARNER_RESULTS][DEFAULT_MODULE_ID]["policy_loss"]
         print(f"{self.prefix} " f"Avg-return: {mean_return} " f"pi-loss: {pi_loss}")
 
     def close(self):

--- a/rllib/examples/ray_tune/custom_logger.py
+++ b/rllib/examples/ray_tune/custom_logger.py
@@ -52,6 +52,10 @@ Closing
 
 from ray import air, tune
 from ray.rllib.algorithms.ppo import PPOConfig
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.tune.logger import Logger, LegacyLoggerCallback
 
 
@@ -119,7 +123,7 @@ if __name__ == "__main__":
         )
     )
 
-    stop = {"env_runner_results/episode_return_mean": 200.0}
+    stop = {f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 200.0}
 
     # Run the actual experiment (using Tune).
     results = tune.Tuner(

--- a/rllib/examples/ray_tune/custom_progress_reporter.py
+++ b/rllib/examples/ray_tune/custom_progress_reporter.py
@@ -46,6 +46,10 @@ You should see something similar to the following in your console output:
 from ray import air, tune
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 
 
 my_multi_agent_progress_reporter = tune.CLIReporter(
@@ -61,7 +65,7 @@ my_multi_agent_progress_reporter = tune.CLIReporter(
             "num_env_steps_sampled_lifetime": "ts",
             # RLlib always sums up all agents' rewards and reports it under:
             # result_dict[env_runner_results][episode_return_mean].
-            "env_runner_results/episode_return_mean": "combined return",
+            f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": "combined return",
         },
         # Because RLlib sums up all returns of all agents, we would like to also
         # see the individual agents' returns. We can find these under the result dict's
@@ -102,7 +106,7 @@ if __name__ == "__main__":
         )
     )
 
-    stop = {"env_runner_results/episode_return_mean": 200.0}
+    stop = {f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 200.0}
 
     # Run the actual experiment (using Tune).
     results = tune.Tuner(

--- a/rllib/examples/ray_tune/custom_progress_reporter.py
+++ b/rllib/examples/ray_tune/custom_progress_reporter.py
@@ -44,11 +44,13 @@ You should see something similar to the following in your console output:
 
 """
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 
 

--- a/rllib/examples/ray_tune/custom_progress_reporter.py
+++ b/rllib/examples/ray_tune/custom_progress_reporter.py
@@ -60,18 +60,18 @@ my_multi_agent_progress_reporter = tune.CLIReporter(
     # exact path.
     metric_columns={
         **{
-            "training_iteration": "iter",
+            TRAINING_ITERATION: "iter",
             "time_total_s": "total time (s)",
-            "num_env_steps_sampled_lifetime": "ts",
+            NUM_ENV_STEPS_SAMPLED_LIFETIME: "ts",
             # RLlib always sums up all agents' rewards and reports it under:
-            # result_dict[env_runner_results][episode_return_mean].
+            # result_dict[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN].
             f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": "combined return",
         },
         # Because RLlib sums up all returns of all agents, we would like to also
         # see the individual agents' returns. We can find these under the result dict's
-        # 'env_runner_results/module_episode_returns_mean/' key (then the policy ID):
+        # 'env_runners/module_episode_returns_mean/' key (then the policy ID):
         **{
-            f"env_runner_results/module_episode_returns_mean/{pid}": f"return {pid}"
+            f"{ENV_RUNNER_RESULTS}/module_episode_returns_mean/{pid}": f"return {pid}"
             for pid in ["policy1", "policy2", "policy3"]
         },
     },

--- a/rllib/examples/replay_buffer_api.py
+++ b/rllib/examples/replay_buffer_api.py
@@ -13,8 +13,10 @@ import argparse
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.dqn import DQNConfig
 from ray.rllib.utils.framework import try_import_tf
+from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
 from ray.rllib.utils.replay_buffers.replay_buffer import StorageUnit
 
 tf1, tf, tfv = try_import_tf()

--- a/rllib/examples/replay_buffer_api.py
+++ b/rllib/examples/replay_buffer_api.py
@@ -65,8 +65,8 @@ if __name__ == "__main__":
     )
 
     stop_config = {
-        "num_env_steps_sampled_lifetime": args.stop_timesteps,
-        "training_iteration": args.stop_iters,
+        NUM_ENV_STEPS_SAMPLED_LIFETIME: args.stop_timesteps,
+        TRAINING_ITERATION: args.stop_iters,
     }
 
     results = tune.Tuner(

--- a/rllib/models/tests/test_attention_nets.py
+++ b/rllib/models/tests/test_attention_nets.py
@@ -79,7 +79,7 @@ class TestAttentionNets(unittest.TestCase):
             tune.Tuner(
                 "PPO",
                 param_space=config,
-                run_config=air.RunConfig(stop={"training_iteration": 1}, verbose=1),
+                run_config=air.RunConfig(stop={TRAINING_ITERATION: 1}, verbose=1),
             ).fit()
 
     def test_ppo_attention_net_learning(self):

--- a/rllib/models/tests/test_attention_nets.py
+++ b/rllib/models/tests/test_attention_nets.py
@@ -2,8 +2,8 @@ from gymnasium.spaces import Box, Dict, Discrete, MultiDiscrete, Tuple
 import unittest
 
 import ray
-from ray import air
-from ray import tune
+from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.examples.envs.classes.random_env import RandomEnv
 from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole
 from ray.rllib.models.catalog import ModelCatalog

--- a/rllib/models/tests/test_attention_nets.py
+++ b/rllib/models/tests/test_attention_nets.py
@@ -104,7 +104,7 @@ class TestAttentionNets(unittest.TestCase):
                         "position_wise_mlp_dim": 32,
                     },
                 },
-            }
+            },
         )
         tune.Tuner(
             "PPO",

--- a/rllib/models/tests/test_attention_nets.py
+++ b/rllib/models/tests/test_attention_nets.py
@@ -8,6 +8,11 @@ from ray.rllib.examples.envs.classes.random_env import RandomEnv
 from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole
 from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.models.tf.attention_net import GTrXLNet
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.rllib.utils.test_utils import framework_iterator
 
 
@@ -21,8 +26,8 @@ class TestAttentionNets(unittest.TestCase):
     }
 
     stop = {
-        "episode_reward_mean": 150.0,
-        "timesteps_total": 5000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 150.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 5000000,
     }
 
     @classmethod

--- a/rllib/models/tests/test_lstms.py
+++ b/rllib/models/tests/test_lstms.py
@@ -67,7 +67,7 @@ class TestLSTMs(unittest.TestCase):
             tune.Tuner(
                 "PPO",
                 param_space=config.to_dict(),
-                run_config=air.RunConfig(stop={"training_iteration": 1}, verbose=1),
+                run_config=air.RunConfig(stop={TRAINING_ITERATION: 1}, verbose=1),
             ).fit()
 
 

--- a/rllib/models/tests/test_lstms.py
+++ b/rllib/models/tests/test_lstms.py
@@ -2,8 +2,8 @@ from gymnasium.spaces import Box, Dict, Discrete, MultiDiscrete, Tuple
 import unittest
 
 import ray
-from ray import air
-from ray import tune
+from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms import ppo
 from ray.rllib.examples.envs.classes.random_env import RandomEnv
 from ray.rllib.utils.test_utils import framework_iterator

--- a/rllib/offline/estimators/tests/test_ope.py
+++ b/rllib/offline/estimators/tests/test_ope.py
@@ -232,7 +232,7 @@ class TestOPE(unittest.TestCase):
         # Test OPE in DQN, during training as well as by calling evaluate()
         algo = self.config_dqn_on_cartpole.build()
         results = algo.train()
-        ope_results = results["evaluation_results"]["off_policy_estimator"]
+        ope_results = results[EVALUATION_RESULTS]["off_policy_estimator"]
         # Check that key exists AND is not {}
         self.assertEqual(set(ope_results.keys()), {"is", "wis", "dm_fqe", "dr_fqe"})
 

--- a/rllib/offline/estimators/tests/test_ope.py
+++ b/rllib/offline/estimators/tests/test_ope.py
@@ -28,6 +28,7 @@ from ray.rllib.offline.estimators import (
 from ray.rllib.offline.estimators.fqe_torch_model import FQETorchModel
 from ray.rllib.policy.sample_batch import SampleBatch, concat_samples
 from ray.rllib.utils.framework import try_import_torch
+from ray.rllib.utils.metrics import EVALUATION_RESULTS
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.test_utils import check
 

--- a/rllib/scripts.py
+++ b/rllib/scripts.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from rich.table import Table
 import typer
 
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib import train as train_module
 from ray.rllib.common import CLIArguments as cli
 from ray.rllib.common import (

--- a/rllib/scripts.py
+++ b/rllib/scripts.py
@@ -108,7 +108,7 @@ def run(example_id: str = typer.Argument(..., help="Example ID to run.")):
         checkpoint_freq=1,
         checkpoint_at_end=True,
         keep_checkpoints_num=None,
-        checkpoint_score_attr="training_iteration",
+        checkpoint_score_attr=TRAINING_ITERATION,
         framework=FrameworkEnum.tf2,
         v=True,
         vv=False,

--- a/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
+++ b/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
     stop = experiment_config.get("stop", {})
     # .. but override with command line provided ones.
     if args.stop_iters:
-        stop["training_iteration"] = args.stop_iters
+        stop[TRAINING_ITERATION] = args.stop_iters
     if args.stop_timesteps:
         stop[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] = args.stop_timesteps
     if args.stop_reward:
@@ -224,7 +224,7 @@ if __name__ == "__main__":
 
     # Criterion is to have reached some min reward within given
     # wall time, iters, or timesteps.
-    if stop.get("episode_return_mean") is not None:
+    if stop.get(EPISODE_RETURN_MEAN) is not None:
         max_avg_reward = np.max(
             [r[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] for r in last_results]
         )

--- a/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
+++ b/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
@@ -32,7 +32,11 @@ import os
 import subprocess
 import yaml
 
-from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -153,7 +157,8 @@ if __name__ == "__main__":
 
     # Invalid pass criteria.
     if stop.get("episode_reward_mean") is None and (
-        stop.get(f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}") is None or stop.get("time_total_s") is None
+        stop.get(f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}") is None
+        or stop.get("time_total_s") is None
     ):
         raise ValueError(
             "Invalid pass criterium! Must use either "
@@ -220,15 +225,21 @@ if __name__ == "__main__":
     # Criterion is to have reached some min reward within given
     # wall time, iters, or timesteps.
     if stop.get("episode_return_mean") is not None:
-        max_avg_reward = np.max([r[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] for r in last_results])
+        max_avg_reward = np.max(
+            [r[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] for r in last_results]
+        )
         if max_avg_reward < stop[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]:
             raise ValueError(
-                "`stop-reward` of {} not reached!".format(stop[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"])
+                "`stop-reward` of {} not reached!".format(
+                    stop[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]
+                )
             )
     # Criterion is to have run through n env timesteps in some wall time m
     # (minimum throughput).
     else:
-        total_timesteps = np.sum([r[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] for r in last_results])
+        total_timesteps = np.sum(
+            [r[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] for r in last_results]
+        )
         total_time = np.sum([r["time_total_s"] for r in last_results])
         desired_speed = stop[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] / stop["time_total_s"]
         actual_speed = total_timesteps / total_time

--- a/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
+++ b/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
@@ -32,6 +32,7 @@ import os
 import subprocess
 import yaml
 
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,

--- a/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
+++ b/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
@@ -32,6 +32,8 @@ import os
 import subprocess
 import yaml
 
+from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
+
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--run",
@@ -143,7 +145,7 @@ if __name__ == "__main__":
     if args.stop_iters:
         stop["training_iteration"] = args.stop_iters
     if args.stop_timesteps:
-        stop["timesteps_total"] = args.stop_timesteps
+        stop[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] = args.stop_timesteps
     if args.stop_reward:
         stop["episode_reward_mean"] = args.stop_reward
     if args.stop_time:
@@ -151,7 +153,7 @@ if __name__ == "__main__":
 
     # Invalid pass criteria.
     if stop.get("episode_reward_mean") is None and (
-        stop.get("timesteps_total") is None or stop.get("time_total_s") is None
+        stop.get(f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}") is None or stop.get("time_total_s") is None
     ):
         raise ValueError(
             "Invalid pass criterium! Must use either "
@@ -217,25 +219,25 @@ if __name__ == "__main__":
 
     # Criterion is to have reached some min reward within given
     # wall time, iters, or timesteps.
-    if stop.get("episode_reward_mean") is not None:
-        max_avg_reward = np.max([r["episode_reward_mean"] for r in last_results])
-        if max_avg_reward < stop["episode_reward_mean"]:
+    if stop.get("episode_return_mean") is not None:
+        max_avg_reward = np.max([r[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN] for r in last_results])
+        if max_avg_reward < stop[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]:
             raise ValueError(
-                "`stop-reward` of {} not reached!".format(stop["episode_reward_mean"])
+                "`stop-reward` of {} not reached!".format(stop[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"])
             )
     # Criterion is to have run through n env timesteps in some wall time m
     # (minimum throughput).
     else:
-        total_timesteps = np.sum([r["timesteps_total"] for r in last_results])
+        total_timesteps = np.sum([r[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] for r in last_results])
         total_time = np.sum([r["time_total_s"] for r in last_results])
-        desired_speed = stop["timesteps_total"] / stop["time_total_s"]
+        desired_speed = stop[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] / stop["time_total_s"]
         actual_speed = total_timesteps / total_time
         # We stopped because we reached the time limit ->
         # Means throughput is too slow (time steps not reached).
         if actual_speed < desired_speed:
             raise ValueError(
                 "`stop-timesteps` of {} not reached in {}sec!".format(
-                    stop["timesteps_total"], stop["time_total_s"]
+                    stop[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], stop["time_total_s"]
                 )
             )
 

--- a/rllib/tests/mock_worker.py
+++ b/rllib/tests/mock_worker.py
@@ -54,7 +54,7 @@ class _MockWorker:
 
 class _MockWorkerSet(EnvRunnerGroup):
     def __init__(self, num_mock_workers):
-        super().__init__(local_worker=False, _setup=False)
+        super().__init__(local_env_runner=False, _setup=False)
         self.add_workers(num_workers=num_mock_workers, validate=False)
 
     def _make_worker(self, *args, **kwargs):

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -33,6 +33,7 @@ from ray.rllib.utils.deprecation import deprecation_warning
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
 )
 from ray.tune import run_experiments
 
@@ -288,7 +289,8 @@ if __name__ == "__main__":
                 # not, use `episode_return_mean`.
                 if check_eval:
                     min_reward = t.stopping_criterion.get(
-                        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}",
+                        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/"
+                        f"{EPISODE_RETURN_MEAN}",
                         t.stopping_criterion.get(
                             f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
                         ),

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -30,6 +30,10 @@ from ray.rllib import _register_all
 from ray.rllib.common import SupportedFileType
 from ray.rllib.train import load_experiments_from_file
 from ray.rllib.utils.deprecation import deprecation_warning
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.tune import run_experiments
 
 parser = argparse.ArgumentParser()
@@ -193,7 +197,7 @@ if __name__ == "__main__":
         # long learning tests such as sac and ddpg on the pendulum environment.
         if args.override_mean_reward != 0.0:
             exp["stop"][
-                "env_runner_results/episode_return_mean"
+                f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
             ] = args.override_mean_reward
 
         # Checkpoint settings.
@@ -271,7 +275,7 @@ if __name__ == "__main__":
                     ]
                     if check_eval
                     else (
-                        # Some algos don't store sampler results under `sampler_results`
+                        # Some algos don't store sampler results under `env_runners`
                         # e.g. ARS. Need to keep this logic around for now.
                         t.last_result["env_runner_results"]["episode_return_mean"]
                         if "env_runner_results" in t.last_result
@@ -281,18 +285,18 @@ if __name__ == "__main__":
 
                 # If we are using evaluation workers, we may have
                 # a stopping criterion under the "evaluation/" scope. If
-                # not, use `episode_reward_mean`.
+                # not, use `episode_return_mean`.
                 if check_eval:
                     min_reward = t.stopping_criterion.get(
                         "evaluation_results/env_runner_results/episode_return_mean",
                         t.stopping_criterion.get(
-                            "env_runner_results/episode_return_mean"
+                            f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
                         ),
                     )
-                # Otherwise, expect `episode_reward_mean` to be set.
+                # Otherwise, expect `env_runners/episode_return_mean` to be set.
                 else:
                     min_reward = t.stopping_criterion.get(
-                        "env_runner_results/episode_return_mean"
+                        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
                     )
 
                 # If min reward not defined, always pass.

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -270,16 +270,16 @@ if __name__ == "__main__":
                 # we evaluate against an actual environment.
                 check_eval = bool(exp["config"].get("evaluation_interval"))
                 reward_mean = (
-                    t.last_result["evaluation_results"]["env_runner_results"][
-                        "episode_return_mean"
+                    t.last_result[EVALUATION_RESULTS][ENV_RUNNER_RESULTS][
+                        EPISODE_RETURN_MEAN
                     ]
                     if check_eval
                     else (
                         # Some algos don't store sampler results under `env_runners`
                         # e.g. ARS. Need to keep this logic around for now.
-                        t.last_result["env_runner_results"]["episode_return_mean"]
-                        if "env_runner_results" in t.last_result
-                        else t.last_result["episode_return_mean"]
+                        t.last_result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
+                        if ENV_RUNNER_RESULTS in t.last_result
+                        else t.last_result[EPISODE_RETURN_MEAN]
                     )
                 )
 
@@ -288,7 +288,7 @@ if __name__ == "__main__":
                 # not, use `episode_return_mean`.
                 if check_eval:
                     min_reward = t.stopping_criterion.get(
-                        "evaluation_results/env_runner_results/episode_return_mean",
+                        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}",
                         t.stopping_criterion.get(
                             f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
                         ),

--- a/rllib/tests/test_custom_resource.py
+++ b/rllib/tests/test_custom_resource.py
@@ -24,7 +24,7 @@ def test_custom_resource(algorithm):
         .env_runners(num_env_runners=1)
         .resources(num_gpus=0, custom_resources_per_worker={"custom_resource": 0.01})
     )
-    stop = {"training_iteration": 1}
+    stop = {TRAINING_ITERATION: 1}
 
     tune.Tuner(
         algorithm,

--- a/rllib/tests/test_custom_resource.py
+++ b/rllib/tests/test_custom_resource.py
@@ -1,8 +1,8 @@
 import pytest
 
 import ray
-from ray import air
-from ray import tune
+from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.tune.registry import get_trainable_cls
 
 

--- a/rllib/tests/test_eager_support.py
+++ b/rllib/tests/test_eager_support.py
@@ -1,8 +1,8 @@
 import unittest
 
 import ray
-from ray import air
-from ray import tune
+from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.utils.framework import try_import_tf
 from ray.tune.registry import get_trainable_cls
 

--- a/rllib/tests/test_eager_support.py
+++ b/rllib/tests/test_eager_support.py
@@ -29,7 +29,7 @@ def check_support(alg, config, test_eager=False, test_trace=True):
             tune.Tuner(
                 a,
                 param_space=config,
-                run_config=air.RunConfig(stop={"training_iteration": 1}, verbose=1),
+                run_config=air.RunConfig(stop={TRAINING_ITERATION: 1}, verbose=1),
             ).fit()
         if test_trace:
             config["eager_tracing"] = True
@@ -37,7 +37,7 @@ def check_support(alg, config, test_eager=False, test_trace=True):
             tune.Tuner(
                 a,
                 param_space=config,
-                run_config=air.RunConfig(stop={"training_iteration": 1}, verbose=1),
+                run_config=air.RunConfig(stop={TRAINING_ITERATION: 1}, verbose=1),
             ).fit()
 
 

--- a/rllib/tests/test_gpus.py
+++ b/rllib/tests/test_gpus.py
@@ -77,7 +77,7 @@ class TestGPUs(unittest.TestCase):
                                     "PPO",
                                     param_space=config,
                                     run_config=air.RunConfig(
-                                        stop={"training_iteration": 0}
+                                        stop={TRAINING_ITERATION: 0}
                                     ),
                                 ).fit()
         ray.shutdown()
@@ -105,7 +105,7 @@ class TestGPUs(unittest.TestCase):
                     tune.Tuner(
                         "PPO",
                         param_space=config,
-                        run_config=air.RunConfig(stop={"training_iteration": 0}),
+                        run_config=air.RunConfig(stop={TRAINING_ITERATION: 0}),
                     ).fit()
 
         ray.shutdown()

--- a/rllib/tests/test_gpus.py
+++ b/rllib/tests/test_gpus.py
@@ -2,6 +2,7 @@ import unittest
 
 import ray
 from ray import air
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.utils.framework import try_import_torch
 from ray.rllib.utils.test_utils import framework_iterator

--- a/rllib/tests/test_io.py
+++ b/rllib/tests/test_io.py
@@ -115,7 +115,9 @@ class AgentIOTest(unittest.TestCase):
             print("WROTE TO: ", self.test_dir)
             algo = config.build()
             result = algo.train()
-            self.assertEqual(result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], 250)  # read from input
+            self.assertEqual(
+                result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], 250
+            )  # read from input
             self.assertTrue(np.isnan(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]))
 
     def test_split_by_episode(self):
@@ -164,7 +166,9 @@ class AgentIOTest(unittest.TestCase):
 
             algo = config.build()
             result = algo.train()
-            self.assertEqual(result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], 250)  # read from input
+            self.assertEqual(
+                result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], 250
+            )  # read from input
             self.assertTrue(np.isnan(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]))
             algo.stop()
 
@@ -207,7 +211,9 @@ class AgentIOTest(unittest.TestCase):
             config.offline_data(input_=glob.glob(self.test_dir + fw + "/*.json"))
             algo = config.build()
             result = algo.train()
-            self.assertEqual(result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], 250)  # read from input
+            self.assertEqual(
+                result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], 250
+            )  # read from input
             self.assertTrue(np.isnan(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]))
             algo.stop()
 
@@ -223,7 +229,9 @@ class AgentIOTest(unittest.TestCase):
             )
             algo = config.build()
             result = algo.train()
-            self.assertTrue(not np.isnan(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]))
+            self.assertTrue(
+                not np.isnan(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN])
+            )
             algo.stop()
 
     def test_custom_input_procedure(self):
@@ -256,7 +264,9 @@ class AgentIOTest(unittest.TestCase):
                 algo = config.build()
                 result = algo.train()
                 self.assertEqual(result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], 4000)
-                self.assertTrue(np.isnan(result[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]))
+                self.assertTrue(
+                    np.isnan(result[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"])
+                )
                 algo.stop()
 
     def test_multiple_output_workers(self):

--- a/rllib/tests/test_io.py
+++ b/rllib/tests/test_io.py
@@ -25,6 +25,12 @@ from ray.rllib.offline import (
 from ray.rllib.offline.json_reader import from_json_data
 from ray.rllib.offline.json_writer import _to_json_dict, _to_json
 from ray.rllib.policy.sample_batch import SampleBatch, convert_ma_batch_to_sample_batch
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.rllib.utils.test_utils import framework_iterator
 
 SAMPLES = SampleBatch(
@@ -109,8 +115,8 @@ class AgentIOTest(unittest.TestCase):
             print("WROTE TO: ", self.test_dir)
             algo = config.build()
             result = algo.train()
-            self.assertEqual(result["timesteps_total"], 250)  # read from input
-            self.assertTrue(np.isnan(result["episode_reward_mean"]))
+            self.assertEqual(result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], 250)  # read from input
+            self.assertTrue(np.isnan(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]))
 
     def test_split_by_episode(self):
         splits = SAMPLES.split_by_episode()
@@ -158,8 +164,8 @@ class AgentIOTest(unittest.TestCase):
 
             algo = config.build()
             result = algo.train()
-            self.assertEqual(result["timesteps_total"], 250)  # read from input
-            self.assertTrue(np.isnan(result["episode_reward_mean"]))
+            self.assertEqual(result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], 250)  # read from input
+            self.assertTrue(np.isnan(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]))
             algo.stop()
 
     def test_agent_input_eval_sampler(self):
@@ -181,10 +187,10 @@ class AgentIOTest(unittest.TestCase):
             algo = config.build()
             result = algo.train()
             assert np.isnan(
-                result["episode_reward_mean"]
+                result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
             ), "episode reward should not be computed for offline data"
             assert not np.isnan(
-                result["evaluation"]["episode_reward_mean"]
+                result[EVALUATION_RESULTS][ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
             ), "Did not see simulation results during evaluation"
             algo.stop()
 
@@ -201,8 +207,8 @@ class AgentIOTest(unittest.TestCase):
             config.offline_data(input_=glob.glob(self.test_dir + fw + "/*.json"))
             algo = config.build()
             result = algo.train()
-            self.assertEqual(result["timesteps_total"], 250)  # read from input
-            self.assertTrue(np.isnan(result["episode_reward_mean"]))
+            self.assertEqual(result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], 250)  # read from input
+            self.assertTrue(np.isnan(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]))
             algo.stop()
 
     def test_agent_input_dict(self):
@@ -217,7 +223,7 @@ class AgentIOTest(unittest.TestCase):
             )
             algo = config.build()
             result = algo.train()
-            self.assertTrue(not np.isnan(result["episode_reward_mean"]))
+            self.assertTrue(not np.isnan(result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]))
             algo.stop()
 
     def test_custom_input_procedure(self):
@@ -249,8 +255,8 @@ class AgentIOTest(unittest.TestCase):
                 config.offline_data(input_config={"input_files": self.test_dir + fw})
                 algo = config.build()
                 result = algo.train()
-                self.assertEqual(result["timesteps_total"], 4000)
-                self.assertTrue(np.isnan(result["episode_reward_mean"]))
+                self.assertEqual(result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"], 4000)
+                self.assertTrue(np.isnan(result[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]))
                 algo.stop()
 
     def test_multiple_output_workers(self):

--- a/rllib/tests/test_placement_groups.py
+++ b/rllib/tests/test_placement_groups.py
@@ -2,10 +2,10 @@ import os
 import unittest
 
 import ray
-from ray import air
-from ray import tune
-from ray.tune import Callback
+from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.ppo import PPO, PPOConfig
+from ray.tune import Callback
 from ray.tune.experiment import Trial
 from ray.tune.execution.placement_groups import PlacementGroupFactory
 

--- a/rllib/tests/test_placement_groups.py
+++ b/rllib/tests/test_placement_groups.py
@@ -62,7 +62,7 @@ class TestPlacementGroups(unittest.TestCase):
             "my_trainable",
             param_space=config,
             run_config=air.RunConfig(
-                stop={"training_iteration": 2},
+                stop={TRAINING_ITERATION: 2},
                 verbose=2,
                 callbacks=[_TestCallback()],
             ),
@@ -87,7 +87,7 @@ class TestPlacementGroups(unittest.TestCase):
             PPO,
             param_space=config,
             run_config=air.RunConfig(
-                stop={"training_iteration": 2},
+                stop={TRAINING_ITERATION: 2},
                 verbose=2,
                 callbacks=[_TestCallback()],
             ),
@@ -106,7 +106,7 @@ class TestPlacementGroups(unittest.TestCase):
             tune.Tuner(
                 tune.with_resources(PPO, PlacementGroupFactory([{"CPU": 1}])),
                 param_space=config,
-                run_config=air.RunConfig(stop={"training_iteration": 2}, verbose=2),
+                run_config=air.RunConfig(stop={TRAINING_ITERATION: 2}, verbose=2),
             ).fit()
         except ValueError as e:
             assert "have been automatically set to" in e.args[0]

--- a/rllib/tests/test_ray_client.py
+++ b/rllib/tests/test_ray_client.py
@@ -3,6 +3,7 @@ import unittest
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 import ray.rllib.algorithms.ppo as ppo
 from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole
 from ray.util.client.ray_client_helpers import ray_start_client_server

--- a/rllib/tests/test_ray_client.py
+++ b/rllib/tests/test_ray_client.py
@@ -43,9 +43,7 @@ class TestRayClient(unittest.TestCase):
                 "env": StatelessCartPole,
             }
 
-            stop = {
-                "training_iteration": 3,
-            }
+            stop = {TRAINING_ITERATION: 3}
 
             tune.Tuner(
                 "PPO",

--- a/rllib/tests/test_rllib_train_and_evaluate.py
+++ b/rllib/tests/test_rllib_train_and_evaluate.py
@@ -310,7 +310,8 @@ class TestCLISmokeTests(unittest.TestCase):
         assert os.popen(
             f"python {rllib_dir}/scripts.py train file tuned_examples/ppo/"
             f"cartpole_ppo_envrunner.py "
-            f"--stop={'timesteps_total': 50000, 'episode_reward_mean': 200}"
+            f"--stop={{'num_env_steps_sampled_lifetime': 50000, "
+            f"'env_runners/episode_return_mean': 200}}"
         ).read()
 
     def test_all_example_files_exist(self):

--- a/rllib/tests/test_rllib_train_and_evaluate.py
+++ b/rllib/tests/test_rllib_train_and_evaluate.py
@@ -12,7 +12,6 @@ from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
-    EVALUATION_RESULTS,
 )
 from ray.rllib.utils.test_utils import framework_iterator
 from ray.tune.registry import get_trainable_cls

--- a/rllib/tests/test_rllib_train_and_evaluate.py
+++ b/rllib/tests/test_rllib_train_and_evaluate.py
@@ -9,6 +9,11 @@ import ray
 from ray import air, tune
 from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+)
 from ray.rllib.utils.test_utils import framework_iterator
 from ray.tune.registry import get_trainable_cls
 
@@ -201,7 +206,7 @@ def learn_test_multi_agent_plus_evaluate(algo: str):
             )
         )
 
-        stop = {"episode_reward_mean": 100.0}
+        stop = {f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 100.0}
 
         with mock.patch.dict({"TEST_TMPDIR": tmp_dir}):
             results = tune.Tuner(
@@ -219,7 +224,7 @@ def learn_test_multi_agent_plus_evaluate(algo: str):
 
         # Find last checkpoint and use that for the rollout.
         best_checkpoint = results.get_best_result(
-            metric="episode_reward_mean",
+            metric=f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}",
             mode="max",
         ).checkpoint
 

--- a/rllib/tuned_examples/appo/cartpole-appo-fake-gpus.yaml
+++ b/rllib/tuned_examples/appo/cartpole-appo-fake-gpus.yaml
@@ -2,7 +2,7 @@ cartpole-appo-vtrace-fake-gpus:
     env: CartPole-v1
     run: APPO
     stop:
-        env_runner_results/episode_return_mean: 150
+        env_runners/episode_return_mean: 150
         training_iteration: 400
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/appo/cartpole-appo-fake-gpus.yaml
+++ b/rllib/tuned_examples/appo/cartpole-appo-fake-gpus.yaml
@@ -2,7 +2,7 @@ cartpole-appo-vtrace-fake-gpus:
     env: CartPole-v1
     run: APPO
     stop:
-        sampler_results/episode_reward_mean: 150
+        env_runner_results/episode_return_mean: 150
         training_iteration: 400
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/appo/cartpole-appo-separate-losses.py
+++ b/rllib/tuned_examples/appo/cartpole-appo-separate-losses.py
@@ -1,10 +1,15 @@
 from ray.rllib.algorithms.appo import APPOConfig
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray import tune
 
 
 stop = {
-    "sampler_results/episode_reward_mean": 150,
-    "timesteps_total": 200000,
+    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 150,
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000,
 }
 
 config = (

--- a/rllib/tuned_examples/appo/cartpole-appo-w-rl-modules-and-learner.yaml
+++ b/rllib/tuned_examples/appo/cartpole-appo-w-rl-modules-and-learner.yaml
@@ -2,7 +2,7 @@ cartpole-appo-w-rl-modules-and-learner:
     env: CartPole-v1
     run: APPO
     stop:
-        env_runner_results/episode_return_mean: 150
+        env_runners/episode_return_mean: 150
         timesteps_total: 200000
     config:
         # Run with Learner- and RLModule API (new stack).

--- a/rllib/tuned_examples/appo/cartpole-appo-w-rl-modules-and-learner.yaml
+++ b/rllib/tuned_examples/appo/cartpole-appo-w-rl-modules-and-learner.yaml
@@ -2,7 +2,7 @@ cartpole-appo-w-rl-modules-and-learner:
     env: CartPole-v1
     run: APPO
     stop:
-        sampler_results/episode_reward_mean: 150
+        env_runner_results/episode_return_mean: 150
         timesteps_total: 200000
     config:
         # Run with Learner- and RLModule API (new stack).

--- a/rllib/tuned_examples/appo/cartpole-appo.yaml
+++ b/rllib/tuned_examples/appo/cartpole-appo.yaml
@@ -2,7 +2,7 @@ cartpole-appo:
     env: CartPole-v1
     run: APPO
     stop:
-        env_runner_results/episode_return_mean: 180
+        env_runners/episode_return_mean: 180
         timesteps_total: 200000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/appo/cartpole-appo.yaml
+++ b/rllib/tuned_examples/appo/cartpole-appo.yaml
@@ -2,7 +2,7 @@ cartpole-appo:
     env: CartPole-v1
     run: APPO
     stop:
-        sampler_results/episode_reward_mean: 180
+        env_runner_results/episode_return_mean: 180
         timesteps_total: 200000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/appo/cartpole-crashing-and-stalling-recreate-workers-appo.py
+++ b/rllib/tuned_examples/appo/cartpole-crashing-and-stalling-recreate-workers-appo.py
@@ -11,6 +11,12 @@ from gymnasium.wrappers import TimeLimit
 
 from ray.rllib.algorithms.appo import APPOConfig
 from ray.rllib.examples.envs.classes.cartpole_crashing import CartPoleCrashing
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray import tune
 
 
@@ -67,8 +73,8 @@ config = (
 )
 
 stop = {
-    "evaluation/sampler_results/episode_reward_mean": 500.0,
-    "num_env_steps_sampled": 2000000,
+    f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 500.0,
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 2000000,
 }
 
 if __name__ == "__main__":

--- a/rllib/tuned_examples/appo/cartpole-crashing-recreate-workers-appo.py
+++ b/rllib/tuned_examples/appo/cartpole-crashing-recreate-workers-appo.py
@@ -8,14 +8,20 @@ The environment we use here is configured to crash with a certain probability on
 """
 from ray.rllib.algorithms.appo import APPOConfig
 from ray.rllib.examples.envs.classes.cartpole_crashing import CartPoleCrashing
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray import tune
 
 tune.register_env("env", lambda cfg: CartPoleCrashing(cfg))
 
 
 stop = {
-    "evaluation/sampler_results/episode_reward_mean": 400.0,
-    "num_env_steps_sampled": 250000,
+    f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 400.0,
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 250000,
 }
 
 config = (

--- a/rllib/tuned_examples/appo/frozenlake-appo-vtrace.yaml
+++ b/rllib/tuned_examples/appo/frozenlake-appo-vtrace.yaml
@@ -2,7 +2,7 @@ frozenlake-appo-vtrace:
     env: FrozenLake-v1
     run: APPO
     stop:
-        env_runner_results/episode_return_mean: 0.99
+        env_runners/episode_return_mean: 0.99
         timesteps_total: 1000000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/appo/frozenlake-appo-vtrace.yaml
+++ b/rllib/tuned_examples/appo/frozenlake-appo-vtrace.yaml
@@ -2,7 +2,7 @@ frozenlake-appo-vtrace:
     env: FrozenLake-v1
     run: APPO
     stop:
-        sampler_results/episode_reward_mean: 0.99
+        env_runner_results/episode_return_mean: 0.99
         timesteps_total: 1000000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/appo/multi-agent-cartpole-crashing-and-stalling-recreate-workers-appo.py
+++ b/rllib/tuned_examples/appo/multi-agent-cartpole-crashing-and-stalling-recreate-workers-appo.py
@@ -9,13 +9,19 @@ The environment we use here is configured to crash with a certain probability on
 """
 from ray.rllib.algorithms.appo import APPOConfig
 from ray.rllib.examples.envs.classes.cartpole_crashing import MultiAgentCartPoleCrashing
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray import tune
 
 tune.register_env("ma_env", lambda cfg: MultiAgentCartPoleCrashing(cfg))
 
 stop = {
-    "evaluation/sampler_results/episode_reward_mean": 800.0,
-    "num_env_steps_sampled": 250000,
+    f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 800.0,
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 250000,
 }
 
 config = (

--- a/rllib/tuned_examples/appo/multi-agent-cartpole-crashing-recreate-workers-appo.py
+++ b/rllib/tuned_examples/appo/multi-agent-cartpole-crashing-recreate-workers-appo.py
@@ -9,13 +9,19 @@ The environment we use here is configured to crash with a certain probability on
 """
 from ray.rllib.algorithms.appo import APPOConfig
 from ray.rllib.examples.envs.classes.cartpole_crashing import MultiAgentCartPoleCrashing
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray import tune
 
 tune.register_env("ma_env", lambda cfg: MultiAgentCartPoleCrashing(cfg))
 
 stop = {
-    "evaluation/sampler_results/episode_reward_mean": 800.0,
-    "num_env_steps_sampled": 250000,
+    f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 800.0,
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 250000,
 }
 
 config = (

--- a/rllib/tuned_examples/appo/multi-agent-cartpole-w-100-policies-appo.py
+++ b/rllib/tuned_examples/appo/multi-agent-cartpole-w-100-policies-appo.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from ray.rllib.algorithms.appo import APPOConfig
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
+from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
 from ray.tune.registry import register_env
 
 
@@ -70,5 +71,5 @@ config = (
 # Define some stopping criteria.
 stop = {
     "evaluation/policy_reward_mean/pol0": 50.0,
-    "timesteps_total": 500000,
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 500000,
 }

--- a/rllib/tuned_examples/appo/multi_agent_cartpole_appo.py
+++ b/rllib/tuned_examples/appo/multi_agent_cartpole_appo.py
@@ -1,5 +1,10 @@
 from ray.rllib.algorithms.appo import APPOConfig
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray import tune
 
 tune.registry.register_env("env", lambda cfg: MultiAgentCartPole(config=cfg))
@@ -31,6 +36,6 @@ config = (
 )
 
 stop = {
-    "sampler_results/episode_reward_mean": 600,  # 600 / 4 (==num_agents) = 150
-    "timesteps_total": 200000,
+    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 600,  # 600 / 4 (==num_agents) = 150
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000,
 }

--- a/rllib/tuned_examples/appo/pendulum-appo.yaml
+++ b/rllib/tuned_examples/appo/pendulum-appo.yaml
@@ -2,7 +2,7 @@ pendulum-appo-vtrace:
     env: Pendulum-v1
     run: APPO
     stop:
-        env_runner_results/episode_return_mean: -1000  # just check it learns a bit
+        env_runners/episode_return_mean: -1000  # just check it learns a bit
         timesteps_total: 500000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/appo/pendulum-appo.yaml
+++ b/rllib/tuned_examples/appo/pendulum-appo.yaml
@@ -2,7 +2,7 @@ pendulum-appo-vtrace:
     env: Pendulum-v1
     run: APPO
     stop:
-        sampler_results/episode_reward_mean: -1000  # just check it learns a bit
+        env_runner_results/episode_return_mean: -1000  # just check it learns a bit
         timesteps_total: 500000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/appo/pong-appo-w-rl-modules-and-learner.yaml
+++ b/rllib/tuned_examples/appo/pong-appo-w-rl-modules-and-learner.yaml
@@ -4,7 +4,7 @@ appo-pongnoframeskip-v5:
     env: ALE/Pong-v5
     run: APPO
     stop:
-        env_runner_results/episode_return_mean: 18.0
+        env_runners/episode_return_mean: 18.0
         timesteps_total: 20000000
     config:
         # Run with Learner- and RLModule API (new stack).

--- a/rllib/tuned_examples/appo/pong-appo-w-rl-modules-and-learner.yaml
+++ b/rllib/tuned_examples/appo/pong-appo-w-rl-modules-and-learner.yaml
@@ -4,7 +4,7 @@ appo-pongnoframeskip-v5:
     env: ALE/Pong-v5
     run: APPO
     stop:
-        sampler_results/episode_reward_mean: 18.0
+        env_runner_results/episode_return_mean: 18.0
         timesteps_total: 20000000
     config:
         # Run with Learner- and RLModule API (new stack).

--- a/rllib/tuned_examples/appo/pong-appo.yaml
+++ b/rllib/tuned_examples/appo/pong-appo.yaml
@@ -7,7 +7,7 @@ pong-appo:
     env: ALE/Pong-v5
     run: APPO
     stop:
-        env_runner_results/episode_return_mean: 18.0
+        env_runners/episode_return_mean: 18.0
         timesteps_total: 5000000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/appo/pong-appo.yaml
+++ b/rllib/tuned_examples/appo/pong-appo.yaml
@@ -7,7 +7,7 @@ pong-appo:
     env: ALE/Pong-v5
     run: APPO
     stop:
-        sampler_results/episode_reward_mean: 18.0
+        env_runner_results/episode_return_mean: 18.0
         timesteps_total: 5000000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/appo/stateless_cartpole_appo.py
+++ b/rllib/tuned_examples/appo/stateless_cartpole_appo.py
@@ -1,5 +1,10 @@
 from ray.rllib.algorithms.appo.appo import APPOConfig
 from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 
 
 config = (
@@ -23,6 +28,6 @@ config = (
 )
 
 stop = {
-    "timesteps_total": 500000,
-    "sampler_results/episode_reward_mean": 150.0,
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 500000,
+    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 150.0,
 }

--- a/rllib/tuned_examples/cql/pendulum-cql.yaml
+++ b/rllib/tuned_examples/cql/pendulum-cql.yaml
@@ -6,7 +6,7 @@ pendulum-cql:
     env: Pendulum-v1
     run: CQL
     stop:
-        evaluation/env_runner_results/episode_return_mean: -700
+        evaluation/env_runners/episode_return_mean: -700
         timesteps_total: 800000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/cql/pendulum-cql.yaml
+++ b/rllib/tuned_examples/cql/pendulum-cql.yaml
@@ -6,7 +6,7 @@ pendulum-cql:
     env: Pendulum-v1
     run: CQL
     stop:
-        evaluation/sampler_results/episode_reward_mean: -700
+        evaluation/env_runner_results/episode_return_mean: -700
         timesteps_total: 800000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/dqn/benchmark_dqn_atari.py
+++ b/rllib/tuned_examples/dqn/benchmark_dqn_atari.py
@@ -4,6 +4,11 @@ from gymnasium.wrappers import AtariPreprocessing
 from ray.rllib.algorithms.dqn.dqn import DQNConfig
 from ray.rllib.connectors.env_to_module.frame_stacking import FrameStackingEnvToModule
 from ray.rllib.connectors.learner.frame_stacking import FrameStackingLearner
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.tune import Stopper
 from ray import train, tune
 
@@ -16,220 +21,220 @@ from ray import train, tune
 
 benchmark_envs = {
     "AlienNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 6022.9,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 6022.9,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "AmidarNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 202.8,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 202.8,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "AssaultNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 14491.7,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 14491.7,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "AsterixNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 280114.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 280114.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "AsteroidsNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 2249.4,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 2249.4,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "AtlantisNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 814684.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 814684.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BankHeistNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 826.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 826.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BattleZoneNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 52040.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 52040.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BeamRiderNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 21768.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 21768.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BerzerkNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 1793.4,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 1793.4,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BowlingNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 39.4,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 39.4,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BoxingNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 54.9,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 54.9,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BreakoutNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 379.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 379.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "CentipedeNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 7160.9,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 7160.9,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "ChopperCommandNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 10916.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 10916.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "CrazyClimberNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 143962.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 143962.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "DefenderNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 47671.3,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 47671.3,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "DemonAttackNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 109670.7,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 109670.7,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "DoubleDunkNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": -0.6,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -0.6,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "EnduroNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 2061.1,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 2061.1,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "FishingDerbyNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 22.6,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 22.6,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "FreewayNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 29.1,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 29.1,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "FrostbiteNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 4141.1,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 4141.1,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "GopherNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 72595.7,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 72595.7,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "GravitarNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 567.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 567.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "HeroNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 50496.8,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 50496.8,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "IceHockeyNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": -11685.8,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -11685.8,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "KangarooNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 10841.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 10841.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "KrullNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 6715.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 6715.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "KungFuMasterNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 28999.8,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 28999.8,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "MontezumaRevengeNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 154.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 154.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "MsPacmanNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 2570.2,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 2570.2,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "NameThisGameNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 11686.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 11686.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "PhoenixNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 103061.6,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 103061.6,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "PitfallNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": -37.6,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -37.6,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "PongNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 19.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 19.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "PrivateEyeNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 1704.4,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 1704.4,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "QbertNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 18397.6,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 18397.6,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "RoadRunnerNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 54261.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 54261.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "RobotankNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 55.2,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 55.2,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "SeaquestNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 19176.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 19176.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "SkiingNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": -11685.8,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -11685.8,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "SolarisNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 2860.7,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 2860.7,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "SpaceInvadersNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 12629.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 12629.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "StarGunnerNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 123853.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 123853.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "SurroundNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 7.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 7.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "TennisNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": -2.2,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -2.2,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "TimePilotNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 11190.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 11190.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "TutankhamNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 126.9,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 126.9,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "VentureNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 45.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 45.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "VideoPinballNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 506817.2,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 506817.2,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "WizardOfWorNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 14631.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 14631.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "YarsRevengeNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 93007.9,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 93007.9,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "ZaxxonNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 19658.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 19658.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
 }
 
@@ -263,14 +268,14 @@ class BenchmarkStopper(Stopper):
     def __call__(self, trial_id, result):
         # Stop training if the mean reward is reached.
         if (
-            result["sampler_results"]["episode_reward_mean"]
-            >= self.benchmark_envs[result["env"]]["sampler_results/episode_reward_mean"]
+            result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
+            >= self.benchmark_envs[result["env"]][f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]
         ):
             return True
         # Otherwise check, if the total number of timesteps is exceeded.
         elif (
-            result["timesteps_total"]
-            >= self.benchmark_envs[result["env"]]["timesteps_total"]
+            result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
+            >= self.benchmark_envs[result["env"]][f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
         ):
             return True
         # Otherwise continue training.

--- a/rllib/tuned_examples/dqn/benchmark_dqn_atari.py
+++ b/rllib/tuned_examples/dqn/benchmark_dqn_atari.py
@@ -269,7 +269,9 @@ class BenchmarkStopper(Stopper):
         # Stop training if the mean reward is reached.
         if (
             result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
-            >= self.benchmark_envs[result["env"]][f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]
+            >= self.benchmark_envs[result["env"]][
+                f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
+            ]
         ):
             return True
         # Otherwise check, if the total number of timesteps is exceeded.

--- a/rllib/tuned_examples/dqn/benchmark_dqn_atari_rllib_preprocessing.py
+++ b/rllib/tuned_examples/dqn/benchmark_dqn_atari_rllib_preprocessing.py
@@ -255,7 +255,9 @@ class BenchmarkStopper(Stopper):
         # Stop training if the mean reward is reached.
         if (
             result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
-            >= self.benchmark_envs[result["env"]][f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]
+            >= self.benchmark_envs[result["env"]][
+                f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
+            ]
         ):
             return True
         # Otherwise check, if the total number of timesteps is exceeded.

--- a/rllib/tuned_examples/dqn/benchmark_dqn_atari_rllib_preprocessing.py
+++ b/rllib/tuned_examples/dqn/benchmark_dqn_atari_rllib_preprocessing.py
@@ -2,6 +2,11 @@ import gymnasium as gym
 
 from ray.rllib.algorithms.dqn.dqn import DQNConfig
 from ray.rllib.env.wrappers.atari_wrappers import wrap_atari_for_new_api_stack
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.tune import Stopper
 from ray import train, tune
 
@@ -14,220 +19,220 @@ from ray import train, tune
 
 benchmark_envs = {
     "AlienNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 6022.9,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 6022.9,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "AmidarNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 202.8,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 202.8,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "AssaultNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 14491.7,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 14491.7,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "AsterixNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 280114.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 280114.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "AsteroidsNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 2249.4,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 2249.4,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "AtlantisNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 814684.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 814684.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BankHeistNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 826.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 826.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BattleZoneNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 52040.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 52040.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BeamRiderNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 21768.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 21768.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BerzerkNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 1793.4,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 1793.4,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BowlingNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 39.4,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 39.4,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BoxingNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 54.9,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 54.9,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "BreakoutNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 379.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 379.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "CentipedeNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 7160.9,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 7160.9,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "ChopperCommandNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 10916.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 10916.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "CrazyClimberNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 143962.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 143962.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "DefenderNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 47671.3,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 47671.3,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "DemonAttackNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 109670.7,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 109670.7,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "DoubleDunkNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": -0.6,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -0.6,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "EnduroNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 2061.1,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 2061.1,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "FishingDerbyNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 22.6,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 22.6,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "FreewayNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 29.1,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 29.1,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "FrostbiteNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 4141.1,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 4141.1,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "GopherNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 72595.7,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 72595.7,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "GravitarNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 567.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 567.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "HeroNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 50496.8,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 50496.8,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "IceHockeyNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": -11685.8,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -11685.8,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "KangarooNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 10841.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 10841.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "KrullNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 6715.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 6715.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "KungFuMasterNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 28999.8,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 28999.8,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "MontezumaRevengeNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 154.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 154.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "MsPacmanNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 2570.2,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 2570.2,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "NameThisGameNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 11686.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 11686.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "PhoenixNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 103061.6,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 103061.6,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "PitfallNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": -37.6,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -37.6,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "PongNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 19.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 19.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "PrivateEyeNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 1704.4,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 1704.4,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "QbertNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 18397.6,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 18397.6,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "RoadRunnerNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 54261.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 54261.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "RobotankNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 55.2,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 55.2,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "SeaquestNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 19176.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 19176.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "SkiingNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": -11685.8,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -11685.8,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "SolarisNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 2860.7,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 2860.7,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "SpaceInvadersNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 12629.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 12629.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "StarGunnerNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 123853.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 123853.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "SurroundNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 7.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 7.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "TennisNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": -2.2,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -2.2,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "TimePilotNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 11190.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 11190.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "TutankhamNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 126.9,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 126.9,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "VentureNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 45.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 45.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "VideoPinballNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 506817.2,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 506817.2,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "WizardOfWorNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 14631.5,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 14631.5,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "YarsRevengeNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 93007.9,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 93007.9,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
     "ZaxxonNoFrameskip-v4": {
-        "sampler_results/episode_reward_mean": 19658.0,
-        "timesteps_total": 200000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 19658.0,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000000,
     },
 }
 
@@ -249,14 +254,14 @@ class BenchmarkStopper(Stopper):
     def __call__(self, trial_id, result):
         # Stop training if the mean reward is reached.
         if (
-            result["sampler_results"]["episode_reward_mean"]
-            >= self.benchmark_envs[result["env"]]["sampler_results/episode_reward_mean"]
+            result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
+            >= self.benchmark_envs[result["env"]][f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]
         ):
             return True
         # Otherwise check, if the total number of timesteps is exceeded.
         elif (
-            result["timesteps_total"]
-            >= self.benchmark_envs[result["env"]]["timesteps_total"]
+            result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
+            >= self.benchmark_envs[result["env"]][f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
         ):
             return True
         # Otherwise continue training.

--- a/rllib/tuned_examples/dqn/cartpole-dqn-fake-gpus.yaml
+++ b/rllib/tuned_examples/dqn/cartpole-dqn-fake-gpus.yaml
@@ -2,7 +2,7 @@ cartpole-dqn-fake-gpus:
     env: CartPole-v1
     run: DQN
     stop:
-        env_runner_results/episode_return_mean: 150
+        env_runners/episode_return_mean: 150
         training_iteration: 400
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/dqn/cartpole-dqn-fake-gpus.yaml
+++ b/rllib/tuned_examples/dqn/cartpole-dqn-fake-gpus.yaml
@@ -2,7 +2,7 @@ cartpole-dqn-fake-gpus:
     env: CartPole-v1
     run: DQN
     stop:
-        sampler_results/episode_reward_mean: 150
+        env_runner_results/episode_return_mean: 150
         training_iteration: 400
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/dqn/cartpole-dqn-param-noise.yaml
+++ b/rllib/tuned_examples/dqn/cartpole-dqn-param-noise.yaml
@@ -2,7 +2,7 @@ cartpole-dqn-w-param-noise:
     env: CartPole-v1
     run: DQN
     stop:
-        sampler_results/episode_reward_mean: 150
+        env_runner_results/episode_return_mean: 150
         timesteps_total: 300000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/dqn/cartpole-dqn-param-noise.yaml
+++ b/rllib/tuned_examples/dqn/cartpole-dqn-param-noise.yaml
@@ -2,7 +2,7 @@ cartpole-dqn-w-param-noise:
     env: CartPole-v1
     run: DQN
     stop:
-        env_runner_results/episode_return_mean: 150
+        env_runners/episode_return_mean: 150
         timesteps_total: 300000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/dqn/cartpole-dqn-softq.yaml
+++ b/rllib/tuned_examples/dqn/cartpole-dqn-softq.yaml
@@ -2,7 +2,7 @@ cartpole-dqn:
     env: CartPole-v1
     run: DQN
     stop:
-        env_runner_results/episode_return_mean: 150
+        env_runners/episode_return_mean: 150
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/dqn/cartpole-dqn-softq.yaml
+++ b/rllib/tuned_examples/dqn/cartpole-dqn-softq.yaml
@@ -2,7 +2,7 @@ cartpole-dqn:
     env: CartPole-v1
     run: DQN
     stop:
-        sampler_results/episode_reward_mean: 150
+        env_runner_results/episode_return_mean: 150
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/dqn/cartpole-dqn.yaml
+++ b/rllib/tuned_examples/dqn/cartpole-dqn.yaml
@@ -2,7 +2,7 @@ cartpole-dqn:
     env: CartPole-v1
     run: DQN
     stop:
-        env_runner_results/episode_return_mean: 100
+        env_runners/episode_return_mean: 100
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/dqn/cartpole-dqn.yaml
+++ b/rllib/tuned_examples/dqn/cartpole-dqn.yaml
@@ -2,7 +2,7 @@ cartpole-dqn:
     env: CartPole-v1
     run: DQN
     stop:
-        sampler_results/episode_reward_mean: 100
+        env_runner_results/episode_return_mean: 100
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/dqn/cartpole_dqn_envrunner.py
+++ b/rllib/tuned_examples/dqn/cartpole_dqn_envrunner.py
@@ -49,6 +49,6 @@ config = (
 )
 
 stop = {
-    "evaluation_results/env_runner_results/episode_return_mean": 450.0,
-    "num_env_steps_sampled_lifetime": 100000,
+    f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 450.0,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME: 100000,
 }

--- a/rllib/tuned_examples/dqn/cartpole_dqn_envrunner.py
+++ b/rllib/tuned_examples/dqn/cartpole_dqn_envrunner.py
@@ -1,4 +1,10 @@
 from ray.rllib.algorithms.dqn import DQNConfig
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 
 config = (
     DQNConfig()

--- a/rllib/tuned_examples/dqn/pong-dqn.yaml
+++ b/rllib/tuned_examples/dqn/pong-dqn.yaml
@@ -3,7 +3,7 @@ pong-deterministic-dqn:
     env: ALE/Pong-v5
     run: DQN
     stop:
-        sampler_results/episode_reward_mean: 20
+        env_runner_results/episode_return_mean: 20
         time_total_s: 7200
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/dqn/pong-dqn.yaml
+++ b/rllib/tuned_examples/dqn/pong-dqn.yaml
@@ -3,7 +3,7 @@ pong-deterministic-dqn:
     env: ALE/Pong-v5
     run: DQN
     stop:
-        env_runner_results/episode_return_mean: 20
+        env_runners/episode_return_mean: 20
         time_total_s: 7200
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/dqn/pong-rainbow.yaml
+++ b/rllib/tuned_examples/dqn/pong-rainbow.yaml
@@ -2,7 +2,7 @@ pong-deterministic-rainbow:
     env: ALE/Pong-v5
     run: DQN
     stop:
-        sampler_results/episode_reward_mean: 20
+        env_runner_results/episode_return_mean: 20
     config:
         # Make analogous to old v4 + NoFrameskip.
         env_config:

--- a/rllib/tuned_examples/dqn/pong-rainbow.yaml
+++ b/rllib/tuned_examples/dqn/pong-rainbow.yaml
@@ -2,7 +2,7 @@ pong-deterministic-rainbow:
     env: ALE/Pong-v5
     run: DQN
     stop:
-        env_runner_results/episode_return_mean: 20
+        env_runners/episode_return_mean: 20
     config:
         # Make analogous to old v4 + NoFrameskip.
         env_config:

--- a/rllib/tuned_examples/impala/cartpole-impala-fake-gpus.yaml
+++ b/rllib/tuned_examples/impala/cartpole-impala-fake-gpus.yaml
@@ -2,7 +2,7 @@ cartpole-impala-fake-gpus:
     env: CartPole-v1
     run: IMPALA
     stop:
-        sampler_results/episode_reward_mean: 150
+        env_runner_results/episode_return_mean: 150
         training_iteration: 400
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/impala/cartpole-impala-fake-gpus.yaml
+++ b/rllib/tuned_examples/impala/cartpole-impala-fake-gpus.yaml
@@ -2,7 +2,7 @@ cartpole-impala-fake-gpus:
     env: CartPole-v1
     run: IMPALA
     stop:
-        env_runner_results/episode_return_mean: 150
+        env_runners/episode_return_mean: 150
         training_iteration: 400
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/impala/cartpole-impala-separate-losses.py
+++ b/rllib/tuned_examples/impala/cartpole-impala-separate-losses.py
@@ -1,9 +1,14 @@
 from ray.rllib.algorithms.impala import ImpalaConfig
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 
 
 stop = {
-    "sampler_results/episode_reward_mean": 150,
-    "timesteps_total": 200000,
+    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 150,
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000,
 }
 
 config = (

--- a/rllib/tuned_examples/impala/cartpole-impala.yaml
+++ b/rllib/tuned_examples/impala/cartpole-impala.yaml
@@ -2,7 +2,7 @@ cartpole-impala:
     env: CartPole-v1
     run: IMPALA
     stop:
-        sampler_results/episode_reward_mean: 150
+        env_runner_results/episode_return_mean: 150
         timesteps_total: 500000
     config:
         enable_rl_module_and_learner: true

--- a/rllib/tuned_examples/impala/cartpole-impala.yaml
+++ b/rllib/tuned_examples/impala/cartpole-impala.yaml
@@ -2,7 +2,7 @@ cartpole-impala:
     env: CartPole-v1
     run: IMPALA
     stop:
-        env_runner_results/episode_return_mean: 150
+        env_runners/episode_return_mean: 150
         timesteps_total: 500000
     config:
         enable_rl_module_and_learner: true

--- a/rllib/tuned_examples/impala/multi_agent_cartpole_impala.py
+++ b/rllib/tuned_examples/impala/multi_agent_cartpole_impala.py
@@ -32,6 +32,6 @@ config = (
 )
 
 stop = {
-    "sampler_results/episode_reward_mean": 600,  # 600 / 4 (==num_agents) = 150
-    "timesteps_total": 200000,
+    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 600,  # 600 / 4 (==num_agents) = 150
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 200000,
 }

--- a/rllib/tuned_examples/impala/multi_agent_cartpole_impala.py
+++ b/rllib/tuned_examples/impala/multi_agent_cartpole_impala.py
@@ -1,5 +1,10 @@
 from ray.rllib.algorithms.impala import ImpalaConfig
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray import tune
 
 tune.registry.register_env("env", lambda cfg: MultiAgentCartPole(config=cfg))

--- a/rllib/tuned_examples/impala/pendulum-impala.yaml
+++ b/rllib/tuned_examples/impala/pendulum-impala.yaml
@@ -2,5 +2,5 @@ pendulum-impala-tf:
     env: Pendulum-v1
     run: IMPALA
     stop:
-        sampler_results/episode_reward_mean: -700
+        env_runner_results/episode_return_mean: -700
         timesteps_total: 500000

--- a/rllib/tuned_examples/impala/pendulum-impala.yaml
+++ b/rllib/tuned_examples/impala/pendulum-impala.yaml
@@ -2,5 +2,5 @@ pendulum-impala-tf:
     env: Pendulum-v1
     run: IMPALA
     stop:
-        env_runner_results/episode_return_mean: -700
+        env_runners/episode_return_mean: -700
         timesteps_total: 500000

--- a/rllib/tuned_examples/ppo/benchmark_ppo_mujoco.py
+++ b/rllib/tuned_examples/ppo/benchmark_ppo_mujoco.py
@@ -62,7 +62,9 @@ class BenchmarkStopper(Stopper):
         # Stop training if the mean reward is reached.
         if (
             result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
-            >= self.benchmark_envs[result["env"]][f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]
+            >= self.benchmark_envs[result["env"]][
+                f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
+            ]
         ):
             return True
         # Otherwise check, if the total number of timesteps is exceeded.

--- a/rllib/tuned_examples/ppo/benchmark_ppo_mujoco.py
+++ b/rllib/tuned_examples/ppo/benchmark_ppo_mujoco.py
@@ -1,4 +1,9 @@
 from ray.rllib.algorithms.ppo.ppo import PPOConfig
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.tune import Stopper
 from ray import train, tune
 
@@ -17,32 +22,32 @@ from ray import train, tune
 #   AgileRL: https://github.com/AgileRL/AgileRL?tab=readme-ov-file#benchmarks
 benchmark_envs = {
     "HalfCheetah-v4": {
-        "sampler_results/episode_reward_mean": 2000,
-        "timesteps_total": 1000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 2000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
     "Hopper-v4": {
-        "sampler_results/episode_reward_mean": 2250,
-        "timesteps_total": 1000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 2250,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
     "InvertedPendulum-v4": {
-        "sampler_results/episode_reward_mean": 1000,
-        "timesteps_total": 1000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 1000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
     "InvertedDoublePendulum-v4": {
-        "sampler_results/episode_reward_mean": 8000,
-        "timesteps_total": 1000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 8000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
     "Reacher-v4": {
-        "sampler_results/episode_reward_mean": -15,
-        "timesteps_total": 1000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -15,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
     "Swimmer-v4": {
-        "sampler_results/episode_reward_mean": 120,
-        "timesteps_total": 1000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 120,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
     "Walker2d-v4": {
-        "sampler_results/episode_reward_mean": 3500,
-        "timesteps_total": 1000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 3500,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
 }
 
@@ -56,14 +61,14 @@ class BenchmarkStopper(Stopper):
     def __call__(self, trial_id, result):
         # Stop training if the mean reward is reached.
         if (
-            result["sampler_results"]["episode_reward_mean"]
-            >= self.benchmark_envs[result["env"]]["sampler_results/episode_reward_mean"]
+            result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
+            >= self.benchmark_envs[result["env"]][f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]
         ):
             return True
         # Otherwise check, if the total number of timesteps is exceeded.
         elif (
-            result["timesteps_total"]
-            >= self.benchmark_envs[result["env"]]["timesteps_total"]
+            result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
+            >= self.benchmark_envs[result["env"]][f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
         ):
             return True
         # Otherwise continue training.

--- a/rllib/tuned_examples/ppo/benchmark_ppo_mujoco_pb2.py
+++ b/rllib/tuned_examples/ppo/benchmark_ppo_mujoco_pb2.py
@@ -1,5 +1,6 @@
 import time
 from ray.rllib.algorithms.ppo.ppo import PPOConfig
+from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
 from ray.tune.schedulers.pb2 import PB2
 from ray import train, tune
 
@@ -17,26 +18,26 @@ from ray import train, tune
 #   AgileRL: https://github.com/AgileRL/AgileRL?tab=readme-ov-file#benchmarks
 benchmark_envs = {
     "HalfCheetah-v4": {
-        "timesteps_total": 1000000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
     "Hopper-v4": {
-        "timesteps_total": 1000000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
     "InvertedPendulum-v4": {
-        "timesteps_total": 1000000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
     "InvertedDoublePendulum-v4": {
-        "timesteps_total": 1000000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
-    "Reacher-v4": {"timesteps_total": 1000000},
-    "Swimmer-v4": {"timesteps_total": 1000000},
+    "Reacher-v4": {f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000},
+    "Swimmer-v4": {f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000},
     "Walker2d-v4": {
-        "timesteps_total": 1000000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
 }
 
 pb2_scheduler = PB2(
-    time_attr="timesteps_total",
+    time_attr=f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}",
     metric="episode_reward_mean",
     mode="max",
     perturbation_interval=50000,

--- a/rllib/tuned_examples/ppo/cartpole-ppo-fake-gpus.yaml
+++ b/rllib/tuned_examples/ppo/cartpole-ppo-fake-gpus.yaml
@@ -2,7 +2,7 @@ cartpole-ppo-fake-gpus:
     env: CartPole-v1
     run: PPO
     stop:
-        sampler_results/episode_reward_mean: 150
+        env_runner_results/episode_return_mean: 150
         training_iteration: 400
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/cartpole-ppo-fake-gpus.yaml
+++ b/rllib/tuned_examples/ppo/cartpole-ppo-fake-gpus.yaml
@@ -2,7 +2,7 @@ cartpole-ppo-fake-gpus:
     env: CartPole-v1
     run: PPO
     stop:
-        env_runner_results/episode_return_mean: 150
+        env_runners/episode_return_mean: 150
         training_iteration: 400
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/cartpole-ppo-grid-search-example.yaml
+++ b/rllib/tuned_examples/ppo/cartpole-ppo-grid-search-example.yaml
@@ -2,7 +2,7 @@ cartpole-ppo-grid-search-example:
     env: CartPole-v1
     run: PPO
     stop:
-        env_runner_results/episode_return_mean: 200
+        env_runners/episode_return_mean: 200
         time_total_s: 180
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/cartpole-ppo-grid-search-example.yaml
+++ b/rllib/tuned_examples/ppo/cartpole-ppo-grid-search-example.yaml
@@ -2,7 +2,7 @@ cartpole-ppo-grid-search-example:
     env: CartPole-v1
     run: PPO
     stop:
-        episode_reward_mean: 200
+        env_runner_results/episode_return_mean: 200
         time_total_s: 180
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/cartpole-ppo-hyperband.yaml
+++ b/rllib/tuned_examples/ppo/cartpole-ppo-hyperband.yaml
@@ -3,7 +3,7 @@ cartpole-ppo:
     run: PPO
     num_samples: 3
     stop:
-        sampler_results/episode_reward_mean: 200
+        env_runner_results/episode_return_mean: 200
         time_total_s: 180
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/cartpole-ppo-hyperband.yaml
+++ b/rllib/tuned_examples/ppo/cartpole-ppo-hyperband.yaml
@@ -3,7 +3,7 @@ cartpole-ppo:
     run: PPO
     num_samples: 3
     stop:
-        env_runner_results/episode_return_mean: 200
+        env_runners/episode_return_mean: 200
         time_total_s: 180
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/cartpole-ppo.yaml
+++ b/rllib/tuned_examples/ppo/cartpole-ppo.yaml
@@ -2,7 +2,7 @@ cartpole-ppo:
     env: CartPole-v1
     run: PPO
     stop:
-        sampler_results/episode_reward_mean: 150
+        env_runner_results/episode_return_mean: 150
         timesteps_total: 100000
     config:
         # Works for both torch and tf2.

--- a/rllib/tuned_examples/ppo/cartpole-ppo.yaml
+++ b/rllib/tuned_examples/ppo/cartpole-ppo.yaml
@@ -2,7 +2,7 @@ cartpole-ppo:
     env: CartPole-v1
     run: PPO
     stop:
-        env_runner_results/episode_return_mean: 150
+        env_runners/episode_return_mean: 150
         timesteps_total: 100000
     config:
         # Works for both torch and tf2.

--- a/rllib/tuned_examples/ppo/cartpole_ppo_envrunner.py
+++ b/rllib/tuned_examples/ppo/cartpole_ppo_envrunner.py
@@ -1,4 +1,10 @@
 from ray.rllib.algorithms.ppo import PPOConfig
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 
 
 config = (
@@ -32,6 +38,6 @@ config = (
 )
 
 stop = {
-    "num_env_steps_sampled_lifetime": 100000,
-    "evaluation_results/env_runner_results/episode_return_mean": 150.0,
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 100000,
+    f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 150.0,
 }

--- a/rllib/tuned_examples/ppo/cartpole_truncated_ppo.py
+++ b/rllib/tuned_examples/ppo/cartpole_truncated_ppo.py
@@ -2,6 +2,12 @@ import gymnasium as gym
 from gymnasium.wrappers import TimeLimit
 
 from ray.rllib.algorithms.ppo import PPOConfig
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.tune.registry import register_env
 
 
@@ -24,6 +30,6 @@ config = (
 )
 
 stop = {
-    "timesteps_total": 500000,
-    "evaluation/sampler_results/episode_reward_mean": 200.0,
+    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 500000,
+    f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 200.0,
 }

--- a/rllib/tuned_examples/ppo/halfcheetah-ppo.yaml
+++ b/rllib/tuned_examples/ppo/halfcheetah-ppo.yaml
@@ -2,7 +2,7 @@ halfcheetah-ppo:
     env: HalfCheetah-v2
     run: PPO
     stop:
-        env_runner_results/episode_return_mean: 9800
+        env_runners/episode_return_mean: 9800
         time_total_s: 10800
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/halfcheetah-ppo.yaml
+++ b/rllib/tuned_examples/ppo/halfcheetah-ppo.yaml
@@ -2,7 +2,7 @@ halfcheetah-ppo:
     env: HalfCheetah-v2
     run: PPO
     stop:
-        sampler_results/episode_reward_mean: 9800
+        env_runner_results/episode_return_mean: 9800
         time_total_s: 10800
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/humanoid-ppo-gae.yaml
+++ b/rllib/tuned_examples/ppo/humanoid-ppo-gae.yaml
@@ -2,7 +2,7 @@ humanoid-ppo-gae:
     env: Humanoid-v1
     run: PPO
     stop:
-        env_runner_results/episode_return_mean: 6000
+        env_runners/episode_return_mean: 6000
     config:
         # Works for both torch and tf.
         framework: torch

--- a/rllib/tuned_examples/ppo/humanoid-ppo-gae.yaml
+++ b/rllib/tuned_examples/ppo/humanoid-ppo-gae.yaml
@@ -2,7 +2,7 @@ humanoid-ppo-gae:
     env: Humanoid-v1
     run: PPO
     stop:
-        sampler_results/episode_reward_mean: 6000
+        env_runner_results/episode_return_mean: 6000
     config:
         # Works for both torch and tf.
         framework: torch

--- a/rllib/tuned_examples/ppo/humanoid-ppo.yaml
+++ b/rllib/tuned_examples/ppo/humanoid-ppo.yaml
@@ -2,7 +2,7 @@ humanoid-ppo:
     env: Humanoid-v1
     run: PPO
     stop:
-        sampler_results/episode_reward_mean: 6000
+        env_runner_results/episode_return_mean: 6000
     config:
         # Works for both torch and tf.
         framework: torch

--- a/rllib/tuned_examples/ppo/humanoid-ppo.yaml
+++ b/rllib/tuned_examples/ppo/humanoid-ppo.yaml
@@ -2,7 +2,7 @@ humanoid-ppo:
     env: Humanoid-v1
     run: PPO
     stop:
-        env_runner_results/episode_return_mean: 6000
+        env_runners/episode_return_mean: 6000
     config:
         # Works for both torch and tf.
         framework: torch

--- a/rllib/tuned_examples/ppo/multi_agent_pendulum_ppo_envrunner.py
+++ b/rllib/tuned_examples/ppo/multi_agent_pendulum_ppo_envrunner.py
@@ -3,6 +3,7 @@ from ray.rllib.examples.envs.classes.multi_agent import MultiAgentPendulum
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 from ray.tune.registry import register_env
 

--- a/rllib/tuned_examples/ppo/multi_agent_pendulum_ppo_envrunner.py
+++ b/rllib/tuned_examples/ppo/multi_agent_pendulum_ppo_envrunner.py
@@ -41,7 +41,7 @@ config = (
 )
 
 stop = {
-    "num_env_steps_sampled_lifetime": 500000,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME: 500000,
     # Divide by num_agents for actual reward per agent.
     f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -800.0,
 }

--- a/rllib/tuned_examples/ppo/multi_agent_pendulum_ppo_envrunner.py
+++ b/rllib/tuned_examples/ppo/multi_agent_pendulum_ppo_envrunner.py
@@ -1,5 +1,9 @@
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentPendulum
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.tune.registry import register_env
 
 
@@ -39,7 +43,7 @@ config = (
 stop = {
     "num_env_steps_sampled_lifetime": 500000,
     # Divide by num_agents for actual reward per agent.
-    "env_runner_results/episode_return_mean": -800.0,
+    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -800.0,
 }
 
 

--- a/rllib/tuned_examples/ppo/pendulum-ppo.yaml
+++ b/rllib/tuned_examples/ppo/pendulum-ppo.yaml
@@ -3,7 +3,7 @@ pendulum-ppo:
     env: Pendulum-v1
     run: PPO
     stop:
-        env_runner_results/episode_return_mean: -400
+        env_runners/episode_return_mean: -400
         timesteps_total: 400000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/pendulum-ppo.yaml
+++ b/rllib/tuned_examples/ppo/pendulum-ppo.yaml
@@ -3,7 +3,7 @@ pendulum-ppo:
     env: Pendulum-v1
     run: PPO
     stop:
-        sampler_results/episode_reward_mean: -400
+        env_runner_results/episode_return_mean: -400
         timesteps_total: 400000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/pendulum-transformed-actions-ppo.yaml
+++ b/rllib/tuned_examples/ppo/pendulum-transformed-actions-ppo.yaml
@@ -3,7 +3,7 @@ pendulum-ppo:
     env: ray.rllib.examples.envs.classes.transformed_action_space_env.TransformedActionPendulum
     run: PPO
     stop:
-        env_runner_results/episode_return_mean: -500
+        env_runners/episode_return_mean: -500
         timesteps_total: 400000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/pendulum-transformed-actions-ppo.yaml
+++ b/rllib/tuned_examples/ppo/pendulum-transformed-actions-ppo.yaml
@@ -3,7 +3,7 @@ pendulum-ppo:
     env: ray.rllib.examples.envs.classes.transformed_action_space_env.TransformedActionPendulum
     run: PPO
     stop:
-        sampler_results/episode_reward_mean: -500
+        env_runner_results/episode_return_mean: -500
         timesteps_total: 400000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/pendulum_ppo_envrunner.py
+++ b/rllib/tuned_examples/ppo/pendulum_ppo_envrunner.py
@@ -1,5 +1,10 @@
 from ray.rllib.algorithms.ppo import PPOConfig
-
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 
 config = (
     PPOConfig()
@@ -33,6 +38,6 @@ config = (
 )
 
 stop = {
-    "num_env_steps_sampled_lifetime": 400000,
-    "evaluation_results/env_runner_results/episode_return_mean": -400.0,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME: 400000,
+    f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -400.0,
 }

--- a/rllib/tuned_examples/ppo/recomm-sys001-ppo.yaml
+++ b/rllib/tuned_examples/ppo/recomm-sys001-ppo.yaml
@@ -2,7 +2,7 @@ recomm-sys001-ppo:
     env: ray.rllib.examples.envs.classes.recommender_system_envs.RecommSys001
     run: PPO
     stop:
-        #evaluation/env_runner_results/episode_return_mean: 48.0
+        #evaluation/env_runners/episode_return_mean: 48.0
         timesteps_total: 200000
     config:
         framework: torch

--- a/rllib/tuned_examples/ppo/recomm-sys001-ppo.yaml
+++ b/rllib/tuned_examples/ppo/recomm-sys001-ppo.yaml
@@ -2,7 +2,7 @@ recomm-sys001-ppo:
     env: ray.rllib.examples.envs.classes.recommender_system_envs.RecommSys001
     run: PPO
     stop:
-        #evaluation/sampler_results/episode_reward_mean: 48.0
+        #evaluation/env_runner_results/episode_return_mean: 48.0
         timesteps_total: 200000
     config:
         framework: torch

--- a/rllib/tuned_examples/ppo/repeatafterme-ppo-lstm.yaml
+++ b/rllib/tuned_examples/ppo/repeatafterme-ppo-lstm.yaml
@@ -3,7 +3,7 @@ repeat-after-me-ppo-w-lstm:
     env: ray.rllib.examples.envs.classes.repeat_after_me_env.RepeatAfterMeEnv
     run: PPO
     stop:
-        env_runner_results/episode_return_mean: 50
+        env_runners/episode_return_mean: 50
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/ppo/repeatafterme-ppo-lstm.yaml
+++ b/rllib/tuned_examples/ppo/repeatafterme-ppo-lstm.yaml
@@ -3,7 +3,7 @@ repeat-after-me-ppo-w-lstm:
     env: ray.rllib.examples.envs.classes.repeat_after_me_env.RepeatAfterMeEnv
     run: PPO
     stop:
-        sampler_results/episode_reward_mean: 50
+        env_runner_results/episode_return_mean: 50
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/benchmark_sac_mujoco.py
+++ b/rllib/tuned_examples/sac/benchmark_sac_mujoco.py
@@ -16,21 +16,21 @@ from ray import train, tune
 #   AgileRL: https://github.com/AgileRL/AgileRL?tab=readme-ov-file#benchmarks
 benchmark_envs = {
     "HalfCheetah-v4": {
-        "sampler_results/episode_reward_mean": 15000,
-        "timesteps_total": 3000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 15000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 3000000,
     },
     "Hopper-v4": {
-        "sampler_results/episode_reward_mean": 3500,
-        "timesteps_total": 1000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 3500,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
     "Humanoid-v4": {
-        "sampler_results/episode_reward_mean": 8000,
-        "timesteps_total": 10000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 8000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 10000000,
     },
-    "Ant-v4": {"sampler_results/episode_reward_mean": 5500, "timesteps_total": 3000000},
+    "Ant-v4": {f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 5500, f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 3000000},
     "Walker2d-v4": {
-        "sampler_results/episode_reward_mean": 6000,
-        "timesteps_total": 3000000,
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 6000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 3000000,
     },
 }
 
@@ -44,14 +44,14 @@ class BenchmarkStopper(Stopper):
     def __call__(self, trial_id, result):
         # Stop training if the mean reward is reached.
         if (
-            result["sampler_results"]["episode_reward_mean"]
-            >= self.benchmark_envs[result["env"]]["sampler_results/episode_reward_mean"]
+            result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
+            >= self.benchmark_envs[result["env"]][f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]
         ):
             return True
         # Otherwise check, if the total number of timesteps is exceeded.
         elif (
-            result["timesteps_total"]
-            >= self.benchmark_envs[result["env"]]["timesteps_total"]
+            result[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
+            >= self.benchmark_envs[result["env"]][f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"]
         ):
             return True
         # Otherwise continue training.

--- a/rllib/tuned_examples/sac/benchmark_sac_mujoco.py
+++ b/rllib/tuned_examples/sac/benchmark_sac_mujoco.py
@@ -1,4 +1,9 @@
 from ray.rllib.algorithms.sac.sac import SACConfig
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.tune import Stopper
 from ray import train, tune
 
@@ -27,7 +32,10 @@ benchmark_envs = {
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 8000,
         f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 10000000,
     },
-    "Ant-v4": {f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 5500, f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 3000000},
+    "Ant-v4": {
+        f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 5500,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 3000000,
+    },
     "Walker2d-v4": {
         f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 6000,
         f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 3000000,
@@ -45,7 +53,9 @@ class BenchmarkStopper(Stopper):
         # Stop training if the mean reward is reached.
         if (
             result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
-            >= self.benchmark_envs[result["env"]][f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"]
+            >= self.benchmark_envs[result["env"]][
+                f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
+            ]
         ):
             return True
         # Otherwise check, if the total number of timesteps is exceeded.

--- a/rllib/tuned_examples/sac/benchmark_sac_mujoco_pb2.py
+++ b/rllib/tuned_examples/sac/benchmark_sac_mujoco_pb2.py
@@ -1,5 +1,10 @@
 import time
 from ray.rllib.algorithms.sac.sac import SACConfig
+from ray.rllib.utils.metrics import (
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 from ray.tune.schedulers.pb2 import PB2
 from ray import train, tune
 
@@ -17,23 +22,23 @@ from ray import train, tune
 #   AgileRL: https://github.com/AgileRL/AgileRL?tab=readme-ov-file#benchmarks
 benchmark_envs = {
     "HalfCheetah-v4": {
-        "timesteps_total": 3000000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 3000000,
     },
     "Hopper-v4": {
-        "timesteps_total": 1000000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 1000000,
     },
     "Humanoid-v4": {
-        "timesteps_total": 10000000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 10000000,
     },
-    "Ant-v4": {"timesteps_total": 3000000},
+    "Ant-v4": {f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 3000000},
     "Walker2d-v4": {
-        "timesteps_total": 3000000,
+        f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 3000000,
     },
 }
 
 pb2_scheduler = PB2(
-    time_attr="timesteps_total",
-    metric="episode_reward_mean",
+    time_attr=NUM_ENV_STEPS_SAMPLED_LIFETIME,
+    metric=f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}",
     mode="max",
     perturbation_interval=50000,
     # Copy bottom % with top % weights.

--- a/rllib/tuned_examples/sac/cartpole-continuous-pybullet-sac.yaml
+++ b/rllib/tuned_examples/sac/cartpole-continuous-pybullet-sac.yaml
@@ -2,7 +2,7 @@ cartpole-sac:
     env: CartPoleContinuousBulletEnv-v0
     run: SAC
     stop:
-        env_runner_results/episode_return_mean: 40
+        env_runners/episode_return_mean: 40
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/cartpole-continuous-pybullet-sac.yaml
+++ b/rllib/tuned_examples/sac/cartpole-continuous-pybullet-sac.yaml
@@ -2,7 +2,7 @@ cartpole-sac:
     env: CartPoleContinuousBulletEnv-v0
     run: SAC
     stop:
-        sampler_results/episode_reward_mean: 40
+        env_runner_results/episode_return_mean: 40
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/cartpole-sac.yaml
+++ b/rllib/tuned_examples/sac/cartpole-sac.yaml
@@ -2,7 +2,7 @@ cartpole-sac:
     env: CartPole-v1
     run: SAC
     stop:
-        sampler_results/episode_reward_mean: 150.0
+        env_runner_results/episode_return_mean: 150.0
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/cartpole-sac.yaml
+++ b/rllib/tuned_examples/sac/cartpole-sac.yaml
@@ -2,7 +2,7 @@ cartpole-sac:
     env: CartPole-v1
     run: SAC
     stop:
-        env_runner_results/episode_return_mean: 150.0
+        env_runners/episode_return_mean: 150.0
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/halfcheetah-pybullet-sac.yaml
+++ b/rllib/tuned_examples/sac/halfcheetah-pybullet-sac.yaml
@@ -2,7 +2,7 @@ halfcheetah-pybullet-sac:
     env: HalfCheetahBulletEnv-v0
     run: SAC
     stop:
-        sampler_results/episode_reward_mean: 800.0
+        env_runner_results/episode_return_mean: 800.0
     config:
         # Works for both torch and tf.
         framework: torch

--- a/rllib/tuned_examples/sac/halfcheetah-pybullet-sac.yaml
+++ b/rllib/tuned_examples/sac/halfcheetah-pybullet-sac.yaml
@@ -2,7 +2,7 @@ halfcheetah-pybullet-sac:
     env: HalfCheetahBulletEnv-v0
     run: SAC
     stop:
-        env_runner_results/episode_return_mean: 800.0
+        env_runners/episode_return_mean: 800.0
     config:
         # Works for both torch and tf.
         framework: torch

--- a/rllib/tuned_examples/sac/halfcheetah-sac.yaml
+++ b/rllib/tuned_examples/sac/halfcheetah-sac.yaml
@@ -3,7 +3,7 @@ halfcheetah_sac:
     env: HalfCheetah-v3
     run: SAC
     stop:
-        sampler_results/episode_reward_mean: 9000
+        env_runner_results/episode_return_mean: 9000
     config:
         # Works for both torch and tf.
         framework: torch

--- a/rllib/tuned_examples/sac/halfcheetah-sac.yaml
+++ b/rllib/tuned_examples/sac/halfcheetah-sac.yaml
@@ -3,7 +3,7 @@ halfcheetah_sac:
     env: HalfCheetah-v3
     run: SAC
     stop:
-        env_runner_results/episode_return_mean: 9000
+        env_runners/episode_return_mean: 9000
     config:
         # Works for both torch and tf.
         framework: torch

--- a/rllib/tuned_examples/sac/mspacman-sac.yaml
+++ b/rllib/tuned_examples/sac/mspacman-sac.yaml
@@ -5,7 +5,7 @@ mspacman-sac-tf:
     env: ALE/MsPacman-v5
     run: SAC
     stop:
-        sampler_results/episode_reward_mean: 800
+        env_runner_results/episode_return_mean: 800
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/mspacman-sac.yaml
+++ b/rllib/tuned_examples/sac/mspacman-sac.yaml
@@ -5,7 +5,7 @@ mspacman-sac-tf:
     env: ALE/MsPacman-v5
     run: SAC
     stop:
-        env_runner_results/episode_return_mean: 800
+        env_runners/episode_return_mean: 800
         timesteps_total: 100000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/pendulum-sac-fake-gpus.yaml
+++ b/rllib/tuned_examples/sac/pendulum-sac-fake-gpus.yaml
@@ -2,7 +2,7 @@ pendulum-sac-fake-gpus:
       env: Pendulum-v1
       run: SAC
       stop:
-          env_runner_results/episode_return_mean: -270
+          env_runners/episode_return_mean: -270
           timesteps_total: 10000
       config:
           # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/pendulum-sac-fake-gpus.yaml
+++ b/rllib/tuned_examples/sac/pendulum-sac-fake-gpus.yaml
@@ -2,7 +2,7 @@ pendulum-sac-fake-gpus:
       env: Pendulum-v1
       run: SAC
       stop:
-          sampler_results/episode_reward_mean: -270
+          env_runner_results/episode_return_mean: -270
           timesteps_total: 10000
       config:
           # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/pendulum-sac.yaml
+++ b/rllib/tuned_examples/sac/pendulum-sac.yaml
@@ -4,7 +4,7 @@ pendulum-sac:
     env: Pendulum-v1
     run: SAC
     stop:
-        sampler_results/episode_reward_mean: -250
+        env_runner_results/episode_return_mean: -250
         timesteps_total: 10000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/pendulum-sac.yaml
+++ b/rllib/tuned_examples/sac/pendulum-sac.yaml
@@ -4,7 +4,7 @@ pendulum-sac:
     env: Pendulum-v1
     run: SAC
     stop:
-        env_runner_results/episode_return_mean: -250
+        env_runners/episode_return_mean: -250
         timesteps_total: 10000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/pendulum-transformed-actions-sac.yaml
+++ b/rllib/tuned_examples/sac/pendulum-transformed-actions-sac.yaml
@@ -4,7 +4,7 @@ transformed-actions-pendulum-sac-dummy-torch:
     env: ray.rllib.examples.envs.classes.transformed_action_space_env.TransformedActionPendulum
     run: SAC
     stop:
-        sampler_results/episode_reward_mean: -200
+        env_runner_results/episode_return_mean: -200
         timesteps_total: 10000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/pendulum-transformed-actions-sac.yaml
+++ b/rllib/tuned_examples/sac/pendulum-transformed-actions-sac.yaml
@@ -4,7 +4,7 @@ transformed-actions-pendulum-sac-dummy-torch:
     env: ray.rllib.examples.envs.classes.transformed_action_space_env.TransformedActionPendulum
     run: SAC
     stop:
-        env_runner_results/episode_return_mean: -200
+        env_runners/episode_return_mean: -200
         timesteps_total: 10000
     config:
         # Works for both torch and tf.

--- a/rllib/tuned_examples/sac/pendulum_sac_envrunner.py
+++ b/rllib/tuned_examples/sac/pendulum_sac_envrunner.py
@@ -49,6 +49,6 @@ config = (
 )
 
 stop = {
-    "num_env_steps_sampled_lifetime": 20000,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME: 20000,
     f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -250.0,
 }

--- a/rllib/tuned_examples/sac/pendulum_sac_envrunner.py
+++ b/rllib/tuned_examples/sac/pendulum_sac_envrunner.py
@@ -1,4 +1,8 @@
 from ray.rllib.algorithms.sac.sac import SACConfig
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+)
 
 config = (
     SACConfig()
@@ -46,5 +50,5 @@ config = (
 
 stop = {
     "num_env_steps_sampled_lifetime": 20000,
-    "env_runner_results/episode_return_mean": -250.0,
+    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": -250.0,
 }

--- a/rllib/tuned_examples/sac/pendulum_sac_envrunner.py
+++ b/rllib/tuned_examples/sac/pendulum_sac_envrunner.py
@@ -2,6 +2,7 @@ from ray.rllib.algorithms.sac.sac import SACConfig
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
 
 config = (

--- a/rllib/utils/exploration/tests/test_curiosity.py
+++ b/rllib/utils/exploration/tests/test_curiosity.py
@@ -7,12 +7,14 @@ import unittest
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 import ray.rllib.algorithms.ppo as ppo
 from ray.rllib.utils.test_utils import check_learning_achieved, framework_iterator
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MAX,
+    EPISODE_RETURN_MEAN,
 )
 from ray.rllib.utils.numpy import one_hot
 from ray.tune import register_env

--- a/rllib/utils/exploration/tests/test_curiosity.py
+++ b/rllib/utils/exploration/tests/test_curiosity.py
@@ -10,6 +10,10 @@ from ray import air, tune
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 import ray.rllib.algorithms.ppo as ppo
 from ray.rllib.utils.test_utils import check_learning_achieved, framework_iterator
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MAX,
+)
 from ray.rllib.utils.numpy import one_hot
 from ray.tune import register_env
 
@@ -195,7 +199,7 @@ class TestCuriosity(unittest.TestCase):
             for i in range(num_iterations):
                 result = algo.train()
                 print(result)
-                if result["episode_reward_max"] > 0.0:
+                if result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MAX] > 0.0:
                     print("Reached goal after {} iters!".format(i))
                     learnt = True
                     break
@@ -213,7 +217,7 @@ class TestCuriosity(unittest.TestCase):
             #    rewards_wo = 0.0
             #    for _ in range(num_iterations):
             #        result = algo.train()
-            #        rewards_wo += result["episode_reward_mean"]
+            #        rewards_wo += result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]
             #        print(result)
             #    algo.stop()
             #    self.assertTrue(rewards_wo == 0.0)

--- a/rllib/utils/exploration/tests/test_curiosity.py
+++ b/rllib/utils/exploration/tests/test_curiosity.py
@@ -33,7 +33,7 @@ class MyCallBack(DefaultCallbacks):
         policies,
         postprocessed_batch,
         original_batches,
-        **kwargs
+        **kwargs,
     ):
         pos = np.argmax(postprocessed_batch["obs"], -1)
         x, y = pos % 8, pos // 8
@@ -268,8 +268,8 @@ class TestCuriosity(unittest.TestCase):
 
         min_reward = 0.001
         stop = {
-            "training_iteration": 25,
-            "episode_reward_mean": min_reward,
+            TRAINING_ITERATION: 25,
+            f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": min_reward,
         }
         for _ in framework_iterator(config, frameworks="torch"):
             # To replay:
@@ -291,13 +291,13 @@ class TestCuriosity(unittest.TestCase):
                 run_config=air.RunConfig(stop=stop, verbose=1),
             ).fit()
             check_learning_achieved(results, min_reward)
-            iters = results.get_best_result().metrics["training_iteration"]
+            iters = results.get_best_result().metrics[TRAINING_ITERATION]
             print("Reached in {} iterations.".format(iters))
 
             # config_wo = config.copy()
             # config_wo["exploration_config"] = {"type": "StochasticSampling"}
             # stop_wo = stop.copy()
-            # stop_wo["training_iteration"] = iters
+            # stop_wo[TRAINING_ITERATION] = iters
             # results = tune.Tuner(
             #     "PPO", param_space=config_wo, stop=stop_wo, verbose=1).fit()
             # try:

--- a/rllib/utils/exploration/tests/test_random_encoder.py
+++ b/rllib/utils/exploration/tests/test_random_encoder.py
@@ -7,6 +7,10 @@ from ray.rllib.utils.test_utils import framework_iterator
 import ray.rllib.algorithms.ppo as ppo
 import ray.rllib.algorithms.sac as sac
 from ray.rllib.algorithms.callbacks import RE3UpdateCallbacks
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MAX,
+)
 
 
 class TestRE3(unittest.TestCase):
@@ -60,7 +64,7 @@ class TestRE3(unittest.TestCase):
             for i in range(num_iterations):
                 result = algo.train()
                 print(result)
-                if result["episode_reward_max"] > -900.0:
+                if result[ENV_RUNNER_RESULTS][EPISODE_RETURN_MAX] > -900.0:
                     print("Reached goal after {} iters!".format(i))
                     learnt = True
                     break

--- a/rllib/utils/metrics/__init__.py
+++ b/rllib/utils/metrics/__init__.py
@@ -20,6 +20,10 @@ NUM_ENV_STEPS_SAMPLED_FOR_EVALUATION_THIS_ITER = (
 NUM_MODULE_STEPS_SAMPLED = "num_module_steps_sampled"
 NUM_MODULE_STEPS_SAMPLED_LIFETIME = "num_module_steps_sampled_lifetime"
 
+EPISODE_DURATION_SEC_MEAN = "episode_duration_sec_mean"
+EPISODE_LEN_MEAN = "episode_len_mean"
+EPISODE_LEN_MAX = "episode_len_max"
+EPISODE_LEN_MIN = "episode_len_min"
 EPISODE_RETURN_MEAN = "episode_return_mean"
 EPISODE_RETURN_MAX = "episode_return_max"
 EPISODE_RETURN_MIN = "episode_return_min"

--- a/rllib/utils/metrics/__init__.py
+++ b/rllib/utils/metrics/__init__.py
@@ -1,10 +1,8 @@
 # Algorithm ResultDict keys.
-# TODO (sven): Change the actual strings into more fitting ones (e.g. `sampler_results`
-#  -> `env_runners` and `learner_stats` -> `learners`).
-EVALUATION_RESULTS = "evaluation_results"
-ENV_RUNNER_RESULTS = "env_runner_results"
-LEARNER_RESULTS = "learner_results"
-FAULT_TOLERANCE_STATS = "fault_tolerance_stats"
+EVALUATION_RESULTS = "evaluation"
+ENV_RUNNER_RESULTS = "env_runners"
+LEARNER_RESULTS = "learners"
+FAULT_TOLERANCE_STATS = "fault_tolerance"
 TIMERS = "timers"
 # ALGORITHM_RESULTS = "algorithm"
 
@@ -21,6 +19,10 @@ NUM_ENV_STEPS_SAMPLED_FOR_EVALUATION_THIS_ITER = (
 )
 NUM_MODULE_STEPS_SAMPLED = "num_module_steps_sampled"
 NUM_MODULE_STEPS_SAMPLED_LIFETIME = "num_module_steps_sampled_lifetime"
+
+EPISODE_RETURN_MEAN = "episode_return_mean"
+EPISODE_RETURN_MAX = "episode_return_max"
+EPISODE_RETURN_MIN = "episode_return_min"
 NUM_EPISODES = "num_episodes"
 NUM_EPISODES_LIFETIME = "num_episodes_lifetime"
 

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -40,10 +40,12 @@ from ray.rllib.utils.framework import try_import_jax, try_import_tf, try_import_
 from ray.rllib.utils.metrics import (
     DIFF_NUM_GRAD_UPDATES_VS_SAMPLER_POLICY,
     ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
     EVALUATION_RESULTS,
-    NUM_ENV_STEPS_SAMPLED,
-    NUM_ENV_STEPS_SAMPLED_LIFETIME,
     NUM_ENV_STEPS_TRAINED,
+    NUM_ENV_STEPS_TRAINED_LIFETIME,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+    NUM_EPISODES_LIFETIME,
 )
 from ray.rllib.utils.nested_dict import NestedDict
 from ray.rllib.utils.typing import ResultDict
@@ -1146,7 +1148,10 @@ def run_learning_tests_from_yaml_or_py(
                     NUM_ENV_STEPS_TRAINED_LIFETIME: "ts (trained)",
                     NUM_EPISODES_LIFETIME: "train_episodes",
                     f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": "reward_mean",
-                    f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": "eval_reward_mean",
+                    (
+                        f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/"
+                        f"{EPISODE_RETURN_MEAN}"
+                    ): "eval_reward_mean",
                 },
                 parameter_columns=["framework"],
                 sort_by_metric=True,
@@ -1189,7 +1194,8 @@ def run_learning_tests_from_yaml_or_py(
                     episode_reward_mean = np.mean(
                         [
                             t.metric_analysis[
-                                f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
+                                f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/"
+                                f"{EPISODE_RETURN_MEAN}"
                             ]["max"]
                             for t in trials_for_experiment
                         ]
@@ -1197,9 +1203,9 @@ def run_learning_tests_from_yaml_or_py(
                 else:
                     episode_reward_mean = np.mean(
                         [
-                            t.metric_analysis[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"][
-                                "max"
-                            ]
+                            t.metric_analysis[
+                                f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
+                            ]["max"]
                             for t in trials_for_experiment
                         ]
                     )

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -30,6 +30,7 @@ import yaml
 
 import ray
 from ray import air, tune
+from ray.air.constants import TRAINING_ITERATION
 from ray.air.integrations.wandb import WandbLoggerCallback
 from ray.rllib.common import SupportedFileType
 from ray.rllib.env.wrappers.atari_wrappers import is_atari, wrap_deepmind

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -719,7 +719,7 @@ def check_train_results_new_api_stack(train_results: ResultDict) -> None:
         NUM_AGENT_STEPS_SAMPLED_LIFETIME,
         NUM_ENV_STEPS_SAMPLED_LIFETIME,
         TIMERS,
-        "training_iteration",
+        TRAINING_ITERATION,
         "config",
     ]:
         assert (
@@ -1142,7 +1142,7 @@ def run_learning_tests_from_yaml_or_py(
             verbose=2,
             progress_reporter=CLIReporter(
                 metric_columns={
-                    "training_iteration": "iter",
+                    TRAINING_ITERATION: "iter",
                     "time_total_s": "time_total_s",
                     NUM_ENV_STEPS_SAMPLED_LIFETIME: "ts (sampled)",
                     NUM_ENV_STEPS_TRAINED_LIFETIME: "ts (trained)",
@@ -1308,7 +1308,7 @@ def run_rllib_example_script_experiment(
     `args.no_tune` is set to True) using the stopping criteria in `stop`.
 
     At the end of the experiment, if `args.as_test` is True, checks, whether the
-    Algorithm reached the `success_metric` (if None, use `env_runner_results/
+    Algorithm reached the `success_metric` (if None, use `env_runners/
     episode_return_mean` with a minimum value of `args.stop_reward`).
 
     See https://github.com/ray-project/ray/tree/master/rllib/examples for an overview
@@ -1325,13 +1325,13 @@ def run_rllib_example_script_experiment(
             `no_tune`, `verbose`, `checkpoint_freq`, `as_test`. Optionally, for WandB
             logging: `wandb_key`, `wandb_project`, `wandb_run_name`.
         stop: An optional dict mapping ResultDict key strings (using "/" in case of
-            nesting, e.g. "env_runner_results/episode_return_mean" for referring to
-            `result_dict['env_runner_results']['episode_return_mean']` to minimum
+            nesting, e.g. "env_runners/episode_return_mean" for referring to
+            `result_dict['env_runners']['episode_return_mean']` to minimum
             values, reaching of which will stop the experiment). Default is:
             {
-            "env_runner_results/episode_return_mean": args.stop_reward,
+            "env_runners/episode_return_mean": args.stop_reward,
             "training_iteration": args.stop_iters,
-            "timesteps_total": args.stop_timesteps,
+            "num_env_steps_sampled_lifetime": args.stop_timesteps,
             }
         success_metric: Only relevant if `args.as_test` is True.
             A dict mapping a single(!) ResultDict key string (using "/" in
@@ -1358,7 +1358,7 @@ def run_rllib_example_script_experiment(
         stop = {
             f"{ENV_RUNNER_RESULTS}/episode_return_mean": args.stop_reward,
             f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": args.stop_timesteps,
-            "training_iteration": args.stop_iters,
+            TRAINING_ITERATION: args.stop_iters,
         }
 
     # Enhance the `base_config`, based on provided `args`.
@@ -1388,10 +1388,10 @@ def run_rllib_example_script_experiment(
         algo = config.build()
         for _ in range(args.stop_iters):
             results = algo.train()
-            print(f"R={results[ENV_RUNNER_RESULTS]['episode_return_mean']}", end="")
+            print(f"R={results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]}", end="")
             if EVALUATION_RESULTS in results:
                 Reval = results[EVALUATION_RESULTS][ENV_RUNNER_RESULTS][
-                    "episode_return_mean"
+                    EPISODE_RETURN_MEAN
                 ]
                 print(f" R(eval)={Reval}", end="")
             print()
@@ -1433,10 +1433,10 @@ def run_rllib_example_script_experiment(
         progress_reporter = CLIReporter(
             metric_columns={
                 **{
-                    "training_iteration": "iter",
+                    TRAINING_ITERATION: "iter",
                     "time_total_s": "total time (s)",
-                    "num_env_steps_sampled_lifetime": "ts",
-                    f"{ENV_RUNNER_RESULTS}/episode_return_mean": "combined return",
+                    NUM_ENV_STEPS_SAMPLED_LIFETIME: "ts",
+                    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": "combined return",
                 },
                 **{
                     (
@@ -1595,9 +1595,7 @@ def check_reproducibilty(
     from ray.rllib.policy.sample_batch import DEFAULT_POLICY_ID
     from ray.rllib.utils.metrics.learner_info import LEARNER_INFO
 
-    stop_dict = {
-        "training_iteration": training_iteration,
-    }
+    stop_dict = {TRAINING_ITERATION: training_iteration}
     # use 0 and 2 workers (for more that 4 workers we have to make sure the instance
     # type in ci build has enough resources)
     for num_workers in [0, 2]:

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -614,8 +614,8 @@ def check_learning_achieved(
     Args:
         tune_results: The tune.Tuner().fit() returned results object.
         min_reward: The min reward that must be reached.
-        evaluation: If True, use `evaluation/sampler_results/[metric]`, if False, use
-            `sampler_results/[metric]`, if None, use evaluation sampler results if
+        evaluation: If True, use `evaluation/env_runners/[metric]`, if False, use
+            `env_runners/[metric]`, if None, use evaluation sampler results if
             available otherwise, use train sampler results.
 
     Raises:
@@ -1064,9 +1064,9 @@ def run_learning_tests_from_yaml_or_py(
 
             check_eval = should_check_eval(e)
             episode_reward_key = (
-                "sampler_results/episode_reward_mean"
+                f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
                 if not check_eval
-                else "evaluation/sampler_results/episode_reward_mean"
+                else f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
             )
 
             # For smoke-tests, we just run for n min.
@@ -1142,11 +1142,11 @@ def run_learning_tests_from_yaml_or_py(
                 metric_columns={
                     "training_iteration": "iter",
                     "time_total_s": "time_total_s",
-                    NUM_ENV_STEPS_SAMPLED: "ts (sampled)",
-                    NUM_ENV_STEPS_TRAINED: "ts (trained)",
-                    "episodes_this_iter": "train_episodes",
-                    "episode_reward_mean": "reward_mean",
-                    "evaluation/episode_reward_mean": "eval_reward_mean",
+                    NUM_ENV_STEPS_SAMPLED_LIFETIME: "ts (sampled)",
+                    NUM_ENV_STEPS_TRAINED_LIFETIME: "ts (trained)",
+                    NUM_EPISODES_LIFETIME: "train_episodes",
+                    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": "reward_mean",
+                    f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": "eval_reward_mean",
                 },
                 parameter_columns=["framework"],
                 sort_by_metric=True,
@@ -1189,7 +1189,7 @@ def run_learning_tests_from_yaml_or_py(
                     episode_reward_mean = np.mean(
                         [
                             t.metric_analysis[
-                                "evaluation/sampler_results/episode_reward_mean"
+                                f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
                             ]["max"]
                             for t in trials_for_experiment
                         ]
@@ -1197,7 +1197,7 @@ def run_learning_tests_from_yaml_or_py(
                 else:
                     episode_reward_mean = np.mean(
                         [
-                            t.metric_analysis["sampler_results/episode_reward_mean"][
+                            t.metric_analysis[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"][
                                 "max"
                             ]
                             for t in trials_for_experiment
@@ -1329,8 +1329,8 @@ def run_rllib_example_script_experiment(
             }
         success_metric: Only relevant if `args.as_test` is True.
             A dict mapping a single(!) ResultDict key string (using "/" in
-            case of nesting, e.g. "env_runner_results/episode_return_mean" for referring
-            to `result_dict['env_runner_results']['episode_return_mean']` to a single(!)
+            case of nesting, e.g. "env_runners/episode_return_mean" for referring
+            to `result_dict['env_runners']['episode_return_mean']` to a single(!)
             minimum value to be reached in order for the experiment to count as
             successful. If `args.as_test` is True AND this `success_metric` is not
             reached with the bounds defined by `stop`, will raise an Exception.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Provide more constants for common result dict keys, e.g. `EPISODE_RETURN_MEAN`.
* EPISODE_RETURN_MEAN
* EPISODE_RETURN_MAX
* EPISODE_RETURN_MIN

Switch all remaining "sampler_results" to `ENV_RUNNER_RESULTS`, "evaluation" to `EVALUATION_RESULTS`, etc.. in all yamls and py files.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
