### PR TITLE
[core] add EC2InstanceTerminator and refactor killer creation

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1493,8 +1493,7 @@ class ResourceKillerActor:
         return self.killed
 
 
-@ray.remote(num_cpus=0)
-class NodeKillerActor(ResourceKillerActor):
+class NodeActorBase(ResourceKillerActor):
     async def _find_resource_to_kill(self):
         node_to_kill_ip = None
         node_to_kill_port = None
@@ -1521,6 +1520,16 @@ class NodeKillerActor(ResourceKillerActor):
 
         return node_id, node_to_kill_ip, node_to_kill_port
 
+    def _get_alive_nodes(self, nodes):
+        alive_nodes = 0
+        for node in nodes:
+            if node["Alive"]:
+                alive_nodes += 1
+        return alive_nodes
+
+
+@ray.remote(num_cpus=0)
+class NodeKillerActor(NodeActorBase):
     def _kill_resource(self, node_id, node_to_kill_ip, node_to_kill_port):
         if node_to_kill_port is not None:
             try:
@@ -1531,6 +1540,33 @@ class NodeKillerActor(ResourceKillerActor):
                 f"Killed node {node_id} at address: "
                 f"{node_to_kill_ip}, port: {node_to_kill_port}"
             )
+            self.killed.add(node_id)
+
+    def _kill_raylet(self, ip, port, graceful=False):
+        import grpc
+        from grpc._channel import _InactiveRpcError
+        from ray.core.generated import node_manager_pb2_grpc
+
+        raylet_address = f"{ip}:{port}"
+        channel = grpc.insecure_channel(raylet_address)
+        stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
+        try:
+            stub.ShutdownRaylet(
+                node_manager_pb2.ShutdownRayletRequest(graceful=graceful)
+            )
+        except _InactiveRpcError:
+            assert not graceful
+
+
+@ray.remote(num_cpus=0)
+class EC2InstanceTerminator(NodeActorBase):
+    def _kill_resource(self, node_id, node_to_kill_ip, _):
+        if node_to_kill_ip is not None:
+            try:
+                self._terminate_ec2_instance(node_to_kill_ip)
+            except Exception:
+                pass
+            logging.info(f"Terminated instance, {node_id=}, address={node_to_kill_ip}")
             self.killed.add(node_id)
 
     def _terminate_ec2_instance(self, ip):
@@ -1551,28 +1587,6 @@ class NodeKillerActor(ResourceKillerActor):
         )
         print(f"STDOUT:\n{result.stdout}\n")
         print(f"STDERR:\n{result.stderr}\n")
-
-    def _kill_raylet(self, ip, port, graceful=False):
-        import grpc
-        from grpc._channel import _InactiveRpcError
-        from ray.core.generated import node_manager_pb2_grpc
-
-        raylet_address = f"{ip}:{port}"
-        channel = grpc.insecure_channel(raylet_address)
-        stub = node_manager_pb2_grpc.NodeManagerServiceStub(channel)
-        try:
-            stub.ShutdownRaylet(
-                node_manager_pb2.ShutdownRayletRequest(graceful=graceful)
-            )
-        except _InactiveRpcError:
-            assert not graceful
-
-    def _get_alive_nodes(self, nodes):
-        alive_nodes = 0
-        for node in nodes:
-            if node["Alive"]:
-                alive_nodes += 1
-        return alive_nodes
 
 
 @ray.remote(num_cpus=0)

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1493,7 +1493,7 @@ class ResourceKillerActor:
         return self.killed
 
 
-class NodeActorBase(ResourceKillerActor):
+class NodeKillerBase(ResourceKillerActor):
     async def _find_resource_to_kill(self):
         node_to_kill_ip = None
         node_to_kill_port = None
@@ -1529,7 +1529,7 @@ class NodeActorBase(ResourceKillerActor):
 
 
 @ray.remote(num_cpus=0)
-class NodeKillerActor(NodeActorBase):
+class RayletKiller(NodeKillerBase):
     def _kill_resource(self, node_id, node_to_kill_ip, node_to_kill_port):
         if node_to_kill_port is not None:
             try:
@@ -1559,7 +1559,7 @@ class NodeKillerActor(NodeActorBase):
 
 
 @ray.remote(num_cpus=0)
-class EC2InstanceTerminator(NodeActorBase):
+class EC2InstanceTerminator(NodeKillerBase):
     def _kill_resource(self, node_id, node_to_kill_ip, _):
         if node_to_kill_ip is not None:
             try:

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -37,7 +37,7 @@ from ray._private.test_utils import (
     find_available_port,
     wait_for_condition,
     find_free_port,
-    NodeKillerActor,
+    RayletKiller,
 )
 from ray.cluster_utils import AutoscalingCluster, Cluster, cluster_not_supported
 
@@ -921,7 +921,7 @@ def _ray_start_chaos_cluster(request):
     assert len(nodes) == 1
 
     if kill_interval is not None:
-        node_killer = get_and_run_resource_killer(NodeKillerActor, kill_interval)
+        node_killer = get_and_run_resource_killer(RayletKiller, kill_interval)
 
     yield cluster
 

--- a/release/nightly_tests/chaos_test/test_chaos_basic.py
+++ b/release/nightly_tests/chaos_test/test_chaos_basic.py
@@ -206,7 +206,7 @@ def main():
     # Step 3
     print("Running with failures")
     start = time.time()
-    node_killer = ray.get_actor("NodeKillerActor", namespace="release_test_namespace")
+    node_killer = ray.get_actor("RayletKiller", namespace="release_test_namespace")
     node_killer.run.remote()
     workload(total_num_cpus, args.smoke)
     print(f"Runtime when there are many failures: {time.time() - start}")

--- a/release/nightly_tests/setup_chaos.py
+++ b/release/nightly_tests/setup_chaos.py
@@ -103,7 +103,7 @@ def get_chaos_killer(args):
     elif chaos_type == "KillWorker":
         return WorkerKillerActor, task_filter(args.task_names)
     elif chaos_type == "TerminateEC2Instance":
-        raise EC2InstanceTerminator, task_node_filter(args.task_names)
+        return EC2InstanceTerminator, task_node_filter(args.task_names)
     else:
         raise ValueError(f"Chaos type {chaos_type} not supported.")
 

--- a/release/nightly_tests/setup_chaos.py
+++ b/release/nightly_tests/setup_chaos.py
@@ -18,9 +18,9 @@ def parse_script_args():
     parser.add_argument("--kill-workers", action="store_true", default=False)
 
     parser.add_argument(
-        '--chaos',
+        "--chaos",
         type=str,
-        default='',
+        default="",
         help=(
             "Chaos to inject into the test environment. "
             "Options: KillRaylet, KillWorker, TerminateEC2Instance."
@@ -90,13 +90,14 @@ def task_node_filter(task_names):
 
     return _task_node_filter
 
+
 def get_chaos_killer(args):
     if args.chaos != "":
         chaos_type = args.chaos
     elif args.kill_workers:
         chaos_type = "KillWorker"
     else:
-        chaos_type = "KillRaylet" # default
+        chaos_type = "KillRaylet"  # default
 
     if chaos_type == "KillRaylet":
         return RayletKiller, task_node_filter(args.task_names)
@@ -106,6 +107,7 @@ def get_chaos_killer(args):
         return EC2InstanceTerminator, task_node_filter(args.task_names)
     else:
         raise ValueError(f"Chaos type {chaos_type} not supported.")
+
 
 def main():
     """Start the chaos testing.

--- a/release/nightly_tests/setup_chaos.py
+++ b/release/nightly_tests/setup_chaos.py
@@ -5,7 +5,7 @@ import ray
 
 from ray._private.test_utils import (
     get_and_run_resource_killer,
-    NodeKillerActor,
+    RayletKiller,
     WorkerKillerActor,
     EC2InstanceTerminator,
 )
@@ -99,7 +99,7 @@ def get_chaos_killer(args):
         chaos_type = "KillRaylet" # default
 
     if chaos_type == "KillRaylet":
-        return NodeKillerActor, task_node_filter(args.task_names)
+        return RayletKiller, task_node_filter(args.task_names)
     elif chaos_type == "KillWorker":
         return WorkerKillerActor, task_filter(args.task_names)
     elif chaos_type == "TerminateEC2Instance":

--- a/release/nightly_tests/setup_chaos.py
+++ b/release/nightly_tests/setup_chaos.py
@@ -7,12 +7,26 @@ from ray._private.test_utils import (
     get_and_run_resource_killer,
     NodeKillerActor,
     WorkerKillerActor,
+    EC2InstanceTerminator,
 )
 
 
 def parse_script_args():
     parser = argparse.ArgumentParser()
+
+    # '--kill-workers' to be deprecated in favor of '--chaos'
     parser.add_argument("--kill-workers", action="store_true", default=False)
+
+    parser.add_argument(
+        '--chaos',
+        type=str,
+        default='',
+        help=(
+            "Chaos to inject into the test environment. "
+            "Options: KillRaylet, KillWorker, TerminateEC2Instance."
+        ),
+    )
+
     parser.add_argument("--kill-interval", type=int, default=60)
     parser.add_argument("--max-to-kill", type=int, default=2)
     parser.add_argument(
@@ -76,6 +90,22 @@ def task_node_filter(task_names):
 
     return _task_node_filter
 
+def get_chaos_killer(args):
+    if args.chaos != "":
+        chaos_type = args.chaos
+    elif args.kill_workers:
+        chaos_type = "KillWorker"
+    else:
+        chaos_type = "KillRaylet" # default
+
+    if chaos_type == "KillRaylet":
+        return NodeKillerActor, task_node_filter(args.task_names)
+    elif chaos_type == "KillWorker":
+        return WorkerKillerActor, task_filter(args.task_names)
+    elif chaos_type == "TerminateEC2Instance":
+        raise EC2InstanceTerminator, task_node_filter(args.task_names)
+    else:
+        raise ValueError(f"Chaos type {chaos_type} not supported.")
 
 def main():
     """Start the chaos testing.
@@ -84,12 +114,7 @@ def main():
     """
     args, _ = parse_script_args()
     ray.init(address="auto")
-    if args.kill_workers:
-        resource_killer_cls = WorkerKillerActor
-        kill_filter_fn = task_filter(args.task_names)
-    else:
-        resource_killer_cls = NodeKillerActor
-        kill_filter_fn = task_node_filter(args.task_names)
+    resource_killer_cls, kill_filter_fn = get_chaos_killer(args)
 
     get_and_run_resource_killer(
         resource_killer_cls,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Separated from https://github.com/ray-project/ray/pull/45364

With this change, the rest of chaos testing is only config changes. For example:

```yaml
    prepare: python setup_chaos.py --no-start --chaos TerminateEC2Instance
    script: python chaos_test/test_chaos_basic.py --workload=actors
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
