### PR TITLE
[Databricks] Remove pricing warning when starting cluster

### DIFF
--- a/python/ray/util/spark/databricks_hook.py
+++ b/python/ray/util/spark/databricks_hook.py
@@ -83,14 +83,6 @@ class DefaultDatabricksRayOnSparkStartHook(RayOnSparkStartHook):
     def on_cluster_created(self, ray_cluster_handler):
         db_api_entry = get_db_entry_point()
 
-        try:
-            get_databricks_display_html_function()(
-                "<b style='background-color:yellow;'>When you are using Ray on Spark "
-                "cluster, you only pay for Spark cluster usage.</b>"
-            )
-        except Exception:
-            pass
-
         if ray_cluster_handler.autoscale or self.is_global:
             # Disable auto shutdown if
             # 1) autoscaling enabled


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The pricing warning when starting a cluster doesn't belong in stdout information statements, but rather in Databricks documentation. Removing this alert as it is jarring and out of place. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
