### PR TITLE
[core][dashboard] Use executor for list_tasks

### DIFF
--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import fields
 import dataclasses
 from itertools import islice
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from ray._private.ray_constants import env_integer
 from ray._private.profiling import chrome_tracing_dump
+from ray._private.utils import get_or_create_event_loop
 
 import ray.dashboard.memory_utils as memory_utils
 from ray.dashboard.utils import compose_state_message
@@ -146,6 +147,8 @@ class StateAPIManager:
 
     def __init__(self, state_data_source_client: StateDataSourceClient):
         self._client = state_data_source_client
+
+        self._thread_pool_executor = ThreadPoolExecutor(thread_name_prefix="state_head")
 
     @property
     def data_source_client(self):
@@ -421,26 +424,32 @@ class StateAPIManager:
         except DataSourceUnavailable:
             raise DataSourceUnavailable(GCS_QUERY_FAILURE_WARNING)
 
-        result = [
-            protobuf_to_task_state_dict(message) for message in reply.events_by_task
-        ]
+        def transform(reply):
+            result = [
+                protobuf_to_task_state_dict(message) for message in reply.events_by_task
+            ]
 
-        # Num pre-truncation is the number of tasks returned from
-        # source + num filtered on source
-        num_after_truncation = len(result) + reply.num_filtered_on_gcs
-        num_total = reply.num_total_stored + reply.num_status_task_events_dropped
+            # Num pre-truncation is the number of tasks returned from
+            # source + num filtered on source
+            num_after_truncation = len(result) + reply.num_filtered_on_gcs
+            num_total = reply.num_total_stored + reply.num_status_task_events_dropped
 
-        result = self._filter(result, option.filters, TaskState, option.detail)
-        num_filtered = len(result)
+            result = self._filter(result, option.filters, TaskState, option.detail)
+            num_filtered = len(result)
 
-        result.sort(key=lambda entry: entry["task_id"])
-        result = list(islice(result, option.limit))
-        # TODO(rickyx): we could do better with the warning logic. It's messy now.
-        return ListApiResponse(
-            result=result,
-            total=num_total,
-            num_after_truncation=num_after_truncation,
-            num_filtered=num_filtered,
+            result.sort(key=lambda entry: entry["task_id"])
+            result = list(islice(result, option.limit))
+
+            # TODO(rickyx): we could do better with the warning logic. It's messy now.
+            return ListApiResponse(
+                result=result,
+                total=num_total,
+                num_after_truncation=num_after_truncation,
+                num_filtered=num_filtered,
+            )
+
+        return await get_or_create_event_loop().run_in_executor(
+            self._thread_pool_executor, transform, reply
         )
 
     async def list_objects(self, *, option: ListApiOptions) -> ListApiResponse:

--- a/dashboard/state_aggregator.py
+++ b/dashboard/state_aggregator.py
@@ -425,6 +425,12 @@ class StateAPIManager:
             raise DataSourceUnavailable(GCS_QUERY_FAILURE_WARNING)
 
         def transform(reply):
+            """
+            Transforms from proto to dict, applies filters, sorts, and truncates.
+            This function is executed in a separate thread.
+
+            Returns the ListApiResponse.
+            """
             result = [
                 protobuf_to_task_state_dict(message) for message in reply.events_by_task
             ]


### PR DESCRIPTION
In a big cluster, list_tasks can take long and can block the event loop. This PR puts it in another thread pool to free up the event loop.

Also optimized protobuf_compat.py to avoid inspecting the protobuf package for every single message.