### PR TITLE
[Data] Hard deprecate `set_progress_bar` 

### DIFF
--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -32,18 +32,10 @@ def set_progress_bars(enabled: bool) -> bool:
     Returns:
         Whether progress bars were previously enabled.
     """
-    from ray.data import DataContext
-
-    warnings.warn(
+    raise DeprecationWarning(
         "`set_progress_bars` is deprecated. Set "
         "`ray.data.DataContext.get_current().enable_progress_bars` instead.",
-        DeprecationWarning,
     )
-
-    ctx = DataContext.get_current()
-    old_value = ctx.enable_progress_bars
-    ctx.enable_progress_bars = enabled
-    return old_value
 
 
 class ProgressBar:

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -1,5 +1,4 @@
 import threading
-import warnings
 from typing import Any, List, Optional
 
 import ray

--- a/python/ray/data/tests/test_progress_bar.py
+++ b/python/ray/data/tests/test_progress_bar.py
@@ -17,7 +17,7 @@ def enable_tqdm_ray(request):
 
 
 def test_set_progress_bars_is_deprecated():
-    with pytest.warns(DeprecationWarning):
+    with pytest.raises(DeprecationWarning):
         ray.data.set_progress_bars(True)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`set_progress_bar` has been soft deprecated (raises a warning) for several releases. In accordance with our deprecation policy, this PR hard deprecates it (makes it raise an error). 

## Related issue number

<!-- For example: "Closes #1234" -->

Towards https://github.com/ray-project/ray/issues/43576

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
