### PR TITLE
[core][debug] Add tool to easily print containers.

### DIFF
--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -85,6 +85,7 @@ cc_test(
     ],
     deps = [
         "//src/ray/util",
+        "//src/ray/common:id",
         "@boost//:asio",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest_main",


### PR DESCRIPTION
We use `RAY_LOG(INFO) << str;` to print strings. However when it comes to containers, you can only use for loop and it's very clumsy. This PR introduces a wrapper to easily print containers, like `RAY_LOG(INFO) << ContainerLog(my_container);`.

To maximize ease, `ContainerLog` can print:
- anything already printable (has operator<<)
- containers, with `.begin()` and `.end()` and elements are ContainerLog-printable
- std::pair, whose `.first` is printable, and `.second` is ContainerLog-printable

The pair is used to support maps. With these, we can print:

- int, std::string, ObjectID
- std::vector<ObjectID>, std::list<ObjectID>
- absl::flat_hash_map<ObjectID, std::vector<NodeID>>

We don't support looking into shared_ptr yet, but we can easily add them later, if there's use.

Added C++ tests.