### PR TITLE
[RLlib] Fix wrong `env` being passed into `on_episode_end` callback on MultiAgentEnvRunner when sampling whole episodes.

### DIFF
--- a/rllib/algorithms/tests/test_callbacks_on_env_runner.py
+++ b/rllib/algorithms/tests/test_callbacks_on_env_runner.py
@@ -1,10 +1,15 @@
 from collections import Counter
 import unittest
 
+import gymnasium as gym
+
 import ray
+from ray import tune
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.algorithms.ppo import PPOConfig
-from ray.rllib.utils.test_utils import framework_iterator
+from ray.rllib.env.env_runner import EnvRunner
+from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
+from ray.rllib.utils.metrics.metrics_logger import MetricsLogger
 
 
 class EpisodeAndSampleCallbacks(DefaultCallbacks):
@@ -12,24 +17,38 @@ class EpisodeAndSampleCallbacks(DefaultCallbacks):
         super().__init__()
         self.counts = Counter()
 
-    def on_environment_created(self, *args, **kwargs):
+    def on_environment_created(self, *args, env_runner, metrics_logger, env, **kwargs):
+
         self.counts.update({"env_created": 1})
 
-    def on_episode_start(self, *args, **kwargs):
+    def on_episode_start(self, *args, env_runner, metrics_logger, env, **kwargs):
+        assert isinstance(env_runner, EnvRunner)
+        assert isinstance(metrics_logger, MetricsLogger)
+        assert isinstance(env, gym.Env)
         self.counts.update({"start": 1})
 
-    def on_episode_step(self, *args, **kwargs):
+    def on_episode_step(self, *args, env_runner, metrics_logger, env, **kwargs):
+        assert isinstance(env_runner, EnvRunner)
+        assert isinstance(metrics_logger, MetricsLogger)
+        assert isinstance(env, gym.Env)
         self.counts.update({"step": 1})
 
-    def on_episode_end(self, *args, **kwargs):
+    def on_episode_end(self, *args, env_runner, metrics_logger, env, **kwargs):
+        assert isinstance(env_runner, EnvRunner)
+        assert isinstance(metrics_logger, MetricsLogger)
+        assert isinstance(env, gym.Env)
         self.counts.update({"end": 1})
 
-    def on_sample_end(self, *args, **kwargs):
+    def on_sample_end(self, *args, env_runner, metrics_logger, **kwargs):
+        assert isinstance(env_runner, EnvRunner)
+        assert isinstance(metrics_logger, MetricsLogger)
         self.counts.update({"sample": 1})
 
 
 class OnEnvironmentCreatedCallback(DefaultCallbacks):
     def on_environment_created(self, *, env_runner, env, env_context, **kwargs):
+        assert isinstance(env_runner, EnvRunner)
+        assert isinstance(env, gym.Env)
         # Create a vector-index-sum property per remote worker.
         if not hasattr(env_runner, "sum_sub_env_vector_indices"):
             env_runner.sum_sub_env_vector_indices = 0
@@ -63,6 +82,7 @@ class OnEpisodeCreatedCallback(DefaultCallbacks):
 class TestCallbacks(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        tune.register_env("ma_cart", lambda _: MultiAgentCartPole({"num_agents": 2}))
         ray.init()
 
     @classmethod
@@ -88,7 +108,14 @@ class TestCallbacks(unittest.TestCase):
                 num_sgd_iter=1,
             )
         )
-        for _ in framework_iterator(config, frameworks=("torch", "tf2")):
+
+        for multi_agent in [False, True]:
+            if multi_agent:
+                config.multi_agent(
+                    policies={"p0", "p1"},
+                    policy_mapping_fn=lambda aid, *a, **kw: f"p{aid}",
+                )
+                config.environment("ma_cart")
             algo = config.build()
             callback_obj = algo.workers.local_worker()._callbacks
 
@@ -133,7 +160,15 @@ class TestCallbacks(unittest.TestCase):
                 num_sgd_iter=1,
             )
         )
-        for _ in framework_iterator(config, frameworks=("torch", "tf2")):
+
+        for multi_agent in [False, True]:
+            if multi_agent:
+                config.multi_agent(
+                    policies={"p0", "p1"},
+                    policy_mapping_fn=lambda aid, *a, **kw: f"p{aid}",
+                )
+                config.environment("ma_cart")
+
             algo = config.build()
             callback_obj = algo.workers.local_worker()._callbacks
 
@@ -142,8 +177,9 @@ class TestCallbacks(unittest.TestCase):
 
             # Train one iteration.
             algo.train()
-            # We must have has exactly one `sample()` call on our EnvRunner.
-            self.assertEqual(callback_obj.counts["sample"], 1)
+            # We must have had exactly one `sample()` call on our EnvRunner.
+            if not multi_agent:
+                self.assertEqual(callback_obj.counts["sample"], 1)
             # We should have had at least one episode start.
             self.assertGreater(callback_obj.counts["start"], 0)
             # Episode starts must be exact same as episode ends (b/c we always complete

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -551,7 +551,7 @@ class MultiAgentEnvRunner(EnvRunner):
                 # but after(!) the last env-to-module connector call has been made.
                 # -> All obs (even the terminal one) should have been processed now (by
                 # the connector, if applicable).
-                self._make_on_episode_callback("on_episode_end")
+                self._make_on_episode_callback("on_episode_end", _episode)
 
                 # Finish the episode.
                 done_episodes_to_return.append(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix wrong `env` being passed into `on_episode_end` callback on MultiAgentEnvRunner when sampling whole episodes.
* Enhance test cases to capture proper callbacks arguments (env, env_runner, metrics_logger).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
