### PR TITLE
[ci] only upload bazel cache result on postmerge

### DIFF
--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -18,8 +18,8 @@ RUN <<EOF
 
 set -euo pipefail
 
-if [[ "$BUILDKITE_PIPELINE_ID" == "0189942e-0876-4b8f-80a4-617f988ec59b" ]]; then
-  # Do not upload cache results for premerge pipeline
+if [[ "$BUILDKITE_PIPELINE_ID" != "0189e759-8c96-4302-b6b5-b4274406bf89" ]]; then
+  # Only upload cache results on (Linux and Windows) postmerge pipeline.
   echo "build --remote_upload_local_results=false" >> ~/.bazelrc
 fi
 


### PR DESCRIPTION
so that microcheck pipeline will stop trying to upload when compiling the ray package
