### PR TITLE
Add perf metrics for 2.24.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 504.754176,
+    "_dashboard_memory_usage_mb": 422.150144,
     "_dashboard_test_success": true,
     "_peak_memory": 3.65,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t1.72GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n904\t0.88GiB\tpython distributed/test_many_actors.py\n293\t0.34GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n720\t0.07GiB\tray::JobSupervisor\n611\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n451\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n966\t0.06GiB\tray::MemoryMonitorActor.run\n1057\t0.05GiB\tray::DashboardTester.run\n392\t0.04GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/log_m",
-    "actors_per_second": 613.8104422632972,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1225\t9.33GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3575\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4789\t0.93GiB\tpython distributed/test_many_actors.py\n2384\t0.29GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3695\t0.24GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2767\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3858\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4583\t0.07GiB\tray::JobSupervisor\n4040\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3856\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "actors_per_second": 656.4820098150251,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 613.8104422632972
+            "perf_metric_value": 656.4820098150251
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 86.057
+            "perf_metric_value": 65.662
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2641.416
+            "perf_metric_value": 3333.28
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5053.446
+            "perf_metric_value": 3456.493
         }
     ],
     "success": "1",
-    "time": 16.291674613952637
+    "time": 15.232709884643555
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 186.650624,
+    "_dashboard_memory_usage_mb": 182.657024,
     "_dashboard_test_success": true,
     "_peak_memory": 1.64,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n293\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1110\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1318\t0.08GiB\tray::StateAPIGeneratorActor.start\n926\t0.07GiB\tray::JobSupervisor\n450\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n448\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n603\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1172\t0.06GiB\tray::MemoryMonitorActor.run\n1264\t0.06GiB\tray::DashboardTester.run",
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3548\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1209\t0.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2279\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3663\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4732\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4938\t0.08GiB\tray::StateAPIGeneratorActor.start\n2760\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4531\t0.07GiB\tray::JobSupervisor\n3825\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4002\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 372.1993782750883
+            "perf_metric_value": 356.96608310545133
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.752
+            "perf_metric_value": 3.877
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 13.367
+            "perf_metric_value": 48.58
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 176.812
+            "perf_metric_value": 197.137
         }
     ],
     "success": "1",
-    "tasks_per_second": 372.1993782750883,
-    "time": 302.6867320537567,
+    "tasks_per_second": 356.96608310545133,
+    "time": 302.80138659477234,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 146.026496,
+    "_dashboard_memory_usage_mb": 137.633792,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.17,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t0.95GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n960\t0.39GiB\tpython distributed/test_many_pgs.py\n293\t0.13GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n775\t0.07GiB\tray::JobSupervisor\n613\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n451\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1021\t0.06GiB\tray::MemoryMonitorActor.run\n1112\t0.05GiB\tray::DashboardTester.run\n391\t0.04GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/raylet/raylet --raylet_socket_name=",
+    "_peak_memory": 2.25,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1224\t9.73GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3624\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4824\t0.42GiB\tpython distributed/test_many_pgs.py\n2809\t0.38GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3749\t0.15GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2607\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4609\t0.07GiB\tray::JobSupervisor\n3914\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4093\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3912\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23.42930283459158
+            "perf_metric_value": 23.5616061289441
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.367
+            "perf_metric_value": 3.492
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.824
+            "perf_metric_value": 12.796
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 898.617
+            "perf_metric_value": 204.615
         }
     ],
-    "pgs_per_second": 23.42930283459158,
+    "pgs_per_second": 23.5616061289441,
     "success": "1",
-    "time": 42.681594371795654
+    "time": 42.44192838668823
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1201.733632,
+    "_dashboard_memory_usage_mb": 1164.107776,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.93,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n178\t2.57GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n293\t0.77GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n908\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1177\t0.08GiB\tray::StateAPIGeneratorActor.start\n1123\t0.08GiB\tray::DashboardTester.run\n724\t0.07GiB\tray::JobSupervisor\n453\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n451\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n612\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n1049\t0.06GiB\tray::MemoryMonitorActor.run",
+    "_peak_memory": 5.08,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3561\t2.86GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4731\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3681\t0.68GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1206\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2174\t0.23GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5002\t0.09GiB\tray::StateAPIGeneratorActor.start\n4947\t0.08GiB\tray::DashboardTester.run\n2551\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3843\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4521\t0.07GiB\tray::JobSupervisor",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 579.8482552816317
+            "perf_metric_value": 587.8163884392604
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 44.327
+            "perf_metric_value": 42.944
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3265.071
+            "perf_metric_value": 3642.242
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4407.973
+            "perf_metric_value": 4549.74
         }
     ],
     "success": "1",
-    "tasks_per_second": 579.8482552816317,
-    "time": 317.24589133262634,
+    "tasks_per_second": 587.8163884392604,
+    "time": 317.01211500167847,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.23.0"}
+{"release_version": "2.24.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8766.429278436297,
-        120.86055337969302
+        8726.401857123754,
+        162.20549696513925
     ],
     "1_1_actor_calls_concurrent": [
-        5466.2521928780425,
-        294.4643111642266
+        5525.453533356669,
+        275.6986719349956
     ],
     "1_1_actor_calls_sync": [
-        2005.483489295091,
-        51.49539414234871
+        2022.1643749529967,
+        42.58171596149864
     ],
     "1_1_async_actor_calls_async": [
-        3485.371511081248,
-        113.58116489466117
+        3295.7761919502855,
+        149.90516121451026
     ],
     "1_1_async_actor_calls_sync": [
-        1347.8868250169457,
-        17.79541434936412
+        1306.2185283312654,
+        22.393311157323094
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2512.820463128068,
-        155.31965794076362
+        2271.9010969950546,
+        58.46933903250449
     ],
     "1_n_actor_calls_async": [
-        8490.352729000244,
-        181.05358592855262
+        8723.546909820518,
+        133.04998221108622
     ],
     "1_n_async_actor_calls_async": [
-        7295.2280994398525,
-        83.24487540906311
+        7526.072989853183,
+        80.26873719023843
     ],
     "client__1_1_actor_calls_async": [
-        987.583992857757,
-        8.55231528044142
+        956.234692691667,
+        10.622834071499192
     ],
     "client__1_1_actor_calls_concurrent": [
-        993.4252979888793,
-        14.709916004253799
+        964.227785207118,
+        19.39077588012691
     ],
     "client__1_1_actor_calls_sync": [
-        527.6097359140301,
-        6.229717007741613
+        511.54682034013,
+        20.183100809422037
     ],
     "client__get_calls": [
-        1122.3334401198258,
-        48.51501029209967
+        1099.299059786817,
+        48.740510949504255
     ],
     "client__put_calls": [
-        799.7415900241213,
-        12.025635667289933
+        793.6471952322032,
+        19.166421115489065
     ],
     "client__put_gigabytes": [
-        0.13117998295265082,
-        0.000998012447116976
+        0.13033848458516117,
+        0.0004047979867318293
     ],
     "client__tasks_and_get_batch": [
-        0.8066078636677214,
-        0.011930458414569594
+        0.9191916564759186,
+        0.004240563507874709
     ],
     "client__tasks_and_put_batch": [
-        11191.448976686781,
-        93.86657449650411
+        11163.342583763659,
+        86.36159399829216
     ],
     "multi_client_put_calls_Plasma_Store": [
-        11889.62967857741,
-        119.20037762191876
+        12352.999319488557,
+        302.78838782381274
     ],
     "multi_client_put_gigabytes": [
-        38.09272404390616,
-        2.3201711068853097
+        35.52392832333356,
+        2.4551866947000778
     ],
     "multi_client_tasks_async": [
-        22255.262702895383,
-        1184.2604056922066
+        23658.661959832083,
+        3659.740758379274
     ],
     "n_n_actor_calls_async": [
-        27321.88100222539,
-        416.48715073593917
+        26706.0034223919,
+        796.7068479444016
     ],
     "n_n_actor_calls_with_arg_async": [
-        2672.287170984248,
-        23.619720775433688
+        2669.6470548189563,
+        37.75431784396307
     ],
     "n_n_async_actor_calls_async": [
-        23164.85974320361,
-        970.0857104946699
+        23029.099137990735,
+        353.5298340819868
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10500.67448465853
+            "perf_metric_value": 10575.12534552304
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5286.037415485109
+            "perf_metric_value": 5342.356803322341
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11889.62967857741
+            "perf_metric_value": 12352.999319488557
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.46923471565212
+            "perf_metric_value": 19.60264129638186
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.730134993824188
+            "perf_metric_value": 7.618329296876913
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 38.09272404390616
+            "perf_metric_value": 35.52392832333356
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.30751068234607
+            "perf_metric_value": 12.459623096174152
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.160164268505817
+            "perf_metric_value": 5.356105950176277
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 974.4612781847234
+            "perf_metric_value": 990.8897375942615
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7378.7495889110505
+            "perf_metric_value": 7728.179866020124
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22255.262702895383
+            "perf_metric_value": 23658.661959832083
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2005.483489295091
+            "perf_metric_value": 2022.1643749529967
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8766.429278436297
+            "perf_metric_value": 8726.401857123754
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5466.2521928780425
+            "perf_metric_value": 5525.453533356669
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8490.352729000244
+            "perf_metric_value": 8723.546909820518
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27321.88100222539
+            "perf_metric_value": 26706.0034223919
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2672.287170984248
+            "perf_metric_value": 2669.6470548189563
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1347.8868250169457
+            "perf_metric_value": 1306.2185283312654
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3485.371511081248
+            "perf_metric_value": 3295.7761919502855
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2512.820463128068
+            "perf_metric_value": 2271.9010969950546
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7295.2280994398525
+            "perf_metric_value": 7526.072989853183
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23164.85974320361
+            "perf_metric_value": 23029.099137990735
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 788.0742341227435
+            "perf_metric_value": 804.4799825746657
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1122.3334401198258
+            "perf_metric_value": 1099.299059786817
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 799.7415900241213
+            "perf_metric_value": 793.6471952322032
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13117998295265082
+            "perf_metric_value": 0.13033848458516117
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11191.448976686781
+            "perf_metric_value": 11163.342583763659
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 527.6097359140301
+            "perf_metric_value": 511.54682034013
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 987.583992857757
+            "perf_metric_value": 956.234692691667
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 993.4252979888793
+            "perf_metric_value": 964.227785207118
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.8066078636677214
+            "perf_metric_value": 0.9191916564759186
         }
     ],
     "placement_group_create/removal": [
-        788.0742341227435,
-        10.00903890631821
+        804.4799825746657,
+        13.347218543583795
     ],
     "single_client_get_calls_Plasma_Store": [
-        10500.67448465853,
-        360.1079441884577
+        10575.12534552304,
+        389.0501847163306
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.30751068234607,
-        0.2608539457674152
+        12.459623096174152,
+        0.16042112976023476
     ],
     "single_client_put_calls_Plasma_Store": [
-        5286.037415485109,
-        74.24170737659924
+        5342.356803322341,
+        87.92133379840806
     ],
     "single_client_put_gigabytes": [
-        20.46923471565212,
-        6.428223549120574
+        19.60264129638186,
+        6.0658657511900165
     ],
     "single_client_tasks_and_get_batch": [
-        7.730134993824188,
-        0.15527622087112827
+        7.618329296876913,
+        0.22870606905835902
     ],
     "single_client_tasks_async": [
-        7378.7495889110505,
-        772.618435291432
+        7728.179866020124,
+        391.64056111377556
     ],
     "single_client_tasks_sync": [
-        974.4612781847234,
-        19.26648673285388
+        990.8897375942615,
+        9.752000220743424
     ],
     "single_client_wait_1k_refs": [
-        5.160164268505817,
-        0.11776044271280343
+        5.356105950176277,
+        0.05359089594239002
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 15.855233231,
+    "broadcast_time": 16.769440987999985,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 15.855233231
+            "perf_metric_value": 16.769440987999985
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.276734743999995,
-    "get_time": 23.992132071,
+    "args_time": 17.085048134999994,
+    "get_time": 23.721352370000005,
     "large_object_size": 107374182400,
-    "large_object_time": 31.869567716000006,
+    "large_object_time": 29.037520325999992,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.276734743999995
+            "perf_metric_value": 17.085048134999994
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.739413628999998
+            "perf_metric_value": 5.574067407000001
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.992132071
+            "perf_metric_value": 23.721352370000005
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 186.46388957200003
+            "perf_metric_value": 192.34304552800003
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 31.869567716000006
+            "perf_metric_value": 29.037520325999992
         }
     ],
-    "queued_time": 186.46388957200003,
-    "returns_time": 5.739413628999998,
+    "queued_time": 192.34304552800003,
+    "returns_time": 5.574067407000001,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0421651029586791,
-    "max_iteration_time": 4.056146621704102,
-    "min_iteration_time": 0.13677406311035156,
+    "avg_iteration_time": 1.0548744773864747,
+    "max_iteration_time": 3.340198516845703,
+    "min_iteration_time": 0.4613649845123291,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0421651029586791
+            "perf_metric_value": 1.0548744773864747
         }
     ],
     "success": 1,
-    "total_time": 104.2167329788208
+    "total_time": 105.48765969276428
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.619915246963501
+            "perf_metric_value": 10.161747217178345
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 27.771051788330077
+            "perf_metric_value": 25.27835304737091
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 73.57129535675048
+            "perf_metric_value": 55.185825729370116
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.6484127044677734
+            "perf_metric_value": 1.5885274410247803
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3348.829131603241
+            "perf_metric_value": 3104.279580116272
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4547737011485014
+            "perf_metric_value": 0.4851944753960548
         }
     ],
-    "stage_0_time": 12.619915246963501,
-    "stage_1_avg_iteration_time": 27.771051788330077,
-    "stage_1_max_iteration_time": 29.194735288619995,
-    "stage_1_min_iteration_time": 26.235360383987427,
-    "stage_1_time": 277.7106223106384,
-    "stage_2_avg_iteration_time": 73.57129535675048,
-    "stage_2_max_iteration_time": 125.31455945968628,
-    "stage_2_min_iteration_time": 60.081254720687866,
-    "stage_2_time": 367.85813307762146,
-    "stage_3_creation_time": 1.6484127044677734,
-    "stage_3_time": 3348.829131603241,
-    "stage_4_spread": 0.4547737011485014,
+    "stage_0_time": 10.161747217178345,
+    "stage_1_avg_iteration_time": 25.27835304737091,
+    "stage_1_max_iteration_time": 25.942532539367676,
+    "stage_1_min_iteration_time": 24.44790744781494,
+    "stage_1_time": 252.78363347053528,
+    "stage_2_avg_iteration_time": 55.185825729370116,
+    "stage_2_max_iteration_time": 56.937405824661255,
+    "stage_2_min_iteration_time": 53.556705951690674,
+    "stage_2_time": 275.930006980896,
+    "stage_3_creation_time": 1.5885274410247803,
+    "stage_3_time": 3104.279580116272,
+    "stage_4_spread": 0.4851944753960548,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9066000405417517,
-    "avg_pg_remove_time_ms": 0.8566281216197303,
+    "avg_pg_create_time_ms": 0.9132710030025517,
+    "avg_pg_remove_time_ms": 0.9020739549548232,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9066000405417517
+            "perf_metric_value": 0.9132710030025517
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.8566281216197303
+            "perf_metric_value": 0.9020739549548232
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 9.59%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2512.820463128068 to 2271.9010969950546 in microbenchmark.json
REGRESSION 6.74%: multi_client_put_gigabytes (THROUGHPUT) regresses from 38.09272404390616 to 35.52392832333356 in microbenchmark.json
REGRESSION 6.37%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.30751068234607 to 12.459623096174152 in microbenchmark.json
REGRESSION 5.44%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 3485.371511081248 to 3295.7761919502855 in microbenchmark.json
REGRESSION 4.23%: single_client_put_gigabytes (THROUGHPUT) regresses from 20.46923471565212 to 19.60264129638186 in microbenchmark.json
REGRESSION 4.09%: tasks_per_second (THROUGHPUT) regresses from 372.1993782750883 to 356.96608310545133 in benchmarks/many_nodes.json
REGRESSION 3.17%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 987.583992857757 to 956.234692691667 in microbenchmark.json
REGRESSION 3.09%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1347.8868250169457 to 1306.2185283312654 in microbenchmark.json
REGRESSION 3.04%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 527.6097359140301 to 511.54682034013 in microbenchmark.json
REGRESSION 2.94%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 993.4252979888793 to 964.227785207118 in microbenchmark.json
REGRESSION 2.25%: n_n_actor_calls_async (THROUGHPUT) regresses from 27321.88100222539 to 26706.0034223919 in microbenchmark.json
REGRESSION 2.05%: client__get_calls (THROUGHPUT) regresses from 1122.3334401198258 to 1099.299059786817 in microbenchmark.json
REGRESSION 1.45%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.730134993824188 to 7.618329296876913 in microbenchmark.json
REGRESSION 0.76%: client__put_calls (THROUGHPUT) regresses from 799.7415900241213 to 793.6471952322032 in microbenchmark.json
REGRESSION 0.64%: client__put_gigabytes (THROUGHPUT) regresses from 0.13117998295265082 to 0.13033848458516117 in microbenchmark.json
REGRESSION 0.59%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23164.85974320361 to 23029.099137990735 in microbenchmark.json
REGRESSION 0.46%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8766.429278436297 to 8726.401857123754 in microbenchmark.json
REGRESSION 0.25%: client__tasks_and_put_batch (THROUGHPUT) regresses from 11191.448976686781 to 11163.342583763659 in microbenchmark.json
REGRESSION 0.10%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2672.287170984248 to 2669.6470548189563 in microbenchmark.json
REGRESSION 263.43%: dashboard_p95_latency_ms (LATENCY) regresses from 13.367 to 48.58 in benchmarks/many_nodes.json
REGRESSION 26.19%: dashboard_p95_latency_ms (LATENCY) regresses from 2641.416 to 3333.28 in benchmarks/many_actors.json
REGRESSION 11.55%: dashboard_p95_latency_ms (LATENCY) regresses from 3265.071 to 3642.242 in benchmarks/many_tasks.json
REGRESSION 11.50%: dashboard_p99_latency_ms (LATENCY) regresses from 176.812 to 197.137 in benchmarks/many_nodes.json
REGRESSION 6.69%: stage_4_spread (LATENCY) regresses from 0.4547737011485014 to 0.4851944753960548 in stress_tests/stress_test_many_tasks.json
REGRESSION 5.77%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 15.855233231 to 16.769440987999985 in scalability/object_store.json
REGRESSION 5.31%: avg_pg_remove_time_ms (LATENCY) regresses from 0.8566281216197303 to 0.9020739549548232 in stress_tests/stress_test_placement_group.json
REGRESSION 3.71%: dashboard_p50_latency_ms (LATENCY) regresses from 3.367 to 3.492 in benchmarks/many_pgs.json
REGRESSION 3.33%: dashboard_p50_latency_ms (LATENCY) regresses from 3.752 to 3.877 in benchmarks/many_nodes.json
REGRESSION 3.22%: dashboard_p99_latency_ms (LATENCY) regresses from 4407.973 to 4549.74 in benchmarks/many_tasks.json
REGRESSION 3.15%: 1000000_queued_time (LATENCY) regresses from 186.46388957200003 to 192.34304552800003 in scalability/single_node.json
REGRESSION 1.22%: avg_iteration_time (LATENCY) regresses from 1.0421651029586791 to 1.0548744773864747 in stress_tests/stress_test_dead_actors.json
REGRESSION 0.74%: avg_pg_create_time_ms (LATENCY) regresses from 0.9066000405417517 to 0.9132710030025517 in stress_tests/stress_test_placement_group.json
```