### PR TITLE
Spread replicas with custom resources in torch tune serve release test

### DIFF
--- a/release/golden_notebook_tests/gpu_tpl_aws.yaml
+++ b/release/golden_notebook_tests/gpu_tpl_aws.yaml
@@ -13,3 +13,6 @@ worker_node_types:
       min_workers: 2
       max_workers: 2
       use_spot: true
+      resources:
+        custom_resources:
+          worker: 1

--- a/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
+++ b/release/golden_notebook_tests/workloads/torch_tune_serve_test.py
@@ -180,7 +180,10 @@ def setup_serve(model, use_gpu: bool = False):
     )  # Start on every node so `predict` can hit localhost.
     serve.run(
         MnistDeployment.options(
-            num_replicas=2, ray_actor_options={"num_gpus": bool(use_gpu)}
+            num_replicas=2,
+            ray_actor_options={"num_gpus": 1, "resources": {"worker": 1}}
+            if use_gpu
+            else {},
         ).bind(model)
     )
 


### PR DESCRIPTION
Spread replicas with custom resources in torch tune serve release test

For the Golden Notebook Torch Tune Serve release test.
Use custom resources to make sure one replica gets scheduled for each of the two nodes in the cluster.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
