### PR TITLE
Add perf metrics for 2.30.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 422.150144,
+    "_dashboard_memory_usage_mb": 519.7824,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.65,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1225\t9.33GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3575\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4789\t0.93GiB\tpython distributed/test_many_actors.py\n2384\t0.29GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3695\t0.24GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2767\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3858\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4583\t0.07GiB\tray::JobSupervisor\n4040\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3856\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
-    "actors_per_second": 656.4820098150251,
+    "_peak_memory": 3.68,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1129\t10.07GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3486\t1.75GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4783\t0.88GiB\tpython distributed/test_many_actors.py\n3601\t0.35GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2162\t0.34GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n2442\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3767\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4572\t0.07GiB\tray::JobSupervisor\n3952\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3765\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "actors_per_second": 591.1743697324424,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 656.4820098150251
+            "perf_metric_value": 591.1743697324424
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 65.662
+            "perf_metric_value": 45.706
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3333.28
+            "perf_metric_value": 2267.179
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3456.493
+            "perf_metric_value": 4758.759
         }
     ],
     "success": "1",
-    "time": 15.232709884643555
+    "time": 16.915482997894287
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 182.657024,
+    "_dashboard_memory_usage_mb": 190.62784,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.64,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3548\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1209\t0.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2279\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3663\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4732\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4938\t0.08GiB\tray::StateAPIGeneratorActor.start\n2760\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4531\t0.07GiB\tray::JobSupervisor\n3825\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4002\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "_peak_memory": 1.65,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3477\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1138\t0.26GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2497\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3592\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4784\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5053\t0.09GiB\tray::StateAPIGeneratorActor.start\n4585\t0.07GiB\tray::JobSupervisor\n2500\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3753\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3755\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 356.96608310545133
+            "perf_metric_value": 352.0746471744154
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.877
+            "perf_metric_value": 3.748
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 48.58
+            "perf_metric_value": 25.011
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 197.137
+            "perf_metric_value": 114.271
         }
     ],
     "success": "1",
-    "tasks_per_second": 356.96608310545133,
-    "time": 302.80138659477234,
+    "tasks_per_second": 352.0746471744154,
+    "time": 302.8403067588806,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 137.633792,
+    "_dashboard_memory_usage_mb": 161.296384,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.25,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1224\t9.73GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3624\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4824\t0.42GiB\tpython distributed/test_many_pgs.py\n2809\t0.38GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3749\t0.15GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2607\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4609\t0.07GiB\tray::JobSupervisor\n3914\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4093\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3912\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 2.12,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3579\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5010\t0.4GiB\tpython distributed/test_many_pgs.py\n2403\t0.36GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1271\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3696\t0.1GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2581\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3877\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4807\t0.07GiB\tray::JobSupervisor\n4061\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3875\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23.5616061289441
+            "perf_metric_value": 22.36956883941179
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.492
+            "perf_metric_value": 3.497
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.796
+            "perf_metric_value": 11.291
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 204.615
+            "perf_metric_value": 217.033
         }
     ],
-    "pgs_per_second": 23.5616061289441,
+    "pgs_per_second": 22.36956883941179,
     "success": "1",
-    "time": 42.44192838668823
+    "time": 44.70358848571777
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1164.107776,
+    "_dashboard_memory_usage_mb": 1095.335936,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.08,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3561\t2.86GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4731\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3681\t0.68GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1206\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2174\t0.23GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5002\t0.09GiB\tray::StateAPIGeneratorActor.start\n4947\t0.08GiB\tray::DashboardTester.run\n2551\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3843\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4521\t0.07GiB\tray::JobSupervisor",
+    "_peak_memory": 4.75,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3469\t2.3GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3594\t0.91GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4714\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1134\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2294\t0.24GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4967\t0.09GiB\tray::StateAPIGeneratorActor.start\n4913\t0.09GiB\tray::DashboardTester.run\n2366\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4503\t0.07GiB\tray::JobSupervisor\n3765\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 587.8163884392604
+            "perf_metric_value": 583.5060688927706
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 42.944
+            "perf_metric_value": 123.652
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3642.242
+            "perf_metric_value": 1260.189
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4549.74
+            "perf_metric_value": 3549.123
         }
     ],
     "success": "1",
-    "tasks_per_second": 587.8163884392604,
-    "time": 317.01211500167847,
+    "tasks_per_second": 583.5060688927706,
+    "time": 317.1377823352814,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.24.0"}
+{"release_version": "2.30.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8726.401857123754,
-        162.20549696513925
+        9031.717791623294,
+        192.8094467105873
     ],
     "1_1_actor_calls_concurrent": [
-        5525.453533356669,
-        275.6986719349956
+        5674.648008482862,
+        213.93402347245598
     ],
     "1_1_actor_calls_sync": [
-        2022.1643749529967,
-        42.58171596149864
+        2100.2077559510417,
+        17.79775141354136
     ],
     "1_1_async_actor_calls_async": [
-        3295.7761919502855,
-        149.90516121451026
+        3559.7058767231556,
+        85.90147942074165
     ],
     "1_1_async_actor_calls_sync": [
-        1306.2185283312654,
-        22.393311157323094
+        1344.1591739622095,
+        43.87958394024655
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2271.9010969950546,
-        58.46933903250449
+        2584.460785144293,
+        43.34232271632638
     ],
     "1_n_actor_calls_async": [
-        8723.546909820518,
-        133.04998221108622
+        8884.115379043567,
+        254.927340235733
     ],
     "1_n_async_actor_calls_async": [
-        7526.072989853183,
-        80.26873719023843
+        7610.6877946166605,
+        40.04292562143709
     ],
     "client__1_1_actor_calls_async": [
-        956.234692691667,
-        10.622834071499192
+        916.2659145904904,
+        26.390232921162806
     ],
     "client__1_1_actor_calls_concurrent": [
-        964.227785207118,
-        19.39077588012691
+        881.8820523473596,
+        10.542366983687044
     ],
     "client__1_1_actor_calls_sync": [
-        511.54682034013,
-        20.183100809422037
+        491.0521520633998,
+        18.457136230455724
     ],
     "client__get_calls": [
-        1099.299059786817,
-        48.740510949504255
+        1052.0806198982318,
+        22.30285026731644
     ],
     "client__put_calls": [
-        793.6471952322032,
-        19.166421115489065
+        841.9202869949634,
+        17.28917717385826
     ],
     "client__put_gigabytes": [
-        0.13033848458516117,
-        0.0004047979867318293
+        0.13121585960885135,
+        0.0008462343207558118
     ],
     "client__tasks_and_get_batch": [
-        0.9191916564759186,
-        0.004240563507874709
+        0.9228165417546772,
+        0.03080670475678442
     ],
     "client__tasks_and_put_batch": [
-        11163.342583763659,
-        86.36159399829216
+        11892.666392463261,
+        260.515882221264
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12352.999319488557,
-        302.78838782381274
+        12859.321156086282,
+        141.19275528753255
     ],
     "multi_client_put_gigabytes": [
-        35.52392832333356,
-        2.4551866947000778
+        33.57305818008913,
+        2.371834567847487
     ],
     "multi_client_tasks_async": [
-        23658.661959832083,
-        3659.740758379274
+        4380.675445374336,
+        15.990446702845365
     ],
     "n_n_actor_calls_async": [
-        26706.0034223919,
-        796.7068479444016
+        26066.334327455046,
+        1609.994527151627
     ],
     "n_n_actor_calls_with_arg_async": [
-        2669.6470548189563,
-        37.75431784396307
+        2625.3114806038075,
+        41.66924735479181
     ],
     "n_n_async_actor_calls_async": [
-        23029.099137990735,
-        353.5298340819868
+        22473.36680019349,
+        978.0020060542345
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10575.12534552304
+            "perf_metric_value": 10447.993136996853
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5342.356803322341
+            "perf_metric_value": 5355.048189801414
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12352.999319488557
+            "perf_metric_value": 12859.321156086282
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.60264129638186
+            "perf_metric_value": 19.7492591299831
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.618329296876913
+            "perf_metric_value": 7.401087223556004
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 35.52392832333356
+            "perf_metric_value": 33.57305818008913
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.459623096174152
+            "perf_metric_value": 12.47010395868836
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.356105950176277
+            "perf_metric_value": 5.386835201432421
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 990.8897375942615
+            "perf_metric_value": 821.7242249574133
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7728.179866020124
+            "perf_metric_value": 7914.550524761689
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23658.661959832083
+            "perf_metric_value": 4380.675445374336
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2022.1643749529967
+            "perf_metric_value": 2100.2077559510417
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8726.401857123754
+            "perf_metric_value": 9031.717791623294
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5525.453533356669
+            "perf_metric_value": 5674.648008482862
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8723.546909820518
+            "perf_metric_value": 8884.115379043567
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26706.0034223919
+            "perf_metric_value": 26066.334327455046
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2669.6470548189563
+            "perf_metric_value": 2625.3114806038075
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1306.2185283312654
+            "perf_metric_value": 1344.1591739622095
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3295.7761919502855
+            "perf_metric_value": 3559.7058767231556
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2271.9010969950546
+            "perf_metric_value": 2584.460785144293
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7526.072989853183
+            "perf_metric_value": 7610.6877946166605
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23029.099137990735
+            "perf_metric_value": 22473.36680019349
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 804.4799825746657
+            "perf_metric_value": 871.318654044455
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1099.299059786817
+            "perf_metric_value": 1052.0806198982318
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 793.6471952322032
+            "perf_metric_value": 841.9202869949634
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13033848458516117
+            "perf_metric_value": 0.13121585960885135
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11163.342583763659
+            "perf_metric_value": 11892.666392463261
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 511.54682034013
+            "perf_metric_value": 491.0521520633998
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 956.234692691667
+            "perf_metric_value": 916.2659145904904
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 964.227785207118
+            "perf_metric_value": 881.8820523473596
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9191916564759186
+            "perf_metric_value": 0.9228165417546772
         }
     ],
     "placement_group_create/removal": [
-        804.4799825746657,
-        13.347218543583795
+        871.318654044455,
+        3.7346713437660473
     ],
     "single_client_get_calls_Plasma_Store": [
-        10575.12534552304,
-        389.0501847163306
+        10447.993136996853,
+        83.07185815932432
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.459623096174152,
-        0.16042112976023476
+        12.47010395868836,
+        0.04903136852276722
     ],
     "single_client_put_calls_Plasma_Store": [
-        5342.356803322341,
-        87.92133379840806
+        5355.048189801414,
+        21.29328703266545
     ],
     "single_client_put_gigabytes": [
-        19.60264129638186,
-        6.0658657511900165
+        19.7492591299831,
+        5.157591067423617
     ],
     "single_client_tasks_and_get_batch": [
-        7.618329296876913,
-        0.22870606905835902
+        7.401087223556004,
+        0.3609618419034673
     ],
     "single_client_tasks_async": [
-        7728.179866020124,
-        391.64056111377556
+        7914.550524761689,
+        462.6843222291564
     ],
     "single_client_tasks_sync": [
-        990.8897375942615,
-        9.752000220743424
+        821.7242249574133,
+        4.410590220247194
     ],
     "single_client_wait_1k_refs": [
-        5.356105950176277,
-        0.05359089594239002
+        5.386835201432421,
+        0.12976981210726096
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 16.769440987999985,
+    "broadcast_time": 14.063101355999947,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.769440987999985
+            "perf_metric_value": 14.063101355999947
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.085048134999994,
-    "get_time": 23.721352370000005,
+    "args_time": 17.329141636999992,
+    "get_time": 23.16759225,
     "large_object_size": 107374182400,
-    "large_object_time": 29.037520325999992,
+    "large_object_time": 31.97225643500002,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.085048134999994
+            "perf_metric_value": 17.329141636999992
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.574067407000001
+            "perf_metric_value": 5.610097861
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.721352370000005
+            "perf_metric_value": 23.16759225
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 192.34304552800003
+            "perf_metric_value": 187.288716495
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.037520325999992
+            "perf_metric_value": 31.97225643500002
         }
     ],
-    "queued_time": 192.34304552800003,
-    "returns_time": 5.574067407000001,
+    "queued_time": 187.288716495,
+    "returns_time": 5.610097861,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0548744773864747,
-    "max_iteration_time": 3.340198516845703,
-    "min_iteration_time": 0.4613649845123291,
+    "avg_iteration_time": 1.0770559978485108,
+    "max_iteration_time": 3.1346068382263184,
+    "min_iteration_time": 0.4668869972229004,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0548744773864747
+            "perf_metric_value": 1.0770559978485108
         }
     ],
     "success": 1,
-    "total_time": 105.48765969276428
+    "total_time": 107.70581555366516
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.161747217178345
+            "perf_metric_value": 11.451530933380127
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.27835304737091
+            "perf_metric_value": 26.063378763198852
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 55.185825729370116
+            "perf_metric_value": 55.24269065856934
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5885274410247803
+            "perf_metric_value": 1.83331298828125
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3104.279580116272
+            "perf_metric_value": 3115.7028617858887
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4851944753960548
+            "perf_metric_value": 0.5052365708415846
         }
     ],
-    "stage_0_time": 10.161747217178345,
-    "stage_1_avg_iteration_time": 25.27835304737091,
-    "stage_1_max_iteration_time": 25.942532539367676,
-    "stage_1_min_iteration_time": 24.44790744781494,
-    "stage_1_time": 252.78363347053528,
-    "stage_2_avg_iteration_time": 55.185825729370116,
-    "stage_2_max_iteration_time": 56.937405824661255,
-    "stage_2_min_iteration_time": 53.556705951690674,
-    "stage_2_time": 275.930006980896,
-    "stage_3_creation_time": 1.5885274410247803,
-    "stage_3_time": 3104.279580116272,
-    "stage_4_spread": 0.4851944753960548,
+    "stage_0_time": 11.451530933380127,
+    "stage_1_avg_iteration_time": 26.063378763198852,
+    "stage_1_max_iteration_time": 27.1235830783844,
+    "stage_1_min_iteration_time": 25.202977657318115,
+    "stage_1_time": 260.63388085365295,
+    "stage_2_avg_iteration_time": 55.24269065856934,
+    "stage_2_max_iteration_time": 56.02961587905884,
+    "stage_2_min_iteration_time": 53.06244683265686,
+    "stage_2_time": 276.214262008667,
+    "stage_3_creation_time": 1.83331298828125,
+    "stage_3_time": 3115.7028617858887,
+    "stage_4_spread": 0.5052365708415846,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9132710030025517,
-    "avg_pg_remove_time_ms": 0.9020739549548232,
+    "avg_pg_create_time_ms": 0.914931959460137,
+    "avg_pg_remove_time_ms": 0.9115524369356258,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9132710030025517
+            "perf_metric_value": 0.914931959460137
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9020739549548232
+            "perf_metric_value": 0.9115524369356258
         }
     ],
     "success": 1


### PR DESCRIPTION
Based on https://buildkite.com/ray-project/release-automation/builds/604
```
REGRESSION 81.48%: multi_client_tasks_async (THROUGHPUT) regresses from 23658.661959832083 to 4380.675445374336 in microbenchmark.json
REGRESSION 17.07%: single_client_tasks_sync (THROUGHPUT) regresses from 990.8897375942615 to 821.7242249574133 in microbenchmark.json
REGRESSION 9.95%: actors_per_second (THROUGHPUT) regresses from 656.4820098150251 to 591.1743697324424 in benchmarks/many_actors.json
REGRESSION 8.54%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 964.227785207118 to 881.8820523473596 in microbenchmark.json
REGRESSION 5.49%: multi_client_put_gigabytes (THROUGHPUT) regresses from 35.52392832333356 to 33.57305818008913 in microbenchmark.json
REGRESSION 5.06%: pgs_per_second (THROUGHPUT) regresses from 23.5616061289441 to 22.36956883941179 in benchmarks/many_pgs.json
REGRESSION 4.30%: client__get_calls (THROUGHPUT) regresses from 1099.299059786817 to 1052.0806198982318 in microbenchmark.json
REGRESSION 4.18%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 956.234692691667 to 916.2659145904904 in microbenchmark.json
REGRESSION 4.01%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 511.54682034013 to 491.0521520633998 in microbenchmark.json
REGRESSION 2.85%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.618329296876913 to 7.401087223556004 in microbenchmark.json
REGRESSION 2.41%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23029.099137990735 to 22473.36680019349 in microbenchmark.json
REGRESSION 2.40%: n_n_actor_calls_async (THROUGHPUT) regresses from 26706.0034223919 to 26066.334327455046 in microbenchmark.json
REGRESSION 1.66%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2669.6470548189563 to 2625.3114806038075 in microbenchmark.json
REGRESSION 1.37%: tasks_per_second (THROUGHPUT) regresses from 356.96608310545133 to 352.0746471744154 in benchmarks/many_nodes.json
REGRESSION 1.20%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10575.12534552304 to 10447.993136996853 in microbenchmark.json
REGRESSION 0.73%: tasks_per_second (THROUGHPUT) regresses from 587.8163884392604 to 583.5060688927706 in benchmarks/many_tasks.json
REGRESSION 187.94%: dashboard_p50_latency_ms (LATENCY) regresses from 42.944 to 123.652 in benchmarks/many_tasks.json
REGRESSION 37.68%: dashboard_p99_latency_ms (LATENCY) regresses from 3456.493 to 4758.759 in benchmarks/many_actors.json
REGRESSION 15.41%: stage_3_creation_time (LATENCY) regresses from 1.5885274410247803 to 1.83331298828125 in stress_tests/stress_test_many_tasks.json
REGRESSION 12.69%: stage_0_time (LATENCY) regresses from 10.161747217178345 to 11.451530933380127 in stress_tests/stress_test_many_tasks.json
REGRESSION 10.11%: 107374182400_large_object_time (LATENCY) regresses from 29.037520325999992 to 31.97225643500002 in scalability/single_node.json
REGRESSION 6.07%: dashboard_p99_latency_ms (LATENCY) regresses from 204.615 to 217.033 in benchmarks/many_pgs.json
REGRESSION 4.13%: stage_4_spread (LATENCY) regresses from 0.4851944753960548 to 0.5052365708415846 in stress_tests/stress_test_many_tasks.json
REGRESSION 3.11%: stage_1_avg_iteration_time (LATENCY) regresses from 25.27835304737091 to 26.063378763198852 in stress_tests/stress_test_many_tasks.json
REGRESSION 2.10%: avg_iteration_time (LATENCY) regresses from 1.0548744773864747 to 1.0770559978485108 in stress_tests/stress_test_dead_actors.json
REGRESSION 1.43%: 10000_args_time (LATENCY) regresses from 17.085048134999994 to 17.329141636999992 in scalability/single_node.json
REGRESSION 1.05%: avg_pg_remove_time_ms (LATENCY) regresses from 0.9020739549548232 to 0.9115524369356258 in stress_tests/stress_test_placement_group.json
REGRESSION 0.65%: 3000_returns_time (LATENCY) regresses from 5.574067407000001 to 5.610097861 in scalability/single_node.json
REGRESSION 0.37%: stage_3_time (LATENCY) regresses from 3104.279580116272 to 3115.7028617858887 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.18%: avg_pg_create_time_ms (LATENCY) regresses from 0.9132710030025517 to 0.914931959460137 in stress_tests/stress_test_placement_group.json
REGRESSION 0.14%: dashboard_p50_latency_ms (LATENCY) regresses from 3.492 to 3.497 in benchmarks/many_pgs.json
REGRESSION 0.10%: stage_2_avg_iteration_time (LATENCY) regresses from 55.185825729370116 to 55.24269065856934 in stress_tests/stress_test_many_tasks.json
```