### PR TITLE
[Doc] Turn on nitpicky mode

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,7 +34,7 @@ sys.path.insert(0, os.path.abspath("../../python/"))
 # cross-reference to the Python function “filter”. The default is None, which doesn’t
 # reassign the default role.
 
-default_role = "py:obj"
+default_role = "code"
 
 sys.path.append(os.path.abspath("./_ext"))
 
@@ -91,6 +91,9 @@ myst_enable_extensions = [
 ]
 
 myst_heading_anchors = 3
+
+nitpicky = True
+nitpick_ignore_regex = [("py:class", ".*")]
 
 # Cache notebook outputs in _build/.jupyter_cache
 # To prevent notebook execution, set this to "off". To force re-execution, set this to

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,11 +29,13 @@ sys.path.insert(0, os.path.abspath("../../python/"))
 
 # -- General configuration ------------------------------------------------
 
-# The name of a reST role (builtin or Sphinx extension) to use as the default role, that
-# is, for text marked up `like this`. This can be set to 'py:obj' to make `filter` a
-# cross-reference to the Python function “filter”. The default is None, which doesn’t
-# reassign the default role.
-
+# This setting controls how single backticks are handled by sphinx. Developers
+# are used to using single backticks for code, but RST syntax requires that code
+# code to be denoted with _double_ backticks.
+# Here we make sphinx treat single backticks as code also, because everyone is
+# used to using single backticks as is done with markdown; without this setting,
+# lots of documentation ends up getting committed with single backticks anyway,
+# so we might as well make it work as developers intend for it to.
 default_role = "code"
 
 sys.path.append(os.path.abspath("./_ext"))
@@ -92,6 +94,11 @@ myst_enable_extensions = [
 
 myst_heading_anchors = 3
 
+# Make broken internal references into build time errors.
+# See https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpicky
+# for more information. :py:class: references are ignored due to false positives
+# arising from type annotations. See https://github.com/ray-project/ray/pull/46103
+# for additional context.
 nitpicky = True
 nitpick_ignore_regex = [("py:class", ".*")]
 


### PR DESCRIPTION
## Why are these changes needed?

This PR prevents developers from breaking _internal_ sphinx references by causing the docs build to fail if a broken reference is found.

Previously, broken references would simply be rendered as inline code but now they will raise an exception during the build process. It will be the responsibility of the developer who changes/adds/removes APIs or documentation to ensure the documentation is updated accordingly.

Furthermore, single backticks (`` ` ``) will now default to just being rendered as code; previously Sphinx considered anything in single backticks a reference. Most developers who touch documentation are familiar with markdown rather than RST, and use single backticks to denote code although it is not valid RST syntax for code (RST uses double backticks). As a result, there are many _many_ places in the documentation that use single backticks to mean code, and it would be impractical to expect contributors to adhere strictly to RST syntax when everyone is used to markdown. So instead we modify the `default_role` to eliminate this problem entirely, and treat anything in single backticks as code.

## Related issue number

Closes #39658. Currently blocked by #46102; will mark this as ready once that PR is merged.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
