### PR TITLE
[RLlib] Cleanup metrics-spam in algo's result dicts (retire "sampler_results", don't dump env-runner-results into top-level).

### DIFF
--- a/doc/source/ray-overview/doc_test/ray_rllib.py
+++ b/doc/source/ray-overview/doc_test/ray_rllib.py
@@ -4,7 +4,7 @@ from ray.rllib.algorithms.ppo import PPO
 tuner = tune.Tuner(
     PPO,
     run_config=train.RunConfig(
-        stop={"episode_len_mean": 20},
+        stop={"env_runners/episode_len_mean": 20},
     ),
     param_space={"env": "CartPole-v1", "framework": "torch", "log_level": "INFO"},
 )

--- a/doc/source/rllib/doc_code/getting_started.py
+++ b/doc/source/rllib/doc_code/getting_started.py
@@ -38,7 +38,7 @@ if False:
     tuner = tune.Tuner(
         "PPO",
         run_config=train.RunConfig(
-            stop={"episode_reward_mean": 150},
+            stop={"env_runners/episode_return_mean": 150},
         ),
         param_space=config,
     )
@@ -52,7 +52,7 @@ if False:
         "PPO",
         param_space=config,
         run_config=train.RunConfig(
-            stop={"episode_reward_mean": 150},
+            stop={"env_runners/episode_return_mean": 150},
             checkpoint_config=train.CheckpointConfig(checkpoint_at_end=True),
         ),
     )
@@ -60,7 +60,9 @@ if False:
     results = tuner.fit()
 
     # Get the best result based on a particular metric.
-    best_result = results.get_best_result(metric="episode_reward_mean", mode="max")
+    best_result = results.get_best_result(
+        metric="env_runners/episode_return_mean", mode="max"
+    )
 
     # Get the best checkpoint corresponding to the best result.
     best_checkpoint = best_result.checkpoint

--- a/doc/source/rllib/doc_code/replay_buffer_demo.py
+++ b/doc/source/rllib/doc_code/replay_buffer_demo.py
@@ -144,6 +144,8 @@ config = (
 tune.Tuner(
     "DQN",
     param_space=config.to_dict(),
-    run_config=air.RunConfig(stop={"episode_reward_mean": 40, "training_iteration": 7}),
+    run_config=air.RunConfig(
+        stop={"env_runners/episode_return_mean": 40, "training_iteration": 7},
+    ),
 ).fit()
 # __sphinx_doc_replay_buffer_advanced_usage_underlying_buffers__end__

--- a/doc/source/rllib/doc_code/rllib_on_ray_readme.py
+++ b/doc/source/rllib/doc_code/rllib_on_ray_readme.py
@@ -74,7 +74,7 @@ algo = config.build()
 # we can expect to reach an optimal episode reward of -0.1*18 + 1.0 = -0.8
 for i in range(5):
     results = algo.train()
-    print(f"Iter: {i}; avg. return={results['env_runenrs']['episode_return_mean']}")
+    print(f"Iter: {i}; avg. return={results['env_runners']['episode_return_mean']}")
 
 # Perform inference (action computations) based on given env observations.
 # Note that we are using a slightly different env here (len 10 instead of 20),

--- a/doc/source/rllib/doc_code/rllib_on_ray_readme.py
+++ b/doc/source/rllib/doc_code/rllib_on_ray_readme.py
@@ -74,7 +74,7 @@ algo = config.build()
 # we can expect to reach an optimal episode reward of -0.1*18 + 1.0 = -0.8
 for i in range(5):
     results = algo.train()
-    print(f"Iter: {i}; avg. reward={results['episode_reward_mean']}")
+    print(f"Iter: {i}; avg. return={results['env_runenrs']['episode_return_mean']}")
 
 # Perform inference (action computations) based on given env observations.
 # Note that we are using a slightly different env here (len 10 instead of 20),

--- a/doc/source/rllib/doc_code/rllib_on_ray_readme.py
+++ b/doc/source/rllib/doc_code/rllib_on_ray_readme.py
@@ -71,7 +71,7 @@ algo = config.build()
 # Train for n iterations and report results (mean episode rewards).
 # Since we have to move at least 19 times in the env to reach the goal and
 # each move gives us -0.1 reward (except the last move at the end: +1.0),
-# we can expect to reach an optimal episode reward of -0.1*18 + 1.0 = -0.8
+# Expect to reach an optimal episode reward of `-0.1*18 + 1.0 = -0.8`.
 for i in range(5):
     results = algo.train()
     print(f"Iter: {i}; avg. return={results['env_runners']['episode_return_mean']}")

--- a/doc/source/rllib/rllib-advanced-api.rst
+++ b/doc/source/rllib/rllib-advanced-api.rst
@@ -74,9 +74,9 @@ training loop.
         while True:
             result = algo.train()
             train.report(result)
-            if result["episode_reward_mean"] > 200:
+            if result["env_runners"]["episode_return_mean"] > 200:
                 task = 2
-            elif result["episode_reward_mean"] > 100:
+            elif result["env_runners"]["episode_return_mean"] > 100:
                 task = 1
             else:
                 task = 0
@@ -110,9 +110,9 @@ results:
 
     class MyCallbacks(DefaultCallbacks):
         def on_train_result(self, algorithm, result, **kwargs):
-            if result["episode_reward_mean"] > 200:
+            if result["env_runners"]["episode_return_mean"] > 200:
                 task = 2
-            elif result["episode_reward_mean"] > 100:
+            elif result["env_runners"]["episode_return_mean"] > 100:
                 task = 1
             else:
                 task = 0
@@ -465,12 +465,13 @@ the ``evaluation`` key of normal training results:
     Result for PG_SimpleCorridor_2c6b27dc:
       ...
       evaluation:
-        custom_metrics: {}
-        episode_len_mean: 15.864661654135338
-        episode_reward_max: 1.0
-        episode_reward_mean: 0.49624060150375937
-        episode_reward_min: 0.0
-        episodes_this_iter: 133
+        env_runners:
+          custom_metrics: {}
+          episode_len_mean: 15.864661654135338
+          episode_return_max: 1.0
+          episode_return_mean: 0.49624060150375937
+          episode_return_min: 0.0
+          episodes_this_iter: 133
 
 .. code-block:: bash
 
@@ -489,13 +490,14 @@ the ``evaluation`` key of normal training results:
     Result for PG_SimpleCorridor_0de4e686:
       ...
       evaluation:
-        custom_metrics: {}
-        episode_len_mean: 9.15695067264574
-        episode_reward_max: 1.0
-        episode_reward_mean: 0.9596412556053812
-        episode_reward_min: 0.0
-        episodes_this_iter: 223
-        foo: 1
+        env_runners:
+          custom_metrics: {}
+          episode_len_mean: 9.15695067264574
+          episode_return_max: 1.0
+          episode_return_mean: 0.9596412556053812
+          episode_return_min: 0.0
+          episodes_this_iter: 223
+          foo: 1
 
 
 Rewriting Trajectories

--- a/doc/source/rllib/rllib-cli.md
+++ b/doc/source/rllib/rllib-cli.md
@@ -84,9 +84,9 @@ After all, running on Ray Clusters is what RLlib was built for.
 
 ### Running tuned examples
 
-Let's run the example next!
-After showing how to start the training run, we give you some sample output of it below.
-Note that by default, RLlib will create an indicative experiment name for you, and logs
+Run the example next.
+After following the instructions for starting the training run, see some sample output below.
+Note that by default, RLlib creates an indicative experiment name for you, and logs
 important metrics such as the `return`, the `episode_return_max`, or the
 `episode_return_min`.
 

--- a/doc/source/rllib/rllib-cli.md
+++ b/doc/source/rllib/rllib-cli.md
@@ -87,8 +87,8 @@ After all, running on Ray Clusters is what RLlib was built for.
 Let's run the example next!
 After showing how to start the training run, we give you some sample output of it below.
 Note that by default, RLlib will create an indicative experiment name for you, and logs
-important metrics such as the `reward`, the `episode_reward_max`, or the
-`episode_reward_min`.
+important metrics such as the `return`, the `episode_return_max`, or the
+`episode_return_min`.
 
 ```{raw} html
 
@@ -100,7 +100,7 @@ important metrics such as the `reward`, the `episode_reward_max`, or the
     </span>
     <span data-ty>
     ... | Trial name                  | status  | ...
-    |   reward |   episode_reward_max |   episode_reward_min | ...
+    |   reward |   episode_return_max |   episode_return_min | ...
     </span>
     <span data-ty>
     ... | PPO_CartPole-v0_9931e_00000 | RUNNING | ...

--- a/doc/source/rllib/rllib-env.rst
+++ b/doc/source/rllib/rllib-env.rst
@@ -324,8 +324,8 @@ Metrics are reported for each policy separately, for example:
 
     Result for PPO_multi_cartpole_0:
       episode_len_mean: 34.025862068965516
-      episode_reward_max: 159.0
-      episode_reward_mean: 86.06896551724138
+      episode_return_max: 159.0
+      episode_return_mean: 86.06896551724138
       info:
         policy_0:
           cur_lr: 4.999999873689376e-05

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -539,7 +539,7 @@ class Algorithm(Trainable, AlgorithmBase):
         self.evaluation_workers: Optional[EnvRunnerGroup] = None
         # Initialize common evaluation_metrics to nan, before they become
         # available. We want to make sure the metrics are always present
-        # (although their values may be nan), so that Tune does not complain
+        # (although their values may be nan), so that Tune doesn't complain
         # when we use these as stopping criteria.
         self.evaluation_metrics = {
             "evaluation": {

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -542,11 +542,7 @@ class Algorithm(Trainable, AlgorithmBase):
         # (although their values may be nan), so that Tune does not complain
         # when we use these as stopping criteria.
         self.evaluation_metrics = {
-            # TODO: Don't dump sampler results into top-level.
             "evaluation": {
-                EPISODE_RETURN_MAX: np.nan,
-                EPISODE_RETURN_MIN: np.nan,
-                EPISODE_RETURN_MEAN: np.nan,
                 ENV_RUNNER_RESULTS: {
                     EPISODE_RETURN_MAX: np.nan,
                     EPISODE_RETURN_MIN: np.nan,
@@ -1050,7 +1046,7 @@ class Algorithm(Trainable, AlgorithmBase):
                 ) = self._evaluate_with_fixed_duration()
         # Can't find a good way to run this evaluation -> Wait for next iteration.
         else:
-            pass
+            eval_results = {}
 
         if self.config.enable_env_runner_and_connector_v2:
             # Lifetime eval counters.
@@ -1070,10 +1066,7 @@ class Algorithm(Trainable, AlgorithmBase):
                 key=EVALUATION_RESULTS, return_stats_obj=False
             )
         else:
-            eval_results = dict(
-                {"sampler_results": eval_results, ENV_RUNNER_RESULTS: eval_results},
-                **eval_results,
-            )
+            eval_results = {ENV_RUNNER_RESULTS: eval_results}
             eval_results[NUM_AGENT_STEPS_SAMPLED_THIS_ITER] = agent_steps
             eval_results[NUM_ENV_STEPS_SAMPLED_THIS_ITER] = env_steps
             eval_results["timesteps_this_iter"] = env_steps
@@ -3326,8 +3319,6 @@ class Algorithm(Trainable, AlgorithmBase):
                     self.evaluation_config.keep_per_episode_custom_metrics
                 ),
             )
-            # TODO: Don't dump sampler results into top-level.
-            eval_results = dict({"sampler_results": eval_results}, **eval_results)
             eval_results[NUM_AGENT_STEPS_SAMPLED_THIS_ITER] = agent_steps
             eval_results[NUM_ENV_STEPS_SAMPLED_THIS_ITER] = env_steps
             # TODO: Remove this key at some point. Here for backward compatibility.
@@ -3479,13 +3470,11 @@ class Algorithm(Trainable, AlgorithmBase):
         self._episode_history = self._episode_history[
             -self.config.metrics_num_episodes_for_smoothing :
         ]
-        results["sampler_results"] = results[ENV_RUNNER_RESULTS] = summarize_episodes(
+        results[ENV_RUNNER_RESULTS] = summarize_episodes(
             episodes_for_metrics,
             episodes_this_iter,
             self.config.keep_per_episode_custom_metrics,
         )
-        # TODO: Don't dump sampler results into top-level.
-        results.update(results[ENV_RUNNER_RESULTS])
 
         results["num_healthy_workers"] = self.workers.num_healthy_remote_workers()
         results["num_in_flight_async_reqs"] = self.workers.num_in_flight_async_reqs()

--- a/rllib/algorithms/cql/tests/test_cql.py
+++ b/rllib/algorithms/cql/tests/test_cql.py
@@ -9,6 +9,7 @@ from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
 )
 from ray.rllib.utils.test_utils import (
     check_compute_single_action,
@@ -82,7 +83,7 @@ class TestCQL(unittest.TestCase):
                 results = algo.train()
                 check_train_results(results)
                 print(results)
-                eval_results = results["evaluation"]
+                eval_results = results[EVALUATION_RESULTS]
                 print(
                     f"iter={algo.iteration} "
                     f"R={eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN]}"

--- a/rllib/algorithms/marwil/tests/test_marwil.py
+++ b/rllib/algorithms/marwil/tests/test_marwil.py
@@ -13,6 +13,7 @@ from ray.rllib.utils.framework import try_import_tf, try_import_torch
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
 )
 from ray.rllib.utils.test_utils import (
     check,
@@ -76,7 +77,7 @@ class TestMARWIL(unittest.TestCase):
                 check_train_results(results)
                 print(results)
 
-                eval_results = results.get("evaluation")
+                eval_results = results.get(EVALUATION_RESULTS)
                 if eval_results:
                     print(
                         "iter={} R={} ".format(

--- a/rllib/algorithms/tests/test_algorithm.py
+++ b/rllib/algorithms/tests/test_algorithm.py
@@ -17,6 +17,7 @@ from ray.rllib.examples.evaluation.evaluation_parallel_to_training import (
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
 )
 from ray.rllib.utils.metrics.learner_info import LEARNER_INFO
 from ray.rllib.utils.test_utils import check, framework_iterator
@@ -268,13 +269,15 @@ class TestAlgorithm(unittest.TestCase):
             print(r3)
             algo.stop()
 
-            self.assertFalse("evaluation" in r0)
-            self.assertTrue("evaluation" in r1)
-            self.assertFalse("evaluation" in r2)
-            self.assertTrue("evaluation" in r3)
-            self.assertTrue(ENV_RUNNER_RESULTS in r1["evaluation"])
-            self.assertTrue(EPISODE_RETURN_MEAN in r1["evaluation"][ENV_RUNNER_RESULTS])
-            self.assertNotEqual(r1["evaluation"], r3["evaluation"])
+            self.assertFalse(EVALUATION_RESULTS in r0)
+            self.assertTrue(EVALUATION_RESULTS in r1)
+            self.assertFalse(EVALUATION_RESULTS in r2)
+            self.assertTrue(EVALUATION_RESULTS in r3)
+            self.assertTrue(ENV_RUNNER_RESULTS in r1[EVALUATION_RESULTS])
+            self.assertTrue(
+                EPISODE_RETURN_MEAN in r1[EVALUATION_RESULTS][ENV_RUNNER_RESULTS]
+            )
+            self.assertNotEqual(r1[EVALUATION_RESULTS], r3[EVALUATION_RESULTS])
 
     def test_evaluation_option_always_attach_eval_metrics(self):
         # Use a custom callback that asserts that we are running the
@@ -304,10 +307,10 @@ class TestAlgorithm(unittest.TestCase):
             # Eval results are not available at step 0.
             # But step 3 should still have it, even though no eval was
             # run during that step.
-            self.assertTrue("evaluation" in r0)
-            self.assertTrue("evaluation" in r1)
-            self.assertTrue("evaluation" in r2)
-            self.assertTrue("evaluation" in r3)
+            self.assertTrue(EVALUATION_RESULTS in r0)
+            self.assertTrue(EVALUATION_RESULTS in r1)
+            self.assertTrue(EVALUATION_RESULTS in r2)
+            self.assertTrue(EVALUATION_RESULTS in r3)
 
     def test_evaluation_wo_evaluation_env_runner_group(self):
         # Use a custom callback that asserts that we are running the

--- a/rllib/common.py
+++ b/rllib/common.py
@@ -289,7 +289,10 @@ EXAMPLES = {
     },
     "cartpole-a2c": {
         "file": "tuned_examples/a2c/cartpole_a2c.py",
-        "stop": "{'timesteps_total': 50000, 'episode_reward_mean': 200}",
+        "stop": (
+            "{'num_env_steps_sampled_lifetime': 50000, "
+            "'env_runners/episode_return_mean': 200}"
+        ),
         "description": "Runs A2C on the CartPole-v1 environment.",
     },
     "cartpole-a2c-micro": {
@@ -299,7 +302,10 @@ EXAMPLES = {
     # A3C
     "cartpole-a3c": {
         "file": "tuned_examples/a3c/cartpole_a3c.py",
-        "stop": "{'timesteps_total': 20000, 'episode_reward_mean': 150}",
+        "stop": (
+            "{'num_env_steps_sampled_lifetime': 20000, "
+            "'env_runners/episode_return_mean': 150}"
+        ),
         "description": "Runs A3C on the CartPole-v1 environment.",
     },
     "pong-a3c": {

--- a/rllib/examples/_old_api_stack/sb2rllib_rllib_example.py
+++ b/rllib/examples/_old_api_stack/sb2rllib_rllib_example.py
@@ -29,7 +29,7 @@ analysis = tune.Tuner(
     param_space={"env": env_name, "lr": learning_rate},
 ).fit()
 # retrieve the checkpoint path
-analysis.default_metric = "episode_reward_mean"
+analysis.default_metric = "episode_return_mean"
 analysis.default_mode = "max"
 checkpoint_path = analysis.get_best_checkpoint(trial=analysis.get_best_trial())
 print(f"Trained model saved at {checkpoint_path}")

--- a/rllib/examples/custom_metrics_and_callbacks.py
+++ b/rllib/examples/custom_metrics_and_callbacks.py
@@ -145,14 +145,15 @@ class MyCallbacks(DefaultCallbacks):
         # of the given metric.
         # For the sake of this example, we will instead compute the variance and mean
         # of the pole angle over the evaluation episodes.
-        pole_angle = result["custom_metrics"]["pole_angle"]
+        custom_metrics = result[ENV_RUNNER_RESULTS]["custom_metrics"]
+        pole_angle = custom_metrics["pole_angle"]
         var = np.var(pole_angle)
         mean = np.mean(pole_angle)
-        result["custom_metrics"]["pole_angle_var"] = var
-        result["custom_metrics"]["pole_angle_mean"] = mean
+        custom_metrics["pole_angle_var"] = var
+        custom_metrics["pole_angle_mean"] = mean
         # We are not interested in these original values
-        del result["custom_metrics"]["pole_angle"]
-        del result["custom_metrics"]["num_batches"]
+        del custom_metrics["pole_angle"]
+        del custom_metrics["num_batches"]
 
     def on_learn_on_batch(
         self, *, policy: Policy, train_batch: SampleBatch, result: dict, **kwargs
@@ -207,7 +208,7 @@ if __name__ == "__main__":
     result = tuner.fit().get_best_result()
 
     # Verify episode-related custom metrics are there.
-    custom_metrics = result.metrics[ENV_RUNNER_RESULTS]["custom_metrics"]
+    custom_metrics = result.metrics["env_runners"]["custom_metrics"]
     print(custom_metrics)
     assert "pole_angle_mean" in custom_metrics
     assert "pole_angle_var" in custom_metrics

--- a/rllib/examples/custom_metrics_and_callbacks.py
+++ b/rllib/examples/custom_metrics_and_callbacks.py
@@ -24,6 +24,7 @@ from ray.rllib.env import BaseEnv
 from ray.rllib.evaluation import Episode, RolloutWorker
 from ray.rllib.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.utils.metrics import ENV_RUNNER_RESULTS
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -206,7 +207,7 @@ if __name__ == "__main__":
     result = tuner.fit().get_best_result()
 
     # Verify episode-related custom metrics are there.
-    custom_metrics = result.metrics["custom_metrics"]
+    custom_metrics = result.metrics[ENV_RUNNER_RESULTS]["custom_metrics"]
     print(custom_metrics)
     assert "pole_angle_mean" in custom_metrics
     assert "pole_angle_var" in custom_metrics

--- a/rllib/examples/debugging/deterministic_training.py
+++ b/rllib/examples/debugging/deterministic_training.py
@@ -14,6 +14,7 @@ from ray.rllib.examples.envs.classes.env_using_remote_actor import (
     CartPoleWithRemoteParamServer,
     ParameterStorage,
 )
+from ray.rllib.utils.metrics import ENV_RUNNER_RESULTS
 from ray.rllib.utils.metrics.learner_info import LEARNER_INFO
 from ray.rllib.utils.test_utils import check
 from ray.tune.registry import get_trainable_cls
@@ -85,7 +86,10 @@ if __name__ == "__main__":
         results1 = results1.get_best_result().metrics
         results2 = results2.get_best_result().metrics
         # Test rollout behavior.
-        check(results1["hist_stats"], results2["hist_stats"])
+        check(
+            results1[ENV_RUNNER_RESULTS]["hist_stats"],
+            results2[ENV_RUNNER_RESULTS]["hist_stats"],
+        )
         # As well as training behavior (minibatch sequence during SGD
         # iterations).
         if config.enable_rl_module_and_learner:

--- a/rllib/examples/learners/train_w_bc_finetune_w_ppo.py
+++ b/rllib/examples/learners/train_w_bc_finetune_w_ppo.py
@@ -18,6 +18,10 @@ from ray.rllib.algorithms.ppo.torch.ppo_torch_rl_module import PPOTorchRLModule
 from ray.rllib.algorithms.ppo.ppo_catalog import PPOCatalog
 from ray.rllib.core.models.base import ACTOR, ENCODER_OUT
 from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
+from ray.rllib.utils.metrics import (
+    EPISODE_RETURN_MEAN,
+    ENV_RUNNER_RESULTS,
+)
 
 GYM_ENV_NAME = "CartPole-v1"
 GYM_ENV = gym.make(GYM_ENV_NAME)
@@ -136,7 +140,9 @@ def train_ppo_agent_from_checkpointed_module(
         ),
     )
     results = tuner.fit()
-    best_reward_mean = results.get_best_result().metrics["episode_reward_mean"]
+    best_reward_mean = results.get_best_result().metrics[ENV_RUNNER_RESULTS][
+        EPISODE_RETURN_MEAN
+    ]
     return best_reward_mean
 
 

--- a/rllib/examples/multi_agent/utils/self_play_callback.py
+++ b/rllib/examples/multi_agent/utils/self_play_callback.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
+from ray.rllib.utils.metrics import ENV_RUNNER_RESULTS
 
 
 class SelfPlayCallback(DefaultCallbacks):
@@ -23,8 +24,8 @@ class SelfPlayCallback(DefaultCallbacks):
         # Note that normally, one should set up a proper evaluation config,
         # such that evaluation always happens on the already updated policy,
         # instead of on the already used train_batch.
-        main_rew = result["hist_stats"].pop("policy_main_reward")
-        opponent_rew = list(result["hist_stats"].values())[0]
+        main_rew = result[ENV_RUNNER_RESULTS]["hist_stats"].pop("policy_main_reward")
+        opponent_rew = list(result[ENV_RUNNER_RESULTS]["hist_stats"].values())[0]
         assert len(main_rew) == len(opponent_rew)
         won = 0
         for r_main, r_opponent in zip(main_rew, opponent_rew):

--- a/rllib/examples/multi_agent/utils/self_play_callback_old_api_stack.py
+++ b/rllib/examples/multi_agent/utils/self_play_callback_old_api_stack.py
@@ -5,7 +5,7 @@ from ray.rllib.utils.deprecation import Deprecated
 from ray.rllib.utils.metrics import ENV_RUNNER_RESULTS
 
 
-@Deprecated(help="Use the example for the new RLlib API stack", error=False)
+@Deprecated(help="Use the example for the new RLlib API stack.", error=False)
 class SelfPlayCallbackOldAPIStack(DefaultCallbacks):
     def __init__(self, win_rate_threshold):
         super().__init__()
@@ -17,7 +17,7 @@ class SelfPlayCallbackOldAPIStack(DefaultCallbacks):
 
     def on_train_result(self, *, algorithm, result, **kwargs):
         # Get the win rate for the train batch.
-        # Note that normally, one should set up a proper evaluation config,
+        # Note that normally, you should set up a proper evaluation config,
         # such that evaluation always happens on the already updated policy,
         # instead of on the already used train_batch.
         main_rew = result[ENV_RUNNER_RESULTS]["hist_stats"].pop("policy_main_reward")

--- a/rllib/examples/multi_agent/utils/self_play_callback_old_api_stack.py
+++ b/rllib/examples/multi_agent/utils/self_play_callback_old_api_stack.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.utils.deprecation import Deprecated
+from ray.rllib.utils.metrics import ENV_RUNNER_RESULTS
 
 
 @Deprecated(help="Use the example for the new RLlib API stack", error=False)
@@ -19,8 +20,8 @@ class SelfPlayCallbackOldAPIStack(DefaultCallbacks):
         # Note that normally, one should set up a proper evaluation config,
         # such that evaluation always happens on the already updated policy,
         # instead of on the already used train_batch.
-        main_rew = result["hist_stats"].pop("policy_main_reward")
-        opponent_rew = list(result["hist_stats"].values())[0]
+        main_rew = result[ENV_RUNNER_RESULTS]["hist_stats"].pop("policy_main_reward")
+        opponent_rew = list(result[ENV_RUNNER_RESULTS]["hist_stats"].values())[0]
         assert len(main_rew) == len(opponent_rew)
         won = 0
         for r_main, r_opponent in zip(main_rew, opponent_rew):

--- a/rllib/examples/multi_agent/utils/self_play_league_based_callback.py
+++ b/rllib/examples/multi_agent/utils/self_play_league_based_callback.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.core.rl_module.rl_module import SingleAgentRLModuleSpec
+from ray.rllib.utils.metrics import ENV_RUNNER_RESULTS
 
 
 class SelfPlayLeagueBasedCallback(DefaultCallbacks):
@@ -43,7 +44,7 @@ class SelfPlayLeagueBasedCallback(DefaultCallbacks):
         # such that evaluation always happens on the already updated policy,
         # instead of on the already used train_batch.
         league_changed = False
-        for module_id, rew in result["hist_stats"].items():
+        for module_id, rew in result[ENV_RUNNER_RESULTS]["hist_stats"].items():
             mo = re.match("^policy_(.+)_reward$", module_id)
             if mo is None:
                 continue

--- a/rllib/examples/multi_agent/utils/self_play_league_based_callback_old_api_stack.py
+++ b/rllib/examples/multi_agent/utils/self_play_league_based_callback_old_api_stack.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.utils.deprecation import Deprecated
+from ray.rllib.utils.metrics import ENV_RUNNER_RESULTS
 
 
 @Deprecated(help="Use the example for the new RLlib API stack", error=False)
@@ -36,7 +37,7 @@ class SelfPlayLeagueBasedCallbackOldAPIStack(DefaultCallbacks):
         # Note that normally, one should set up a proper evaluation config,
         # such that evaluation always happens on the already updated policy,
         # instead of on the already used train_batch.
-        for policy_id, rew in result["hist_stats"].items():
+        for policy_id, rew in result[ENV_RUNNER_RESULTS]["hist_stats"].items():
             mo = re.match("^policy_(.+)_reward$", policy_id)
             if mo is None:
                 continue

--- a/rllib/examples/multi_agent/utils/self_play_league_based_callback_old_api_stack.py
+++ b/rllib/examples/multi_agent/utils/self_play_league_based_callback_old_api_stack.py
@@ -34,7 +34,7 @@ class SelfPlayLeagueBasedCallbackOldAPIStack(DefaultCallbacks):
         _trainable_policies = self.trainable_policies
 
         # Get the win rate for the train batch.
-        # Note that normally, one should set up a proper evaluation config,
+        # Note that normally, you should set up a proper evaluation config,
         # such that evaluation always happens on the already updated policy,
         # instead of on the already used train_batch.
         for policy_id, rew in result[ENV_RUNNER_RESULTS]["hist_stats"].items():

--- a/rllib/examples/offline_rl/offline_rl.py
+++ b/rllib/examples/offline_rl/offline_rl.py
@@ -31,6 +31,7 @@ from ray.rllib.utils.framework import try_import_torch
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
 )
 
 torch, _ = try_import_torch()
@@ -111,7 +112,7 @@ if __name__ == "__main__":
     learnt = False
     for i in range(num_iterations):
         print(f"Iter {i}")
-        eval_results = cql_algorithm.train().get("evaluation")
+        eval_results = cql_algorithm.train().get(EVALUATION_RESULTS)
         if eval_results:
             print(
                 "... R={}".format(eval_results[ENV_RUNNER_RESULTS][EPISODE_RETURN_MEAN])

--- a/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
+++ b/rllib/tests/git_bisect/debug_learning_failure_git_bisect.py
@@ -152,12 +152,12 @@ if __name__ == "__main__":
     if args.stop_timesteps:
         stop[f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}"] = args.stop_timesteps
     if args.stop_reward:
-        stop["episode_reward_mean"] = args.stop_reward
+        stop[f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"] = args.stop_reward
     if args.stop_time:
         stop["time_total_s"] = args.stop_time
 
     # Invalid pass criteria.
-    if stop.get("episode_reward_mean") is None and (
+    if stop.get(ENV_RUNNER_RESULTS, {}).get(EPISODE_RETURN_MEAN) is None and (
         stop.get(f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}") is None
         or stop.get("time_total_s") is None
     ):

--- a/rllib/tests/test_reproducibility.py
+++ b/rllib/tests/test_reproducibility.py
@@ -4,6 +4,11 @@ import unittest
 
 import ray
 from ray.rllib.algorithms.dqn import DQNConfig
+from ray.rllib.utils.metrics import (
+    EPISODE_RETURN_MAX,
+    EPISODE_RETURN_MIN,
+    ENV_RUNNER_RESULTS,
+)
 from ray.rllib.utils.test_utils import framework_iterator
 from ray.tune.registry import register_env
 
@@ -48,8 +53,8 @@ class TestReproducibility(unittest.TestCase):
                 trajectory = list()
                 for _ in range(8):
                     r = algo.train()
-                    trajectory.append(r["episode_reward_max"])
-                    trajectory.append(r["episode_reward_min"])
+                    trajectory.append(r[ENV_RUNNER_RESULTS][EPISODE_RETURN_MAX])
+                    trajectory.append(r[ENV_RUNNER_RESULTS][EPISODE_RETURN_MIN])
                 trajs.append(trajectory)
 
                 algo.stop()

--- a/rllib/tests/test_rllib_train_and_evaluate.py
+++ b/rllib/tests/test_rllib_train_and_evaluate.py
@@ -115,7 +115,7 @@ def learn_test_plus_evaluate(algo: str, env="CartPole-v1"):
             + eval_
             + fw_
             + '}" '
-            + '--stop="{\\"env_runner/episode_return_mean\\": 100.0}"'
+            + '--stop="{\\"env_runners/episode_return_mean\\": 100.0}"'
             + " --env={}".format(env)
         )
 

--- a/rllib/tests/test_rllib_train_and_evaluate.py
+++ b/rllib/tests/test_rllib_train_and_evaluate.py
@@ -115,7 +115,7 @@ def learn_test_plus_evaluate(algo: str, env="CartPole-v1"):
             + eval_
             + fw_
             + '}" '
-            + '--stop="{\\"episode_reward_mean\\": 100.0}"'
+            + '--stop="{\\"env_runner/episode_return_mean\\": 100.0}"'
             + " --env={}".format(env)
         )
 

--- a/rllib/tuned_examples/appo/multi-agent-cartpole-w-100-policies-appo.py
+++ b/rllib/tuned_examples/appo/multi-agent-cartpole-w-100-policies-appo.py
@@ -2,7 +2,11 @@ import numpy as np
 
 from ray.rllib.algorithms.appo import APPOConfig
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
-from ray.rllib.utils.metrics import NUM_ENV_STEPS_SAMPLED_LIFETIME
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
 from ray.tune.registry import register_env
 
 
@@ -70,6 +74,6 @@ config = (
 
 # Define some stopping criteria.
 stop = {
-    "evaluation/policy_reward_mean/pol0": 50.0,
+    f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/policy_reward_mean/pol0": 50.0,
     f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 500000,
 }

--- a/rllib/tuned_examples/ppo/benchmark_ppo_mujoco_pb2.py
+++ b/rllib/tuned_examples/ppo/benchmark_ppo_mujoco_pb2.py
@@ -38,7 +38,7 @@ benchmark_envs = {
 
 pb2_scheduler = PB2(
     time_attr=f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}",
-    metric="episode_reward_mean",
+    metric="env_runners/episode_return_mean",
     mode="max",
     perturbation_interval=50000,
     # Copy bottom % with top % weights.

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -783,32 +783,38 @@ def check_train_results(train_results: ResultDict):
 
     # Assert that some keys are where we would expect them.
     for key in [
-        "agent_timesteps_total",
         "config",
         "custom_metrics",
+        ENV_RUNNER_RESULTS,
+        "info",
+        "iterations_since_restore",
+        "num_healthy_workers",
+        "perf",
+        "time_since_restore",
+        "time_this_iter_s",
+        "timers",
+        "time_total_s",
+        TRAINING_ITERATION,
+    ]:
+        assert (
+            key in train_results
+        ), f"'{key}' not found in `train_results` ({train_results})!"
+
+    for key in [
         "episode_len_mean",
         "episode_reward_max",
         "episode_reward_mean",
         "episode_reward_min",
         "hist_stats",
-        "info",
-        "iterations_since_restore",
-        "num_healthy_workers",
-        "perf",
         "policy_reward_max",
         "policy_reward_mean",
         "policy_reward_min",
         "sampler_perf",
-        "time_since_restore",
-        "time_this_iter_s",
-        "timesteps_total",
-        "timers",
-        "time_total_s",
-        "training_iteration",
     ]:
-        assert (
-            key in train_results
-        ), f"'{key}' not found in `train_results` ({train_results})!"
+        assert key in train_results[ENV_RUNNER_RESULTS], (
+            f"'{key}' not found in `train_results[ENV_RUNNER_RESULTS]` "
+            f"({train_results[ENV_RUNNER_RESULTS]})!"
+        )
 
     # Make sure, `config` is an actual dict, not an AlgorithmConfig object.
     assert isinstance(
@@ -1634,7 +1640,10 @@ def check_reproducibilty(
             results2 = results2.get_best_result().metrics
 
             # Test rollout behavior.
-            check(results1["hist_stats"], results2["hist_stats"])
+            check(
+                results1[ENV_RUNNER_RESULTS]["hist_stats"],
+                results2[ENV_RUNNER_RESULTS]["hist_stats"],
+            )
             # As well as training behavior (minibatch sequence during SGD
             # iterations).
             # As well as training behavior (minibatch sequence during SGD

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -1198,7 +1198,7 @@ def run_learning_tests_from_yaml_or_py(
             else:
                 # Use best_result's reward to check min_reward.
                 if check_eval:
-                    episode_reward_mean = np.mean(
+                    episode_return_mean = np.mean(
                         [
                             t.metric_analysis[
                                 f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/"
@@ -1208,7 +1208,7 @@ def run_learning_tests_from_yaml_or_py(
                         ]
                     )
                 else:
-                    episode_reward_mean = np.mean(
+                    episode_return_mean = np.mean(
                         [
                             t.metric_analysis[
                                 f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
@@ -1238,7 +1238,7 @@ def run_learning_tests_from_yaml_or_py(
 
                 # Record performance.
                 stats[experiment] = {
-                    "episode_reward_mean": float(episode_reward_mean),
+                    "episode_reward_mean": float(episode_return_mean),
                     "throughput": (
                         float(throughput) if throughput is not None else 0.0
                     ),
@@ -1250,12 +1250,12 @@ def run_learning_tests_from_yaml_or_py(
                 )
 
                 # We failed to reach desired reward or the desired throughput.
-                if (desired_reward and episode_reward_mean < desired_reward) or (
+                if (desired_reward and episode_return_mean < desired_reward) or (
                     desired_throughput and throughput < desired_throughput
                 ):
                     print(
                         " ... Not successful: Actual "
-                        f"reward={episode_reward_mean}; "
+                        f"return={episode_return_mean}; "
                         f"actual throughput={throughput}"
                     )
                     checks[experiment]["failures"] += 1
@@ -1263,7 +1263,7 @@ def run_learning_tests_from_yaml_or_py(
                 else:
                     print(
                         " ... Successful: (mark ok). Actual "
-                        f"reward={episode_reward_mean}; "
+                        f"return={episode_return_mean}; "
                         f"actual throughput={throughput}"
                     )
                     checks[experiment]["passed"] = True


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Cleanup metrics-spam in algo's result dicts:
* retire "sampler_results"
* don't dump env-runner-results into top-level
* The new structure of ResultDict will be:

```
[top level]
    lifetime counts, e.g. NUM_ENV_STEPS_SAMPLED_LIFETIME

env_runners/
    [all env runner metrics, e.g. EPISODE_RETURN_MEAN]

learners/
    __all_modules__/
        [all learning related metrics of all modules/policies, e.g. TOTAL_LOSS]

    default_policy/    
        [all learning related metrics of default policy, e.g. losses]

fault_tolerance/
    num_worker_failures
    num_active_workers
```

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
