### PR TITLE
[Data] Remove unnecessary logic that manually adds partition columns

### DIFF
--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -546,7 +546,6 @@ def _read_fragments(
     assert len(fragments) > 0
 
     import pyarrow as pa
-    from pyarrow.dataset import _get_partition_keys
 
     logger.debug(f"Reading {len(fragments)} parquet fragments")
     use_threads = to_batches_kwargs.pop("use_threads", False)

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -552,7 +552,6 @@ def _read_fragments(
     use_threads = to_batches_kwargs.pop("use_threads", False)
     batch_size = to_batches_kwargs.pop("batch_size", default_read_batch_size_rows)
     for fragment in fragments:
-        part = _get_partition_keys(fragment.partition_expression)
         batches = fragment.to_batches(
             use_threads=use_threads,
             columns=columns,
@@ -562,15 +561,6 @@ def _read_fragments(
         )
         for batch in batches:
             table = pa.Table.from_batches([batch], schema=schema)
-            if part:
-                for col, value in part.items():
-                    if columns and col not in columns:
-                        continue
-                    table = table.set_column(
-                        table.schema.get_field_index(col),
-                        col,
-                        pa.array([value] * len(table)),
-                    )
             if include_paths:
                 table = table.append_column("path", [[fragment.path]] * len(table))
             # If the table is empty, drop it.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`ParquetDatasource` implements logic to manually add partition values. This PR removes that logic for two reasons:
1. PyArrow detects and add partition values automatically; consequently, the manual logic adds unnecessary complexity.
2. The code has a bug where it doesn't respect the user-specified types (see below).

```python
import pandas as pd
import pyarrow as pa
import pyarrow.parquet as pq

import ray

df = pd.DataFrame({"column1": [0, 1], "column2": ["a", "a"]})
table = pa.Table.from_pandas(df)
pq.write_to_dataset(
    table,
    root_path="/tmp/repro",
    partition_cols=["column1"],
)
schema = pa.schema([("column1", pa.int32()), ("column2", pa.string())])
partitioning = pa.dataset.partitioning(schema, flavor="hive")

ds = ray.data.read_parquet("/tmp/repro", dataset_kwargs=dict(partitioning=partitioning))

print(ds.materialize().schema())
# The type of 'column1' is `int64`, but it should be `int32`.
#
# Column   Type
# ------   ----
# column2  string
# column1  int64
```

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/ray/pull/17716

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
