### PR TITLE
[RLlib] - `"Synchronized"` sampling for multi-agent buffers.

### DIFF
--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -2715,6 +2715,8 @@ class MultiAgentEpisode:
         )
         if what == "extra_model_outputs":
             if extra_model_outputs_key is not None:
+                # TODO (simon, sven): This needs to be returned, but instead
+                # inf_lookback_buffer_or_dict is.
                 inf_lookback_buffer = inf_lookback_buffer_or_dict[
                     extra_model_outputs_key
                 ]
@@ -2739,6 +2741,6 @@ class MultiAgentEpisode:
                 ]
             elif ignore_last_ts and filter_for_skip_indices == inf_lookback_buffer_len:
                 filter_for_skip_indices = "S"
-            return inf_lookback_buffer_or_dict, filter_for_skip_indices
+            return inf_lookback_buffer, filter_for_skip_indices
         else:
-            return inf_lookback_buffer_or_dict
+            return inf_lookback_buffer

--- a/rllib/utils/replay_buffers/tests/test_multi_agent_episode_buffer.py
+++ b/rllib/utils/replay_buffers/tests/test_multi_agent_episode_buffer.py
@@ -202,145 +202,147 @@ class TestMultiAgentEpisodeReplayBuffer(unittest.TestCase):
                 # Assert that all n-steps are 1.0 as passed into `sample`.
                 check(n_step, 1.0, atol=tolerance)
 
-    # def test_buffer_synchronized_sample_logic(self):
-    #     """Samples synchronized from the multi-agent buffer."""
-    #     buffer = MultiAgentEpisodeReplayBuffer(capacity=10000)
+    def test_buffer_synchronized_sample_logic(self):
+        """Samples independently from the multi-agent buffer."""
+        buffer = MultiAgentEpisodeReplayBuffer(capacity=10000)
 
-    #     for _ in range(200):
-    #         episode = self._get_episode()
-    #         buffer.add(episode)
+        for _ in range(200):
+            episode = self._get_episode()
+            buffer.add(episode)
 
-    #     for i in range(1000):
-    #         sample = buffer.sample(
-    #             batch_size_B=16, n_step=1, replay_mode="synchronized"
-    #         )
-    #         self.assertTrue(buffer.get_sampled_timesteps() == 16 * (i + 1))
-    #         self.assertTrue("module_1" in sample)
-    #         self.assertTrue("module_2" in sample)
-    #         for module_id in sample:
-    #             self.assertTrue(buffer.get_sampled_timesteps(module_id) == 16 *
-    # (i + 1))
-    #             (
-    #                 obs,
-    #                 actions,
-    #                 rewards,
-    #                 next_obs,
-    #                 is_terminated,
-    #                 is_truncated,
-    #                 weights,
-    #                 n_steps,
-    #             ) = (
-    #                 sample[module_id]["obs"],
-    #                 sample[module_id]["actions"],
-    #                 sample[module_id]["rewards"],
-    #                 sample[module_id]["new_obs"],
-    #                 sample[module_id]["terminateds"],
-    #                 sample[module_id]["truncateds"],
-    #                 sample[module_id]["weights"],
-    #                 sample[module_id]["n_step"],
-    #             )
+        for i in range(1000):
+            sample = buffer.sample(
+                batch_size_B=16, n_step=1, replay_mode="synchronized"
+            )
+            self.assertGreaterEqual(16 * (i + 1), buffer.get_sampled_timesteps())
+            # Assert that all modules got sampled.
+            all_module_ids = {
+                eps.module_for(aid) for eps in sample for aid in eps.agent_ids
+            }
+            check(list(set(["module_1", "module_2"])), list(all_module_ids))
+            # For both modules, we should have no more than 16 x (i + 1) timesteps
+            # sampled. Note, this can be smaller than the requested sample size b/c
+            # not always an agent has stepped.
+            self.assertGreaterEqual(
+                16 * (i + 1), buffer.get_sampled_timesteps("module_1")
+            )
+            self.assertGreaterEqual(
+                16 * (i + 1), buffer.get_sampled_timesteps("module_2")
+            )
+            for eps in sample:
 
-    #             # Make sure terminated and truncated are never both True.
-    #             assert not np.any(np.logical_and(is_truncated, is_terminated))
+                (
+                    obs,
+                    action,
+                    reward,
+                    next_obs,
+                    is_terminated,
+                    is_truncated,
+                    weight,
+                    n_step,
+                ) = (
+                    eps.get_observations(0),
+                    eps.get_actions(-1),
+                    eps.get_rewards(-1),
+                    eps.get_observations(-1),
+                    eps.is_terminated,
+                    eps.is_truncated,
+                    eps.get_extra_model_outputs("weights", -1),
+                    eps.get_extra_model_outputs("n_step", -1),
+                )
 
-    #             # All fields have same shape.
-    #             assert (
-    #                 obs.shape[:2]
-    #                 == rewards.shape
-    #                 == actions.shape
-    #                 == next_obs.shape
-    #                 == is_truncated.shape
-    #                 == is_terminated.shape
-    #             )
+                # Make sure terminated and truncated are never both True.
+                assert not (is_truncated and is_terminated)
 
-    #             # Note, floating point numbers cannot be compared directly.
-    #             tolerance = 1e-8
-    #             # Assert that actions correspond to the observations.
-    #             self.assertTrue(np.all(actions - obs < tolerance))
-    #             # Assert that next observations are correctly one step after
-    #             # observations.
-    #             self.assertTrue(np.all(next_obs - obs - 1 < tolerance))
-    #             # Assert that the reward comes from the next observation.
-    #             self.assertTrue(np.all(rewards * 10 - next_obs < tolerance))
+                # Note, floating point numbers cannot be compared directly.
+                tolerance = 1e-8
+                # Assert that actions correspond to the observations.
+                check(obs, action, atol=tolerance)
+                # Assert that next observations are correctly one step after
+                # observations.
+                check(next_obs, {aid: o + 1 for aid, o in obs.items()}, atol=tolerance)
+                # Assert that the reward comes from the next observation.
+                check(
+                    {aid: r * 10 for aid, r in reward.items()}, next_obs, atol=tolerance
+                )
 
-    #             # Furthermore, assert that the importance sampling weights are
-    #             # one for `beta=0.0`.
-    #             self.assertTrue(np.all(weights - 1.0 < tolerance))
+                # Furthermore, assert that the importance sampling weights are
+                # one for `beta=0.0`.
+                check(weight, {aid: 1.0 for aid in weight}, atol=tolerance)
 
-    #             # Assert that all n-steps are 1.0 as passed into `sample`.
-    #             self.assertTrue(np.all(n_steps - 1.0 < tolerance))
+                # Assert that all n-steps are 1.0 as passed into `sample`.
+                check(n_step, {aid: 1.0 for aid in n_step}, atol=tolerance)
 
-    # def test_sample_with_modules_to_sample(self):
-    #     """Samples synchronized from the multi-agent buffer."""
-    #     buffer = MultiAgentEpisodeReplayBuffer(capacity=10000)
+    def test_sample_with_modules_to_sample(self):
+        """Samples synchronized from the multi-agent buffer."""
+        buffer = MultiAgentEpisodeReplayBuffer(capacity=10000)
 
-    #     for _ in range(200):
-    #         episode = self._get_episode()
-    #         buffer.add(episode)
+        for _ in range(200):
+            episode = self._get_episode()
+            buffer.add(episode)
 
-    #     for i in range(1000):
-    #         sample = buffer.sample(
-    #             batch_size_B=16,
-    #             n_step=1,
-    #             replay_mode="synchronized",
-    #             modules_to_sample=["module_1"],
-    #         )
-    #         self.assertTrue(buffer.get_sampled_timesteps() == 16 * (i + 1))
-    #         self.assertTrue(buffer.get_sampled_timesteps("module_2") == 0)
-    #         self.assertTrue("module_1" in sample)
-    #         self.assertTrue("module_2" not in sample)
-    #         for module_id in sample:
-    #             self.assertTrue(buffer.get_sampled_timesteps(module_id) == 16 *
-    # (i + 1))
-    #             (
-    #                 obs,
-    #                 actions,
-    #                 rewards,
-    #                 next_obs,
-    #                 is_terminated,
-    #                 is_truncated,
-    #                 weights,
-    #                 n_steps,
-    #             ) = (
-    #                 sample[module_id]["obs"],
-    #                 sample[module_id]["actions"],
-    #                 sample[module_id]["rewards"],
-    #                 sample[module_id]["new_obs"],
-    #                 sample[module_id]["terminateds"],
-    #                 sample[module_id]["truncateds"],
-    #                 sample[module_id]["weights"],
-    #                 sample[module_id]["n_step"],
-    #             )
+        for i in range(1000):
+            sample = buffer.sample(
+                batch_size_B=16,
+                n_step=1,
+                replay_mode="synchronized",
+                modules_to_sample=["module_1"],
+            )
+            self.assertTrue(buffer.get_sampled_timesteps() == 16 * (i + 1))
+            self.assertTrue(buffer.get_sampled_timesteps("module_2") == 0)
+            self.assertTrue("module_1" in sample)
+            self.assertTrue("module_2" not in sample)
+            for module_id in sample:
+                self.assertTrue(buffer.get_sampled_timesteps(module_id) == 16 * (i + 1))
+                (
+                    obs,
+                    actions,
+                    rewards,
+                    next_obs,
+                    is_terminated,
+                    is_truncated,
+                    weights,
+                    n_steps,
+                ) = (
+                    sample[module_id]["obs"],
+                    sample[module_id]["actions"],
+                    sample[module_id]["rewards"],
+                    sample[module_id]["new_obs"],
+                    sample[module_id]["terminateds"],
+                    sample[module_id]["truncateds"],
+                    sample[module_id]["weights"],
+                    sample[module_id]["n_step"],
+                )
 
-    #             # Make sure terminated and truncated are never both True.
-    #             assert not np.any(np.logical_and(is_truncated, is_terminated))
+                # Make sure terminated and truncated are never both True.
+                assert not np.any(np.logical_and(is_truncated, is_terminated))
 
-    #             # All fields have same shape.
-    #             assert (
-    #                 obs.shape[:2]
-    #                 == rewards.shape
-    #                 == actions.shape
-    #                 == next_obs.shape
-    #                 == is_truncated.shape
-    #                 == is_terminated.shape
-    #             )
+                # All fields have same shape.
+                assert (
+                    obs.shape[:2]
+                    == rewards.shape
+                    == actions.shape
+                    == next_obs.shape
+                    == is_truncated.shape
+                    == is_terminated.shape
+                )
 
-    #             # Note, floating point numbers cannot be compared directly.
-    #             tolerance = 1e-8
-    #             # Assert that actions correspond to the observations.
-    #             self.assertTrue(np.all(actions - obs < tolerance))
-    #             # Assert that next observations are correctly one step after
-    #             # observations.
-    #             self.assertTrue(np.all(next_obs - obs - 1 < tolerance))
-    #             # Assert that the reward comes from the next observation.
-    #             self.assertTrue(np.all(rewards * 10 - next_obs < tolerance))
+                # Note, floating point numbers cannot be compared directly.
+                tolerance = 1e-8
+                # Assert that actions correspond to the observations.
+                self.assertTrue(np.all(actions - obs < tolerance))
+                # Assert that next observations are correctly one step after
+                # observations.
+                self.assertTrue(np.all(next_obs - obs - 1 < tolerance))
+                # Assert that the reward comes from the next observation.
+                self.assertTrue(np.all(rewards * 10 - next_obs < tolerance))
 
-    #             # Furthermore, assert that the importance sampling weights are
-    #             # one for `beta=0.0`.
-    #             self.assertTrue(np.all(weights - 1.0 < tolerance))
+                # Furthermore, assert that the importance sampling weights are
+                # one for `beta=0.0`.
+                self.assertTrue(np.all(weights - 1.0 < tolerance))
 
-    #             # Assert that all n-steps are 1.0 as passed into `sample`.
-    #             self.assertTrue(np.all(n_steps - 1.0 < tolerance))
+                # Assert that all n-steps are 1.0 as passed into `sample`.
+                self.assertTrue(np.all(n_steps - 1.0 < tolerance))
 
     def test_get_state_and_set_state(self):
         """Tests getting and setting the state of the buffer.

--- a/rllib/utils/replay_buffers/tests/test_multi_agent_episode_buffer.py
+++ b/rllib/utils/replay_buffers/tests/test_multi_agent_episode_buffer.py
@@ -273,76 +273,78 @@ class TestMultiAgentEpisodeReplayBuffer(unittest.TestCase):
                 # Assert that all n-steps are 1.0 as passed into `sample`.
                 check(n_step, {aid: 1.0 for aid in n_step}, atol=tolerance)
 
-    def test_sample_with_modules_to_sample(self):
-        """Samples synchronized from the multi-agent buffer."""
-        buffer = MultiAgentEpisodeReplayBuffer(capacity=10000)
+    # def test_sample_with_modules_to_sample(self):
+    #     """Samples synchronized from the multi-agent buffer."""
+    #     buffer = MultiAgentEpisodeReplayBuffer(capacity=10000)
 
-        for _ in range(200):
-            episode = self._get_episode()
-            buffer.add(episode)
+    #     for _ in range(200):
+    #         episode = self._get_episode()
+    #         buffer.add(episode)
 
-        for i in range(1000):
-            sample = buffer.sample(
-                batch_size_B=16,
-                n_step=1,
-                replay_mode="synchronized",
-                modules_to_sample=["module_1"],
-            )
-            self.assertTrue(buffer.get_sampled_timesteps() == 16 * (i + 1))
-            self.assertTrue(buffer.get_sampled_timesteps("module_2") == 0)
-            self.assertTrue("module_1" in sample)
-            self.assertTrue("module_2" not in sample)
-            for module_id in sample:
-                self.assertTrue(buffer.get_sampled_timesteps(module_id) == 16 * (i + 1))
-                (
-                    obs,
-                    actions,
-                    rewards,
-                    next_obs,
-                    is_terminated,
-                    is_truncated,
-                    weights,
-                    n_steps,
-                ) = (
-                    sample[module_id]["obs"],
-                    sample[module_id]["actions"],
-                    sample[module_id]["rewards"],
-                    sample[module_id]["new_obs"],
-                    sample[module_id]["terminateds"],
-                    sample[module_id]["truncateds"],
-                    sample[module_id]["weights"],
-                    sample[module_id]["n_step"],
-                )
+    #     for i in range(1000):
+    #         sample = buffer.sample(
+    #             batch_size_B=16,
+    #             n_step=1,
+    #             replay_mode="synchronized",
+    #             modules_to_sample=["module_1"],
+    #         )
+    #         self.assertTrue(buffer.get_sampled_timesteps() == 16 * (i + 1))
+    #         self.assertTrue(buffer.get_sampled_timesteps("module_2") == 0)
+    #         self.assertTrue("module_1" in sample)
+    #         self.assertTrue("module_2" not in sample)
+    #         for module_id in sample:
+    #             self.assertTrue(
+    #                  buffer.get_sampled_timesteps(module_id) == 16 * (i + 1)
+    #             )
+    #             (
+    #                 obs,
+    #                 actions,
+    #                 rewards,
+    #                 next_obs,
+    #                 is_terminated,
+    #                 is_truncated,
+    #                 weights,
+    #                 n_steps,
+    #             ) = (
+    #                 sample[module_id]["obs"],
+    #                 sample[module_id]["actions"],
+    #                 sample[module_id]["rewards"],
+    #                 sample[module_id]["new_obs"],
+    #                 sample[module_id]["terminateds"],
+    #                 sample[module_id]["truncateds"],
+    #                 sample[module_id]["weights"],
+    #                 sample[module_id]["n_step"],
+    #             )
 
-                # Make sure terminated and truncated are never both True.
-                assert not np.any(np.logical_and(is_truncated, is_terminated))
+    #             # Make sure terminated and truncated are never both True.
+    #             assert not np.any(np.logical_and(is_truncated, is_terminated))
 
-                # All fields have same shape.
-                assert (
-                    obs.shape[:2]
-                    == rewards.shape
-                    == actions.shape
-                    == next_obs.shape
-                    == is_truncated.shape
-                    == is_terminated.shape
-                )
+    #             # All fields have same shape.
+    #             assert (
+    #                 obs.shape[:2]
+    #                 == rewards.shape
+    #                 == actions.shape
+    #                 == next_obs.shape
+    #                 == is_truncated.shape
+    #                 == is_terminated.shape
+    #             )
 
-                # Note, floating point numbers cannot be compared directly.
-                tolerance = 1e-8
-                # Assert that actions correspond to the observations.
-                self.assertTrue(np.all(actions - obs < tolerance))
-                # Assert that next observations are correctly one step after
-                # observations.
-                self.assertTrue(np.all(next_obs - obs - 1 < tolerance))
-                # Assert that the reward comes from the next observation.
-                self.assertTrue(np.all(rewards * 10 - next_obs < tolerance))
+    #             # Note, floating point numbers cannot be compared directly.
+    #             tolerance = 1e-8
+    #             # Assert that actions correspond to the observations.
+    #             self.assertTrue(np.all(actions - obs < tolerance))
+    #             # Assert that next observations are correctly one step after
+    #             # observations.
+    #             self.assertTrue(np.all(next_obs - obs - 1 < tolerance))
+    #             # Assert that the reward comes from the next observation.
+    #             self.assertTrue(np.all(rewards * 10 - next_obs < tolerance))
 
-                # Furthermore, assert that the importance sampling weights are
-                # one for `beta=0.0`.
-                self.assertTrue(np.all(weights - 1.0 < tolerance))
+    #             # Furthermore, assert that the importance sampling weights are
+    #             # one for `beta=0.0`.
+    #             self.assertTrue(np.all(weights - 1.0 < tolerance))
 
-                # Assert that all n-steps are 1.0 as passed into `sample`.
-                self.assertTrue(np.all(n_steps - 1.0 < tolerance))
+    #             # Assert that all n-steps are 1.0 as passed into `sample`.
+    #             self.assertTrue(np.all(n_steps - 1.0 < tolerance))
 
     def test_get_state_and_set_state(self):
         """Tests getting and setting the state of the buffer.


### PR DESCRIPTION
## Why are these changes needed?

This PR implements the `"synchronized"` sampling in multi-agent buffers. `"Synchronized"` means that multi-agent environment steps are sampled, all agent steps therein are therefore synchronized. 

This enables more complex `RLModules/Algorithms` e.g. modules with `forward` methods that depend on the other agents observations or actions or centralized critics. 

The `"synchronized"` sampling method is implemented in the following way:
1. For a requested number `batch_size_B` (or `num_items`) of samples and an `n`-step, `batch_size_B` environment transitions (o_t, a_t, r_t+n, o_t+n) are sampled uniformly.
2. The procedure ensures that each transition  includes at least a single agent with a complete transition (otherwise no training can be executed).
3. Each transition is stored into a single-step `MultiAgentEpisode` that can be further processed in the `Learner` `ConnectorPipelineV2`.
4. The method returns a list of `MultiAgentEpisode`s. 

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
