### PR TITLE
[ci] fixes cuda version expansion in wanda matrix

### DIFF
--- a/ci/docker/ray.cuda.base.aarch64.wanda.yaml
+++ b/ci/docker/ray.cuda.base.aarch64.wanda.yaml
@@ -1,5 +1,5 @@
 name: "ray-py$PYTHON_VERSION-cu$CUDA_VERSION-base-aarch64"
-froms: ["nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04"]
+froms: ["nvidia/cuda:$CUDA_VERSION-cudnn8-devel-ubuntu20.04"]
 dockerfile: docker/base-deps/Dockerfile
 build_args:
   - PYTHON_VERSION

--- a/ci/docker/ray.cuda.base.wanda.yaml
+++ b/ci/docker/ray.cuda.base.wanda.yaml
@@ -1,5 +1,5 @@
 name: "ray-py$PYTHON_VERSION-cu$CUDA_VERSION-base"
-froms: ["nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04"]
+froms: ["nvidia/cuda:$CUDA_VERSION-cudnn8-devel-ubuntu20.04"]
 dockerfile: docker/base-deps/Dockerfile
 build_args:
   - PYTHON_VERSION


### PR DESCRIPTION
`froms` needs to pick the env var to track the correct base image content for caching validation

