### PR TITLE
[serve][1k release test] don't run replicas on head node

### DIFF
--- a/release/serve_tests/compute_tpl_32_cpu.yaml
+++ b/release/serve_tests/compute_tpl_32_cpu.yaml
@@ -16,6 +16,9 @@ worker_node_types:
       min_workers: 32
       max_workers: 32
       use_spot: false
+      resources:
+        custom_resources:
+          worker: 1
 
 aws:
   TagSpecifications:

--- a/release/serve_tests/workloads/serve_test_utils.py
+++ b/release/serve_tests/workloads/serve_test_utils.py
@@ -265,6 +265,7 @@ def run_wrk_on_all_nodes(
     http_port: str,
     all_endpoints: List[str] = None,
     ignore_output: bool = False,
+    exclude_head: bool = False,
     debug: bool = False,
 ):
     """
@@ -281,6 +282,9 @@ def run_wrk_on_all_nodes(
     all_wrk_stdout = []
     rst_ray_refs = []
     for node in ray.nodes():
+        if exclude_head and node["Resources"].get("node:__internal_head__") == 1.0:
+            continue
+
         if node["Alive"]:
             node_resource = f"node:{node['NodeManagerAddress']}"
             # Randomly pick one from all available endpoints in ray cluster


### PR DESCRIPTION
[serve][1k release test] don't run replicas on head node

For the multi deployment 1k noop replica release test, don't run replicas on the head node.


Signed-off-by: Cindy Zhang <cindyzyx9@gmail.com>
