### PR TITLE
[ci][release] add default cluster environment variable

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -419,9 +419,18 @@ class Test(dict):
         """
         Returns the runtime environment variables for the BYOD cluster.
         """
-        if not self.is_byod_cluster():
-            return {}
-        return _convert_env_list_to_dict(self["cluster"]["byod"].get("runtime_env", []))
+        default = {
+            "MATCH_AUTOSCALER_AND_RAY_IMAGES": "1",
+            "RAY_BACKEND_LOG_JSON": "1",
+            "RAY_USAGE_STATS_ENABLED": "1",
+            "RAY_USAGE_STATS_SOURCE": "nightly-tests",
+            "RAY_USAGE_STATS_EXTRA_TAGS": f"test_name={self.get_name()}",
+        }
+        default.update(
+            _convert_env_list_to_dict(self["cluster"]["byod"].get("runtime_env", []))
+        )
+
+        return default
 
     def get_byod_pips(self) -> List[str]:
         """

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -94,7 +94,7 @@ class MinimalSessionManagerTest(unittest.TestCase):
             test=MockTest(
                 {
                     "name": f"unit_test__{self.__class__.__name__}",
-                    "cluster": {},
+                    "cluster": {"byod": {}},
                 }
             ),
         )
@@ -125,7 +125,7 @@ class MinimalSessionManagerTest(unittest.TestCase):
         sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
         sdk.returns["get_cloud"] = APIDict(result=APIDict(provider="AWS"))
         cluster_manager = self.cls(
-            test=MockTest({"name": "test", "cluster": {}}),
+            test=MockTest({"name": "test", "cluster": {"byod": {}}}),
             project_id=UNIT_TEST_PROJECT_ID,
             smoke_test=False,
             sdk=sdk,
@@ -134,7 +134,7 @@ class MinimalSessionManagerTest(unittest.TestCase):
         self.assertEqual(
             cluster_manager.cluster_env_name,
             "anyscale__env__"
-            "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+            "4a357b04dec89a619929eb16e1035bf8ffe1d9757bbd4fba520c03a3a2620d05",
         )
 
     @patch("time.sleep", lambda *a, **kw: None)

--- a/release/ray_release/tests/test_glue.py
+++ b/release/ray_release/tests/test_glue.py
@@ -164,7 +164,9 @@ class GlueTest(unittest.TestCase):
             ),
             working_dir=self.tempdir,
             cluster=dict(
-                cluster_env="cluster_env.yaml", cluster_compute="cluster_compute.yaml"
+                cluster_env="cluster_env.yaml",
+                cluster_compute="cluster_compute.yaml",
+                byod={},
             ),
             alert="unit_test_alerter",
         )

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -140,6 +140,24 @@ def test_get_ray_image():
         )
 
 
+def test_get_byod_runtime_env():
+    test = _stub_test(
+        {
+            "python": "3.11",
+            "cluster": {
+                "byod": {
+                    "runtime_env": ["a=b"],
+                },
+            },
+        }
+    )
+    runtime_env = test.get_byod_runtime_env()
+    assert runtime_env.get("RAY_USAGE_STATS_SOURCE") == "nightly-tests"
+    assert runtime_env.get("RAY_BACKEND_LOG_JSON") == "1"
+    assert runtime_env.get("RAY_USAGE_STATS_EXTRA_TAGS") == "test_name=test"
+    assert runtime_env.get("a") == "b"
+
+
 def test_get_anyscale_byod_image():
     os.environ["BUILDKITE_BRANCH"] = "master"
     os.environ["BUILDKITE_COMMIT"] = "1234567890"


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/40807/files mistakenly removed a few default cluster env variable; this PR add it back

Test:
- CI