### PR TITLE
[ci][microcheck] recover the logic to compute new tests

### DIFF
--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -416,10 +416,15 @@ def _get_high_impact_test_targets(
         for test in itertools.chain.from_iterable(step_id_to_tests.values())
         if test.get_oncall() == team
     }
+    new_tests = _get_new_tests(os_prefix, container)
     changed_tests = _get_changed_tests()
     human_specified_tests = _get_human_specified_tests()
 
-    return high_impact_tests.union(changed_tests).union(human_specified_tests)
+    return (
+        high_impact_tests.union(new_tests)
+        .union(changed_tests)
+        .union(human_specified_tests)
+    )
 
 
 def _get_human_specified_tests() -> Set[str]:
@@ -443,6 +448,20 @@ def _get_human_specified_tests() -> Set[str]:
     logger.info(f"Human specified tests: {tests}")
 
     return tests
+
+
+def _get_new_tests(prefix: str, container: TesterContainer) -> Set[str]:
+    """
+    Get all local test targets that are not in database
+    """
+    local_test_targets = set(
+        container.run_script_with_output(['bazel query "tests(//...)"'])
+        .strip()
+        .split(os.linesep)
+    )
+    db_test_targets = {test.get_target() for test in Test.gen_from_s3(prefix=prefix)}
+
+    return local_test_targets.difference(db_test_targets)
 
 
 def _get_changed_tests() -> Set[str]:


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/45462 adds a new tests by changing bazel rule instead of adding a new test file; this case can only be covered by our previous logic of computing new tests; recover this logic (in addition to the logic of computing new tests by looking at changed test files)

This is a redo of https://github.com/ray-project/ray/pull/45495 which got reverted. The difference now is that we run the bazel command in a container instead of on the current environment. bazel seems to have issues sharing the cache when calling bazel within bazel (https://buildkite.com/ray-project/microcheck/builds/444#018fa23a-6e31-435b-a0ea-412ca2d1017b/175-1476)

Test:
- CI
- full microcheck run: https://buildkite.com/ray-project/microcheck/builds/464