### PR TITLE
Revert "[cpp] use bazelisk in template example"

### DIFF
--- a/cpp/example/run.sh
+++ b/cpp/example/run.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
 
-# Cause the script to exit if a single command fails.
+#Cause the script to exit if a single command fails.
 set -e
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" || exit; pwd)"
 
-if [[ "${USE_BAZEL_VERSION:-}" == "" ]]; then
-    export USE_BAZEL_VERSION=6.5.0
-fi
-
-bazelisk --nosystem_rc --nohome_rc build //:example
-
+bazel --nosystem_rc --nohome_rc build //:example
 if [[ "$OSTYPE" == "darwin"* ]]; then
     DYLD_LIBRARY_PATH="$ROOT_DIR/thirdparty/lib" "${ROOT_DIR}"/bazel-bin/example
 else


### PR DESCRIPTION
Reverts ray-project/ray#45805

the cpp worker test does not have bazelisk available in the test context, and it is failing