### PR TITLE
[core] fiber: increase fiber stack size 

### DIFF
--- a/src/ray/core_worker/fiber.h
+++ b/src/ray/core_worker/fiber.h
@@ -160,15 +160,7 @@ class FiberState {
   }
 
  private:
-  // The fiber stack size. 128 KiB on Linux and Windows. 256 KiB on Mac.
-  // Note that the default fiber stack size is 128 KiB. In the Mac CI environment, this is
-  // not large enough and thus it causes segfaults. See
-  // https://github.com/ray-project/ray/pull/44331.
-#if defined(__APPLE__)
   static constexpr size_t kStackSize = 1024 * 256;
-#else
-  static constexpr size_t kStackSize = 1024 * 128;
-#endif
 
   // The fiber stack allocator.
   boost::fibers::fixedsize_stack allocator_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When vLLm updated some dependencies, they had hit issues of stack overflow.
I'm increasing the stack size to unblock the issue for now.

Meanwhile I will work on a patch to get rid of fiber since we don't need fiber anymore. That work should resolve the stack issue completely.

## Related issue number

https://github.com/ray-project/ray/issues/46086

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
