### PR TITLE
[serve] allow build_serve_application to happen in parallel

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1003,7 +1003,7 @@ class ApplicationStateManager:
         )
 
 
-@ray.remote(num_cpus=0, max_calls=1)
+@ray.remote(num_cpus=0)
 def build_serve_application(
     import_path: str,
     config_deployments: List[str],


### PR DESCRIPTION
## Why are these changes needed?

Proposal based on the conversation [here](https://ray-distributed.slack.com/archives/CNCKBBRJL/p1715701141467729). 

We are using the [Multi-app containers](https://docs.ray.io/en/latest/serve/advanced-guides/multi-app-container.html) pattern and have a large number of apps, and each of the images is quite large (ray-gpu base + our own dependencies). We run KubeRay and have noticed that the call to build all the apps for a deploy is run from the ServeController, which runs on the head node. Practically the head node will never need any of these images, but that is mostly a separate issue. The main bottleneck is that if all of these build tasks are going to be run on the head anyway, we'd like to at least do them in parallel. 

The supporting code comment seems to intend to kick off a job, but the decorator here limits concurrency, and I don't think you can override this via `options` at the call site.

```python
# application_state.py

            # Kick off new build app task
            logger.info(f"Importing and building app '{self._name}'.")
            build_app_obj_ref = build_serve_application.options(
                runtime_env=config.runtime_env,
                enable_task_events=RAY_SERVE_ENABLE_TASK_EVENTS,
            ).remote(
                config.import_path,
                config.deployment_names,
                config_version,
                config.name,
                config.args,
            )

```

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
