### PR TITLE
[Data] Add `is_lineage_serializable` to `LogicalOperator` interface

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -80,3 +80,13 @@ class LogicalOperator(Operator):
     def output_data(self) -> Optional[List["RefBundle"]]:
         """The output data of this operator, or ``None`` if not known."""
         return None
+
+    def is_lineage_serializable(self) -> bool:
+        """Returns whether the lineage of this operator can be serialized.
+
+        An operator is lineage serializable if you can serialize it on one machine and
+        deserialize it on another without losing information. Operators that store
+        object references (e.g., ``InputData``) aren't lineage serializable because the
+        objects aren't available on the deserialized machine.
+        """
+        return True

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -49,6 +49,10 @@ class AbstractFrom(LogicalOperator, metaclass=abc.ABCMeta):
     def output_data(self) -> Optional[List[RefBundle]]:
         return self._input_data
 
+    def is_lineage_serializable(self) -> bool:
+        # This operator isn't serializable because it contains ObjectRefs.
+        return False
+
 
 class FromItems(AbstractFrom):
     """Logical operator for `from_items`."""

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -45,3 +45,7 @@ class InputData(LogicalOperator):
         if self.input_data is None:
             return None
         return self.input_data
+
+    def is_lineage_serializable(self) -> bool:
+        # This operator isn't serializable because it contains ObjectRefs.
+        return False

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -17,6 +17,12 @@ class NAry(LogicalOperator):
         """
         super().__init__(self.__class__.__name__, list(input_ops), num_outputs)
 
+    def is_lineage_serializable(self) -> bool:
+        # NOTE: Historically, lineage serialization was explicitly not supported for
+        # `NAry` operators. I'm not sure if we still need this restriction, but I'm
+        # keeping it to be safe. See https://github.com/ray-project/ray/pull/24190.
+        return False
+
 
 class Zip(NAry):
     """Logical operator for zip."""

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -17,12 +17,6 @@ class NAry(LogicalOperator):
         """
         super().__init__(self.__class__.__name__, list(input_ops), num_outputs)
 
-    def is_lineage_serializable(self) -> bool:
-        # NOTE: Historically, lineage serialization was explicitly not supported for
-        # `NAry` operators. I'm not sure if we still need this restriction, but I'm
-        # keeping it to be safe. See https://github.com/ray-project/ray/pull/24190.
-        return False
-
 
 class Zip(NAry):
     """Logical operator for zip."""

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4607,7 +4607,10 @@ class Dataset:
             >>> ray.data.read_csv("s3://anonymous@ray-example-data/iris.csv").has_serializable_lineage()
             True
         """  # noqa: E501
-        return self._plan.has_lazy_input()
+        return all(
+            op.is_lineage_serializable()
+            for op in self._logical_plan.dag.post_order_iter()
+        )
 
     @DeveloperAPI
     def serialize_lineage(self) -> bytes:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ray Data serializes `Dataset` objects so that they can be tuned as a hyperparameter for Ray Tune. To determine if a `Dataset` can be tuned, Ray Data explicitly checks if the input operator is a `Read` operator. To decouple this logic from a specific implementation and allow us to add other lineage-serializable input operators, this PR adds a `is_lineage_serializable` method to the interface.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
