### PR TITLE
[Data] Allow user to configure timeout for actor pool 

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -28,10 +28,6 @@ logger = logging.getLogger(__name__)
 # fairly high since streaming backpressure prevents us from overloading actors.
 DEFAULT_MAX_TASKS_IN_FLIGHT = 4
 
-# The default time to wait for minimum requested actors
-# to start before raising a timeout, in seconds.
-DEFAULT_WAIT_FOR_MIN_ACTORS_SEC = 60 * 10
-
 
 class ActorPoolMapOperator(MapOperator):
     """A MapOperator implementation that executes tasks on an actor pool.
@@ -132,7 +128,8 @@ class ActorPoolMapOperator(MapOperator):
         # upstream operators, leading to a spike in memory usage prior to steady state.
         logger.debug(f"{self._name}: Waiting for {len(refs)} pool actors to start...")
         try:
-            ray.get(refs, timeout=DEFAULT_WAIT_FOR_MIN_ACTORS_SEC)
+            timeout = DataContext.get_current().default_wait_for_min_actors_s
+            ray.get(refs, timeout=timeout)
         except ray.exceptions.GetTimeoutError:
             raise ray.exceptions.GetTimeoutError(
                 "Timed out while starting actors. "

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -128,7 +128,7 @@ class ActorPoolMapOperator(MapOperator):
         # upstream operators, leading to a spike in memory usage prior to steady state.
         logger.debug(f"{self._name}: Waiting for {len(refs)} pool actors to start...")
         try:
-            timeout = DataContext.get_current().wait_for_min_actors_timeout_s
+            timeout = DataContext.get_current().wait_for_min_actors_s
             ray.get(refs, timeout=timeout)
         except ray.exceptions.GetTimeoutError:
             raise ray.exceptions.GetTimeoutError(

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -128,7 +128,7 @@ class ActorPoolMapOperator(MapOperator):
         # upstream operators, leading to a spike in memory usage prior to steady state.
         logger.debug(f"{self._name}: Waiting for {len(refs)} pool actors to start...")
         try:
-            timeout = DataContext.get_current().default_wait_for_min_actors_s
+            timeout = DataContext.get_current().wait_for_min_actors_timeout_s
             ray.get(refs, timeout=timeout)
         except ray.exceptions.GetTimeoutError:
             raise ray.exceptions.GetTimeoutError(

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -275,7 +275,7 @@ class DataContext:
     )
     print_on_execution_start: bool = True
     s3_try_create_dir: bool = DEFAULT_S3_TRY_CREATE_DIR
-    wait_for_min_actors_s: int = DEFAULT_WAIT_FOR_MIN_ACTORS_S
+    wait_for_min_actors_timeout_s: int = DEFAULT_WAIT_FOR_MIN_ACTORS_S
 
     def __post_init__(self):
         # The additonal ray remote args that should be added to

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -275,7 +275,7 @@ class DataContext:
     )
     print_on_execution_start: bool = True
     s3_try_create_dir: bool = DEFAULT_S3_TRY_CREATE_DIR
-    wait_for_min_actors_timeout_s: int = DEFAULT_WAIT_FOR_MIN_ACTORS_S
+    wait_for_min_actors_s: int = DEFAULT_WAIT_FOR_MIN_ACTORS_S
 
     def __post_init__(self):
         # The additonal ray remote args that should be added to

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -228,7 +228,7 @@ class DataContext:
             execution starts.
         s3_try_create_dir: If ``True``, try to create directories on S3 when a write
             call is made with a S3 URI.
-        default_wait_for_min_actors_s: The default time to wait for minimum requested
+        wait_for_min_actors_s: The default time to wait for minimum requested
             actors to start before raising a timeout, in seconds.
     """
 
@@ -275,7 +275,7 @@ class DataContext:
     )
     print_on_execution_start: bool = True
     s3_try_create_dir: bool = DEFAULT_S3_TRY_CREATE_DIR
-    default_wait_for_min_actors_s: int = DEFAULT_WAIT_FOR_MIN_ACTORS_S
+    wait_for_min_actors_s: int = DEFAULT_WAIT_FOR_MIN_ACTORS_S
 
     def __post_init__(self):
         # The additonal ray remote args that should be added to

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -128,6 +128,10 @@ DEFAULT_MAX_NUM_BLOCKS_IN_STREAMING_GEN_BUFFER = 2
 # calls if the URI is an S3 URI.
 DEFAULT_S3_TRY_CREATE_DIR = False
 
+DEFAULT_WAIT_FOR_MIN_ACTORS_S = env_integer(
+    "RAY_DATA_DEFAULT_WAIT_FOR_MIN_ACTORS_S", 60 * 10
+)
+
 
 def _execution_options_factory() -> "ExecutionOptions":
     # Lazily import to avoid circular dependencies.
@@ -224,6 +228,8 @@ class DataContext:
             execution starts.
         s3_try_create_dir: If ``True``, try to create directories on S3 when a write
             call is made with a S3 URI.
+        default_wait_for_min_actors_s: The default time to wait for minimum requested
+            actors to start before raising a timeout, in seconds.
     """
 
     target_max_block_size: int = DEFAULT_TARGET_MAX_BLOCK_SIZE
@@ -269,6 +275,7 @@ class DataContext:
     )
     print_on_execution_start: bool = True
     s3_try_create_dir: bool = DEFAULT_S3_TRY_CREATE_DIR
+    default_wait_for_min_actors_s: int = DEFAULT_WAIT_FOR_MIN_ACTORS_S
 
     def __post_init__(self):
         # The additonal ray remote args that should be added to

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -525,7 +525,7 @@ def test_start_actor_timeout(ray_start_regular_shared, restore_data_context):
 
     from ray.exceptions import GetTimeoutError
 
-    ray.data.DataContext.get_current().wait_for_min_actors_timeout_s = 1
+    ray.data.DataContext.get_current().wait_for_min_actors_s = 1
 
     with pytest.raises(
         GetTimeoutError,

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -515,7 +515,7 @@ class TestActorPool(unittest.TestCase):
         assert res3 is None
 
 
-def test_start_actor_timeout(ray_start_regular_shared):
+def test_start_actor_timeout(ray_start_regular_shared, restore_data_context):
     """Tests that ActorPoolMapOperator raises an exception on
     timeout while waiting for actors."""
 
@@ -523,11 +523,9 @@ def test_start_actor_timeout(ray_start_regular_shared):
         def __call__(self, x):
             return x
 
-    from ray.data._internal.execution.operators import actor_pool_map_operator
     from ray.exceptions import GetTimeoutError
 
-    original_timeout = actor_pool_map_operator.DEFAULT_WAIT_FOR_MIN_ACTORS_SEC
-    actor_pool_map_operator.DEFAULT_WAIT_FOR_MIN_ACTORS_SEC = 1
+    ray.data.DataContext.get_current().wait_for_min_actors_timeout_s = 1
 
     with pytest.raises(
         GetTimeoutError,
@@ -544,7 +542,6 @@ def test_start_actor_timeout(ray_start_regular_shared):
             compute=ray.data.ActorPoolStrategy(size=5),
             num_gpus=100,
         ).take_all()
-    actor_pool_map_operator.DEFAULT_WAIT_FOR_MIN_ACTORS_SEC = original_timeout
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If your `Dataset` waits more than 10 minutes to launch GPU actors, your program fails. This PR allows you to configure this behavior so that you can wait longer. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
