### PR TITLE
[Data] Add configuration to `PhysicalOperator` to allow disabling operator fusion

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -443,5 +443,5 @@ class PhysicalOperator(Operator):
         return False
 
     def supports_fusion(self) -> bool:
-        """Return ```True``` if this operator can be fused with other operators."""
-        return True
+        """Returns ```True``` if this operator can be fused with other operators."""
+        return False

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -441,3 +441,7 @@ class PhysicalOperator(Operator):
         # all operators in the dataset have implemented accurate memory accounting.
         # Eventually all operators should implement accurate memory accounting.
         return False
+
+    def supports_fusion(self) -> bool:
+        """Return ```True``` if this operator can be fused with other operators."""
+        return True

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -51,6 +51,7 @@ class ActorPoolMapOperator(MapOperator):
         compute_strategy: ActorPoolStrategy,
         name: str = "ActorPoolMap",
         min_rows_per_bundle: Optional[int] = None,
+        supports_fusion: bool = True,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
@@ -68,6 +69,7 @@ class ActorPoolMapOperator(MapOperator):
                 transform_fn, or None to use the block size. Setting the batch size is
                 important for the performance of GPU-accelerated transform functions.
                 The actual rows passed may be less if the dataset is small.
+            supports_fusion: Whether this operator supports fusion with other operators.
             ray_remote_args_fn: A function that returns a dictionary of remote args
                 passed to each map worker. The purpose of this argument is to generate
                 dynamic arguments for each actor/task, and will be called each time
@@ -82,6 +84,7 @@ class ActorPoolMapOperator(MapOperator):
             name,
             target_max_block_size,
             min_rows_per_bundle,
+            supports_fusion,
             ray_remote_args_fn,
             ray_remote_args,
         )

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -131,6 +131,9 @@ class AllToAllOperator(PhysicalOperator):
             for sub_bar in self._sub_progress_bar_dict.values():
                 sub_bar.close()
 
+    def supports_fusion(self):
+        return True
+
 
 class NAryOperator(PhysicalOperator):
     """An operator that has multiple input dependencies and one output.

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -24,6 +24,7 @@ class TaskPoolMapOperator(MapOperator):
         name: str = "TaskPoolMap",
         min_rows_per_bundle: Optional[int] = None,
         concurrency: Optional[int] = None,
+        supports_fusion: bool = True,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
@@ -41,6 +42,7 @@ class TaskPoolMapOperator(MapOperator):
                 The actual rows passed may be less if the dataset is small.
             concurrency: The maximum number of Ray tasks to use concurrently,
                 or None to use as many tasks as possible.
+            supports_fusion: Whether this operator supports fusion with other operators.
             ray_remote_args_fn: A function that returns a dictionary of remote args
                 passed to each map worker. The purpose of this argument is to generate
                 dynamic arguments for each actor/task, and will be called each time
@@ -55,6 +57,7 @@ class TaskPoolMapOperator(MapOperator):
             name,
             target_max_block_size,
             min_rows_per_bundle,
+            supports_fusion,
             ray_remote_args_fn,
             ray_remote_args,
         )

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -35,6 +35,9 @@ class AbstractAllToAll(LogicalOperator):
         self._ray_remote_args = ray_remote_args or {}
         self._sub_progress_bar_names = sub_progress_bar_names
 
+    def supports_fusion(self):
+        return True
+
 
 class RandomizeBlocks(AbstractAllToAll):
     """Logical operator for randomize_block_order."""

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -35,9 +35,6 @@ class AbstractAllToAll(LogicalOperator):
         self._ray_remote_args = ray_remote_args or {}
         self._sub_progress_bar_names = sub_progress_bar_names
 
-    def supports_fusion(self):
-        return True
-
 
 class RandomizeBlocks(AbstractAllToAll):
     """Logical operator for randomize_block_order."""

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -134,6 +134,9 @@ class OperatorFusionRule(Rule):
             AbstractUDFMap,
         )
 
+        if not up_op.supports_fusion() or not down_op.supports_fusion():
+            return False
+
         # We currently only support fusing for the following cases:
         # - TaskPoolMapOperator -> TaskPoolMapOperator/ActorPoolMapOperator
         # - TaskPoolMapOperator -> AllToAllOperator


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ray Data automatically fuses task pool operators together. However, in some cases, we want to not fuse task pool operators. To allow us to disable fusion in those cases, this PR adds a `supports_fusion` parameter to the physical `MapOperator`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
