### PR TITLE
[serve] increase size of test deployment scheduler

### DIFF
--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -26,7 +26,6 @@ py_test_module_list(
         "test_deployment_graph_handle_serde.py",
         "test_deployment_graph_ingress.py",
         "test_deployment_node.py",
-        "test_deployment_scheduler.py",
         "test_deployment_version.py",
         "test_enable_task_events.py",
         "test_expected_versions.py",
@@ -78,6 +77,7 @@ py_test_module_list(
         "test_request_timeout.py",
         "test_streaming_response.py",
         "test_target_capacity.py",
+        "test_deployment_scheduler.py",
     ],
     tags = [
         "exclusive",


### PR DESCRIPTION
[serve] increase size of test deployment scheduler

Change `test_deployment_scheduler` to medium.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
