### PR TITLE
[core] Deflake test_get_locations on windows.

### DIFF
--- a/python/ray/tests/test_get_locations.py
+++ b/python/ray/tests/test_get_locations.py
@@ -168,7 +168,6 @@ def gen_big_objects(block_size, block_count):
 
 def assert_object_size_gt(obj_ref: ray.ObjectRef, size: int):
     d = ray.experimental.get_local_object_locations([obj_ref])
-    print(d)
     assert d is not None
     assert len(d) == 1
     assert d[obj_ref]["object_size"] > size

--- a/python/ray/tests/test_get_locations.py
+++ b/python/ray/tests/test_get_locations.py
@@ -151,8 +151,7 @@ BIG_OBJ_SIZE = 3 * 1024 * 1024  # 3 MiB
 
 class BigObject:
     def __init__(self):
-        # 100 MiB of memory used...
-        self.data = np.zeros((100 * 1024 * 1024), dtype=np.uint8)
+        self.data = np.zeros((BIG_OBJ_SIZE,), dtype=np.uint8)
 
 
 @ray.remote
@@ -169,6 +168,7 @@ def gen_big_objects(block_size, block_count):
 
 def assert_object_size_gt(obj_ref: ray.ObjectRef, size: int):
     d = ray.experimental.get_local_object_locations([obj_ref])
+    print(d)
     assert d is not None
     assert len(d) == 1
     assert d[obj_ref]["object_size"] > size


### PR DESCRIPTION
PR #45309 tried to deflake windows://python/ray/tests:test_get_locations by reducing object size used in tests. However that PR missed a line of change so it only worked on size asserting, not on size creation. This made the windows test still in failure. This PR fixes it properly.