### PR TITLE
[ci][doc/4] init api object from sphinx autodoc

### DIFF
--- a/ci/ray_ci/doc/BUILD.bazel
+++ b/ci/ray_ci/doc/BUILD.bazel
@@ -34,3 +34,18 @@ py_test(
         ci_require("pytest"),
     ],
 )
+
+py_test(
+    name = "test_api",
+    size = "small",
+    srcs = ["test_api.py"],
+    exec_compatible_with = ["//:hermetic_python"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":doc",
+        ci_require("pytest"),
+    ],
+)

--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -1,5 +1,12 @@
+import re
+
 from enum import Enum
 from dataclasses import dataclass
+from typing import Optional, List
+
+
+_SPHINX_AUTOSUMMARY_HEADER = ".. autosummary::"
+_SPHINX_AUTOCLASS_HEADER = ".. autoclass::"
 
 
 class AnnotationType(Enum):
@@ -19,3 +26,67 @@ class API:
     name: str
     annotation_type: AnnotationType
     code_type: CodeType
+
+    def from_autosummary(doc: str, current_module: Optional[str] = None) -> List["API"]:
+        """
+        Parse API from the following autosummary sphinx block.
+
+        .. autosummary::
+            :option_01
+            :option_02
+
+            api_01
+            api_02
+        """
+        apis = []
+        lines = doc.splitlines()
+        if not lines:
+            return apis
+
+        if lines[0].strip() != _SPHINX_AUTOSUMMARY_HEADER:
+            return apis
+
+        for line in lines:
+            if line == _SPHINX_AUTOSUMMARY_HEADER:
+                continue
+            if line.strip().startswith(":"):
+                # option lines
+                continue
+            if not line.strip():
+                # empty lines
+                continue
+            if not re.match(r"\s", line):
+                # end of autosummary, \s means empty space, this line is checking if
+                # the line is not empty and not starting with empty space
+                break
+            api_name = (
+                f"{current_module}.{line.strip()}" if current_module else line.strip()
+            )
+            apis.append(
+                API(
+                    name=api_name,
+                    annotation_type=AnnotationType.PUBLIC_API,
+                    code_type=CodeType.FUNCTION,
+                )
+            )
+
+        return apis
+
+    def from_autoclass(
+        doc: str, current_module: Optional[str] = None
+    ) -> Optional["API"]:
+        """
+        Parse API from the following autoclass sphinx block.
+
+        .. autoclass:: api_01
+        """
+        doc = doc.strip()
+        if not doc.startswith(_SPHINX_AUTOCLASS_HEADER):
+            return None
+        api_name = doc[len(_SPHINX_AUTOCLASS_HEADER) :].strip()
+
+        return API(
+            name=f"{current_module}.{api_name}" if current_module else api_name,
+            annotation_type=AnnotationType.PUBLIC_API,
+            code_type=CodeType.CLASS,
+        )

--- a/ci/ray_ci/doc/test_api.py
+++ b/ci/ray_ci/doc/test_api.py
@@ -1,0 +1,104 @@
+import sys
+import pytest
+
+from ci.ray_ci.doc.api import (
+    API,
+    AnnotationType,
+    CodeType,
+    _SPHINX_AUTOCLASS_HEADER,
+    _SPHINX_AUTOSUMMARY_HEADER,
+)
+
+
+def test_from_autosummary():
+    test_data = [
+        {
+            "input": {
+                "doc": (
+                    f"{_SPHINX_AUTOSUMMARY_HEADER}\n"
+                    "\t:toc\n"
+                    "\n"
+                    "\tfun_01\n"
+                    "\tfun_02\n"
+                    "something else"
+                ),
+                "module": "mymodule",
+            },
+            "output": [
+                API(
+                    name="mymodule.fun_01",
+                    annotation_type=AnnotationType.PUBLIC_API,
+                    code_type=CodeType.FUNCTION,
+                ),
+                API(
+                    name="mymodule.fun_02",
+                    annotation_type=AnnotationType.PUBLIC_API,
+                    code_type=CodeType.FUNCTION,
+                ),
+            ],
+        },
+        {
+            "input": {
+                "doc": "invalid string",
+                "module": "mymodule",
+            },
+            "output": [],
+        },
+    ]
+
+    for test in test_data:
+        assert str(
+            API.from_autosummary(
+                test["input"]["doc"],
+                test["input"]["module"],
+            )
+        ) == str(test["output"])
+
+
+def test_from_autoclasss():
+    test_data = [
+        # valid input, no module
+        {
+            "input": {
+                "doc": f"{_SPHINX_AUTOCLASS_HEADER} myclass",
+                "module": None,
+            },
+            "output": API(
+                name="myclass",
+                annotation_type=AnnotationType.PUBLIC_API,
+                code_type=CodeType.CLASS,
+            ),
+        },
+        # valid input, with module
+        {
+            "input": {
+                "doc": f"{_SPHINX_AUTOCLASS_HEADER} myclass",
+                "module": "mymodule",
+            },
+            "output": API(
+                name="mymodule.myclass",
+                annotation_type=AnnotationType.PUBLIC_API,
+                code_type=CodeType.CLASS,
+            ),
+        },
+        # invalid input
+        {
+            "input": {
+                "doc": "invalid",
+                "module": None,
+            },
+            "output": None,
+        },
+    ]
+
+    for test in test_data:
+        assert str(
+            API.from_autoclass(
+                test["input"]["doc"],
+                test["input"]["module"],
+            )
+        ) == str(test["output"])
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Initialize API from sphinx autodoc syntax (autoclass and autosummary).

This is part of the work to check for the consistency between API declaration in doc vs code

Test:
- CI