### PR TITLE
[serve] deflake autoscaling tests

### DIFF
--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -9,7 +9,7 @@ import requests
 
 import ray
 from ray import serve
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import SignalActor, wait_for_condition
 from ray._private.usage import usage_lib
 from ray.cluster_utils import AutoscalingCluster, Cluster
 from ray.serve._private.test_utils import (
@@ -125,6 +125,17 @@ def serve_instance(_shared_serve_instance):
     _shared_serve_instance.delete_all_apps()
     # Clear the ServeHandle cache between tests to avoid them piling up.
     _shared_serve_instance.shutdown_cached_handles()
+
+
+@pytest.fixture
+def serve_instance_with_signal(serve_instance):
+    client = serve_instance
+
+    signal = SignalActor.options(name="signal123").remote()
+    yield client, signal
+
+    # Delete signal actor so there is no conflict between tests
+    ray.kill(signal)
 
 
 def check_ray_stop():


### PR DESCRIPTION
[serve] deflake autoscaling tests

Deflake `test_autoscaling_policy.py` which contains e2e autoscaling tests.

1. While debugging, we saw that `test_handle_deleted_on_crashed_replica` would sometimes spit out an error (after the test passes) because the restarted Router replica fails to initialize because the controller already started shutting down all deployments. This PR adds a wait condition to make sure router replica is restarted before test ends.
2. `SignalActor`, with the same actor name, is used in a few of the tests. If Ray doesn't garbage collect fast enough, then the actor won't be killed fast enough and consecutive test runs will error out saying an actor of the same name already exists. This PR makes sure to kill the signal actor at the end of tests that use it.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
