### PR TITLE
[core] On GCS restart, destroy not forget the unused workers. Fixing PG leaks.

### DIFF
--- a/src/mock/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -30,7 +30,7 @@ class MockGcsActorSchedulerInterface : public GcsActorSchedulerInterface {
               (override));
   MOCK_METHOD(
       void,
-      ReleaseUnusedWorkers,
+      ReleaseUnusedActorWorkers,
       ((const absl::flat_hash_map<NodeID, std::vector<WorkerID>> &node_to_workers)),
       (override));
 };
@@ -70,7 +70,7 @@ class MockGcsActorScheduler : public GcsActorScheduler {
               (override));
   MOCK_METHOD(
       void,
-      ReleaseUnusedWorkers,
+      ReleaseUnusedActorWorkers,
       ((const absl::flat_hash_map<NodeID, std::vector<WorkerID>> &node_to_workers)),
       (override));
   MOCK_METHOD(void,

--- a/src/mock/ray/raylet_client/raylet_client.h
+++ b/src/mock/ray/raylet_client/raylet_client.h
@@ -49,9 +49,9 @@ class MockRayletClientInterface : public RayletClientInterface {
                const rpc::ClientCallback<rpc::GetTaskFailureCauseReply> &callback),
               (override));
   MOCK_METHOD(void,
-              ReleaseUnusedWorkers,
+              ReleaseUnusedActorWorkers,
               (const std::vector<WorkerID> &workers_in_use,
-               const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback),
+               const rpc::ClientCallback<rpc::ReleaseUnusedActorWorkersReply> &callback),
               (override));
   MOCK_METHOD(void,
               CancelWorkerLease,

--- a/src/ray/core_worker/test/direct_task_transport_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_test.cc
@@ -233,9 +233,10 @@ class MockRayletClient : public WorkerLeaseInterface {
     callbacks.push_back(callback);
   }
 
-  void ReleaseUnusedWorkers(
+  void ReleaseUnusedActorWorkers(
       const std::vector<WorkerID> &workers_in_use,
-      const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) override {}
+      const rpc::ClientCallback<rpc::ReleaseUnusedActorWorkersReply> &callback) override {
+  }
 
   void CancelWorkerLease(
       const TaskID &task_id,

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1480,7 +1480,7 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
   });
 
   // Notify raylets to release unused workers.
-  gcs_actor_scheduler_->ReleaseUnusedWorkers(node_to_workers);
+  gcs_actor_scheduler_->ReleaseUnusedActorWorkers(node_to_workers);
 
   RAY_LOG(DEBUG) << "The number of registered actors is " << registered_actors_.size()
                  << ", and the number of created actors is " << created_actors_.size();

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -82,7 +82,7 @@ class GcsActorSchedulerInterface {
   /// Notify raylets to release unused workers.
   ///
   /// \param node_to_workers Workers used by each node.
-  virtual void ReleaseUnusedWorkers(
+  virtual void ReleaseUnusedActorWorkers(
       const absl::flat_hash_map<NodeID, std::vector<WorkerID>> &node_to_workers) = 0;
 
   /// Handle the destruction of an actor.
@@ -178,7 +178,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   /// Notify raylets to release unused workers.
   ///
   /// \param node_to_workers Workers used by each node.
-  void ReleaseUnusedWorkers(
+  void ReleaseUnusedActorWorkers(
       const absl::flat_hash_map<NodeID, std::vector<WorkerID>> &node_to_workers) override;
 
   /// Handle the destruction of an actor.
@@ -418,7 +418,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   FRIEND_TEST(GcsActorSchedulerTest, TestWorkerFailedWhenCreating);
   FRIEND_TEST(GcsActorSchedulerTest, TestSpillback);
   FRIEND_TEST(GcsActorSchedulerTest, TestReschedule);
-  FRIEND_TEST(GcsActorSchedulerTest, TestReleaseUnusedWorkers);
+  FRIEND_TEST(GcsActorSchedulerTest, TestReleaseUnusedActorWorkers);
   FRIEND_TEST(GcsActorSchedulerTest, TestScheduleFailedWithZeroNodeByGcs);
   FRIEND_TEST(GcsActorSchedulerTest, TestNotEnoughClusterResources);
   FRIEND_TEST(GcsActorSchedulerTest, TestScheduleAndDestroyOneActor);
@@ -431,7 +431,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   FRIEND_TEST(GcsActorSchedulerTest, TestNodeFailedWhenCreatingByGcs);
   FRIEND_TEST(GcsActorSchedulerTest, TestWorkerFailedWhenCreatingByGcs);
   FRIEND_TEST(GcsActorSchedulerTest, TestRescheduleByGcs);
-  FRIEND_TEST(GcsActorSchedulerTest, TestReleaseUnusedWorkersByGcs);
+  FRIEND_TEST(GcsActorSchedulerTest, TestReleaseUnusedActorWorkersByGcs);
 
   friend class GcsActorSchedulerMockTest;
   FRIEND_TEST(GcsActorSchedulerMockTest, KillWorkerLeak1);

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -37,7 +37,7 @@ class MockActorScheduler : public gcs::GcsActorSchedulerInterface {
 
   void Schedule(std::shared_ptr<gcs::GcsActor> actor) { actors.push_back(actor); }
   void Reschedule(std::shared_ptr<gcs::GcsActor> actor) {}
-  void ReleaseUnusedWorkers(
+  void ReleaseUnusedActorWorkers(
       const absl::flat_hash_map<NodeID, std::vector<WorkerID>> &node_to_workers) {}
   void OnActorDestruction(std::shared_ptr<gcs::GcsActor> actor) {
     const auto &actor_id = actor->GetActorID();

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -100,9 +100,10 @@ struct GcsServerMocker {
     }
 
     /// WorkerLeaseInterface
-    void ReleaseUnusedWorkers(
+    void ReleaseUnusedActorWorkers(
         const std::vector<WorkerID> &workers_in_use,
-        const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) override {
+        const rpc::ClientCallback<rpc::ReleaseUnusedActorWorkersReply> &callback)
+        override {
       num_release_unused_workers += 1;
       release_callbacks.push_back(callback);
     }
@@ -188,8 +189,8 @@ struct GcsServerMocker {
       }
     }
 
-    bool ReplyReleaseUnusedWorkers() {
-      rpc::ReleaseUnusedWorkersReply reply;
+    bool ReplyReleaseUnusedActorWorkers() {
+      rpc::ReleaseUnusedActorWorkersReply reply;
       if (release_callbacks.size() == 0) {
         return false;
       } else {
@@ -335,7 +336,8 @@ struct GcsServerMocker {
     std::list<rpc::ClientCallback<rpc::DrainRayletReply>> drain_raylet_callbacks = {};
     std::list<rpc::ClientCallback<rpc::RequestWorkerLeaseReply>> callbacks = {};
     std::list<rpc::ClientCallback<rpc::CancelWorkerLeaseReply>> cancel_callbacks = {};
-    std::list<rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply>> release_callbacks = {};
+    std::list<rpc::ClientCallback<rpc::ReleaseUnusedActorWorkersReply>>
+        release_callbacks = {};
     int num_lease_requested = 0;
     int num_return_requested = 0;
     int num_commit_requested = 0;

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -142,8 +142,7 @@ message ReleaseUnusedActorWorkersRequest {
   repeated bytes worker_ids_in_use = 1;
 }
 
-message ReleaseUnusedActorWorkersReply {
-}
+message ReleaseUnusedActorWorkersReply {}
 
 message ShutdownRayletRequest {
   /// Whether the shutdown request is graceful or not.

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -138,11 +138,11 @@ message ReturnWorkerRequest {
 message ReturnWorkerReply {
 }
 
-message ReleaseUnusedWorkersRequest {
+message ReleaseUnusedActorWorkersRequest {
   repeated bytes worker_ids_in_use = 1;
 }
 
-message ReleaseUnusedWorkersReply {
+message ReleaseUnusedActorWorkersReply {
 }
 
 message ShutdownRayletRequest {
@@ -383,8 +383,8 @@ service NodeManagerService {
   // that may be leaked. When GCS restarts, it doesn't know which workers it has leased
   // in the previous lifecycle. In this case, GCS will send a list of worker ids that
   // are still needed. And Raylet will release other leased workers.
-  rpc ReleaseUnusedWorkers(ReleaseUnusedWorkersRequest)
-      returns (ReleaseUnusedWorkersReply);
+  rpc ReleaseUnusedActorWorkers(ReleaseUnusedActorWorkersRequest)
+      returns (ReleaseUnusedActorWorkersReply);
   /// Shutdown the raylet (node manager).
   rpc ShutdownRaylet(ShutdownRayletRequest) returns (ShutdownRayletReply);
   // Request to drain the raylet.

--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -1137,12 +1137,12 @@ void LocalTaskManager::DebugStr(std::stringstream &buffer) const {
                                          .GetTaskSpecification()
                                          .FunctionDescriptor()
                                          ->CallString();
-    buffer << "    - ("
-           << "language="
+    buffer << "    - (language="
            << rpc::Language_descriptor()->FindValueByNumber(worker->GetLanguage())->name()
            << " "
            << "actor_or_task=" << task_or_actor_name << " "
-           << "pid=" << worker->GetProcess().GetId() << "): "
+           << "pid=" << worker->GetProcess().GetId() << " "
+           << "worker_id=" << worker->WorkerId() << "): "
            << worker->GetAssignedTask()
                   .GetTaskSpecification()
                   .GetRequiredResources()

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2020,9 +2020,10 @@ void NodeManager::HandleShutdownRaylet(rpc::ShutdownRayletRequest request,
   send_reply_callback(Status::OK(), shutdown_after_reply, shutdown_after_reply);
 }
 
-void NodeManager::HandleReleaseUnusedWorkers(rpc::ReleaseUnusedWorkersRequest request,
-                                             rpc::ReleaseUnusedWorkersReply *reply,
-                                             rpc::SendReplyCallback send_reply_callback) {
+void NodeManager::HandleReleaseUnusedActorWorkers(
+    rpc::ReleaseUnusedActorWorkersRequest request,
+    rpc::ReleaseUnusedActorWorkersReply *reply,
+    rpc::SendReplyCallback send_reply_callback) {
   std::unordered_set<WorkerID> in_use_worker_ids;
   for (int index = 0; index < request.worker_ids_in_use_size(); ++index) {
     auto worker_id = WorkerID::FromBinary(request.worker_ids_in_use(index));
@@ -2031,8 +2032,7 @@ void NodeManager::HandleReleaseUnusedWorkers(rpc::ReleaseUnusedWorkersRequest re
 
   std::vector<std::shared_ptr<WorkerInterface>> unused_workers;
   for (auto &iter : leased_workers_) {
-    // We need to exclude workers used by common tasks.
-    // Because they are not used by GCS.
+    // We only kill *actor* workers.
     if (!iter.second->GetActorId().IsNil() && !in_use_worker_ids.count(iter.first)) {
       unused_workers.push_back(iter.second);
     }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2030,7 +2030,7 @@ void NodeManager::HandleReleaseUnusedActorWorkers(
     in_use_worker_ids.emplace(worker_id);
   }
 
-  std::vector<std::shared_ptr<WorkerInterface>> unused_workers;
+  std::vector<std::shared_ptr<WorkerInterface>> unused_actor_workers;
   for (auto &iter : leased_workers_) {
     // We only kill *actor* workers.
     if (!iter.second->GetActorId().IsNil() && !in_use_worker_ids.count(iter.first)) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2034,11 +2034,13 @@ void NodeManager::HandleReleaseUnusedActorWorkers(
   for (auto &iter : leased_workers_) {
     // We only kill *actor* workers.
     if (!iter.second->GetActorId().IsNil() && !in_use_worker_ids.count(iter.first)) {
-      unused_workers.push_back(iter.second);
+      unused_actor_workers.push_back(iter.second);
     }
   }
 
-  for (auto &worker : unused_workers) {
+  for (auto &worker : unused_actor_workers) {
+    RAY_LOG(DEBUG) << "GCS requested to release unused actor worker: "
+                   << worker->WorkerId();
     DestroyWorker(worker,
                   rpc::WorkerExitType::INTENDED_SYSTEM_EXIT,
                   "Worker is no longer needed by the GCS.");

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -535,7 +535,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
 
   /// Handle a `ReleaseUnusedActorWorkers` request.
   // On GCS restart, there's a pruning effort. GCS sends raylet a list of actor workers it still
-  // wants (that it keeps tracks of); and the raylet destroys all other workers.
+  // wants (that it keeps tracks of); and the raylet destroys all other actor workers.
   void HandleReleaseUnusedActorWorkers(
       rpc::ReleaseUnusedActorWorkersRequest request,
       rpc::ReleaseUnusedActorWorkersReply *reply,

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -533,12 +533,13 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
                           rpc::ReturnWorkerReply *reply,
                           rpc::SendReplyCallback send_reply_callback) override;
 
-  /// Handle a `ReleaseUnusedWorkers` request.
+  /// Handle a `ReleaseUnusedActorWorkers` request.
   // On GCS restart, there's a pruning effort. GCS sends raylet a list of workers it still
   // wants (that it keeps tracks of); and the raylet destroys all other workers.
-  void HandleReleaseUnusedWorkers(rpc::ReleaseUnusedWorkersRequest request,
-                                  rpc::ReleaseUnusedWorkersReply *reply,
-                                  rpc::SendReplyCallback send_reply_callback) override;
+  void HandleReleaseUnusedActorWorkers(
+      rpc::ReleaseUnusedActorWorkersRequest request,
+      rpc::ReleaseUnusedActorWorkersReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `ShutdownRaylet` request.
   void HandleShutdownRaylet(rpc::ShutdownRayletRequest request,

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -229,15 +229,12 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   }
 
  private:
+  // Removes the worker from node_manager's leased_workers_ map.
+  // Warning: this does NOT release the worker's resources, or put the leased worker
+  // back to the worker pool, or destroy the worker. The caller must handle the worker's
+  // resources well.
   void ReleaseWorker(const WorkerID &worker_id) {
     leased_workers_.erase(worker_id);
-    SetIdleIfLeaseEmpty();
-  }
-
-  void ReleaseWorkers(const std::vector<WorkerID> &worker_ids) {
-    for (auto &it : worker_ids) {
-      leased_workers_.erase(it);
-    }
     SetIdleIfLeaseEmpty();
   }
 
@@ -537,6 +534,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
                           rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `ReleaseUnusedWorkers` request.
+  // On GCS restart, there's a pruning effort. GCS sends raylet a list of workers it still
+  // wants (that it keeps tracks of); and the raylet destroys all other workers.
   void HandleReleaseUnusedWorkers(rpc::ReleaseUnusedWorkersRequest request,
                                   rpc::ReleaseUnusedWorkersReply *reply,
                                   rpc::SendReplyCallback send_reply_callback) override;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -534,7 +534,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
                           rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `ReleaseUnusedActorWorkers` request.
-  // On GCS restart, there's a pruning effort. GCS sends raylet a list of workers it still
+  // On GCS restart, there's a pruning effort. GCS sends raylet a list of actor workers it still
   // wants (that it keeps tracks of); and the raylet destroys all other workers.
   void HandleReleaseUnusedActorWorkers(
       rpc::ReleaseUnusedActorWorkersRequest request,

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -534,8 +534,9 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
                           rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `ReleaseUnusedActorWorkers` request.
-  // On GCS restart, there's a pruning effort. GCS sends raylet a list of actor workers it still
-  // wants (that it keeps tracks of); and the raylet destroys all other actor workers.
+  // On GCS restart, there's a pruning effort. GCS sends raylet a list of actor workers it
+  // still wants (that it keeps tracks of); and the raylet destroys all other actor
+  // workers.
   void HandleReleaseUnusedActorWorkers(
       rpc::ReleaseUnusedActorWorkersRequest request,
       rpc::ReleaseUnusedActorWorkersReply *reply,

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -441,16 +441,16 @@ void raylet::RayletClient::PushMutableObject(
       });
 }
 
-void raylet::RayletClient::ReleaseUnusedWorkers(
+void raylet::RayletClient::ReleaseUnusedActorWorkers(
     const std::vector<WorkerID> &workers_in_use,
-    const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) {
-  rpc::ReleaseUnusedWorkersRequest request;
+    const rpc::ClientCallback<rpc::ReleaseUnusedActorWorkersReply> &callback) {
+  rpc::ReleaseUnusedActorWorkersRequest request;
   for (auto &worker_id : workers_in_use) {
     request.add_worker_ids_in_use(worker_id.Binary());
   }
-  grpc_client_->ReleaseUnusedWorkers(
+  grpc_client_->ReleaseUnusedActorWorkers(
       request,
-      [callback](const Status &status, const rpc::ReleaseUnusedWorkersReply &reply) {
+      [callback](const Status &status, const rpc::ReleaseUnusedActorWorkersReply &reply) {
         if (!status.ok()) {
           RAY_LOG(WARNING)
               << "Error releasing workers from raylet, the raylet may have died:"

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -90,9 +90,9 @@ class WorkerLeaseInterface {
   /// \param workers_in_use Workers currently in use.
   /// \param callback Callback that will be called after raylet completes the release of
   /// unused workers. \return ray::Status
-  virtual void ReleaseUnusedWorkers(
+  virtual void ReleaseUnusedActorWorkers(
       const std::vector<WorkerID> &workers_in_use,
-      const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) = 0;
+      const rpc::ClientCallback<rpc::ReleaseUnusedActorWorkersReply> &callback) = 0;
 
   virtual void CancelWorkerLease(
       const TaskID &task_id,
@@ -476,9 +476,9 @@ class RayletClient : public RayletClientInterface {
       const std::vector<rpc::WorkerBacklogReport> &backlog_reports) override;
 
   /// Implements WorkerLeaseInterface.
-  void ReleaseUnusedWorkers(
+  void ReleaseUnusedActorWorkers(
       const std::vector<WorkerID> &workers_in_use,
-      const rpc::ClientCallback<rpc::ReleaseUnusedWorkersReply> &callback) override;
+      const rpc::ClientCallback<rpc::ReleaseUnusedActorWorkersReply> &callback) override;
 
   void CancelWorkerLease(
       const TaskID &task_id,

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -111,7 +111,7 @@ class NodeManagerWorkerClient
 
   /// Release unused workers.
   VOID_RPC_CLIENT_METHOD(NodeManagerService,
-                         ReleaseUnusedWorkers,
+                         ReleaseUnusedActorWorkers,
                          grpc_client_,
                          /*method_timeout_ms*/ -1, )
 

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -28,29 +28,29 @@ namespace rpc {
   RPC_SERVICE_HANDLER_CUSTOM_AUTH(NodeManagerService, METHOD, -1, AuthType::NO_AUTH)
 
 /// NOTE: See src/ray/core_worker/core_worker.h on how to add a new grpc handler.
-#define RAY_NODE_MANAGER_RPC_HANDLERS                          \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetResourceLoad)        \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(NotifyGCSRestart)       \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(RequestWorkerLease)     \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReportWorkerBacklog)    \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReturnWorker)           \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReleaseUnusedWorkers)   \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(CancelWorkerLease)      \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(PinObjectIDs)           \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetNodeStats)           \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GlobalGC)               \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(FormatGlobalMemoryInfo) \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(PrepareBundleResources) \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(CommitBundleResources)  \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(CancelResourceReserve)  \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReleaseUnusedBundles)   \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetSystemConfig)        \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ShutdownRaylet)         \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(DrainRaylet)            \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetTasksInfo)           \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetObjectsInfo)         \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetTaskFailureCause)    \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(RegisterMutableObject)  \
+#define RAY_NODE_MANAGER_RPC_HANDLERS                             \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetResourceLoad)           \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(NotifyGCSRestart)          \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(RequestWorkerLease)        \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReportWorkerBacklog)       \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReturnWorker)              \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReleaseUnusedActorWorkers) \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(CancelWorkerLease)         \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(PinObjectIDs)              \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetNodeStats)              \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GlobalGC)                  \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(FormatGlobalMemoryInfo)    \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(PrepareBundleResources)    \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(CommitBundleResources)     \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(CancelResourceReserve)     \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ReleaseUnusedBundles)      \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetSystemConfig)           \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ShutdownRaylet)            \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(DrainRaylet)               \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetTasksInfo)              \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetObjectsInfo)            \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetTaskFailureCause)       \
+  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(RegisterMutableObject)     \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(PushMutableObject)
 
 /// Interface of the `NodeManagerService`, see `src/ray/protobuf/node_manager.proto`.
@@ -87,9 +87,9 @@ class NodeManagerServiceHandler {
                                   ReturnWorkerReply *reply,
                                   SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleReleaseUnusedWorkers(ReleaseUnusedWorkersRequest request,
-                                          ReleaseUnusedWorkersReply *reply,
-                                          SendReplyCallback send_reply_callback) = 0;
+  virtual void HandleReleaseUnusedActorWorkers(ReleaseUnusedActorWorkersRequest request,
+                                               ReleaseUnusedActorWorkersReply *reply,
+                                               SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleShutdownRaylet(ShutdownRayletRequest request,
                                     ShutdownRayletReply *reply,


### PR DESCRIPTION
On GCS restart, it prunes any worker it did not bookkeep, via the RPC `ReleaseUnusedWorkers`. Raylet receives it and removes any workers not in a `worker_ids_in_use` list. However, it's only *forgetting* the worker by removing it from the `leased_workers_` not *killing* the worker, but the worker can be still in running and never gets killed, hence leaked.

The evidence leading to this PR is, in a Ray cluster I observed GCS failed to kill a placement group: it sends "pls remove all workers in this PG", and raylet did not kill any workers, and then it finds the PG is still in used and replied "failed, pls retry" for many minutes, and finally GCS gave up and the PG is removed from the GCS, and the worker leaked. I found the PG holding worker is NOT in leased_workers_, but it IS known by worker_pool, since it shows up in worker pool's state dump.

The reason behind the above case is, when GCS is restarting, it **wrongly** thinks the worker is no longer needed (due to another bug (https://github.com/ray-project/ray/pull/45791 actors whose parent is detached actor is considered dead but should be alive), and orders Raylet to release it. Raylet, as fixed in this PR, simply forgets the worker but does not kill it.

To make things more clear, here is a timeline:

1. Creates a detached actor `Parent`, which creates a PG `pg` and a normal actor `Child` in pg
2. Job for `Parent` dies. Everyone should live on, since everyone's lifetime = detached Parent's
3. GCS restarts
4. BUG1 (Fixed by #45791): GCS thinks `Child` should be die, and,
    - did not load it (it's forgotten by GCS). This makes the child is never killed later
        - should be: load it, can kill it later 
    - sends `ReleaseUnusedWorkers` to Raylet with this worker as "not used"
        - should be: mark this as "used" so it's not killed by Raylet
 5. BUG2 (this bug): Raylet should kill the worker since it's "not used" by GCS. However it simply forgets it.
    - this makes the worker leak on Raylet side: later when it needs to be killed (by PG removal), it can not.
    - should be: kill it (DestroyWorker) on the RPC, so we could have exposed the first bug earlier.
6. Because of BUG1, when the detached actor Parent is dead, nobody is killing Child actor. (forgot by GCS)
7. Because of BUG2, when the PG is removed since Parent is dead, the PG removal failed with a worker leak (forgot by raylet)

Note since FIX1 (#45791) is merged, Raylet should no longer kill the detached actor on RPC because it's considered used. This FIX2 is just for the sake of completeness, and for future leaks.


In this PR:
- On `ReleaseUnusedWorkers`, instead of forgetting the workers we call DestroyWorker to kill it
- In state dump, print the actors' worker ID for debugging ease.
- Removed useless `ReleaseWorkers` method
- Comments
- Renamed RPC to `ReleaseUnusedActorWorkers` to make it dead clear.

Fixes #45598.