### PR TITLE
Unpin setproctitile

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -514,7 +514,7 @@ install_thirdparty_packages() {
   fi
   mkdir -p "${WORKSPACE_DIR}/python/ray/thirdparty_files"
   RAY_THIRDPARTY_FILES="$(realpath "${WORKSPACE_DIR}/python/ray/thirdparty_files")"
-  CC=gcc python -m pip install psutil==5.9.6 setproctitle==1.2.2 colorama==0.4.6 --target="${RAY_THIRDPARTY_FILES}"
+  CC=gcc python -m pip install psutil==5.9.6 "setproctitle>=1.2.2,<1.4" colorama==0.4.6 --target="${RAY_THIRDPARTY_FILES}"
 }
 
 install_dependencies() {

--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -296,7 +296,9 @@ ray.get(f.remote())
             submission_job = jobs[3]
             # Skip the first letter in commands, since on macos it can be
             # either python or Python
-            assert list2cmdline(commands)[1:] in submission_job["Entrypoint"]
+            # Skip the last letter to work around
+            # https://github.com/dvarrazzo/py-setproctitle/issues/118
+            assert list2cmdline(commands)[1:-1] in submission_job["Entrypoint"]
             return True
 
         wait_for_condition(verify)

--- a/python/setup.py
+++ b/python/setup.py
@@ -516,7 +516,7 @@ def build(build_python, build_java, build_cpp):
     # that certain flags will not be passed along such as --user or sudo.
     # TODO(rkn): Fix this.
     if not os.getenv("SKIP_THIRDPARTY_INSTALL"):
-        pip_packages = ["psutil", "setproctitle==1.2.2", "colorama"]
+        pip_packages = ["psutil", "setproctitle>=1.2.2,<1.4", "colorama"]
         subprocess.check_call(
             [
                 sys.executable,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Fixes #40289, which was reverted in #45539. Also adapt tests to run locally by changing the pattern matching for the case where the tests are run in a virtualenv, and the process reporting mechanism gets the full path to the original python. Additiionally, on macos that original python may be Python with a capital `P` so loosen the pattern matcing.

#40289 was reverted due to breaking a test due to https://github.com/dvarrazzo/py-setproctitle/issues/118. Again, allow the pattern matching to pass even when a single character is missing from the end of the command.

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
