### PR TITLE
[data][api/1] explicitly mark _LegacyDatasourceReader as internal

### DIFF
--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -141,6 +141,7 @@ class Reader:
         raise NotImplementedError
 
 
+@DeveloperAPI
 class _LegacyDatasourceReader(Reader):
     def __init__(self, datasource: Datasource, **read_args):
         self._datasource = datasource


### PR DESCRIPTION
The `_LegacyDatasourceReader` class currently inherits the `@Deprecated` annotation from its parent, the `Reader` class. Mark `_LegacyDatasourceReader` explicitly that they are internal (@DeveloperAPI)

Test:
- CI