### PR TITLE
[Core] Add warning when uploading large working dirs

### DIFF
--- a/dashboard/modules/dashboard_sdk.py
+++ b/dashboard/modules/dashboard_sdk.py
@@ -352,8 +352,8 @@ class SubmissionClient:
             package_size = package_file.stat().st_size
             if package_size > 100 * 1024 * 1024:  # 100 MiB
                 logger.warning(
-                    f"The package {package_path} is very large. "
-                    "Consider adding some files or directories to 'excludes'"
+                    f"The package {package_path} is larger than the maximum allowed "
+                    "size. Consider adding some files or directories to 'excludes'"
                     "list to skip uploading them: `ray.init(..., "
                     "runtime_env={'excludes': ['.git', '*.log', 'tmp/']})`"
                 )

--- a/dashboard/modules/dashboard_sdk.py
+++ b/dashboard/modules/dashboard_sdk.py
@@ -348,6 +348,15 @@ class SubmissionClient:
                     include_parent_dir=include_parent_dir,
                     excludes=excludes,
                 )
+
+            package_size = package_file.stat().st_size
+            if package_size > 100 * 1024 * 1024:  # 100 MiB
+                logger.warning(
+                    f"The package {package_path} is very large. "
+                    "Consider adding some files or directories to 'excludes'"
+                    "list to skip uploading them: `ray.init(..., "
+                    "runtime_env={'excludes': ['.git', '*.log', 'tmp/']})`"
+                )
             try:
                 r = self._do_request(
                     "PUT",


### PR DESCRIPTION

## Why are these changes needed?

Currently, a warning is logged only when packaging and uploading large files. No warning is logged for large working directories with small files. This change adds a warning  just before uploading the zipped working directory, if the zipped size is >100 MiB.

## Related issue number

Closes #45602 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
