### PR TITLE
[Data] Update `ipywidgets==8.0.6`

### DIFF
--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -72,7 +72,7 @@ xlrd==2.0.1
 yq==3.2.2
 memray; platform_system != "Windows" and sys_platform != "darwin" and platform_machine != 'aarch64'
 numpy==1.24.4
-ipywidgets==7.7.2
+ipywidgets==8.0.6
 
 # For doc tests
 myst-parser==0.15.2

--- a/release/ray_release/byod/requirements_ml_byod_3.9.in
+++ b/release/ray_release/byod/requirements_ml_byod_3.9.in
@@ -18,11 +18,7 @@ fastapi
 filelock
 gcsfs==2023.5.0
 gsutil
-# Ray Data progress bars do not load with newer versions of
-# ipywidgets + older versions of VSCode Web. Pin the version
-# until VSCode Web is updated, as recommended in
-# https://github.com/microsoft/vscode-jupyter/issues/8552.
-ipywidgets==7.7.2
+ipywidgets
 jupytext
 lm_eval
 locust==2.18.0

--- a/release/ray_release/byod/requirements_ml_byod_3.9.txt
+++ b/release/ray_release/byod/requirements_ml_byod_3.9.txt
@@ -1609,7 +1609,7 @@ ipython-genutils==0.2.0 \
     #   ipywidgets
     #   nbclassic
     #   notebook
-ipywidgets==7.7.2 \
+ipywidgets==8.0.6 \
     --hash=sha256:3d47a7826cc6e2644d7cb90db26699451f8b42379cf63b761431b63d19984ca2 \
     --hash=sha256:449ab8e7872d0f388ee5c5b3666b9d6af5e5618a5749fd62652680be37dff2af
     # via


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When using Jupyter notebooks on VSCode with lower versions of `ipywidgets` (<8), users will sometimes see warnings like
```
INFO util.py:154 -- Outdated packages:
  ipywidgets==7.7.2 found, needs ipywidgets>=8
Run `pip install -U ipywidgets`, then restart the notebook server for rich notebook output.
```

This upgrades the version of `ipywidgets` to avoid this error. 


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
