### PR TITLE
[core][2/2] Kill worker on root detached actor died.

### DIFF
--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -193,6 +193,15 @@ class ActorInfoAccessor {
   /// \return Whether the specified actor is unsubscribed.
   virtual bool IsActorUnsubscribed(const ActorID &actor_id);
 
+  /// Subscribe to all update operations of all actors.
+  ///
+  /// \param subscribe Callback that will be called each time when an actor is updated.
+  /// \param done Callback that will be called when subscription is complete.
+  /// \return Status
+  virtual Status AsyncSubscribeAll(
+      const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
+      const StatusCallback &done);
+
  private:
   // Mutex to protect the resubscribe_operations_ field and fetch_data_operations_ field.
   absl::Mutex mutex_;
@@ -204,6 +213,8 @@ class ActorInfoAccessor {
   /// Save the fetch data operation of actors.
   absl::flat_hash_map<ActorID, FetchDataOperation> fetch_data_operations_
       ABSL_GUARDED_BY(mutex_);
+
+  SubscribeOperation subscribe_all_operation_ ABSL_GUARDED_BY(mutex_);
 
   GcsClient *client_impl_;
 };

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -554,6 +554,8 @@ class GcsActorManager : public rpc::ActorInfoHandler {
     actor_delta->set_state(actor.state());
     actor_delta->mutable_death_cause()->CopyFrom(actor.death_cause());
     actor_delta->mutable_address()->CopyFrom(actor.address());
+    // Actor's is_detached is used by raylet to kill descendants.
+    actor_delta->set_is_detached(actor.is_detached());
     actor_delta->set_num_restarts(actor.num_restarts());
     actor_delta->set_timestamp(actor.timestamp());
     actor_delta->set_pid(actor.pid());
@@ -561,7 +563,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
     actor_delta->set_end_time(actor.end_time());
     actor_delta->set_repr_name(actor.repr_name());
     actor_delta->set_preempted(actor.preempted());
-    // Acotr's namespace and name are used for removing cached name when it's dead.
+    // Actor's namespace and name are used for removing cached name when it's dead.
     if (!actor.ray_namespace().empty()) {
       actor_delta->set_ray_namespace(actor.ray_namespace());
     }

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -551,6 +551,9 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   std::shared_ptr<rpc::ActorTableData> GenActorDataOnlyWithStates(
       const rpc::ActorTableData &actor) {
     auto actor_delta = std::make_shared<rpc::ActorTableData>();
+    // TODO: this is not a delta
+    actor_delta->set_is_detached(actor.is_detached());
+
     actor_delta->set_state(actor.state());
     actor_delta->mutable_death_cause()->CopyFrom(actor.death_cause());
     actor_delta->mutable_address()->CopyFrom(actor.address());

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -551,9 +551,6 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   std::shared_ptr<rpc::ActorTableData> GenActorDataOnlyWithStates(
       const rpc::ActorTableData &actor) {
     auto actor_delta = std::make_shared<rpc::ActorTableData>();
-    // TODO: this is not a delta
-    actor_delta->set_is_detached(actor.is_detached());
-
     actor_delta->set_state(actor.state());
     actor_delta->mutable_death_cause()->CopyFrom(actor.death_cause());
     actor_delta->mutable_address()->CopyFrom(actor.address());

--- a/src/ray/gcs/pubsub/gcs_pub_sub.h
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.h
@@ -115,6 +115,10 @@ class GcsSubscriber {
 
   bool IsActorUnsubscribed(const ActorID &id);
 
+  Status SubscribeAllActors(
+      const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
+      const StatusCallback &done);
+
   Status SubscribeAllJobs(const SubscribeCallback<JobID, rpc::JobTableData> &subscribe,
                           const StatusCallback &done);
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -423,6 +423,11 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
 
   void HandleActorUpdate(const ActorID &actor_id, const rpc::ActorTableData &actor_data);
 
+  /// Kills leased workers if `predicate(worker) == true`. Leased workers are scanned
+  /// exactly once.
+  void KillLeasedWorkersByPredicate(
+      std::function<bool(const WorkerInterface &)> predicate);
+
   /// Process client message of NotifyDirectCallTaskBlocked
   ///
   /// \param message_data A pointer to the message data.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -421,6 +421,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// \return Void.
   void HandleJobFinished(const JobID &job_id, const JobTableData &job_data);
 
+  void HandleActorUpdate(const ActorID &actor_id, const rpc::ActorTableData &actor_data);
+
   /// Process client message of NotifyDirectCallTaskBlocked
   ///
   /// \param message_data A pointer to the message data.

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -258,6 +258,10 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// \return void
   void OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker);
 
+  /// To be invoked when a detached actor died. Kills all workers whose root detached
+  /// actor == this actor_id.
+  void OnDetachedActorDied(const ActorID &actor_id);
+
   /// Register a new driver.
   ///
   /// \param[in] worker The driver to be registered.

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -460,6 +460,11 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
 
   void KillIdleWorker(std::shared_ptr<WorkerInterface> worker, int64_t last_time_used_ms);
 
+  // If `root_detached_actor_id` is not nil, return if it's finished.
+  // Else, return if the job is finished.
+  bool IsJobOrRootDetachedActorFinished(JobID job_id,
+                                        ActorID root_detached_actor_id) const;
+
   /// Gloabl startup token variable. Incremented once assigned
   /// to a worker process and is added to
   /// state.worker_processes.
@@ -753,6 +758,9 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
 
   /// Set of jobs whose drivers have exited.
   absl::flat_hash_set<JobID> finished_jobs_;
+
+  /// Set of detached actors who have exited.
+  absl::flat_hash_set<ActorID> finished_detached_actors_;
 
   /// A map of idle workers that are pending exit.
   absl::flat_hash_map<WorkerID, std::shared_ptr<WorkerInterface>>


### PR DESCRIPTION
PR #44214 fixes issue that when a job finished, there are workers leaked. However if a worker is assigned to a detached actor, they still leak. This PR fixes this by listening on actor death and kill assigned workers accordingly.

Based on #45637 which adds SubscribeAllActors to GcsClient. This PR uses it in node_manager and kills workers. `node_manager` listens to all actor changes in `NodeManager::HandleActorUpdate`, and it kills running workers and invoke `worker_pool` callback to bookkeep the died actor. `worker_pool` will then kill workers in periodic loops and worker start callbacks.

There are several kinds of workers to kill:

1. running workers, kept in `NodeManager::leased_workers_`, killed in the subscription callback in `NodeManager::HandleActorUpdate`
2. idle workers, killed in `WorkerPool::TryKillingIdleWorkers` -> `WorkerPool::KillIdleWorker`
3. pending pop-from-pool workers, fail in `WorkerPool::PopWorkerCallbackInternal`
4. pending push-to-pool workers (just started, or returned from lease), fail in `WorkerPool::InvokePopWorkerCallbackForProcess`

...and we treat them accordingly.

Fixes part of #45596.