### PR TITLE
[Data] Remove unused `_split_at_index`

### DIFF
--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -3,7 +3,6 @@ import logging
 from typing import Iterable, List, Tuple, Union
 
 import ray
-from ray.data._internal.block_list import BlockList
 from ray.data._internal.memory_tracing import trace_deallocation
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data.block import (

--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -296,25 +296,3 @@ def _split_at_indices(
 def _get_num_rows(block: Block) -> int:
     """Get the number of rows contained in the provided block."""
     return BlockAccessor.for_block(block).num_rows()
-
-
-def _split_at_index(
-    block_list: BlockList,
-    index: int,
-) -> Tuple[
-    List[ObjectRef[Block]],
-    List[BlockMetadata],
-    List[ObjectRef[Block]],
-    List[BlockMetadata],
-]:
-    """Split blocks at the provided index.
-    Args:
-        blocks_with_metadata: Block futures to split, including the associated metadata.
-        index: The (global) index at which to split the blocks.
-    Returns:
-        The block split futures and their metadata for left and right of the index.
-    """
-    blocks_splits, metadata_splits = _split_at_indices(
-        block_list.get_blocks_with_metadata(), [index], block_list._owned_by_consumer
-    )
-    return blocks_splits[0], metadata_splits[0], blocks_splits[1], metadata_splits[1]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `_split_at_index` function isn't used anywhere. This PR removes it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
