### PR TITLE
fix node detail page grid being hard to select

### DIFF
--- a/dashboard/client/src/pages/node/NodeDetail.tsx
+++ b/dashboard/client/src/pages/node/NodeDetail.tsx
@@ -92,7 +92,7 @@ const NodeDetailPage = () => {
         </Tabs>
         {nodeDetail && selectedTab === "info" && (
           <div className={classes.paper}>
-            <Grid container spacing={2}>
+            <Grid container>
               <Grid item xs>
                 <div className={classes.label}>Hostname</div>{" "}
                 {nodeDetail.hostname}
@@ -101,7 +101,7 @@ const NodeDetailPage = () => {
                 <div className={classes.label}>IP</div> {nodeDetail.ip}
               </Grid>
             </Grid>
-            <Grid container spacing={2}>
+            <Grid container>
               <Grid item xs>
                 {nodeDetail.cpus && (
                   <React.Fragment>
@@ -118,7 +118,7 @@ const NodeDetailPage = () => {
                     .join("/")}
               </Grid>
             </Grid>
-            <Grid container spacing={2}>
+            <Grid container>
               <Grid item xs>
                 <div className={classes.label}>Load per CPU (1/5/15min)</div>{" "}
                 {nodeDetail?.loadAvg[1] &&
@@ -131,7 +131,7 @@ const NodeDetailPage = () => {
                 {formatDateFromTimeMs(nodeDetail.bootTime * 1000)}
               </Grid>
             </Grid>
-            <Grid container spacing={2}>
+            <Grid container>
               <Grid item xs>
                 <div className={classes.label}>Sent Tps</div>{" "}
                 {memoryConverter(nodeDetail?.networkSpeed[0])}/s
@@ -141,7 +141,7 @@ const NodeDetailPage = () => {
                 {memoryConverter(nodeDetail?.networkSpeed[1])}/s
               </Grid>
             </Grid>
-            <Grid container spacing={2}>
+            <Grid container>
               <Grid item xs>
                 <div className={classes.label}>Memory</div>{" "}
                 {nodeDetail?.mem && (
@@ -161,7 +161,7 @@ const NodeDetailPage = () => {
                 </PercentageBar>
               </Grid>
             </Grid>
-            <Grid container spacing={2}>
+            <Grid container>
               {nodeDetail?.disk &&
                 Object.entries(nodeDetail?.disk).map(([path, obj]) => (
                   <Grid item xs={6} key={path}>
@@ -175,7 +175,7 @@ const NodeDetailPage = () => {
                   </Grid>
                 ))}
             </Grid>
-            <Grid container spacing={2}>
+            <Grid container>
               <Grid item xs>
                 <div className={classes.label}>Logs</div>{" "}
                 <Link
@@ -192,7 +192,7 @@ const NodeDetailPage = () => {
         {raylet && Object.keys(raylet).length > 0 && selectedTab === "raylet" && (
           <React.Fragment>
             <div className={classes.paper}>
-              <Grid container spacing={2}>
+              <Grid container>
                 <Grid item xs>
                   <div className={classes.label}>Command</div>
                   <br />
@@ -201,7 +201,7 @@ const NodeDetailPage = () => {
                   </div>
                 </Grid>
               </Grid>
-              <Grid container spacing={2}>
+              <Grid container>
                 <Grid item xs>
                   <div className={classes.label}>Pid</div> {raylet?.pid}
                 </Grid>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There are no visual changes, but this makes the "size" of the box match the size of the text. Previously, the box was larger than the text so each box would disrupt trying to select text from another box.

<img width="1358" alt="Screenshot 2024-05-28 at 5 33 13 PM" src="https://github.com/ray-project/ray/assets/711935/54e489d8-1f94-40d7-a39d-d8c2d7caae43">
<img width="253" alt="Screenshot 2024-05-28 at 5 33 16 PM" src="https://github.com/ray-project/ray/assets/711935/33bc36a5-8b28-4d1c-989f-bb5d59622fd8">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
