### PR TITLE
[train] Update Torch default timeout_s to use Torch's default timeout

### DIFF
--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -47,11 +47,12 @@ class TorchConfig(BackendConfig):
             for environment variable initialization or "tcp" for TCP
             initialization. Defaults to "env".
         timeout_s: Seconds for process group operations to timeout.
+            Default value is None, which will use Torch's default timeout.
     """
 
     backend: Optional[str] = None
     init_method: str = "env"
-    timeout_s: int = 1800
+    timeout_s: Optional[int] = None
 
     @property
     def backend_cls(self):
@@ -67,7 +68,7 @@ def _setup_torch_process_group(
     world_rank: int,
     world_size: int,
     init_method: str,
-    timeout_s: int = 1800,
+    timeout_s: Optional[int] = None,
 ):
     """Connects the distributed PyTorch backend.
 
@@ -109,12 +110,14 @@ def _setup_torch_process_group(
         import habana_frameworks.torch.core as htcore  # noqa: F401
         import habana_frameworks.torch.distributed.hccl as hpu_dist  # noqa: F401
 
+    timeout = timedelta(seconds=timeout_s) if timeout_s is not None else None
+
     dist.init_process_group(
         backend=backend,
         init_method=init_method,
         rank=world_rank,
         world_size=world_size,
-        timeout=timedelta(seconds=timeout_s),
+        timeout=timeout,
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Previously the default was hardcoded to 30 minutes. By defaulting to `None`, it will use Torch Distributed's default value. For NCCL, this will be 10 minutes (see [torch.distributed.init_process_group](https://pytorch.org/docs/stable/distributed.html#torch.distributed.init_process_group)). 

This should help reduce time to detect hanging NCCL training jobs from 30 minutes to 10 minutes.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
