### PR TITLE
add env var to allow dashboard http server to serve static files with symlinks

### DIFF
--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -28,6 +28,15 @@ from ray.dashboard.optional_deps import aiohttp, hdrs
 logger = logging.getLogger(__name__)
 routes = dashboard_optional_utils.DashboardHeadRouteTable
 
+# Env var that enables follow_symlinks for serving UI static files.
+# This is an advanced setting that should only be used with special Ray installations
+# where the dashboard build files are symlinked to a different directory.
+# This is not recommended for most users and can pose a security risk.
+# Please reference the aiohttp docs here:
+# https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.UrlDispatcher.add_static
+ENV_VAR_FOLLOW_SYMLINKS = "RAY_DASHBOARD_BUILD_FOLLOW_SYMLINKS"
+FOLLOW_SYMLINKS_ENABLED = os.environ.get(ENV_VAR_FOLLOW_SYMLINKS, "0") == "1"
+
 
 def setup_static_dir():
     build_dir = os.path.join(
@@ -47,7 +56,7 @@ def setup_static_dir():
         )
 
     static_dir = os.path.join(build_dir, "static")
-    routes.static("/static", static_dir)
+    routes.static("/static", static_dir, follow_symlinks=FOLLOW_SYMLINKS_ENABLED)
     return build_dir
 
 

--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -35,7 +35,13 @@ routes = dashboard_optional_utils.DashboardHeadRouteTable
 # Please reference the aiohttp docs here:
 # https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.UrlDispatcher.add_static
 ENV_VAR_FOLLOW_SYMLINKS = "RAY_DASHBOARD_BUILD_FOLLOW_SYMLINKS"
-FOLLOW_SYMLINKS_ENABLED = os.environ.get(ENV_VAR_FOLLOW_SYMLINKS, "0") == "1"
+FOLLOW_SYMLINKS_ENABLED = os.environ.get(ENV_VAR_FOLLOW_SYMLINKS) == "1"
+if FOLLOW_SYMLINKS_ENABLED:
+    logger.warning(
+        "Enabling RAY_DASHBOARD_BUILD_FOLLOW_SYMLINKS is not recommended as it "
+        "allows symlinks to directories outside the dashboard build folder. "
+        "You may accidentally expose files on your system outside of these directories."
+    )
 
 
 def setup_static_dir():

--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -40,7 +40,7 @@ if FOLLOW_SYMLINKS_ENABLED:
     logger.warning(
         "Enabling RAY_DASHBOARD_BUILD_FOLLOW_SYMLINKS is not recommended as it "
         "allows symlinks to directories outside the dashboard build folder. "
-        "You may accidentally expose files on your system outside of these directories."
+        "You may accidentally expose files on your system outside of the build directory."
     )
 
 

--- a/dashboard/http_server_head.py
+++ b/dashboard/http_server_head.py
@@ -40,7 +40,8 @@ if FOLLOW_SYMLINKS_ENABLED:
     logger.warning(
         "Enabling RAY_DASHBOARD_BUILD_FOLLOW_SYMLINKS is not recommended as it "
         "allows symlinks to directories outside the dashboard build folder. "
-        "You may accidentally expose files on your system outside of the build directory."
+        "You may accidentally expose files on your system outside of the "
+        "build directory."
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

New env var is called `RAY_DASHBOARD_BUILD_FOLLOW_SYMLINKS`.

This is an advanced setting that should only be used with special Ray installations
where the dashboard build files are symlinked to a different directory.
This is not recommended for most users and can pose a security risk.
Please reference the aiohttp docs here:
https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.UrlDispatcher.add_static

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
