### PR TITLE
[Data] Clean up some uses of `check_num_computed` in `test_parquet.py`

### DIFF
--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -143,24 +143,20 @@ def test_parquet_read_basic(ray_start_regular_shared, fs, data_path):
     ds = ray.data.read_parquet(data_path, filesystem=fs)
 
     # Test metadata-only parquet ops.
-    check_num_computed(ds, 0)
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     # Schema information is available from Parquet metadata, so
     # we do not need to compute the first block.
     assert ds.schema() is not None
-    check_num_computed(ds, 0)
     input_files = ds.input_files()
     assert len(input_files) == 2, input_files
     assert "test1.parquet" in str(input_files)
     assert "test2.parquet" in str(input_files)
     assert str(ds) == "Dataset(num_rows=6, schema={one: int64, two: string})", ds
     assert repr(ds) == "Dataset(num_rows=6, schema={one: int64, two: string})", ds
-    check_num_computed(ds, 0)
 
     # Forces a data read.
     values = [[s["one"], s["two"]] for s in ds.take_all()]
-    check_num_computed(ds, 0)
     assert sorted(values) == [
         [1, "a"],
         [2, "b"],
@@ -224,7 +220,6 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
     assert ds._meta_count() is None
 
     # Expect to lazily compute all metadata correctly.
-    check_num_computed(ds, 0)
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     assert ds.schema() is not None
@@ -234,11 +229,9 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
     assert "test2.parquet" in str(input_files)
     assert str(ds) == "Dataset(num_rows=6, schema={one: int64, two: string})", ds
     assert repr(ds) == "Dataset(num_rows=6, schema={one: int64, two: string})", ds
-    check_num_computed(ds, 2)
 
     # Forces a data read.
     values = [[s["one"], s["two"]] for s in ds.take()]
-    check_num_computed(ds, 2)
     assert sorted(values) == [
         [1, "a"],
         [2, "b"],
@@ -482,16 +475,13 @@ def test_parquet_read_partitioned(ray_start_regular_shared, fs, data_path):
     ds = ray.data.read_parquet(data_path, filesystem=fs)
 
     # Test metadata-only parquet ops.
-    check_num_computed(ds, 0)
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     # Schema information and input files are available from Parquet metadata,
     # so we do not need to compute the first block.
     assert ds.schema() is not None
-    check_num_computed(ds, 0)
     input_files = ds.input_files()
     assert len(input_files) == 2, input_files
-    check_num_computed(ds, 0)
     assert str(ds) == (
         "Dataset(\n"
         "   num_rows=6,\n"
@@ -506,7 +496,6 @@ def test_parquet_read_partitioned(ray_start_regular_shared, fs, data_path):
         "one: dictionary<values=int32, indices=int32, ordered=0>}\n"
         ")"
     ), ds
-    check_num_computed(ds, 0)
 
     # Forces a data read.
     values = [[s["one"], s["two"]] for s in ds.take()]
@@ -518,13 +507,11 @@ def test_parquet_read_partitioned(ray_start_regular_shared, fs, data_path):
         [3, "f"],
         [3, "g"],
     ]
-    check_num_computed(ds, 0)
 
     # Test column selection.
     ds = ray.data.read_parquet(data_path, columns=["one"], filesystem=fs)
     values = [s["one"] for s in ds.take()]
     assert sorted(values) == [1, 1, 1, 3, 3, 3]
-    check_num_computed(ds, 0)
 
 
 def test_parquet_read_partitioned_with_filter(ray_start_regular_shared, tmp_path):
@@ -543,7 +530,6 @@ def test_parquet_read_partitioned_with_filter(ray_start_regular_shared, tmp_path
     )
 
     values = [[s["one"], s["two"]] for s in ds.take()]
-    check_num_computed(ds, 0)
     assert sorted(values) == [[1, "a"], [1, "a"]]
     assert ds.count() == 2
 
@@ -554,7 +540,6 @@ def test_parquet_read_partitioned_with_filter(ray_start_regular_shared, tmp_path
     )
 
     values = [[s["one"], s["two"]] for s in ds.take()]
-    check_num_computed(ds, 0)
     assert sorted(values) == [[1, "a"], [1, "a"]]
     assert ds.count() == 2
 
@@ -594,7 +579,6 @@ def test_parquet_read_partitioned_with_columns(ray_start_regular_shared, fs, dat
     )
     assert ds.columns() == ["y", "z"]
     values = [[s["y"], s["z"]] for s in ds.take()]
-    check_num_computed(ds, 0)
     assert sorted(values) == [
         ["a", 0.1],
         ["a", 0.3],
@@ -656,7 +640,6 @@ def test_parquet_read_partitioned_with_partition_filter(
 
     assert ds.columns() == ["x", "y", "z"]
     values = [[s["x"], s["y"], s["z"]] for s in ds.take()]
-    check_num_computed(ds, 0)
     assert sorted(values) == [[0, "a", 0.1]]
 
 
@@ -674,28 +657,23 @@ def test_parquet_read_partitioned_explicit(ray_start_regular_shared, tmp_path):
 
     schema = pa.schema([("one", pa.int32()), ("two", pa.string())])
     partitioning = pa.dataset.partitioning(schema, flavor="hive")
-
     ds = ray.data.read_parquet(
         str(tmp_path), dataset_kwargs=dict(partitioning=partitioning)
     )
 
     # Test metadata-only parquet ops.
-    check_num_computed(ds, 0)
     assert ds.count() == 6
     assert ds.size_bytes() > 0
     # Schema information and input files are available from Parquet metadata,
     # so we do not need to compute the first block.
-    check_num_computed(ds, 0)
     assert ds.schema() is not None
     input_files = ds.input_files()
     assert len(input_files) == 2, input_files
     assert str(ds) == "Dataset(num_rows=6, schema={two: string, one: int32})", ds
     assert repr(ds) == "Dataset(num_rows=6, schema={two: string, one: int32})", ds
-    check_num_computed(ds, 0)
 
     # Forces a data read.
     values = [[s["one"], s["two"]] for s in ds.take()]
-    check_num_computed(ds, 0)
     assert sorted(values) == [
         [1, "a"],
         [1, "b"],
@@ -726,7 +704,6 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
     )
 
     ones, twos = zip(*[[s["one"], s["two"]] for s in ds.take()])
-    check_num_computed(ds, 0)
     np.testing.assert_array_equal(sorted(ones), np.array(one_data) + 1)
 
     # 2 blocks/read tasks
@@ -736,7 +713,6 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
     )
 
     ones, twos = zip(*[[s["one"], s["two"]] for s in ds.take()])
-    check_num_computed(ds, 0)
     np.testing.assert_array_equal(sorted(ones), np.array(one_data) + 1)
 
     # 2 blocks/read tasks, 1 empty block
@@ -749,7 +725,6 @@ def test_parquet_read_with_udf(ray_start_regular_shared, tmp_path):
     )
 
     ones, twos = zip(*[[s["one"], s["two"]] for s in ds.take()])
-    check_num_computed(ds, 0)
     np.testing.assert_array_equal(sorted(ones), np.array(one_data[:2]) + 1)
 
 
@@ -781,7 +756,6 @@ def test_parquet_read_parallel_meta_fetch(ray_start_regular_shared, fs, data_pat
     )
 
     # Test metadata-only parquet ops.
-    check_num_computed(ds, 0)
     assert ds.count() == num_dfs * 3
     assert ds.size_bytes() > 0
     # Schema information and input files are available from Parquet metadata,
@@ -789,11 +763,9 @@ def test_parquet_read_parallel_meta_fetch(ray_start_regular_shared, fs, data_pat
     assert ds.schema() is not None
     input_files = ds.input_files()
     assert len(input_files) == num_dfs, input_files
-    check_num_computed(ds, 0)
 
     # Forces a data read.
     values = [s["one"] for s in ds.take(limit=3 * num_dfs)]
-    check_num_computed(ds, 0)
     assert sorted(values) == list(range(3 * num_dfs))
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`check_num_computed` counts the number of read tasks executed within a `LazyBlockList`. With the removal of the legacy execution backend (https://github.com/ray-project/ray/pull/42780), this value is typically 0, and it's not useful to test against.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
