### PR TITLE
[core][experimental] Driver on different node can read from accelerated DAG output

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -390,9 +390,10 @@ class CompiledDAG:
         reader ref on the driver node if the channel backing store needs to be resized.
         However, remote functions cannot be invoked on the driver.
 
-        An accelerated DAG creates an instance of this class when the DAG is
-        initialized. This class has an empty implementation, though it serves as a way
-        for the output writer to invoke remote functions on the driver node.
+        An accelerated DAG creates an actor from this class when the DAG is intialized.
+        The actor is on the same node as the driver. This class has an empty
+        implementation, though it serves as a way for the output writer to invoke remote
+        functions on the driver node.
         """
 
         pass
@@ -482,18 +483,13 @@ class CompiledDAG:
         # this DAG, if any.
         self._nccl_group_id: Optional[str] = None
 
-        # Creates the driver actor.
+        # Creates the driver actor on the same node as the driver.
         #
         # To support the driver as a reader, the output writer needs to be able to
-        # invoke remote functions on the driver. This is necessary so that the output
-        # writer can create a reader ref on the driver node, and later potentially
-        # create a larger reader ref on the driver node if the channel backing store
-        # needs to be resized. However, remote functions cannot be invoked on the
-        # driver.
-        #
-        # An accelerated DAG creates an instance of this class when the DAG is
-        # initialized. This class has an empty implementation, though it serves as a way
-        # for the output writer to invoke remote functions on the driver node.
+        # invoke remote functions on the driver (e.g., to create the reader ref, to
+        # create a reader ref for a larger object when the channel backing store is
+        # resized, etc.). The `_driver_actor` serves as a way for the output writer to
+        # invoke remote functions on the driver node.
         self._driver_actor = CompiledDAG.DAGDriverProxyActor.options(
             scheduling_strategy=NodeAffinitySchedulingStrategy(
                 ray.get_runtime_context().get_node_id(), soft=False

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -188,7 +188,7 @@ class Channel(ChannelInterface):
         """
         assert len(readers) > 0
         for reader in readers:
-            assert reader is not None
+            assert isinstance(reader, ray.actor.ActorHandle)
 
         if typ is None:
             typ = SharedMemoryType(DEFAULT_MAX_BUFFER_SIZE)

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -163,7 +163,7 @@ class Channel(ChannelInterface):
     def __init__(
         self,
         writer: Optional[ray.actor.ActorHandle],
-        readers: List[Optional[ray.actor.ActorHandle]],
+        readers: List[ray.actor.ActorHandle],
         typ: Optional[Union[int, SharedMemoryType]] = None,
         _writer_node_id: Optional["ray.NodeID"] = None,
         _reader_node_id: Optional["ray.NodeID"] = None,
@@ -179,8 +179,7 @@ class Channel(ChannelInterface):
 
         Args:
             writer: The actor that may write to the channel. None signifies the driver.
-            readers: The actors that may read from the channel. None signifies
-                the driver.
+            readers: The actors that may read from the channel. No reader may be None.
             typ: Type information about the values passed through the channel.
                 Either an integer representing the max buffer size in bytes
                 allowed, or a SharedMemoryType.
@@ -188,6 +187,8 @@ class Channel(ChannelInterface):
             Channel: A wrapper around ray.ObjectRef.
         """
         assert len(readers) > 0
+        for reader in readers:
+            assert reader is not None
 
         if typ is None:
             typ = SharedMemoryType(DEFAULT_MAX_BUFFER_SIZE)
@@ -235,21 +236,14 @@ class Channel(ChannelInterface):
             )
             self._writer_ref = _create_channel_ref(self, typ.buffer_size_bytes)
 
-            if readers[0] is None:
-                # Reader is the driver. We assume that the reader and the writer are on
-                # the same node.
-                self._reader_node_id = self._writer_node_id
-                self._reader_ref = self._writer_ref
-            else:
-                # Reader and writer *may* be on different nodes.
-                self._reader_node_id = _get_reader_node_id(self, readers[0])
-                for reader in readers:
-                    reader_node_id = _get_reader_node_id(self, reader)
-                    if reader_node_id != self._reader_node_id:
-                        raise NotImplementedError(
-                            "All readers must be on the same node for now."
-                        )
-                self._create_reader_ref(readers, typ.buffer_size_bytes)
+            self._reader_node_id = _get_reader_node_id(self, readers[0])
+            for reader in readers:
+                reader_node_id = _get_reader_node_id(self, reader)
+                if reader_node_id != self._reader_node_id:
+                    raise NotImplementedError(
+                        "All readers must be on the same node for now."
+                    )
+            self._create_reader_ref(readers, typ.buffer_size_bytes)
 
             assert self._reader_ref is not None
         else:
@@ -308,17 +302,12 @@ class Channel(ChannelInterface):
             self._reader_ref
         ), "`self._reader_ref` must be not be None when registering a writer, because "
         "it should have been initialized in the constructor."
-
-        if len(self._readers) == 1 and self._readers[0] is None:
-            actor_id = ray.ActorID.nil()
-        else:
-            actor_id = self._readers[0]._actor_id
         self._worker.core_worker.experimental_channel_register_writer(
             self._writer_ref,
             self._reader_ref,
             self._writer_node_id,
             self._reader_node_id,
-            actor_id,
+            self._readers[0]._actor_id,
             len(self._readers),
         )
         self._writer_registered = True

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -10,8 +10,31 @@ import pytest
 import ray
 import ray.cluster_utils
 import ray.experimental.channel as ray_channel
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 logger = logging.getLogger(__name__)
+
+
+@ray.remote
+class DriverActor:
+    """
+    This actor exists simply so that the driver can read from channels. When a channel
+    backing store is created or resized, the writer may need to invoke a remote function
+    on the reader node. A remote function cannot be invoked on the driver, so this actor
+    runs on the same node as the driver to run the remote function.
+
+    This actor itself does not read from the channel.
+    """
+
+    pass
+
+
+def get_driver_actor():
+    return DriverActor.options(
+        scheduling_strategy=NodeAffinitySchedulingStrategy(
+            ray.get_runtime_context().get_node_id(), soft=False
+        )
+    ).remote()
 
 
 @pytest.mark.skipif(
@@ -19,10 +42,7 @@ logger = logging.getLogger(__name__)
     reason="Requires Linux or Mac.",
 )
 def test_put_local_get(ray_start_regular):
-    """
-    Tests that the driver can write and read from a channel.
-    """
-    chan = ray_channel.Channel(None, [None], 1000)
+    chan = ray_channel.Channel(None, [get_driver_actor()], 1000)
 
     num_writes = 1000
     for i in range(num_writes):
@@ -30,6 +50,50 @@ def test_put_local_get(ray_start_regular):
         chan.write(val)
         assert chan.begin_read() == val
         chan.end_read()
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux" and sys.platform != "darwin",
+    reason="Requires Linux or Mac.",
+)
+@pytest.mark.parametrize("remote", [True, False])
+def test_driver_as_reader(ray_start_cluster, remote):
+    cluster = ray_start_cluster
+    if remote:
+        # This node is for the driver. num_cpus is 1 because the DriverActor needs a
+        # place to run.
+        cluster.add_node(num_cpus=1)
+        ray.init(address=cluster.address)
+        # This node is for the writer actor.
+        cluster.add_node(num_cpus=1)
+    else:
+        # This node is for both the driver (including the DriverHelperActor) and the
+        # writer actor.
+        cluster.add_node(num_cpus=2)
+        ray.init(address=cluster.address)
+
+    @ray.remote(num_cpus=1)
+    class Actor:
+        def setup(self, driver_actor):
+            self._channel = ray_channel.Channel(
+                ray.get_runtime_context().current_actor,
+                [driver_actor],
+                1000,
+            )
+
+        def get_channel(self):
+            return self._channel
+
+        def write(self):
+            self._channel.write(b"x")
+
+    a = Actor.remote()
+    ray.get(a.setup.remote(get_driver_actor()))
+    chan = ray.get(a.get_channel.remote())
+
+    ray.get(a.write.remote())
+    assert chan.begin_read() == b"x"
+    chan.end_read()
 
 
 @pytest.mark.skipif(
@@ -110,7 +174,7 @@ def test_errors(ray_start_regular):
 
     a = Actor.remote()
     # Multiple consecutive reads from the same process are fine.
-    chan = ray.get(a.make_chan.remote([None], do_write=True))
+    chan = ray.get(a.make_chan.remote([get_driver_actor()], do_write=True))
     assert chan.begin_read() == b"hello"
     chan.end_read()
 
@@ -137,10 +201,7 @@ def test_errors(ray_start_regular):
     reason="Requires Linux or Mac.",
 )
 def test_put_different_meta(ray_start_regular):
-    """
-    Tests that different object/primitive types can be passed through the same channel.
-    """
-    chan = ray_channel.Channel(None, [None], 1000)
+    chan = ray_channel.Channel(None, [get_driver_actor()], 1000)
 
     def _test(val):
         chan.write(val)
@@ -204,7 +265,7 @@ def test_resize_channel_on_same_node(ray_start_regular):
     Tests that the channel backing store is automatically increased when a large object
     is written to it. The writer and reader are on the same node.
     """
-    chan = ray_channel.Channel(None, [None], 1000)
+    chan = ray_channel.Channel(None, [get_driver_actor()], 1000)
 
     def _test(val):
         chan.write(val)

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -11,7 +11,7 @@ import ray
 import ray.cluster_utils
 import ray.experimental.channel as ray_channel
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
-from ray.dag import CompiledDAG
+from ray.dag.compiled_dag_node import CompiledDAG
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -16,8 +16,8 @@ from ray.dag.compiled_dag_node import CompiledDAG
 logger = logging.getLogger(__name__)
 
 
-def get_driver_actor():
-    return CompiledDAG.DriverActor.options(
+def create_driver_actor():
+    return CompiledDAG.DAGDriverProxyActor.options(
         scheduling_strategy=NodeAffinitySchedulingStrategy(
             ray.get_runtime_context().get_node_id(), soft=False
         )
@@ -29,7 +29,7 @@ def get_driver_actor():
     reason="Requires Linux or Mac.",
 )
 def test_put_local_get(ray_start_regular):
-    chan = ray_channel.Channel(None, [get_driver_actor()], 1000)
+    chan = ray_channel.Channel(None, [create_driver_actor()], 1000)
 
     num_writes = 1000
     for i in range(num_writes):
@@ -47,8 +47,8 @@ def test_put_local_get(ray_start_regular):
 def test_driver_as_reader(ray_start_cluster, remote):
     cluster = ray_start_cluster
     if remote:
-        # This node is for the driver. num_cpus is 1 because the CompiledDAG.DriverActor
-        # needs a place to run.
+        # This node is for the driver. num_cpus is 1 because the
+        # CompiledDAG.DAGDriverProxyActor needs a place to run.
         cluster.add_node(num_cpus=1)
         ray.init(address=cluster.address)
         # This node is for the writer actor.
@@ -75,7 +75,7 @@ def test_driver_as_reader(ray_start_cluster, remote):
             self._channel.write(b"x")
 
     a = Actor.remote()
-    ray.get(a.setup.remote(get_driver_actor()))
+    ray.get(a.setup.remote(create_driver_actor()))
     chan = ray.get(a.get_channel.remote())
 
     ray.get(a.write.remote())
@@ -161,7 +161,7 @@ def test_errors(ray_start_regular):
 
     a = Actor.remote()
     # Multiple consecutive reads from the same process are fine.
-    chan = ray.get(a.make_chan.remote([get_driver_actor()], do_write=True))
+    chan = ray.get(a.make_chan.remote([create_driver_actor()], do_write=True))
     assert chan.begin_read() == b"hello"
     chan.end_read()
 
@@ -188,7 +188,7 @@ def test_errors(ray_start_regular):
     reason="Requires Linux or Mac.",
 )
 def test_put_different_meta(ray_start_regular):
-    chan = ray_channel.Channel(None, [get_driver_actor()], 1000)
+    chan = ray_channel.Channel(None, [create_driver_actor()], 1000)
 
     def _test(val):
         chan.write(val)
@@ -252,7 +252,7 @@ def test_resize_channel_on_same_node(ray_start_regular):
     Tests that the channel backing store is automatically increased when a large object
     is written to it. The writer and reader are on the same node.
     """
-    chan = ray_channel.Channel(None, [get_driver_actor()], 1000)
+    chan = ray_channel.Channel(None, [create_driver_actor()], 1000)
 
     def _test(val):
         chan.write(val)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds support for the driver reading from the accelerated DAG output. Previously, this was not possible unless the output writer (i.e., the last task in the DAG) was on the same node as the driver, which may not always be the case.

To support this, the output writer needs to be able to invoke remote functions on the driver. This is necessary so that the output writer can create a reader ref on the driver node, and later potentially create a larger reader ref on the driver node if the channel backing store needs to be resized. However, remote functions cannot be invoked on the driver.

This PR adds a DriverActor that an accelerated DAG creates when it is initialized. This DriverActor has an empty implementation, though it serves as a way for the output writer to invoke remote functions on the driver node. The workflow for creating a channel that has the driver as a reader is this:
1. Output writer creates a writer ref on its own node.
2. Output writer invokes a remote function on DriverActor to create a reader ref on the driver node.
3. Driver gets the channel from the output writer, which already includes the reader ref that the DriverActor created.

The workflow for resizing a channel backing store is similar:
1. Output writer detects that the channel backing store must be resized, so it creates a new writer ref on its own node.
2. Output writer invokes a remote function on DriverActor to create a new reader ref on the driver node.
3. Output writer sends a `_ResizeChannel` message on the channel via the old writer-ref/reader-ref pair. The `_ResizeChannel` message includes the new reader ref.
4. Driver gets `_ResizeChannel` message from the output writer on the old reader ref. The driver then updates its channel to use the new reader ref, which is included in the `_ResizeChannel` message. Note that the DriverActor does not read from the channel, so the driver receives this message.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
