### PR TITLE
[Dashboard] Offload heavy-lifting in `ReporterAgent` onto TPE to avoid blocking the event-loop

### DIFF
--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -1219,8 +1219,8 @@ class ReporterAgent(
 
         while True:
             try:
-                # NOTE: Every iteration is executed inside the thread-pool executor (TPE)
-                #       to avoid blocking the Dashboard's event-loop
+                # NOTE: Every iteration is executed inside the thread-pool
+                #       executor (TPE) to avoid blocking the Dashboard's event-loop
                 await loop.run_in_executor(None, self._perform_iteration, publisher)
 
             except Exception:

--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -1221,7 +1221,9 @@ class ReporterAgent(
         while True:
             try:
                 # Fetch autoscaler debug status
-                autoscaler_status_json_bytes: Optional[bytes] = await self._gcs_aio_client.internal_kv_get(
+                autoscaler_status_json_bytes: Optional[
+                    bytes
+                ] = await self._gcs_aio_client.internal_kv_get(
                     DEBUG_AUTOSCALING_STATUS.encode(),
                     None,
                     timeout=GCS_RPC_TIMEOUT_SECONDS,
@@ -1230,9 +1232,7 @@ class ReporterAgent(
                 # NOTE: Stats collection is executed inside the thread-pool
                 #       executor (TPE) to avoid blocking the Dashboard's event-loop
                 json_payload = await loop.run_in_executor(
-                    None,
-                    self._compose_stats_payload,
-                    autoscaler_status_json_bytes
+                    None, self._compose_stats_payload, autoscaler_status_json_bytes
                 )
 
                 await publisher.publish_resource_usage(self._key, json_payload)
@@ -1242,7 +1242,9 @@ class ReporterAgent(
 
             await asyncio.sleep(reporter_consts.REPORTER_UPDATE_INTERVAL_MS / 1000)
 
-    def _compose_stats_payload(self, cluster_autoscaling_stats_json: Optional[bytes]) -> str:
+    def _compose_stats_payload(
+        self, cluster_autoscaling_stats_json: Optional[bytes]
+    ) -> str:
         stats = self._collect_stats()
 
         # Report stats only when metrics collection is enabled.

--- a/dashboard/modules/reporter/reporter_head.py
+++ b/dashboard/modules/reporter/reporter_head.py
@@ -2,7 +2,6 @@ import json
 import logging
 import asyncio
 import aiohttp.web
-from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Tuple, List
 
 
@@ -639,8 +638,8 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
                 if key is None:
                     continue
 
-                # NOTE: Every iteration is executed inside the thread-pool executor (TPE)
-                #       to avoid blocking the Dashboard's event-loop
+                # NOTE: Every iteration is executed inside the thread-pool executor
+                #       (TPE) to avoid blocking the Dashboard's event-loop
                 parsed_data = await loop.run_in_executor(None, json.loads, data)
 
                 node_id = key.split(":")[-1]

--- a/dashboard/modules/reporter/reporter_head.py
+++ b/dashboard/modules/reporter/reporter_head.py
@@ -641,9 +641,7 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
 
                 # NOTE: Every iteration is executed inside the thread-pool executor (TPE)
                 #       to avoid blocking the Dashboard's event-loop
-                parsed_data = await loop.run_in_executor(
-                    None, json.loads, data
-                )
+                parsed_data = await loop.run_in_executor(None, json.loads, data)
 
                 node_id = key.split(":")[-1]
                 DataSource.node_physical_stats[node_id] = parsed_data

--- a/dashboard/modules/reporter/reporter_head.py
+++ b/dashboard/modules/reporter/reporter_head.py
@@ -68,9 +68,6 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
         )
         self._gcs_aio_client = dashboard_head.gcs_aio_client
         self._state_api = None
-        self.thread_pool_executor = ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="reporter_head_worker"
-        )
 
     async def _update_stubs(self, change):
         if change.old:
@@ -643,7 +640,7 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
                 # blocking the event loop.
                 loop = get_or_create_event_loop()
                 parsed_data = await loop.run_in_executor(
-                    self.thread_pool_executor, json.loads, data
+                    None, json.loads, data
                 )
                 node_id = key.split(":")[-1]
                 DataSource.node_physical_stats[node_id] = parsed_data

--- a/dashboard/modules/reporter/tests/test_reporter.py
+++ b/dashboard/modules/reporter/tests/test_reporter.py
@@ -326,7 +326,7 @@ def test_report_stats():
         }
     }
 
-    records = agent._record_stats(STATS_TEMPLATE, cluster_stats)
+    records = agent._to_records(STATS_TEMPLATE, cluster_stats)
     for record in records:
         name = record.gauge.name
         val = record.value
@@ -337,17 +337,17 @@ def test_report_stats():
     assert len(records) == 36
     # Test stats without raylets
     STATS_TEMPLATE["raylet"] = {}
-    records = agent._record_stats(STATS_TEMPLATE, cluster_stats)
+    records = agent._to_records(STATS_TEMPLATE, cluster_stats)
     assert len(records) == 32
     # Test stats with gpus
     STATS_TEMPLATE["gpus"] = [
         {"utilization_gpu": 1, "memory_used": 100, "memory_total": 1000, "index": 0}
     ]
-    records = agent._record_stats(STATS_TEMPLATE, cluster_stats)
+    records = agent._to_records(STATS_TEMPLATE, cluster_stats)
     assert len(records) == 36
     # Test stats without autoscaler report
     cluster_stats = {}
-    records = agent._record_stats(STATS_TEMPLATE, cluster_stats)
+    records = agent._to_records(STATS_TEMPLATE, cluster_stats)
     assert len(records) == 34
 
 
@@ -420,7 +420,7 @@ def test_report_stats_gpu():
         "node_gram_used": 0,
         "node_gram_available": 0,
     }
-    records = agent._record_stats(STATS_TEMPLATE, {})
+    records = agent._to_records(STATS_TEMPLATE, {})
     # If index is not available, we don't emit metrics.
     num_gpu_records = 0
     for record in records:
@@ -572,7 +572,7 @@ def test_report_per_component_stats():
     """
     Test basic case.
     """
-    records = agent._record_stats(test_stats, cluster_stats)
+    records = agent._to_records(test_stats, cluster_stats)
     uss_records, cpu_records, num_fds_records = get_uss_and_cpu_and_num_fds_records(
         records
     )
@@ -615,7 +615,7 @@ def test_report_per_component_stats():
     """
     # Verify the metrics are reset after ray::func is killed.
     test_stats["workers"] = [idle_stats]
-    records = agent._record_stats(test_stats, cluster_stats)
+    records = agent._to_records(test_stats, cluster_stats)
     uss_records, cpu_records, num_fds_records = get_uss_and_cpu_and_num_fds_records(
         records
     )
@@ -663,7 +663,7 @@ def test_report_per_component_stats():
     }
     test_stats["workers"] = [idle_stats, unknown_stats]
 
-    records = agent._record_stats(test_stats, cluster_stats)
+    records = agent._to_records(test_stats, cluster_stats)
     uss_records, cpu_records, num_fds_records = get_uss_and_cpu_and_num_fds_records(
         records
     )

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -192,9 +192,6 @@ RESOURCE_CONSTRAINT_PREFIX = "accelerator_type:"
 RESOURCES_ENVIRONMENT_VARIABLE = "RAY_OVERRIDE_RESOURCES"
 LABELS_ENVIRONMENT_VARIABLE = "RAY_OVERRIDE_LABELS"
 
-# The reporter will report its statistics this often (milliseconds).
-REPORTER_UPDATE_INTERVAL_MS = env_integer("REPORTER_UPDATE_INTERVAL_MS", 2500)
-
 # Temporary flag to disable log processing in the dashboard.  This is useful
 # if the dashboard is overloaded by logs and failing to process other
 # dashboard API requests (e.g. Job Submission).

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1726,7 +1726,6 @@ def get_or_create_event_loop() -> asyncio.AbstractEventLoop:
         # This follows the implementation of the deprecating `get_event_loop`
         # in python3.10's asyncio. See python3.10/asyncio/events.py
         # _get_event_loop()
-        loop = None
         try:
             loop = asyncio.get_running_loop()
             assert loop is not None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change offloads heavy-lifting inside `ReporterAgent` onto TPE to avoid blocking the event-loop (similar to how it's done in the `ReporterHead`).


Changes
---
 - Offload heavy-lifting inside `ReporterAgent` onto TPE
 - Rebased `ReporterHead` to use EVL default TPE
 - Tidying up

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
