### PR TITLE
[Data] Clarify that `num_rows_per_file` isn't strict

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2795,7 +2795,7 @@ class Dataset:
                 arguments for each dataset block.
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
-                The specified value is a hint, not a strict limit. Ray Data might write 
+                The specified value is a hint, not a strict limit. Ray Data might write
                 more or fewer rows to each file.
             ray_remote_args: Kwargs passed to :meth:`~ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
@@ -2905,7 +2905,7 @@ class Dataset:
                 arguments for each dataset block.
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
-                The specified value is a hint, not a strict limit. Ray Data might write 
+                The specified value is a hint, not a strict limit. Ray Data might write
                 more or fewer rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
@@ -3087,7 +3087,7 @@ class Dataset:
                 write arguments for each dataset block.
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
-                The specified value is a hint, not a strict limit. Ray Data might write 
+                The specified value is a hint, not a strict limit. Ray Data might write
                 more or fewer rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
@@ -3189,7 +3189,7 @@ class Dataset:
                 look like.
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
-                The specified value is a hint, not a strict limit. Ray Data might write 
+                The specified value is a hint, not a strict limit. Ray Data might write
                 more or fewer rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
@@ -3364,7 +3364,7 @@ class Dataset:
                 look like.
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
-                The specified value is a hint, not a strict limit. Ray Data might write 
+                The specified value is a hint, not a strict limit. Ray Data might write
                 more or fewer rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2795,6 +2795,8 @@ class Dataset:
                 arguments for each dataset block.
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
+                The specified value is a hint, not a strict limit. Ray Data might write 
+                more or fewer rows to each file.
             ray_remote_args: Kwargs passed to :meth:`~ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
                 to control number of tasks to run concurrently. This doesn't change the
@@ -2903,6 +2905,8 @@ class Dataset:
                 arguments for each dataset block.
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
+                The specified value is a hint, not a strict limit. Ray Data might write 
+                more or fewer rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
                 to control number of tasks to run concurrently. This doesn't change the
@@ -3083,6 +3087,8 @@ class Dataset:
                 write arguments for each dataset block.
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
+                The specified value is a hint, not a strict limit. Ray Data might write 
+                more or fewer rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
                 to control number of tasks to run concurrently. This doesn't change the
@@ -3183,6 +3189,8 @@ class Dataset:
                 look like.
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
+                The specified value is a hint, not a strict limit. Ray Data might write 
+                more or fewer rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
                 to control number of tasks to run concurrently. This doesn't change the
@@ -3267,6 +3275,8 @@ class Dataset:
                 implementation to write each dataset block to a custom output path.
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
+                The specified value is a hint, not a strict limit. Ray Data might write
+                more or fewer rows to each file.
             ray_remote_args: Kwargs passed to ``ray.remote`` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
                 to control number of tasks to run concurrently. This doesn't change the
@@ -3354,6 +3364,8 @@ class Dataset:
                 look like.
             num_rows_per_file: The target number of rows to write to each file. If
                 ``None``, Ray Data writes a system-chosen number of rows to each file.
+                The specified value is a hint, not a strict limit. Ray Data might write 
+                more or fewer rows to each file.
             ray_remote_args: kwargs passed to :meth:`~ray.remote` in the write tasks.
             concurrency: The maximum number of Ray tasks to run concurrently. Set this
                 to control number of tasks to run concurrently. This doesn't change the


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The parameter name `num_rows_per_file` suggests that the resulting files should have exactly the specified number of rows, but that isn't the case. This PR clarifies that the value is more of a hint.

We can remove this once #45393 and other batching related issues are fixed.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/45530
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
