### PR TITLE
[Dashboard] Parse out json logs

### DIFF
--- a/dashboard/client/src/components/LogView/LogVirtualView.tsx
+++ b/dashboard/client/src/components/LogView/LogVirtualView.tsx
@@ -3,7 +3,13 @@ import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
 import dayjs from "dayjs";
 import low from "lowlight";
-import React, { MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { FixedSizeList as List } from "react-window";
 import DialogWithTitle from "../../common/DialogWithTitle";
 import "./darcula.css";

--- a/dashboard/client/src/components/LogView/LogVirtualView.tsx
+++ b/dashboard/client/src/components/LogView/LogVirtualView.tsx
@@ -201,7 +201,8 @@ const LogVirtualView: React.FC<LogVirtualViewProps> = ({
     let formattedLogLine = origin;
     try {
       const parsed_origin = JSON.parse(origin);
-      message = parsed_origin.message;
+      // Iff the parsed origin has a message field, use it as the message.
+      message = parsed_origin.message || origin;
       formattedLogLine = JSON.stringify(parsed_origin, null, 2);
     } catch (e) {
       // Keep the `origin` as message and formattedLogLine, if json parsing failed.

--- a/dashboard/client/src/components/LogView/LogVirtualView.tsx
+++ b/dashboard/client/src/components/LogView/LogVirtualView.tsx
@@ -110,12 +110,7 @@ const LogLineDetailDialog = ({
   onClose,
 }: LogLineDetailDialogProps) => {
   return (
-    <DialogWithTitle
-      title="Log line details"
-      handleClose={() => {
-        onClose();
-      }}
-    >
+    <DialogWithTitle title="Log line details" handleClose={onClose}>
       <Box
         sx={{
           display: "flex",
@@ -200,10 +195,20 @@ const LogVirtualView: React.FC<LogVirtualViewProps> = ({
     let message = origin;
     let formattedLogLine = origin;
     try {
-      const parsed_origin = JSON.parse(origin);
+      const parsedOrigin = JSON.parse(origin);
       // Iff the parsed origin has a message field, use it as the message.
-      message = parsed_origin.message || origin;
-      formattedLogLine = JSON.stringify(parsed_origin, null, 2);
+      if (parsedOrigin.message) {
+        message = parsedOrigin.message;
+        // If levelname exist on the structured logs, put it in front of the message.
+        if (parsedOrigin.levelname) {
+          message = `${parsedOrigin.levelname} ${message}`;
+        }
+        // If asctime exist on the structured logs, use it as the prefix of the message.
+        if (parsedOrigin.asctime) {
+          message = `${parsedOrigin.asctime}\t${message}`;
+        }
+      }
+      formattedLogLine = JSON.stringify(parsedOrigin, null, 2);
     } catch (e) {
       // Keep the `origin` as message and formattedLogLine, if json parsing failed.
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Most of these are taken from [LogLineDetailDialog](https://github.com/anyscale/product/blob/ccbd8761e40790232483f5c10805020b3a733188/frontend/web/src/common/LogViewerV2/LogViewerV2.tsx#L1008) with some modification to only show the log line itself. 

This PR will allow the dashboard to only render the message part on the log viewer if the log can be parsed as a json object. If not, then the original log line is continue to be rendered. Also enabled the feature to click onto a log line to render the entire log line with json log line being parsed with pretty formatting.

## Related issue number

Closes https://github.com/ray-project/ray/issues/45869

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Also manually tested locally:
Log viewer with json logs only renders the message
<img width="1284" alt="image" src="https://github.com/ray-project/ray/assets/7553988/feb23e1a-1860-4b72-bcd3-9fd4bbaf823c">
Clicked into a log line seeing the full parsed out json log line
<img width="1337" alt="image" src="https://github.com/ray-project/ray/assets/7553988/fdf24a1c-46bb-411b-9615-57c510982ee2">
Log viewer with string logs render the same as before
<img width="1450" alt="image" src="https://github.com/ray-project/ray/assets/7553988/603d5228-40fe-4035-a33c-f3f1119863f1">
Click into the log line continue to see the full message
<img width="1364" alt="image" src="https://github.com/ray-project/ray/assets/7553988/01721a85-ad7d-4b3d-b3ce-0b9402180e6d">


