### PR TITLE
[RLlib] Fix Single/MultiAgentEnvRunner missing env-to-module connector call in `_sample_episodes()`.

### DIFF
--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -386,16 +386,16 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
         infos) have been logged to the given `episode` object, where either terminated
         or truncated were True:
 
-        1) The env is stepped: `final_obs, rewards, ... = env.step([action])`
-        2) The step results are logged `episode.add_env_step(final_obs, rewards)`
-        3) Callback `on_episode_step` is fired.
-        4) Another env-to-module connector call is made (even though we won't need any
+        - The env is stepped: `final_obs, rewards, ... = env.step([action])`
+        - The step results are logged `episode.add_env_step(final_obs, rewards)`
+        - Callback `on_episode_step` is fired.
+        - Another env-to-module connector call is made (even though we won't need any
         RLModule forward pass anymore). We make this additional call to ensure that in
         case users use the connector pipeline to process observations (and write them
         back into the episode), the episode object has all observations - even the
         terminal one - properly processed.
-        5) ---> This callback `on_episode_end()` is fired. <---
-        6) The episode is finalized (i.e. lists of obs/rewards/actions/etc.. are
+        - ---> This callback `on_episode_end()` is fired. <---
+        - The episode is finalized (i.e. lists of obs/rewards/actions/etc.. are
         converted into numpy arrays).
 
         Args:

--- a/rllib/algorithms/callbacks.py
+++ b/rllib/algorithms/callbacks.py
@@ -387,16 +387,21 @@ class DefaultCallbacks(metaclass=_CallbackMeta):
         or truncated were True:
 
         - The env is stepped: `final_obs, rewards, ... = env.step([action])`
+
         - The step results are logged `episode.add_env_step(final_obs, rewards)`
+
         - Callback `on_episode_step` is fired.
+
         - Another env-to-module connector call is made (even though we won't need any
-        RLModule forward pass anymore). We make this additional call to ensure that in
-        case users use the connector pipeline to process observations (and write them
-        back into the episode), the episode object has all observations - even the
-        terminal one - properly processed.
+          RLModule forward pass anymore). We make this additional call to ensure that in
+          case users use the connector pipeline to process observations (and write them
+          back into the episode), the episode object has all observations - even the
+          terminal one - properly processed.
+
         - ---> This callback `on_episode_end()` is fired. <---
+
         - The episode is finalized (i.e. lists of obs/rewards/actions/etc.. are
-        converted into numpy arrays).
+          converted into numpy arrays).
 
         Args:
             episode: The terminated/truncated SingleAgent- or MultiAgentEpisode object

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -320,6 +320,10 @@ class MultiAgentEnvRunner(EnvRunner):
                 extra_model_outputs=extra_model_outputs,
             )
 
+            # Make the `on_episode_step` callback (before finalizing the episode
+            # object).
+            self._make_on_episode_callback("on_episode_step")
+
             # Episode is done for all agents. Wrap up the old one and create a new
             # one (and reset it) to continue.
             if self._episode.is_done:
@@ -329,17 +333,20 @@ class MultiAgentEnvRunner(EnvRunner):
                 # a call and in case the structure of the observations change
                 # sufficiently, the following `finalize()` call on the episode will
                 # fail.
-                self._env_to_module(
-                    episodes=[self._episode],
-                    explore=explore,
-                    rl_module=self.module,
-                    shared_data=self._shared_data,
-                )
+                if self.module is not None:
+                    self._env_to_module(
+                        episodes=[self._episode],
+                        explore=explore,
+                        rl_module=self.module,
+                        shared_data=self._shared_data,
+                    )
 
-                # Make the `on_episode_step` and `on_episode_end` callbacks (before
-                # finalizing the episode object).
-                self._make_on_episode_callback("on_episode_step")
+                # Make the `on_episode_end` callback (before finalizing the episode,
+                # but after(!) the last env-to-module connector call has been made.
+                # -> All obs (even the terminal one) should have been processed now (by
+                # the connector, if applicable).
                 self._make_on_episode_callback("on_episode_end")
+
                 # Finalize (numpy'ize) the episode.
                 self._episode.finalize(drop_zero_len_single_agent_episodes=True)
                 done_episodes_to_return.append(self._episode)
@@ -355,10 +362,6 @@ class MultiAgentEnvRunner(EnvRunner):
 
                 # Make the `on_episode_start` callback.
                 self._make_on_episode_callback("on_episode_start")
-
-            else:
-                # Make the `on_episode_step` callback.
-                self._make_on_episode_callback("on_episode_step")
 
         # Already perform env-to-module connector call for next call to
         # `_sample_timesteps()`. See comment in c'tor for `self._cached_to_module`.
@@ -531,7 +534,24 @@ class MultiAgentEnvRunner(EnvRunner):
                 # Increase episode count.
                 eps += 1
 
-                # Make `on_episode_end` callback before finalizing the episode.
+                # We have to perform an extra env-to-module pass here, just in case
+                # the user's connector pipeline performs (permanent) transforms
+                # on each observation (including this final one here). Without such
+                # a call and in case the structure of the observations change
+                # sufficiently, the following `finalize()` call on the episode will
+                # fail.
+                if self.module is not None:
+                    self._env_to_module(
+                        episodes=[_episode],
+                        explore=explore,
+                        rl_module=self.module,
+                        shared_data=_shared_data,
+                    )
+
+                # Make the `on_episode_end` callback (before finalizing the episode,
+                # but after(!) the last env-to-module connector call has been made.
+                # -> All obs (even the terminal one) should have been processed now (by
+                # the connector, if applicable).
                 self._make_on_episode_callback("on_episode_end")
 
                 # Finish the episode.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix Single/MultiAgentEnvRunner missing env-to-module connector call in `_sample_episodes()`.

The env-to-module connector call on the terminal obs is missing in both Single- and MultiAgentEnvRunners `_sample_episodes()` methods. It is, however, properly implemented in both their `_sample_timesteps()` methods.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
