### PR TITLE
Clean up Serve proxy files

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Awaitable, Callable, Dict, List, Optional
+from typing import Awaitable, Callable, List, Optional
 
 from ray.actor import ActorHandle
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
@@ -697,9 +697,6 @@ class RequestMetadata:
 
     # Serve's gRPC context associated with this request for getting and setting metadata
     grpc_context: Optional[RayServegRPCContext] = None
-
-    # Tracing context
-    tracing_context: Optional[Dict[str, str]] = None
 
     @property
     def is_http_request(self) -> bool:

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Awaitable, Callable, List, Optional
+from typing import Awaitable, Callable, Dict, List, Optional
 
 from ray.actor import ActorHandle
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
@@ -697,6 +697,9 @@ class RequestMetadata:
 
     # Serve's gRPC context associated with this request for getting and setting metadata
     grpc_context: Optional[RayServegRPCContext] = None
+
+    # Tracing context
+    tracing_context: Optional[Dict[str, str]] = None
 
     @property
     def is_http_request(self) -> bool:

--- a/python/ray/serve/tests/test_proxy.py
+++ b/python/ray/serve/tests/test_proxy.py
@@ -92,6 +92,14 @@ class FakeGrpcHandle:
     def options(self, *args, **kwargs):
         return self
 
+    @property
+    def deployment_name(self) -> str:
+        return self.deployment_id.name
+
+    @property
+    def app_name(self) -> str:
+        return self.deployment_id.app_name
+
 
 class FakeProxyRouter(ProxyRouter):
     def __init__(self, *args, **kwargs):
@@ -183,6 +191,14 @@ class FakeHTTPHandle:
 
     def options(self, *args, **kwargs):
         return self
+
+    @property
+    def deployment_name(self) -> str:
+        return self.deployment_id.name
+
+    @property
+    def app_name(self) -> str:
+        return self.deployment_id.app_name
 
 
 class FakeHttpReceive:


### PR DESCRIPTION
This PR includes 2 changes:
1. Cleaning up the proxy file to improve consistency for the HTTP and GRPC proxy.
2. Add missing properties to testing classes to better simulate e2e tests.