### PR TITLE
[core] Add Autoscaler stub methods to GcsClients.

### DIFF
--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -1294,5 +1294,96 @@ Status InternalKVAccessor::Exists(const std::string &ns,
   return ret_promise.get_future().get();
 }
 
+AutoscalerStateAccessor::AutoscalerStateAccessor(GcsClient *client_impl)
+    : client_impl_(client_impl) {}
+
+Status AutoscalerStateAccessor::SyncRequestClusterResourceConstraint(
+    int64_t timeout_ms,
+    const std::vector<std::unordered_map<std::string, double>> &bundles,
+    const std::vector<int64_t> &count_array) {
+  rpc::autoscaler::RequestClusterResourceConstraintRequest request;
+  rpc::autoscaler::RequestClusterResourceConstraintReply reply;
+  RAY_CHECK(bundles.size() == count_array.size());
+  for (size_t i = 0; i < bundles.size(); ++i) {
+    const auto &bundle = bundles[i];
+    auto count = count_array[i];
+
+    auto new_resource_requests_by_count =
+        request.mutable_cluster_resource_constraint()->add_min_bundles();
+
+    new_resource_requests_by_count->mutable_request()->mutable_resources_bundle()->insert(
+        bundle.begin(), bundle.end());
+    new_resource_requests_by_count->set_count(count);
+  }
+
+  return client_impl_->GetGcsRpcClient().SyncRequestClusterResourceConstraint(
+      request, &reply, timeout_ms);
+}
+
+Status AutoscalerStateAccessor::SyncGetClusterResourceState(
+    int64_t timeout_ms, std::string &serialized_reply) {
+  rpc::autoscaler::GetClusterResourceStateRequest request;
+  rpc::autoscaler::GetClusterResourceStateReply reply;
+
+  RAY_RETURN_NOT_OK(client_impl_->GetGcsRpcClient().SyncGetClusterResourceState(
+      request, &reply, timeout_ms));
+
+  if (!reply.SerializeToString(&serialized_reply)) {
+    return Status::IOError("Failed to serialize GetClusterResourceState");
+  }
+  return Status::OK();
+}
+
+Status AutoscalerStateAccessor::SyncGetClusterStatus(int64_t timeout_ms,
+                                                     std::string &serialized_reply) {
+  rpc::autoscaler::GetClusterStatusRequest request;
+  rpc::autoscaler::GetClusterStatusReply reply;
+
+  RAY_RETURN_NOT_OK(
+      client_impl_->GetGcsRpcClient().SyncGetClusterStatus(request, &reply, timeout_ms));
+
+  if (!reply.SerializeToString(&serialized_reply)) {
+    return Status::IOError("Failed to serialize GetClusterStatusReply");
+  }
+  return Status::OK();
+}
+
+Status AutoscalerStateAccessor::SyncReportAutoscalingState(
+    int64_t timeout_ms, const std::string &serialized_state) {
+  rpc::autoscaler::ReportAutoscalingStateRequest request;
+  rpc::autoscaler::ReportAutoscalingStateReply reply;
+
+  if (!request.mutable_autoscaling_state()->ParseFromString(serialized_state)) {
+    return Status::IOError("Failed to parse ReportAutoscalingState");
+  }
+  return client_impl_->GetGcsRpcClient().SyncReportAutoscalingState(
+      request, &reply, timeout_ms);
+}
+
+Status AutoscalerStateAccessor::SyncDrainNode(const std::string &node_id,
+                                              int32_t reason,
+                                              const std::string &reason_message,
+                                              int64_t deadline_timestamp_ms,
+                                              int64_t timeout_ms,
+                                              bool &is_accepted,
+                                              std::string &rejection_reason_message) {
+  rpc::autoscaler::DrainNodeRequest request;
+  request.set_node_id(NodeID::FromHex(node_id).Binary());
+  request.set_reason(static_cast<rpc::autoscaler::DrainNodeReason>(reason));
+  request.set_reason_message(reason_message);
+  request.set_deadline_timestamp_ms(deadline_timestamp_ms);
+
+  rpc::autoscaler::DrainNodeReply reply;
+
+  RAY_RETURN_NOT_OK(
+      client_impl_->GetGcsRpcClient().SyncDrainNode(request, &reply, timeout_ms));
+
+  is_accepted = reply.is_accepted();
+  if (!is_accepted) {
+    rejection_reason_message = reply.rejection_reason_message();
+  }
+  return Status::OK();
+}
+
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -1297,7 +1297,7 @@ Status InternalKVAccessor::Exists(const std::string &ns,
 AutoscalerStateAccessor::AutoscalerStateAccessor(GcsClient *client_impl)
     : client_impl_(client_impl) {}
 
-Status AutoscalerStateAccessor::SyncRequestClusterResourceConstraint(
+Status AutoscalerStateAccessor::RequestClusterResourceConstraint(
     int64_t timeout_ms,
     const std::vector<std::unordered_map<std::string, double>> &bundles,
     const std::vector<int64_t> &count_array) {
@@ -1320,8 +1320,8 @@ Status AutoscalerStateAccessor::SyncRequestClusterResourceConstraint(
       request, &reply, timeout_ms);
 }
 
-Status AutoscalerStateAccessor::SyncGetClusterResourceState(
-    int64_t timeout_ms, std::string &serialized_reply) {
+Status AutoscalerStateAccessor::GetClusterResourceState(int64_t timeout_ms,
+                                                        std::string &serialized_reply) {
   rpc::autoscaler::GetClusterResourceStateRequest request;
   rpc::autoscaler::GetClusterResourceStateReply reply;
 
@@ -1334,8 +1334,8 @@ Status AutoscalerStateAccessor::SyncGetClusterResourceState(
   return Status::OK();
 }
 
-Status AutoscalerStateAccessor::SyncGetClusterStatus(int64_t timeout_ms,
-                                                     std::string &serialized_reply) {
+Status AutoscalerStateAccessor::GetClusterStatus(int64_t timeout_ms,
+                                                 std::string &serialized_reply) {
   rpc::autoscaler::GetClusterStatusRequest request;
   rpc::autoscaler::GetClusterStatusReply reply;
 
@@ -1348,7 +1348,7 @@ Status AutoscalerStateAccessor::SyncGetClusterStatus(int64_t timeout_ms,
   return Status::OK();
 }
 
-Status AutoscalerStateAccessor::SyncReportAutoscalingState(
+Status AutoscalerStateAccessor::ReportAutoscalingState(
     int64_t timeout_ms, const std::string &serialized_state) {
   rpc::autoscaler::ReportAutoscalingStateRequest request;
   rpc::autoscaler::ReportAutoscalingStateReply reply;
@@ -1360,13 +1360,13 @@ Status AutoscalerStateAccessor::SyncReportAutoscalingState(
       request, &reply, timeout_ms);
 }
 
-Status AutoscalerStateAccessor::SyncDrainNode(const std::string &node_id,
-                                              int32_t reason,
-                                              const std::string &reason_message,
-                                              int64_t deadline_timestamp_ms,
-                                              int64_t timeout_ms,
-                                              bool &is_accepted,
-                                              std::string &rejection_reason_message) {
+Status AutoscalerStateAccessor::DrainNode(const std::string &node_id,
+                                          int32_t reason,
+                                          const std::string &reason_message,
+                                          int64_t deadline_timestamp_ms,
+                                          int64_t timeout_ms,
+                                          bool &is_accepted,
+                                          std::string &rejection_reason_message) {
   rpc::autoscaler::DrainNodeRequest request;
   request.set_node_id(NodeID::FromHex(node_id).Binary());
   request.set_reason(static_cast<rpc::autoscaler::DrainNodeReason>(reason));

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -1303,7 +1303,7 @@ Status AutoscalerStateAccessor::RequestClusterResourceConstraint(
     const std::vector<int64_t> &count_array) {
   rpc::autoscaler::RequestClusterResourceConstraintRequest request;
   rpc::autoscaler::RequestClusterResourceConstraintReply reply;
-  RAY_CHECK(bundles.size() == count_array.size());
+  RAY_CHECK_EQ(bundles.size(), count_array.size());
   for (size_t i = 0; i < bundles.size(); ++i) {
     const auto &bundle = bundles[i];
     auto count = count_array[i];

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -895,26 +895,26 @@ class AutoscalerStateAccessor {
   explicit AutoscalerStateAccessor(GcsClient *client_impl);
   virtual ~AutoscalerStateAccessor() = default;
 
-  virtual Status SyncRequestClusterResourceConstraint(
+  virtual Status RequestClusterResourceConstraint(
       int64_t timeout_ms,
       const std::vector<std::unordered_map<std::string, double>> &bundles,
       const std::vector<int64_t> &count_array);
 
-  virtual Status SyncGetClusterResourceState(int64_t timeout_ms,
-                                             std::string &serialized_reply);
+  virtual Status GetClusterResourceState(int64_t timeout_ms,
+                                         std::string &serialized_reply);
 
-  virtual Status SyncGetClusterStatus(int64_t timeout_ms, std::string &serialized_reply);
+  virtual Status GetClusterStatus(int64_t timeout_ms, std::string &serialized_reply);
 
-  virtual Status SyncReportAutoscalingState(int64_t timeout_ms,
-                                            const std::string &serialized_state);
+  virtual Status ReportAutoscalingState(int64_t timeout_ms,
+                                        const std::string &serialized_state);
 
-  virtual Status SyncDrainNode(const std::string &node_id,
-                               int32_t reason,
-                               const std::string &reason_message,
-                               int64_t deadline_timestamp_ms,
-                               int64_t timeout_ms,
-                               bool &is_accepted,
-                               std::string &rejection_reason_message);
+  virtual Status DrainNode(const std::string &node_id,
+                           int32_t reason,
+                           const std::string &reason_message,
+                           int64_t deadline_timestamp_ms,
+                           int64_t timeout_ms,
+                           bool &is_accepted,
+                           std::string &rejection_reason_message);
 
  private:
   GcsClient *client_impl_;

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -885,6 +885,42 @@ class InternalKVAccessor {
   GcsClient *client_impl_;
 };
 
+/// \class AutoscalerStateAccessor
+/// `AutoscalerStateAccessor` is a sub-interface of `GcsClient`.
+/// This class includes all the methods that are related to accessing
+/// autoscaler state information in the GCS.
+class AutoscalerStateAccessor {
+ public:
+  AutoscalerStateAccessor() = default;
+  explicit AutoscalerStateAccessor(GcsClient *client_impl);
+  virtual ~AutoscalerStateAccessor() = default;
+
+  virtual Status SyncRequestClusterResourceConstraint(
+      int64_t timeout_ms,
+      const std::vector<std::unordered_map<std::string, double>> &bundles,
+      const std::vector<int64_t> &count_array);
+
+  virtual Status SyncGetClusterResourceState(int64_t timeout_ms,
+                                             std::string &serialized_reply);
+
+  virtual Status SyncGetClusterStatus(int64_t timeout_ms, std::string &serialized_reply);
+
+  virtual Status SyncReportAutoscalingState(int64_t timeout_ms,
+                                            const std::string &serialized_state);
+
+  virtual Status SyncDrainNode(const std::string &node_id,
+                               int32_t reason,
+                               const std::string &reason_message,
+                               int64_t deadline_timestamp_ms,
+                               int64_t timeout_ms,
+                               bool &is_accepted,
+                               std::string &rejection_reason_message);
+
+ private:
+  GcsClient *client_impl_;
+};
+;
+
 }  // namespace gcs
 
 }  // namespace ray

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -130,6 +130,7 @@ Status GcsClient::Connect(instrumented_io_context &io_service,
   placement_group_accessor_ = std::make_unique<PlacementGroupInfoAccessor>(this);
   internal_kv_accessor_ = std::make_unique<InternalKVAccessor>(this);
   task_accessor_ = std::make_unique<TaskInfoAccessor>(this);
+  autoscaler_state_accessor_ = std::make_unique<AutoscalerStateAccessor>(this);
 
   RAY_LOG(DEBUG) << "GcsClient connected " << options_.gcs_address_ << ":"
                  << options_.gcs_port_;

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -160,6 +160,11 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
     return *placement_group_accessor_;
   }
 
+  AutoscalerStateAccessor &Autoscaler() {
+    RAY_CHECK(autoscaler_state_accessor_ != nullptr);
+    return *autoscaler_state_accessor_;
+  }
+
   const ClusterID &GetClusterId() {
     RAY_CHECK(client_call_manager_) << "Cannot retrieve cluster ID before it is set.";
     return client_call_manager_->GetClusterId();
@@ -184,8 +189,8 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
   std::unique_ptr<WorkerInfoAccessor> worker_accessor_;
   std::unique_ptr<PlacementGroupInfoAccessor> placement_group_accessor_;
   std::unique_ptr<InternalKVAccessor> internal_kv_accessor_;
-
   std::unique_ptr<TaskInfoAccessor> task_accessor_;
+  std::unique_ptr<AutoscalerStateAccessor> autoscaler_state_accessor_;
 
  private:
   const UniqueID gcs_client_id_ = UniqueID::FromRandom();

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -23,6 +23,7 @@
 #include "ray/common/grpc_util.h"
 #include "ray/common/network_util.h"
 #include "ray/rpc/grpc_client.h"
+#include "src/ray/protobuf/autoscaler.grpc.pb.h"
 #include "src/ray/protobuf/gcs_service.grpc.pb.h"
 
 namespace ray {
@@ -55,6 +56,11 @@ class Executor {
   std::function<void()> operation_;
 };
 
+#define VOID_GCS_RPC_CLIENT_METHOD(                         \
+    SERVICE, METHOD, grpc_client, method_timeout_ms, SPECS) \
+  VOID_GCS_RPC_CLIENT_METHOD_FULL(                          \
+      ray::rpc, SERVICE, METHOD, grpc_client, method_timeout_ms, true, SPECS)
+
 /// Define a void GCS RPC client method.
 ///
 /// Example:
@@ -76,6 +82,7 @@ class Executor {
 ///   That says, when there's any RPC failure, the method will automatically retry
 ///   under the hood.
 ///
+/// \param NAMESPACE namespace of the service.
 /// \param SERVICE name of the service.
 /// \param METHOD name of the RPC method.
 /// \param grpc_client The grpc client to invoke RPC.
@@ -84,35 +91,45 @@ class Executor {
 /// whole service, handler, and each call.
 /// The priority of timeout is each call > handler > whole service
 /// (the lower priority timeout is overwritten by the higher priority timeout).
+/// \param handle_payload_status true if the Reply has a status we want to return.
 /// \param SPECS The cpp method spec. For example, override.
 ///
 /// Currently, SyncMETHOD will copy the reply additionally.
 /// TODO(sang): Fix it.
-#define VOID_GCS_RPC_CLIENT_METHOD(                                              \
-    SERVICE, METHOD, grpc_client, method_timeout_ms, SPECS)                      \
-  void METHOD(const METHOD##Request &request,                                    \
-              const ClientCallback<METHOD##Reply> &callback,                     \
-              const int64_t timeout_ms = method_timeout_ms) SPECS {              \
-    invoke_async_method(&SERVICE::Stub::PrepareAsync##METHOD,                    \
-                        *grpc_client,                                            \
-                        #SERVICE ".grpc_client." #METHOD,                        \
-                        request,                                                 \
-                        callback,                                                \
-                        timeout_ms);                                             \
-  }                                                                              \
-                                                                                 \
-  ray::Status Sync##METHOD(const METHOD##Request &request,                       \
-                           METHOD##Reply *reply_in,                              \
-                           const int64_t timeout_ms = method_timeout_ms) {       \
-    std::promise<Status> promise;                                                \
-    METHOD(                                                                      \
-        request,                                                                 \
-        [&promise, reply_in](const Status &status, const METHOD##Reply &reply) { \
-          reply_in->CopyFrom(reply);                                             \
-          promise.set_value(status);                                             \
-        },                                                                       \
-        timeout_ms);                                                             \
-    return promise.get_future().get();                                           \
+#define VOID_GCS_RPC_CLIENT_METHOD_FULL(NAMESPACE,                         \
+                                        SERVICE,                           \
+                                        METHOD,                            \
+                                        grpc_client,                       \
+                                        method_timeout_ms,                 \
+                                        handle_payload_status,             \
+                                        SPECS)                             \
+  void METHOD(const NAMESPACE::METHOD##Request &request,                   \
+              const ClientCallback<NAMESPACE::METHOD##Reply> &callback,    \
+              const int64_t timeout_ms = method_timeout_ms) SPECS {        \
+    invoke_async_method<NAMESPACE::SERVICE,                                \
+                        NAMESPACE::METHOD##Request,                        \
+                        NAMESPACE::METHOD##Reply,                          \
+                        handle_payload_status>(                            \
+        &NAMESPACE::SERVICE::Stub::PrepareAsync##METHOD,                   \
+        *grpc_client,                                                      \
+        #NAMESPACE "::" #SERVICE ".grpc_client." #METHOD,                  \
+        request,                                                           \
+        callback,                                                          \
+        timeout_ms);                                                       \
+  }                                                                        \
+  ray::Status Sync##METHOD(const NAMESPACE::METHOD##Request &request,      \
+                           NAMESPACE::METHOD##Reply *reply_in,             \
+                           const int64_t timeout_ms = method_timeout_ms) { \
+    std::promise<Status> promise;                                          \
+    METHOD(                                                                \
+        request,                                                           \
+        [&promise, reply_in](const Status &status,                         \
+                             const NAMESPACE::METHOD##Reply &reply) {      \
+          reply_in->CopyFrom(reply);                                       \
+          promise.set_value(status);                                       \
+        },                                                                 \
+        timeout_ms);                                                       \
+    return promise.get_future().get();                                     \
   }
 
 /// Client used for communicating with gcs server.
@@ -180,14 +197,19 @@ class GcsRpcClient {
         std::make_unique<GrpcClient<InternalKVGcsService>>(channel_, client_call_manager);
     internal_pubsub_grpc_client_ = std::make_unique<GrpcClient<InternalPubSubGcsService>>(
         channel_, client_call_manager);
-
     task_info_grpc_client_ =
         std::make_unique<GrpcClient<TaskInfoGcsService>>(channel_, client_call_manager);
+    autoscaler_state_grpc_client_ =
+        std::make_unique<GrpcClient<autoscaler::AutoscalerStateService>>(
+            channel_, client_call_manager);
 
     SetupCheckTimer();
   }
 
-  template <typename Service, typename Request, typename Reply>
+  template <typename Service,
+            typename Request,
+            typename Reply,
+            bool handle_payload_status>
   void invoke_async_method(
       PrepareAsyncFunction<Service, Request, Reply> prepare_async_function,
       GrpcClient<Service> &grpc_client,
@@ -199,20 +221,19 @@ class GcsRpcClient {
         [callback](const ray::Status &status) { callback(status, Reply()); });
     auto operation_callback = [this, request, callback, executor, timeout_ms](
                                   const ray::Status &status, const Reply &reply) {
-      if (status.IsTimedOut()) {
-        callback(status, reply);
-        delete executor;
-      } else if (!status.IsGrpcError()) {
-        /* We prioritize RPC status over reply.status when propagating. */
-        if (!status.ok()) {
-          callback(status, reply);
-        } else {
-          auto st =
-              reply.status().code() == (int)StatusCode::OK
+      if (status.ok()) {
+        if constexpr (handle_payload_status) {
+          Status st =
+              (reply.status().code() == (int)StatusCode::OK)
                   ? Status()
                   : Status(StatusCode(reply.status().code()), reply.status().message());
           callback(st, reply);
+        } else {
+          callback(status, reply);
         }
+        delete executor;
+      } else if (!status.IsGrpcError()) {
+        callback(status, reply);
         delete executor;
       } else {
         /* In case of GCS failure, we queue the request and these requests will be */
@@ -513,6 +534,41 @@ class GcsRpcClient {
                              GcsSubscriberCommandBatch,
                              internal_pubsub_grpc_client_,
                              /*method_timeout_ms*/ -1, )
+  /// Operations for autoscaler
+  VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  AutoscalerStateService,
+                                  GetClusterResourceState,
+                                  autoscaler_state_grpc_client_,
+                                  /*method_timeout_ms*/ -1,
+                                  /*handle_payload_status=*/false, )
+
+  VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  AutoscalerStateService,
+                                  ReportAutoscalingState,
+                                  autoscaler_state_grpc_client_,
+                                  /*method_timeout_ms*/ -1,
+                                  /*handle_payload_status=*/false, )
+
+  VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  AutoscalerStateService,
+                                  RequestClusterResourceConstraint,
+                                  autoscaler_state_grpc_client_,
+                                  /*method_timeout_ms*/ -1,
+                                  /*handle_payload_status=*/false, )
+
+  VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  AutoscalerStateService,
+                                  GetClusterStatus,
+                                  autoscaler_state_grpc_client_,
+                                  /*method_timeout_ms*/ -1,
+                                  /*handle_payload_status=*/false, )
+
+  VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  AutoscalerStateService,
+                                  DrainNode,
+                                  autoscaler_state_grpc_client_,
+                                  /*method_timeout_ms*/ -1,
+                                  /*handle_payload_status=*/false, )
 
   void Shutdown() {
     if (!shutdown_.exchange(true)) {
@@ -633,8 +689,9 @@ class GcsRpcClient {
       placement_group_info_grpc_client_;
   std::unique_ptr<GrpcClient<InternalKVGcsService>> internal_kv_grpc_client_;
   std::unique_ptr<GrpcClient<InternalPubSubGcsService>> internal_pubsub_grpc_client_;
-
   std::unique_ptr<GrpcClient<TaskInfoGcsService>> task_info_grpc_client_;
+  std::unique_ptr<GrpcClient<autoscaler::AutoscalerStateService>>
+      autoscaler_state_grpc_client_;
 
   std::shared_ptr<grpc::Channel> channel_;
   bool gcs_is_down_ = false;

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -56,6 +56,10 @@ class Executor {
   std::function<void()> operation_;
 };
 
+/// Convenience macro to invoke VOID_GCS_RPC_CLIENT_METHOD_FULL with defaults.
+///
+/// Creates a Sync and an Async method just like in VOID_GCS_RPC_CLIENT_METHOD_FULL,
+/// with NAMESPACE = ray::rpc, and handle_payload_status = true.
 #define VOID_GCS_RPC_CLIENT_METHOD(                         \
     SERVICE, METHOD, grpc_client, method_timeout_ms, SPECS) \
   VOID_GCS_RPC_CLIENT_METHOD_FULL(                          \
@@ -64,10 +68,12 @@ class Executor {
 /// Define a void GCS RPC client method.
 ///
 /// Example:
-///   VOID_GCS_RPC_CLIENT_METHOD(
+///   VOID_GCS_RPC_CLIENT_METHOD_FULL(
+///     ray::rpc,
 ///     ActorInfoGcsService,
 ///     CreateActor,
 ///     actor_info_grpc_client_,
+///     /*handle_payload_status=*/true,
 ///     /*method_timeout_ms*/ -1,) # Default value
 ///   generates
 ///


### PR DESCRIPTION
ray::rpc::autoscaler::AutoscalerStateService is on GCS, accessible via PythonGcsClient but not via GcsClient. This PR adds all methods and brings feature parity for the latter.

In order to add it to GcsRpcClient, we find 2 challenges:

1. The service and its proto types are in namespace ray::rpc::autoscaler, not ray::rpc as all other services and methods.
2. The reply protos has no `status` field like all other replies.

To support this, I changed `VOID_GCS_RPC_CLIENT_METHOD` to a more generic version `VOID_GCS_RPC_CLIENT_METHOD_FULL` that accepts a namespace and a boolean `handle_payload_status`. The boolean is passed to `invoke_async_method` in compile time. This allows us to only check `status` field if the bool is true, and don't check it for the new autoscaler methods.

The GcsClient methods are only added with sync version and not async version, because the callers only need sync ones.