### PR TITLE
[Data] Explicitly specify metadata provider in `test_parquet_reader_estimate_data_size` 

### DIFF
--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -773,7 +773,9 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
     try:
         tensor_output_path = os.path.join(tmp_path, "tensor")
         ray.data.range_tensor(1000, shape=(1000,)).write_parquet(tensor_output_path)
-        ds = ray.data.read_parquet(tensor_output_path)
+        ds = ray.data.read_parquet(
+            tensor_output_path, meta_provider=ParquetMetadataProvider()
+        )
         assert ds._plan.initial_num_blocks() > 1
         data_size = ds.size_bytes()
         assert (
@@ -784,7 +786,9 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
             data_size >= 7_000_000 and data_size <= 10_000_000
         ), "actual data size is out of expected bound"
 
-        datasource = ParquetDatasource(tensor_output_path)
+        datasource = ParquetDatasource(
+            tensor_output_path, meta_provider=ParquetMetadataProvider()
+        )
         assert (
             datasource._encoding_ratio >= 300 and datasource._encoding_ratio <= 600
         ), "encoding ratio is out of expected bound"
@@ -794,14 +798,18 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
         ), "estimated data size is either out of expected bound"
         assert (
             data_size
-            == ParquetDatasource(tensor_output_path).estimate_inmemory_data_size()
+            == ParquetDatasource(
+                tensor_output_path, meta_provider=ParquetMetadataProvider()
+            ).estimate_inmemory_data_size()
         ), "estimated data size is not deterministic in multiple calls."
 
         text_output_path = os.path.join(tmp_path, "text")
         ray.data.range(1000).map(lambda _: {"text": "a" * 1000}).write_parquet(
             text_output_path
         )
-        ds = ray.data.read_parquet(text_output_path)
+        ds = ray.data.read_parquet(
+            text_output_path, meta_provider=ParquetMetadataProvider()
+        )
         assert ds._plan.initial_num_blocks() > 1
         data_size = ds.size_bytes()
         assert (
@@ -812,7 +820,9 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
             data_size >= 1_000_000 and data_size <= 2_000_000
         ), "actual data size is out of expected bound"
 
-        datasource = ParquetDatasource(text_output_path)
+        datasource = ParquetDatasource(
+            text_output_path, meta_provider=ParquetMetadataProvider()
+        )
         assert (
             datasource._encoding_ratio >= 150 and datasource._encoding_ratio <= 300
         ), "encoding ratio is out of expected bound"
@@ -822,7 +832,9 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
         ), "estimated data size is out of expected bound"
         assert (
             data_size
-            == ParquetDatasource(text_output_path).estimate_inmemory_data_size()
+            == ParquetDatasource(
+                text_output_path, meta_provider=ParquetMetadataProvider()
+            ).estimate_inmemory_data_size()
         ), "estimated data size is not deterministic in multiple calls."
     finally:
         ctx.decoding_size_estimation = old_decoding_size_estimation


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you don't specify a metadata provider, Ray Data chooses a metadata provider to use; a specific metadata provider isn't guaranteed as part of the interface. The issue with `test_parquet_reader_estimate_data_size` is that it assumes that Ray Data chooses `ParquetMetadataProvider`. To avoid depending on this implementation details, this PR updates the test to explicitly pass the metadata provider.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
