### PR TITLE
[cpp] stop mentioning gcc

### DIFF
--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -35,9 +35,6 @@ RUN apt-get install -y -qq \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev \
     clang-format-12 jq \
     clang-tidy-12 clang-12
-# Make using GCC 9 explicit.
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-9 \
-    --slave /usr/bin/gcov gcov /usr/bin/gcov-9
 RUN ln -s /usr/bin/clang-format-12 /usr/bin/clang-format && \
     ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy && \
     ln -s /usr/bin/clang-12 /usr/bin/clang

--- a/ci/docker/base.test.Dockerfile
+++ b/ci/docker/base.test.Dockerfile
@@ -35,11 +35,8 @@ apt-get install -y -qq \
     clang-format-12 jq \
     clang-tidy-12 clang-12
 
-# Make using GCC 9 explicit.
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-9 \
-    --slave /usr/bin/gcov gcov /usr/bin/gcov-9
-ln -s /usr/bin/clang-format-12 /usr/bin/clang-format && \
-ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy && \
+ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
+ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy
 ln -s /usr/bin/clang-12 /usr/bin/clang
 
 EOF

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -127,13 +127,8 @@ To build Ray on Ubuntu, run the following commands:
 
 .. code-block:: bash
 
-  # Add a PPA containing gcc-9 for older versions of Ubuntu.
-  sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   sudo apt-get update
-  sudo apt-get install -y build-essential curl gcc-9 g++-9 pkg-config psmisc unzip
-  sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 \
-                --slave /usr/bin/g++ g++ /usr/bin/g++-9 \
-                --slave /usr/bin/gcov gcov /usr/bin/gcov-9
+  sudo apt-get install -y build-essential curl clang-12 pkg-config psmisc unzip
 
   # Install Bazelisk.
   ci/env/install-bazel.sh


### PR DESCRIPTION
we use clang now; no gcc