### PR TITLE
[ci] deflake rllib release tests

### DIFF
--- a/release/ray_release/byod/byod_rllib_dreamerv3_test.sh
+++ b/release/ray_release/byod/byod_rllib_dreamerv3_test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# This script is used to build an extra layer on top of the base anyscale/ray image 
+# to run RLlib dreamerv3 release tests.
+
+set -exo pipefail
+
+# Only DreamerV3 still uses tf on the new API stack. But requires tf==2.11.1 to run.
+pip uninstall -y tensorflow tensorflow_probability
+pip install tensorflow==2.11.1 tensorflow_probability==0.19.0

--- a/release/ray_release/byod/byod_rllib_test.sh
+++ b/release/ray_release/byod/byod_rllib_test.sh
@@ -14,7 +14,3 @@ pip install werkzeug==2.3.8
 
 # not strictly necessary, but makes debugging easier
 git clone https://github.com/ray-project/ray.git
-
-# Only DreamerV3 still uses tf on the new API stack. But requires tf==2.11.1 to run.
-pip uninstall -y tensorflow tensorflow_probability
-pip install tensorflow==2.11.1 tensorflow_probability==0.19.0

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2747,14 +2747,14 @@
   group: RLlib tests
   working_dir: rllib_tests
 
-  stable: true
+  stable: false
 
   frequency: weekly
   team: rllib
   cluster:
     byod:
       type: gpu
-      post_build_script: byod_rllib_test.sh
+      post_build_script: byod_rllib_dreamerv3_test.sh
       runtime_env:
         - RLLIB_TEST_NO_JAX_IMPORT=1
         - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/ray/.mujoco/mujoco210/bin


### PR DESCRIPTION
Some of the rllib release tests are still flaky; let's first narrow down the impact to the dreamerv3 test only to deflake other tests; also mark dreamerv3 as non-release-blocking, would love your confirmation here @sven1977  thanks

Test:
- release tests