### PR TITLE
[ci] avoid deadlocking bazel query and bazel run

### DIFF
--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -38,8 +38,10 @@ copyright_format() {
 }
 
 bazel_team() {
-  bazelisk query 'kind("cc_test", //...)' --output=xml | bazelisk run //ci/lint:check_bazel_team_owner
-  bazelisk query 'kind("py_test", //...)' --output=xml | bazelisk run //ci/lint:check_bazel_team_owner
+  TMP_DIR="$(mktemp -d)"
+  bazelisk query 'kind("cc_test|py_test", //...)' --output=xml > "${TMP_DIR}/tests.xml"
+  bazelisk run //ci/lint:check_bazel_team_owner < "${TMP_DIR}/tests.xml"
+  rm -rf "${TMP_DIR}"
 }
 
 bazel_buildifier() {


### PR DESCRIPTION
in team attribute checking
