### PR TITLE
[rllib] uninstall tensorflow + tensorflow_probabily before reinstall

### DIFF
--- a/release/ray_release/byod/byod_rllib_test.sh
+++ b/release/ray_release/byod/byod_rllib_test.sh
@@ -6,14 +6,15 @@ set -exo pipefail
 
 
 # TODO: https://github.com/Farama-Foundation/AutoROM/issues/48
-pip3 install https://ray-ci-deps-wheels.s3.us-west-2.amazonaws.com/AutoROM.accept_rom_license-0.5.4-py3-none-any.whl
+pip install https://ray-ci-deps-wheels.s3.us-west-2.amazonaws.com/AutoROM.accept_rom_license-0.5.4-py3-none-any.whl
 git clone https://github.com/ray-project/rl-experiments.git
 unzip rl-experiments/halfcheetah-sac/2022-12-17/halfcheetah_1500_mean_reward_sac.zip -d ~/.
-pip3 uninstall -y minigrid
-pip3 install werkzeug==2.3.8
+pip uninstall -y minigrid
+pip install werkzeug==2.3.8
 
 # not strictly necessary, but makes debugging easier
 git clone https://github.com/ray-project/ray.git
 
 # Only DreamerV3 still uses tf on the new API stack. But requires tf==2.11.1 to run.
-pip3 install tensorflow==2.11.1 tensorflow_probability==0.19.0
+pip uninstall -y tensorflow tensorflow_probability
+pip install tensorflow==2.11.1 tensorflow_probability==0.19.0


### PR DESCRIPTION
Some release tests are failing https://github.com/orgs/anyscale/projects/76/views/1?pane=issue&itemId=66842882 with the error 

`tensorflow.python.util.tf_export.SymbolAlreadyExposedError: Symbol Zeros is already exposed as ().`

Some suggestions on the internet suggests the installation of tensorlfow might be corrupted

Test:
- CI
- Release test