### PR TITLE
[ci][microcheck] compute high impact for all platform

### DIFF
--- a/ci/ray_ci/automation/determine_microcheck_step_ids.py
+++ b/ci/ray_ci/automation/determine_microcheck_step_ids.py
@@ -1,7 +1,12 @@
 import click
 
 from ci.ray_ci.utils import ci_init
-from ray_release.test import Test, LINUX_TEST_PREFIX
+from ray_release.test import (
+    Test,
+    LINUX_TEST_PREFIX,
+    WINDOWS_TEST_PREFIX,
+    MACOS_TEST_PREFIX,
+)
 
 
 @click.command()
@@ -10,7 +15,13 @@ def main() -> None:
     This script determines the rayci step ids to run microcheck tests.
     """
     ci_init()
-    print(",".join(Test.gen_high_impact_tests(LINUX_TEST_PREFIX).keys()))
+    steps = (
+        Test.gen_high_impact_tests(LINUX_TEST_PREFIX).keys()
+        + Test.gen_high_impact_tests(WINDOWS_TEST_PREFIX).keys()
+        + Test.gen_high_impact_tests(MACOS_TEST_PREFIX).keys()
+    )
+
+    print(",".join(steps))
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/automation/determine_microcheck_step_ids.py
+++ b/ci/ray_ci/automation/determine_microcheck_step_ids.py
@@ -16,9 +16,9 @@ def main() -> None:
     """
     ci_init()
     steps = (
-        Test.gen_high_impact_tests(LINUX_TEST_PREFIX).keys()
-        + Test.gen_high_impact_tests(WINDOWS_TEST_PREFIX).keys()
-        + Test.gen_high_impact_tests(MACOS_TEST_PREFIX).keys()
+        list(Test.gen_high_impact_tests(LINUX_TEST_PREFIX).keys())
+        + list(Test.gen_high_impact_tests(WINDOWS_TEST_PREFIX).keys())
+        + list(Test.gen_high_impact_tests(MACOS_TEST_PREFIX).keys())
     )
 
     print(",".join(steps))


### PR DESCRIPTION
Compute high impact tests for all platform. This is to support windows + macos tests for microcheck.

Test:
- CI

> bazel run //ci/ray_ci/automation:determine_microcheck_step_ids
> g3_s0,g8_s18,g5_s11,g4_s11,g5_s10,g13_s9,g8_s7,g8_s11,g4_s6,g13_s12,g5_s13,g5_s8,g5_s6,g12_s13,g14_s2,g14_s3,g4_s22,g4_s24,g4_s25,g4_s14,g8_s6,g8_s13,g8_s17,g8_s9,g4_s12,g14_s5,g4_s10,g13_s7,g12_s14,g12_s5,g12_s17,g12_s4,g12_s6,g12_s2