### PR TITLE
[core] re-enable test_accelerated_dag tests

### DIFF
--- a/python/ray/dag/BUILD
+++ b/python/ray/dag/BUILD
@@ -76,8 +76,7 @@ py_test_module_list(
     "tests/experimental/test_torch_tensor_dag.py",
   ],
   size = "medium",
-  # Marking these as manual until they are deflaked.
-  tags = ["exclusive", "accelerated_dag", "no_windows", "team:core", "manual"],
+  tags = ["exclusive", "accelerated_dag", "no_windows", "team:core"],
   deps = ["//:ray_lib"],
 )
 


### PR DESCRIPTION
The tests are passing now; reenable them on CI

Test:
- CI