### PR TITLE
[docs] add LLM to example title for easy skimming

### DIFF
--- a/doc/source/serve/examples.yml
+++ b/doc/source/serve/examples.yml
@@ -16,7 +16,7 @@ examples:
       - generative ai
     link: tutorials/stable-diffusion
     related_technology: ml applications
-  - title: Serve a Large Language Model
+  - title: Serve a Large Language Model (LLM)
     skill_level: beginner
     use_cases:
       - generative ai


### PR DESCRIPTION
Just noticed that we had trouble finding the LLM model in the Serve examples page, but it was because we were pattern matching for `LLM`, not `Large Language Models`.
cc: @GokuMohandas 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
