### PR TITLE
[WIP] [Core] Support of reading Working dir from HUAWEI Object Storage Service (OBS)

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -89,13 +89,14 @@ class Protocol(Enum):
     HTTPS = "https", "Remote https path, assumes everything packed in one zip file."
     S3 = "s3", "Remote s3 path, assumes everything packed in one zip file."
     GS = "gs", "Remote google storage path, assumes everything packed in one zip file."
+    OBS = "obs", "Remote huawei obs path, assumes everything packed in one zip file."
     FILE = "file", "File storage path, assumes everything packed in one zip file."
 
     @classmethod
     def remote_protocols(cls):
         # Returns a list of protocols that support remote storage
         # These protocols should only be used with paths that end in ".zip" or ".whl"
-        return [cls.HTTPS, cls.S3, cls.GS, cls.FILE]
+        return [cls.HTTPS, cls.S3, cls.GS, cls.FILE, cls.OBS]
 
 
 def _xor_bytes(left: bytes, right: bytes) -> bytes:
@@ -718,6 +719,16 @@ async def download_and_unpack_package(
                             "`pip install google-cloud-storage` "
                             "to fetch URIs in Google Cloud Storage bucket."
                             + install_warning
+                        )
+                elif protocol == Protocol.OBS:
+                    try:
+                        from obs import ObsClient  # noqa: F401
+                        from smart_open import open as open_file
+                    except ImportError:
+                        raise ImportError(
+                            "You must `pip install smart_open` and "
+                            "`pip install esdk-obs-python` to fetch URIs in obs "
+                            "bucket. " + install_warning
                         )
                 elif protocol == Protocol.FILE:
                     pkg_uri = pkg_uri[len("file://") :]


### PR DESCRIPTION
This PR add ability to read working dir stored as archive in OBS.

## Why are these changes needed?

User will be able to run submit tasks specifying the location of the working directory in OBS.

## Related issue number

Changes made according to [REP](https://github.com/ray-project/enhancements/pull/50)
PR to [smart_open](https://github.com/piskvorky/smart_open/pull/823)

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   
@edoakes please take this PR.