### PR TITLE
[core] log dedup should not dedup number only lines

### DIFF
--- a/python/ray/_private/ray_logging.py
+++ b/python/ray/_private/ray_logging.py
@@ -284,11 +284,16 @@ class LogDeduplicator:
                 continue
             dedup_key = _canonicalise_log_line(line)
 
+            if dedup_key == "":
+                # Don't dedup messages that are empty after canonicalization.
+                # Because that's all the information users want to see.
+                output[0]["lines"].append(line)
+                continue
+
             if dedup_key in self.recent:
                 sources = self.recent[dedup_key].sources
                 sources.add(source)
-                # We deduplicate the warnings/errorm essages from
-                # raylet by default.
+                # We deduplicate the warnings/error messages from raylet by default.
                 if len(sources) > 1 or batch["pid"] == "raylet":
                     state = self.recent[dedup_key]
                     self.recent[dedup_key] = DedupState(

--- a/python/ray/tests/test_log_dedup.py
+++ b/python/ray/tests/test_log_dedup.py
@@ -19,6 +19,41 @@ def test_nodedup_logs_single_process():
     assert out1 == [batch1]
 
 
+def test_nodedup_logs_only_canonicalized_lines():
+    now = 142300000.0
+
+    def gettime():
+        return now
+
+    dedup = LogDeduplicator(5, None, None, _timesource=gettime)
+    batch1 = {
+        "ip": "node1",
+        "pid": 100,
+        # numbers are canonicalised, so this would lead to empty dedup_key
+        "lines": ["1"],
+    }
+    batch2 = {
+        "ip": "node1",
+        "pid": 200,
+        "lines": ["2"],
+    }
+
+    # Immediately prints always.
+    out1 = dedup.deduplicate(batch1)
+    assert out1 == [batch1]
+
+    now += 1.0
+    # Should buffer duplicates.
+    out2 = dedup.deduplicate(batch2)
+    assert out2 == [
+        {
+            "ip": "node1",
+            "pid": 200,
+            "lines": ["2"],
+        }
+    ]
+
+
 def test_dedup_logs_multiple_processes():
     now = 142300000.0
 

--- a/python/ray/tests/test_log_dedup.py
+++ b/python/ray/tests/test_log_dedup.py
@@ -19,7 +19,7 @@ def test_nodedup_logs_single_process():
     assert out1 == [batch1]
 
 
-def test_nodedup_logs_only_canonicalized_lines():
+def test_nodedup_logs_buffer_only_lines():
     now = 142300000.0
 
     def gettime():
@@ -32,23 +32,42 @@ def test_nodedup_logs_only_canonicalized_lines():
         # numbers are canonicalised, so this would lead to empty dedup_key
         "lines": ["1"],
     }
-    batch2 = {
-        "ip": "node1",
-        "pid": 200,
-        "lines": ["2"],
-    }
 
     # Immediately prints always.
     out1 = dedup.deduplicate(batch1)
     assert out1 == [batch1]
 
     now += 1.0
-    # Should buffer duplicates.
+
+    # Should print new lines even if it is number only again
+    batch2 = {
+        "ip": "node2",
+        "pid": 200,
+        "lines": ["2"],
+    }
     out2 = dedup.deduplicate(batch2)
     assert out2 == [
         {
-            "ip": "node1",
+            "ip": "node2",
             "pid": 200,
+            "lines": ["2"],
+        }
+    ]
+
+    now += 3.0
+
+    # Should print new lines even if it is same number
+    batch3 = {
+        "ip": "node3",
+        "pid": 300,
+        "lines": ["2"],
+    }
+    # Should buffer duplicates.
+    out3 = dedup.deduplicate(batch3)
+    assert out3 == [
+        {
+            "ip": "node3",
+            "pid": 300,
             "lines": ["2"],
         }
     ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ray runtime in driver deduplicates similar logs from all workers by default. In this case, all numbers are canonicalized, i.e. treated equal.

If all that prints are just numbers, it would be really bad user experience to dedup them. Because that's all the information that users want to see. If they can't see them, they will be confused.

## Related issue number

<!-- For example: "Closes #1234" -->

Fix https://github.com/ray-project/ray/issues/45262

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
