### PR TITLE
[core] On GCS restart, load actors whose job is dead but root detached actor is alive.

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -108,6 +108,7 @@ const ray::rpc::ActorDeathCause GenActorOutOfScopeCause(const ray::gcs::GcsActor
       "The actor is dead because all references to the actor were removed.");
   return death_cause;
 }
+
 }  // namespace
 
 namespace ray {
@@ -1386,61 +1387,53 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
   const auto &jobs = gcs_init_data.Jobs();
   const auto &actor_task_specs = gcs_init_data.ActorTaskSpecs();
   absl::flat_hash_map<NodeID, std::vector<WorkerID>> node_to_workers;
-  std::vector<ActorID> dead_actors;
+
   for (const auto &[actor_id, actor_table_data] : gcs_init_data.Actors()) {
-    auto job_iter = jobs.find(actor_id.JobId());
-    auto is_job_dead = (job_iter == jobs.end() || job_iter->second.is_dead());
-    // We only load actors which are supposed to be alive:
-    //   - Actors which are not dead.
-    //   - Non-deatched actors whoes owner is alive.
-    //   - Detached actors which lives even when their original owner is dead.
-    if (actor_table_data.state() != ray::rpc::ActorTableData::DEAD &&
-        (!is_job_dead || actor_table_data.is_detached())) {
-      const auto &iter = actor_task_specs.find(actor_id);
-      RAY_CHECK(iter != actor_task_specs.end());
-      auto actor = std::make_shared<GcsActor>(
-          actor_table_data, iter->second, actor_state_counter_);
-      registered_actors_.emplace(actor_id, actor);
-      function_manager_.AddJobReference(actor->GetActorID().JobId());
-      if (!actor->GetName().empty()) {
-        auto &actors_in_namespace = named_actors_[actor->GetRayNamespace()];
-        actors_in_namespace.emplace(actor->GetName(), actor->GetActorID());
-      }
-
-      if (actor_table_data.state() == ray::rpc::ActorTableData::DEPENDENCIES_UNREADY) {
-        const auto &owner = actor->GetOwnerAddress();
-        const auto &owner_node = NodeID::FromBinary(owner.raylet_id());
-        const auto &owner_worker = WorkerID::FromBinary(owner.worker_id());
-        RAY_CHECK(unresolved_actors_[owner_node][owner_worker]
-                      .emplace(actor->GetActorID())
-                      .second);
-      } else if (actor_table_data.state() == ray::rpc::ActorTableData::ALIVE) {
-        created_actors_[actor->GetNodeID()].emplace(actor->GetWorkerID(),
-                                                    actor->GetActorID());
-      }
-
-      if (!actor->IsDetached()) {
-        // This actor is owned. Send a long polling request to the actor's
-        // owner to determine when the actor should be removed.
-        PollOwnerForActorOutOfScope(actor);
-      }
-
-      if (!actor->GetWorkerID().IsNil()) {
-        RAY_CHECK(!actor->GetNodeID().IsNil());
-        node_to_workers[actor->GetNodeID()].emplace_back(actor->GetWorkerID());
-      }
-    } else {
-      dead_actors.push_back(actor_id);
+    // Bookkeep DEAD actors.
+    if (actor_table_data.state() == rpc::ActorTableData::DEAD) {
       auto actor = std::make_shared<GcsActor>(actor_table_data, actor_state_counter_);
-      destroyed_actors_.emplace(actor_id, actor);
-      sorted_destroyed_actor_list_.emplace_back(actor_id,
-                                                (int64_t)actor_table_data.timestamp());
+      AddDestroyedActorToCache(actor);
+      continue;
+    }
+    // Load all non-DEAD actors. Some of these actors are actually already dead, e.g.
+    // those whose jobs are dead, or root_detached_actors are dead. These actors are
+    // destroyed in PollOwnerForActorOutOfScope's callback.
+    const auto &actor_task_spec = map_find_or_die(actor_task_specs, actor_id);
+    auto actor = std::make_shared<GcsActor>(
+        actor_table_data, actor_task_spec, actor_state_counter_);
+
+    registered_actors_.emplace(actor_id, actor);
+    function_manager_.AddJobReference(actor->GetActorID().JobId());
+    if (!actor->GetName().empty()) {
+      named_actors_[actor->GetRayNamespace()][actor->GetName()] = actor->GetActorID();
+    }
+
+    if (actor_table_data.state() == ray::rpc::ActorTableData::DEPENDENCIES_UNREADY) {
+      const auto &owner = actor->GetOwnerAddress();
+      const auto &owner_node = NodeID::FromBinary(owner.raylet_id());
+      const auto &owner_worker = WorkerID::FromBinary(owner.worker_id());
+      RAY_CHECK(unresolved_actors_[owner_node][owner_worker]
+                    .emplace(actor->GetActorID())
+                    .second);
+    } else if (actor_table_data.state() == ray::rpc::ActorTableData::ALIVE) {
+      created_actors_[actor->GetNodeID()].emplace(actor->GetWorkerID(),
+                                                  actor->GetActorID());
+    }
+
+    if (!actor->IsDetached()) {
+      // This actor is owned. Send a long polling request to the actor's
+      // owner to determine when the actor should be removed.
+      PollOwnerForActorOutOfScope(actor);
+    }
+
+    if (!actor->GetWorkerID().IsNil()) {
+      RAY_CHECK(!actor->GetNodeID().IsNil());
+      node_to_workers[actor->GetNodeID()].emplace_back(actor->GetWorkerID());
     }
   }
-  if (!dead_actors.empty()) {
-    RAY_CHECK_OK(
-        gcs_table_storage_->ActorTaskSpecTable().BatchDelete(dead_actors, nullptr));
-  }
+  // `AddDestroyedActorToCache` assumes the new calls come with actors with a more
+  // recent timestamp. This is not true in Initialize, so we sort it here.
+  // IDEA: instead of manually managing this sorted list, make a proper ring buffer.
   sorted_destroyed_actor_list_.sort([](const std::pair<ActorID, int64_t> &left,
                                        const std::pair<ActorID, int64_t> &right) {
     return left.second < right.second;

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -291,7 +291,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
       std::shared_ptr<GcsPublisher> gcs_publisher,
       RuntimeEnvManager &runtime_env_manager,
       GcsFunctionManager &function_manager,
-      std::function<void(const ActorID &)> destroy_ownded_placement_group_if_needed,
+      std::function<void(const ActorID &)> destroy_owned_placement_group_if_needed,
       const rpc::ClientFactoryFn &worker_client_factory = nullptr);
 
   ~GcsActorManager() = default;


### PR DESCRIPTION
When GCS is restarting, gcs_actor_manager initializes by loading actors from the redis persisted data. It now discards these actors and does not load them:

1. Actors whose state is DEAD.
2. Actors whose jobs are DEAD, unless they are detached.

Clause 2 is wrong. A non-detached actor spawned and hence owned by a detached actor outlives its job. These actors are "forgotten" by the GCS, and when GCS needs to kill it (e.g. when the root detached actor dies), it leaks. This is especially problematic because it's a common pattern in Ray Serve where detached actors are prevalent and spawns children actors.

This PR fixes by changing the clause 2. The new no-load conditions are:

- Actors whose state is DEAD.
- Actors who has root detached actor, and that actor's state is DEAD.
- Actors who has NO root detached actor, and its job's state is DEAD.

Part of #45596.

