### PR TITLE
[bazel] remove incompatible_linkopts_to_linklibs flag

### DIFF
--- a/ci/build/build-manylinux-forge.sh
+++ b/ci/build/build-manylinux-forge.sh
@@ -39,7 +39,6 @@ ln -sf "$(which bazelisk)" /usr/local/bin/bazel
 {
   echo "build --config=ci"
   echo "build --announce_rc"
-  echo "build --incompatible_linkopts_to_linklibs"
   if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
     echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL:-}"
   fi


### PR DESCRIPTION
the flag already flipped its default to true in bazel 5.6.x , and it is removed in bazel 6.x

