### PR TITLE
[release] mark chaos_torch_batch_inference_16_gpu_300gb_raw as non-stable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -199,6 +199,7 @@
 - name: chaos_torch_batch_inference_16_gpu_300gb_raw
   group: data-tests
   working_dir: nightly_tests
+  stable: false
 
   frequency: nightly
   team: data


### PR DESCRIPTION
This test might be still flaky https://github.com/orgs/anyscale/projects/76/views/1?pane=issue&itemId=63092837. If it is should we mark it unstable to unblock the release, and mark it stable again once it is deflaked. Thankks.

Test:
- CI