### PR TITLE
Add perf metrics for 2.23.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 504.754176,
+    "_dashboard_test_success": true,
+    "_peak_memory": 3.65,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t1.72GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n904\t0.88GiB\tpython distributed/test_many_actors.py\n293\t0.34GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n720\t0.07GiB\tray::JobSupervisor\n611\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n451\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n966\t0.06GiB\tray::MemoryMonitorActor.run\n1057\t0.05GiB\tray::DashboardTester.run\n392\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
+    "actors_per_second": 613.8104422632972,
+    "num_actors": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "actors_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 613.8104422632972
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 86.057
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 2641.416
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 5053.446
+        }
+    ],
+    "success": "1",
+    "time": 16.291674613952637
+}

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 186.650624,
+    "_dashboard_test_success": true,
+    "_peak_memory": 1.64,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n293\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1110\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1318\t0.08GiB\tray::StateAPIGeneratorActor.start\n926\t0.07GiB\tray::JobSupervisor\n450\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n448\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n603\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1172\t0.06GiB\tray::MemoryMonitorActor.run\n1264\t0.06GiB\tray::DashboardTester.run",
+    "num_tasks": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 372.1993782750883
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 250.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.752
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 13.367
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 176.812
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 372.1993782750883,
+    "time": 302.6867320537567,
+    "used_cpus": 250.0
+}

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,0 +1,32 @@
+{
+    "_dashboard_memory_usage_mb": 146.026496,
+    "_dashboard_test_success": true,
+    "_peak_memory": 2.17,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t0.95GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n960\t0.39GiB\tpython distributed/test_many_pgs.py\n293\t0.13GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n775\t0.07GiB\tray::JobSupervisor\n613\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n451\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1021\t0.06GiB\tray::MemoryMonitorActor.run\n1112\t0.05GiB\tray::DashboardTester.run\n391\t0.04GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=",
+    "num_pgs": 1000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "pgs_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 23.42930283459158
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3.367
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 12.824
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 898.617
+        }
+    ],
+    "pgs_per_second": 23.42930283459158,
+    "success": "1",
+    "time": 42.681594371795654
+}

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,0 +1,38 @@
+{
+    "_dashboard_memory_usage_mb": 1201.733632,
+    "_dashboard_test_success": true,
+    "_peak_memory": 4.93,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t2.57GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n293\t0.77GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n908\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1177\t0.08GiB\tray::StateAPIGeneratorActor.start\n1123\t0.08GiB\tray::DashboardTester.run\n724\t0.07GiB\tray::JobSupervisor\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n451\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n612\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1049\t0.06GiB\tray::MemoryMonitorActor.run",
+    "num_tasks": 10000,
+    "perf_metrics": [
+        {
+            "perf_metric_name": "tasks_per_second",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 579.8482552816317
+        },
+        {
+            "perf_metric_name": "used_cpus_by_deadline",
+            "perf_metric_type": "THROUGHPUT",
+            "perf_metric_value": 2500.0
+        },
+        {
+            "perf_metric_name": "dashboard_p50_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 44.327
+        },
+        {
+            "perf_metric_name": "dashboard_p95_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 3265.071
+        },
+        {
+            "perf_metric_name": "dashboard_p99_latency_ms",
+            "perf_metric_type": "LATENCY",
+            "perf_metric_value": 4407.973
+        }
+    ],
+    "success": "1",
+    "tasks_per_second": 579.8482552816317,
+    "time": 317.24589133262634,
+    "used_cpus": 2500.0
+}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        9062.792852859755,
-        201.88082345014254
+        8766.429278436297,
+        120.86055337969302
     ],
     "1_1_actor_calls_concurrent": [
-        5479.71996068499,
-        360.8246009353858
+        5466.2521928780425,
+        294.4643111642266
     ],
     "1_1_actor_calls_sync": [
-        2096.4576697416196,
-        54.90895331226573
+        2005.483489295091,
+        51.49539414234871
     ],
     "1_1_async_actor_calls_async": [
-        3314.3892417930037,
-        132.65271504449134
+        3485.371511081248,
+        113.58116489466117
     ],
     "1_1_async_actor_calls_sync": [
-        1325.7852093012016,
-        28.80251158731383
+        1347.8868250169457,
+        17.79541434936412
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2343.1487246339175,
-        64.07964858250249
+        2512.820463128068,
+        155.31965794076362
     ],
     "1_n_actor_calls_async": [
-        8606.08018065877,
-        464.65178014068323
+        8490.352729000244,
+        181.05358592855262
     ],
     "1_n_async_actor_calls_async": [
-        7460.166048300169,
-        81.1534935797334
+        7295.2280994398525,
+        83.24487540906311
     ],
     "client__1_1_actor_calls_async": [
-        907.189714069745,
-        30.09285092604243
+        987.583992857757,
+        8.55231528044142
     ],
     "client__1_1_actor_calls_concurrent": [
-        862.2264504688716,
-        15.31700423704598
+        993.4252979888793,
+        14.709916004253799
     ],
     "client__1_1_actor_calls_sync": [
-        465.4585783069056,
-        10.3283151207103
+        527.6097359140301,
+        6.229717007741613
     ],
     "client__get_calls": [
-        1158.7613618440014,
-        15.2470079224923
+        1122.3334401198258,
+        48.51501029209967
     ],
     "client__put_calls": [
-        789.0311690962432,
-        11.582638068164687
+        799.7415900241213,
+        12.025635667289933
     ],
     "client__put_gigabytes": [
-        0.13155858254345548,
-        0.0006237409662319517
+        0.13117998295265082,
+        0.000998012447116976
     ],
     "client__tasks_and_get_batch": [
-        0.9229179501706766,
-        0.016042442038446857
+        0.8066078636677214,
+        0.011930458414569594
     ],
     "client__tasks_and_put_batch": [
-        11657.997816451738,
-        122.84381416507865
+        11191.448976686781,
+        93.86657449650411
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12873.027401685875,
-        206.74322585504657
+        11889.62967857741,
+        119.20037762191876
     ],
     "multi_client_put_gigabytes": [
-        35.8680482168819,
-        1.6837276555923617
+        38.09272404390616,
+        2.3201711068853097
     ],
     "multi_client_tasks_async": [
-        21743.557366389494,
-        766.3008688107913
+        22255.262702895383,
+        1184.2604056922066
     ],
     "n_n_actor_calls_async": [
-        27688.27595653398,
-        786.3443469102006
+        27321.88100222539,
+        416.48715073593917
     ],
     "n_n_actor_calls_with_arg_async": [
-        2713.504279822532,
-        69.57915774978693
+        2672.287170984248,
+        23.619720775433688
     ],
     "n_n_async_actor_calls_async": [
-        23092.83239112525,
-        497.909562630626
+        23164.85974320361,
+        970.0857104946699
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10269.932297010477
+            "perf_metric_value": 10500.67448465853
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5196.004383289357
+            "perf_metric_value": 5286.037415485109
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12873.027401685875
+            "perf_metric_value": 11889.62967857741
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.09665460590859
+            "perf_metric_value": 20.46923471565212
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8.144156516407913
+            "perf_metric_value": 7.730134993824188
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 35.8680482168819
+            "perf_metric_value": 38.09272404390616
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.25584597642898
+            "perf_metric_value": 13.30751068234607
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.012190250895254
+            "perf_metric_value": 5.160164268505817
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 971.317197225919
+            "perf_metric_value": 974.4612781847234
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8194.32696391844
+            "perf_metric_value": 7378.7495889110505
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21743.557366389494
+            "perf_metric_value": 22255.262702895383
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2096.4576697416196
+            "perf_metric_value": 2005.483489295091
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9062.792852859755
+            "perf_metric_value": 8766.429278436297
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5479.71996068499
+            "perf_metric_value": 5466.2521928780425
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8606.08018065877
+            "perf_metric_value": 8490.352729000244
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27688.27595653398
+            "perf_metric_value": 27321.88100222539
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2713.504279822532
+            "perf_metric_value": 2672.287170984248
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1325.7852093012016
+            "perf_metric_value": 1347.8868250169457
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3314.3892417930037
+            "perf_metric_value": 3485.371511081248
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2343.1487246339175
+            "perf_metric_value": 2512.820463128068
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7460.166048300169
+            "perf_metric_value": 7295.2280994398525
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23092.83239112525
+            "perf_metric_value": 23164.85974320361
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 838.5131869401664
+            "perf_metric_value": 788.0742341227435
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1158.7613618440014
+            "perf_metric_value": 1122.3334401198258
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 789.0311690962432
+            "perf_metric_value": 799.7415900241213
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13155858254345548
+            "perf_metric_value": 0.13117998295265082
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11657.997816451738
+            "perf_metric_value": 11191.448976686781
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 465.4585783069056
+            "perf_metric_value": 527.6097359140301
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 907.189714069745
+            "perf_metric_value": 987.583992857757
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 862.2264504688716
+            "perf_metric_value": 993.4252979888793
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9229179501706766
+            "perf_metric_value": 0.8066078636677214
         }
     ],
     "placement_group_create/removal": [
-        838.5131869401664,
-        8.669141107798977
+        788.0742341227435,
+        10.00903890631821
     ],
     "single_client_get_calls_Plasma_Store": [
-        10269.932297010477,
-        323.15008192139106
+        10500.67448465853,
+        360.1079441884577
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.25584597642898,
-        0.06849427287247552
+        13.30751068234607,
+        0.2608539457674152
     ],
     "single_client_put_calls_Plasma_Store": [
-        5196.004383289357,
-        39.378140465481884
+        5286.037415485109,
+        74.24170737659924
     ],
     "single_client_put_gigabytes": [
-        20.09665460590859,
-        4.950859874261046
+        20.46923471565212,
+        6.428223549120574
     ],
     "single_client_tasks_and_get_batch": [
-        8.144156516407913,
-        0.26484235965448855
+        7.730134993824188,
+        0.15527622087112827
     ],
     "single_client_tasks_async": [
-        8194.32696391844,
-        355.25438679131315
+        7378.7495889110505,
+        772.618435291432
     ],
     "single_client_tasks_sync": [
-        971.317197225919,
-        32.73250539384329
+        974.4612781847234,
+        19.26648673285388
     ],
     "single_client_wait_1k_refs": [
-        5.012190250895254,
-        0.17129235302778886
+        5.160164268505817,
+        0.11776044271280343
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 18.67043262200002,
+    "broadcast_time": 15.855233231,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.67043262200002
+            "perf_metric_value": 15.855233231
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.131764829000005,
-    "get_time": 23.237287506,
+    "args_time": 17.276734743999995,
+    "get_time": 23.992132071,
     "large_object_size": 107374182400,
-    "large_object_time": 31.629831378000006,
+    "large_object_time": 31.869567716000006,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.131764829000005
+            "perf_metric_value": 17.276734743999995
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.7444607429999905
+            "perf_metric_value": 5.739413628999998
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.237287506
+            "perf_metric_value": 23.992132071
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 188.938811406
+            "perf_metric_value": 186.46388957200003
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 31.629831378000006
+            "perf_metric_value": 31.869567716000006
         }
     ],
-    "queued_time": 188.938811406,
-    "returns_time": 5.7444607429999905,
+    "queued_time": 186.46388957200003,
+    "returns_time": 5.739413628999998,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.5098540854454041,
-    "max_iteration_time": 4.985053539276123,
-    "min_iteration_time": 0.6889913082122803,
+    "avg_iteration_time": 1.0421651029586791,
+    "max_iteration_time": 4.056146621704102,
+    "min_iteration_time": 0.13677406311035156,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5098540854454041
+            "perf_metric_value": 1.0421651029586791
         }
     ],
     "success": 1,
-    "total_time": 150.98566269874573
+    "total_time": 104.2167329788208
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.160747766494751
+            "perf_metric_value": 12.619915246963501
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.831846237182617
+            "perf_metric_value": 27.771051788330077
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 54.19231338500977
+            "perf_metric_value": 73.57129535675048
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.171973943710327
+            "perf_metric_value": 1.6484127044677734
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2976.5505974292755
+            "perf_metric_value": 3348.829131603241
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.6098190516734817
+            "perf_metric_value": 0.4547737011485014
         }
     ],
-    "stage_0_time": 12.160747766494751,
-    "stage_1_avg_iteration_time": 23.831846237182617,
-    "stage_1_max_iteration_time": 25.01764941215515,
-    "stage_1_min_iteration_time": 22.995277881622314,
-    "stage_1_time": 238.31863117218018,
-    "stage_2_avg_iteration_time": 54.19231338500977,
-    "stage_2_max_iteration_time": 54.958396911621094,
-    "stage_2_min_iteration_time": 52.179816246032715,
-    "stage_2_time": 270.96241092681885,
-    "stage_3_creation_time": 2.171973943710327,
-    "stage_3_time": 2976.5505974292755,
-    "stage_4_spread": 0.6098190516734817,
+    "stage_0_time": 12.619915246963501,
+    "stage_1_avg_iteration_time": 27.771051788330077,
+    "stage_1_max_iteration_time": 29.194735288619995,
+    "stage_1_min_iteration_time": 26.235360383987427,
+    "stage_1_time": 277.7106223106384,
+    "stage_2_avg_iteration_time": 73.57129535675048,
+    "stage_2_max_iteration_time": 125.31455945968628,
+    "stage_2_min_iteration_time": 60.081254720687866,
+    "stage_2_time": 367.85813307762146,
+    "stage_3_creation_time": 1.6484127044677734,
+    "stage_3_time": 3348.829131603241,
+    "stage_4_spread": 0.4547737011485014,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.8636297822809175,
-    "avg_pg_remove_time_ms": 0.9039912897897018,
+    "avg_pg_create_time_ms": 0.9066000405417517,
+    "avg_pg_remove_time_ms": 0.8566281216197303,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.8636297822809175
+            "perf_metric_value": 0.9066000405417517
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9039912897897018
+            "perf_metric_value": 0.8566281216197303
         }
     ],
     "success": 1


### PR DESCRIPTION
```
New release perf metrics missing file benchmarks/benchmarks/many_pgs.json
New release perf metrics missing file benchmarks/benchmarks/many_tasks.json
New release perf metrics missing file benchmarks/benchmarks/many_nodes.json
New release perf metrics missing file benchmarks/benchmarks/many_actors.json
New release perf metrics missing file metadata.json
Old release perf metrics missing file benchmarks/many_tasks.json
Old release perf metrics missing file benchmarks/many_pgs.json
Old release perf metrics missing file benchmarks/many_nodes.json
Old release perf metrics missing file benchmarks/many_actors.json
REGRESSION 12.60%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9229179501706766 to 0.8066078636677214 in microbenchmark.json
REGRESSION 9.95%: single_client_tasks_async (THROUGHPUT) regresses from 8194.32696391844 to 7378.7495889110505 in microbenchmark.json
REGRESSION 7.64%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12873.027401685875 to 11889.62967857741 in microbenchmark.json
REGRESSION 6.02%: placement_group_create/removal (THROUGHPUT) regresses from 838.5131869401664 to 788.0742341227435 in microbenchmark.json
REGRESSION 5.08%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 8.144156516407913 to 7.730134993824188 in microbenchmark.json
REGRESSION 4.34%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2096.4576697416196 to 2005.483489295091 in microbenchmark.json
REGRESSION 4.00%: client__tasks_and_put_batch (THROUGHPUT) regresses from 11657.997816451738 to 11191.448976686781 in microbenchmark.json
REGRESSION 3.27%: 1_1_actor_calls_async (THROUGHPUT) regresses from 9062.792852859755 to 8766.429278436297 in microbenchmark.json
REGRESSION 3.14%: client__get_calls (THROUGHPUT) regresses from 1158.7613618440014 to 1122.3334401198258 in microbenchmark.json
REGRESSION 2.21%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7460.166048300169 to 7295.2280994398525 in microbenchmark.json
REGRESSION 1.52%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2713.504279822532 to 2672.287170984248 in microbenchmark.json
REGRESSION 1.34%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8606.08018065877 to 8490.352729000244 in microbenchmark.json
REGRESSION 1.32%: n_n_actor_calls_async (THROUGHPUT) regresses from 27688.27595653398 to 27321.88100222539 in microbenchmark.json
REGRESSION 0.29%: client__put_gigabytes (THROUGHPUT) regresses from 0.13155858254345548 to 0.13117998295265082 in microbenchmark.json
REGRESSION 0.25%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5479.71996068499 to 5466.2521928780425 in microbenchmark.json
REGRESSION 35.76%: stage_2_avg_iteration_time (LATENCY) regresses from 54.19231338500977 to 73.57129535675048 in stress_tests/stress_test_many_tasks.json
REGRESSION 16.53%: stage_1_avg_iteration_time (LATENCY) regresses from 23.831846237182617 to 27.771051788330077 in stress_tests/stress_test_many_tasks.json
REGRESSION 12.51%: stage_3_time (LATENCY) regresses from 2976.5505974292755 to 3348.829131603241 in stress_tests/stress_test_many_tasks.json
REGRESSION 4.98%: avg_pg_create_time_ms (LATENCY) regresses from 0.8636297822809175 to 0.9066000405417517 in stress_tests/stress_test_placement_group.json
REGRESSION 3.78%: stage_0_time (LATENCY) regresses from 12.160747766494751 to 12.619915246963501 in stress_tests/stress_test_many_tasks.json
REGRESSION 3.25%: 10000_get_time (LATENCY) regresses from 23.237287506 to 23.992132071 in scalability/single_node.json
REGRESSION 0.85%: 10000_args_time (LATENCY) regresses from 17.131764829000005 to 17.276734743999995 in scalability/single_node.json
REGRESSION 0.76%: 107374182400_large_object_time (LATENCY) regresses from 31.629831378000006 to 31.869567716000006 in scalability/single_node.json
```