### PR TITLE
[ci] add security requirements constraint

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -106,7 +106,8 @@ compile_pip_dependencies() {
     "${WORKSPACE_DIR}/python/requirements/ml/train-requirements.txt" \
     "${WORKSPACE_DIR}/python/requirements/ml/train-test-requirements.txt" \
     "${WORKSPACE_DIR}/python/requirements/ml/tune-requirements.txt" \
-    "${WORKSPACE_DIR}/python/requirements/ml/tune-test-requirements.txt"
+    "${WORKSPACE_DIR}/python/requirements/ml/tune-test-requirements.txt" \
+    "${WORKSPACE_DIR}/python/requirements/security-requirements.txt"
 
   # Remove some pins from upstream dependencies:
   # ray, xgboost-ray, lightgbm-ray, tune-sklearn

--- a/python/requirements/security-requirements.txt
+++ b/python/requirements/security-requirements.txt
@@ -1,0 +1,7 @@
+# Requirement constraints for security.
+#
+# Only for constraining version ranges. Packages listed might not be installed,
+# might not be ray requirements. They are only used in compiling the
+# constraint file
+
+idna>=3.7

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -372,6 +372,8 @@ cryptography==38.0.1
     #   python-jose
     #   sshpubkeys
     #   trustme
+cupy-cuda11x==13.1.0 ; sys_platform != "darwin"
+    # via -r /ray/ci/../python/requirements/ml/dl-cpu-requirements.txt
 cycler==0.12.1
     # via matplotlib
 cython==0.29.37
@@ -496,6 +498,8 @@ fasteners==0.19
     #   gsutil
 fastjsonschema==2.19.0
     # via nbformat
+fastrlock==0.8.2
+    # via cupy-cuda11x
 feather-format==0.4.1
     # via -r /ray/ci/../python/requirements/test-requirements.txt
 ffmpy==0.3.1
@@ -765,8 +769,9 @@ humanfriendly==10.0
     #   coloredlogs
 hyperopt==0.2.7
     # via -r /ray/ci/../python/requirements/ml/tune-requirements.txt
-idna==3.6
+idna==3.7
     # via
+    #   -r /ray/ci/../python/requirements/security-requirements.txt
     #   anyio
     #   httpx
     #   jsonschema
@@ -1239,6 +1244,7 @@ numpy==1.24.4
     #   cmdstanpy
     #   configspace
     #   contourpy
+    #   cupy-cuda11x
     #   dask
     #   datasets
     #   deepspeed


### PR DESCRIPTION
for bumping package versions up in the container and dodging cve's

also upgrade `idna` and add missing `cupy-cuda11x` package in constraints..
