### PR TITLE
 [core] fix exit handling of FiberState threads

### DIFF
--- a/src/ray/core_worker/fiber.h
+++ b/src/ray/core_worker/fiber.h
@@ -102,7 +102,7 @@ class FiberState {
         rate_limiter_(max_concurrency),
         fiber_stopped_event_(std::make_shared<StdEvent>()) {
     std::shared_ptr<StdEvent> fiber_stopped_event = fiber_stopped_event_;
-    fiber_runner_thread_ = std::thread([&, fiber_stopped_event]() {
+    auto fiber_runner_thread = std::thread([&, fiber_stopped_event]() {
       while (!channel_.is_closed()) {
         std::function<void()> func;
         auto op_status = channel_.pop(func);
@@ -141,7 +141,7 @@ class FiberState {
       }
     });
 
-    fiber_runner_thread_.detach();
+    fiber_runner_thread.detach();
   }
 
   void EnqueueFiber(std::function<void()> &&callback) {
@@ -173,19 +173,18 @@ class FiberState {
   // The fiber stack allocator.
   boost::fibers::fixedsize_stack allocator_;
   /// The fiber channel used to send task between the submitter thread
-  /// (main direct_actor_trasnport thread) and the fiber_runner_thread_ (defined below)
+  /// (main direct_actor_trasnport thread) and the fiber_runner_thread
   FiberChannel channel_;
   /// The fiber semaphore used to limit the number of concurrent fibers
   /// running at once.
   FiberRateLimiter rate_limiter_;
-  /// The fiber event used to notify that all worker fibers are stopped running.
-  /// Since we don't join the fiber_runner_thread, it's possible that the
+  /// The fiber event used to notify that the event loop in fiber_runner_thread
+  /// have stopped running.
+  /// Since we don't join the fiber threads, it's possible that the
   /// `fiber_runner_thread_` still accesses the `fiber_stopped_event_` after it's
   /// deallocated in the main thread. As a result, we use a shared_ptr here to make sure
   /// it's not deallocated if `fiber_runner_thread_` still has a reference to it.
   std::shared_ptr<StdEvent> fiber_stopped_event_;
-  /// The thread that runs all asyncio fibers. is_asyncio_ must be true.
-  std::thread fiber_runner_thread_;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/fiber.h
+++ b/src/ray/core_worker/fiber.h
@@ -140,6 +140,8 @@ class FiberState {
         std::this_thread::sleep_for(std::chrono::hours(1));
       }
     });
+
+    fiber_runner_thread_.detach();
   }
 
   void EnqueueFiber(std::function<void()> &&callback) {
@@ -155,7 +157,6 @@ class FiberState {
 
   void Join() {
     fiber_stopped_event_->Wait();
-    fiber_runner_thread_.detach();
   }
 
  private:

--- a/src/ray/core_worker/test/fiber_state_test.cc
+++ b/src/ray/core_worker/test/fiber_state_test.cc
@@ -95,6 +95,14 @@ TEST(FiberStateTest, RespectsConcurrencyLimit) {
   fiber_state.Join();
 }
 
+TEST(FiberStateTest, DoubleStopJoin) {
+  FiberState fiber_state(2);
+  fiber_state.Stop();
+  fiber_state.Join();
+  fiber_state.Stop();
+  fiber_state.Join();
+}
+
 }  // namespace core
 }  // namespace ray
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently `fiber_runner_thread_.detach()` is called in `Fiber.Join()`. But `Fiber.Join()` could be called multiple times. For example, `ConcurrencyGroupManager` could call `Join()` the same number of times as the number of workers. This could result in double `detach()` failure.

`detach()` **should** be called after `fiber_runner_thread_` was created. That's the right pattern to use std thread.

## Related issue number

<!-- For example: "Closes #1234" -->

Fix https://github.com/ray-project/ray/issues/45656

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
