### PR TITLE
[Serve] Run `__del__` even if constructor is still in-progress

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -731,9 +731,8 @@ class ReplicaActor:
         try:
             await self._user_callable_wrapper.call_destructor()
         except:
-            # We catch a blanket exception here because the constructor may
-            # still be running and may not have set some variables that the
-            # destructor uses.
+            # We catch a blanket exception since the constructor may still be
+            # running, so instance variables used by the destructor may not exist.
             if self._user_callable_initialized:
                 logger.exception(
                     "__del__ ran before replica finished initializing, and "

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -730,7 +730,7 @@ class ReplicaActor:
 
         try:
             await self._user_callable_wrapper.call_destructor()
-        except:
+        except:  # noqa: E722
             # We catch a blanket exception since the constructor may still be
             # running, so instance variables used by the destructor may not exist.
             if self._user_callable_initialized:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -728,8 +728,12 @@ class ReplicaActor:
         if self._user_callable_initialized:
             await self._drain_ongoing_requests()
 
-        await self._user_callable_wrapper.call_destructor()
         await self._metrics_manager.shutdown()
+
+        # We call the destructor last because the replica may not have
+        # initialized yet. The destructor may depend on instance variables
+        # that haven't been set yet, so it may raise an error.
+        await self._user_callable_wrapper.call_destructor()
 
     async def check_health(self):
         await self._user_callable_wrapper.call_user_health_check()

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1163,9 +1163,15 @@ class UserCallableWrapper:
     async def call_destructor(self):
         """Explicitly call the `__del__` method of the user callable.
 
-        Calling this multiple times has no effect; only the first call will actually
-        call the destructor.
+        Calling this multiple times has no effect; only the first call will
+        actually call the destructor.
         """
+        if self._callable is None:
+            logger.info(
+                "This replica has not yet started running user code. "
+                "Skipping __del__."
+            )
+            return
 
         # Only run the destructor once. This is safe because there is no `await` between
         # checking the flag here and flipping it to `True` below.

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -727,8 +727,8 @@ class ReplicaActor:
         # can skip the wait period.
         if self._user_callable_initialized:
             await self._drain_ongoing_requests()
-            await self._user_callable_wrapper.call_destructor()
 
+        await self._user_callable_wrapper.call_destructor()
         await self._metrics_manager.shutdown()
 
     async def check_health(self):
@@ -1162,7 +1162,6 @@ class UserCallableWrapper:
         Calling this multiple times has no effect; only the first call will actually
         call the destructor.
         """
-        self._raise_if_not_initialized("call_destructor")
 
         # Only run the destructor once. This is safe because there is no `await` between
         # checking the flag here and flipping it to `True` below.

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -731,7 +731,7 @@ class ReplicaActor:
         await self._metrics_manager.shutdown()
 
         # We call the destructor last because the replica may not have
-        # initialized yet. The destructor may depend on instance variables
+        # been initialized yet. The destructor may depend on instance variables
         # that haven't been set yet, so it may raise an error.
         await self._user_callable_wrapper.call_destructor()
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -727,13 +727,25 @@ class ReplicaActor:
         # can skip the wait period.
         if self._user_callable_initialized:
             await self._drain_ongoing_requests()
+            await self._user_callable_wrapper.call_destructor()
+        else:
+            try:
+                await self._user_callable_wrapper.call_destructor()
+            except:
+                # We catch a blanket exception here because the constructor is
+                # still running and may not have set some variables that the
+                # destructor uses. As a result, the destructor may fail for
+                # many reasons.
+                logger.exception(
+                    "__del__ ran before replica finished initializing, and "
+                    "raised an exception."
+                )
 
         await self._metrics_manager.shutdown()
 
         # We call the destructor last because the replica may not have
         # been initialized yet. The destructor may depend on instance variables
         # that haven't been set yet, so it may raise an error.
-        await self._user_callable_wrapper.call_destructor()
 
     async def check_health(self):
         await self._user_callable_wrapper.call_user_health_check()

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -441,7 +441,7 @@ async def test_delete_while_initializing(serve_instance):
 
     @serve.deployment
     class HangingStart:
-        async def __init__(self, event_holder, counter):
+        async def __init__(self, event_holder: ray.actor.ActorHandle, counter: ray.actor.ActorHandle):
             self.event_holder = event_holder
             self.counter = counter
             await event_holder.set.remote()

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -433,7 +433,7 @@ async def test_delete_while_initializing(serve_instance):
         def incr(self):
             self.count += 1
 
-        def get_count(self):
+        def get_count(self) -> int:
             return self.count
 
     event_holder = EventHolder.remote()

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -146,9 +146,6 @@ async def test_calling_methods_before_initialize():
     with pytest.raises(RuntimeError):
         await user_callable_wrapper.call_reconfigure(None)
 
-    with pytest.raises(RuntimeError):
-        await user_callable_wrapper.call_destructor()
-
 
 @pytest.mark.asyncio
 async def test_basic_class_callable():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change makes replicas run the `__del__` method even if the constructor hasn't finished running yet.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #41606.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
     - This change adds a unit test to `test_api.py`.
