### PR TITLE
[Core] Cache the expensive TPUAcceleratorManager.get_current_node_num_accelerators

### DIFF
--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -3,6 +3,7 @@ import re
 import glob
 import requests
 import logging
+from functools import lru_cache
 from typing import Dict, Optional, List, Tuple
 
 from ray._private.accelerators.accelerator import AcceleratorManager
@@ -93,6 +94,7 @@ class TPUAcceleratorManager(AcceleratorManager):
         return list(tpu_visible_chips.split(","))
 
     @staticmethod
+    @lru_cache()
     def get_current_node_num_accelerators() -> int:
         """Attempt to detect the number of TPUs on this machine.
 

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -18,6 +18,7 @@ def test_autodetect_num_tpus_accel(mock_glob):
         "/dev/accel2",
         "/dev/accel3",
     ]
+    TPUAcceleratorManager.get_current_node_num_accelerators.cache_clear()
     assert TPUAcceleratorManager.get_current_node_num_accelerators() == 4
 
 
@@ -26,6 +27,7 @@ def test_autodetect_num_tpus_accel(mock_glob):
 def test_autodetect_num_tpus_vfio(mock_list, mock_glob):
     mock_glob.return_value = []
     mock_list.return_value = [f"{i}" for i in range(4)]
+    TPUAcceleratorManager.get_current_node_num_accelerators.cache_clear()
     assert TPUAcceleratorManager.get_current_node_num_accelerators() == 4
 
 
@@ -34,6 +36,7 @@ def test_autodetect_num_tpus_vfio(mock_list, mock_glob):
 def test_autodetect_num_tpus_without_devices(mock_list, mock_glob):
     mock_list.side_effect = FileNotFoundError
     mock_glob.return_value = []
+    TPUAcceleratorManager.get_current_node_num_accelerators.cache_clear()
     assert TPUAcceleratorManager.get_current_node_num_accelerators() == 0
 
 
@@ -198,6 +201,7 @@ def test_set_tpu_visible_ids_and_bounds(mock_glob, test_case):
     num_devices, tpu_chips = test_case
     mock_glob.return_value = ["/dev/accel" + str(x) for x in range(num_devices)]
     with patch.dict("os.environ", {}, clear=True):
+        TPUAcceleratorManager.get_current_node_num_accelerators.cache_clear()
         TPUAcceleratorManager.set_current_process_visible_accelerator_ids(tpu_chips)
         if len(tpu_chips) == 1:
             assert (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`TPUAcceleratorManager.get_current_node_num_accelerators` is expensive and it doesn't change during the lifetime of the program so we can cache it.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
