### PR TITLE
[data][api] move many public apis to developer

### DIFF
--- a/python/ray/data/datasource/avro_datasource.py
+++ b/python/ray/data/datasource/avro_datasource.py
@@ -5,13 +5,13 @@ from ray.data._internal.util import _check_import
 from ray.data.block import Block
 from ray.data.context import DataContext
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
 
 
-@PublicAPI(stability="alpha")
+@DeveloperAPI
 class AvroDatasource(FileBasedDatasource):
     """A datasource that reads Avro files."""
 

--- a/python/ray/data/datasource/bigquery_datasource.py
+++ b/python/ray/data/datasource/bigquery_datasource.py
@@ -4,12 +4,12 @@ from typing import List, Optional
 from ray.data._internal.util import _check_import
 from ray.data.block import Block, BlockMetadata
 from ray.data.datasource.datasource import Datasource, ReadTask
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 logger = logging.getLogger(__name__)
 
 
-@PublicAPI(stability="alpha")
+@DeveloperAPI
 class BigQueryDatasource(Datasource):
     def __init__(
         self,

--- a/python/ray/data/datasource/binary_datasource.py
+++ b/python/ray/data/datasource/binary_datasource.py
@@ -2,13 +2,13 @@ from typing import TYPE_CHECKING
 
 from ray.data._internal.arrow_block import ArrowBlockBuilder
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
 
 
-@PublicAPI
+@DeveloperAPI
 class BinaryDatasource(FileBasedDatasource):
     """Binary datasource, for reading and writing binary files."""
 

--- a/python/ray/data/datasource/csv_datasource.py
+++ b/python/ray/data/datasource/csv_datasource.py
@@ -2,13 +2,13 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 
 from ray.data.block import Block
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
 
 
-@PublicAPI
+@DeveloperAPI
 class CSVDatasource(FileBasedDatasource):
     """CSV datasource, for reading and writing CSV files."""
 

--- a/python/ray/data/datasource/json_datasource.py
+++ b/python/ray/data/datasource/json_datasource.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from ray.air.util.tensor_extensions.arrow import pyarrow_table_from_pydict
 from ray.data.context import DataContext
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@PublicAPI
+@DeveloperAPI
 class JSONDatasource(FileBasedDatasource):
     """JSON datasource, for reading and writing JSON and JSONL files."""
 

--- a/python/ray/data/datasource/mongo_datasource.py
+++ b/python/ray/data/datasource/mongo_datasource.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 from ray.data.block import Block, BlockMetadata
 from ray.data.datasource.datasource import Datasource, ReadTask
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pymongoarrow.api
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@PublicAPI(stability="alpha")
+@DeveloperAPI
 class MongoDatasource(Datasource):
     """Datasource for reading from and writing to MongoDB."""
 

--- a/python/ray/data/datasource/numpy_datasource.py
+++ b/python/ray/data/datasource/numpy_datasource.py
@@ -5,13 +5,13 @@ import numpy as np
 
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
 
 
-@PublicAPI
+@DeveloperAPI
 class NumpyDatasource(FileBasedDatasource):
     """Numpy datasource, for reading and writing Numpy files."""
 

--- a/python/ray/data/datasource/parquet_bulk_datasource.py
+++ b/python/ray/data/datasource/parquet_bulk_datasource.py
@@ -2,7 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@PublicAPI
+@DeveloperAPI
 class ParquetBulkDatasource(FileBasedDatasource):
     """Minimal Parquet datasource, for reading and writing Parquet files."""
 

--- a/python/ray/data/datasource/parquet_datasource.py
+++ b/python/ray/data/datasource/parquet_datasource.py
@@ -39,7 +39,7 @@ from ray.data.datasource.path_util import (
     _has_file_extension,
     _resolve_paths_and_filesystem,
 )
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
@@ -143,7 +143,7 @@ def _check_for_legacy_tensor_type(schema):
             )
 
 
-@PublicAPI
+@DeveloperAPI
 class ParquetDatasource(Datasource):
     """Parquet datasource, for reading and writing Parquet files.
 

--- a/python/ray/data/datasource/range_datasource.py
+++ b/python/ray/data/datasource/range_datasource.py
@@ -9,10 +9,10 @@ from ray.data._internal.util import _check_pyarrow_version
 from ray.data.block import Block, BlockAccessor, BlockMetadata
 from ray.data.context import DataContext
 from ray.data.datasource import Datasource, ReadTask
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 
-@PublicAPI
+@DeveloperAPI
 class RangeDatasource(Datasource):
     """An example datasource that generates ranges of numbers from [0..n)."""
 

--- a/python/ray/data/datasource/sql_datasource.py
+++ b/python/ray/data/datasource/sql_datasource.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Iterable, Iterator, List, Optional
 
 from ray.data.block import Block, BlockAccessor, BlockMetadata
 from ray.data.datasource.datasource import Datasource, ReadTask
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 Connection = Any  # A Python DB API2-compliant `Connection` object.
 Cursor = Any  # A Python DB API2-compliant `Cursor` object.
@@ -72,7 +72,7 @@ def _connect(connection_factory: Callable[[], Connection]) -> Iterator[Cursor]:
         connection.close()
 
 
-@PublicAPI(stability="alpha")
+@DeveloperAPI
 class SQLDatasource(Datasource):
 
     NUM_SAMPLE_ROWS = 100

--- a/python/ray/data/datasource/text_datasource.py
+++ b/python/ray/data/datasource/text_datasource.py
@@ -3,13 +3,13 @@ from typing import TYPE_CHECKING, Iterator, List
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data.block import Block
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
 
 
-@PublicAPI
+@DeveloperAPI
 class TextDatasource(FileBasedDatasource):
     """Text datasource, for reading and writing text files."""
 

--- a/python/ray/data/datasource/tfrecords_datasource.py
+++ b/python/ray/data/datasource/tfrecords_datasource.py
@@ -10,7 +10,7 @@ from ray.air.util.tensor_extensions.arrow import pyarrow_table_from_pydict
 from ray.data.aggregate import AggregateFn
 from ray.data.block import Block
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -45,7 +45,7 @@ class TFXReadOptions:
     auto_infer_schema: bool = True
 
 
-@PublicAPI(stability="alpha")
+@DeveloperAPI
 class TFRecordDatasource(FileBasedDatasource):
     """TFRecord datasource, for reading and writing TFRecord files."""
 

--- a/python/ray/data/datasource/webdataset_datasource.py
+++ b/python/ray/data/datasource/webdataset_datasource.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from ray.data.block import BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
@@ -300,7 +300,7 @@ def _make_iterable(block: BlockAccessor):
     return block.iter_rows(public_row_format=False)
 
 
-@PublicAPI(stability="alpha")
+@DeveloperAPI
 class WebDatasetDatasource(FileBasedDatasource):
     """A Datasource for WebDataset datasets (tar format with naming conventions)."""
 


### PR DESCRIPTION
On my quest to clean up API documentation for data team, I notice this list of `@PublicAPI` classes that are not documented. After talking with @bveeramani, we decide to move them to be internal.

Test:
- CI