### PR TITLE
[ci] run some python lints on oss ci base

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -8,17 +8,26 @@ steps:
       - ./ci/lint/lint.sh {{matrix}}
     matrix:
       - clang_format
-      - code_format
       - untested_code_snippet
       - banned_words
       - doc_readme
       - dashboard_format
       - copyright_format
-      - bazel_team
       - bazel_buildifier
       - pytest_format
       - test_coverage
       - documentation_style
+
+  - label: ":lint-roller: lint: {{matrix}}"
+    key: lint-small-py
+    depends_on:
+      - oss-ci-base_build
+    commands:
+      - ./ci/lint/lint.sh {{matrix}}
+    job_env: oss-ci-base_build
+    matrix:
+      - code_format
+      - bazel_team
 
   - label: ":lint-roller: lint: {{matrix}}"
     key: lint-medium


### PR DESCRIPTION
these lints have assumptions on what python version the environment is using. forge's python is from base ubuntu, and oss ci base's python is from conda, which is the default python version.

this required for upgrading ubuntu base image everywhere, as ubuntu 22.04's python default version is 3.10, where ubuntu 20.04 uses 3.9. the python version change will break these lints.
