### PR TITLE
[serve] fix lossy serve config

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import json
 import os
 import pathlib
 import re
@@ -611,8 +612,8 @@ def run(
     required=False,
     type=str,
     help=(
-        "Name of an application. Only applies to multi-application mode. If set, this "
-        "will only fetch the config for the specified application."
+        "Name of an application. If set, this will only fetch the config "
+        "for the specified application."
     ),
 )
 def config(address: str, name: Optional[str]):
@@ -623,18 +624,16 @@ def config(address: str, name: Optional[str]):
     )
 
     # Fetch app configs for all live applications on the cluster
+    schema = serve_details._to_deploy_schema()
     if name is None:
-        print(
-            "\n---\n\n".join(
+        if schema:
+            print(
                 yaml.safe_dump(
-                    app.deployed_app_config.dict(exclude_unset=True),
+                    json.loads(schema.json(exclude_unset=True)),
                     sort_keys=False,
-                )
-                for app in serve_details.applications.values()
-                if app.deployed_app_config is not None
-            ),
-            end="",
-        )
+                ),
+                end="",
+            )
     # Fetch a specific app config by name.
     else:
         app = serve_details.applications.get(name)


### PR DESCRIPTION
[serve] fix lossy serve config

Before: we output only the application configs, but not the system level information like http options. This PR adds system level information to the output of `serve config`.

Note that the output of `serve config` is still not identical to whatever the user submitted with `serve deploy`. We output the full system-level information, which may include defaults that the user didn't touch, e.g:
```
http_options:
  host: 127.0.0.1
```
will turn into:
```
http_options:
  host: 127.0.0.1
  port: 8000
  root_path: ''
  request_timeout_s: null
  keep_alive_timeout_s: 5
```

However the system level options, even if outputted in full, is not very spammy (unlike the application/deployment options) and the information is generally helpful as well.

Closes https://github.com/ray-project/ray/issues/40907.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
