### PR TITLE
[Core] Expose NodeDeathInfo in state CLI

### DIFF
--- a/dashboard/datacenter.py
+++ b/dashboard/datacenter.py
@@ -138,8 +138,9 @@ class DataOrganizer:
 
         # Merge GcsNodeInfo to node physical stats
         node_info["raylet"].update(node)
+        death_info = node.get("deathInfo", {})
         node_info["raylet"]["stateMessage"] = compose_state_message(
-            node.get("deathInfo", {})
+            death_info.get("reason", None), death_info.get("reasonMessage", None)
         )
 
         if not get_summary:

--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -324,7 +324,10 @@ class StateAPIManager:
             data["node_ip"] = data["node_manager_address"]
             data["start_time_ms"] = int(data["start_time_ms"])
             data["end_time_ms"] = int(data["end_time_ms"])
-            data["state_message"] = compose_state_message(data.get("death_info", {}))
+            death_info = data.get("death_info", {})
+            data["state_message"] = compose_state_message(
+                death_info.get("reason", None), death_info.get("reason_message", None)
+            )
 
             result.append(data)
 

--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -11,6 +11,7 @@ from ray._private.ray_constants import env_integer
 from ray._private.profiling import chrome_tracing_dump
 
 import ray.dashboard.memory_utils as memory_utils
+from ray.dashboard.utils import compose_state_message
 
 from ray.util.state.common import (
     protobuf_message_to_dict,
@@ -323,6 +324,7 @@ class StateAPIManager:
             data["node_ip"] = data["node_manager_address"]
             data["start_time_ms"] = int(data["start_time_ms"])
             data["end_time_ms"] = int(data["end_time_ms"])
+            data["state_message"] = compose_state_message(data.get("death_info", {}))
 
             result.append(data)
 

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -656,13 +656,17 @@ def get_address_for_submission_client(address: Optional[str]) -> str:
     return address
 
 
-def compose_state_message(death_info_dict: dict) -> Optional[str]:
+def compose_state_message(
+    death_reason: Optional[str], death_reason_message: Optional[str]
+) -> Optional[str]:
     """Compose node state message based on death information.
 
     Args:
-        death_info_dict: the node_death field in GcsNodeInfo, in dict type.
+        death_reason: The reason of node death.
+            This is a string representation of `gcs_pb2.NodeDeathInfo.Reason`.
+        death_reason_message: The message of node death.
+            This corresponds to `gcs_pb2.NodeDeathInfo.ReasonMessage`.
     """
-    death_reason = death_info_dict.get("reason", None)
     if death_reason == "EXPECTED_TERMINATION":
         state_message = "Expected termination"
     elif death_reason == "UNEXPECTED_TERMINATION":
@@ -674,7 +678,6 @@ def compose_state_message(death_info_dict: dict) -> Optional[str]:
     else:
         state_message = None
 
-    death_reason_message = death_info_dict.get("reasonMessage", None)
     if death_reason_message:
         if state_message:
             state_message += f": {death_reason_message}"

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -204,7 +204,8 @@ ray.get(x)
         verify_failed_task,
         name="node-killed",
         error_type="NODE_DIED",
-        error_message="Task failed due to the node dying",
+        error_message="Task failed due to the node (where this task was running) "
+        " was dead or unavailable",
     )
 
 

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -507,6 +507,9 @@ class NodeState(StateSchema):
     #: ALIVE: The node is alive.
     #: DEAD: The node is dead.
     state: TypeNodeStatus = state_column(filterable=True)
+    #: The death info of the node.
+    #: When `state` is ALIVE, this field is None.
+    death_info: Optional[dict] = state_column(filterable=False)
     #: The name of the node if it is given by the name argument.
     node_name: str = state_column(filterable=True)
     #: The total resources of the node.

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -507,9 +507,9 @@ class NodeState(StateSchema):
     #: ALIVE: The node is alive.
     #: DEAD: The node is dead.
     state: TypeNodeStatus = state_column(filterable=True)
-    #: The death info of the node.
-    #: When `state` is ALIVE, this field is None.
-    death_info: Optional[dict] = state_column(filterable=False)
+    #: The state message of the node.
+    #: This provides more detailed information about the node's state.
+    state_message: Optional[str] = state_column(filterable=True)
     #: The name of the node if it is given by the name argument.
     node_name: str = state_column(filterable=True)
     #: The total resources of the node.

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -509,7 +509,7 @@ class NodeState(StateSchema):
     state: TypeNodeStatus = state_column(filterable=True)
     #: The state message of the node.
     #: This provides more detailed information about the node's state.
-    state_message: Optional[str] = state_column(filterable=True)
+    state_message: Optional[str] = state_column(filterable=False)
     #: The name of the node if it is given by the name argument.
     node_name: str = state_column(filterable=True)
     #: The total resources of the node.

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -728,13 +728,14 @@ void CoreWorkerDirectTaskSubmitter::HandleGetTaskFailureCause(
                      << " ip: " << addr.ip_address();
     task_error_type = rpc::ErrorType::NODE_DIED;
     std::stringstream buffer;
-    buffer << "Task failed due to the node dying.\n\nThe node (IP: " << addr.ip_address()
+    buffer << "Task failed due to the node (where this task was running) "
+           << " was dead or unreachable.\n\nThe node IP: " << addr.ip_address()
            << ", node ID: " << NodeID::FromBinary(addr.raylet_id())
-           << ") where this task was running crashed unexpectedly. "
-           << "This can happen if: (1) the instance where the node was running failed, "
-              "(2) raylet crashes unexpectedly (OOM, preempted node, etc).\n\n"
-           << "To see more information about the crash, use `ray logs raylet.out -ip "
-           << addr.ip_address() << "`";
+           << "This can happen if the instance where the node was running failed, "
+           << "the node was preempted, or raylet crashed unexpectedly "
+           << "(e.g., due to OOM) etc.\n\n"
+           << "To see node death information, use `ray list nodes`, "
+           << "or check Ray dashboard cluster page, or search the node ID in GCS log.";
     error_info = std::make_unique<rpc::RayErrorInfo>();
     error_info->set_error_message(buffer.str());
     error_info->set_error_type(rpc::ErrorType::NODE_DIED);

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -729,13 +729,15 @@ void CoreWorkerDirectTaskSubmitter::HandleGetTaskFailureCause(
     task_error_type = rpc::ErrorType::NODE_DIED;
     std::stringstream buffer;
     buffer << "Task failed due to the node (where this task was running) "
-           << " was dead or unreachable.\n\nThe node IP: " << addr.ip_address()
-           << ", node ID: " << NodeID::FromBinary(addr.raylet_id())
+           << " was dead or unavailable.\n\nThe node IP: " << addr.ip_address()
+           << ", node ID: " << NodeID::FromBinary(addr.raylet_id()) << "\n\n"
            << "This can happen if the instance where the node was running failed, "
            << "the node was preempted, or raylet crashed unexpectedly "
            << "(e.g., due to OOM) etc.\n\n"
-           << "To see node death information, use `ray list nodes`, "
-           << "or check Ray dashboard cluster page, or search the node ID in GCS log.";
+           << "To see node death information, use `ray list nodes --filter \"node_id="
+           << NodeID::FromBinary(addr.raylet_id()) << "\"`, "
+           << "or check Ray dashboard cluster page, or search the node ID in GCS log, "
+           << "or use `ray logs raylet.out -ip " << addr.ip_address() << "`";
     error_info = std::make_unique<rpc::RayErrorInfo>();
     error_info->set_error_message(buffer.str());
     error_info->set_error_type(rpc::ErrorType::NODE_DIED);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is the 5th (last) PR of a series to better propagate and expose node death information.

This PR does the following:
* Expose NodeDeathInfo in state CLI
* Update NodeDiedError message to direct to the accurate node death info

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
[1/5] https://github.com/ray-project/ray/pull/45128
[2/5] https://github.com/ray-project/ray/pull/45357
[3/5] https://github.com/ray-project/ray/pull/45320
[4/5] https://github.com/ray-project/ray/pull/45497

<!-- For example: "Closes #1234" -->

## Sample output
```
ray list nodes
======== List: 2024-05-31 10:17:06.320697 ========
Stats:
------------------------------
Total: 2

Table:
------------------------------
    NODE_ID                                                   NODE_IP    IS_HEAD_NODE    STATE    STATE_MESSAGE                                                   NODE_NAME    RESOURCES_TOTAL                   LABELS
 0  9e757009998dbdbe546068b7b898af3d34dfa82e89f4854de422ab5f  127.0.0.1  True            ALIVE                                                                    127.0.0.1    CPU: 1.0                          ray.io/node_id: 9e757009998dbdbe546068b7b898af3d34dfa82e89f4854de422ab5f
                                                                                                                                                                               head: 1.0
                                                                                                                                                                               memory: 17.474 GiB
                                                                                                                                                                               node:127.0.0.1: 1.0
                                                                                                                                                                               node:__internal_head__: 1.0
                                                                                                                                                                               object_store_memory: 150.000 MiB
 1  bc74e1484266e0e5b9f0c8c610a07d8dfc0052f46fc3b07fda46220c  127.0.0.1  False           DEAD     Terminated due to idle (no Ray activity): idle for long enough  127.0.0.1    CPU: 1.0                          ray.io/node_id: bc74e1484266e0e5b9f0c8c610a07d8dfc0052f46fc3b07fda46220c
                                                                                                                                                                               memory: 19.238 GiB
                                                                                                                                                                               node:127.0.0.1: 1.0
                                                                                                                                                                               object_store_memory: 150.000 MiB
                                                                                                                                                                               worker: 1.0
```

```
ray list nodes --detail
---
-   node_id: 9e757009998dbdbe546068b7b898af3d34dfa82e89f4854de422ab5f
    node_ip: 127.0.0.1
    is_head_node: true
    state: ALIVE
    state_message: null
    node_name: 127.0.0.1
    resources_total:
        object_store_memory: 150.000 MiB
        memory: 17.474 GiB
        node:127.0.0.1: 1.0
        head: 1.0
        CPU: 1.0
        node:__internal_head__: 1.0
    labels:
        ray.io/node_id: 9e757009998dbdbe546068b7b898af3d34dfa82e89f4854de422ab5f
    start_time_ms: '2024-05-31 10:16:51.475000'
    end_time_ms: '1969-12-31 16:00:00'
-   node_id: bc74e1484266e0e5b9f0c8c610a07d8dfc0052f46fc3b07fda46220c
    node_ip: 127.0.0.1
    is_head_node: false
    state: DEAD
    state_message: 'Terminated due to idle (no Ray activity): idle for long enough'
    node_name: 127.0.0.1
    resources_total:
        CPU: 1.0
        object_store_memory: 150.000 MiB
        node:127.0.0.1: 1.0
        memory: 19.238 GiB
        worker: 1.0
    labels:
        ray.io/node_id: bc74e1484266e0e5b9f0c8c610a07d8dfc0052f46fc3b07fda46220c
    start_time_ms: '2024-05-31 10:16:52.014000'
    end_time_ms: '2024-05-31 10:16:53.266000'
...
```

Also checked dashboard has no regression:
<img width="1586" alt="Screenshot 2024-05-31 at 10 17 54 AM" src="https://github.com/ray-project/ray/assets/161574667/c258fa2c-d6ac-407f-b942-f5def7e0b035">

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
