### PR TITLE
[Data] Remove unused `force_reads` parameter from `execute_to_iterator`

### DIFF
--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -471,7 +471,6 @@ class ExecutionPlan:
     def execute_to_iterator(
         self,
         allow_clear_input_blocks: bool = True,
-        force_read: bool = False,
     ) -> Tuple[
         Iterator[Tuple[ObjectRef[Block], BlockMetadata]],
         DatasetStats,
@@ -484,7 +483,6 @@ class ExecutionPlan:
         Args:
             allow_clear_input_blocks: Whether we should try to clear the input blocks
                 for each operator.
-            force_read: Whether to force the read operator to fully execute.
 
         Returns:
             Tuple of iterator over output blocks and the executor.
@@ -496,7 +494,7 @@ class ExecutionPlan:
         if self.has_computed_output():
             return (
                 self.execute(
-                    allow_clear_input_blocks, force_read
+                    allow_clear_input_blocks, force_read=False
                 ).iter_blocks_with_metadata(),
                 self._snapshot_stats,
                 None,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Title.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
