### PR TITLE
[Data] Rename `ParquetBaseDatasource` to `ParquetBulkDatasource`

### DIFF
--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -42,7 +42,7 @@ from ray.data.datasource.mongo_datasink import _MongoDatasink
 from ray.data.datasource.mongo_datasource import MongoDatasource
 from ray.data.datasource.numpy_datasink import _NumpyDatasink
 from ray.data.datasource.numpy_datasource import NumpyDatasource
-from ray.data.datasource.parquet_base_datasource import ParquetBaseDatasource
+from ray.data.datasource.parquet_bulk_datasource import ParquetBulkDatasource
 from ray.data.datasource.parquet_datasink import _ParquetDatasink
 from ray.data.datasource.parquet_datasource import ParquetDatasource
 from ray.data.datasource.partitioning import (
@@ -95,7 +95,7 @@ __all__ = [
     "LanceDatasource",
     "_NumpyDatasink",
     "NumpyDatasource",
-    "ParquetBaseDatasource",
+    "ParquetBulkDatasource",
     "_ParquetDatasink",
     "ParquetDatasource",
     "ParquetMetadataProvider",

--- a/python/ray/data/datasource/parquet_bulk_datasource.py
+++ b/python/ray/data/datasource/parquet_bulk_datasource.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 @PublicAPI
-class ParquetBaseDatasource(FileBasedDatasource):
+class ParquetBulkDatasource(FileBasedDatasource):
     """Minimal Parquet datasource, for reading and writing Parquet files."""
 
     _FILE_EXTENSIONS = ["parquet"]

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -186,7 +186,7 @@ def _check_for_legacy_tensor_type(schema):
 class ParquetDatasource(Datasource):
     """Parquet datasource, for reading and writing Parquet files.
 
-    The primary difference from ParquetBaseDatasource is that this uses
+    The primary difference from ParquetBulkDatasource is that this uses
     PyArrow's `ParquetDataset` abstraction for dataset reads, and thus offers
     automatic Arrow dataset schema inference and row count collection at the
     cost of some potential performance and/or compatibility penalties.
@@ -527,8 +527,8 @@ class ParquetDatasource(Datasource):
 
     def get_name(self):
         """Return a human-readable name for this datasource.
+
         This will be used as the names of the read tasks.
-        Note: overrides the base `ParquetBaseDatasource` method.
         """
         return "Parquet"
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -60,7 +60,7 @@ from ray.data.datasource import (
     LanceDatasource,
     MongoDatasource,
     NumpyDatasource,
-    ParquetBaseDatasource,
+    ParquetBulkDatasource,
     ParquetDatasource,
     ParquetMetadataProvider,
     PathPartitionFilter,
@@ -967,7 +967,7 @@ def read_parquet_bulk(
     partition_filter: Optional[PathPartitionFilter] = None,
     shuffle: Union[Literal["files"], None] = None,
     include_paths: bool = False,
-    file_extensions: Optional[List[str]] = ParquetBaseDatasource._FILE_EXTENSIONS,
+    file_extensions: Optional[List[str]] = ParquetBulkDatasource._FILE_EXTENSIONS,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
     **arrow_parquet_args,
@@ -1062,7 +1062,7 @@ def read_parquet_bulk(
     if columns is not None:
         read_table_args["columns"] = columns
 
-    datasource = ParquetBaseDatasource(
+    datasource = ParquetBulkDatasource(
         paths,
         read_table_args=read_table_args,
         filesystem=filesystem,

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -17,7 +17,7 @@ from ray.data.datasource import (
     DefaultFileMetadataProvider,
     DefaultParquetMetadataProvider,
 )
-from ray.data.datasource.parquet_base_datasource import ParquetBaseDatasource
+from ray.data.datasource.parquet_bulk_datasource import ParquetBulkDatasource
 from ray.data.datasource.parquet_datasource import (
     NUM_CPUS_FOR_META_FETCH_TASK,
     PARALLELIZE_META_FETCH_THRESHOLD,
@@ -1092,7 +1092,7 @@ def test_parquet_datasource_names(ray_start_regular_shared, tmp_path):
     path = os.path.join(tmp_path, "data.parquet")
     df.to_parquet(path)
 
-    assert ParquetBaseDatasource(path).get_name() == "ParquetBulk"
+    assert ParquetBulkDatasource(path).get_name() == "ParquetBulk"
     assert ParquetDatasource(path).get_name() == "Parquet"
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

`ParquetDatasource` used to extend from `ParquetBaseDatasource`. However, after https://github.com/ray-project/ray/pull/40900, `ParquetBaseDatasource` is only used by `read_bulk_datasource`. To reflect this change, this PR renames `ParquetBaseDatasource` to `ParquetBulkDatasource`.
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
