### PR TITLE
[wheel] remove py38 in build wheel script

### DIFF
--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -6,7 +6,6 @@ export RAY_INSTALL_JAVA="${RAY_INSTALL_JAVA:-0}"
 
 # Python version key, interpreter version code
 PYTHON_VERSIONS=(
-  "py38 cp38-cp38"
   "py39 cp39-cp39"
   "py310 cp310-cp310"
   "py311 cp311-cp311"


### PR DESCRIPTION
py38 is gone and it is not buildable
