### PR TITLE
[core] make sure PYTHONSAFEPATH is disabled

### DIFF
--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -727,7 +727,12 @@ if __name__ == "__main__":
         test_driver = os.path.join(tmpdir, "test_load_code_from_local.py")
         with open(test_driver, "w") as f:
             f.write(code_test.format(repr(ray_start_regular_shared["address"])))
-        output = subprocess.check_output([sys.executable, test_driver])
+
+        # Ray's handling of sys.path does not work with PYTHONSAFEPATH.
+        env = os.environ.copy()
+        if env.get("PYTHONSAFEPATH", "") != "":
+            env["PYTHONSAFEPATH"] = ""  # Set to empty string to disable.
+        output = subprocess.check_output([sys.executable, test_driver], env=env)
         assert b"OK" in output, f"Output has no 'OK': {output.decode()}"
 
 


### PR DESCRIPTION
make sure it is disabled when launching a new file/module from a local or temp directory. newer bazel versions will enable `PYTHONSAFEPATH` by default in python tests and binaries, and it will break ray.
