### PR TITLE
[ray] build the arm64 linux wheel for python 3.12

### DIFF
--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -63,6 +63,7 @@ steps:
       - "3.9"
       - "3.10"
       - "3.11"
+      - "3.12"
     depends_on:
       - manylinux-aarch64
       - forge-aarch64


### PR DESCRIPTION
Forgot to build the arm64 linux wheel for python 3.12. Fix in this PR.

Test:
- CI