### PR TITLE
[Core] Fix worker column off-by-one in dashboard

### DIFF
--- a/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/dashboard/client/src/pages/node/NodeRow.tsx
@@ -279,6 +279,7 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
       <TableCell>
         <StatusChip type="worker" status="ALIVE" />
       </TableCell>
+      <TableCell align="center">N/A</TableCell>
       <TableCell align="center">
         {coreWorker && (
           <Tooltip title={coreWorker.workerId} arrow>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In #45320, we introduced "State Message" column for nodes. However, workers share the same row structure with nodes, and without changing the workers row, there will be an off-by-one issue in the dashboard. This PR fixes the issue.

Before the fix:
<img width="2462" alt="Screenshot 2024-05-30 at 5 10 14 PM" src="https://github.com/ray-project/ray/assets/161574667/9bbdb2fd-9202-4b2e-a241-6549d6384bd6">

After the fix:
<img width="2467" alt="Screenshot 2024-05-30 at 5 06 15 PM" src="https://github.com/ray-project/ray/assets/161574667/8c59d963-098e-4f73-b29b-8298c7a2175d">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
