### PR TITLE
[Core] Fix race condition in setting node death info

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -382,7 +382,6 @@ void GcsNodeManager::OnNodeFailure(const NodeID &node_id,
       RAY_CHECK_OK(gcs_publisher_->PublishNodeInfo(node_id, *node_info_delta, nullptr));
     };
     RAY_CHECK_OK(gcs_table_storage_->NodeTable().Put(node_id, *node, on_done));
-
   } else if (node_table_updated_callback != nullptr) {
     node_table_updated_callback(Status::OK());
   }

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -348,10 +348,6 @@ void GcsNodeManager::OnNodeFailure(const NodeID &node_id,
   if (maybe_node.has_value()) {
     rpc::NodeDeathInfo death_info = InferDeathInfo(node_id);
     auto node = RemoveNode(node_id, death_info);
-    if (!node) {
-      return;
-    }
-
     node->set_state(rpc::GcsNodeInfo::DEAD);
     node->set_end_time_ms(current_sys_time_ms());
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -223,18 +223,6 @@ absl::optional<std::shared_ptr<rpc::GcsNodeInfo>> GcsNodeManager::GetAliveNode(
   return iter->second;
 }
 
-void GcsNodeManager::SetDeathInfo(const NodeID &node_id,
-                                  const rpc::NodeDeathInfo &death_info) {
-  auto maybe_node = GetAliveNode(node_id);
-  if (!maybe_node.has_value()) {
-    return;
-  }
-
-  auto node = std::move(maybe_node.value());
-  auto node_death_info = node->mutable_death_info();
-  node_death_info->CopyFrom(death_info);
-}
-
 rpc::NodeDeathInfo GcsNodeManager::InferDeathInfo(const NodeID &node_id) {
   auto iter = draining_nodes_.find(node_id);
   rpc::NodeDeathInfo death_info;

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -322,7 +322,7 @@ std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
           << " and node name: " << removed_node->node_name()
           << " has been marked dead because the detector"
           << " has missed too many heartbeats from it. This can happen when a "
-             "\t(1) raylet crashes unexpectedly (OOM, preempted node, etc.) \n"
+             "\t(1) raylet crashes unexpectedly (OOM, etc.) \n"
           << "\t(2) raylet has lagging heartbeats due to slow network or busy workload.";
       RAY_EVENT(ERROR, EL_RAY_NODE_REMOVED)
               .WithField("node_id", node_id.Hex())

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -113,8 +113,7 @@ void GcsNodeManager::HandleUnregisterNode(rpc::UnregisterNodeRequest request,
                                           rpc::SendReplyCallback send_reply_callback) {
   NodeID node_id = NodeID::FromBinary(request.node_id());
   RAY_LOG(DEBUG) << "HandleUnregisterNode() for node id = " << node_id;
-  SetDeathInfo(node_id, request.node_death_info());
-  auto node = RemoveNode(node_id, /* is_intended = */ true);
+  auto node = RemoveNode(node_id, request.node_death_info());
   if (!node) {
     RAY_LOG(INFO) << "Node " << node_id << " is already removed";
     return;
@@ -237,13 +236,8 @@ void GcsNodeManager::SetDeathInfo(const NodeID &node_id,
 }
 
 rpc::NodeDeathInfo GcsNodeManager::InferDeathInfo(const NodeID &node_id) {
-  auto maybe_node = GetAliveNode(node_id);
-  RAY_CHECK(maybe_node.has_value())
-      << "InferDeathInfo() should be called before node is removed";
-  auto node = maybe_node.value();
   auto iter = draining_nodes_.find(node_id);
   rpc::NodeDeathInfo death_info;
-
   bool expect_force_termination;
   if (iter == draining_nodes_.end()) {
     expect_force_termination = false;
@@ -288,7 +282,11 @@ void GcsNodeManager::SetNodeDraining(
     const NodeID &node_id,
     std::shared_ptr<rpc::autoscaler::DrainNodeRequest> drain_request) {
   auto maybe_node = GetAliveNode(node_id);
-  RAY_CHECK(maybe_node.has_value());
+  if (!maybe_node.has_value()) {
+    RAY_LOG(INFO) << "Skip setting node " << node_id << " to be draining, "
+                  << "which is already removed";
+    return;
+  }
   auto iter = draining_nodes_.find(node_id);
   if (iter == draining_nodes_.end()) {
     draining_nodes_.emplace(node_id, drain_request);
@@ -303,16 +301,20 @@ void GcsNodeManager::SetNodeDraining(
 }
 
 std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
-    const ray::NodeID &node_id, bool is_intended /*= false*/) {
+    const ray::NodeID &node_id, const rpc::NodeDeathInfo &node_death_info) {
   std::shared_ptr<rpc::GcsNodeInfo> removed_node;
   auto iter = alive_nodes_.find(node_id);
   if (iter != alive_nodes_.end()) {
     removed_node = std::move(iter->second);
-    auto death_info = removed_node->death_info();
+
+    // Set node death info.
+    auto death_info = removed_node->mutable_death_info();
+    death_info->CopyFrom(node_death_info);
+
     RAY_LOG(INFO) << "Removing node, node id = " << node_id
                   << ", node name = " << removed_node->node_name() << ", death reason = "
-                  << rpc::NodeDeathInfo_Reason_Name(death_info.reason())
-                  << ", death message = " << death_info.reason_message();
+                  << rpc::NodeDeathInfo_Reason_Name(death_info->reason())
+                  << ", death message = " << death_info->reason_message();
     // Record stats that there's a new removed node.
     stats::NodeFailureTotal.Record(1);
     // Remove from alive nodes.
@@ -320,7 +322,7 @@ std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
     node_map_.left.erase(node_id);
     // Remove from draining nodes if present.
     draining_nodes_.erase(node_id);
-    if (!is_intended) {
+    if (death_info->reason() == rpc::NodeDeathInfo::UNEXPECTED_TERMINATION) {
       // Broadcast a warning to all of the drivers indicating that the node
       // has been marked as dead.
       // TODO(rkn): Define this constant somewhere else.
@@ -354,11 +356,14 @@ std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
 
 void GcsNodeManager::OnNodeFailure(const NodeID &node_id,
                                    const StatusCallback &node_table_updated_callback) {
-  rpc::NodeDeathInfo death_info = InferDeathInfo(node_id);
-  SetDeathInfo(node_id, death_info);
-  bool is_expected_termination =
-      (death_info.reason() == rpc::NodeDeathInfo::AUTOSCALER_DRAIN_PREEMPTED);
-  if (auto node = RemoveNode(node_id, is_expected_termination)) {
+  auto maybe_node = GetAliveNode(node_id);
+  if (maybe_node.has_value()) {
+    rpc::NodeDeathInfo death_info = InferDeathInfo(node_id);
+    auto node = RemoveNode(node_id, death_info);
+    if (!node) {
+      return;
+    }
+
     node->set_state(rpc::GcsNodeInfo::DEAD);
     node->set_end_time_ms(current_sys_time_ms());
 
@@ -377,6 +382,7 @@ void GcsNodeManager::OnNodeFailure(const NodeID &node_id,
       RAY_CHECK_OK(gcs_publisher_->PublishNodeInfo(node_id, *node_info_delta, nullptr));
     };
     RAY_CHECK_OK(gcs_table_storage_->NodeTable().Put(node_id, *node, on_done));
+
   } else if (node_table_updated_callback != nullptr) {
     node_table_updated_callback(Status::OK());
   }

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -177,12 +177,6 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// \param node The node which is dead.
   void AddDeadNodeToCache(std::shared_ptr<rpc::GcsNodeInfo> node);
 
-  /// Set the death info of the node.
-  ///
-  /// \param node_id The ID of the node.
-  /// \param death_info The death info of the node.
-  void SetDeathInfo(const NodeID &node_id, const rpc::NodeDeathInfo &death_info);
-
   /// Infer death cause of the node based on existing draining requests.
   ///
   /// \param node_id The ID of the node. The node must not be removed

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -109,13 +109,12 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   void SetNodeDraining(const NodeID &node_id,
                        std::shared_ptr<rpc::autoscaler::DrainNodeRequest> request);
 
-  /// Remove from alive nodes.
+  /// Remove a node from alive nodes. The node's death information will also be set.
   ///
   /// \param node_id The ID of the node to be removed.
-  /// \param is_intended False if this is triggered by `node_failure_detector_`, else
-  /// True.
+  /// \param node_death_info The death info of the node to set.
   std::shared_ptr<rpc::GcsNodeInfo> RemoveNode(const NodeID &node_id,
-                                               bool is_intended = false);
+                                               const rpc::NodeDeathInfo &node_death_info);
 
   /// Get alive node by ID.
   ///

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -112,7 +112,9 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Remove a node from alive nodes. The node's death information will also be set.
   ///
   /// \param node_id The ID of the node to be removed.
-  /// \param node_death_info The death info of the node to set.
+  /// \param node_death_info The node death info to set.
+  /// \return The removed node, with death info set. If the node is not found, return
+  /// nullptr.
   std::shared_ptr<rpc::GcsNodeInfo> RemoveNode(const NodeID &node_id,
                                                const rpc::NodeDeathInfo &node_death_info);
 

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
@@ -334,7 +334,8 @@ TEST_F(GcsActorSchedulerTest, TestNodeFailedWhenLeasing) {
 
   // Remove the node and cancel the scheduling on this node, the scheduling should be
   // interrupted.
-  gcs_node_manager_->RemoveNode(node_id);
+  rpc::NodeDeathInfo death_info;
+  gcs_node_manager_->RemoveNode(node_id, death_info);
   ASSERT_EQ(0, gcs_node_manager_->GetAllAliveNodes().size());
   auto actor_ids = gcs_actor_scheduler_->CancelOnNode(node_id);
   ASSERT_EQ(1, actor_ids.size());
@@ -422,7 +423,8 @@ TEST_F(GcsActorSchedulerTest, TestNodeFailedWhenCreating) {
 
   // Remove the node and cancel the scheduling on this node, the scheduling should be
   // interrupted.
-  gcs_node_manager_->RemoveNode(node_id);
+  rpc::NodeDeathInfo death_info;
+  gcs_node_manager_->RemoveNode(node_id, death_info);
   ASSERT_EQ(0, gcs_node_manager_->GetAllAliveNodes().size());
   auto actor_ids = gcs_actor_scheduler_->CancelOnNode(node_id);
   ASSERT_EQ(1, actor_ids.size());
@@ -934,7 +936,8 @@ TEST_F(GcsActorSchedulerTest, TestNodeFailedWhenLeasingByGcs) {
 
   // Remove the node and cancel the scheduling on this node, the scheduling should be
   // interrupted.
-  gcs_node_manager_->RemoveNode(node_id);
+  rpc::NodeDeathInfo death_info;
+  gcs_node_manager_->RemoveNode(node_id, death_info);
   ASSERT_EQ(0, gcs_node_manager_->GetAllAliveNodes().size());
   auto actor_ids = gcs_actor_scheduler_->CancelOnNode(node_id);
   ASSERT_EQ(1, actor_ids.size());
@@ -1028,7 +1031,8 @@ TEST_F(GcsActorSchedulerTest, TestNodeFailedWhenCreatingByGcs) {
 
   // Remove the node and cancel the scheduling on this node, the scheduling should be
   // interrupted.
-  gcs_node_manager_->RemoveNode(node_id);
+  rpc::NodeDeathInfo death_info;
+  gcs_node_manager_->RemoveNode(node_id, death_info);
   ASSERT_EQ(0, gcs_node_manager_->GetAllAliveNodes().size());
   auto actor_ids = gcs_actor_scheduler_->CancelOnNode(node_id);
   ASSERT_EQ(1, actor_ids.size());

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -51,7 +51,8 @@ TEST_F(GcsNodeManagerTest, TestManagement) {
   node_manager.AddNode(node);
   ASSERT_EQ(node, node_manager.GetAliveNode(node_id).value());
 
-  node_manager.RemoveNode(node_id);
+  rpc::NodeDeathInfo death_info;
+  node_manager.RemoveNode(node_id, death_info);
   ASSERT_TRUE(!node_manager.GetAliveNode(node_id).has_value());
 }
 
@@ -84,8 +85,9 @@ TEST_F(GcsNodeManagerTest, TestListener) {
       [&removed_nodes](std::shared_ptr<rpc::GcsNodeInfo> node) {
         removed_nodes.emplace_back(std::move(node));
       });
+  rpc::NodeDeathInfo death_info;
   for (int i = 0; i < node_count; ++i) {
-    node_manager.RemoveNode(NodeID::FromBinary(added_nodes[i]->node_id()));
+    node_manager.RemoveNode(NodeID::FromBinary(added_nodes[i]->node_id()), death_info);
   }
   ASSERT_EQ(node_count, removed_nodes.size());
   ASSERT_TRUE(node_manager.GetAllAliveNodes().empty());

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -125,7 +125,8 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
   }
 
   void RemoveNode(const std::shared_ptr<rpc::GcsNodeInfo> &node) {
-    gcs_node_manager_->RemoveNode(NodeID::FromBinary(node->node_id()));
+    rpc::NodeDeathInfo death_info;
+    gcs_node_manager_->RemoveNode(NodeID::FromBinary(node->node_id()), death_info);
     gcs_resource_manager_->OnNodeDead(NodeID::FromBinary(node->node_id()));
   }
 

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -450,7 +450,7 @@ int main(int argc, char *argv[]) {
         drain_request->reason() ==
             ray::rpc::autoscaler::DrainNodeReason::DRAIN_NODE_REASON_PREEMPTION &&
         drain_request->deadline_timestamp_ms() != 0 &&
-        drain_request->deadline_timestamp_ms() < current_time_ms()) {
+        drain_request->deadline_timestamp_ms() < current_sys_time_ms()) {
       node_death_info.set_reason(ray::rpc::NodeDeathInfo::AUTOSCALER_DRAIN_PREEMPTED);
       node_death_info.set_reason_message(drain_request->reason_message());
     } else {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When setting node death info, node was checked to be alive and then later used.
However, there could be other callers that remove the alive node in between the
check and use. This PR fixes the race condition by rechecking at the use time and
skip the action if it is already removed.

It also fixes the preemption deadline checking by using `current_sys_time_ms()`
instead of `current_time_ms()`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #45625
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
