### PR TITLE
[Core] Don't add core context if Ray is not initialized

### DIFF
--- a/python/ray/_private/ray_logging/filters.py
+++ b/python/ray/_private/ray_logging/filters.py
@@ -6,6 +6,7 @@ from ray._private.ray_logging.constants import LogKey
 class CoreContextFilter(logging.Filter):
     def filter(self, record):
         if not ray.is_initialized():
+            # There is no additional context if ray is not initialized
             return True
 
         runtime_context = ray.get_runtime_context()

--- a/python/ray/_private/ray_logging/filters.py
+++ b/python/ray/_private/ray_logging/filters.py
@@ -5,6 +5,9 @@ from ray._private.ray_logging.constants import LogKey
 
 class CoreContextFilter(logging.Filter):
     def filter(self, record):
+        if not ray.is_initialized():
+            return True
+
         runtime_context = ray.get_runtime_context()
         setattr(record, LogKey.JOB_ID, runtime_context.get_job_id())
         setattr(record, LogKey.WORKER_ID, runtime_context.get_worker_id())

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1396,6 +1396,11 @@ def init(
     else:
         logging.getLogger("ray").handlers.clear()
 
+    # Configure the logging settings for the driver process.
+    if logging_config:
+        dict_config = logging_config._get_dict_config()
+        logging.config.dictConfig(dict_config)
+
     # Parse the hidden options:
     _enable_object_reconstruction: bool = kwargs.pop(
         "_enable_object_reconstruction", False
@@ -1792,13 +1797,6 @@ def init(
 
     for hook in _post_init_hooks:
         hook()
-
-    # Configure the logging settings for the user driver program.
-    # This needs to be done after Ray is initialized since
-    # logger needs runtime context to get context like job id.
-    if logging_config:
-        dict_config = logging_config._get_dict_config()
-        logging.config.dictConfig(dict_config)
 
     node_id = global_worker.core_worker.get_current_node_id()
     global_node_address_info = _global_node.address_info.copy()

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1396,11 +1396,6 @@ def init(
     else:
         logging.getLogger("ray").handlers.clear()
 
-    # Configure the logging settings for the driver process.
-    if logging_config:
-        dict_config = logging_config._get_dict_config()
-        logging.config.dictConfig(dict_config)
-
     # Parse the hidden options:
     _enable_object_reconstruction: bool = kwargs.pop(
         "_enable_object_reconstruction", False
@@ -1797,6 +1792,13 @@ def init(
 
     for hook in _post_init_hooks:
         hook()
+
+    # Configure the logging settings for the user driver program.
+    # This needs to be done after Ray is initialized since
+    # it needs runtime context to get log context.
+    if logging_config:
+        dict_config = logging_config._get_dict_config()
+        logging.config.dictConfig(dict_config)
 
     node_id = global_worker.core_worker.get_current_node_id()
     global_node_address_info = _global_node.address_info.copy()

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1795,7 +1795,7 @@ def init(
 
     # Configure the logging settings for the user driver program.
     # This needs to be done after Ray is initialized since
-    # it needs runtime context to get log context.
+    # logger needs runtime context to get context like job id.
     if logging_config:
         dict_config = logging_config._get_dict_config()
         logging.config.dictConfig(dict_config)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`CoreContextFilter` uses runtime context to add additional context to log but if Ray is not initialized yet, there is no context to add so we should early return.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
