### PR TITLE
[ci] fix bazel version use in release automation

### DIFF
--- a/.buildkite/release-automation/forge_arm64.Dockerfile
+++ b/.buildkite/release-automation/forge_arm64.Dockerfile
@@ -31,6 +31,5 @@ EOF
 
 ENV CC=clang
 ENV CXX=clang++-12
-ENV USE_BAZEL_VERSION=5.4.1
 
 CMD ["echo", "ray release-automation forge"]

--- a/.buildkite/release-automation/forge_x86_64.Dockerfile
+++ b/.buildkite/release-automation/forge_x86_64.Dockerfile
@@ -40,6 +40,5 @@ EOF
 USER forge
 ENV CC=clang
 ENV CXX=clang++-12
-ENV USE_BAZEL_VERSION=5.4.1
 
 CMD ["echo", "ray release-automation forge"]

--- a/.buildkite/release-automation/verify-macos-wheels.sh
+++ b/.buildkite/release-automation/verify-macos-wheels.sh
@@ -15,7 +15,7 @@ if [[ $# -ne 1 ]]; then
 fi
 
 mac_architecture=$1 # First argument is the architecture of the machine, e.g. x86_64, arm64
-export USE_BAZEL_VERSION="${USE_BAZEL_VERSION:-5.4.1}"
+export USE_BAZEL_VERSION="${USE_BAZEL_VERSION:-6.5.0}"
 
 install_bazel() {
     if [[ "${mac_architecture}" = "arm64" ]]; then

--- a/release/util/sanity_check_cpp.sh
+++ b/release/util/sanity_check_cpp.sh
@@ -4,4 +4,10 @@
 set -e
 rm -rf ray-template
 ray cpp --generate-bazel-project-template-to ray-template
-pushd ray-template && bash run.sh
+(
+    cd ray-template
+
+    # Our generated CPP template does not work with bazel 7.x ,
+    # so pin the bazel version to 6
+    USE_BAZEL_VERSION=6.5.0 bash run.sh
+)


### PR DESCRIPTION
don't pin bazel version globally; only pin it for cpp sanity check. fixes nightly release automation.