### PR TITLE
[Data] Merge `DefaultParquetMetadataProvider` and `ParquetMetadataProvider`

### DIFF
--- a/doc/source/data/api/input_output.rst
+++ b/doc/source/data/api/input_output.rst
@@ -312,9 +312,8 @@ MetadataProvider API
 
    datasource.FileMetadataProvider
    datasource.BaseFileMetadataProvider
-   datasource.ParquetMetadataProvider
    datasource.DefaultFileMetadataProvider
-   datasource.DefaultParquetMetadataProvider
+   datasource.ParquetMetadataProvider
    datasource.FastFileMetadataProvider
 
    

--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -43,10 +43,7 @@ from ray.data.datasource.numpy_datasource import NumpyDatasource
 from ray.data.datasource.parquet_bulk_datasource import ParquetBulkDatasource
 from ray.data.datasource.parquet_datasink import _ParquetDatasink
 from ray.data.datasource.parquet_datasource import ParquetDatasource
-from ray.data.datasource.parquet_meta_provider import (
-    DefaultParquetMetadataProvider,
-    ParquetMetadataProvider,
-)
+from ray.data.datasource.parquet_meta_provider import ParquetMetadataProvider
 from ray.data.datasource.partitioning import (
     Partitioning,
     PartitionStyle,
@@ -83,7 +80,6 @@ __all__ = [
     "SQLDatasource",
     "DefaultBlockWritePathProvider",
     "DefaultFileMetadataProvider",
-    "DefaultParquetMetadataProvider",
     "DummyOutputDatasink",
     "FastFileMetadataProvider",
     "FileBasedDatasource",

--- a/python/ray/data/datasource/_default_metadata_providers.py
+++ b/python/ray/data/datasource/_default_metadata_providers.py
@@ -5,7 +5,7 @@ from ray.data.datasource.file_meta_provider import (
     FastFileMetadataProvider,
 )
 from ray.data.datasource.image_datasource import _ImageFileMetadataProvider
-from ray.data.datasource.parquet_meta_provider import DefaultParquetMetadataProvider
+from ray.data.datasource.parquet_meta_provider import ParquetMetadataProvider
 
 
 def get_generic_metadata_provider(file_extensions: Optional[List[str]]):
@@ -15,7 +15,7 @@ def get_generic_metadata_provider(file_extensions: Optional[List[str]]):
 
 def get_parquet_metadata_provider():
     # Used by `read_parquet`
-    return DefaultParquetMetadataProvider()
+    return ParquetMetadataProvider()
 
 
 def get_parquet_bulk_metadata_provider():

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -32,10 +32,7 @@ from ray.data.datasource._default_metadata_providers import (
 )
 from ray.data.datasource.datasource import ReadTask
 from ray.data.datasource.file_meta_provider import _handle_read_os_error
-from ray.data.datasource.parquet_meta_provider import (
-    DefaultParquetMetadataProvider,
-    ParquetMetadataProvider,
-)
+from ray.data.datasource.parquet_meta_provider import ParquetMetadataProvider
 from ray.data.datasource.partitioning import PathPartitionFilter
 from ray.data.datasource.path_util import (
     _has_file_extension,
@@ -190,7 +187,7 @@ class ParquetDatasource(Datasource):
         _block_udf: Optional[Callable[[Block], Block]] = None,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         schema: Optional[Union[type, "pyarrow.lib.Schema"]] = None,
-        meta_provider: ParquetMetadataProvider = DefaultParquetMetadataProvider(),
+        meta_provider: ParquetMetadataProvider = ParquetMetadataProvider(),
         partition_filter: PathPartitionFilter = None,
         shuffle: Union[Literal["files"], None] = None,
         include_paths: bool = False,

--- a/python/ray/data/datasource/parquet_meta_provider.py
+++ b/python/ray/data/datasource/parquet_meta_provider.py
@@ -87,7 +87,7 @@ class ParquetMetadataProvider(FileMetadataProvider):
         self,
         fragments: List["pyarrow.dataset.ParquetFileFragment"],
         **ray_remote_args,
-    ) -> List["pyarrow.parquet.FileMetaData"]:
+    ) -> Optional[List["pyarrow.parquet.FileMetaData"]]:
         """Pre-fetches file metadata for all Parquet file fragments in a single batch.
 
         Subsets of the metadata returned will be provided as input to subsequent calls
@@ -98,7 +98,7 @@ class ParquetMetadataProvider(FileMetadataProvider):
             fragments: The Parquet file fragments to fetch metadata for.
 
         Returns:
-            Metadata resolved for each input file fragment. Metadata
+            Metadata resolved for each input file fragment, or `None`. Metadata
             must be returned in the same order as all input file fragments, such
             that `metadata[i]` always contains the metadata for `fragments[i]`.
         """

--- a/python/ray/data/datasource/parquet_meta_provider.py
+++ b/python/ray/data/datasource/parquet_meta_provider.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from ray.data._internal.util import call_with_retry
 from ray.data.block import BlockMetadata

--- a/python/ray/data/datasource/parquet_meta_provider.py
+++ b/python/ray/data/datasource/parquet_meta_provider.py
@@ -32,16 +32,7 @@ RETRY_MAX_BACKOFF_S_FOR_META_FETCH_TASK = 64
 
 @DeveloperAPI
 class ParquetMetadataProvider(FileMetadataProvider):
-    """Abstract callable that provides block metadata for Arrow Parquet file fragments.
-
-    All file fragments should belong to a single dataset block.
-
-    Supports optional pre-fetching of ordered metadata for all file fragments in
-    a single batch to help optimize metadata resolution.
-
-    Current subclasses:
-        - :class:`~ray.data.datasource.file_meta_provider.DefaultParquetMetadataProvider`
-    """  # noqa: E501
+    """Provides block metadata for Arrow Parquet file fragments."""
 
     def _get_block_metadata(
         self,
@@ -49,7 +40,7 @@ class ParquetMetadataProvider(FileMetadataProvider):
         schema: Optional[Union[type, "pyarrow.lib.Schema"]],
         *,
         num_fragments: int,
-        prefetched_metadata: Optional[List[Any]],
+        prefetched_metadata: Optional[List["_ParquetFileFragmentMetaData"]],
     ) -> BlockMetadata:
         """Resolves and returns block metadata for files of a single dataset block.
 
@@ -66,49 +57,6 @@ class ParquetMetadataProvider(FileMetadataProvider):
         Returns:
             BlockMetadata aggregated across the given file paths.
         """
-        raise NotImplementedError
-
-    def prefetch_file_metadata(
-        self,
-        fragments: List["pyarrow.dataset.ParquetFileFragment"],
-        **ray_remote_args,
-    ) -> Optional[List[Any]]:
-        """Pre-fetches file metadata for all Parquet file fragments in a single batch.
-
-        Subsets of the metadata returned will be provided as input to subsequent calls
-        to ``_get_block_metadata`` together with their corresponding Parquet file
-        fragments.
-
-        Implementations that don't support pre-fetching file metadata shouldn't
-        override this method.
-
-        Args:
-            fragments: The Parquet file fragments to fetch metadata for.
-
-        Returns:
-            Metadata resolved for each input file fragment, or `None`. Metadata
-            must be returned in the same order as all input file fragments, such
-            that `metadata[i]` always contains the metadata for `fragments[i]`.
-        """
-        return None
-
-
-@DeveloperAPI
-class DefaultParquetMetadataProvider(ParquetMetadataProvider):
-    """The default file metadata provider for ParquetDatasource.
-
-    Aggregates total block bytes and number of rows using the Parquet file metadata
-    associated with a list of Arrow Parquet dataset file fragments.
-    """
-
-    def _get_block_metadata(
-        self,
-        paths: List[str],
-        schema: Optional[Union[type, "pyarrow.lib.Schema"]],
-        *,
-        num_fragments: int,
-        prefetched_metadata: Optional[List["_ParquetFileFragmentMetaData"]],
-    ) -> BlockMetadata:
         if (
             prefetched_metadata is not None
             and len(prefetched_metadata) == num_fragments
@@ -139,7 +87,21 @@ class DefaultParquetMetadataProvider(ParquetMetadataProvider):
         self,
         fragments: List["pyarrow.dataset.ParquetFileFragment"],
         **ray_remote_args,
-    ) -> Optional[List["pyarrow.parquet.FileMetaData"]]:
+    ) -> List["pyarrow.parquet.FileMetaData"]:
+        """Pre-fetches file metadata for all Parquet file fragments in a single batch.
+
+        Subsets of the metadata returned will be provided as input to subsequent calls
+        to ``_get_block_metadata`` together with their corresponding Parquet file
+        fragments.
+
+        Args:
+            fragments: The Parquet file fragments to fetch metadata for.
+
+        Returns:
+            Metadata resolved for each input file fragment. Metadata
+            must be returned in the same order as all input file fragments, such
+            that `metadata[i]` always contains the metadata for `fragments[i]`.
+        """
         from ray.data.datasource.parquet_datasource import _SerializedFragment
 
         if len(fragments) > PARALLELIZE_META_FETCH_THRESHOLD:

--- a/python/ray/data/tests/test_metadata_provider.py
+++ b/python/ray/data/tests/test_metadata_provider.py
@@ -70,9 +70,6 @@ def test_file_metadata_providers_not_implemented():
         meta_provider(["/foo/bar.csv"], None, rows_per_file=None, file_sizes=[None])
     with pytest.raises(NotImplementedError):
         meta_provider.expand_paths(["/foo/bar.csv"], None)
-    meta_provider = ParquetMetadataProvider()
-    with pytest.raises(NotImplementedError):
-        meta_provider(["/foo/bar.csv"], None, num_fragments=0, prefetched_metadata=None)
     assert meta_provider.prefetch_file_metadata(["test"]) is None
 
 

--- a/python/ray/data/tests/test_metadata_provider.py
+++ b/python/ray/data/tests/test_metadata_provider.py
@@ -15,7 +15,6 @@ from pytest_lazyfixture import lazy_fixture
 from ray.data.datasource import (
     BaseFileMetadataProvider,
     DefaultFileMetadataProvider,
-    DefaultParquetMetadataProvider,
     FastFileMetadataProvider,
     FileMetadataProvider,
     ParquetMetadataProvider,
@@ -108,7 +107,7 @@ def test_default_parquet_metadata_provider(fs, data_path):
     table = pa.Table.from_pandas(df2)
     pq.write_table(table, paths[1], filesystem=fs)
 
-    meta_provider = DefaultParquetMetadataProvider()
+    meta_provider = ParquetMetadataProvider()
     pq_ds = pq.ParquetDataset(paths, filesystem=fs, use_legacy_dataset=False)
     file_metas = meta_provider.prefetch_file_metadata(pq_ds.fragments)
     fragment_file_metas = [_ParquetFileFragmentMetaData(m) for m in file_metas]

--- a/python/ray/data/tests/test_metadata_provider.py
+++ b/python/ray/data/tests/test_metadata_provider.py
@@ -70,7 +70,6 @@ def test_file_metadata_providers_not_implemented():
         meta_provider(["/foo/bar.csv"], None, rows_per_file=None, file_sizes=[None])
     with pytest.raises(NotImplementedError):
         meta_provider.expand_paths(["/foo/bar.csv"], None)
-    assert meta_provider.prefetch_file_metadata(["test"]) is None
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -13,10 +13,7 @@ from pytest_lazyfixture import lazy_fixture
 import ray
 from ray.data.block import BlockAccessor
 from ray.data.context import DataContext
-from ray.data.datasource import (
-    DefaultFileMetadataProvider,
-    DefaultParquetMetadataProvider,
-)
+from ray.data.datasource import DefaultFileMetadataProvider, ParquetMetadataProvider
 from ray.data.datasource.parquet_bulk_datasource import ParquetBulkDatasource
 from ray.data.datasource.parquet_datasource import (
     NUM_CPUS_FOR_META_FETCH_TASK,
@@ -205,7 +202,7 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
     path2 = os.path.join(setup_data_path, "test2.parquet")
     pq.write_table(table, path2, filesystem=fs)
 
-    class TestMetadataProvider(DefaultParquetMetadataProvider):
+    class TestMetadataProvider(ParquetMetadataProvider):
         def prefetch_file_metadata(self, fragments, **ray_remote_args):
             assert ray_remote_args["num_cpus"] == NUM_CPUS_FOR_META_FETCH_TASK
             assert (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`DefaultParquetMetadataProvider` is the only implementation of `ParquetMetadataProvider`, and we don't expect anyone (internally or externally) to add other implementations. To avoid an unnecessarily deep inheritance hierarchy, this PR removes `DefaultParquetMetadataProvider` and moves its implementation to `ParquetMetadataProvider`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
