### PR TITLE
[ci][release] relax the enum of byod type

### DIFF
--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -98,14 +98,8 @@
 			"type": "object",
 			"additionalProperties": false,
 			"properties": {
-				"type": {
-					"type": "string",
-					"enum": [
-						"cpu",
-						"gpu",
-						"cu118",
-						"cu121"
-					]
+				"type":{
+					"type": "string"
 				},
 				"post_build_script":{
 					"type": "string"


### PR DESCRIPTION
Relax the enum of byod type; this value is basically used as the suffix of the image, which can have a lot of different values. This will allow more than just the ray base image to be used for running release tests.

Test:
- CI