### PR TITLE
[doc] correct a typo in the parameter server example

### DIFF
--- a/doc/source/ray-core/examples/plot_parameter_server.ipynb
+++ b/doc/source/ray-core/examples/plot_parameter_server.ipynb
@@ -324,7 +324,7 @@
    "source": [
     "## Asynchronous Parameter Server Training\n",
     "\n",
-    "We'll now create a synchronous parameter server training scheme. We'll first\n",
+    "We'll now create an asynchronous parameter server training scheme. We'll first\n",
     "instantiate a process for the parameter server, along with multiple\n",
     "workers."
    ]


### PR DESCRIPTION
Asynchronous was mistakenly written as synchronous, I corrected it.
