### PR TITLE
MADDPG framework should be TensorFlow

### DIFF
--- a/rllib_contrib/maddpg/tuned_examples/two-step-game-maddpg.yaml
+++ b/rllib_contrib/maddpg/tuned_examples/two-step-game-maddpg.yaml
@@ -9,7 +9,7 @@ two-step-game-maddpg:
         timesteps_total: 20000
     config:
         # MADDPG only supports tf for now.
-        framework: torch
+        framework: tf
 
         env_config:
             env_config:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes the MADDPG example from rllib_contrib
I've tested it by running: `rllib train file two-step-game-maddpg.yaml` 

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
