### PR TITLE
[Serve] Keep `object_store_memory` an int

### DIFF
--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -222,7 +222,7 @@ class RayActorOptionsSchema(BaseModel):
         ),
         ge=0,
     )
-    object_store_memory: float = Field(
+    object_store_memory: int = Field(
         default=None,
         description=(
             "Restrict the object store memory used per replica when "

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -226,7 +226,7 @@ class RayActorOptionsSchema(BaseModel):
         default=None,
         description=(
             "Restrict the object store memory used per replica when "
-            "creating objects. Uses a default if null."
+            "creating objects. Must be an int. Uses a default if null."
         ),
         ge=0,
     )

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -225,7 +225,7 @@ class RayActorOptionsSchema(BaseModel):
     object_store_memory: int = Field(
         default=None,
         description=(
-            "Restrict the object store memory used per replica when "
+            "Restrict the object store memory used per replica (in bytes) when "
             "creating objects. Must be an int. Uses a default if null."
         ),
         ge=0,

--- a/python/ray/serve/tests/test_regression.py
+++ b/python/ray/serve/tests/test_regression.py
@@ -17,6 +17,9 @@ from ray.serve.handle import DeploymentHandle
 
 @pytest.fixture
 def shutdown_ray():
+    if ray.is_initialized():
+        serve.shutdown()
+        ray.shutdown()
     yield
     serve.shutdown()
     ray.shutdown()

--- a/python/ray/serve/tests/test_regression.py
+++ b/python/ray/serve/tests/test_regression.py
@@ -263,5 +263,21 @@ def test_healthcheck_timeout(serve_instance):
     response.result()
 
 
+def test_object_store_memory(shutdown_ray):
+    """Test that object_store_memory can be specified.
+
+    See https://github.com/ray-project/ray/issues/45321
+    """
+
+    ray.init()
+
+    @serve.deployment(ray_actor_options={"object_store_memory": 1024})
+    def f():
+        return "hello"
+
+    h = serve.run(f.bind())
+    assert h.remote().result() == "hello"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ray Serve converts `object_store_memory` into a float, but Ray Core requires it to be an int. This change makes Serve keep it an int.

**Note:** I added the unit test to `test_regression.py`, but it makes more sense to keep it in `test_api.py`. I'm going to hold off on adding it there until https://github.com/ray-project/ray/issues/45780 is resolved. If I add it to `test_api.py` now, the test passes and then hangs while cleaning up.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #45321

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
