### PR TITLE
[doc][api/01] script to find annotated apis

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -29,6 +29,7 @@ steps:
       - ./ci/lint/lint.sh {{matrix}}
     matrix:
       - api_annotations
+      - api_discrepancy
 
   - label: ":lint-roller: lint: linkcheck"
     instance_type: medium

--- a/ci/lint/check_api_discrepancy.py
+++ b/ci/lint/check_api_discrepancy.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+import click
+import inspect
+
+import ray
+from ray.util.annotations import _is_annotated
+
+
+VISITED = set()
+ANNOTATED_CLASSES = set()
+ANNOTATED_FUNCTIONS = set()
+
+
+@click.command()
+def main() -> None:
+    """
+    This script checks for annotated classes and functions in a module, and finds
+    discrepancies between the annotations and the documentation.
+    """
+    walk(ray.data)  # TODO(can): parameterize the module to walk
+
+    print("ANNOTATED CLASSES")
+    for classes in sorted(ANNOTATED_CLASSES):
+        print(classes)
+    print("\n")
+    print("ANNOTATED FUNCTIONS")
+    for functions in sorted(ANNOTATED_FUNCTIONS):
+        print(functions)
+
+
+def walk(module) -> None:
+    """
+    Depth-first search through the module and its children to find annotated classes
+    and functions.
+    """
+    if module in VISITED:
+        return
+    VISITED.add(module)
+    if not _fullname(module).startswith("ray.data"):
+        return
+
+    for child in dir(module):
+        attribute = getattr(module, child)
+
+        if inspect.ismodule(attribute):
+            walk(attribute)
+        if inspect.isclass(attribute):
+            if _is_annotated(attribute):
+                ANNOTATED_CLASSES.add(_fullname(attribute))
+            walk(attribute)
+        if inspect.isfunction(attribute) and _is_annotated(attribute):
+            ANNOTATED_FUNCTIONS.add(_fullname(attribute))
+    return
+
+
+def _fullname(attr):
+    return inspect.getmodule(attr).__name__ + "." + attr.__name__
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -61,6 +61,12 @@ api_annotations() {
   ./ci/lint/check_api_annotations.py
 }
 
+api_discrepancy() {
+  # shellcheck disable=SC2102
+  RAY_DISABLE_EXTRA_CPP=1 pip install -e python/[all]
+  ./ci/lint/check_api_discrepancy.py
+}
+
 documentation_style() {
   ./ci/lint/check-documentation-style.sh
 }


### PR DESCRIPTION
- Script to find annotated apis for a given ray module
- Add annotation type (publicapi, developerapi, deprecated, etc.) to all
classes and functions. We need this information to determine if a class
or function should be rendered in our doc.


Test:
- CI
- run the script locally