### PR TITLE
[core] Avoid `TypeError` when `RayTaskError.cause` is a `BaseExceptionGroup`

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -160,6 +160,12 @@ class RayTaskError(RayError):
                 # https://stackoverflow.com/a/49715949/2213289
                 self.args = (cause,)
 
+            def __new__(cls, cause):.
+                if sys.version_info >= (3, 11) and issubclass(cls, BaseExceptionGroup):
+                    return super().__new__(cls, "", (cause,))
+                else:
+                    return super().__new__(cls)
+
             def __getattr__(self, name):
                 return getattr(self.cause, name)
 

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from traceback import format_exception
 from typing import Optional, Type, Union
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`BaseExceptionGroup.__new__` requires 2 arguments. This PR passes the 2 arguments to avoid `TypeError`

## Related issue number

Closes #45520

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
