### PR TITLE
[Data] Make number of file reading threads configurable by `DataContext`

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -132,6 +132,10 @@ DEFAULT_WAIT_FOR_MIN_ACTORS_S = env_integer(
     "RAY_DATA_DEFAULT_WAIT_FOR_MIN_ACTORS_S", 60 * 10
 )
 
+DEFAULT_OVERRIDE_NUM_FILE_READING_THREADS: Optional[int] = env_integer(
+    "RAY_OVERRIDE_NUM_FILE_READING_THREADS", None
+)
+
 
 def _execution_options_factory() -> "ExecutionOptions":
     # Lazily import to avoid circular dependencies.
@@ -230,6 +234,8 @@ class DataContext:
             call is made with a S3 URI.
         wait_for_min_actors_s: The default time to wait for minimum requested
             actors to start before raising a timeout, in seconds.
+        override_num_file_reading_threads: The number of threads to use for reading. If
+            not set, the number of threads is determined by the particular API.
     """
 
     target_max_block_size: int = DEFAULT_TARGET_MAX_BLOCK_SIZE
@@ -276,6 +282,9 @@ class DataContext:
     print_on_execution_start: bool = True
     s3_try_create_dir: bool = DEFAULT_S3_TRY_CREATE_DIR
     wait_for_min_actors_s: int = DEFAULT_WAIT_FOR_MIN_ACTORS_S
+    override_num_file_reading_threads: Optional[
+        int
+    ] = DEFAULT_OVERRIDE_NUM_FILE_READING_THREADS
 
     def __post_init__(self):
         # The additonal ray remote args that should be added to

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -269,7 +269,11 @@ class FileBasedDatasource(Datasource):
                 file_sizes=file_sizes,
             )
 
-            read_task_fn = create_read_task_fn(read_paths, self._NUM_THREADS_PER_TASK)
+            num_threads = self._NUM_THREADS_PER_TASK
+            if ctx.override_num_file_reading_threads is not None:
+                num_threads = ctx.override_num_file_reading_threads
+
+            read_task_fn = create_read_task_fn(read_paths, num_threads)
 
             read_task = ReadTask(read_task_fn, meta)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`TestReadImages::test_multi_threading` tests `read_images` with varying numbers of threads. To do so, it modifies the `_NUM_THREADS_PER_TASK` attribute of `ImageDatasource`: https://github.com/ray-project/ray/blob/d844d63d9ad932c1311cf0e393f9233ac0346c1b/python/ray/data/tests/test_image.py#L35-L39

To avoid breaking abstraction this abstraction barrier (i.e., that `read_images` is implemented with `ImageDatasource`), this PR allows you to configure the number of threads via the `DataContext`.
 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
