### PR TITLE
[ci][doc/01] move module walking class to ray_ci

### DIFF
--- a/ci/ray_ci/doc/BUILD.bazel
+++ b/ci/ray_ci/doc/BUILD.bazel
@@ -8,6 +8,7 @@ py_library(
         exclude = [
             "test_*.py",
             "cmd_*.py",
+            "mock_module.py",
         ],
     ),
     visibility = ["//ci/ray_ci/doc:__subpackages__"],
@@ -16,7 +17,7 @@ py_library(
 py_test(
     name = "test_module",
     size = "small",
-    srcs = ["test_module.py"],
+    srcs = ["test_module.py", "mock_module.py"],
     exec_compatible_with = ["//:hermetic_python"],
     tags = [
         "ci_unit",

--- a/ci/ray_ci/doc/BUILD.bazel
+++ b/ci/ray_ci/doc/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@py_deps_buildkite//:requirements.bzl", ci_require = "requirement")
+
+py_library(
+    name = "doc",
+    srcs = glob(
+        ["*.py"],
+        exclude = [
+            "test_*.py",
+            "cmd_*.py",
+        ],
+    ),
+    visibility = ["//ci/ray_ci/doc:__subpackages__"],
+)
+
+py_test(
+    name = "test_module",
+    size = "small",
+    srcs = ["test_module.py"],
+    exec_compatible_with = ["//:hermetic_python"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":doc",
+        ci_require("pytest"),
+    ],
+)

--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -1,0 +1,21 @@
+from enum import Enum
+from dataclasses import dataclass
+
+
+class AnnotationType(Enum):
+    PUBLIC_API = "PublicAPI"
+    DEVELOPER_API = "DeveloperAPI"
+    DEPRECATED = "Deprecated"
+    UNKNOWN = "Unknown"
+
+
+class CodeType(Enum):
+    CLASS = "Class"
+    FUNCTION = "Function"
+
+
+@dataclass
+class API:
+    name: str
+    annotation_type: AnnotationType
+    code_type: CodeType

--- a/ci/ray_ci/doc/mock_module.py
+++ b/ci/ray_ci/doc/mock_module.py
@@ -1,16 +1,42 @@
+from ci.ray_ci.doc.api import AnnotationType
+
+
+def PublicAPI(*args, **kwargs):
+    if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        return PublicAPI()(args[0])
+
+    def wrap(obj):
+        obj._annotated = None
+        obj._annotated_type = AnnotationType.PUBLIC_API
+        return obj
+
+    return wrap
+
+
+def Deprecated(*args, **kwargs):
+    if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        return Deprecated()(args[0])
+
+    def wrap(obj):
+        obj._annotated = None
+        obj._annotated_type = AnnotationType.DEPRECATED
+        return obj
+
+    return wrap
+
+
+@PublicAPI
 class MockClass:
     """
     This class is used for testing purpose only. It should not be used in production.
     """
 
-    _attribute = None
+    pass
 
 
+@Deprecated
 def mock_function():
     """
     This function is used for testing purpose only. It should not be used in production.
     """
     pass
-
-
-mock_function._attribute = None

--- a/ci/ray_ci/doc/mock_module.py
+++ b/ci/ray_ci/doc/mock_module.py
@@ -1,0 +1,16 @@
+class MockClass:
+    """
+    This class is used for testing purpose only. It should not be used in production.
+    """
+
+    _attribute = None
+
+
+def mock_function():
+    """
+    This function is used for testing purpose only. It should not be used in production.
+    """
+    pass
+
+
+mock_function._attribute = None

--- a/ci/ray_ci/doc/module.py
+++ b/ci/ray_ci/doc/module.py
@@ -1,0 +1,63 @@
+import importlib
+import inspect
+from types import ModuleType
+from typing import Set
+
+
+class Module:
+    def __init__(self, module: str):
+        self._module = importlib.import_module(module)
+        self._visited = set()
+        self._class_apis = set()
+        self._function_apis = set()
+
+    def walk(self) -> None:
+        self._walk(self._module)
+
+    def get_class_apis(self) -> Set:
+        self.walk()
+        return self._class_apis
+
+    def get_function_apis(self) -> Set:
+        self.walk()
+        return self._function_apis
+
+    def _walk(self, module: ModuleType) -> None:
+        """
+        Depth-first search through the module and its children to find annotated classes
+        and functions.
+        """
+        if module in self._visited:
+            return
+        self._visited.add(module)
+
+        if not self._is_valid_child(module):
+            return
+
+        for child in dir(module):
+            attribute = getattr(module, child)
+
+            if inspect.ismodule(attribute):
+                self._walk(attribute)
+            if inspect.isclass(attribute):
+                if self._is_api(attribute):
+                    self._class_apis.add(self._fullname(attribute))
+                self._walk(attribute)
+            if inspect.isfunction(attribute):
+                if self._is_api(attribute):
+                    self._function_apis.add(self._fullname(attribute))
+
+        return
+
+    def _fullname(self, module: ModuleType) -> str:
+        return f"{module.__module__}.{module.__qualname__}"
+
+    def _is_valid_child(self, module: ModuleType) -> bool:
+        """
+        This module is a valid child of the top level module if its module name
+        starts with the top level module name.
+        """
+        return inspect.getmodule(module).__name__.startswith(self._module.__name__)
+
+    def _is_api(self, module: ModuleType) -> bool:
+        return self._is_valid_child(module) and hasattr(module, "_attribute")

--- a/ci/ray_ci/doc/test_module.py
+++ b/ci/ray_ci/doc/test_module.py
@@ -2,16 +2,18 @@ import sys
 import pytest
 
 from ci.ray_ci.doc.module import Module
+from ci.ray_ci.doc.api import AnnotationType, CodeType
 
 
 def test_walk():
     module = Module("ci.ray_ci.doc.mock_module")
-    assert module.get_class_apis() == {
-        "ci.ray_ci.doc.mock_module.MockClass",
-    }
-    assert module.get_function_apis() == {
-        "ci.ray_ci.doc.mock_module.mock_function",
-    }
+    apis = module.get_apis()
+    assert apis[0].name == "ci.ray_ci.doc.mock_module.MockClass"
+    assert apis[0].annotation_type.value == AnnotationType.PUBLIC_API.value
+    assert apis[0].code_type.value == CodeType.CLASS.value
+    assert apis[1].name == "ci.ray_ci.doc.mock_module.mock_function"
+    assert apis[1].annotation_type.value == AnnotationType.DEPRECATED.value
+    assert apis[1].code_type.value == CodeType.FUNCTION.value
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/doc/test_module.py
+++ b/ci/ray_ci/doc/test_module.py
@@ -1,0 +1,18 @@
+import sys
+import pytest
+
+from ci.ray_ci.doc.module import Module
+
+
+def test_walk():
+    module = Module("ci.ray_ci.doc.mock_module")
+    assert module.get_class_apis() == {
+        "ci.ray_ci.doc.mock_module.MockClass",
+    }
+    assert module.get_function_apis() == {
+        "ci.ray_ci.doc.mock_module.mock_function",
+    }
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Move module walking class and the logic to find class/function api to ray_ci, so that it can be tested.

The `Module` class walks through all its children attribute, check if an attribute is an API (by checking a special field name) and record if it is.

Test:
- CI