### PR TITLE
[core] refactor worker sys path test

### DIFF
--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -149,10 +149,10 @@ ray.get(a.pid.remote())
 def test_worker_sys_path_contains_driver_script_directory(tmp_path, monkeypatch):
     package_folder = tmp_path / "package"
     package_folder.mkdir()
-    init_file = tmp_path / "package" / "__init__.py"
+    init_file = package_folder / "__init__.py"
     init_file.write_text("")
 
-    module1_file = tmp_path / "package" / "module1.py"
+    module1_file = package_folder / "module1.py"
     module1_file.write_text(
         f"""
 import sys
@@ -163,14 +163,15 @@ ray.init()
 def sys_path():
     return sys.path
 
-assert r'{str(tmp_path / "package")}' in ray.get(sys_path.remote())
+remote_sys_path = ray.get(sys_path.remote())
+assert r'{str(package_folder)}' in remote_sys_path, remote_sys_path
 """
     )
-    subprocess.check_call(["python", str(module1_file)])
+    subprocess.check_call([sys.executable, str(module1_file)])
 
     # If the driver script is run via `python -m`,
     # the script directory is not included in sys.path.
-    module2_file = tmp_path / "package" / "module2.py"
+    module2_file = package_folder / "module2.py"
     module2_file.write_text(
         f"""
 import sys
@@ -181,11 +182,12 @@ ray.init()
 def sys_path():
     return sys.path
 
-assert r'{str(tmp_path / "package")}' not in ray.get(sys_path.remote())
+remote_sys_path = ray.get(sys_path.remote())
+assert r'{str(package_folder)}' not in remote_sys_path, remote_sys_path
 """
     )
     monkeypatch.chdir(str(tmp_path))
-    subprocess.check_call(["python", "-m", "package.module2"])
+    subprocess.check_call([sys.executable, "-m", "package.module2"])
 
 
 def test_worker_kv_calls(monkeypatch, shutdown_only):


### PR DESCRIPTION
prints out `sys_path` got from remote, and reuse the package directory.

also, uses `sys.executable` instead of `python` from `PATH`, as in bazel managed sandbox environments, these can be two different python binaries.