### PR TITLE
[core] Eagerly kill idle workers on job finish.

### DIFF
--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -223,7 +223,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// \return Void
   void HandleJobStarted(const JobID &job_id, const rpc::JobConfig &job_config);
 
-  /// Handles the event that a job is finished.
+  /// Handles the event that a job is finished. Kills all idle workers for this job with
+  /// no root detached actors.
   ///
   /// \param job_id ID of the finished job.
   /// \return Void.
@@ -455,6 +456,12 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   const std::vector<std::string> &LookupWorkerDynamicOptions(StartupToken token) const;
 
   void KillIdleWorker(std::shared_ptr<WorkerInterface> worker, int64_t last_time_used_ms);
+
+  /// Kills any idle workers with `should_kill(worker, last_time_used_ms) == true`.
+  /// `should_kill` is guaranteed to be called exactly once for each idle worker and in
+  /// FIFO order. Returns the number of workers killed.
+  size_t KillIdleWorkersByPredicate(
+      std::function<bool(const WorkerInterface &, int64_t)> should_kill);
 
   /// Gloabl startup token variable. Incremented once assigned
   /// to a worker process and is added to


### PR DESCRIPTION
Refactors how worker_pool.cc kills idle workers. Previously we have an ad hoc big loop through `idle_of_all_languages_` and decide if each workers need a kill. Now, we have a `KillIdleWorkersByPredicate` which splits the decision logic and the iteration logic. Use it to kill workers on job finish and still on periodic loop.

Note: this changes the idle killing order. For long-idle workers for a running job, previously we scan the list 2 times to count the numbers and to do FIFO killing. Now, this PR reduces it to 1 pass scan, at the cost of no longer FIFO. Instead, we only keep the first `desired` workers and kill the rest, making it (kind of) FILO.

Note: in the periodic loop we still check the finished job ID because there may be pushed workers *after* the job finished.