### PR TITLE
[RLlib] Add option for APPO/IMPALA to change number of GPU-loader threads and skip mixin buffer if not needed.

### DIFF
--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -129,6 +129,7 @@ class ImpalaConfig(AlgorithmConfig):
         self.timeout_s_aggregator_manager = 0.0
         self.broadcast_interval = 1
         self.num_aggregation_workers = 0
+        self.num_gpu_loader_threads = 16
 
         self.grad_clip = 40.0
         # Note: Only when using enable_rl_module_and_learner=True can the clipping mode
@@ -193,6 +194,7 @@ class ImpalaConfig(AlgorithmConfig):
         timeout_s_aggregator_manager: Optional[float] = NotProvided,
         broadcast_interval: Optional[int] = NotProvided,
         num_aggregation_workers: Optional[int] = NotProvided,
+        num_gpu_loader_threads: Optional[int] = NotProvided,
         grad_clip: Optional[float] = NotProvided,
         opt_type: Optional[str] = NotProvided,
         lr_schedule: Optional[List[List[Union[int, float]]]] = NotProvided,
@@ -261,6 +263,8 @@ class ImpalaConfig(AlgorithmConfig):
                 (`num_env_runners`). Note that n should be much smaller than m.
                 This can make sense if ingesting >2GB/s of samples, or if
                 the data requires decompression.
+            num_gpu_loader_threads: The number of GPU loader threads to use for loading
+                train-ready batches to the GPU(s).
             grad_clip: If specified, clip the global norm of gradients by this amount.
             opt_type: Either "adam" or "rmsprop".
             lr_schedule: Learning rate schedule. In the format of
@@ -322,6 +326,8 @@ class ImpalaConfig(AlgorithmConfig):
             self.timeout_s_sampler_manager = timeout_s_sampler_manager
         if timeout_s_aggregator_manager is not NotProvided:
             self.timeout_s_aggregator_manager = timeout_s_aggregator_manager
+        if num_gpu_loader_threads is not NotProvided:
+            self.num_gpu_loader_threads = num_gpu_loader_threads
         if grad_clip is not NotProvided:
             self.grad_clip = grad_clip
         if opt_type is not NotProvided:
@@ -538,6 +544,7 @@ def make_learner_thread(local_worker, config):
             num_sgd_iter=config["num_sgd_iter"],
             learner_queue_size=config["learner_queue_size"],
             learner_queue_timeout=config["learner_queue_timeout"],
+            num_data_load_threads=config["num_gpu_loader_threads"],
         )
     else:
         learner_thread = LearnerThread(
@@ -600,6 +607,8 @@ class Impala(Algorithm):
 
         # Queue of batches to be sent to the Learner.
         self.batches_to_place_on_learner = []
+        # The local mixin buffer (if required).
+        self.local_mixin_buffer = None
 
         # Create extra aggregation workers and assign each rollout worker to
         # one of them.
@@ -642,15 +651,16 @@ class Impala(Algorithm):
             )
         else:
             # Create our local mixin buffer if the num of aggregation workers is 0.
-            self.local_mixin_buffer = MixInMultiAgentReplayBuffer(
-                capacity=(
-                    self.config.replay_buffer_num_slots
-                    if self.config.replay_buffer_num_slots > 0
-                    else 1
-                ),
-                replay_ratio=self.config.replay_ratio,
-                replay_mode=ReplayMode.LOCKSTEP,
-            )
+            if self.config.replay_proportion > 0.0:
+                self.local_mixin_buffer = MixInMultiAgentReplayBuffer(
+                    capacity=(
+                        self.config.replay_buffer_num_slots
+                        if self.config.replay_buffer_num_slots > 0
+                        else 1
+                    ),
+                    replay_ratio=self.config.replay_ratio,
+                    replay_mode=ReplayMode.LOCKSTEP,
+                )
             self._aggregator_actor_manager = None
 
         # This variable is used to keep track of the statistics from the most recent
@@ -1063,8 +1073,11 @@ class Impala(Algorithm):
                 batch, ObjectRef
             ), "process_experiences_directly can not handle ObjectRefs. "
             batch = batch.decompress_if_needed()
-            self.local_mixin_buffer.add(batch)
-            batch = self.local_mixin_buffer.replay(_ALL_POLICIES)
+            # Only make a pass through the buffer, if replay proportion is > 0.0 (and
+            # we actually have one).
+            if self.local_mixin_buffer:
+                self.local_mixin_buffer.add(batch)
+                batch = self.local_mixin_buffer.replay(_ALL_POLICIES)
             if batch:
                 processed_batches.append(batch)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
This PR:
* Adds an option to the config for APPO/IMPALA to change number of GPU-loader threads (`config.training(num_gpu_loader_threads=...)`)
* Skips using the local mixin buffer if not needed (if replay proportion is 0.0, which is the default).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
