### PR TITLE
[ci] do not clean up release test data

### DIFF
--- a/release/ray_release/command_runner/anyscale_job_runner.py
+++ b/release/ray_release/command_runner/anyscale_job_runner.py
@@ -349,9 +349,7 @@ class AnyscaleJobRunner(JobRunner):
         )
 
     def cleanup(self):
-        try:
-            self.file_manager.delete(self.path_in_bucket, recursive=True)
-        except Exception:
-            # No big deal if we don't clean up, the bucket
-            # is set to automatically expire objects anyway
-            pass
+        # We piggy back on s3 retention policy for clean up instead of doing this
+        # ourselves. We find many cases where users want the data to be available
+        # for a short-while for debugging purpose.
+        pass


### PR DESCRIPTION
This code path deletes the release test working directory upon the job completion.

We found repetitive cases where users want the data to be available for debugging purpose. Let's rely on s3 policy to clean up the data after a few days.

Test:
- CI