### PR TITLE
[core] add method to kill aws instance to simulate chaos

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1546,7 +1546,7 @@ class NodeKillerActor(ResourceKillerActor):
         # easy ssh access to worker nodes.
         ssh_command = f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 ray@{ip} '{multi_line_command}'"  # noqa: E501
 
-        result = subprocess.run(ssh_command, shell=True, capture_output=True, text=True)
+        result = subprocess.run(ssh_command, shell=True, capture_output=True, text=True, check=True)
         print(f"STDOUT:\n{result.stdout}\n")
         print(f"STDERR:\n{result.stderr}\n")
 

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1546,7 +1546,9 @@ class NodeKillerActor(ResourceKillerActor):
         # easy ssh access to worker nodes.
         ssh_command = f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 ray@{ip} '{multi_line_command}'"  # noqa: E501
 
-        result = subprocess.run(ssh_command, shell=True, capture_output=True, text=True, check=True)
+        result = subprocess.run(
+            ssh_command, shell=True, capture_output=True, text=True, check=True
+        )
         print(f"STDOUT:\n{result.stdout}\n")
         print(f"STDERR:\n{result.stderr}\n")
 

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1533,7 +1533,7 @@ class NodeKillerActor(ResourceKillerActor):
             )
             self.killed.add(node_id)
 
-    def _kill_node(self, ip):
+    def _terminate_ec2_instance(self, ip):
         # This command uses IMDSv2 to get the host instance id and region.
         # After that it terminates itself using aws cli.
         multi_line_command = (

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -24,7 +24,6 @@ import uuid
 from dataclasses import dataclass
 
 import requests
-import paramiko
 from ray._raylet import Config
 
 import psutil  # We must import psutil after ray because we bundle it with ray.
@@ -1537,30 +1536,19 @@ class NodeKillerActor(ResourceKillerActor):
     def _kill_node(self, ip):
         # This command uses IMDSv2 to get the host instance id and region.
         # After that it terminates itself using aws cli.
-        command = """
-        TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-
-        instanceId=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id/)
-        region=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region)
-
-        aws ec2 terminate-instances --region $region --instance-ids $instanceId
-        """  # noqa: E501
-
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
+        multi_line_command = (
+            'TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600");'  # noqa: E501
+            'instanceId=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id/);'  # noqa: E501
+            'region=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region);'  # noqa: E501
+            "aws ec2 terminate-instances --region $region --instance-ids $instanceId"  # noqa: E501
+        )
         # This is a feature on Anyscale platform that enables
         # easy ssh access to worker nodes.
-        ssh.connect(ip, username="ray", port=2222)
+        ssh_command = f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 ray@{ip} '{multi_line_command}'"  # noqa: E501
 
-        stdin, stdout, stderr = ssh.exec_command(command)
-        output = stdout.read().decode()
-        error = stderr.read().decode()
-
-        stdin.close()
-
-        print(f"STDOUT:\n{output}")
-        print(f"STDERR:\n{error}")
+        result = subprocess.run(ssh_command, shell=True, capture_output=True, text=True)
+        print(f"STDOUT:\n{result.stdout}\n")
+        print(f"STDERR:\n{result.stderr}\n")
 
     def _kill_raylet(self, ip, port, graceful=False):
         import grpc


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This is separated from https://github.com/ray-project/ray/pull/45364.
Have tested it for `chaos_test/test_chaos_basic.py`.

How to enable this feature is to be discussed? We can enable it for all chaos tests, maybe? Or we can add a flag to migrate tests one by one?

I will test it on more existing tests and discuss with other teams to decide later.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
