### PR TITLE
[ci] remove 3.8 from ray supported python list

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -24,9 +24,10 @@ steps:
     key: lint-medium
     instance_type: medium
     depends_on:
-      - forge
+      - oss-ci-base_build
     commands:
       - ./ci/lint/lint.sh {{matrix}}
+    job_env: oss-ci-base_build
     matrix:
       - api_annotations
       - api_discrepancy

--- a/python/setup.py
+++ b/python/setup.py
@@ -27,7 +27,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_PYTHONS = [(3, 8), (3, 9), (3, 10), (3, 11)]
+SUPPORTED_PYTHONS = [(3, 9), (3, 10), (3, 11)]
 # When the bazel version is updated, make sure to update it
 # in WORKSPACE file as well.
 


### PR DESCRIPTION
Notice that we haven't removed this support completely once I work on upgrading python 3.12.

Need to change some runtime environment to `oss-ci-base_build` since `forge` is using python 3.8.

Test:
- CI