### PR TITLE
[lint] port check bazel team owner check to bazel

### DIFF
--- a/ci/lint/BUILD.bazel
+++ b/ci/lint/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+
+py_binary(
+    name = "check_bazel_team_owner",
+    srcs = ["check_bazel_team_owner.py"],
+    exec_compatible_with = ["//:hermetic_python"],
+    visibility = ["//visibility:private"],
+)

--- a/ci/lint/check_bazel_team_owner.py
+++ b/ci/lint/check_bazel_team_owner.py
@@ -15,6 +15,7 @@ The bazel output looks like
 ...
 
 """
+import json
 import sys
 import xml.etree.ElementTree as ET
 
@@ -29,7 +30,7 @@ def perform_check(raw_xml_string: str):
         for lst in rule.findall("list"):
             if lst.attrib["name"] != "tags":
                 continue
-            tags = [child.attrib["value"] for child in lst.getchildren()]
+            tags = [child.attrib["value"] for child in lst]
             break
         team_owner = [t for t in tags if t.startswith("team:")]
         if len(team_owner) == 0:
@@ -42,7 +43,7 @@ def perform_check(raw_xml_string: str):
             "`team:*` to the tags."
         )
 
-    print(owners)
+    print(json.dumps(owners, indent="  "))
 
 
 if __name__ == "__main__":

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -38,8 +38,8 @@ copyright_format() {
 }
 
 bazel_team() {
-  bazel query 'kind("cc_test", //...)' --output=xml | python ./ci/lint/check-bazel-team-owner.py
-  bazel query 'kind("py_test", //...)' --output=xml | python ./ci/lint/check-bazel-team-owner.py
+  bazelisk query 'kind("cc_test", //...)' --output=xml | bazelisk run //ci/lint:check_bazel_team_owner
+  bazelisk query 'kind("py_test", //...)' --output=xml | bazelisk run //ci/lint:check_bazel_team_owner
 }
 
 bazel_buildifier() {


### PR DESCRIPTION
so that it uses the default python version used in CI.

required to upgrade ubuntu version.

