### PR TITLE
Enable setting OS disk size in Azure

### DIFF
--- a/python/ray/autoscaler/_private/_azure/azure-vm-template.json
+++ b/python/ray/autoscaler/_private/_azure/azure-vm-template.json
@@ -44,6 +44,13 @@
                 "description": "The version of the VM image"
             }
         },
+        "diskSizeGB": {
+            "type": "int",
+            "defaultValue": 64,
+            "metadata": {
+                "description": "Size of the OS disk in GB"
+            }
+        },
         "vmSize": {
             "type": "string",
             "metadata": {
@@ -220,7 +227,8 @@
                         "createOption": "fromImage",
                         "managedDisk": {
                             "storageAccountType": "[variables('osDiskType')]"
-                        }
+                        },
+                        "diskSizeGB": "[parameters('diskSizeGB')]"
                     },
                     "imageReference": {
                         "publisher": "[parameters('imagePublisher')]",


### PR DESCRIPTION
## Why are these changes needed?

Currently, the default OS disks on Azure have a capacity of around 30GB.  This causes cluster creation and tasks to often fail because many ray docker images and support files are around this size.  When it does succeed, it also prevents object spilling.

This enables specifying the OS disk size to get around these limitations.  It also ups the default OS disk size to 64GB.  

## Related issue number

[This](https://discuss.ray.io/t/azure-vm-disk-specs-via-config/1495) is a related discussion.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
