### PR TITLE
[Data] Refactor `Dataset.split(equal=True)` to not use block lists 

### DIFF
--- a/python/ray/data/_internal/equalize.py
+++ b/python/ray/data/_internal/equalize.py
@@ -1,27 +1,26 @@
 from typing import List, Tuple
 
 from ray.data._internal.block_list import BlockList
+from ray.data._internal.execution.interfaces import RefBundle
 from ray.data._internal.split import _calculate_blocks_rows, _split_at_indices
 from ray.data.block import Block, BlockMetadata, BlockPartition
 from ray.types import ObjectRef
 
 
 def _equalize(
-    per_split_block_lists: List[BlockList],
+    per_split_bundles: List[RefBundle],
     owned_by_consumer: bool,
 ) -> List[BlockList]:
     """Equalize split block lists into equal number of rows.
 
     Args:
-        per_split_block_lists: block lists to equalize.
+        per_split_bundles: ref bundles to equalize.
     Returns:
-        the equalized block lists.
+        the equalized ref bundles.
     """
-    if len(per_split_block_lists) == 0:
-        return per_split_block_lists
-    per_split_blocks_with_metadata = [
-        block_list.get_blocks_with_metadata() for block_list in per_split_block_lists
-    ]
+    if len(per_split_bundles) == 0:
+        return per_split_bundles
+    per_split_blocks_with_metadata = [bundle.blocks for bundle in per_split_bundles]
     per_split_num_rows: List[List[int]] = [
         _calculate_blocks_rows(split) for split in per_split_blocks_with_metadata
     ]
@@ -42,15 +41,8 @@ def _equalize(
 
     # phase 2: based on the num rows needed for each shaved split, split the leftovers
     # in the shape that exactly matches the rows needed.
-    leftover_refs = []
-    leftover_meta = []
-    for (ref, meta) in leftovers:
-        leftover_refs.append(ref)
-        leftover_meta.append(meta)
-    leftover_splits = _split_leftovers(
-        BlockList(leftover_refs, leftover_meta, owned_by_consumer=owned_by_consumer),
-        per_split_needed_rows,
-    )
+    leftover_bundle = RefBundle(leftovers, owns_blocks=owned_by_consumer)
+    leftover_splits = _split_leftovers(leftover_bundle, per_split_needed_rows)
 
     # phase 3: merge the shaved_splits and leftoever splits and return.
     for i, leftover_split in enumerate(leftover_splits):
@@ -63,14 +55,7 @@ def _equalize(
     # Compose the result back to blocklists
     equalized_block_lists: List[BlockList] = []
     for split in shaved_splits:
-        block_refs: List[ObjectRef[Block]] = []
-        meta: List[BlockMetadata] = []
-        for (block_ref, m) in split:
-            block_refs.append(block_ref)
-            meta.append(m)
-        equalized_block_lists.append(
-            BlockList(block_refs, meta, owned_by_consumer=owned_by_consumer)
-        )
+        equalized_block_lists.append(RefBundle(split, owns_blocks=owned_by_consumer))
     return equalized_block_lists
 
 
@@ -137,7 +122,7 @@ def _shave_all_splits(
 
 
 def _split_leftovers(
-    leftovers: BlockList, per_split_needed_rows: List[int]
+    leftovers: RefBundle, per_split_needed_rows: List[int]
 ) -> List[BlockPartition]:
     """Split leftover blocks by the num of rows needed."""
     num_splits = len(per_split_needed_rows)
@@ -149,9 +134,9 @@ def _split_leftovers(
     split_result: Tuple[
         List[List[ObjectRef[Block]]], List[List[BlockMetadata]]
     ] = _split_at_indices(
-        leftovers.get_blocks_with_metadata(),
+        leftovers.blocks,
         split_indices,
-        leftovers._owned_by_consumer,
+        leftovers.owns_blocks,
     )
     return [list(zip(block_refs, meta)) for block_refs, meta in zip(*split_result)][
         :num_splits

--- a/python/ray/data/_internal/equalize.py
+++ b/python/ray/data/_internal/equalize.py
@@ -1,6 +1,5 @@
 from typing import List, Tuple
 
-from ray.data._internal.block_list import BlockList
 from ray.data._internal.execution.interfaces import RefBundle
 from ray.data._internal.split import _calculate_blocks_rows, _split_at_indices
 from ray.data.block import Block, BlockMetadata, BlockPartition
@@ -10,8 +9,8 @@ from ray.types import ObjectRef
 def _equalize(
     per_split_bundles: List[RefBundle],
     owned_by_consumer: bool,
-) -> List[BlockList]:
-    """Equalize split block lists into equal number of rows.
+) -> List[RefBundle]:
+    """Equalize split ref bundles into equal number of rows.
 
     Args:
         per_split_bundles: ref bundles to equalize.
@@ -52,11 +51,11 @@ def _equalize(
         num_shaved_rows = sum([meta.num_rows for _, meta in shaved_splits[i]])
         assert num_shaved_rows == target_split_size
 
-    # Compose the result back to blocklists
-    equalized_block_lists: List[BlockList] = []
+    # Compose the result back to RefBundle
+    equalized_ref_bundles: List[RefBundle] = []
     for split in shaved_splits:
-        equalized_block_lists.append(RefBundle(split, owns_blocks=owned_by_consumer))
-    return equalized_block_lists
+        equalized_ref_bundles.append(RefBundle(split, owns_blocks=owned_by_consumer))
+    return equalized_ref_bundles
 
 
 def _shave_one_split(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1521,7 +1521,7 @@ class Dataset:
             blocks = allocation_per_actor[actor]
             metadata = [metadata_mapping[b] for b in blocks]
             bundle = RefBundle(
-                tuple(zip(blocks, metadata)), owned_by_consumer=owned_by_consumer
+                tuple(zip(blocks, metadata)), owns_blocks=owned_by_consumer
             )
             per_split_bundles.append(bundle)
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -33,7 +33,10 @@ from ray.data._internal.compute import ComputeStrategy
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.equalize import _equalize
 from ray.data._internal.execution.interfaces import RefBundle
-from ray.data._internal.execution.legacy_compat import _block_list_to_bundles
+from ray.data._internal.execution.legacy_compat import (
+    _block_list_to_bundles,
+    _bundles_to_block_list,
+)
 from ray.data._internal.iterator.iterator_impl import DataIteratorImpl
 from ray.data._internal.iterator.stream_split_iterator import StreamSplitDataIterator
 from ray.data._internal.lazy_block_list import LazyBlockList
@@ -1513,23 +1516,23 @@ class Dataset:
 
         assert len(remaining_block_refs) == 0, len(remaining_block_refs)
 
-        per_split_block_lists = [
-            BlockList(
-                allocation_per_actor[actor],
-                [metadata_mapping[b] for b in allocation_per_actor[actor]],
-                owned_by_consumer=owned_by_consumer,
+        per_split_bundles = []
+        for actor in locality_hints:
+            blocks = allocation_per_actor[actor]
+            metadata = [metadata_mapping[b] for b in blocks]
+            bundle = RefBundle(
+                tuple(zip(blocks, metadata)), owned_by_consumer=owned_by_consumer
             )
-            for actor in locality_hints
-        ]
+            per_split_bundles.append(bundle)
 
         if equal:
             # equalize the splits
-            per_split_block_lists = _equalize(per_split_block_lists, owned_by_consumer)
+            per_split_bundles = _equalize(per_split_bundles, owned_by_consumer)
 
         split_datasets = []
-        for block_split in per_split_block_lists:
-            ref_bundles = _block_list_to_bundles(block_split, owned_by_consumer)
-            logical_plan = LogicalPlan(InputData(input_data=ref_bundles))
+        for bundle in per_split_bundles:
+            logical_plan = LogicalPlan(InputData(input_data=bundle))
+            block_split = _bundles_to_block_list([bundle], owned_by_consumer)
             split_datasets.append(
                 MaterializedDataset(
                     ExecutionPlan(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1531,7 +1531,7 @@ class Dataset:
 
         split_datasets = []
         for bundle in per_split_bundles:
-            logical_plan = LogicalPlan(InputData(input_data=bundle))
+            logical_plan = LogicalPlan(InputData(input_data=[bundle]))
             block_split = _bundles_to_block_list([bundle])
             split_datasets.append(
                 MaterializedDataset(

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1532,7 +1532,7 @@ class Dataset:
         split_datasets = []
         for bundle in per_split_bundles:
             logical_plan = LogicalPlan(InputData(input_data=bundle))
-            block_split = _bundles_to_block_list([bundle], owned_by_consumer)
+            block_split = _bundles_to_block_list([bundle])
             split_datasets.append(
                 MaterializedDataset(
                     ExecutionPlan(

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -2,6 +2,7 @@ import itertools
 import math
 import random
 import time
+from typing import Any
 from unittest.mock import patch
 
 import numpy as np
@@ -24,11 +25,12 @@ from ray.data._internal.split import (
     _split_single_block,
 )
 from ray.data._internal.stats import DatasetStats
-from ray.data.block import BlockAccessor, BlockMetadata
+from ray.data.block import Block, BlockAccessor, BlockMetadata
 from ray.data.dataset import Dataset
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.util import extract_values
 from ray.tests.conftest import *  # noqa
+from ray.types import ObjectRef
 
 
 @ray.remote
@@ -497,19 +499,28 @@ def _create_meta(num_rows):
     )
 
 
-def _create_block(data):
-    data = pd.DataFrame({"id": data})
-    return (ray.put(data), _create_meta(len(data)))
+def _create_block_and_metadata(data: Any) -> Tuple[ObjectRef[Block], BlockMetadata]:
+    block = pd.DataFrame({"id": data})
+    metadata = BlockAccessor.for_block(block).get_metadata(
+        input_files=[], exec_stats=None
+    )
+    return (ray.put(block), metadata)
 
 
 def _create_blocklist(blocks):
     block_refs = []
     meta = []
     for block in blocks:
-        block_ref, block_meta = _create_block(block)
+        block_ref, block_meta = _create_block_and_metadata(block)
         block_refs.append(block_ref)
         meta.append(block_meta)
     return BlockList(block_refs, meta, owned_by_consumer=True)
+
+
+def _create_bundle(blocks: List[List[Any]]) -> RefBundle:
+    return RefBundle(
+        [_create_block_and_metadata(block) for block in blocks], owns_blocks=True
+    )
 
 
 def _create_blocks_with_metadata(blocks):
@@ -594,7 +605,11 @@ def verify_splits(splits, blocks_by_split):
 
 
 def test_generate_global_split_results(ray_start_regular_shared):
-    inputs = [_create_block([1]), _create_block([2, 3]), _create_block([4])]
+    inputs = [
+        _create_block_and_metadata([1]),
+        _create_block_and_metadata([2, 3]),
+        _create_block_and_metadata([4]),
+    ]
 
     splits = list(zip(*_generate_global_split_results(iter(inputs), [1, 2, 1])))
     verify_splits(splits, [[[1]], [[2, 3]], [[4]]])
@@ -644,15 +659,15 @@ def test_private_split_at_indices(ray_start_regular_shared):
     verify_splits(splits, [[], [[1], [2, 3], [4]], []])
 
 
-def equalize_helper(input_block_lists):
+def equalize_helper(input_block_lists: List[List[List[Any]]]):
     result = _equalize(
-        [_create_blocklist(block_list) for block_list in input_block_lists],
+        [_create_bundle(block_list) for block_list in input_block_lists],
         owned_by_consumer=True,
     )
     result_block_lists = []
-    for blocklist in result:
+    for bundle in result:
         block_list = []
-        for block_ref, _ in blocklist.get_blocks_with_metadata():
+        for block_ref, _ in bundle.blocks:
             block = ray.get(block_ref)
             block_accessor = BlockAccessor.for_block(block)
             block_list.append(list(block_accessor.to_default()["id"]))

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -2,7 +2,7 @@ import itertools
 import math
 import random
 import time
-from typing import Any
+from typing import Any, List
 from unittest.mock import patch
 
 import numpy as np

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -2,7 +2,7 @@ import itertools
 import math
 import random
 import time
-from typing import Any, List
+from typing import Any, List, Tuple
 from unittest.mock import patch
 
 import numpy as np


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR is part of a larger effort to remove `BlockList` and `LazyBlockList` internally. To this end, this PR removes references to `BlockList` in the `Dataset.split` code path where `equal=True`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
