### PR TITLE
[RLlib] Fix test_actor_manager CI test.

### DIFF
--- a/rllib/utils/tests/test_actor_manager.py
+++ b/rllib/utils/tests/test_actor_manager.py
@@ -366,13 +366,12 @@ class TestActorManager(unittest.TestCase):
 
         manager.foreach_actor_async(lambda w: w.ping(), tag="pingpong")
         manager.foreach_actor_async(lambda w: w.call(), tag="call")
-        time.sleep(2)
         results_ping_pong = manager.fetch_ready_async_reqs(
-            tags="pingpong", timeout_seconds=5
+            tags="pingpong", timeout_seconds=10.0
         )
-        results_call = manager.fetch_ready_async_reqs(tags="call", timeout_seconds=5)
-        self.assertEquals(len(list(results_ping_pong)), 4)
-        self.assertEquals(len(list(results_call)), 4)
+        results_call = manager.fetch_ready_async_reqs(tags="call", timeout_seconds=2.0)
+        self.assertEquals(len(results_ping_pong), 4)
+        self.assertEquals(len(results_call), 4)
         for result in results_ping_pong:
             data = result.get()
             self.assertEqual(data, "pong")
@@ -387,7 +386,7 @@ class TestActorManager(unittest.TestCase):
         manager.foreach_actor_async(lambda w: w.call())
         time.sleep(1)
         results = manager.fetch_ready_async_reqs(timeout_seconds=5)
-        self.assertEquals(len(list(results)), 8)
+        self.assertEquals(len(results), 8)
         for result in results:
             data = result.get()
             self.assertEqual(result.tag, None)
@@ -405,7 +404,7 @@ class TestActorManager(unittest.TestCase):
         results = manager.fetch_ready_async_reqs(
             timeout_seconds=5, tags=["pingpong", "call"]
         )
-        self.assertEquals(len(list(results)), 8)
+        self.assertEquals(len(results), 8)
         for result in results:
             data = result.get()
             if isinstance(data, str):
@@ -422,11 +421,11 @@ class TestActorManager(unittest.TestCase):
         manager.foreach_actor_async(lambda w: w.call(), tag="call")
         time.sleep(1)
         results = manager.fetch_ready_async_reqs(timeout_seconds=5, tags=["incorrect"])
-        self.assertEquals(len(list(results)), 0)
+        self.assertEquals(len(results), 0)
 
         # now test that passing no tags still gives back all of the results
         results = manager.fetch_ready_async_reqs(timeout_seconds=5)
-        self.assertEquals(len(list(results)), 8)
+        self.assertEquals(len(results), 8)
         for result in results:
             data = result.get()
             if isinstance(data, str):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix test_actor_manager CI test.
* Making timeout even more conservative.

The root cause of this test failing is that we are sending out 2x4 ray remote requests to 4 actors (methods "call()" and "ping()") through the ActorManager's async_req utility, which is nothing else other than making the ray remote call on the actors and returning the futures (Ray ObjRefs). Then we sleep, then do a ray.wait() to collect the results.

Any slowdowns here in the past are due to the actors' requests not being scheduled on time due to possibly other actors on the same node taking priority.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
