### PR TITLE
allow runtime env config with image_uri and container

### DIFF
--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -365,19 +365,21 @@ class RuntimeEnv(dict):
             )
 
         if self.get("container"):
-            if len(runtime_env) > 1:
+            invalid_keys = set(runtime_env.keys()) - {"container", "config"}
+            if len(invalid_keys):
                 raise ValueError(
                     "The 'container' field currently cannot be used "
                     "together with other fields of runtime_env. "
-                    f"Specified fields: {runtime_env.keys()}"
+                    f"Specified fields: {invalid_keys}"
                 )
 
         if self.get("image_uri"):
-            if len(runtime_env) > 1:
+            invalid_keys = set(runtime_env.keys()) - {"image_uri", "config"}
+            if len(invalid_keys):
                 raise ValueError(
                     "The 'image_uri' field currently cannot be used "
                     "together with other fields of runtime_env. "
-                    f"Specified fields: {runtime_env.keys()}"
+                    f"Specified fields: {invalid_keys}"
                 )
 
         for option, validate_fn in OPTION_TO_VALIDATION_FN.items():

--- a/python/ray/tests/test_runtime_env_container.py
+++ b/python/ray/tests/test_runtime_env_container.py
@@ -121,6 +121,19 @@ EXPECTED_ERROR = (
 
 
 class TestContainerRuntimeEnvWithOtherRuntimeEnv:
+    def test_container_with_config(self):
+        @ray.remote(
+            runtime_env={
+                "container": {
+                    "image": NESTED_IMAGE_NAME,
+                    "worker_path": "/some/path/to/default_worker.py",
+                },
+                "config": {"setup_timeout_seconds": 10},
+            }
+        )
+        def f():
+            return ray.put((1, 10))
+
     def test_container_with_env_vars(self):
         with pytest.raises(ValueError, match=EXPECTED_ERROR):
 


### PR DESCRIPTION
allow runtime env config with image_uri and container

Allow specifying "config" with "container", and also "config" with "image_uri". "config" configures things like runtime env setup timeout, which does not conflict with the nature of container/image_uri so we should allow it.

Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
