### PR TITLE
[core][1/2] Add SubscribeAllActors to GcsClient.

### DIFF
--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -193,6 +193,15 @@ class ActorInfoAccessor {
   /// \return Whether the specified actor is unsubscribed.
   virtual bool IsActorUnsubscribed(const ActorID &actor_id);
 
+  /// Subscribe to all update operations of all actors.
+  ///
+  /// \param subscribe Callback that will be called each time when an actor is updated.
+  /// \param done Callback that will be called when subscription is complete.
+  /// \return Status
+  virtual Status AsyncSubscribeAll(
+      const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
+      const StatusCallback &done);
+
  private:
   // Mutex to protect the resubscribe_operations_ field and fetch_data_operations_ field.
   absl::Mutex mutex_;
@@ -204,6 +213,8 @@ class ActorInfoAccessor {
   /// Save the fetch data operation of actors.
   absl::flat_hash_map<ActorID, FetchDataOperation> fetch_data_operations_
       ABSL_GUARDED_BY(mutex_);
+
+  SubscribeOperation subscribe_all_operation_ ABSL_GUARDED_BY(mutex_);
 
   GcsClient *client_impl_;
 };

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -554,6 +554,8 @@ class GcsActorManager : public rpc::ActorInfoHandler {
     actor_delta->set_state(actor.state());
     actor_delta->mutable_death_cause()->CopyFrom(actor.death_cause());
     actor_delta->mutable_address()->CopyFrom(actor.address());
+    // Actor's is_detached is used by raylet to kill descendants.
+    actor_delta->set_is_detached(actor.is_detached());
     actor_delta->set_num_restarts(actor.num_restarts());
     actor_delta->set_timestamp(actor.timestamp());
     actor_delta->set_pid(actor.pid());
@@ -561,7 +563,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
     actor_delta->set_end_time(actor.end_time());
     actor_delta->set_repr_name(actor.repr_name());
     actor_delta->set_preempted(actor.preempted());
-    // Acotr's namespace and name are used for removing cached name when it's dead.
+    // Actor's namespace and name are used for removing cached name when it's dead.
     if (!actor.ray_namespace().empty()) {
       actor_delta->set_ray_namespace(actor.ray_namespace());
     }

--- a/src/ray/gcs/pubsub/gcs_pub_sub.h
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.h
@@ -115,6 +115,10 @@ class GcsSubscriber {
 
   bool IsActorUnsubscribed(const ActorID &id);
 
+  Status SubscribeAllActors(
+      const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
+      const StatusCallback &done);
+
   Status SubscribeAllJobs(const SubscribeCallback<JobID, rpc::JobTableData> &subscribe,
                           const StatusCallback &done);
 


### PR DESCRIPTION
This PR adds a new method `gcs_client.Actors().AsyncSubscribeAll(callback, done)`. It subscribes to *all* actor changes and supports resubscriptions like other methods.

The purpose of this method is to support node_manager and worker_pool to kill workers whose root is a dead detached actor. For this, added is_detached to the subscribed delta messages. Splitting this PR out for ease of reviewing.