### PR TITLE
[RLlib] fix VTrace in impala_tf_policy to support Keras 3

### DIFF
--- a/rllib/algorithms/impala/impala_tf_policy.py
+++ b/rllib/algorithms/impala/impala_tf_policy.py
@@ -227,7 +227,7 @@ class VTraceOptimizer:
         config = self.config
         if config["opt_type"] == "adam":
             if config["framework"] == "tf2":
-                optim = tf.keras.optimizers.Adam(self.cur_lr)
+                optim = tf.keras.optimizers.Adam(float(self.cur_lr))
                 if config["_separate_vf_optimizer"]:
                     return optim, tf.keras.optimizers.Adam(config["_lr_vf"])
             else:


### PR DESCRIPTION
Fix ValueError: Argument `learning_rate` should be float, or an instance of LearningRateSchedule, or a callable (that takes in the current iteration value and returns the corresponding learning rate value). Received instead: learning_rate=<tf.Variable 'lr:0' shape=() dtype=float32, numpy=0.0005>

Fixes: https://github.com/ray-project/ray/issues/45050

