### PR TITLE
[RLlib] Fix DreamerV3 bug for `num_env_runners > 0` (users should use `num_envs_per_env_runner > 1` instead, though).

### DIFF
--- a/rllib/algorithms/dreamerv3/dreamerv3.py
+++ b/rllib/algorithms/dreamerv3/dreamerv3.py
@@ -152,6 +152,12 @@ class DreamerV3Config(AlgorithmConfig):
         # Dreamer only runs on the new API stack.
         self.enable_rl_module_and_learner = True
         self.enable_env_runner_and_connector_v2 = True
+        # TODO (sven): DreamerV3 still uses its own EnvRunner class. This env-runner
+        #  does not use connectors. We therefore should not attempt to merge/broadcast
+        #  the connector states between EnvRunners (if >0). Note that this is only
+        #  relevant if num_env_runners > 0, which is normally not the case when using
+        #  this algo.
+        self.use_worker_filter_stats = False
         # __sphinx_doc_end__
         # fmt: on
 

--- a/rllib/algorithms/dreamerv3/tests/test_dreamerv3.py
+++ b/rllib/algorithms/dreamerv3/tests/test_dreamerv3.py
@@ -41,6 +41,7 @@ class TestDreamerV3(unittest.TestCase):
         config = (
             dreamerv3.DreamerV3Config()
             .framework(eager_tracing=False)
+            .env_runners(num_env_runners=2)
             .training(
                 # Keep things simple. Especially the long dream rollouts seem
                 # to take an enormous amount of time (initially).
@@ -52,13 +53,13 @@ class TestDreamerV3(unittest.TestCase):
                 use_float16=False,
             )
             .learners(
-                num_learners=0,  # TODO 2  # Try with 2 Learners.
+                num_learners=2,  # Try with 2 Learners.
                 num_cpus_per_learner=1,
                 num_gpus_per_learner=0,
             )
         )
 
-        num_iterations = 2
+        num_iterations = 3
 
         for env in [
             "FrozenLake-v1",

--- a/rllib/algorithms/dreamerv3/utils/env_runner.py
+++ b/rllib/algorithms/dreamerv3/utils/env_runner.py
@@ -518,8 +518,16 @@ class DreamerV3EnvRunner(EnvRunner):
         # Return reduced metrics.
         return self.metrics.reduce()
 
-    # TODO (sven): Remove the requirement for EnvRunners/RolloutWorkers to have this
-    #  API. Replace by proper state overriding via `EnvRunner.set_state()`
+    def get_weights(self, policies, inference_only):
+        """Returns the weights of our (single-agent) RLModule."""
+        if self.module is None:
+            assert self.config.share_module_between_env_runner_and_learner
+            return {}
+        else:
+            return {
+                DEFAULT_MODULE_ID: self.module.get_state(inference_only=inference_only),
+            }
+
     def set_weights(self, weights, global_vars=None):
         """Writes the weights of our (single-agent) RLModule."""
         if self.module is None:

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -448,7 +448,7 @@ class EnvRunnerGroup:
             }
         # Ignore states from remote EnvRunners (use the current `from_worker` states
         # only).
-        else:
+        elif hasattr(from_worker, "_env_to_module"):
             env_runner_states["connector_states"] = {
                 "env_to_module_states": from_worker._env_to_module.get_state(),
                 "module_to_env_states": from_worker._module_to_env.get_state(),
@@ -464,12 +464,13 @@ class EnvRunnerGroup:
 
         def _update(_env_runner: EnvRunner) -> Any:
             env_runner_states = ray.get(ref_env_runner_states)
-            _env_runner._env_to_module.set_state(
-                env_runner_states["connector_states"]["env_to_module_states"]
-            )
-            _env_runner._module_to_env.set_state(
-                env_runner_states["connector_states"]["module_to_env_states"]
-            )
+            if hasattr(_env_runner, "_env_to_module"):
+                _env_runner._env_to_module.set_state(
+                    env_runner_states["connector_states"]["env_to_module_states"]
+                )
+                _env_runner._module_to_env.set_state(
+                    env_runner_states["connector_states"]["module_to_env_states"]
+                )
             # Update the global number of environment steps for each worker.
             if "env_steps_sampled" in env_runner_states:
                 # _env_runner.global_num_env_steps_sampled =


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix DreamerV3 bug for `num_env_runners > 0`.
Note that users should use `num_envs_per_env_runner > 1` instead, though.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
