### PR TITLE
[Data] Make the seed take effect in Dataset.random_sample()

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1207,13 +1207,7 @@ class Dataset:
                 )
             raise ValueError(f"Unsupported batch type: {type(batch)}")
 
-        if seed is not None:
-            ds = self.materialize()
-            return self.map_batches(
-                random_sample, batch_size=ds.count(), batch_format=None
-            )
-        else:
-            return self.map_batches(random_sample, batch_format=None)
+        return self.map_batches(random_sample, batch_format=None)
 
     @ConsumptionAPI
     def streaming_split(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

A quick fix for the #40406. The `random_sample` is called within the `map_batches`, externally set seed did not take effect in the context. After:

```python
ds = ray.data.range(100000)
ds.random_sample(0.2, seed=1234).count()
Out[3]: 20775
ds.random_sample(0.2, seed=1234).count()
Out[4]: 20775
ds.random_sample(0.2, seed=1234).count()
Out[5]: 20775
```

However, after the fix, we have observed that in some cases, when the seed set, the return size has a significant gap from the expected `fraction * total_rows`, for example:

```python
ds = ray.data.range(1000)
ds.random_sample(0.5, seed=1111).count()
Out[7]: 1000
ds.random_sample(0.5, seed=1234).count()
Out[8]: 500
ds.random_sample(0.5, seed=5).count()
Out[9]: 0
```

The issue seems to be that the `map_batches` groups the samples into very small batches (e.g., 2 samples per batch) and performs random sampling within each batch. With a fixed seed, the samples selected within each batch are deterministic, leading to sampling ratios of 100%, 50%, 0%.

We would like to understand the community's suggestions - after setting the seed, should we eliminate the `map_batches` operation to achieve more stable and reproducible results? Or should we consider setting the default `batch_size` more explicitly and stably, to ensure the **actual effective batch size** is more predictable and consistent.

## Related issue number

<!-- For example: "Closes #1234" -->

#40406 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
