### PR TITLE
[ci][microcheck] add a few cheap tests to microcheck

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -28,6 +28,7 @@ steps:
       - forge
 
   - label: ":tapioca: build: jar"
+    key: java_wheels
     tags:
       - java
       - oss

--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -20,6 +20,7 @@ steps:
       - raycpubase
 
   - label: ":kubernetes: chaos {{matrix.workload}} under {{matrix.fault}}"
+    key: kuberay_tests
     tags:
       - python
       - docker


### PR DESCRIPTION
Add keys to a few cheap builds and tests that I noticed failed on people's PR so we can include them in microcheck. These tests are not covered in the scope of test_in_docker.

Test:
- CI