### PR TITLE
[doc] Added MNIST training using KubeRay doc page

### DIFF
--- a/doc/source/cluster/kubernetes/examples.md
+++ b/doc/source/cluster/kubernetes/examples.md
@@ -7,6 +7,7 @@
 
 examples/ml-example
 examples/gpu-training-example
+examples/mnist-training-example
 examples/stable-diffusion-rayservice
 examples/mobilenet-rayservice
 examples/text-summarizer-rayservice
@@ -22,6 +23,7 @@ This section presents example Ray workloads to try out on your Kubernetes cluste
 
 - {ref}`kuberay-ml-example` (CPU-only)
 - {ref}`kuberay-gpu-training-example`
+- {ref}`kuberay-mnist-training-example` (CPU-only)
 - {ref}`kuberay-mobilenet-rayservice-example` (CPU-only)
 - {ref}`kuberay-stable-diffusion-rayservice-example`
 - {ref}`kuberay-text-summarizer-rayservice-example`

--- a/doc/source/cluster/kubernetes/examples/mnist-training-example.md
+++ b/doc/source/cluster/kubernetes/examples/mnist-training-example.md
@@ -58,7 +58,7 @@ kubectl get rayjob
 # rayjob-pytorch-mnist   SUCCEEDED    Complete            2024-06-17T04:08:25Z   2024-06-17T04:22:21Z   16m
 ```
 
-After Seeing `JOB_STATUS` marked as `SUCCEEDED`, you can check the training logs:
+After seeing `JOB_STATUS` marked as `SUCCEEDED`, you can check the training logs:
 
 ```sh
 # check pods name

--- a/doc/source/cluster/kubernetes/examples/mnist-training-example.md
+++ b/doc/source/cluster/kubernetes/examples/mnist-training-example.md
@@ -2,7 +2,7 @@
 
 # Train a PyTorch Model on Fashion MNIST with CPUs on Kubernetes
 
-This example runs distributed training of a PyTorch model on Fashion MNIST with Ray Train. See [Train a PyTorch Model on Fashion MNIST](../../../train/examples/pytorch/torch_fashion_mnist_example.rst) for more details.
+This example runs distributed training of a PyTorch model on Fashion MNIST with Ray Train. See [Train a PyTorch Model on Fashion MNIST](train-pytorch-fashion-mnist) for more details.
 
 ## Step 1: Create a Kubernetes cluster
 
@@ -27,7 +27,7 @@ curl -LO https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operat
 
 You might need to adjust some fields in the RayJob description YAML file so that it can run in your environment:
 * `replicas` under `workerGroupSpecs` in `rayClusterSpec`: This field specifies the number of worker Pods that will be scheduled to the Kubernetes cluster. Each worker Pod and the head Pod, as described in the `template` field, require 2 CPUs. A RayJob submitter Pod requires 1 CPU. For example, if your machine has 8 CPUs, the maximum `replicas` value will be 2 to allow all Pods to reach the `Running` status.
-* `NUM_WORKERS` under `runtimeEnvYAML` in `spec`: This field indicates the number of Ray actors to launch (see [Document](../../../train/api/doc/ray.train.ScalingConfig.rst) for more information). Each Ray actor must be served by a worker Pod in the Kubernetes cluster. Therefore, `NUM_WORKERS` must be less than or equal to `replicas`.
+* `NUM_WORKERS` under `runtimeEnvYAML` in `spec`: This field indicates the number of Ray actors to launch (see `ScalingConfig` in this [Document](ray-train-configs-api) for more information). Each Ray actor must be served by a worker Pod in the Kubernetes cluster. Therefore, `NUM_WORKERS` must be less than or equal to `replicas`.
 
 ```sh
 # `replicas` and `NUM_WORKERS` set to 2

--- a/doc/source/cluster/kubernetes/examples/mnist-training-example.md
+++ b/doc/source/cluster/kubernetes/examples/mnist-training-example.md
@@ -21,7 +21,7 @@ A RayJob consists of a RayCluster custom resource and a job that can be submitte
 
 ```sh
 # Download `ray-job.pytorch-mnist.yaml`
-curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.0.0/ray-operator/config/samples/pytorch-mnist/ray-job.pytorch-mnist.yaml
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/pytorch-mnist/ray-job.pytorch-mnist.yaml
 
 # Create a RayJob
 kubectl apply -f ray-job.pytorch-mnist.yaml

--- a/doc/source/cluster/kubernetes/examples/mnist-training-example.md
+++ b/doc/source/cluster/kubernetes/examples/mnist-training-example.md
@@ -1,8 +1,8 @@
 (kuberay-mnist-training-example)=
 
-# Train a PyTorch Model on Fashion MNIST with CPUs on Kubernetes
+# Train a PyTorch model on Fashion MNIST with CPUs on Kubernetes
 
-This example runs distributed training of a PyTorch model on Fashion MNIST with Ray Train. See [Train a PyTorch Model on Fashion MNIST](train-pytorch-fashion-mnist) for more details.
+This example runs distributed training of a PyTorch model on Fashion MNIST with Ray Train. See [Train a PyTorch model on Fashion MNIST](train-pytorch-fashion-mnist) for more details.
 
 ## Step 1: Create a Kubernetes cluster
 
@@ -18,7 +18,7 @@ Follow [this document](kuberay-operator-deploy) to install the latest stable Kub
 
 ## Step 3: Create a RayJob
 
-A RayJob consists of a RayCluster custom resource and a job that can be submitted to the RayCluster. With RayJob, KubeRay creates a RayCluster and submits a job when the cluster is ready. Here is a CPU-only RayJob description YAML file for MNIST training on a PyTorch model.
+A RayJob consists of a RayCluster custom resource and a job that can you can submit to the RayCluster. With RayJob, KubeRay creates a RayCluster and submits a job when the cluster is ready. The following is a CPU-only RayJob description YAML file for MNIST training on a PyTorch model.
 
 ```sh
 # Download `ray-job.pytorch-mnist.yaml`
@@ -26,16 +26,16 @@ curl -LO https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operat
 ```
 
 You might need to adjust some fields in the RayJob description YAML file so that it can run in your environment:
-* `replicas` under `workerGroupSpecs` in `rayClusterSpec`: This field specifies the number of worker Pods that will be scheduled to the Kubernetes cluster. Each worker Pod and the head Pod, as described in the `template` field, require 2 CPUs. A RayJob submitter Pod requires 1 CPU. For example, if your machine has 8 CPUs, the maximum `replicas` value will be 2 to allow all Pods to reach the `Running` status.
+* `replicas` under `workerGroupSpecs` in `rayClusterSpec`: This field specifies the number of worker Pods that KubeRay schedules to the Kubernetes cluster. Each worker Pod and the head Pod, as described in the `template` field, requires 2 CPUs. A RayJob submitter Pod requires 1 CPU. For example, if your machine has 8 CPUs, the maximum `replicas` value is 2 to allow all Pods to reach the `Running` status.
 * `NUM_WORKERS` under `runtimeEnvYAML` in `spec`: This field indicates the number of Ray actors to launch (see `ScalingConfig` in this [Document](ray-train-configs-api) for more information). Each Ray actor must be served by a worker Pod in the Kubernetes cluster. Therefore, `NUM_WORKERS` must be less than or equal to `replicas`.
 
 ```sh
-# `replicas` and `NUM_WORKERS` set to 2
-# Create a RayJob
+# `replicas` and `NUM_WORKERS` set to 2.
+# Create a RayJob.
 kubectl apply -f ray-job.pytorch-mnist.yaml
 
-# Check existing Pods: According to `replicas`, there should be 2 worker Pods
-# Make sure all the Pods are in the `Running` status
+# Check existing Pods: According to `replicas`, there should be 2 worker Pods.
+# Make sure all the Pods are in the `Running` status.
 kubectl get pods
 # NAME                                                      READY   STATUS    RESTARTS   AGE
 # kuberay-operator-6dddd689fb-ksmcs                         1/1     Running   0          6m8s
@@ -66,7 +66,7 @@ kubectl get rayjob
 After seeing `JOB_STATUS` marked as `SUCCEEDED`, you can check the training logs:
 
 ```sh
-# Check Pods name
+# Check Pods name.
 kubectl get pods
 # NAME                                                      READY   STATUS      RESTARTS   AGE
 # kuberay-operator-6dddd689fb-ksmcs                         1/1     Running     0          113m
@@ -75,7 +75,7 @@ kubectl get pods
 # rayjob-pytorch-mnist-nxmj2                                0/1     Completed   0          38m
 # rayjob-pytorch-mnist-raycluster-rkdmq-head-m4dsl          1/1     Running     0          38m
 
-# Check training logs
+# Check training logs.
 kubectl logs -f rayjob-pytorch-mnist-nxmj2
 
 # 2024-06-16 22:23:01,047 INFO cli.py:36 -- Job submission server address: http://rayjob-pytorch-mnist-raycluster-rkdmq-head-svc.default.svc.cluster.local:8265
@@ -111,7 +111,7 @@ kubectl logs -f rayjob-pytorch-mnist-nxmj2
 # ...
 ```
 
-## Clean-up
+## Clean up
 
 Delete your RayJob with the following command:
 

--- a/doc/source/cluster/kubernetes/examples/mnist-training-example.md
+++ b/doc/source/cluster/kubernetes/examples/mnist-training-example.md
@@ -1,0 +1,122 @@
+(kuberay-mnist-training-example)=
+
+# Train MNIST on a Neural Network with CPUs on Kubernetes
+
+This guide runs a sample Ray Train workload with CPUs on Kubernetes infrastructure.
+
+## Step 1: Install KubeRay operator
+
+Follow [this document](kuberay-operator-deploy) to install the latest stable KubeRay operator from the Helm repository. After installation, you should see the operator running:
+
+```sh
+# Confirm that the operator is running in the namespace `default`.
+kubectl get pods
+# NAME                                                      READY   STATUS              RESTARTS   AGE
+# kuberay-operator-6dddd689fb-ksmcs                         1/1     Running             0          48s
+```
+
+## Step 2: Create a RayJob
+
+A RayJob consists of a RayCluster custom resource and a job that can be submitted to the RayCluster. With RayJob, KubeRay creates a RayCluster and submit a job when the cluster is ready. Here, we provide a CPU-only RayJob description yaml file for the MNIST training on a Neural Network.
+
+```sh
+# Download `ray-job.pytorch-mnist.yaml`
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.0.0/ray-operator/config/samples/pytorch-mnist/ray-job.pytorch-mnist.yaml
+
+# Create a RayJob
+kubectl apply -f ray-job.pytorch-mnist.yaml
+```
+
+Feel free to adjust the `NUM_WORKERS` field and the `replicas` field under `workerGroupSpecs` in `rayClusterSpec` in the yaml file such that all the worker pods can reach `Running` status.
+
+```sh
+# `replicas` and `NUM_WORKERS` set to 2
+kubectl get pods
+# NAME                                                      READY   STATUS    RESTARTS   AGE
+# kuberay-operator-6dddd689fb-ksmcs                         1/1     Running   0          6m8s
+# pytorch-mnist-raycluster-rkdmq-worker-small-group-c8bwx   1/1     Running   0          5m32s
+# pytorch-mnist-raycluster-rkdmq-worker-small-group-s7wvm   1/1     Running   0          5m32s
+# rayjob-pytorch-mnist-nxmj2                                1/1     Running   0          4m17s
+# rayjob-pytorch-mnist-raycluster-rkdmq-head-m4dsl          1/1     Running   0          5m32s
+```
+
+Check that the job is in the `RUNNING` status:
+
+```sh
+kubectl get rayjob
+# NAME                   JOB STATUS   DEPLOYMENT STATUS   START TIME             END TIME   AGE
+# rayjob-pytorch-mnist   RUNNING      Running             2024-06-17T04:08:25Z              11m
+```
+
+## Step 3: Wait until the job is completed and check the training results
+
+Wait until the job is completed. It might take several minutes.
+
+```sh
+kubectl get rayjob
+# NAME                   JOB STATUS   DEPLOYMENT STATUS   START TIME             END TIME               AGE
+# rayjob-pytorch-mnist   SUCCEEDED    Complete            2024-06-17T04:08:25Z   2024-06-17T04:22:21Z   16m
+```
+
+After Seeing `JOB_STATUS` marked as `SUCCEEDED`, you can check the training logs:
+
+```sh
+# check pods name
+kubectl get pods
+# NAME                                                      READY   STATUS      RESTARTS   AGE
+# kuberay-operator-6dddd689fb-ksmcs                         1/1     Running     0          113m
+# pytorch-mnist-raycluster-rkdmq-worker-small-group-c8bwx   1/1     Running     0          38m
+# pytorch-mnist-raycluster-rkdmq-worker-small-group-s7wvm   1/1     Running     0          38m
+# rayjob-pytorch-mnist-nxmj2                                0/1     Completed   0          38m
+# rayjob-pytorch-mnist-raycluster-rkdmq-head-m4dsl          1/1     Running     0          38m
+
+# check training logs
+kubectl logs -f rayjob-pytorch-mnist-nxmj2
+
+# 2024-06-16 22:23:01,047 INFO cli.py:36 -- Job submission server address: http://rayjob-pytorch-mnist-raycluster-rkdmq-head-svc.default.svc.cluster.local:8265
+# 2024-06-16 22:23:01,844 SUCC cli.py:60 -- -------------------------------------------------------
+# 2024-06-16 22:23:01,844 SUCC cli.py:61 -- Job 'rayjob-pytorch-mnist-l6ccc' submitted successfully
+# 2024-06-16 22:23:01,844 SUCC cli.py:62 -- -------------------------------------------------------
+# ...
+# (RayTrainWorker pid=1138, ip=10.244.0.18) 
+#   0%|          | 0/26421880 [00:00<?, ?it/s]
+# (RayTrainWorker pid=1138, ip=10.244.0.18) 
+#   0%|          | 32768/26421880 [00:00<01:27, 301113.97it/s]
+# ...
+# Training finished iteration 10 at 2024-06-16 22:33:05. Total running time: 7min 9s
+# ╭───────────────────────────────╮
+# │ Training result               │
+# ├───────────────────────────────┤
+# │ checkpoint_dir_name           │
+# │ time_this_iter_s      28.2635 │
+# │ time_total_s          423.388 │
+# │ training_iteration         10 │
+# │ accuracy               0.8748 │
+# │ loss                  0.35477 │
+# ╰───────────────────────────────╯
+
+# Training completed after 10 iterations at 2024-06-16 22:33:06. Total running time: 7min 10s
+
+# Training result: Result(
+#   metrics={'loss': 0.35476621258825347, 'accuracy': 0.8748},
+#   path='/home/ray/ray_results/TorchTrainer_2024-06-16_22-25-55/TorchTrainer_122aa_00000_0_2024-06-16_22-25-55',
+#   filesystem='local',
+#   checkpoint=None
+# )
+# ...
+```
+
+## Clean-up
+
+Delete your RayCluster and KubeRay with the following commands:
+
+```sh
+# check <raycluster-name> by `kubectl get raycluster`
+kubectl delete raycluster <raycluster-name>
+
+# Please make sure the ray cluster has already been removed before delete the operator.
+helm uninstall kuberay-operator
+
+# remove kubernetes cluster created by kind
+kind delete cluster
+```

--- a/doc/source/train/examples/pytorch/torch_fashion_mnist_example.rst
+++ b/doc/source/train/examples/pytorch/torch_fashion_mnist_example.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _train-pytorch-fashion-mnist:
+
 Train a PyTorch Model on Fashion MNIST
 ======================================
 

--- a/doc/source/train/examples/pytorch/torch_fashion_mnist_example.rst
+++ b/doc/source/train/examples/pytorch/torch_fashion_mnist_example.rst
@@ -2,7 +2,7 @@
 
 .. _train-pytorch-fashion-mnist:
 
-Train a PyTorch Model on Fashion MNIST
+Train a PyTorch model on Fashion MNIST
 ======================================
 
 This example runs distributed training of a PyTorch model on Fashion MNIST with Ray Train.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Added a MNIST training page using KubeRay to document page. The training workload is based on (currently in kuberay repo):
https://github.com/ray-project/kuberay/tree/master/ray-operator/config/samples/pytorch-mnist

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
