### PR TITLE
[ci] fix bisect

### DIFF
--- a/ci/ray_ci/bisect/bisector.py
+++ b/ci/ray_ci/bisect/bisector.py
@@ -38,7 +38,7 @@ class Bisector:
             if self._checkout_and_validate(revisions[mid]):
                 revisions = revisions[mid:]
             else:
-                revisions = revisions[:mid]
+                revisions = revisions[: (mid + 1)]
 
         return revisions[-1]
 

--- a/ci/ray_ci/bisect/test_bisector.py
+++ b/ci/ray_ci/bisect/test_bisector.py
@@ -25,11 +25,14 @@ def test_run(mock_get_revision_lists, mock_checkout_and_validate):
     mock_checkout_and_validate.side_effect = _mock_checkout_and_validate
     mock_get_revision_lists.return_value = ["1", "2", "3", "4", "5"]
 
-    # Test case 1: P P P F F
-    assert Bisector(Test(), "1", "5", MacOSValidator(), "dir").run() == "3"
+    # Test case 1: T T T F F
+    assert Bisector(Test(), "1", "5", MacOSValidator(), "dir").run() == "4"
 
-    # Test case 2: P F
-    assert Bisector(Test(), "3", "4", MacOSValidator(), "dir").run() == "3"
+    # Test case 2: T F
+    assert Bisector(Test(), "3", "4", MacOSValidator(), "dir").run() == "4"
+
+    # Test case 3: T F F
+    assert Bisector(Test(), "3", "5", MacOSValidator(), "dir").run() == "4"
 
 
 @mock.patch("subprocess.check_call")


### PR DESCRIPTION
Currently when bisect travels to its left side, it omits the failing revision (since `array[:mid]` does are not inclusive). Our test cases are actually wrong as well (it blames to a passing revision). Change `P` -> `T` (more natural true-false indicators)

Test:
- CI