### PR TITLE
[Data] Allow configuration of MAX_IMAGE_PIXELS in ImageDatasource

### DIFF
--- a/python/ray/data/datasource/image_datasource.py
+++ b/python/ray/data/datasource/image_datasource.py
@@ -41,6 +41,7 @@ class ImageDatasource(FileBasedDatasource):
         paths: Union[str, List[str]],
         size: Optional[Tuple[int, int]] = None,
         mode: Optional[str] = None,
+        max_image_pixels: Optional[int] = None,
         **file_based_datasource_kwargs,
     ):
         super().__init__(paths, **file_based_datasource_kwargs)
@@ -60,6 +61,7 @@ class ImageDatasource(FileBasedDatasource):
 
         self.size = size
         self.mode = mode
+        self.max_image_pixels = max_image_pixels
 
         meta_provider = file_based_datasource_kwargs.get("meta_provider", None)
         if isinstance(meta_provider, _ImageFileMetadataProvider):
@@ -74,6 +76,9 @@ class ImageDatasource(FileBasedDatasource):
         path: str,
     ) -> Iterator[Block]:
         from PIL import Image, UnidentifiedImageError
+
+        if self.max_image_pixels is not None:
+            Image.MAX_IMAGE_PIXELS = self.max_image_pixels
 
         data = f.readall()
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -791,6 +791,7 @@ def read_images(
     file_extensions: Optional[List[str]] = ImageDatasource._FILE_EXTENSIONS,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
+    max_image_pixels: Optional[int] = None,
 ) -> Dataset:
     """Creates a :class:`~ray.data.Dataset` from image files.
 
@@ -888,6 +889,8 @@ def read_images(
             By default, the number of output blocks is dynamically decided based on
             input data size and available resources. You shouldn't manually set this
             value in most cases.
+        max_image_pixels: The maximum allowable image size to download. The value
+            is used to configure PIL.Image.MAX_IMAGE_PIXELS.
 
     Returns:
         A :class:`~ray.data.Dataset` producing tensors that represent the images at
@@ -914,6 +917,7 @@ def read_images(
         ignore_missing_paths=ignore_missing_paths,
         shuffle=shuffle,
         file_extensions=file_extensions,
+        max_image_pixels=max_image_pixels,
     )
     return read_datasource(
         datasource,


### PR DESCRIPTION
## Why are these changes needed?

PIL.Image sets a default limit to image sizes to prevent decompression bomb DOS attacks. Example stack trace:
```
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/data/datasource/image_datasource.py", line 81, in _read_stream
    image = Image.open(io.BytesIO(data))
  File "/home/ray/anaconda3/lib/python3.8/site-packages/PIL/Image.py", line 3133, in open
    im = _open_core(fp, filename, prefix, formats)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/PIL/Image.py", line 3120, in _open_core
    _decompression_bomb_check(im.size)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/PIL/Image.py", line 3029, in _decompression_bomb_check
    raise DecompressionBombError(
PIL.Image.DecompressionBombError: Image size (222926661 pixels) exceeds limit of 178956970 pixels, could be decompression bomb DOS attack.
```

However, the limit should be configurable when processing images with a trusted dataset and users should be able to configure the limit when calling `ray.data.read_images`.  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
