### PR TITLE
[ci] revert python 3.12 wheel for windows + mac

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -26,7 +26,6 @@ steps:
       - "3.9"
       - "3.10"
       - "3.11"
-      - "3.12"
     depends_on: windowsbuild
 
   - label: ":ray: core: :windows: cpp tests"

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -10,7 +10,7 @@ DOWNLOAD_DIR=python_downloads
 
 NODE_VERSION="14"
 
-PY_MMS=("3.9" "3.10" "3.11" "3.12")
+PY_MMS=("3.9" "3.10" "3.11")
 
 if [[ -n "${SKIP_DEP_RES}" ]]; then
   ./ci/env/install-bazel.sh


### PR DESCRIPTION
Revert windows + mac build for python 3.12 in https://github.com/ray-project/ray/pull/45621, they need more work

Test:
- CI