### PR TITLE
[ADAG] Introduce CompiledDAGRef

### DIFF
--- a/python/ray/_private/serialization.py
+++ b/python/ray/_private/serialization.py
@@ -48,6 +48,7 @@ from ray.exceptions import (
     OutOfMemoryError,
     ObjectRefStreamEndOfStreamError,
 )
+from ray.experimental.compiled_dag_ref import CompiledDAGRef
 from ray.util import serialization_addons
 from ray.util import inspect_serializability
 
@@ -130,6 +131,11 @@ class SerializationContext:
             return _actor_handle_deserializer, (serialized, weak_ref)
 
         self._register_cloudpickle_reducer(ray.actor.ActorHandle, actor_handle_reducer)
+
+        def compiled_dag_ref_reducer(obj):
+            raise TypeError("Serialization of CompiledDAGRef is not supported.")
+
+        self._register_cloudpickle_reducer(CompiledDAGRef, compiled_dag_ref_reducer)
 
         def object_ref_reducer(obj):
             worker = ray._private.worker.global_worker

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -88,6 +88,7 @@ from ray.experimental.internal_kv import (
     _internal_kv_reset,
 )
 from ray.experimental import tqdm_ray
+from ray.experimental.compiled_dag_ref import CompiledDAGRef
 from ray.experimental.tqdm_ray import RAY_TQDM_MAGIC
 from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 from ray.util.debug import log_once
@@ -2616,6 +2617,9 @@ def get(
         if isinstance(object_refs, ObjectRefGenerator):
             return object_refs
 
+        if isinstance(object_refs, CompiledDAGRef):
+            return object_refs.get()
+
         is_individual_id = isinstance(object_refs, ray.ObjectRef)
         if is_individual_id:
             object_refs = [object_refs]
@@ -2835,6 +2839,11 @@ def wait(
                 "wait() expected a list of ray.ObjectRef or "
                 "ray.ObjectRefGenerator, "
                 f"got list containing {type(ray_waitable)}"
+            )
+        if isinstance(ray_waitable, CompiledDAGRef):
+            raise TypeError(
+                "wait() does not support CompiledDAGRef. "
+                "Please call ray.get() on the CompiledDAGRef to get the result."
             )
     worker.check_connected()
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -892,6 +892,9 @@ cdef prepare_args_internal(
     total_inlined = 0
     rpc_inline_threshold = RayConfig.instance().task_rpc_inlined_bytes_limit()
     for arg in args:
+        from ray.experimental.compiled_dag_ref import CompiledDAGRef
+        if isinstance(arg, CompiledDAGRef):
+            raise TypeError("CompiledDAGRef cannot be used as Ray task/actor argument.")
         if isinstance(arg, ObjectRef):
             c_arg = (<ObjectRef>arg).native()
             op_status = CCoreWorkerProcess.GetCoreWorker().GetOwnerAddress(

--- a/python/ray/dag/BUILD
+++ b/python/ray/dag/BUILD
@@ -76,7 +76,8 @@ py_test_module_list(
     "tests/experimental/test_torch_tensor_dag.py",
   ],
   size = "medium",
-  tags = ["exclusive", "accelerated_dag", "no_windows", "team:core"],
+  # Marking these as manual until they are deflaked.
+  tags = ["exclusive", "accelerated_dag", "no_windows", "team:core", "manual"],
   deps = ["//:ray_lib"],
 )
 

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -2,11 +2,11 @@ import asyncio
 from collections import defaultdict
 from typing import Any, Dict, List, Tuple, Union, Optional, Set
 import logging
-import traceback
 import threading
+import uuid
 
 import ray
-from ray.exceptions import RayTaskError
+from ray.experimental.compiled_dag_ref import CompiledDAGRef, RayDAGTaskError
 from ray.experimental.channel import (
     ChannelInterface,
     ChannelOutputType,
@@ -31,6 +31,11 @@ from ray.experimental.channel.torch_tensor_nccl_channel import (
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 MAX_BUFFER_SIZE = int(100 * 1e6)  # 100MB
+
+# The maximum total memory that can be used to buffer DAG execution results.
+MAX_BUFFER_TOTAL_MEMORY = int(10 * 1e9)  # 10GB
+
+MAX_BUFFER_COUNT = MAX_BUFFER_TOTAL_MEMORY // MAX_BUFFER_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +143,7 @@ def _exec_task(self, task: "ExecutableTask", idx: int) -> bool:
     output_writer = self._output_writers[idx]
     res = None
     try:
-        res = input_reader.begin_read()
+        res = input_reader.read()
     except IOError:
         # Channel closed. Exit the loop.
         return True
@@ -148,7 +153,6 @@ def _exec_task(self, task: "ExecutableTask", idx: int) -> bool:
         # exception in a RayTaskError here because it has already been wrapped
         # by the previous task.
         output_writer.write(exc)
-        input_reader.end_read()
         return False
 
     resolved_inputs = []
@@ -159,26 +163,11 @@ def _exec_task(self, task: "ExecutableTask", idx: int) -> bool:
         output_val = method(*resolved_inputs)
         output_writer.write(output_val)
     except Exception as exc:
-        output_writer.write(_wrap_exception(exc))
+        # TODO(rui): consider different ways of passing down the exception,
+        # e.g., wrapping with RayTaskError.
+        output_writer.write(RayDAGTaskError(exc))
 
-    try:
-        input_reader.end_read()
-    except IOError:
-        return True
     return False
-
-
-def _wrap_exception(exc):
-    backtrace = ray._private.utils.format_error_message(
-        "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
-        task_exception=True,
-    )
-    wrapped = RayTaskError(
-        function_name="do_exec_tasks",
-        traceback_str=backtrace,
-        cause=exc,
-    )
-    return wrapped
 
 
 @PublicAPI(stability="alpha")
@@ -187,21 +176,11 @@ class AwaitableDAGOutput:
         self._fut = fut
         self._reader = ReaderInterface
 
-    async def begin_read(self):
+    async def get(self):
         ret = await self._fut
         if isinstance(ret, Exception):
             raise ret
         return ret
-
-    def end_read(self):
-        self._reader.end_read()
-
-    async def __aenter__(self):
-        ret = await self._fut
-        return ret
-
-    async def __aexit__(self, exc_type, exc_value, traceback):
-        self.end_read()
 
 
 @DeveloperAPI
@@ -403,6 +382,7 @@ class CompiledDAG:
         buffer_size_bytes: Optional[int],
         enable_asyncio: bool = False,
         async_max_queue_size: Optional[int] = None,
+        max_buffered_results: Optional[int] = None,
     ):
         """
         Args:
@@ -420,9 +400,18 @@ class CompiledDAG:
                 caller is responsible for preventing deadlock, i.e. if the
                 input queue is full, another asyncio task is reading from the
                 DAG output.
+            max_buffered_results: The maximum number of execution results that
+                are allowed to be buffered. Setting a higher value allows more
+                DAGs to be executed before `ray.get()` must be called but also
+                increases the memory usage. Note that if the number of ongoing
+                executions is beyond the DAG capacity, the new execution would
+                be blocked in the first place; therefore, this limit is only
+                enforced when it is smaller than the DAG capacity.
+
         Returns:
             Channel: A wrapper around ray.ObjectRef.
         """
+        self._dag_id = uuid.uuid4().hex
         self._buffer_size_bytes: Optional[int] = buffer_size_bytes
         if self._buffer_size_bytes is None:
             self._buffer_size_bytes = MAX_BUFFER_SIZE
@@ -438,6 +427,10 @@ class CompiledDAG:
         self._enable_asyncio: bool = enable_asyncio
         self._fut_queue = asyncio.Queue()
         self._async_max_queue_size: Optional[int] = async_max_queue_size
+        # TODO(rui): consider unify it with async_max_queue_size
+        self._max_buffered_results: Optional[int] = max_buffered_results
+        if self._max_buffered_results is None:
+            self._max_buffered_results = MAX_BUFFER_COUNT
         # Used to ensure that the future returned to the
         # caller corresponds to the correct DAG output. I.e.
         # order of futures added to fut_queue should match the
@@ -482,6 +475,13 @@ class CompiledDAG:
         # Uniquely identifies the NCCL communicator that will be used within
         # this DAG, if any.
         self._nccl_group_id: Optional[str] = None
+        # The index of the current execution. It is incremented each time
+        # the DAG is executed.
+        self._execution_index: int = 0
+        # The maximum index of finished executions.
+        # All results with higher indexes have not been generated yet.
+        self._max_execution_index: int = -1
+        self._result_buffer: Dict[int, Any] = {}
 
         # Creates the driver actor on the same node as the driver.
         #
@@ -495,6 +495,15 @@ class CompiledDAG:
                 ray.get_runtime_context().get_node_id(), soft=False
             )
         ).remote()
+
+    def get_id(self) -> str:
+        """
+        Get the unique ID of the compiled DAG.
+        """
+        return self._dag_id
+
+    def __str__(self) -> str:
+        return f"CompiledDAG({self._dag_id})"
 
     def _add_node(self, node: "ray.dag.DAGNode") -> None:
         idx = self.counter
@@ -707,9 +716,8 @@ class CompiledDAG:
 
                     #     compiled_dag = dag.experimental_compile()
                     #     output_channel = compiled_dag.execute(1)
-                    #     result = output_channel.begin_read()
+                    #     result = output_channel.read()
                     #     print(result)
-                    #     output_channel.end_read()
 
                     #     compiled_dag.teardown()
                     reader_handles = [self._driver_actor]
@@ -949,11 +957,49 @@ class CompiledDAG:
         monitor.start()
         return monitor
 
+    def _execute_until(
+        self,
+        execution_index: int,
+    ) -> Any:
+        """Repeatedly execute this DAG until the given execution index,
+        and buffer all results up to that index. If the DAG has already
+        been executed up to the given index, just return the result
+        corresponding to the given index.
+
+        Args:
+            execution_index: The execution index to execute until.
+
+        Returns:
+            The execution result corresponding to the given execution index.
+
+        TODO(rui): catch the case that user holds onto the CompiledDAGRefs
+        """
+        while self._max_execution_index < execution_index:
+            if self._max_execution_index + 1 == execution_index:
+                # Directly fetch and return without buffering
+                self._max_execution_index += 1
+                return self._dag_output_fetcher.read()
+            # Otherwise, buffer the result
+            if len(self._result_buffer) >= self._max_buffered_results:
+                raise ValueError(
+                    "Too many buffered results: the allowed max count for "
+                    f"buffered results is {self._max_buffered_results}; call ray.get() "
+                    "on previous CompiledDAGRefs to free them up from buffer."
+                )
+            self._max_execution_index += 1
+            self._result_buffer[
+                self._max_execution_index
+            ] = self._dag_output_fetcher.read()
+
+        # CompiledDAGRef guarantees that the same execution index will not
+        # be requested multiple times
+        return self._result_buffer.pop(execution_index)
+
     def execute(
         self,
         *args,
         **kwargs,
-    ) -> ReaderInterface:
+    ) -> CompiledDAGRef:
         """Execute this DAG using the compiled execution path.
 
         Args:
@@ -962,6 +1008,8 @@ class CompiledDAG:
 
         Returns:
             A list of Channels that can be used to read the DAG result.
+
+        NOTE: Not threadsafe due to _execution_index etc.
         """
         if self._enable_asyncio:
             raise ValueError("Use execute_async if enable_asyncio=True")
@@ -971,7 +1019,9 @@ class CompiledDAG:
         inp = (args, kwargs)
         self._dag_submitter.write(inp)
 
-        return self._dag_output_fetcher
+        ref = CompiledDAGRef(self, self._execution_index)
+        self._execution_index += 1
+        return ref
 
     async def execute_async(
         self,
@@ -1026,11 +1076,13 @@ def build_compiled_dag_from_ray_dag(
     buffer_size_bytes: Optional[int],
     enable_asyncio: bool = False,
     async_max_queue_size: Optional[int] = None,
+    max_buffered_results: Optional[int] = None,
 ) -> "CompiledDAG":
     compiled_dag = CompiledDAG(
         buffer_size_bytes,
         enable_asyncio,
         async_max_queue_size,
+        max_buffered_results,
     )
 
     def _build_compiled_dag(node):

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -131,14 +131,22 @@ class DAGNode(DAGNodeBase):
         buffer_size_bytes: Optional[int] = None,
         enable_asyncio: bool = False,
         async_max_queue_size: Optional[int] = None,
+        max_buffered_results: Optional[int] = None,
     ) -> "ray.dag.CompiledDAG":
         """Compile an accelerated execution path for this DAG.
 
         Args:
             buffer_size_bytes: The maximum size of messages that can be passed
                 between tasks in the DAG.
-            max_concurrency: The max number of concurrent executions to allow for
-                the DAG.
+            enable_asyncio: Whether to enable asyncio for this DAG.
+            async_max_queue_size: The max queue size for the async execution.
+            max_buffered_results: The maximum number of execution results that
+                are allowed to be buffered. Setting a higher value allows more
+                DAGs to be executed before `ray.get()` must be called but also
+                increases the memory usage. Note that if the number of ongoing
+                executions is beyond the DAG capacity, the new execution would
+                be blocked in the first place; therefore, this limit is only
+                enforced when it is smaller than the DAG capacity.
 
         Returns:
             A compiled DAG.
@@ -148,6 +156,7 @@ class DAGNode(DAGNodeBase):
             buffer_size_bytes,
             enable_asyncio,
             async_max_queue_size,
+            max_buffered_results,
         )
 
     def execute(

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1,14 +1,18 @@
 # coding: utf-8
+import asyncio
+import copy
 import logging
 import os
+import pickle
 import random
 import sys
 import time
-import asyncio
 
 import pytest
 
+from ray.experimental.compiled_dag_ref import RayDAGTaskError
 import ray
+import ray._private
 import ray.cluster_utils
 from ray.dag import InputNode, MultiOutputNode
 from ray.tests.conftest import *  # noqa
@@ -98,16 +102,34 @@ def test_basic(ray_start_regular):
         dag = a.inc.bind(i)
 
     compiled_dag = dag.experimental_compile()
+    dag_id = compiled_dag.get_id()
 
     for i in range(3):
-        output_channel = compiled_dag.execute(1)
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(1)
+        assert str(ref) == f"CompiledDAGRef({dag_id}, execution_index={i})"
+        result = ray.get(ref)
         assert result == i + 1
-        output_channel.end_read()
 
     # Note: must teardown before starting a new Ray session, otherwise you'll get
     # a segfault from the dangling monitor thread upon the new Ray init.
+    compiled_dag.teardown()
+
+
+def test_out_of_order_get(ray_start_regular):
+    c = Collector.remote()
+    with InputNode() as i:
+        dag = c.collect.bind(i)
+
+    compiled_dag = dag.experimental_compile()
+
+    ref_a = compiled_dag.execute("a")
+    ref_b = compiled_dag.execute("b")
+
+    result_b = ray.get(ref_b)
+    assert result_b == ["a", "b"]
+    result_a = ray.get(ref_a)
+    assert result_a == ["a"]
+
     compiled_dag.teardown()
 
 
@@ -118,10 +140,9 @@ def test_actor_multi_methods(ray_start_regular):
         dag = a.echo.bind(dag)
 
     compiled_dag = dag.experimental_compile()
-    output_channel = compiled_dag.execute(1)
-    result = output_channel.begin_read()
+    ref = compiled_dag.execute(1)
+    result = ray.get(ref)
     assert result == 1
-    output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -137,11 +158,10 @@ def test_actor_methods_execution_order(ray_start_regular):
         dag = MultiOutputNode([branch2, branch1])
 
     compiled_dag = dag.experimental_compile()
-    output_channel = compiled_dag.execute(1)
-    result = output_channel.begin_read()
+    ref = compiled_dag.execute(1)
+    result = ray.get(ref)
     # test that double_and_inc() is called after inc() on actor1
     assert result == [4, 1]
-    output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -153,10 +173,9 @@ def test_actor_method_multi_binds(ray_start_regular):
         dag = a.inc.bind(dag)
 
     compiled_dag = dag.experimental_compile()
-    output_channel = compiled_dag.execute(1)
-    result = output_channel.begin_read()
+    ref = compiled_dag.execute(1)
+    result = ray.get(ref)
     assert result == 2
-    output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -170,10 +189,9 @@ def test_actor_method_bind_same_constant(ray_start_regular):
         # multiple times should not throw an exception.
 
     compiled_dag = dag2.experimental_compile()
-    output_channel = compiled_dag.execute(1)
-    result = output_channel.begin_read()
+    ref = compiled_dag.execute(1)
+    result = ray.get(ref)
     assert result == 5
-    output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -187,11 +205,9 @@ def test_regular_args(ray_start_regular):
     compiled_dag = dag.experimental_compile()
 
     for i in range(3):
-        output_channel = compiled_dag.execute(1)
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(1)
+        result = ray.get(ref)
         assert result == (i + 1) * 3
-        output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -207,10 +223,9 @@ def test_multi_args_basic(ray_start_regular):
 
     compiled_dag = dag.experimental_compile()
 
-    output_channel = compiled_dag.execute(2, 3)
-    result = output_channel.begin_read()
+    ref = compiled_dag.execute(2, 3)
+    result = ray.get(ref)
     assert result == [3, 2]
-    output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -223,10 +238,9 @@ def test_multi_args_single_actor(ray_start_regular):
     compiled_dag = dag.experimental_compile()
 
     for i in range(3):
-        output_channel = compiled_dag.execute(2, 3)
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(2, 3)
+        result = ray.get(ref)
         assert result == [3, 2] * (i + 1)
-        output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -240,10 +254,9 @@ def test_multi_args_branch(ray_start_regular):
 
     compiled_dag = dag.experimental_compile()
 
-    output_channel = compiled_dag.execute(2, 3)
-    result = output_channel.begin_read()
+    ref = compiled_dag.execute(2, 3)
+    result = ray.get(ref)
     assert result == [2, 3]
-    output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -259,10 +272,9 @@ def test_kwargs_basic(ray_start_regular):
 
     compiled_dag = dag.experimental_compile()
 
-    output_channel = compiled_dag.execute(x=2, y=3)
-    result = output_channel.begin_read()
+    ref = compiled_dag.execute(x=2, y=3)
+    result = ray.get(ref)
     assert result == [3, 2]
-    output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -275,10 +287,9 @@ def test_kwargs_single_actor(ray_start_regular):
     compiled_dag = dag.experimental_compile()
 
     for i in range(3):
-        output_channel = compiled_dag.execute(x=2, y=3)
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(x=2, y=3)
+        result = ray.get(ref)
         assert result == [3, 2] * (i + 1)
-        output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -292,10 +303,9 @@ def test_kwargs_branch(ray_start_regular):
 
     compiled_dag = dag.experimental_compile()
 
-    output_channel = compiled_dag.execute(x=2, y=3)
-    result = output_channel.begin_read()
+    ref = compiled_dag.execute(x=2, y=3)
+    result = ray.get(ref)
     assert result == [3, 2]
-    output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -311,10 +321,9 @@ def test_multi_args_and_kwargs(ray_start_regular):
 
     compiled_dag = dag.experimental_compile()
 
-    output_channel = compiled_dag.execute(2, y=3, z=4)
-    result = output_channel.begin_read()
+    ref = compiled_dag.execute(2, y=3, z=4)
+    result = ray.get(ref)
     assert result == [3, 4, 2]
-    output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -329,11 +338,9 @@ def test_scatter_gather_dag(ray_start_regular, num_actors):
     compiled_dag = dag.experimental_compile()
 
     for i in range(3):
-        output_channels = compiled_dag.execute(1)
-        # TODO(swang): Replace with fake ObjectRef.
-        results = output_channels.begin_read()
+        ref = compiled_dag.execute(1)
+        results = ray.get(ref)
         assert results == [i + 1] * num_actors
-        output_channels.end_read()
 
     compiled_dag.teardown()
 
@@ -349,11 +356,9 @@ def test_chain_dag(ray_start_regular, num_actors):
     compiled_dag = dag.experimental_compile()
 
     for i in range(3):
-        output_channel = compiled_dag.execute([])
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute([])
+        result = ray.get(ref)
         assert result == list(range(num_actors))
-        output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -364,15 +369,16 @@ def test_dag_exception(ray_start_regular, capsys):
         dag = a.inc.bind(inp)
 
     compiled_dag = dag.experimental_compile()
-    output_channel = compiled_dag.execute("hello")
-    with pytest.raises(TypeError):
-        output_channel.begin_read()
-    output_channel.end_read()
+    ref = compiled_dag.execute("hello")
+    result = ray.get(ref)
+    assert isinstance(result, RayDAGTaskError)
+    assert isinstance(result.cause, TypeError)
 
     # Can do it multiple times.
-    output_channel = compiled_dag.execute("hello")
-    with pytest.raises(TypeError):
-        output_channel.begin_read()
+    ref = compiled_dag.execute("hello")
+    result = ray.get(ref)
+    assert isinstance(result, RayDAGTaskError)
+    assert isinstance(result.cause, TypeError)
 
     compiled_dag.teardown()
 
@@ -408,6 +414,92 @@ def test_dag_errors(ray_start_regular):
     ):
         dag.experimental_compile()
 
+    with InputNode() as inp:
+        dag = a.inc.bind(inp)
+    compiled_dag = dag.experimental_compile()
+    ref = compiled_dag.execute(1)
+    with pytest.raises(
+        TypeError,
+        match=(
+            "wait\(\) does not support CompiledDAGRef. "
+            "Please call ray.get\(\) on the CompiledDAGRef to get the result."
+        ),
+    ):
+        ray.wait([ref])
+
+    with pytest.raises(TypeError, match=r".*was found to be non-serializable.*"):
+        ray.put([ref])
+
+    with pytest.raises(ValueError, match="CompiledDAGRef cannot be copied."):
+        copy.copy(ref)
+
+    with pytest.raises(ValueError, match="CompiledDAGRef cannot be deep copied."):
+        copy.deepcopy(ref)
+
+    with pytest.raises(ValueError, match="CompiledDAGRef cannot be pickled."):
+        pickle.dumps(ref)
+
+    with pytest.raises(
+        TypeError, match="CompiledDAGRef cannot be used as Ray task/actor argument."
+    ):
+        f.remote(ref)
+
+    with pytest.raises(
+        TypeError, match="CompiledDAGRef cannot be used as Ray task/actor argument."
+    ):
+        a2.inc.remote(ref)
+
+    result = ray.get(ref)
+    assert result == 1
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "ray.get\(\) can only be called once "
+            "on a CompiledDAGRef and it was already called."
+        ),
+    ):
+        ray.get(ref)
+    compiled_dag.teardown()
+
+
+def test_exceed_max_buffered_results(ray_start_regular):
+    a = Actor.remote(0)
+    with InputNode() as i:
+        dag = a.inc.bind(i)
+
+    compiled_dag = dag.experimental_compile(max_buffered_results=1)
+
+    for i in range(3):
+        ref = compiled_dag.execute(1)
+
+    # ray.get() on the 3rd ref fails because the DAG cannot buffer 2 results.
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Too many buffered results: the allowed max count for buffered "
+            "results is 1; call ray.get\(\) on previous CompiledDAGRefs to "
+            "free them up from buffer"
+        ),
+    ):
+        ray.get(ref)
+
+    compiled_dag.teardown()
+
+
+def test_compiled_dag_ref_del(ray_start_regular):
+    a = Actor.remote(0)
+    with InputNode() as inp:
+        dag = a.inc.bind(inp)
+
+    compiled_dag = dag.experimental_compile()
+    # Test that when ref is deleted or goes out of scope, the corresponding
+    # execution result is retrieved and immediately discarded. This is confirmed
+    # when future execute() methods do not block.
+    for _ in range(10):
+        ref = compiled_dag.execute(1)
+        del ref
+
 
 def test_dag_fault_tolerance_chain(ray_start_regular_shared):
     actors = [
@@ -422,17 +514,19 @@ def test_dag_fault_tolerance_chain(ray_start_regular_shared):
     compiled_dag = dag.experimental_compile()
 
     for i in range(99):
-        output_channels = compiled_dag.execute(i)
-        # TODO(swang): Replace with fake ObjectRef.
-        results = output_channels.begin_read()
+        ref = compiled_dag.execute(i)
+        results = ray.get(ref)
         assert results == i
-        output_channels.end_read()
 
-    with pytest.raises(RuntimeError):
-        for i in range(99):
-            output_channels = compiled_dag.execute(i)
-            output_channels.begin_read()
-            output_channels.end_read()
+    execution_error = None
+    for i in range(99):
+        ref = compiled_dag.execute(i)
+        result = ray.get(ref)
+        if isinstance(result, RayDAGTaskError):
+            execution_error = result
+            break
+    assert execution_error is not None
+    assert isinstance(execution_error.cause, RuntimeError)
 
     compiled_dag.teardown()
 
@@ -448,11 +542,9 @@ def test_dag_fault_tolerance_chain(ray_start_regular_shared):
 
     compiled_dag = dag.experimental_compile()
     for i in range(100):
-        output_channels = compiled_dag.execute(i)
-        # TODO(swang): Replace with fake ObjectRef.
-        results = output_channels.begin_read()
+        ref = compiled_dag.execute(i)
+        results = ray.get(ref)
         assert results == i
-        output_channels.end_read()
 
     compiled_dag.teardown()
 
@@ -469,17 +561,19 @@ def test_dag_fault_tolerance(ray_start_regular_shared):
     compiled_dag = dag.experimental_compile()
 
     for i in range(99):
-        output_channels = compiled_dag.execute(1)
-        # TODO(swang): Replace with fake ObjectRef.
-        results = output_channels.begin_read()
+        ref = compiled_dag.execute(1)
+        results = ray.get(ref)
         assert results == [i + 1] * 4
-        output_channels.end_read()
 
-    with pytest.raises(RuntimeError):
-        for i in range(99):
-            output_channels = compiled_dag.execute(1)
-            output_channels.begin_read()
-            output_channels.end_read()
+    execution_error = None
+    for i in range(99):
+        ref = compiled_dag.execute(1)
+        res = ray.get(ref)
+        if isinstance(res[0], RayDAGTaskError):
+            execution_error = res[0]
+            break
+    assert execution_error is not None
+    assert isinstance(execution_error.cause, RuntimeError)
 
     compiled_dag.teardown()
 
@@ -494,10 +588,8 @@ def test_dag_fault_tolerance(ray_start_regular_shared):
 
     compiled_dag = dag.experimental_compile()
     for i in range(100):
-        output_channels = compiled_dag.execute(1)
-        # TODO(swang): Replace with fake ObjectRef.
-        output_channels.begin_read()
-        output_channels.end_read()
+        ref = compiled_dag.execute(1)
+        ray.get(ref)
 
     compiled_dag.teardown()
 
@@ -514,17 +606,14 @@ def test_dag_fault_tolerance_sys_exit(ray_start_regular_shared):
     compiled_dag = dag.experimental_compile()
 
     for i in range(99):
-        output_channels = compiled_dag.execute(1)
-        # TODO(swang): Replace with fake ObjectRef.
-        results = output_channels.begin_read()
+        ref = compiled_dag.execute(1)
+        results = ray.get(ref)
         assert results == [i + 1] * 4
-        output_channels.end_read()
 
     with pytest.raises(IOError, match="Channel closed."):
         for i in range(99):
-            output_channels = compiled_dag.execute(1)
-            output_channels.begin_read()
-            output_channels.end_read()
+            ref = compiled_dag.execute(1)
+            ray.get(ref)
 
     # Remaining actors are still alive.
     with pytest.raises(ray.exceptions.RayActorError):
@@ -539,10 +628,8 @@ def test_dag_fault_tolerance_sys_exit(ray_start_regular_shared):
 
     compiled_dag = dag.experimental_compile()
     for i in range(100):
-        output_channels = compiled_dag.execute(1)
-        # TODO(swang): Replace with fake ObjectRef.
-        output_channels.begin_read()
-        output_channels.end_read()
+        ref = compiled_dag.execute(1)
+        ray.get(ref)
 
     compiled_dag.teardown()
 
@@ -554,10 +641,10 @@ def test_dag_teardown_while_running(ray_start_regular_shared):
         dag = a.sleep.bind(inp)
 
     compiled_dag = dag.experimental_compile()
-    chan = compiled_dag.execute(3)  # 3-second slow task running async
+    ref = compiled_dag.execute(3)  # 3-second slow task running async
     compiled_dag.teardown()
     try:
-        chan.begin_read()  # Sanity check the channel doesn't block.
+        ray.get(ref)  # Sanity check the channel doesn't block.
     except Exception:
         pass
 
@@ -566,10 +653,9 @@ def test_dag_teardown_while_running(ray_start_regular_shared):
         dag = a.sleep.bind(inp)
 
     compiled_dag = dag.experimental_compile()
-    chan = compiled_dag.execute(0.1)
-    result = chan.begin_read()
+    ref = compiled_dag.execute(0.1)
+    result = ray.get(ref)
     assert result == 0.1
-    chan.end_read()
 
     compiled_dag.teardown()
 
@@ -586,16 +672,9 @@ def test_asyncio(ray_start_regular_shared, max_queue_size):
     )
 
     async def main(i):
-        output_channel = await compiled_dag.execute_async(i)
-        # Using context manager.
-        async with output_channel as result:
-            assert result == i
-
-        # Using begin_read() / end_read().
-        output_channel = await compiled_dag.execute_async(i)
-        result = await output_channel.begin_read()
+        awaitable_output = await compiled_dag.execute_async(i)
+        result = await awaitable_output.get()
         assert result == i
-        output_channel.end_read()
 
     loop.run_until_complete(asyncio.gather(*[main(i) for i in range(10)]))
     # Note: must teardown before starting a new Ray session, otherwise you'll get
@@ -616,29 +695,19 @@ def test_asyncio_exceptions(ray_start_regular_shared, max_queue_size):
 
     async def main():
         for i in range(99):
-            output_channel = await compiled_dag.execute_async(1)
-            async with output_channel as result:
-                assert result == i + 1
+            awaitable_output = await compiled_dag.execute_async(1)
+            result = await awaitable_output.get()
+            assert result == i + 1
 
-        # Using context manager.
-        exc = None
+        execution_error = None
         for i in range(99):
-            output_channel = await compiled_dag.execute_async(1)
-            async with output_channel as result:
-                if isinstance(result, Exception):
-                    exc = result
-        assert isinstance(exc, RuntimeError), exc
-
-        # Using begin_read() / end_read().
-        exc = None
-        for i in range(99):
-            output_channel = await compiled_dag.execute_async(1)
-            try:
-                result = await output_channel.begin_read()
-            except Exception as e:
-                exc = e
-            output_channel.end_read()
-        assert isinstance(exc, RuntimeError), exc
+            awaitable_output = await compiled_dag.execute_async(1)
+            result = await awaitable_output.get()
+            if isinstance(result, RayDAGTaskError):
+                execution_error = result
+                break
+        assert execution_error is not None
+        assert isinstance(execution_error.cause, RuntimeError)
 
     loop.run_until_complete(main())
     # Note: must teardown before starting a new Ray session, otherwise you'll get
@@ -670,20 +739,14 @@ class TestCompositeChannel:
             dag = a.inc.bind(dag)
 
         compiled_dag = dag.experimental_compile()
-        output_channel = compiled_dag.execute(1)
-        result = output_channel.begin_read()
-        assert result == 4
-        output_channel.end_read()
+        ref = compiled_dag.execute(1)
+        assert ray.get(ref) == 4
 
-        output_channel = compiled_dag.execute(2)
-        result = output_channel.begin_read()
-        assert result == 24
-        output_channel.end_read()
+        ref = compiled_dag.execute(2)
+        assert ray.get(ref) == 24
 
-        output_channel = compiled_dag.execute(3)
-        result = output_channel.begin_read()
-        assert result == 108
-        output_channel.end_read()
+        ref = compiled_dag.execute(3)
+        assert ray.get(ref) == 108
 
         compiled_dag.teardown()
 
@@ -708,22 +771,16 @@ class TestCompositeChannel:
 
         # a: 0+1 -> b: 100+1 -> a: 1+101
         compiled_dag = dag.experimental_compile()
-        output_channel = compiled_dag.execute(1)
-        result = output_channel.begin_read()
-        assert result == 102
-        output_channel.end_read()
+        ref = compiled_dag.execute(1)
+        assert ray.get(ref) == 102
 
         # a: 102+2 -> b: 101+104 -> a: 104+205
-        output_channel = compiled_dag.execute(2)
-        result = output_channel.begin_read()
-        assert result == 309
-        output_channel.end_read()
+        ref = compiled_dag.execute(2)
+        assert ray.get(ref) == 309
 
         # a: 309+3 -> b: 205+312 -> a: 312+517
-        output_channel = compiled_dag.execute(3)
-        result = output_channel.begin_read()
-        assert result == 829
-        output_channel.end_read()
+        ref = compiled_dag.execute(3)
+        assert ray.get(ref) == 829
 
         compiled_dag.teardown()
 
@@ -746,15 +803,11 @@ class TestCompositeChannel:
             dag = MultiOutputNode([a.inc.bind(dag), b.inc.bind(dag)])
 
         compiled_dag = dag.experimental_compile()
-        output_channel = compiled_dag.execute(1)
-        result = output_channel.begin_read()
-        assert result == [2, 101]
-        output_channel.end_read()
+        ref = compiled_dag.execute(1)
+        assert ray.get(ref) == [2, 101]
 
-        output_channel = compiled_dag.execute(3)
-        result = output_channel.begin_read()
-        assert result == [10, 106]
-        output_channel.end_read()
+        ref = compiled_dag.execute(3)
+        assert ray.get(ref) == [10, 106]
 
         compiled_dag.teardown()
 

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -86,11 +86,9 @@ def test_torch_tensor_p2p(ray_start_regular):
 
     compiled_dag = dag.experimental_compile()
     for i in range(3):
-        output_channel = compiled_dag.execute(i)
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(i)
+        result = ray.get(ref)
         assert result == (i, shape, dtype)
-        output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -103,11 +101,9 @@ def test_torch_tensor_p2p(ray_start_regular):
         dag = receiver.recv.bind(dag)
     compiled_dag = dag.experimental_compile()
     for i in range(3):
-        output_channel = compiled_dag.execute(i)
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(i)
+        result = ray.get(ref)
         assert result == (i, shape, dtype)
-        output_channel.end_read()
     compiled_dag.teardown()
 
     # Passing a torch.tensor inside of other data is okay even if
@@ -125,9 +121,8 @@ def test_torch_tensor_p2p(ray_start_regular):
 
     compiled_dag = dag.experimental_compile()
 
-    output_channel = compiled_dag.execute((shape, dtype, 1))
-    output_channel.begin_read()
-    output_channel.end_read()
+    ref = compiled_dag.execute((shape, dtype, 1))
+    ray.get(ref)
     compiled_dag.teardown()
 
 
@@ -156,19 +151,15 @@ def test_torch_tensor_as_dag_input(ray_start_regular):
 
     compiled_dag = dag.experimental_compile()
     for i in range(3):
-        output_channel = compiled_dag.execute(torch.ones(shape, dtype=dtype) * i)
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(torch.ones(shape, dtype=dtype) * i)
+        result = ray.get(ref)
         assert result == (i, shape, dtype)
-        output_channel.end_read()
 
     # Passing tensors of a similar or smaller shape is okay.
     for i in range(3):
-        output_channel = compiled_dag.execute(torch.ones((20,), dtype=dtype) * i)
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(torch.ones((20,), dtype=dtype) * i)
+        result = ray.get(ref)
         assert result == (i, (20,), dtype)
-        output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -203,11 +194,9 @@ def test_torch_tensor_nccl(ray_start_regular):
     compiled_dag = dag.experimental_compile()
 
     for i in range(3):
-        output_channel = compiled_dag.execute(i)
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(i)
+        result = ray.get(ref)
         assert result == (i, shape, dtype)
-        output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -232,11 +221,9 @@ def test_torch_tensor_nccl(ray_start_regular):
 
     compiled_dag = dag.experimental_compile()
     for i in range(3):
-        output_channel = compiled_dag.execute(i)
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(i)
+        result = ray.get(ref)
         assert result == (i, shape, dtype)
-        output_channel.end_read()
     compiled_dag.teardown()
 
     # TODO(swang): Check that actors are still alive. Currently this fails due
@@ -272,11 +259,9 @@ def test_torch_tensor_nccl_dynamic(ray_start_regular):
         shape = (i * 10,)
         dtype = torch.float16
         args = (shape, dtype, i)
-        output_channel = compiled_dag.execute(args)
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(args)
+        result = ray.get(ref)
         assert result == (i, shape, dtype)
-        output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -312,9 +297,9 @@ def test_torch_tensor_nccl_wrong_shape(ray_start_regular):
 
     compiled_dag = dag.experimental_compile()
 
-    output_channel = compiled_dag.execute(1)
+    ref = compiled_dag.execute(1)
     with pytest.raises(OSError):
-        output_channel.begin_read()
+        ray.get(ref)
 
     compiled_dag.teardown()
 
@@ -356,12 +341,10 @@ def test_torch_tensor_nccl_nested(ray_start_regular):
     for i in range(3):
         args = (shape, dtype, 1)
 
-        output_channel = compiled_dag.execute(args)
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(args)
+        result = ray.get(ref)
         expected_result = {0: (0, shape, dtype)}
         assert result == expected_result
-        output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -398,12 +381,10 @@ def test_torch_tensor_nccl_nested_dynamic(ray_start_regular):
         dtype = torch.float16
         args = (shape, dtype, i)
 
-        output_channel = compiled_dag.execute(args)
-        # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        ref = compiled_dag.execute(args)
+        result = ray.get(ref)
         expected_result = {j: (j, shape, dtype) for j in range(i)}
         assert result == expected_result
-        output_channel.end_read()
 
     compiled_dag.teardown()
 
@@ -439,9 +420,9 @@ def test_torch_tensor_nccl_direct_return_error(ray_start_regular):
 
     compiled_dag = dag.experimental_compile()
 
-    output_channel = compiled_dag.execute((shape, dtype, 1))
+    ref = compiled_dag.execute((shape, dtype, 1))
     with pytest.raises(OSError):
-        output_channel.begin_read()
+        ray.get(ref)
 
     compiled_dag.teardown()
 

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -192,34 +192,24 @@ class ChannelInterface:
 
         Blocks if there are still pending readers for the previous value. The
         writer may not write again until the specified number of readers have
-        called ``end_read``.
+        read the value.
 
         Args:
             value: The value to write.
         """
         raise NotImplementedError
 
-    def begin_read(self) -> Any:
+    def read(self) -> Any:
         """
         Read the latest value from the channel. This call will block until a
         value is available to read.
 
-        Subsequent calls to begin_read() will *block*, until end_read() is
-        called and the next value is available to read.
+        Subsequent calls to read() may *block* if the deserialized object is
+        zero-copy (e.g., bytes or a numpy array) *and* the object is still in scope.
 
         Returns:
             Any: The deserialized value.
         """
-        raise NotImplementedError
-
-    def end_read(self) -> None:
-        """
-        Signal to the writer that the channel is ready to write again.
-
-        If begin_read is not called first, then this call will block until a
-        value is written, then drop the value.
-        """
-        raise NotImplementedError
 
     def close(self) -> None:
         """
@@ -253,19 +243,16 @@ class ReaderInterface:
     def start(self):
         raise NotImplementedError
 
-    def _begin_read_list(self) -> Any:
+    def _read_list(self) -> Any:
         raise NotImplementedError
 
-    def begin_read(self) -> Any:
-        outputs = self._begin_read_list()
+    def read(self) -> Any:
+        outputs = self._read_list()
         self._num_reads += 1
         if self._has_single_output:
             return outputs[0]
         else:
             return outputs
-
-    def end_read(self) -> Any:
-        raise NotImplementedError
 
     def close(self) -> None:
         self._closed = True
@@ -281,12 +268,8 @@ class SynchronousReader(ReaderInterface):
     def start(self):
         pass
 
-    def _begin_read_list(self) -> Any:
-        return [c.begin_read() for c in self._input_channels]
-
-    def end_read(self) -> Any:
-        for c in self._input_channels:
-            c.end_read()
+    def _read_list(self) -> Any:
+        return [c.read() for c in self._input_channels]
 
 
 @DeveloperAPI
@@ -313,7 +296,7 @@ class AwaitableBackgroundReader(ReaderInterface):
         self._background_task = asyncio.ensure_future(self.run())
 
     def _run(self):
-        vals = [c.begin_read() for c in self._input_channels]
+        vals = [c.read() for c in self._input_channels]
         if self._has_single_output:
             vals = vals[0]
         return vals
@@ -329,10 +312,6 @@ class AwaitableBackgroundReader(ReaderInterface):
 
             # Set the result on the main thread.
             fut.set_result(res)
-
-    def end_read(self) -> Any:
-        for c in self._input_channels:
-            c.end_read()
 
     def close(self):
         self._background_task.cancel()

--- a/python/ray/experimental/channel/intra_process_channel.py
+++ b/python/ray/experimental/channel/intra_process_channel.py
@@ -46,6 +46,9 @@ class IntraProcessChannel(ChannelInterface):
             self._channel_id,
         )
 
+    def __str__(self) -> str:
+        return f"IntraProcessChannel(channel_id={self._channel_id})"
+
     def write(self, value: Any):
         # Because both the reader and writer are in the same worker process,
         # we can directly store the data in the context instead of storing
@@ -53,12 +56,9 @@ class IntraProcessChannel(ChannelInterface):
         ctx = ChannelContext.get_current().serialization_context
         ctx.set_data(self._channel_id, value)
 
-    def begin_read(self) -> Any:
+    def read(self) -> Any:
         ctx = ChannelContext.get_current().serialization_context
         return ctx.get_data(self._channel_id)
-
-    def end_read(self):
-        pass
 
     def close(self) -> None:
         ctx = ChannelContext.get_current().serialization_context

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -361,6 +361,9 @@ class Channel(ChannelInterface):
             self._reader_ref,
         )
 
+    def __str__(self) -> str:
+        return f"Channel(_reader_ref={self._reader_ref})"
+
     def _resize_channel_if_needed(self, serialized_value: str):
         # serialized_value.total_bytes *only* includes the size of the data. It does not
         # include the size of the metadata, so we must account for the size of the
@@ -416,16 +419,11 @@ class Channel(ChannelInterface):
             self._num_readers,
         )
 
-    def begin_read(self) -> Any:
+    def read(self) -> Any:
         self.ensure_registered_as_reader()
         ret = ray.get(self._reader_ref)
 
         if isinstance(ret, _ResizeChannel):
-            # The writer says we need to update the channel backing store (due to a
-            # resize).
-            self._worker.core_worker.experimental_channel_read_release(
-                [self._reader_ref]
-            )
             self._reader_ref = ret._reader_ref
             # We need to register the new reader_ref.
             self._reader_registered = False
@@ -433,10 +431,6 @@ class Channel(ChannelInterface):
             ret = ray.get(self._reader_ref)
 
         return ret
-
-    def end_read(self):
-        self.ensure_registered_as_reader()
-        self._worker.core_worker.experimental_channel_read_release([self._reader_ref])
 
     def close(self) -> None:
         """
@@ -545,20 +539,18 @@ class CompositeChannel(ChannelInterface):
             self._channels,
         )
 
+    def __str__(self) -> str:
+        return f"CompositeChannel(_channels={self._channels})"
+
     def write(self, value: Any):
         self.ensure_registered_as_writer()
         for channel in self._channels:
             channel.write(value)
 
-    def begin_read(self) -> Any:
+    def read(self) -> Any:
         self.ensure_registered_as_reader()
         actor_id = self._get_self_actor_id()
-        return self._channel_dict[actor_id].begin_read()
-
-    def end_read(self):
-        self.ensure_registered_as_reader()
-        actor_id = self._get_self_actor_id()
-        return self._channel_dict[actor_id].end_read()
+        return self._channel_dict[actor_id].read()
 
     def close(self) -> None:
         for channel in self._channels:

--- a/python/ray/experimental/compiled_dag_ref.py
+++ b/python/ray/experimental/compiled_dag_ref.py
@@ -1,0 +1,89 @@
+import traceback
+
+import ray
+
+
+class CompiledDAGRef(ray.ObjectRef):
+    """
+    A reference to a compiled DAG execution result.
+
+    This is a subclass of ObjectRef and resembles ObjectRef in the
+    most common way. For example, similar to ObjectRef, ray.get()
+    can be called on it to retrieve result. However, there are several
+    major differences:
+    1. ray.get() can only be called once on CompiledDAGRef.
+    2. ray.wait() is not supported.
+    3. CompiledDAGRef cannot be copied, deep copied, or pickled.
+    4. CompiledDAGRef cannot be passed as an argument to another task.
+    """
+
+    def __init__(
+        self,
+        dag: "ray.experimental.CompiledDAG",
+        execution_index: int,
+    ):
+        """
+        Args:
+            dag: The compiled DAG that generated this CompiledDAGRef.
+            execution_index: The index of the execution for the DAG.
+                A DAG can be executed multiple times, and execution index
+                indicates which execution this CompiledDAGRef corresponds to.
+        """
+        self._dag = dag
+        self._execution_index = execution_index
+        # Whether ray.get() was called on this CompiledDAGRef.
+        self._ray_get_called = False
+        self._dag_output_channels = dag.dag_output_channels
+
+    def __str__(self):
+        return (
+            f"CompiledDAGRef({self._dag.get_id()}, "
+            f"execution_index={self._execution_index})"
+        )
+
+    def __copy__(self):
+        raise ValueError("CompiledDAGRef cannot be copied.")
+
+    def __deepcopy__(self, memo):
+        raise ValueError("CompiledDAGRef cannot be deep copied.")
+
+    def __reduce__(self):
+        raise ValueError("CompiledDAGRef cannot be pickled.")
+
+    def __del__(self):
+        # If not yet, get the result and discard to avoid execution result leak.
+        if not self._ray_get_called:
+            self.get()
+
+    def get(self):
+        if self._ray_get_called:
+            raise ValueError(
+                "ray.get() can only be called once "
+                "on a CompiledDAGRef and it was already called."
+            )
+        self._ray_get_called = True
+        return self._dag._execute_until(self._execution_index)
+
+
+class RayDAGTaskError:
+    """
+    Wraps an exception that occurred during the execution of a DAG.
+    """
+
+    def __init__(self, exc):
+        """
+        Args:
+            exc: The exception that occurred during the execution of the DAG.
+        """
+        self._cause = exc
+        self._backtrace = ray._private.utils.format_error_message(
+            "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+            task_exception=True,
+        )
+
+    def __str__(self):
+        return "Exception occurred during DAG execution:\n" + self._backtrace
+
+    @property
+    def cause(self):
+        return self._cause

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -35,8 +35,7 @@ def test_put_local_get(ray_start_regular):
     for i in range(num_writes):
         val = i.to_bytes(8, "little")
         chan.write(val)
-        assert chan.begin_read() == val
-        chan.end_read()
+        assert chan.read() == val
 
 
 @pytest.mark.skipif(
@@ -79,8 +78,7 @@ def test_driver_as_reader(ray_start_cluster, remote):
     chan = ray.get(a.get_channel.remote())
 
     ray.get(a.write.remote())
-    assert chan.begin_read() == b"x"
-    chan.end_read()
+    assert chan.read() == b"x"
 
 
 @pytest.mark.parametrize("remote", [True, False])
@@ -122,12 +120,10 @@ def test_driver_as_reader_with_resize(ray_start_cluster, remote):
     chan = ray.get(a.get_channel.remote())
 
     ray.get(a.write.remote())
-    assert chan.begin_read() == b"x"
-    chan.end_read()
+    assert chan.read() == b"x"
 
     ray.get(a.write_large.remote())
-    assert chan.begin_read() == b"x" * 2000
-    chan.end_read()
+    assert chan.read() == b"x" * 2000
 
 
 @pytest.mark.skipif(
@@ -155,11 +151,8 @@ def test_set_error_before_read(ray_start_regular):
         def write(self):
             self._channel.write(b"x")
 
-        def begin_read(self):
-            self._channel.begin_read()
-
-        def end_read(self):
-            self._channel.end_read()
+        def read(self):
+            self._channel.read()
 
     for _ in range(10):
         a = Actor.remote()
@@ -170,20 +163,19 @@ def test_set_error_before_read(ray_start_regular):
 
         # Indirectly registers the channel for both the writer and the reader.
         ray.get(a.write.remote())
-        ray.get(b.begin_read.remote())
-        ray.get(b.end_read.remote())
+        ray.get(b.read.remote())
 
-        # Check that the thread does not block on the second call to begin_read() below.
-        # begin_read() acquires a lock, though if the lock is not released when
-        # begin_read() fails (because the channel has been closed), then an additional
-        # call to begin_read() *could* block.
+        # Check that the thread does not block on the second call to read() below.
+        # read() acquires a lock, though if the lock is not released when
+        # read() fails (because the channel has been closed), then an additional
+        # call to read() *could* block.
 
-        # We wrap both calls to begin_read() in pytest.raises() as both calls could
+        # We wrap both calls to read() in pytest.raises() as both calls could
         # trigger an IOError exception if the channel has already been closed.
         with pytest.raises(ray.exceptions.RayTaskError):
-            ray.get([a.close.remote(), b.begin_read.remote()])
+            ray.get([a.close.remote(), b.read.remote()])
         with pytest.raises(ray.exceptions.RayTaskError):
-            ray.get(b.begin_read.remote())
+            ray.get(b.read.remote())
 
 
 @pytest.mark.skipif(
@@ -209,8 +201,7 @@ def test_errors(ray_start_regular):
     a = Actor.remote()
     # Multiple consecutive reads from the same process are fine.
     chan = ray.get(a.make_chan.remote([create_driver_actor()], do_write=True))
-    assert chan.begin_read() == b"hello"
-    chan.end_read()
+    assert chan.read() == b"hello"
 
     @ray.remote
     class Reader:
@@ -218,7 +209,7 @@ def test_errors(ray_start_regular):
             pass
 
         def read(self, chan):
-            return chan.begin_read()
+            return chan.read()
 
     readers = [Reader.remote(), Reader.remote()]
     # Check that an exception is thrown when there are more readers than specificed in
@@ -240,12 +231,11 @@ def test_put_different_meta(ray_start_regular):
     def _test(val):
         chan.write(val)
 
-        read_val = chan.begin_read()
+        read_val = chan.read()
         if isinstance(val, np.ndarray):
             assert np.array_equal(read_val, val)
         else:
             assert read_val == val
-        chan.end_read()
 
     _test(b"hello")
     _test("hello")
@@ -270,12 +260,11 @@ def test_multiple_channels_different_nodes(ray_start_cluster):
             pass
 
         def read(self, channel, val):
-            read_val = channel.begin_read()
+            read_val = channel.read()
             if isinstance(val, np.ndarray):
                 assert np.array_equal(read_val, val)
             else:
                 assert read_val == val
-            channel.end_read()
 
     a = Actor.remote()
     chan_a = ray_channel.Channel(None, [a], 1000)
@@ -304,12 +293,11 @@ def test_resize_channel_on_same_node(ray_start_regular):
     def _test(val):
         chan.write(val)
 
-        read_val = chan.begin_read()
+        read_val = chan.read()
         if isinstance(val, np.ndarray):
             assert np.array_equal(read_val, val)
         else:
             assert read_val == val
-        chan.end_read()
 
     # `np.random.rand(100)` requires more than 1000 bytes of storage. The channel is
     # allocated above with a backing store size of 1000 bytes.
@@ -336,12 +324,11 @@ def test_resize_channel_on_same_node_with_actor(ray_start_regular):
             pass
 
         def read(self, channel, val):
-            read_val = channel.begin_read()
+            read_val = channel.read()
             if isinstance(val, np.ndarray):
                 assert np.array_equal(read_val, val)
             else:
                 assert read_val == val
-            channel.end_read()
 
     def _test(channel, actor, val):
         channel.write(val)
@@ -381,12 +368,11 @@ def test_resize_channel_on_different_nodes(ray_start_cluster):
             pass
 
         def read(self, channel, val):
-            read_val = channel.begin_read()
+            read_val = channel.read()
             if isinstance(val, np.ndarray):
                 assert np.array_equal(read_val, val)
             else:
                 assert read_val == val
-            channel.end_read()
 
     def _test(channel, actor, val):
         channel.write(val)
@@ -422,21 +408,18 @@ def test_put_remote_get(ray_start_regular, num_readers):
         def read(self, chan, num_writes):
             for i in range(num_writes):
                 val = i.to_bytes(8, "little")
-                assert chan.begin_read() == val
-                chan.end_read()
+                assert chan.read() == val
 
             for i in range(num_writes):
                 val = i.to_bytes(100, "little")
-                assert chan.begin_read() == val
-                chan.end_read()
+                assert chan.read() == val
 
             for val in [
                 b"hello world",
                 "hello again",
                 1000,
             ]:
-                assert chan.begin_read() == val
-                chan.end_read()
+                assert chan.read() == val
 
     num_writes = 1000
     readers = [Reader.remote() for _ in range(num_readers)]
@@ -505,8 +488,7 @@ def test_remote_reader(ray_start_cluster, remote):
 
         def read(self, num_reads):
             for i in range(num_reads):
-                self._reader_chan.begin_read()
-                self._reader_chan.end_read()
+                self._reader_chan.read()
 
     readers = [Reader.remote() for _ in range(num_readers)]
     channel = ray_channel.Channel(None, readers, 1000)
@@ -531,11 +513,11 @@ def test_remote_reader(ray_start_cluster, remote):
 @pytest.mark.parametrize("remote", [True, False])
 def test_remote_reader_close(ray_start_cluster, remote):
     """
-    Tests that readers do not block forever on begin_read() when they close the channel.
+    Tests that readers do not block forever on read() when they close the channel.
     Specifically, the following behavior should happen:
-    1. Each reader calls begin_read() on one channel.
+    1. Each reader calls read() on one channel.
     2. Each reader calls close() on the channel on a different thread.
-    3. Each reader should unblock and return from begin_read().
+    3. Each reader should unblock and return from read().
 
     Tests (1) the readers and writer on the same node (remote=False) along with
     different nodes (remote=True).
@@ -567,7 +549,7 @@ def test_remote_reader_close(ray_start_cluster, remote):
 
         def read(self):
             try:
-                self._reader_chan.begin_read()
+                self._reader_chan.read()
             except IOError:
                 pass
 
@@ -616,7 +598,7 @@ def test_intra_process_channel(ray_start_cluster):
             self._chan = channel
 
         def read(self):
-            return self._chan.begin_read()
+            return self._chan.read()
 
         def write(self, value):
             self._chan.write(value)
@@ -672,7 +654,7 @@ def test_composite_channel_single_reader(ray_start_cluster):
             return self._chan
 
         def read(self):
-            return self._chan.begin_read()
+            return self._chan.read()
 
         def write(self, value):
             self._chan.write(value)
@@ -704,7 +686,7 @@ def test_composite_channel_single_reader(ray_start_cluster):
         actor2.create_composite_channel.remote(actor2, [create_driver_actor()])
     )
     ray.get(actor2.write.remote("world hello"))
-    assert actor2_to_driver_channel.begin_read() == "world hello"
+    assert actor2_to_driver_channel.read() == "world hello"
 
 
 @pytest.mark.skipif(
@@ -739,10 +721,7 @@ def test_composite_channel_multiple_readers(ray_start_cluster):
             return self._chan
 
         def read(self):
-            return self._chan.begin_read()
-
-        def end_read(self):
-            return self._chan.end_read()
+            return self._chan.read()
 
         def write(self, value):
             self._chan.write(value)

--- a/python/ray/tests/test_nccl_channel.py
+++ b/python/ray/tests/test_nccl_channel.py
@@ -52,9 +52,8 @@ class Worker:
         self.chan.write(t)
 
     def receive(self):
-        t = self.chan.begin_read()
+        t = self.chan.read()
         data = (t[0].clone(), t.shape, t.dtype)
-        self.chan.end_read()
         return data
 
 

--- a/release/microbenchmark/experimental/accelerated_dag_gpu_microbenchmark.py
+++ b/release/microbenchmark/experimental/accelerated_dag_gpu_microbenchmark.py
@@ -126,9 +126,8 @@ def exec_ray_dag(
             i = np.random.randint(100)
             output_channel = dag.execute(i)
             # TODO(swang): Replace with fake ObjectRef.
-            result = output_channel.begin_read()
+            result = output_channel.read()
             assert result == (i, SHAPE, DTYPE)
-            output_channel.end_read()
 
     else:
 
@@ -171,10 +170,9 @@ def exec_ray_dag_ipc(label, sender, receiver, use_nccl=False):
         i = np.random.randint(100)
         output_channel = compiled_dag.execute(i)
         # TODO(swang): Replace with fake ObjectRef.
-        result = output_channel.begin_read()
+        result = output_channel.read()
         if result != (i, SHAPE, DTYPE):
             ok[0] = False
-        output_channel.end_read()
 
     results = timeit(label, _run)
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1550,6 +1550,7 @@ Status CoreWorker::Get(const std::vector<ObjectID> &ids,
   }
   results.resize(ids.size(), nullptr);
 
+#if defined(__APPLE__) || defined(__linux__)
   // Check whether these are experimental.Channel objects.
   bool is_experimental_channel = false;
   for (const ObjectID &id : ids) {
@@ -1570,6 +1571,7 @@ Status CoreWorker::Get(const std::vector<ObjectID> &ids,
     }
     return GetExperimentalMutableObjects(ids, results);
   }
+#endif
 
   return GetObjects(ids, timeout_ms, results);
 }

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -150,7 +150,7 @@ class MutableObjectProvider {
   std::shared_ptr<plasma::PlasmaClientInterface> plasma_;
 
   // Object manager for the mutable objects.
-  ray::experimental::MutableObjectManager object_manager_;
+  std::shared_ptr<ray::experimental::MutableObjectManager> object_manager_;
 
   // Protects `remote_writer_object_to_local_reader_`.
   absl::Mutex remote_writer_object_to_local_reader_lock_;
@@ -182,6 +182,8 @@ class MutableObjectProvider {
   // Threads that wait for local mutable object changes (one thread per mutable object)
   // and then send the changes to remote nodes via the network.
   std::vector<std::unique_ptr<std::thread>> io_threads_;
+
+  friend class MutableObjectProvider_MutableObjectBufferReadRelease_Test;
 };
 
 }  // namespace experimental


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR:
1. Revives the following 3 PRs which were reverted due to windows CI tests failures (in the 1st commit: 9564765c1c453bb302a854d9dc11e7447e4e811e)
- https://github.com/ray-project/ray/pull/45687
- https://github.com/ray-project/ray/pull/45951
- https://github.com/ray-project/ray/pull/45950 
2. Fixes windows CI tests (in the 2nd commit: 80405386b22b37e83f187ed58ab84097e5220a17) 
Windows test failed because of an issue existed before the change: `experimental_mutable_object_provider_` of `CoreWorker` is not initialized for Windows. The issue did not manifest perhaps due to compiler optimizations. 
The PR fixes the issue by only enabling `experimental_mutable_object_provider_` dereference and related code for non-Windows platforms.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
