### PR TITLE
[RLlib] Fix release test JSON summary problem (if e.g. numpy data in result dict).

### DIFF
--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -1622,7 +1622,17 @@ def run_rllib_example_script_experiment(
                 os.environ.get("TEST_OUTPUT_JSON", "/tmp/learning_test.json"),
                 "wt",
             ) as f:
-                json.dump(json_summary, f)
+                try:
+                    json.dump(json_summary, f)
+                # Something went wrong writing json. Try again w/ simplified stats.
+                except Exception:
+                    from ray.rllib.algorithms.algorithm import Algorithm
+
+                    simplified_stats = {
+                        k: stats[k] for k in Algorithm._progress_metrics if k in stats
+                    }
+                    json_summary["stats"] = simplified_stats
+                    json.dump(json_summary, f)
 
         if not test_passed:
             raise ValueError(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix release test JSON summary problem (if e.g. numpy data in result dict).

Our DreamerV3 release test currently fails, only b/c it cannot write the final JSON summary due to some numpy data present in the final result dict. Changes our `test_utils.py::run_rllib_example_script_experiment()` utility to defend against such cases.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
