### PR TITLE
[ci][doc/02] support annotation type and code type for apis

### DIFF
--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -1,0 +1,21 @@
+from enum import Enum
+from dataclasses import dataclass
+
+
+class AnnotationType(Enum):
+    PUBLIC_API = "PublicAPI"
+    DEVELOPER_API = "DeveloperAPI"
+    DEPRECATED = "Deprecated"
+    UNKNOWN = "Unknown"
+
+
+class CodeType(Enum):
+    CLASS = "Class"
+    FUNCTION = "Function"
+
+
+@dataclass
+class API:
+    name: str
+    annotation_type: AnnotationType
+    code_type: CodeType

--- a/ci/ray_ci/doc/mock_module.py
+++ b/ci/ray_ci/doc/mock_module.py
@@ -3,7 +3,8 @@ class MockClass:
     This class is used for testing purpose only. It should not be used in production.
     """
 
-    _attribute = None
+    _annotated = None
+    _annotated_type = "PublicAPI"
 
 
 def mock_function():
@@ -13,4 +14,5 @@ def mock_function():
     pass
 
 
-mock_function._attribute = None
+mock_function._annotated = None
+mock_function._annotated_type = "Deprecated"

--- a/ci/ray_ci/doc/module.py
+++ b/ci/ray_ci/doc/module.py
@@ -1,26 +1,23 @@
 import importlib
 import inspect
 from types import ModuleType
-from typing import Set
+from typing import List
+
+from ci.ray_ci.doc.api import API, AnnotationType, CodeType
 
 
 class Module:
     def __init__(self, module: str):
         self._module = importlib.import_module(module)
         self._visited = set()
-        self._class_apis = set()
-        self._function_apis = set()
+        self._apis = []
 
     def walk(self) -> None:
         self._walk(self._module)
 
-    def get_class_apis(self) -> Set:
+    def get_apis(self) -> List[API]:
         self.walk()
-        return self._class_apis
-
-    def get_function_apis(self) -> Set:
-        self.walk()
-        return self._function_apis
+        return self._apis
 
     def _walk(self, module: ModuleType) -> None:
         """
@@ -41,11 +38,23 @@ class Module:
                 self._walk(attribute)
             if inspect.isclass(attribute):
                 if self._is_api(attribute):
-                    self._class_apis.add(self._fullname(attribute))
+                    self._apis.append(
+                        API(
+                            name=self._fullname(attribute),
+                            annotation_type=self._get_annotation_type(attribute),
+                            code_type=CodeType.CLASS,
+                        )
+                    )
                 self._walk(attribute)
             if inspect.isfunction(attribute):
                 if self._is_api(attribute):
-                    self._function_apis.add(self._fullname(attribute))
+                    self._apis.append(
+                        API(
+                            name=self._fullname(attribute),
+                            annotation_type=self._get_annotation_type(attribute),
+                            code_type=CodeType.FUNCTION,
+                        )
+                    )
 
         return
 
@@ -60,4 +69,7 @@ class Module:
         return inspect.getmodule(module).__name__.startswith(self._module.__name__)
 
     def _is_api(self, module: ModuleType) -> bool:
-        return self._is_valid_child(module) and hasattr(module, "_attribute")
+        return self._is_valid_child(module) and hasattr(module, "_annotated")
+
+    def _get_annotation_type(self, module: ModuleType) -> AnnotationType:
+        return AnnotationType(module._annotated_type)

--- a/ci/ray_ci/doc/test_module.py
+++ b/ci/ray_ci/doc/test_module.py
@@ -6,12 +6,13 @@ from ci.ray_ci.doc.module import Module
 
 def test_walk():
     module = Module("ci.ray_ci.doc.mock_module")
-    assert module.get_class_apis() == {
-        "ci.ray_ci.doc.mock_module.MockClass",
-    }
-    assert module.get_function_apis() == {
-        "ci.ray_ci.doc.mock_module.mock_function",
-    }
+    apis = module.get_apis()
+    assert apis[0].name == "ci.ray_ci.doc.mock_module.MockClass"
+    assert apis[0].annotation_type.value == "PublicAPI"
+    assert apis[0].code_type.value == "Class"
+    assert apis[1].name == "ci.ray_ci.doc.mock_module.mock_function"
+    assert apis[1].annotation_type.value == "Deprecated"
+    assert apis[1].code_type.value == "Function"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add API class to capture name, annotation and code type of an API
- Record APIs class when walking through a module

Test:
- CI