### PR TITLE
[data][api] mark StreamSplitDataIterator as DeveloperAPI

### DIFF
--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -15,6 +15,7 @@ from ray.data._internal.util import create_dataset_tag
 from ray.data.block import Block, BlockMetadata
 from ray.data.iterator import DataIterator
 from ray.types import ObjectRef
+from ray.util.annotations import DeveloperAPI
 from ray.util.debug import log_once
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
@@ -29,6 +30,7 @@ logger = logging.getLogger(__name__)
 BLOCKED_CLIENT_WARN_TIMEOUT = 30
 
 
+@DeveloperAPI
 class StreamSplitDataIterator(DataIterator):
     """Implements a collection of iterators over a shared data stream."""
 

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -141,7 +141,6 @@ class Reader:
         raise NotImplementedError
 
 
-@DeveloperAPI
 class _LegacyDatasourceReader(Reader):
     def __init__(self, datasource: Datasource, **read_args):
         self._datasource = datasource

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -141,6 +141,7 @@ class Reader:
         raise NotImplementedError
 
 
+@DeveloperAPI
 class _LegacyDatasourceReader(Reader):
     def __init__(self, datasource: Datasource, **read_args):
         self._datasource = datasource


### PR DESCRIPTION
Annotation are inheritable, so even though `StreamSplitDataIterator` doesn't explicitly declared itself as public, it's inherit the @PublicAPI property from `DataIterator` (in the point of view of python import + sphinx autodoc). Mark it as @DeveloperAPI explicilty

Test:
- CI