### PR TITLE
add oss tag to container tests

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -315,6 +315,7 @@ steps:
     tags:
       - python
       - docker
+      - oss
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- docker --platform cpu


### PR DESCRIPTION
add oss tag to container tests

Add `oss` tag to container tests.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
