### PR TITLE
[Data] Optimizing the multi column groupby

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -658,3 +658,11 @@ py_test(
     tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],
 )
+
+py_test(
+    name = "test_block_boundaries",
+    size = "small",
+    srcs = ["tests/test_block_boundaries.py"],
+    tags = ["team:data", "exclusive"],
+    deps = ["//:ray_lib", ":conftest"],
+)

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -1201,6 +1201,42 @@ def test_groupby_map_groups_multicolumn(
     ]
 
 
+@pytest.mark.parametrize("num_parts", [1, 30])
+@pytest.mark.parametrize("ds_format", ["pyarrow", "pandas", "numpy"])
+def test_groupby_map_groups_multicolumn_with_nan(
+    ray_start_regular_shared, ds_format, num_parts, use_push_based_shuffle
+):
+    # Test with some NaN values
+    rng = np.random.default_rng(RANDOM_SEED)
+    xs = np.arange(100, dtype=np.float64)
+    xs[-5:] = np.nan
+    rng.shuffle(xs)
+
+    ds = ray.data.from_items(
+        [
+            {
+                "A": (x % 2) if np.isfinite(x) else x,
+                "B": (x % 3) if np.isfinite(x) else x,
+            }
+            for x in xs
+        ]
+    ).repartition(num_parts)
+
+    agg_ds = ds.groupby(["A", "B"]).map_groups(
+        lambda df: {"count": [len(df["A"])]}, batch_format=ds_format
+    )
+    assert agg_ds.count() == 7
+    assert agg_ds.take_all() == [
+        {"count": 16},
+        {"count": 16},
+        {"count": 16},
+        {"count": 16},
+        {"count": 16},
+        {"count": 15},
+        {"count": 5},
+    ]
+
+
 def test_groupby_map_groups_with_partial():
     """
     The partial function name should show up as

--- a/python/ray/data/tests/test_block_boundaries.py
+++ b/python/ray/data/tests/test_block_boundaries.py
@@ -1,0 +1,62 @@
+import numpy as np
+
+from ray.data.block import _get_block_boundaries
+
+
+def test_groupby_map_groups_get_block_boundaries():
+    """Test for cases with Nan or None"""
+    indices = _get_block_boundaries(
+        [
+            np.array([1, 1, 2, 2, 3, 3]),
+            np.array([1, 1, 2, 2, 3, 4]),
+        ]
+    )
+
+    assert list(indices) == [0, 2, 4, 5, 6]
+
+    indices = _get_block_boundaries(
+        [
+            np.array([1, 1, 2, 2, 3, 3]),
+            np.array(["a", "b", "a", "a", "b", "b"]),
+        ]
+    )
+
+    assert list(indices) == [0, 1, 2, 4, 6]
+
+    indices = _get_block_boundaries([np.array([1, 1, 2, 2, 3, 3])])
+
+    assert list(indices) == [0, 2, 4, 6]
+
+
+def test_groupby_map_groups_get_block_boundaries_with_nan():
+    """Test for cases with Nan or None. Since the arrays are sorted
+    in the groupby, they are located at the end. Also, nans/None are
+    treated as the same group.
+    """
+
+    indices = _get_block_boundaries(
+        [
+            np.array([1, 1, 2, 2, 3, np.nan, np.nan]),
+            np.array([1, 1, 2, 2, 3, 4, np.nan]),
+        ]
+    )
+
+    assert list(indices) == [0, 2, 4, 5, 6, 7]
+
+    indices = _get_block_boundaries(
+        [
+            np.array([1, 1, 2, 2, 3, 3, np.nan]),
+            np.array(["a", "b", "a", "a", "b", "b", None]),
+        ]
+    )
+
+    assert list(indices) == [0, 1, 2, 4, 6, 7]
+
+    indices = _get_block_boundaries(
+        [
+            np.array([1, 1, 2, 2, 3, 3, 4]),
+            np.array(["a", "b", "a", "a", "b", "b", None]),
+        ]
+    )
+
+    assert list(indices) == [0, 1, 2, 4, 6, 7]


### PR DESCRIPTION
This PR improves the "get group boundaries" function in `groupby.map_groups()`. This is not a bottleneck so the overall runtime will likely have minimal improvement, but the function itself is optimized and the code is cleaner.

Changes:
* Instead of custom class implementation (`_MultiColumnSortedKey`, which I wrote a few months ago...), a numpy record array is constructed.
* Changed from "np.searchsorted + while-loop" to `np.where`

In addition, I have cleaned some indexing and added docstrings and tests.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The pure `numpy` implementation is about 8x faster. The result below is for 100K elements. (similar results for 10M elements)

```
------------------------------------------------------------------------------------------------ benchmark: 2 tests -----------------------------------------------------------------------------------------------
Name (time in ms)                                    Min                 Max                Mean            StdDev              Median               IQR            Outliers      OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark[get_key_boundaries]               21.1100 (1.0)       25.5830 (1.0)       22.2432 (1.0)      1.0147 (1.0)       22.1691 (1.0)      0.8943 (1.0)           8;4  44.9575 (1.0)          30           1
test_benchmark[get_key_boundaries_original]     175.2830 (8.30)     178.6610 (6.98)     176.4963 (7.93)     1.4369 (1.42)     175.8079 (7.93)     2.5007 (2.80)          2;0   5.6658 (0.13)          6           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

The custom `_MultiColumnSortedKey` class was introduced as a work-around. The numpy recarray should be preferred as it allows vectorization.

### Time complexity / Speed up

Most of the speed up is coming from the use of recarray. This gives about 7x speed up.

A little more speed up was achieved when using `np.where`, although the time complexity changed from the current O( k log n) to O(n) with the new implementation (`np.where`), where k is the number of groups and n is the length of the array. This is likely due to the vectorization (less branching).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
