### PR TITLE
[ADAG] Support multi-args and kwargs in Accelerate DAG

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -106,11 +106,30 @@ def _prep_task(self, task: "ExecutableTask") -> None:
     """
     Prepare the task for execution.
     """
-    # Add placeholders for input channels.
-    for idx, inp in enumerate(task.resolved_args):
-        if isinstance(inp, ChannelInterface):
-            task.input_channels.append(inp)
-            task.input_channel_idxs.append(idx)
+    for arg_idx, inp in enumerate(task.resolved_args):
+        if isinstance(inp, ChannelInterface) or isinstance(inp, DAGInputAdapter):
+            if isinstance(inp, ChannelInterface):
+                channel = inp
+            else:
+                adapter = inp
+                channel = adapter.get_dag_input_channel()
+                task.dag_input_adapters[arg_idx] = adapter
+
+            if channel in task.input_channel_to_idx:
+                # Input channel already exists for this task:
+                # add arg index to the list of indices for this channel.
+                task.input_channel_arg_idxs[task.input_channel_to_idx[channel]].append(
+                    arg_idx
+                )
+            else:
+                # Add a new channel to the list of input channels.
+                task.input_channels.append(channel)
+                task.input_channel_arg_idxs.append([arg_idx])
+                task.input_channel_to_idx[channel] = (
+                    len(task.input_channel_arg_idxs) - 1
+                )
+
+            # Add a placeholder for later resolution.
             task.resolved_inputs.append(None)
         else:
             task.resolved_inputs.append(inp)
@@ -158,8 +177,13 @@ def _exec_task(self, task: "ExecutableTask", idx: int) -> bool:
         input_reader.end_read()
         return False
 
-    for idx, output in zip(task.input_channel_idxs, res):
-        task.resolved_inputs[idx] = output
+    for arg_idxs, output in zip(task.input_channel_arg_idxs, res):
+        for arg_idx in arg_idxs:
+            if arg_idx in task.dag_input_adapters:
+                adapter = task.dag_input_adapters[arg_idx]
+                task.resolved_inputs[arg_idx] = adapter.adapt(output)
+            else:
+                task.resolved_inputs[arg_idx] = output
 
     try:
         output_val = method(*task.resolved_inputs)
@@ -271,7 +295,46 @@ class ExecutableTask:
 
         self.resolved_inputs: List[Union[Any, ChannelInterface]] = []
         self.input_channels: List[ChannelInterface] = []
-        self.input_channel_idxs: List[int] = []
+        # The inner list is indices of resolved_args that correspond
+        # to each input channel.
+        self.input_channel_arg_idxs: List[List[int]] = []
+
+        self.dag_input_adapters: dict[int, DAGInputAdapter] = {}
+        # Reverse map for input_channels: maps an input channel to
+        # its index in input_channels.
+        self.input_channel_to_idx: dict[ChannelInterface, int] = {}
+
+
+@DeveloperAPI
+class DAGInputAdapter:
+    """Adapter to extract individual positional arguments and kwargs
+    from objects read from DAG input channel."""
+
+    def __init__(
+        self,
+        input_attr_node: "ray.dag.InputAttributeNode",
+        dag_input_channel: "ray.experimental.channel.ChannelInterface",
+    ):
+        self._dag_input_channel = dag_input_channel
+
+        def extractor(key: Union[int, str]):
+            def extract_arg(args_tuple):
+                positional_args, kwargs = args_tuple
+                if isinstance(key, int):
+                    return positional_args[key]
+                else:
+                    return kwargs[key]
+
+            return extract_arg
+
+        key = input_attr_node.get_other_args_to_resolve()["key"]
+        self._adapt_method = extractor(key)
+
+    def adapt(self, input):
+        return self._adapt_method(input)
+
+    def get_dag_input_channel(self):
+        return self._dag_input_channel
 
 
 @DeveloperAPI
@@ -398,22 +461,28 @@ class CompiledDAG:
 
         nccl_actors: Set["ray.actor.ActorHandle"] = set()
 
+        # Find the input node to the DAG.
+        for idx, task in self.idx_to_task.items():
+            if isinstance(task.dag_node, InputNode):
+                assert self.input_task_idx is None, "more than one InputNode found"
+                self.input_task_idx = idx
+        # TODO: Support no-input DAGs (use an empty object to signal).
+        if self.input_task_idx is None:
+            raise NotImplementedError(
+                "Compiled DAGs currently require exactly one InputNode"
+            )
+
         # For each task node, set its upstream and downstream task nodes.
         # Also collect the set of tasks that produce torch.tensors.
         for node_idx, task in self.idx_to_task.items():
             dag_node = task.dag_node
             if not (
                 isinstance(dag_node, InputNode)
+                or isinstance(dag_node, InputAttributeNode)
                 or isinstance(dag_node, MultiOutputNode)
                 or isinstance(dag_node, ClassMethodNode)
             ):
-                if isinstance(dag_node, InputAttributeNode):
-                    # TODO(swang): Support multi args.
-                    raise NotImplementedError(
-                        "Compiled DAGs currently do not support kwargs or "
-                        "multiple args for InputNode"
-                    )
-                elif isinstance(dag_node, FunctionNode):
+                if isinstance(dag_node, FunctionNode):
                     # TODO(swang): Support non-actor tasks.
                     raise NotImplementedError(
                         "Compiled DAGs currently only support actor method nodes"
@@ -456,6 +525,22 @@ class CompiledDAG:
                 downstream_actor_handle = None
                 if isinstance(task.dag_node, ClassMethodNode):
                     downstream_actor_handle = task.dag_node._get_actor_handle()
+
+                # If the upstream node is an InputAttributeNode, treat the
+                # DAG's input node as the actual upstream node
+                if isinstance(upstream_node.dag_node, InputAttributeNode):
+                    assert (
+                        "dag_input_node"
+                        in upstream_node.dag_node.get_other_args_to_resolve()
+                    )
+                    dag_input_node_index = self.dag_node_to_idx[
+                        upstream_node.dag_node.get_other_args_to_resolve()[
+                            "dag_input_node"
+                        ]
+                    ]
+                    assert dag_input_node_index == self.input_task_idx
+                    upstream_node = self.idx_to_task[dag_input_node_index]
+
                 upstream_node.downstream_node_idxs[node_idx] = downstream_actor_handle
                 task.arg_type_hints.append(upstream_node.dag_node.type_hint)
 
@@ -466,19 +551,12 @@ class CompiledDAG:
             if dag_node.type_hint is not None:
                 self._type_hints.append(dag_node.type_hint)
 
-        # Find the input node to the DAG.
-        for idx, task in self.idx_to_task.items():
-            if isinstance(task.dag_node, InputNode):
-                assert self.input_task_idx is None, "more than one InputNode found"
-                self.input_task_idx = idx
-        # TODO: Support no-input DAGs (use an empty object to signal).
-        if self.input_task_idx is None:
-            raise NotImplementedError(
-                "Compiled DAGs currently require exactly one InputNode"
-            )
-
         # Find the (multi-)output node to the DAG.
         for idx, task in self.idx_to_task.items():
+            if idx == self.input_task_idx or isinstance(
+                task.dag_node, InputAttributeNode
+            ):
+                continue
             if len(task.downstream_node_idxs) == 0:
                 assert self.output_task_idx is None, "More than one output node found"
                 self.output_task_idx = idx
@@ -516,7 +594,13 @@ class CompiledDAG:
         _dag_output_fetcher will be set and can be used to invoke and fetch
         outputs for the DAG.
         """
-        from ray.dag import DAGNode, InputNode, MultiOutputNode, ClassMethodNode
+        from ray.dag import (
+            DAGNode,
+            InputNode,
+            InputAttributeNode,
+            MultiOutputNode,
+            ClassMethodNode,
+        )
 
         if self.input_task_idx is None:
             self._preprocess()
@@ -582,35 +666,32 @@ class CompiledDAG:
                 self.actor_refs.add(actor_handle)
                 self.actor_to_tasks[actor_handle].append(task)
             elif isinstance(task.dag_node, InputNode):
-                readers = [self.idx_to_task[idx] for idx in task.downstream_node_idxs]
-                reader_handles = []
                 reader_handles_set = set()
-                for reader in readers:
-                    reader_handle = reader.dag_node._get_actor_handle()
-                    if reader_handle in reader_handles_set:
-                        raise NotImplementedError(
-                            "Compiled DAGs currently do not support binding the "
-                            "same input on the same actor multiple times. "
-                            f"Violating actor: {reader_handle}"
-                        )
+                for idx in task.downstream_node_idxs:
+                    reader_task = self.idx_to_task[idx]
+                    assert isinstance(reader_task.dag_node, ClassMethodNode)
+                    reader_handle = reader_task.dag_node._get_actor_handle()
                     reader_handles_set.add(reader_handle)
-                    reader_handles.append(reader_handle)
                 task.output_channel = do_allocate_channel(
                     self,
-                    reader_handles,
+                    list(reader_handles_set),
                     typ=type_hint,
                 )
             else:
-                assert isinstance(task.dag_node, MultiOutputNode)
+                assert isinstance(task.dag_node, InputAttributeNode) or isinstance(
+                    task.dag_node, MultiOutputNode
+                )
 
             for idx in task.downstream_node_idxs:
                 frontier.append(idx)
 
         # Validate input channels for tasks that have not been visited
         for node_idx, task in self.idx_to_task.items():
-            if node_idx == self.input_task_idx:
-                continue
-            if node_idx == self.output_task_idx:
+            if (
+                node_idx == self.input_task_idx
+                or node_idx == self.output_task_idx
+                or isinstance(task.dag_node, InputAttributeNode)
+            ):
                 continue
             if node_idx not in visited:
                 has_at_least_one_channel_input = False
@@ -623,6 +704,11 @@ class CompiledDAG:
                         "or at least one other DAGNode as an input"
                     )
 
+        input_task = self.idx_to_task[self.input_task_idx]
+        # Register custom serializers for inputs provided to dag.execute().
+        input_task.dag_node.type_hint.register_custom_serializer()
+        self.dag_input_channel = input_task.output_channel
+
         # Create executable tasks for each actor
         for actor_handle, tasks in self.actor_to_tasks.items():
             executable_tasks = []
@@ -631,7 +717,11 @@ class CompiledDAG:
                 resolved_args = []
                 has_at_least_one_channel_input = False
                 for arg in task.args:
-                    if isinstance(arg, DAGNode):
+                    if isinstance(arg, InputAttributeNode):
+                        input_adapter = DAGInputAdapter(arg, self.dag_input_channel)
+                        resolved_args.append(input_adapter)
+                        has_at_least_one_channel_input = True
+                    elif isinstance(arg, DAGNode):  # Other DAGNodes
                         arg_idx = self.dag_node_to_idx[arg]
                         arg_channel = self.idx_to_task[arg_idx].output_channel
                         assert arg_channel is not None
@@ -665,12 +755,6 @@ class CompiledDAG:
                 do_exec_tasks,
                 executable_tasks,
             )
-
-        input_task = self.idx_to_task[self.input_task_idx]
-        # Register custom serializers for inputs provided to dag.execute().
-        input_task.dag_node.type_hint.register_custom_serializer()
-
-        self.dag_input_channel = input_task.output_channel
 
         self.dag_output_channels = []
         for output in self.idx_to_task[self.output_task_idx].args:
@@ -708,7 +792,6 @@ class CompiledDAG:
 
         self._dag_submitter.start()
         self._dag_output_fetcher.start()
-        return
 
     def _monitor_failures(self):
         outer = self
@@ -805,24 +888,17 @@ class CompiledDAG:
 
         Args:
             args: Args to the InputNode.
-            kwargs: Kwargs to the InputNode. Not supported yet.
+            kwargs: Kwargs to the InputNode
 
         Returns:
             A list of Channels that can be used to read the DAG result.
         """
-        # These errors should already be caught during compilation, but just in
-        # case.
-        if len(args) != 1:
-            raise NotImplementedError("Compiled DAGs support exactly one InputNode arg")
-        if len(kwargs) != 0:
-            raise NotImplementedError("Compiled DAGs do not support kwargs")
-
         if self._enable_asyncio:
             raise ValueError("Use execute_async if enable_asyncio=True")
 
         self._get_or_compile()
 
-        inp = args[0]
+        inp = (args, kwargs)
         self._dag_submitter.write(inp)
 
         return self._dag_output_fetcher
@@ -838,25 +914,17 @@ class CompiledDAG:
 
         Args:
             args: Args to the InputNode.
-            kwargs: Kwargs to the InputNode. Not supported yet.
+            kwargs: Kwargs to the InputNode.
 
         Returns:
             A list of Channels that can be used to read the DAG result.
         """
-        # These errors should already be caught during compilation, but just in
-        # case.
-        if len(args) != 1:
-            raise NotImplementedError("Compiled DAGs support exactly one InputNode arg")
-        if len(kwargs) != 0:
-            raise NotImplementedError("Compiled DAGs do not support kwargs")
-
         if not self._enable_asyncio:
             raise ValueError("Use execute if enable_asyncio=False")
 
         self._get_or_compile()
         async with self._dag_submission_lock:
-            inp = args[0]
-
+            inp = (args, kwargs)
             await self._dag_submitter.write(inp)
             # Allocate a future that the caller can use to get the result.
             fut = asyncio.Future()

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -106,8 +106,8 @@ def _prep_task(self, task: "ExecutableTask") -> None:
     """
     Prepare the task for execution.
     """
-    for type_hint in task.input_type_hints:
-        type_hint.register_custom_serializer()
+    for typ_hint in task.input_type_hints:
+        typ_hint.register_custom_serializer()
     task.output_type_hint.register_custom_serializer()
 
     input_reader: ReaderInterface = SynchronousReader(task.input_channels)

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -278,8 +278,7 @@ class DAGInputAdapter:
         return self._dag_input_channel
 
 
-@DeveloperAPI
-class ExecutableTaskInput:
+class _ExecutableTaskInput:
     """Represents an input to an ExecutableTask.
 
     Args:
@@ -297,7 +296,7 @@ class ExecutableTaskInput:
         self.input_variant = input_variant
         self.channel_idx = channel_idx
 
-    def resolve(self, channel_results):
+    def resolve(self, channel_results: Any):
         """
         Resolve the input value from the channel results.
 
@@ -340,7 +339,7 @@ class ExecutableTask:
         self.output_type_hint: "ChannelOutputType" = task.dag_node.type_hint
 
         self.input_channels: List[ChannelInterface] = []
-        self.task_inputs: List[ExecutableTaskInput] = []
+        self.task_inputs: List[_ExecutableTaskInput] = []
 
         # Reverse map for input_channels: maps an input channel to
         # its index in input_channels.
@@ -363,9 +362,9 @@ class ExecutableTask:
                     channel_idx = len(self.input_channels) - 1
                     input_channel_to_idx[channel] = channel_idx
 
-                task_input = ExecutableTaskInput(arg, channel_idx)
+                task_input = _ExecutableTaskInput(arg, channel_idx)
             else:
-                task_input = ExecutableTaskInput(arg, None)
+                task_input = _ExecutableTaskInput(arg, None)
             self.task_inputs.append(task_input)
 
 

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -323,7 +323,6 @@ class ExecutableTask:
         self.input_type_hints: List["ChannelOutputType"] = task.arg_type_hints
         self.output_type_hint: "ChannelOutputType" = task.dag_node.type_hint
 
-        # self.resolved_inputs: List[Union[Any, ChannelInterface]] = []
         self.input_channels: List[ChannelInterface] = []
         self.task_inputs: List[ExecutableTaskInput] = []
 

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -381,17 +381,6 @@ def test_dag_errors(ray_start_regular):
     ):
         dag.experimental_compile()
 
-    with InputNode() as inp:
-        dag = a.inc.bind(inp)
-        dag2 = a.inc.bind(inp)
-        dag3 = a.inc_two.bind(dag, dag2)
-    with pytest.raises(
-        NotImplementedError,
-        match=r"Compiled DAGs currently do not support binding the same input "
-        "on the same actor multiple times.*",
-    ):
-        dag3.experimental_compile()
-
     @ray.remote
     def f(x):
         return x
@@ -401,24 +390,6 @@ def test_dag_errors(ray_start_regular):
     with pytest.raises(
         NotImplementedError,
         match="Compiled DAGs currently only support actor method nodes",
-    ):
-        dag.experimental_compile()
-
-    with InputNode() as inp:
-        dag = a.inc_two.bind(inp[0], inp[1])
-    with pytest.raises(
-        NotImplementedError,
-        match="Compiled DAGs currently do not support kwargs or multiple args "
-        "for InputNode",
-    ):
-        dag.experimental_compile()
-
-    with InputNode() as inp:
-        dag = a.inc_two.bind(inp.x, inp.y)
-    with pytest.raises(
-        NotImplementedError,
-        match="Compiled DAGs currently do not support kwargs or multiple args "
-        "for InputNode",
     ):
         dag.experimental_compile()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently accelerated DAG only supports a single argument per task. We would like to add general support for multi-args and kwargs.

<!-- Please give a short summary of the change and the problem this solves. -->
This PR adds multi-arg and kwarg support by serializing all positional args and kwargs and passing it through the channel. When the channel is read at runtime, the individual args are extracted first before passing to the consuming tasks.

## Related issue number
Closes #42793
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
