### PR TITLE
[ci][microcheck] a few more steps into microcheck

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -40,6 +40,7 @@ steps:
     job_env: manylinux
 
   - label: ":tapioca: build: doc"
+    key: doc_build
     instance_type: medium
     commands:
       - FAST=True make -C doc/ html

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -8,6 +8,7 @@ steps:
     wanda: ci/docker/doctest.build.wanda.yaml
 
   - label: ":tapioca: build: pip-compile dependencies"
+    key: pip_compile_dependencies
     instance_type: small
     commands:
       # uncomment the following line to update the pinned versions of pip dependencies


### PR DESCRIPTION
Add a few more non-test related to microcheck
- pip compile dependency: this is required for any folks who want to add dependencies
- doc build: no covered by any test job (maybe cover by readthedocs but well)

Test:
- CI