### PR TITLE
[RLlib] DreamerV3 reporting fix for `config.report_dream_data=True`.

### DIFF
--- a/rllib/algorithms/dreamerv3/dreamerv3.py
+++ b/rllib/algorithms/dreamerv3/dreamerv3.py
@@ -690,6 +690,7 @@ class DreamerV3(Algorithm):
             do_report=(
                 self.config.report_dream_data and self.training_iteration % 100 == 0
             ),
+            framework=self.config.framework_str,
         )
 
         # Update weights - after learning on the LearnerGroup - on all EnvRunner

--- a/rllib/algorithms/dreamerv3/tf/dreamerv3_tf_learner.py
+++ b/rllib/algorithms/dreamerv3/tf/dreamerv3_tf_learner.py
@@ -284,13 +284,12 @@ class DreamerV3TfLearner(DreamerV3Learner, TfLearner):
             self.metrics.log_dict(
                 {
                     # Replace 'T' with '1'.
-                    f"DREAM_DATA_{key[:-1]}1": (
-                        value[:, config.batch_size_B_per_learner]
-                    )
+                    key[:-1] + "1": value[:, :: config.batch_length_T]
                     for key, value in dream_data.items()
                     if key.endswith("H_BxT")
                 },
-                key=module_id,
+                key=(module_id, "dream_data"),
+                reduce=None,
                 window=1,  # <- single items (should not be mean/ema-reduced over time).
             )
 

--- a/rllib/algorithms/dreamerv3/utils/summaries.py
+++ b/rllib/algorithms/dreamerv3/utils/summaries.py
@@ -239,7 +239,7 @@ def report_dreamed_eval_trajectory_vs_samples(
 
     # Obs MSE.
     dreamed_obs_H_B = reconstruct_obs_from_h_and_z(
-        h_t0_to_H=dream_data["h_states_t0_to_H_Bx1"][0],
+        h_t0_to_H=dream_data["h_states_t0_to_H_Bx1"][0],  # [0] b/c reduce=None (list)
         z_t0_to_H=dream_data["z_states_prior_t0_to_H_Bx1"][0],
         dreamer_model=dreamer_model,
         obs_dims_shape=sample[Columns.OBS].shape[2:],

--- a/rllib/algorithms/dreamerv3/utils/summaries.py
+++ b/rllib/algorithms/dreamerv3/utils/summaries.py
@@ -30,6 +30,7 @@ def reconstruct_obs_from_h_and_z(
     z_t0_to_H,
     dreamer_model,
     obs_dims_shape,
+    framework="torch",
 ):
     """Returns"""
     shape = h_t0_to_H.shape
@@ -39,19 +40,27 @@ def reconstruct_obs_from_h_and_z(
     # Note that the last h-state (T+1) is NOT used here as it's already part of
     # a new trajectory.
     # Use mean() of the Gaussian, no sample! -> No need to construct dist object here.
-    device = next(iter(dreamer_model.world_model.decoder.parameters())).device
-    reconstructed_obs_distr_means_TxB = (
-        dreamer_model.world_model.decoder(
-            # Fold time rank.
-            h=torch.from_numpy(h_t0_to_H).reshape((T * B, -1)).to(device),
-            z=torch.from_numpy(z_t0_to_H)
-            .reshape((T * B,) + z_t0_to_H.shape[2:])
-            .to(device),
+    if framework == "torch":
+        device = next(iter(dreamer_model.world_model.decoder.parameters())).device
+        reconstructed_obs_distr_means_TxB = (
+            dreamer_model.world_model.decoder(
+                # Fold time rank.
+                h=torch.from_numpy(h_t0_to_H).reshape((T * B, -1)).to(device),
+                z=torch.from_numpy(z_t0_to_H)
+                .reshape((T * B,) + z_t0_to_H.shape[2:])
+                .to(device),
+            )
+            .detach()
+            .cpu()
+            .numpy()
         )
-        .detach()
-        .cpu()
-        .numpy()
-    )
+    else:
+        reconstructed_obs_distr_means_TxB = dreamer_model.world_model.decoder(
+            # Fold time rank.
+            h=h_t0_to_H.reshape((T * B, -1)),
+            z=z_t0_to_H.reshape((T * B,) + z_t0_to_H.shape[2:]),
+        )
+
     # Unfold time rank again.
     reconstructed_obs_T_B = np.reshape(
         reconstructed_obs_distr_means_TxB, (T, B) + obs_dims_shape
@@ -69,6 +78,7 @@ def report_dreamed_trajectory(
     batch_indices=(0,),
     desc=None,
     include_images=True,
+    framework="torch",
 ):
     if not include_images:
         return
@@ -79,6 +89,7 @@ def report_dreamed_trajectory(
         z_t0_to_H=dream_data["z_states_prior_t0_to_H_BxT"],
         dreamer_model=dreamer_model,
         obs_dims_shape=obs_dims_shape,
+        framework=framework,
     )
     func = (
         create_cartpole_dream_image
@@ -194,6 +205,7 @@ def report_dreamed_eval_trajectory_vs_samples(
     dreamer_model,
     symlog_obs: bool = True,
     do_report: bool = True,
+    framework="torch",
 ) -> None:
     """Logs dreamed observations, rewards, continues and compares them vs sampled data.
 
@@ -243,6 +255,7 @@ def report_dreamed_eval_trajectory_vs_samples(
         z_t0_to_H=dream_data["z_states_prior_t0_to_H_Bx1"][0],
         dreamer_model=dreamer_model,
         obs_dims_shape=sample[Columns.OBS].shape[2:],
+        framework=framework,
     )
     t0 = burn_in_T
     tH = t0 + dreamed_T


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

DreamerV3 reporting fix for `config.report_dream_data=True`.

DreamerV3 currently crashes when config.report_dream_data=True due to a bug in the summary code.

Note: This bug does not affect learning and can be avoided by switching `config.report_dream_data=False` for now.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
