### PR TITLE
[core] change GcsClient.get_all_node_info return type to proto type.

### DIFF
--- a/python/ray/_private/gcs_aio_client.py
+++ b/python/ray/_private/gcs_aio_client.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, List, Optional
 from concurrent.futures import ThreadPoolExecutor
-from ray._raylet import GcsClient
+from ray._raylet import GcsClient, JobID
 from ray.core.generated import (
     gcs_pb2,
 )
@@ -146,7 +146,7 @@ class GcsAioClient:
 
     async def get_all_job_info(
         self, timeout: Optional[float] = None
-    ) -> Dict[bytes, gcs_pb2.JobTableData]:
+    ) -> Dict[JobID, gcs_pb2.JobTableData]:
         """
         Return dict key: bytes of job_id; value: JobTableData pb message.
         """

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -556,7 +556,7 @@ def get_total_num_nodes_to_report(gcs_client, timeout=None) -> Optional[int]:
         result = gcs_client.get_all_node_info(timeout=timeout)
         total_num_nodes = 0
         for node_id, node_info in result.items():
-            if node_info["state"] == gcs_pb2.GcsNodeInfo.GcsNodeState.ALIVE:
+            if node_info.state == gcs_pb2.GcsNodeInfo.GcsNodeState.ALIVE:
                 total_num_nodes += 1
         return total_num_nodes
     except Exception as e:

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2880,7 +2880,7 @@ cdef class GcsClient:
                 c_uri, expiration_s, timeout_ms))
 
     @_auto_reconnect
-    def get_all_node_info(self, timeout=None) -> Dict[bytes, GcsNodeInfo]:
+    def get_all_node_info(self, timeout=None) -> Dict[NodeID, GcsNodeInfo]:
         cdef:
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
             CGcsNodeInfo c_node_info
@@ -2895,11 +2895,11 @@ cdef class GcsClient:
         for serialized in serialized_node_infos:
             node_info = GcsNodeInfo()
             node_info.ParseFromString(serialized)
-            result[node_info.node_id] = node_info
+            result[NodeID.from_binary(node_info.node_id)] = node_info
         return result
 
     @_auto_reconnect
-    def get_all_job_info(self, timeout=None) -> Dict[bytes, JobTableData]:
+    def get_all_job_info(self, timeout=None) -> Dict[JobID, JobTableData]:
         # Ideally we should use json_format.MessageToDict(job_info),
         # but `job_info` is a cpp pb message not a python one.
         # Manually converting each and every protobuf field is out of question,
@@ -2917,7 +2917,7 @@ cdef class GcsClient:
         for serialized in serialized_job_infos:
             job_info = JobTableData()
             job_info.ParseFromString(serialized)
-            result[job_info.job_id] = job_info
+            result[JobID.from_binary(job_info.job_id)] = job_info
         return result
 
     @_auto_reconnect

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2895,7 +2895,7 @@ cdef class GcsClient:
         for serialized in serialized_node_infos:
             node_info = GcsNodeInfo()
             node_info.ParseFromString(serialized)
-            result[NodeID.from_binary(node_info.node_id)] = node_info
+            result[NodeID(node_info.node_id)] = node_info
         return result
 
     @_auto_reconnect
@@ -2917,7 +2917,7 @@ cdef class GcsClient:
         for serialized in serialized_job_infos:
             job_info = JobTableData()
             job_info.ParseFromString(serialized)
-            result[JobID.from_binary(job_info.job_id)] = job_info
+            result[JobID(job_info.job_id)] = job_info
         return result
 
     @_auto_reconnect

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2895,7 +2895,7 @@ cdef class GcsClient:
         for serialized in serialized_node_infos:
             node_info = GcsNodeInfo()
             node_info.ParseFromString(serialized)
-            result[NodeID(node_info.node_id)] = node_info
+            result[NodeID.from_binary(node_info.node_id)] = node_info
         return result
 
     @_auto_reconnect
@@ -2917,7 +2917,7 @@ cdef class GcsClient:
         for serialized in serialized_job_infos:
             job_info = JobTableData()
             job_info.ParseFromString(serialized)
-            result[JobID(job_info.job_id)] = job_info
+            result[JobID.from_binary(job_info.job_id)] = job_info
         return result
 
     @_auto_reconnect

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -506,7 +506,7 @@ cdef extern from "src/ray/protobuf/gcs.pb.h" nogil:
 
     cdef cppclass CJobConfig "ray::rpc::JobConfig":
         c_string ray_namespace() const
-        const c_string &SerializeAsString()
+        const c_string &SerializeAsString() const
 
     cdef cppclass CNodeDeathInfo "ray::rpc::NodeDeathInfo":
         int reason() const
@@ -526,6 +526,7 @@ cdef extern from "src/ray/protobuf/gcs.pb.h" nogil:
         int runtime_env_agent_port() const
         CNodeDeathInfo death_info() const
         void ParseFromString(const c_string &serialized)
+        const c_string& SerializeAsString() const
 
     cdef enum CGcsNodeState "ray::rpc::GcsNodeInfo_GcsNodeState":
         ALIVE "ray::rpc::GcsNodeInfo_GcsNodeState_ALIVE",
@@ -534,7 +535,7 @@ cdef extern from "src/ray/protobuf/gcs.pb.h" nogil:
         c_string job_id() const
         c_bool is_dead() const
         CJobConfig config() const
-        const c_string &SerializeAsString()
+        const c_string &SerializeAsString() const
 
     cdef cppclass CPythonFunction "ray::rpc::PythonFunction":
         void set_key(const c_string &key)
@@ -570,7 +571,7 @@ cdef extern from "src/ray/protobuf/gcs.pb.h" nogil:
     cdef cppclass CActorTableData "ray::rpc::ActorTableData":
         CAddress address() const
         void ParseFromString(const c_string &serialized)
-        const c_string &SerializeAsString()
+        const c_string &SerializeAsString() const
 
 cdef extern from "ray/common/task/task_spec.h" nogil:
     cdef cppclass CConcurrencyGroup "ray::ConcurrencyGroup":

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -230,6 +230,12 @@ cdef class JobID(BaseID):
         check_id(id, CJobID.Size())
         self.data = CJobID.FromBinary(<c_string>id)
 
+    @classmethod
+    def from_binary(cls, id_bytes):
+        if not isinstance(id_bytes, bytes):
+            raise TypeError("Expect bytes, got " + str(type(id_bytes)))
+        return cls(id_bytes)
+
     cdef CJobID native(self):
         return <CJobID>self.data
 

--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -26,7 +26,7 @@ class ClusterNodeInfoCache(ABC):
         """
         nodes = self._gcs_client.get_all_node_info(timeout=RAY_GCS_RPC_TIMEOUT_S)
         alive_nodes = [
-            (ray.NodeID.from_binary(node_id).hex(), node.node_name)
+            (node_id.hex(), node.node_name)
             for (node_id, node) in nodes.items()
             if node.state == ray.core.generated.gcs_pb2.GcsNodeInfo.ALIVE
         ]
@@ -35,16 +35,12 @@ class ClusterNodeInfoCache(ABC):
         sorted(alive_nodes)
         self._cached_alive_nodes = alive_nodes
         self._cached_node_labels = {
-            ray.NodeID.from_binary(node_id).hex(): {
-                label_name.decode("utf-8"): label_value.decode("utf-8")
-                for label_name, label_value in node["labels"].items()
-            }
-            for (node_id, node) in nodes.items()
+            node_id.hex(): dict(node.labels) for (node_id, node) in nodes.items()
         }
 
         # Node resources
         self._cached_total_resources_per_node = {
-            ray.NodeID.from_binary(node_id).hex(): node["resources"]
+            node_id.hex(): dict(node.resources_total)
             for (node_id, node) in nodes.items()
         }
 

--- a/python/ray/serve/_private/cluster_node_info_cache.py
+++ b/python/ray/serve/_private/cluster_node_info_cache.py
@@ -26,9 +26,9 @@ class ClusterNodeInfoCache(ABC):
         """
         nodes = self._gcs_client.get_all_node_info(timeout=RAY_GCS_RPC_TIMEOUT_S)
         alive_nodes = [
-            (ray.NodeID.from_binary(node_id).hex(), node["node_name"].decode("utf-8"))
+            (ray.NodeID.from_binary(node_id).hex(), node.node_name)
             for (node_id, node) in nodes.items()
-            if node["state"] == ray.core.generated.gcs_pb2.GcsNodeInfo.ALIVE
+            if node.state == ray.core.generated.gcs_pb2.GcsNodeInfo.ALIVE
         ]
 
         # Sort on NodeID to ensure the ordering is deterministic across the cluster.

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -3584,7 +3584,7 @@ def test_job_info_is_running_task(shutdown_only):
     ray.get(signal.wait.remote())
 
     client = ray.worker.global_worker.gcs_client
-    job_id = ray.worker.global_worker.current_job_id.binary()
+    job_id = ray.worker.global_worker.current_job_id
     all_job_info = client.get_all_job_info()
     assert len(all_job_info) == 1
     assert job_id in all_job_info


### PR DESCRIPTION
This PR removes a custom proto-to-dict conversion by directly returning protos. This avoids some arbitrary data type semantics and prepares for the removal of PythonGcsClient. Also returns dict keys with JobID and NodeID.

Before:
- def get_all_job_info(self, timeout=None) -> Dict[bytes, JobTableData]
- def get_all_node_info(self, timeout=None) -> Dict[bytes, dict] # dict has "node_name", "state", "labels", "resources"

After:
- def get_all_job_info(self, timeout=None) -> Dict[JobID, JobTableData]
- def get_all_node_info(self, timeout=None) -> Dict[NodeID, GcsNodeInfo]
