### PR TITLE
[core] print error output on `test_load_code_from_local`

### DIFF
--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -728,7 +728,7 @@ if __name__ == "__main__":
         with open(test_driver, "w") as f:
             f.write(code_test.format(repr(ray_start_regular_shared["address"])))
         output = subprocess.check_output([sys.executable, test_driver])
-        assert b"OK" in output
+        assert b"OK" in output, f"Output has no 'OK': {output.decode()}"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
so that we know what it outputs and why it fails
