### PR TITLE
Revert "[ci][microcheck] include step id from all step job flavors"

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -57,7 +57,7 @@ steps:
     depends_on: servepydantic1build
 
   - label: ":ray-serve: serve: python {{matrix.python}} tests ({{matrix.worker_id}})"
-    if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89"
+    if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags: 
       - serve
       - python

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -204,19 +204,10 @@ class Test(dict):
         ]
         step_id_to_tests = {}
         for test in high_impact_tests:
-            recent_results = test.get_test_results()
-            if not recent_results:
+            step_id = test.get_test_results(limit=1)[0].rayci_step_id
+            if not step_id:
                 continue
-            recent_commit = recent_results[0].commit
-            for result in recent_results:
-                # consider all results with the same recent commit; this is to make sure
-                # we will include different job flavors of the same test
-                if result.commit != recent_commit:
-                    continue
-                step_id = result.rayci_step_id
-                if not step_id:
-                    continue
-                step_id_to_tests[step_id] = step_id_to_tests.get(step_id, []) + [test]
+            step_id_to_tests[step_id] = step_id_to_tests.get(step_id, []) + [test]
 
         return step_id_to_tests
 

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -61,11 +61,11 @@ def _stub_test(val: dict) -> Test:
 
 
 def _stub_test_result(
-    status: ResultStatus = ResultStatus.SUCCESS, rayci_step_id="123", commit="456"
+    status: ResultStatus = ResultStatus.SUCCESS, rayci_step_id="123"
 ) -> TestResult:
     return TestResult(
         status=status.value,
-        commit=commit,
+        commit="1234567890",
         branch="master",
         url="url",
         timestamp=0,
@@ -340,7 +340,7 @@ def gen_high_impact_tests(mock_gen_from_s3) -> None:
             "name": "core_test",
             Test.KEY_IS_HIGH_IMPACT: "false",
             "test_results": [
-                _stub_test_result(rayci_step_id="corebuild", commit="123"),
+                _stub_test_result(rayci_step_id="corebuild"),
             ],
         }
     )
@@ -349,9 +349,7 @@ def gen_high_impact_tests(mock_gen_from_s3) -> None:
             "name": "data_test_01",
             Test.KEY_IS_HIGH_IMPACT: "true",
             "test_results": [
-                _stub_test_result(rayci_step_id="databuild", commit="123"),
-                _stub_test_result(rayci_step_id="data15build", commit="123"),
-                _stub_test_result(rayci_step_id="data12build", commit="456"),
+                _stub_test_result(rayci_step_id="databuild"),
             ],
         }
     )
@@ -360,7 +358,7 @@ def gen_high_impact_tests(mock_gen_from_s3) -> None:
             "name": "data_test_02",
             Test.KEY_IS_HIGH_IMPACT: "true",
             "test_results": [
-                _stub_test_result(rayci_step_id="databuild", commit="789"),
+                _stub_test_result(rayci_step_id="databuild"),
             ],
         }
     )
@@ -368,8 +366,7 @@ def gen_high_impact_tests(mock_gen_from_s3) -> None:
     mock_gen_from_s3.return_value = [core_test, data_test_01, data_test_02]
 
     assert Test.gen_high_impact_tests("linux") == {
-        "databuild": [data_test_01, data_test_02],
-        "data15build": [data_test_01],
+        "databuild": [data_test_01, data_test_02]
     }
 
 


### PR DESCRIPTION
Reverts ray-project/ray#45403. This seems like not a good idea. Run between different test flavors do not provide a lot of signals, but there are a lot of those so it is notably more expensive.

Test:
- https://buildkite.com/ray-project/microcheck/builds/488