### PR TITLE
[docs] [serve] adding use case tags to Serve examples and fixing a typo

### DIFF
--- a/doc/source/serve/examples.yml
+++ b/doc/source/serve/examples.yml
@@ -4,11 +4,14 @@ examples:
     skill_level: beginner
     frameworks:
       - pytorch
+    use_cases:
+      - computer vision
     link: tutorials/serve-ml-models
   - title: Serve a Stable Diffusion Model
     skill_level: beginner
     use_cases:
       - computer vision
+      - generative ai
     link: tutorials/stable-diffusion
   - title: Serve a Text Classification Model
     skill_level: beginner
@@ -20,12 +23,16 @@ examples:
     use_cases:
       - computer vision
     link: tutorials/object-detection
-
   - title: Serve an Inference Model on AWS NeuronCores Using FastAPI
     skill_level: intermediate
+    use_cases:
+      - natural language processing
     link: tutorials/aws-neuron-core-inference
   - title: Serve an Inference with Stable Diffusion Model on AWS NeuronCores Using FastAPI
     skill_level: intermediate
+    use_cases:
+      - computer vision
+      - generative ai
     link: tutorials/aws-neuron-core-inference-stable-diffusion
   - title: Serve a model on Intel Gaudi Accelerator
     skill_level: intermediate
@@ -37,15 +44,30 @@ examples:
     link: tutorials/intel-gaudi-inference
   - title: Scale a Gradio App with Ray Serve
     skill_level: intermediate
+    use_cases:
+      - generative ai
+      - large language models
+      - natural language processing
     link: tutorials/gradio-integration
   - title: Serve a Text Generator with Request Batching
     skill_level: intermediate
+    use_cases:
+      - generative ai
+      - large language models
+      - natural language processing
     link: tutorials/batch
   - title: Serve a Chatbot with Request and Response Streaming
     skill_level: intermediate
+    use_cases:
+      - generative ai
+      - large language models
+      - natural language processing
     link: tutorials/streaming
   - title: Serving models with Triton Server in Ray Serve
     skill_level: intermediate
+    use_cases:
+      - computer vision
+      - generative ai
     link: tutorials/triton-server-integration
 
   - title: Serve a Java App

--- a/doc/source/serve/tutorials/java.md
+++ b/doc/source/serve/tutorials/java.md
@@ -77,7 +77,7 @@ You can test the `strategy` deployment using RayServeHandle inside Ray:
 :start-after: docs-calc-start
 ```
 
-This code executes the calculation of each bank's each indicator serially, and sends it to Ray for execution. You can make the calculation concurrent, which not only improves the calculation efficiency, but also solves the bottleneck of single machine.
+This code executes the calculation of each bank's indicator serially, and sends it to Ray for execution. You can make the calculation concurrent, which not only improves the calculation efficiency, but also solves the bottleneck of single machine.
 
 ```{literalinclude} ../../../../java/serve/src/test/java/io/ray/serve/docdemo/StrategyCalcOnRayServe.java
 :end-before: docs-parallel-calc-end


### PR DESCRIPTION
Noticed that in the Example Gallery, using the `Serve` and `LLM` filters didn't return the relevant examples. Here's my guess on the tags to add to the examples. 
cc: @shrekris-anyscale 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
