### PR TITLE
[Core] Remove dead gcs_failover_worker_reconnect_timeout config

### DIFF
--- a/dashboard/modules/serve/tests/test_serve_dashboard.py
+++ b/dashboard/modules/serve/tests/test_serve_dashboard.py
@@ -648,7 +648,6 @@ def test_default_dashboard_agent_listen_port():
     [
         {
             **generate_system_config_map(
-                gcs_failover_worker_reconnect_timeout=20,
                 gcs_rpc_server_reconnect_timeout_s=3600,
                 gcs_server_request_timeout_seconds=3,
             ),

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -52,7 +52,6 @@ def cluster_kill_gcs_wait(cluster):
     "ray_start_regular_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=60,
         )
     ],
@@ -84,7 +83,6 @@ def test_gcs_server_restart(ray_start_regular_with_external_redis):
     "ray_start_regular_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=60,
         )
     ],
@@ -121,7 +119,6 @@ def test_gcs_server_restart_during_actor_creation(
     "ray_start_cluster_head_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=2,
             gcs_rpc_server_reconnect_timeout_s=60,
             health_check_initial_delay_ms=0,
             health_check_period_ms=1000,
@@ -161,7 +158,6 @@ def test_autoscaler_init(
     "ray_start_cluster_head_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=2,
             gcs_rpc_server_reconnect_timeout_s=60,
             health_check_initial_delay_ms=0,
             health_check_period_ms=1000,
@@ -223,7 +219,6 @@ def test_node_failure_detector_when_gcs_server_restart(
     "ray_start_regular_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=60,
         )
     ],
@@ -264,7 +259,6 @@ def test_actor_raylet_resubscription(ray_start_regular_with_external_redis):
     "ray_start_regular_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=60,
         )
     ],
@@ -301,7 +295,6 @@ def test_del_actor_after_gcs_server_restart(ray_start_regular_with_external_redi
     "ray_start_regular_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=60,
         )
     ],
@@ -366,7 +359,6 @@ def test_worker_raylet_resubscription(tmp_path, ray_start_regular_with_external_
     "ray_start_regular_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=60,
         )
     ],
@@ -407,7 +399,6 @@ def test_core_worker_resubscription(tmp_path, ray_start_regular_with_external_re
     "ray_start_regular_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=60,
         )
     ],
@@ -515,7 +506,6 @@ def test_gcs_aio_client_reconnect(
     [
         {
             **generate_system_config_map(
-                gcs_failover_worker_reconnect_timeout=20,
                 gcs_rpc_server_reconnect_timeout_s=3600,
             ),
             "namespace": "actor",
@@ -585,7 +575,6 @@ assert ray.get(a.r.remote(10)) == 10
     [
         {
             **generate_system_config_map(
-                gcs_failover_worker_reconnect_timeout=20,
                 gcs_rpc_server_reconnect_timeout_s=3600,
                 gcs_server_request_timeout_seconds=10,
             ),
@@ -629,7 +618,6 @@ def test_named_actor_workloads(ray_start_regular_with_external_redis):
     [
         {
             **generate_system_config_map(
-                gcs_failover_worker_reconnect_timeout=20,
                 gcs_rpc_server_reconnect_timeout_s=3600,
             ),
             "namespace": "actor",
@@ -675,7 +663,6 @@ def test_pg_actor_workloads(ray_start_regular_with_external_redis):
     "ray_start_regular_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=60,
             gcs_server_request_timeout_seconds=10,
         )
@@ -705,7 +692,6 @@ def test_get_actor_when_gcs_is_down(ray_start_regular_with_external_redis):
     "ray_start_regular_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=60,
             gcs_server_request_timeout_seconds=10,
         )
@@ -749,7 +735,6 @@ def redis_replicas(monkeypatch):
     "ray_start_cluster_head_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=60,
             gcs_server_request_timeout_seconds=10,
             redis_db_connect_retries=50,
@@ -950,7 +935,6 @@ def test_session_name(ray_start_cluster):
     "ray_start_regular_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=60,
             gcs_server_request_timeout_seconds=10,
             raylet_liveness_self_check_interval_ms=3000,
@@ -1027,7 +1011,6 @@ def test_redis_logs(external_redis):
     "ray_start_cluster_head_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=20,
             gcs_rpc_server_reconnect_timeout_s=2,
         )
     ],

--- a/python/ray/tests/test_placement_group_2.py
+++ b/python/ray/tests/test_placement_group_2.py
@@ -729,7 +729,6 @@ ray.shutdown()
     "ray_start_cluster_head_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=10,
             gcs_rpc_server_reconnect_timeout_s=60,
         )
     ],
@@ -772,7 +771,6 @@ def test_create_placement_group_after_gcs_server_restart(
     "ray_start_cluster_head_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=10,
             gcs_rpc_server_reconnect_timeout_s=60,
         )
     ],
@@ -803,7 +801,6 @@ def test_create_actor_with_placement_group_after_gcs_server_restart(
     "ray_start_cluster_head_with_external_redis",
     [
         generate_system_config_map(
-            gcs_failover_worker_reconnect_timeout=10,
             gcs_rpc_server_reconnect_timeout_s=60,
         )
     ],

--- a/release/k8s_tests/ray_v1alpha1_rayservice_template.yaml
+++ b/release/k8s_tests/ray_v1alpha1_rayservice_template.yaml
@@ -167,8 +167,6 @@ spec:
                   value: redis-{cluster_id}:6379
                 - name: RAY_gcs_rpc_server_reconnect_timeout_s
                   value: "600"
-                - name: RAY_gcs_failover_worker_reconnect_timeout
-                  value: "600"
                 - name: SERVE_DEPLOYMENT_HANDLE_IS_SYNC
                   value: "1"
               resources:
@@ -282,8 +280,6 @@ spec:
                       fieldRef:
                         fieldPath: status.podIP
                   - name: RAY_gcs_rpc_server_reconnect_timeout_s
-                    value: "600"
-                  - name: RAY_gcs_failover_worker_reconnect_timeout
                     value: "600"
                   - name: RAY_gcs_server_request_timeout_seconds
                     value: "5"

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -52,13 +52,6 @@ RAY_CONFIG(int64_t, handler_warning_timeout_ms, 1000)
 /// The duration between loads pulled by GCS
 RAY_CONFIG(uint64_t, gcs_pull_resource_loads_period_milliseconds, 1000)
 
-/// If GCS restarts, before the first heatbeat is sent,
-/// gcs_failover_worker_reconnect_timeout is used for the threshold
-/// of the raylet. This is very useful given that raylet might need
-/// a while to reconnect to the GCS, for example, when GCS is available
-/// but not reachable to raylet.
-RAY_CONFIG(int64_t, gcs_failover_worker_reconnect_timeout, 120)
-
 /// The duration between reporting resources sent by the raylets.
 RAY_CONFIG(uint64_t, raylet_report_resources_period_milliseconds, 100)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This config is not used in the code.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
