### PR TITLE
Adds new working dir upload protocol PLASMA, and use it in job submission.

### DIFF
--- a/dashboard/modules/dashboard_sdk.py
+++ b/dashboard/modules/dashboard_sdk.py
@@ -23,7 +23,10 @@ from ray._private.runtime_env.packaging import (
     get_uri_for_package,
 )
 from ray._private.runtime_env.py_modules import upload_py_modules_if_needed
-from ray._private.runtime_env.working_dir import upload_working_dir_if_needed
+from ray._private.runtime_env.working_dir import (
+    upload_working_dir_if_needed,
+    Protocol as WorkingDirProtocol,
+)
 from ray.dashboard.modules.job.common import uri_to_http_components
 
 from ray.util.annotations import DeveloperAPI, PublicAPI
@@ -369,9 +372,13 @@ class SubmissionClient:
         is_file: bool = False,
     ) -> str:
         if is_file:
-            package_uri = get_uri_for_package(Path(package_path))
+            package_uri = get_uri_for_package(
+                Path(package_path), protocol=WorkingDirProtocol.PLASMA
+            )
         else:
-            package_uri = get_uri_for_directory(package_path, excludes=excludes)
+            package_uri = get_uri_for_directory(
+                package_path, excludes=excludes, protocol=WorkingDirProtocol.PLASMA
+            )
 
         if not self._package_exists(package_uri):
             self._upload_package(
@@ -395,7 +402,9 @@ class SubmissionClient:
                 is_file=is_file,
             )
 
-        upload_working_dir_if_needed(runtime_env, upload_fn=_upload_fn)
+        upload_working_dir_if_needed(
+            runtime_env, upload_fn=_upload_fn, protocol=WorkingDirProtocol.PLASMA
+        )
 
     def _upload_py_modules_if_needed(self, runtime_env: Dict[str, Any]):
         def _upload_fn(module_path, excludes, is_file=False):
@@ -403,7 +412,9 @@ class SubmissionClient:
                 module_path, include_parent_dir=True, excludes=excludes, is_file=is_file
             )
 
-        upload_py_modules_if_needed(runtime_env, upload_fn=_upload_fn)
+        upload_py_modules_if_needed(
+            runtime_env, upload_fn=_upload_fn, protocol=WorkingDirProtocol.PLASMA
+        )
 
     @PublicAPI(stability="beta")
     def get_version(self) -> str:

--- a/dashboard/modules/job/job_head.py
+++ b/dashboard/modules/job/job_head.py
@@ -19,7 +19,7 @@ import ray.dashboard.utils as dashboard_utils
 from ray._private.runtime_env.packaging import (
     package_exists,
     pin_runtime_env_uri,
-    upload_package_to_gcs,
+    upload_package_to_gcs_plasma,
 )
 from ray._private.utils import get_or_create_event_loop
 from ray.dashboard.modules.job.common import (
@@ -269,7 +269,7 @@ class JobHead(dashboard_utils.DashboardHeadModule):
             data = await req.read()
             await get_or_create_event_loop().run_in_executor(
                 self._upload_package_thread_pool_executor,
-                upload_package_to_gcs,
+                upload_package_to_gcs_plasma,
                 package_uri,
                 data,
             )

--- a/python/ray/_private/data_holder.py
+++ b/python/ray/_private/data_holder.py
@@ -1,0 +1,88 @@
+import ray
+import dataclasses
+from typing import Dict
+
+
+@dataclasses.dataclass
+class RefCountedObject:
+    """
+    Ref-counted bytes.
+    """
+
+    object_ref: ray.ObjectRef
+    ref_count: int
+
+
+# For circular imports, we can't use `ray.remote` here.
+# Instead we wrap the actor in get_data_holder().
+# @ray.remote(num_cpus=0)
+class DataHolder:
+    """
+    Global singleton that holds ref-counted bytes to be shared.
+    """
+
+    def __init__(self):
+        self.data: Dict[str, RefCountedObject] = {}
+
+    def create(self, key: str, value: bytes):
+        if not isinstance(key, str):
+            raise TypeError(f"Key must be str, got {type(key)}")
+        if not isinstance(value, bytes):
+            raise TypeError(f"Value must be bytes, got {type(value)}")
+        if key in self.data:
+            raise KeyError(f"Key {key} already exists.")
+        object_ref = ray.put(value)
+        self.data[key] = RefCountedObject(object_ref, 1)
+        return object_ref
+
+    def exists(self, key: str):
+        return key in self.data
+
+    def increment(self, key: str):
+        if key not in self.data:
+            raise KeyError(f"Key {key} does not exist.")
+        self.data[key].ref_count += 1
+        return self.data[key].object_ref
+
+    def decrement(self, key: str):
+        """
+        Returns True if the object is deleted.
+
+        TODO: Now it seems there's no clean up in packaging.py. It imports
+        _internal_kv_put but not _internal_kv_del. For a true "forever running cluster"
+        we will need to clean up.
+        """
+        if key not in self.data:
+            raise KeyError(f"Key {key} does not exist.")
+        self.data[key].ref_count -= 1
+        if self.data[key].ref_count == 0:
+            del self.data[key]
+            return True
+        return False
+
+    def get(self, key: str):
+        if key not in self.data:
+            raise KeyError(f"Key {key} does not exist.")
+        return self.data[key].object_ref
+
+
+DATA_HOLDER_NAME = "data_holder"
+DATA_HOLDER_NAMESPACE = "_data_holder"
+
+_global_data_holder = None
+
+
+def get_data_holder() -> DataHolder:
+    global _global_data_holder
+    if _global_data_holder is None:
+        _global_data_holder = (
+            ray.remote(num_cpus=0)(DataHolder)
+            .options(
+                name=DATA_HOLDER_NAME,
+                namespace=DATA_HOLDER_NAMESPACE,
+                get_if_exists=True,
+                lifetime="detached",
+            )
+            .remote()
+        )
+    return _global_data_holder


### PR DESCRIPTION
When user inits Ray with a working_dir, under the hood we package the user-local directory/zip and upload to the Ray cluster. However we are uploading it to the GCS Internal KV, which may pose unnecessary burden to our global process, who can already be very busy on large clusters.

This PR introduces a new "remote protocol" `plasma`. It spins up a global singleton detached actor `DataHolder`, which stores bytes into the Object Store. The package uploader invokes a Ray remote method to store it; the package downloader just do regular ray.get to download.

Problem: this requires `ray` be initialized in the first place. So when you do `ray.init(runtime_env={"working_dir":"./"}` you introduce a circular dependency between ray and DataHolder, which fails. For similar reasons, Ray Client can hardly do this.

Fortunately, Jobs can do that just fine. When you do `ray job submit`, it actually makes a HTTP PUT call to the dashboard JobAgent, which invokes anything needed to save the package. And there, DataHolder can work.

In this PR:
- a singleton DataHolder actor
- a new Protocol.PLASMA type
- changed all code from defaulting to GCS to require a Protocol type, and work with DataHolder if it's PLASMA.
- Use the new plasma in JobSubmissionClient & ServeSubmissionClient.

What's not changed:
- Ray driver script: `ray.init()` still uses GCS.
- Ray Client still uses GCS.

In the long run: we can extend Ray driver script & Ray client cases to all use HTTP PUT, and remove GCS code path.