### PR TITLE
[ci][microcheck/13] reuse the logic to determine microcheck tests

### DIFF
--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -57,10 +57,10 @@ steps:
     depends_on: data15build
 
   - label: ":database: data: arrow nightly tests"
+    if: pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags: 
       - python
       - data
-      - skip-on-premerge
     instance_type: medium
     parallelism: 2
     commands:

--- a/ci/ray_ci/automation/determine_microcheck_step_ids.py
+++ b/ci/ray_ci/automation/determine_microcheck_step_ids.py
@@ -1,4 +1,5 @@
 import click
+import os
 
 from ci.ray_ci.utils import ci_init
 from ray_release.test import (
@@ -8,6 +9,8 @@ from ray_release.test import (
     MACOS_TEST_PREFIX,
 )
 
+BAZEL_WORKSPACE_DIR = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
+
 
 @click.command()
 def main() -> None:
@@ -16,9 +19,9 @@ def main() -> None:
     """
     ci_init()
     steps = (
-        list(Test.gen_high_impact_tests(LINUX_TEST_PREFIX).keys())
-        + list(Test.gen_high_impact_tests(WINDOWS_TEST_PREFIX).keys())
-        + list(Test.gen_high_impact_tests(MACOS_TEST_PREFIX).keys())
+        Test.gen_microcheck_step_ids(LINUX_TEST_PREFIX, BAZEL_WORKSPACE_DIR)
+        + Test.gen_microcheck_step_ids(WINDOWS_TEST_PREFIX, BAZEL_WORKSPACE_DIR)
+        + Test.gen_microcheck_step_ids(MACOS_TEST_PREFIX, BAZEL_WORKSPACE_DIR)
     )
 
     print(",".join(steps))

--- a/ci/ray_ci/automation/determine_microcheck_step_ids.py
+++ b/ci/ray_ci/automation/determine_microcheck_step_ids.py
@@ -20,8 +20,8 @@ def main() -> None:
     ci_init()
     steps = (
         Test.gen_microcheck_step_ids(LINUX_TEST_PREFIX, BAZEL_WORKSPACE_DIR)
-        + Test.gen_microcheck_step_ids(WINDOWS_TEST_PREFIX, BAZEL_WORKSPACE_DIR)
-        + Test.gen_microcheck_step_ids(MACOS_TEST_PREFIX, BAZEL_WORKSPACE_DIR)
+        .union(Test.gen_microcheck_step_ids(WINDOWS_TEST_PREFIX, BAZEL_WORKSPACE_DIR))
+        .union(Test.gen_microcheck_step_ids(MACOS_TEST_PREFIX, BAZEL_WORKSPACE_DIR))
     )
 
     print(",".join(steps))

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -128,7 +128,7 @@ def test_get_test_targets() -> None:
             "ray_release.test.Test.get_changed_tests",
             return_value=set(),
         ), mock.patch(
-            "ci.ray_ci.tester._get_new_tests",
+            "ray_release.test.Test.get_new_tests",
             return_value=set(),
         ):
             assert set(
@@ -250,7 +250,7 @@ def test_get_high_impact_test_targets() -> None:
             "ray_release.test.Test.gen_high_impact_tests",
             return_value={"step": test["input"]},
         ), mock.patch(
-            "ci.ray_ci.tester._get_new_tests",
+            "ray_release.test.Test.get_new_tests",
             return_value=test["new_tests"],
         ), mock.patch(
             "ray_release.test.Test.get_changed_tests",

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -13,17 +13,9 @@ from ci.ray_ci.tester import (
     _get_container,
     _get_all_test_query,
     _get_test_targets,
-<<<<<<< HEAD
-    _get_high_impact_test_targets,
     _get_new_tests,
-=======
->>>>>>> [ci][microcheck/13] sync microcheck test determinator
     _get_flaky_test_targets,
     _get_tag_matcher,
-    _get_new_tests,
-    _get_changed_files,
-    _get_changed_tests,
-    _get_human_specified_tests,
 )
 from ray_release.test import Test, TestState
 
@@ -129,6 +121,9 @@ def test_get_test_targets() -> None:
             "ray_release.test.Test.gen_from_s3",
             return_value=test_objects,
         ), mock.patch(
+            "ci.ray_ci.tester._get_new_tests",
+            return_value=set(),
+        ), mock.patch(
             "ray_release.test.Test.gen_microcheck_tests",
             return_value={test.get_target() for test in test_objects},
         ):
@@ -212,65 +207,6 @@ def test_get_all_test_query() -> None:
     )
 
 
-<<<<<<< HEAD
-def test_get_high_impact_test_targets() -> None:
-    test_harness = [
-        {
-            "input": [],
-            "new_tests": set(),
-            "changed_tests": set(),
-            "human_tests": set(),
-            "output": set(),
-        },
-        {
-            "input": [
-                _stub_test(
-                    {
-                        "name": "linux://core_good",
-                        "team": "core",
-                    }
-                ),
-                _stub_test(
-                    {
-                        "name": "linux://serve_good",
-                        "team": "serve",
-                    }
-                ),
-            ],
-            "new_tests": {"//core_new"},
-            "changed_tests": {"//core_new"},
-            "human_tests": {"//human_test"},
-            "output": {
-                "//core_good",
-                "//core_new",
-                "//human_test",
-            },
-        },
-    ]
-    for test in test_harness:
-        with mock.patch(
-            "ray_release.test.Test.gen_high_impact_tests",
-            return_value={"step": test["input"]},
-        ), mock.patch(
-            "ray_release.test.Test.get_new_tests",
-            return_value=test["new_tests"],
-        ), mock.patch(
-            "ray_release.test.Test.get_changed_tests",
-            return_value=test["changed_tests"],
-        ), mock.patch(
-            "ray_release.test.Test.get_human_specified_tests",
-            return_value=test["human_tests"],
-        ):
-            assert (
-                _get_high_impact_test_targets(
-                    "core",
-                    "linux",
-                    LinuxTesterContainer("test", skip_ray_installation=True),
-                )
-                == test["output"]
-            )
-
-
 @mock.patch("ci.ray_ci.tester_container.TesterContainer.run_script_with_output")
 @mock.patch("ray_release.test.Test.gen_from_s3")
 def test_get_new_tests(mock_gen_from_s3, mock_run_script_with_output) -> None:
@@ -278,47 +214,12 @@ def test_get_new_tests(mock_gen_from_s3, mock_run_script_with_output) -> None:
         _stub_test({"name": "linux://old_test_01"}),
         _stub_test({"name": "linux://old_test_02"}),
     ]
-    mock_check_output.return_value = b"//old_test_01\n//new_test"
-    assert _get_new_tests("linux") == {"//new_test"}
+    mock_run_script_with_output.return_value = "//old_test_01\n//new_test"
+    assert _get_new_tests(
+        "linux", LinuxTesterContainer("test", skip_ray_installation=True)
+    ) == {"//new_test"}
 
 
-@mock.patch.dict(
-    os.environ,
-    {"BUILDKITE_PULL_REQUEST_BASE_BRANCH": "base", "BUILDKITE_COMMIT": "commit"},
-)
-@mock.patch("subprocess.check_call")
-@mock.patch("subprocess.check_output")
-def test_get_changed_files(mock_check_output, mock_check_call) -> None:
-    mock_check_output.return_value = b"file1\nfile2\n"
-    assert _get_changed_files() == {"file1", "file2"}
-
-
-@mock.patch("ci.ray_ci.tester._get_test_targets_per_file")
-@mock.patch("ci.ray_ci.tester._get_changed_files")
-def test_get_changed_tests(
-    mock_get_changed_files, mock_get_test_targets_per_file
-) -> None:
-    mock_get_changed_files.return_value = {"test_src", "build_src"}
-    mock_get_test_targets_per_file.side_effect = (
-        lambda x: {"//t1", "//t2"} if x == "test_src" else {}
-    )
-
-    assert _get_changed_tests() == {"//t1", "//t2"}
-
-
-@mock.patch.dict(
-    os.environ,
-    {"BUILDKITE_PULL_REQUEST_BASE_BRANCH": "base", "BUILDKITE_COMMIT": "commit"},
-)
-@mock.patch("subprocess.check_call")
-@mock.patch("subprocess.check_output")
-def test_get_human_specified_tests(mock_check_output, mock_check_call) -> None:
-    mock_check_output.return_value = b"hi\n@microcheck //test01 //test02\nthere"
-    assert _get_human_specified_tests() == {"//test01", "//test02"}
-
-
-=======
->>>>>>> [ci][microcheck/13] sync microcheck test determinator
 def test_get_flaky_test_targets() -> None:
     test_harness = [
         {

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -13,8 +13,11 @@ from ci.ray_ci.tester import (
     _get_container,
     _get_all_test_query,
     _get_test_targets,
+<<<<<<< HEAD
     _get_high_impact_test_targets,
     _get_new_tests,
+=======
+>>>>>>> [ci][microcheck/13] sync microcheck test determinator
     _get_flaky_test_targets,
     _get_tag_matcher,
     _get_new_tests,
@@ -126,14 +129,8 @@ def test_get_test_targets() -> None:
             "ray_release.test.Test.gen_from_s3",
             return_value=test_objects,
         ), mock.patch(
-            "ray_release.test.Test.gen_high_impact_tests",
-            return_value={"step": test_objects},
-        ), mock.patch(
-            "ray_release.test.Test.get_changed_tests",
-            return_value=set(),
-        ), mock.patch(
-            "ray_release.test.Test.get_new_tests",
-            return_value=set(),
+            "ray_release.test.Test.gen_microcheck_tests",
+            return_value={test.get_target() for test in test_objects},
         ):
             assert set(
                 _get_test_targets(
@@ -215,6 +212,7 @@ def test_get_all_test_query() -> None:
     )
 
 
+<<<<<<< HEAD
 def test_get_high_impact_test_targets() -> None:
     test_harness = [
         {
@@ -319,6 +317,8 @@ def test_get_human_specified_tests(mock_check_output, mock_check_call) -> None:
     assert _get_human_specified_tests() == {"//test01", "//test02"}
 
 
+=======
+>>>>>>> [ci][microcheck/13] sync microcheck test determinator
 def test_get_flaky_test_targets() -> None:
     test_harness = [
         {

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -14,9 +14,9 @@ from ci.ray_ci.tester import (
     _get_all_test_query,
     _get_test_targets,
     _get_high_impact_test_targets,
+    _get_new_tests,
     _get_flaky_test_targets,
     _get_tag_matcher,
-    _get_new_tests,
 )
 from ray_release.test import Test, TestState
 

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 import sys
 from typing import List, Set, Tuple, Optional
@@ -37,7 +36,6 @@ A copy of this license is made available in this container at /NGC-DL-CONTAINER-
 """  # noqa: E501
 
 DEFAULT_EXCEPT_TAGS = {"manual"}
-MICROCHECK_COMMAND = "@microcheck"
 
 # Gets the path of product/tools/docker (i.e. the parent of 'common')
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
@@ -394,36 +392,14 @@ def _get_test_targets(
     if get_high_impact_tests:
         # run high impact test cases, so we include only high impact tests in the list
         # of targets provided by users
-        high_impact_tests = _get_high_impact_test_targets(
-            team, operating_system, container
-        )
+        high_impact_tests = Test.gen_microcheck_tests(
+            prefix=f"{operating_system}:",
+            bazel_workspace_dir=bazel_workspace_dir,
+            team=team,
+        ).union(_get_new_tests(f"{operating_system}:", container)
         final_targets = high_impact_tests.intersection(final_targets)
 
     return list(final_targets)
-
-
-def _get_high_impact_test_targets(
-    team: str, operating_system: str, container: TesterContainer
-) -> Set[str]:
-    """
-    Get all test targets that are high impact
-    """
-    os_prefix = f"{operating_system}:"
-    step_id_to_tests = Test.gen_high_impact_tests(prefix=os_prefix)
-    high_impact_tests = {
-        test.get_name().lstrip(os_prefix)
-        for test in itertools.chain.from_iterable(step_id_to_tests.values())
-        if test.get_oncall() == team
-    }
-    new_tests = _get_new_tests(os_prefix, container)
-    changed_tests = Test.get_changed_tests(bazel_workspace_dir)
-    human_specified_tests = Test.get_human_specified_tests(bazel_workspace_dir)
-
-    return (
-        high_impact_tests.union(new_tests)
-        .union(changed_tests)
-        .union(human_specified_tests)
-    )
 
 
 def _get_new_tests(prefix: str, container: TesterContainer) -> Set[str]:

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -392,11 +392,15 @@ def _get_test_targets(
     if get_high_impact_tests:
         # run high impact test cases, so we include only high impact tests in the list
         # of targets provided by users
+        prefix = f"{operating_system}:"
+        # TODO(can): we should also move the logic of _get_new_tests into the
+        # gen_microcheck_tests function; this is currently blocked by the fact that
+        # we need a container to run _get_new_tests
         high_impact_tests = Test.gen_microcheck_tests(
-            prefix=f"{operating_system}:",
+            prefix=prefix,
             bazel_workspace_dir=bazel_workspace_dir,
             team=team,
-        ).union(_get_new_tests(f"{operating_system}:", container)
+        ).union(_get_new_tests(prefix, container))
         final_targets = high_impact_tests.intersection(final_targets)
 
     return list(final_targets)

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -219,7 +219,7 @@ class Test(dict):
                 if result.commit == recent_results[0].commit and result.rayci_step_id
             }
             if test_step_ids and not step_ids.intersection(test_step_ids):
-                step_ids.add(test_step_ids.pop())
+                step_ids.add(sorted(test_step_ids)[0])
 
         return step_ids
 


### PR DESCRIPTION
Currently the logic to determine the list of microcheck tests and their rayci step ids are diverging. This PR move more function into Test class, so we converge more these two logic. 

This make sure that we will trigger the right buildkite steps to cover most if not all microcheck tests.

Test:
- CI