### PR TITLE
Add perf metrics for 2.30.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 422.150144,
+    "_dashboard_memory_usage_mb": 518.90176,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.65,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1225\t9.33GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3575\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4789\t0.93GiB\tpython distributed/test_many_actors.py\n2384\t0.29GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3695\t0.24GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2767\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3858\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4583\t0.07GiB\tray::JobSupervisor\n4040\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3856\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
-    "actors_per_second": 656.4820098150251,
+    "_peak_memory": 3.68,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3503\t1.78GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5372\t0.96GiB\tpython distributed/test_many_actors.py\n2288\t0.33GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1139\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3618\t0.24GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3785\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2805\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5165\t0.07GiB\tray::JobSupervisor\n3975\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3783\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "actors_per_second": 617.6896831488957,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 656.4820098150251
+            "perf_metric_value": 617.6896831488957
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 65.662
+            "perf_metric_value": 47.275
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3333.28
+            "perf_metric_value": 2423.563
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3456.493
+            "perf_metric_value": 4809.161
         }
     ],
     "success": "1",
-    "time": 15.232709884643555
+    "time": 16.189358949661255
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 182.657024,
+    "_dashboard_memory_usage_mb": 186.085376,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.64,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3548\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1209\t0.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2279\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3663\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4732\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4938\t0.08GiB\tray::StateAPIGeneratorActor.start\n2760\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4531\t0.07GiB\tray::JobSupervisor\n3825\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4002\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "_peak_memory": 1.65,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3458\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1181\t0.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2465\t0.24GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3573\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4837\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5106\t0.08GiB\tray::StateAPIGeneratorActor.start\n4635\t0.07GiB\tray::JobSupervisor\n3736\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2666\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3734\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 356.96608310545133
+            "perf_metric_value": 344.6572790384348
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.877
+            "perf_metric_value": 3.756
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 48.58
+            "perf_metric_value": 37.938
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 197.137
+            "perf_metric_value": 195.419
         }
     ],
     "success": "1",
-    "tasks_per_second": 356.96608310545133,
-    "time": 302.80138659477234,
+    "tasks_per_second": 344.6572790384348,
+    "time": 302.90143299102783,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 137.633792,
+    "_dashboard_memory_usage_mb": 146.956288,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.25,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1224\t9.73GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3624\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4824\t0.42GiB\tpython distributed/test_many_pgs.py\n2809\t0.38GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3749\t0.15GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2607\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4609\t0.07GiB\tray::JobSupervisor\n3914\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4093\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3912\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 2.18,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1202\t9.89GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3564\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4710\t0.41GiB\tpython distributed/test_many_pgs.py\n2110\t0.38GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3679\t0.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2313\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4496\t0.07GiB\tray::JobSupervisor\n3846\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4036\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3844\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23.5616061289441
+            "perf_metric_value": 23.122692911575257
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.492
+            "perf_metric_value": 3.234
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.796
+            "perf_metric_value": 17.006
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 204.615
+            "perf_metric_value": 490.457
         }
     ],
-    "pgs_per_second": 23.5616061289441,
+    "pgs_per_second": 23.122692911575257,
     "success": "1",
-    "time": 42.44192838668823
+    "time": 43.24755787849426
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1164.107776,
+    "_dashboard_memory_usage_mb": 1169.338368,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.08,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3561\t2.86GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4731\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3681\t0.68GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1206\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2174\t0.23GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5002\t0.09GiB\tray::StateAPIGeneratorActor.start\n4947\t0.08GiB\tray::DashboardTester.run\n2551\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3843\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4521\t0.07GiB\tray::JobSupervisor",
+    "_peak_memory": 4.78,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3605\t2.08GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3720\t1.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4785\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1221\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2764\t0.24GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5053\t0.08GiB\tray::StateAPIGeneratorActor.start\n4998\t0.08GiB\tray::DashboardTester.run\n2987\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4583\t0.07GiB\tray::JobSupervisor\n3888\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 587.8163884392604
+            "perf_metric_value": 589.9220404343542
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 42.944
+            "perf_metric_value": 38.598
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3642.242
+            "perf_metric_value": 3102.89
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4549.74
+            "perf_metric_value": 4330.086
         }
     ],
     "success": "1",
-    "tasks_per_second": 587.8163884392604,
-    "time": 317.01211500167847,
+    "tasks_per_second": 589.9220404343542,
+    "time": 316.95139241218567,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.24.0"}
+{"release_version": "2.30.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8726.401857123754,
-        162.20549696513925
+        8933.20887285504,
+        177.9934113962222
     ],
     "1_1_actor_calls_concurrent": [
-        5525.453533356669,
-        275.6986719349956
+        5433.519532534513,
+        164.1306697381876
     ],
     "1_1_actor_calls_sync": [
-        2022.1643749529967,
-        42.58171596149864
+        2065.600257768727,
+        62.805248400133635
     ],
     "1_1_async_actor_calls_async": [
-        3295.7761919502855,
-        149.90516121451026
+        3288.4752616288997,
+        106.50912257511672
     ],
     "1_1_async_actor_calls_sync": [
-        1306.2185283312654,
-        22.393311157323094
+        1298.3259900715077,
+        30.9960059878394
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2271.9010969950546,
-        58.46933903250449
+        2282.9083135396877,
+        33.569211303281655
     ],
     "1_n_actor_calls_async": [
-        8723.546909820518,
-        133.04998221108622
+        7999.09786468534,
+        240.5274055318131
     ],
     "1_n_async_actor_calls_async": [
-        7526.072989853183,
-        80.26873719023843
+        7148.833981156601,
+        140.55726545377746
     ],
     "client__1_1_actor_calls_async": [
-        956.234692691667,
-        10.622834071499192
+        1004.5373307362321,
+        7.2386406094867235
     ],
     "client__1_1_actor_calls_concurrent": [
-        964.227785207118,
-        19.39077588012691
+        993.150411111262,
+        6.495370194557394
     ],
     "client__1_1_actor_calls_sync": [
-        511.54682034013,
-        20.183100809422037
+        525.5676701595513,
+        7.259223093436164
     ],
     "client__get_calls": [
-        1099.299059786817,
-        48.740510949504255
+        1027.2844127511862,
+        43.787332210624506
     ],
     "client__put_calls": [
-        793.6471952322032,
-        19.166421115489065
+        782.6829866165862,
+        12.444956861586565
     ],
     "client__put_gigabytes": [
-        0.13033848458516117,
-        0.0004047979867318293
+        0.12974867196873113,
+        0.0008153816205802196
     ],
     "client__tasks_and_get_batch": [
-        0.9191916564759186,
-        0.004240563507874709
+        0.8448091448208279,
+        0.03277995280220994
     ],
     "client__tasks_and_put_batch": [
-        11163.342583763659,
-        86.36159399829216
+        10913.81106126635,
+        163.45505630570557
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12352.999319488557,
-        302.78838782381274
+        12847.965582428995,
+        227.371465552808
     ],
     "multi_client_put_gigabytes": [
-        35.52392832333356,
-        2.4551866947000778
+        32.74094571462406,
+        1.8518261729618408
     ],
     "multi_client_tasks_async": [
-        23658.661959832083,
-        3659.740758379274
+        21834.59499226869,
+        1466.306541428481
     ],
     "n_n_actor_calls_async": [
-        26706.0034223919,
-        796.7068479444016
+        27240.503592641795,
+        285.1485495890741
     ],
     "n_n_actor_calls_with_arg_async": [
-        2669.6470548189563,
-        37.75431784396307
+        2573.976684531894,
+        82.19775263467561
     ],
     "n_n_async_actor_calls_async": [
-        23029.099137990735,
-        353.5298340819868
+        22180.601943156536,
+        662.4659543753717
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10575.12534552304
+            "perf_metric_value": 10612.85977893251
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5342.356803322341
+            "perf_metric_value": 5156.839238498811
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12352.999319488557
+            "perf_metric_value": 12847.965582428995
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.60264129638186
+            "perf_metric_value": 19.128661449193785
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.618329296876913
+            "perf_metric_value": 7.735617799600968
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 35.52392832333356
+            "perf_metric_value": 32.74094571462406
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.459623096174152
+            "perf_metric_value": 12.781987811502956
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.356105950176277
+            "perf_metric_value": 5.386309531741722
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 990.8897375942615
+            "perf_metric_value": 1001.380589618519
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7728.179866020124
+            "perf_metric_value": 7857.638521551526
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23658.661959832083
+            "perf_metric_value": 21834.59499226869
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2022.1643749529967
+            "perf_metric_value": 2065.600257768727
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8726.401857123754
+            "perf_metric_value": 8933.20887285504
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5525.453533356669
+            "perf_metric_value": 5433.519532534513
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8723.546909820518
+            "perf_metric_value": 7999.09786468534
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26706.0034223919
+            "perf_metric_value": 27240.503592641795
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2669.6470548189563
+            "perf_metric_value": 2573.976684531894
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1306.2185283312654
+            "perf_metric_value": 1298.3259900715077
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3295.7761919502855
+            "perf_metric_value": 3288.4752616288997
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2271.9010969950546
+            "perf_metric_value": 2282.9083135396877
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7526.072989853183
+            "perf_metric_value": 7148.833981156601
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23029.099137990735
+            "perf_metric_value": 22180.601943156536
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 804.4799825746657
+            "perf_metric_value": 798.5897498740229
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1099.299059786817
+            "perf_metric_value": 1027.2844127511862
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 793.6471952322032
+            "perf_metric_value": 782.6829866165862
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13033848458516117
+            "perf_metric_value": 0.12974867196873113
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11163.342583763659
+            "perf_metric_value": 10913.81106126635
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 511.54682034013
+            "perf_metric_value": 525.5676701595513
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 956.234692691667
+            "perf_metric_value": 1004.5373307362321
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 964.227785207118
+            "perf_metric_value": 993.150411111262
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9191916564759186
+            "perf_metric_value": 0.8448091448208279
         }
     ],
     "placement_group_create/removal": [
-        804.4799825746657,
-        13.347218543583795
+        798.5897498740229,
+        13.543156241895135
     ],
     "single_client_get_calls_Plasma_Store": [
-        10575.12534552304,
-        389.0501847163306
+        10612.85977893251,
+        270.52509099812664
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.459623096174152,
-        0.16042112976023476
+        12.781987811502956,
+        0.14597397314905913
     ],
     "single_client_put_calls_Plasma_Store": [
-        5342.356803322341,
-        87.92133379840806
+        5156.839238498811,
+        51.564900584700915
     ],
     "single_client_put_gigabytes": [
-        19.60264129638186,
-        6.0658657511900165
+        19.128661449193785,
+        5.44250703557405
     ],
     "single_client_tasks_and_get_batch": [
-        7.618329296876913,
-        0.22870606905835902
+        7.735617799600968,
+        0.6212378115067596
     ],
     "single_client_tasks_async": [
-        7728.179866020124,
-        391.64056111377556
+        7857.638521551526,
+        362.4721080511504
     ],
     "single_client_tasks_sync": [
-        990.8897375942615,
-        9.752000220743424
+        1001.380589618519,
+        29.289784910461382
     ],
     "single_client_wait_1k_refs": [
-        5.356105950176277,
-        0.05359089594239002
+        5.386309531741722,
+        0.14180324417145865
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 16.769440987999985,
+    "broadcast_time": 17.659990787000027,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.769440987999985
+            "perf_metric_value": 17.659990787000027
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.085048134999994,
-    "get_time": 23.721352370000005,
+    "args_time": 17.397838494999988,
+    "get_time": 22.694496589999986,
     "large_object_size": 107374182400,
-    "large_object_time": 29.037520325999992,
+    "large_object_time": 29.366374017999988,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.085048134999994
+            "perf_metric_value": 17.397838494999988
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.574067407000001
+            "perf_metric_value": 5.513575275999997
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.721352370000005
+            "perf_metric_value": 22.694496589999986
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 192.34304552800003
+            "perf_metric_value": 183.01543519700002
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.037520325999992
+            "perf_metric_value": 29.366374017999988
         }
     ],
-    "queued_time": 192.34304552800003,
-    "returns_time": 5.574067407000001,
+    "queued_time": 183.01543519700002,
+    "returns_time": 5.513575275999997,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0548744773864747,
-    "max_iteration_time": 3.340198516845703,
-    "min_iteration_time": 0.4613649845123291,
+    "avg_iteration_time": 1.0871897959709167,
+    "max_iteration_time": 2.8652021884918213,
+    "min_iteration_time": 0.13084864616394043,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0548744773864747
+            "perf_metric_value": 1.0871897959709167
         }
     ],
     "success": 1,
-    "total_time": 105.48765969276428
+    "total_time": 108.71918201446533
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.161747217178345
+            "perf_metric_value": 10.09369158744812
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.27835304737091
+            "perf_metric_value": 24.93844430446625
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 55.185825729370116
+            "perf_metric_value": 59.59709148406982
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5885274410247803
+            "perf_metric_value": 1.687410831451416
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3104.279580116272
+            "perf_metric_value": 3216.0363504886627
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4851944753960548
+            "perf_metric_value": 0.4720456406930635
         }
     ],
-    "stage_0_time": 10.161747217178345,
-    "stage_1_avg_iteration_time": 25.27835304737091,
-    "stage_1_max_iteration_time": 25.942532539367676,
-    "stage_1_min_iteration_time": 24.44790744781494,
-    "stage_1_time": 252.78363347053528,
-    "stage_2_avg_iteration_time": 55.185825729370116,
-    "stage_2_max_iteration_time": 56.937405824661255,
-    "stage_2_min_iteration_time": 53.556705951690674,
-    "stage_2_time": 275.930006980896,
-    "stage_3_creation_time": 1.5885274410247803,
-    "stage_3_time": 3104.279580116272,
-    "stage_4_spread": 0.4851944753960548,
+    "stage_0_time": 10.09369158744812,
+    "stage_1_avg_iteration_time": 24.93844430446625,
+    "stage_1_max_iteration_time": 26.48196816444397,
+    "stage_1_min_iteration_time": 23.490055084228516,
+    "stage_1_time": 249.38453197479248,
+    "stage_2_avg_iteration_time": 59.59709148406982,
+    "stage_2_max_iteration_time": 61.32059621810913,
+    "stage_2_min_iteration_time": 57.57088589668274,
+    "stage_2_time": 297.9873077869415,
+    "stage_3_creation_time": 1.687410831451416,
+    "stage_3_time": 3216.0363504886627,
+    "stage_4_spread": 0.4720456406930635,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9132710030025517,
-    "avg_pg_remove_time_ms": 0.9020739549548232,
+    "avg_pg_create_time_ms": 0.9000045735734334,
+    "avg_pg_remove_time_ms": 0.8979432732736121,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9132710030025517
+            "perf_metric_value": 0.9000045735734334
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9020739549548232
+            "perf_metric_value": 0.8979432732736121
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 8.30%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8723.546909820518 to 7999.09786468534 in microbenchmark.json
REGRESSION 8.09%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9191916564759186 to 0.8448091448208279 in microbenchmark.json
REGRESSION 7.83%: multi_client_put_gigabytes (THROUGHPUT) regresses from 35.52392832333356 to 32.74094571462406 in microbenchmark.json
REGRESSION 7.71%: multi_client_tasks_async (THROUGHPUT) regresses from 23658.661959832083 to 21834.59499226869 in microbenchmark.json
REGRESSION 6.55%: client__get_calls (THROUGHPUT) regresses from 1099.299059786817 to 1027.2844127511862 in microbenchmark.json
REGRESSION 5.91%: actors_per_second (THROUGHPUT) regresses from 656.4820098150251 to 617.6896831488957 in benchmarks/many_actors.json
REGRESSION 5.01%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7526.072989853183 to 7148.833981156601 in microbenchmark.json
REGRESSION 3.68%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23029.099137990735 to 22180.601943156536 in microbenchmark.json
REGRESSION 3.58%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2669.6470548189563 to 2573.976684531894 in microbenchmark.json
REGRESSION 3.47%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5342.356803322341 to 5156.839238498811 in microbenchmark.json
REGRESSION 3.45%: tasks_per_second (THROUGHPUT) regresses from 356.96608310545133 to 344.6572790384348 in benchmarks/many_nodes.json
REGRESSION 2.42%: single_client_put_gigabytes (THROUGHPUT) regresses from 19.60264129638186 to 19.128661449193785 in microbenchmark.json
REGRESSION 2.24%: client__tasks_and_put_batch (THROUGHPUT) regresses from 11163.342583763659 to 10913.81106126635 in microbenchmark.json
REGRESSION 1.86%: pgs_per_second (THROUGHPUT) regresses from 23.5616061289441 to 23.122692911575257 in benchmarks/many_pgs.json
REGRESSION 1.66%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5525.453533356669 to 5433.519532534513 in microbenchmark.json
REGRESSION 1.38%: client__put_calls (THROUGHPUT) regresses from 793.6471952322032 to 782.6829866165862 in microbenchmark.json
REGRESSION 0.73%: placement_group_create/removal (THROUGHPUT) regresses from 804.4799825746657 to 798.5897498740229 in microbenchmark.json
REGRESSION 0.60%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1306.2185283312654 to 1298.3259900715077 in microbenchmark.json
REGRESSION 0.45%: client__put_gigabytes (THROUGHPUT) regresses from 0.13033848458516117 to 0.12974867196873113 in microbenchmark.json
REGRESSION 0.22%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 3295.7761919502855 to 3288.4752616288997 in microbenchmark.json
REGRESSION 139.70%: dashboard_p99_latency_ms (LATENCY) regresses from 204.615 to 490.457 in benchmarks/many_pgs.json
REGRESSION 39.13%: dashboard_p99_latency_ms (LATENCY) regresses from 3456.493 to 4809.161 in benchmarks/many_actors.json
REGRESSION 32.90%: dashboard_p95_latency_ms (LATENCY) regresses from 12.796 to 17.006 in benchmarks/many_pgs.json
REGRESSION 7.99%: stage_2_avg_iteration_time (LATENCY) regresses from 55.185825729370116 to 59.59709148406982 in stress_tests/stress_test_many_tasks.json
REGRESSION 6.22%: stage_3_creation_time (LATENCY) regresses from 1.5885274410247803 to 1.687410831451416 in stress_tests/stress_test_many_tasks.json
REGRESSION 5.31%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 16.769440987999985 to 17.659990787000027 in scalability/object_store.json
REGRESSION 3.60%: stage_3_time (LATENCY) regresses from 3104.279580116272 to 3216.0363504886627 in stress_tests/stress_test_many_tasks.json
REGRESSION 3.06%: avg_iteration_time (LATENCY) regresses from 1.0548744773864747 to 1.0871897959709167 in stress_tests/stress_test_dead_actors.json
REGRESSION 1.83%: 10000_args_time (LATENCY) regresses from 17.085048134999994 to 17.397838494999988 in scalability/single_node.json
REGRESSION 1.13%: 107374182400_large_object_time (LATENCY) regresses from 29.037520325999992 to 29.366374017999988 in scalability/single_node.json
```