### PR TITLE
[dashboard][cli] add --allow-exists flag to make "ray job submit" idempotent

### DIFF
--- a/dashboard/modules/job/tests/test_cli_integration.py
+++ b/dashboard/modules/job/tests/test_cli_integration.py
@@ -173,6 +173,26 @@ class TestJobSubmit:
         stdout, _ = _run_cmd(f"ray job submit -- bash -c '{cmd}'")
         assert "hello" in stdout
 
+    def test_submit_allow_exists(self, ray_start_stop):
+        """
+        Should not raise exception when using --allow-exists
+        and an existing submission id.
+        """
+        cmd = "echo hello"
+        stdout, _ = _run_cmd(
+            "ray job submit --submission-id test-allow-exists "
+            f"--no-wait -- bash -c '{cmd}'"
+        )
+        assert "hello" not in stdout
+        assert "Tailing logs until the job exits" not in stdout
+
+        stdout, _ = _run_cmd(
+            "ray job submit --submission-id test-allow-exists "
+            f"--allow-exists -- bash -c '{cmd}'"
+        )
+        assert "Job 'test-allow-exists' already exists" in stdout
+        assert "hello" in stdout
+
     def test_multiple_ray_init(self, ray_start_stop):
         cmd = (
             "python -c 'import ray; ray.init(); ray.shutdown(); "


### PR DESCRIPTION
## Why are these changes needed?

This PR adds the `--allow-exists` option to the `ray job submit` command. This is specifically handy in KubeRay RayJob because it has some retry logic where each retry runs `ray job submit` using the same submission ID.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
