### PR TITLE
fix dashboard process reporting on windows

### DIFF
--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -605,9 +605,12 @@ class ReporterAgent(
         if raylet_proc is None:
             return []
         else:
-            workers = {
-                self._generate_worker_key(proc): proc for proc in raylet_proc.children()
-            }
+            workers = {}
+            # windows, get the child process not the runner
+            for child in raylet_proc.children():
+                if child.children():
+                    child = child.children()[0]
+                workers[self._generate_worker_key(child)] = child
 
             # We should keep `raylet_proc.children()` in `self` because
             # when `cpu_percent` is first called, it returns the meaningless 0.
@@ -645,9 +648,15 @@ class ReporterAgent(
         try:
             if not self._raylet_proc:
                 curr_proc = psutil.Process()
-                # Here, parent is always raylet because the
-                # dashboard agent is a child of the raylet process.
-                self._raylet_proc = curr_proc.parent()
+                # The dashboard agent is a child of the raylet process.
+                # It is not necessarily the direct child (python-windows
+                # typically uses a py.exe runner to run python), so search
+                candidate = curr_proc.parent()
+                while candidate:
+                    if "raylet" in candidate.name():
+                        break
+                    candidate = candidate.parent()
+                self._raylet_proc = candidate
 
             if self._raylet_proc is not None:
                 if self._raylet_proc.pid == 1:

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -606,11 +606,17 @@ class ReporterAgent(
             return []
         else:
             workers = {}
-            # windows, get the child process not the runner
-            for child in raylet_proc.children():
-                if child.children():
-                    child = child.children()[0]
-                workers[self._generate_worker_key(child)] = child
+            if sys.platform == "win32":
+                # windows, get the child process not the runner
+                for child in raylet_proc.children():
+                    if child.children():
+                        child = child.children()[0]
+                    workers[self._generate_worker_key(child)] = child
+            else:
+                workers = {
+                    self._generate_worker_key(proc): proc
+                    for proc in raylet_proc.children()
+                }
 
             # We should keep `raylet_proc.children()` in `self` because
             # when `cpu_percent` is first called, it returns the meaningless 0.

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -657,6 +657,7 @@ class ReporterAgent(
                 # The dashboard agent is a child of the raylet process.
                 # It is not necessarily the direct child (python-windows
                 # typically uses a py.exe runner to run python), so search
+                # up for a process named 'raylet'
                 candidate = curr_proc.parent()
                 while candidate:
                     if "raylet" in candidate.name():

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -116,6 +116,9 @@ def random_work():
         np.random.rand(5 * 1024 * 1024)  # 40 MB
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="setproctitle does not change psutil.cmdline"
+)
 def test_node_physical_stats(enable_test_module, shutdown_only):
     addresses = ray.init(include_dashboard=True, num_cpus=6)
 
@@ -793,7 +796,7 @@ def test_get_task_traceback_running_task(shutdown_only):
     params = {
         "task_id": task.task_id().hex(),
         "attempt_number": 0,
-        "node_id": ray.get_runtime_context().node_id.hex(),
+        "node_id": ray.get_runtime_context().get_node_id(),
     }
 
     def verify():
@@ -840,7 +843,7 @@ def test_get_memory_profile_running_task(shutdown_only):
     params = {
         "task_id": task.task_id().hex(),
         "attempt_number": 0,
-        "node_id": ray.get_runtime_context().node_id.hex(),
+        "node_id": ray.get_runtime_context().get_node_id(),
         "duration": 5,
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes two problems found on windows in process dashboard reporting:
- PR #39790 added a `num_fds` metric which is not supported on windows
- Windows runs python via a launcher, which then calls the actual python.exe. See [PEP 397](https://peps.python.org/pep-0397/). Confusingly, both launcher and the actual process it launches are named python.exe. This caused two problems:
  - When looking for the base `raylet` process, it is not sufficient to just check `pid.parent()`, so now the check climbs up the process heirarchy until it finds a process named `raylet*` or reaches the root.
  - When looking for the workers, it is not sufficient to check `raylet.child()`, so for each child the check climbs down the process heirarchy to the bottom.

Happy to add a test, or to enable a skipped windows test. Where can I find one?

With these changes, I now see data in the actor panel of the dashboard.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #44604

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
