### PR TITLE
[ADAG] Detect if ADAG is at capacity for execution

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1121,14 +1121,16 @@ class CompiledDAG:
             if self._raise_if_execution_may_block:
                 raise ValueError(
                     f"This DAG can support at most {self._max_concurrent_executions} "
-                    "concurrent executions. Please call ray.get() on previous CompiledDAGRefs "
-                    "and ensure the results go out of scope before calling dag.execute again."
+                    "concurrent executions. Please call ray.get() on previous "
+                    "CompiledDAGRefs and ensure the results go out of scope before "
+                    "calling dag.execute again."
                 )
             else:
                 logger.warn(
                     f"This DAG can support at most {self._max_concurrent_executions} "
-                    "concurrent executions. Please call ray.get() on previous CompiledDAGRefs "
-                    "and ensure the results go out of scope before calling dag.execute again."
+                    "concurrent executions. Please call ray.get() on previous "
+                    "CompiledDAGRefs and ensure the results go out of scope before "
+                    "calling dag.execute again."
                 )
 
         inp = (args, kwargs)

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -132,6 +132,7 @@ class DAGNode(DAGNodeBase):
         enable_asyncio: bool = False,
         async_max_queue_size: Optional[int] = None,
         max_buffered_results: Optional[int] = None,
+        info_level_when_execution_may_block: Optional[str] = None,
     ) -> "ray.dag.CompiledDAG":
         """Compile an accelerated execution path for this DAG.
 
@@ -147,16 +148,28 @@ class DAGNode(DAGNodeBase):
                 executions is beyond the DAG capacity, the new execution would
                 be blocked in the first place; therefore, this limit is only
                 enforced when it is smaller than the DAG capacity.
+            info_level_when_execution_may_block: The level of information to
+                print when the execution may be blocked due to DAG is at its
+                capacity. `None` means no information will be printed, "WARN"
+                means a warning message will be printed, and "ERROR" means an
+                exception will be thrown.
 
         Returns:
             A compiled DAG.
         """
+        if info_level_when_execution_may_block not in [None, "WARN", "ERROR"]:
+            raise ValueError(
+                "info_level_when_execution_may_block must be one of "
+                "None, 'WARN', or 'ERROR'."
+            )
+
         return build_compiled_dag_from_ray_dag(
             self,
             buffer_size_bytes,
             enable_asyncio,
             async_max_queue_size,
             max_buffered_results,
+            info_level_when_execution_may_block,
         )
 
     def execute(

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -132,7 +132,7 @@ class DAGNode(DAGNodeBase):
         enable_asyncio: bool = False,
         async_max_queue_size: Optional[int] = None,
         max_buffered_results: Optional[int] = None,
-        info_level_when_execution_may_block: Optional[str] = None,
+        raise_if_execution_may_block: bool = True,
     ) -> "ray.dag.CompiledDAG":
         """Compile an accelerated execution path for this DAG.
 
@@ -148,28 +148,20 @@ class DAGNode(DAGNodeBase):
                 executions is beyond the DAG capacity, the new execution would
                 be blocked in the first place; therefore, this limit is only
                 enforced when it is smaller than the DAG capacity.
-            info_level_when_execution_may_block: The level of information to
-                print when the execution may be blocked due to DAG is at its
-                capacity. `None` means no information will be printed, "WARN"
-                means a warning message will be printed, and "ERROR" means an
-                exception will be thrown.
+            raise_if_execution_may_block: if True, an exception will be raised
+                if the execution may block when calling the execute() method.
+                If False, a warning will be printed instead.
 
         Returns:
             A compiled DAG.
         """
-        if info_level_when_execution_may_block not in [None, "WARN", "ERROR"]:
-            raise ValueError(
-                "info_level_when_execution_may_block must be one of "
-                "None, 'WARN', or 'ERROR'."
-            )
-
         return build_compiled_dag_from_ray_dag(
             self,
             buffer_size_bytes,
             enable_asyncio,
             async_max_queue_size,
             max_buffered_results,
-            info_level_when_execution_may_block,
+            raise_if_execution_may_block,
         )
 
     def execute(

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -328,217 +328,6 @@ def test_multi_args_and_kwargs(ray_start_regular):
     compiled_dag.teardown()
 
 
-def test_dag_capacity(ray_start_regular):
-    """
-    Test the capacity of a CompiledDAG and exceptions when the capacity is exceeded.
-
-    This test checks a series of linear and branched DAGs. For each DAG, its structure
-    and capacity of internal components are illustrated with a simple ASCII diagram.
-    A number in a parenthesis indicates the Nth intermediate object, an 'x' indicates
-    the actor or channel is blocked to hold any objects.
-    """
-    # Linear: basic case
-    a = Actor.remote(0)
-    with InputNode() as i:
-        dag = a.inc.bind(i)
-    compiled_dag = dag.experimental_compile(info_level_when_execution_may_block="ERROR")
-    # driver -(3)-> a.inc (2) -(1)-> driver
-    assert compiled_dag.capacity == 3
-    refs = []
-    for i in range(3):
-        ref = compiled_dag.execute(1)
-        refs.append(ref)
-    # No blocking when capacity is not exceeded.
-    result = ray.get(ref)
-    assert result == 3
-    # Throws an error when capacity is exceeded.
-    refs = []
-    for i in range(3):
-        ref = compiled_dag.execute(1)
-        refs.append(ref)
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Execution may be blocked due to DAG is at its capacity \(3\). "
-            "Please call ray.get\(\) on previous CompiledDAGRefs to retrieve"
-            " and release them from the DAG."
-        ),
-    ):
-        compiled_dag.execute(1)
-    compiled_dag.teardown()
-
-    # Linear: multiple actors
-    a1 = Actor.remote(0)
-    a2 = Actor.remote(0)
-    with InputNode() as i:
-        dag = a1.inc.bind(i)
-        dag = a2.inc.bind(dag)
-    compiled_dag = dag.experimental_compile(info_level_when_execution_may_block="ERROR")
-    # driver -(5)-> a1.inc (4) -(3)-> a2.inc (2) -(1)-> driver
-    assert compiled_dag.capacity == 5
-    refs = []
-    for i in range(5):
-        ref = compiled_dag.execute(1)
-        refs.append(ref)
-    # No blocking when capacity is not exceeded.
-    result = ray.get(ref)
-    assert result == 15
-    # Throws an error when capacity is exceeded.
-    refs = []
-    for i in range(5):
-        ref = compiled_dag.execute(1)
-        refs.append(ref)
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Execution may be blocked due to DAG is at its capacity \(5\). "
-            "Please call ray.get\(\) on previous CompiledDAGRefs to retrieve"
-            " and release them from the DAG."
-        ),
-    ):
-        compiled_dag.execute(1)
-    compiled_dag.teardown()
-
-    # Linear: single actor multiple methods
-    a = Actor.remote(0)
-    with InputNode() as inp:
-        dag = a.inc.bind(inp)
-        dag = a.echo.bind(dag)
-    compiled_dag = dag.experimental_compile(info_level_when_execution_may_block="ERROR")
-    # driver -(3)-> a.inc (x) -(x)-> a.echo (2) -(1)-> driver
-    assert compiled_dag.capacity == 3
-    refs = []
-    for i in range(3):
-        ref = compiled_dag.execute(1)
-        refs.append(ref)
-    # No blocking when capacity is not exceeded.
-    result = ray.get(ref)
-    assert result == 3
-    # Throws an error when capacity is exceeded.
-    refs = []
-    for i in range(3):
-        ref = compiled_dag.execute(1)
-        refs.append(ref)
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Execution may be blocked due to DAG is at its capacity \(3\). "
-            "Please call ray.get\(\) on previous CompiledDAGRefs to retrieve"
-            " and release them from the DAG."
-        ),
-    ):
-        compiled_dag.execute(1)
-    compiled_dag.teardown()
-
-    # Linear: single actor repeated methods
-    a = Actor.remote(0)
-    with InputNode() as inp:
-        dag = a.inc.bind(inp)
-        dag = a.inc.bind(dag)
-    compiled_dag = dag.experimental_compile(info_level_when_execution_may_block="ERROR")
-    # driver -(3)-> a.inc (x) -(x)-> a.inc (2) -(1)-> driver
-    assert compiled_dag.capacity == 3
-    refs = []
-    for i in range(3):
-        ref = compiled_dag.execute(1)
-        refs.append(ref)
-    # No blocking when capacity is not exceeded.
-    result = ray.get(ref)
-    assert result == 14
-    # Throws an error when capacity is exceeded.
-    refs = []
-    for i in range(3):
-        ref = compiled_dag.execute(1)
-        refs.append(ref)
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Execution may be blocked due to DAG is at its capacity \(3\). "
-            "Please call ray.get\(\) on previous CompiledDAGRefs to retrieve"
-            " and release them from the DAG."
-        ),
-    ):
-        compiled_dag.execute(1)
-
-    # Linear: long chain
-    actors = [Actor.options(num_cpus=0).remote(0) for _ in range(10)]
-    with InputNode() as inp:
-        dag = inp
-        for a in actors:
-            dag = a.inc.bind(dag)
-    compiled_dag = dag.experimental_compile()
-    # driver -(21)-> a0.inc (20) -(19)-> ... a9.inc (2) -(1)-> driver
-    # 10 (actors) + 10 (output channels of actors) + 1 (input channel)
-    assert compiled_dag.capacity == 21
-
-    # Branches: multiple actors
-    a = Actor.remote(0)
-    c = Collector.remote()
-    with InputNode() as i:
-        branch = a.inc.bind(i[0])
-        dag = c.collect_two.bind(branch, i[1])
-    compiled_dag = dag.experimental_compile(info_level_when_execution_may_block="ERROR")
-    # driver -(x)-> a.inc (3) -> c.collect_two (2) -(1)-> driver
-    #    \                           ^
-    #     \ -----------(3)----------/
-    assert compiled_dag.capacity == 3
-    refs = []
-    for i in range(3):
-        ref = compiled_dag.execute(0, 1)
-        refs.append(ref)
-    # No blocking when capacity is not exceeded.
-    result = ray.get(ref)
-    assert result == [0, 1, 0, 1, 0, 1]
-    # Throws an error when capacity is exceeded.
-    refs = []
-    for i in range(3):
-        ref = compiled_dag.execute(0, 1)
-        refs.append(ref)
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Execution may be blocked due to DAG is at its capacity \(3\). "
-            "Please call ray.get\(\) on previous CompiledDAGRefs to retrieve"
-            " and release them from the DAG."
-        ),
-    ):
-        compiled_dag.execute(1)
-    compiled_dag.teardown()
-
-    # Branches: MultiOutputNode
-    actors = [Actor.remote(0) for _ in range(3)]
-    with InputNode() as i:
-        out = [a.inc.bind(i) for a in actors]
-        dag = MultiOutputNode(out)
-    compiled_dag = dag.experimental_compile(info_level_when_execution_may_block="ERROR")
-    # driver -(3)-> a0.inc (2) -(1)-> driver
-    #  \------(3)-> a1.inc (2) -(1)---/
-    #   \-----(3)-> a2.inc (2) -(1)--/
-    assert compiled_dag.capacity == 3
-    refs = []
-    for i in range(3):
-        ref = compiled_dag.execute(1)
-        refs.append(ref)
-    # No blocking when capacity is not exceeded.
-    result = ray.get(ref)
-    assert result == [3, 3, 3]
-    # Throws an error when capacity is exceeded.
-    refs = []
-    for i in range(3):
-        ref = compiled_dag.execute(1)
-        refs.append(ref)
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Execution may be blocked due to DAG is at its capacity \(3\). "
-            "Please call ray.get\(\) on previous CompiledDAGRefs to retrieve"
-            " and release them from the DAG."
-        ),
-    ):
-        compiled_dag.execute(1)
-    compiled_dag.teardown()
-
-
 @pytest.mark.parametrize("num_actors", [1, 4])
 def test_scatter_gather_dag(ray_start_regular, num_actors):
     actors = [Actor.remote(0) for _ in range(num_actors)]
@@ -926,6 +715,219 @@ def test_asyncio_exceptions(ray_start_regular_shared, max_queue_size):
     compiled_dag.teardown()
 
 
+class TestMaxConcurrency:
+    """
+    Test computation of max concurrent execution of CompiledDAGs and exceptions 
+    when it is exceeded.
+
+    This test checks a series of linear and branched DAGs. For each DAG, its structure
+    and capacity of internal components are illustrated with a simple ASCII diagram.
+    A number in a parenthesis indicates the Nth intermediate object, an 'x' indicates
+    the actor or channel is blocked to hold any objects.
+    """
+
+    def test_basic(self, ray_start_regular):
+        a = Actor.remote(0)
+        with InputNode() as i:
+            dag = a.inc.bind(i)
+        compiled_dag = dag.experimental_compile()
+        # driver -(3)-> a.inc (2) -(1)-> driver
+        assert compiled_dag.max_concurrent_executions == 3
+        refs = []
+        for i in range(3):
+            ref = compiled_dag.execute(1)
+            refs.append(ref)
+        # No blocking when capacity is not exceeded.
+        result = ray.get(ref)
+        assert result == 3
+        # Throws an error when capacity is exceeded.
+        refs = []
+        for i in range(3):
+            ref = compiled_dag.execute(1)
+            refs.append(ref)
+        with pytest.raises(
+            ValueError,
+            match=(
+                "This DAG can support at most 3 concurrent executions. "
+                "Please call ray.get\(\) on previous CompiledDAGRefs and ensure "
+                "the results go out of scope before calling dag.execute again."
+            ),
+        ):
+            compiled_dag.execute(1)
+        compiled_dag.teardown()
+
+    def test_multi_actors(self, ray_start_regular):
+        a1 = Actor.remote(0)
+        a2 = Actor.remote(0)
+        with InputNode() as i:
+            dag = a1.inc.bind(i)
+            dag = a2.inc.bind(dag)
+        compiled_dag = dag.experimental_compile()
+        # driver -(5)-> a1.inc (4) -(3)-> a2.inc (2) -(1)-> driver
+        assert compiled_dag.max_concurrent_executions == 5
+        refs = []
+        for i in range(5):
+            ref = compiled_dag.execute(1)
+            refs.append(ref)
+        # No blocking when capacity is not exceeded.
+        result = ray.get(ref)
+        assert result == 15
+        # Throws an error when capacity is exceeded.
+        refs = []
+        for i in range(5):
+            ref = compiled_dag.execute(1)
+            refs.append(ref)
+        with pytest.raises(
+            ValueError,
+            match=(
+                "This DAG can support at most 5 concurrent executions. "
+                "Please call ray.get\(\) on previous CompiledDAGRefs and ensure "
+                "the results go out of scope before calling dag.execute again."
+            ),
+        ):
+            compiled_dag.execute(1)
+        compiled_dag.teardown()
+
+    def test_single_actor_multi_methods(self, ray_start_regular):
+        a = Actor.remote(0)
+        with InputNode() as inp:
+            dag = a.inc.bind(inp)
+            dag = a.echo.bind(dag)
+        compiled_dag = dag.experimental_compile()
+        # driver -(3)-> a.inc (x) -(x)-> a.echo (2) -(1)-> driver
+        assert compiled_dag.max_concurrent_executions == 3
+        refs = []
+        for i in range(3):
+            ref = compiled_dag.execute(1)
+            refs.append(ref)
+        # No blocking when capacity is not exceeded.
+        result = ray.get(ref)
+        assert result == 3
+        # Throws an error when capacity is exceeded.
+        refs = []
+        for i in range(3):
+            ref = compiled_dag.execute(1)
+            refs.append(ref)
+        with pytest.raises(
+            ValueError,
+            match=(
+                "This DAG can support at most 3 concurrent executions. "
+                "Please call ray.get\(\) on previous CompiledDAGRefs and ensure "
+                "the results go out of scope before calling dag.execute again."
+            ),
+        ):
+            compiled_dag.execute(1)
+        compiled_dag.teardown()
+
+    def test_single_actor_repeated_methods(self, ray_start_regular):
+        a = Actor.remote(0)
+        with InputNode() as inp:
+            dag = a.inc.bind(inp)
+            dag = a.inc.bind(dag)
+        compiled_dag = dag.experimental_compile()
+        # driver -(3)-> a.inc (x) -(x)-> a.inc (2) -(1)-> driver
+        assert compiled_dag.max_concurrent_executions == 3
+        refs = []
+        for i in range(3):
+            ref = compiled_dag.execute(1)
+            refs.append(ref)
+        # No blocking when capacity is not exceeded.
+        result = ray.get(ref)
+        assert result == 14
+        # Throws an error when capacity is exceeded.
+        refs = []
+        for i in range(3):
+            ref = compiled_dag.execute(1)
+            refs.append(ref)
+        with pytest.raises(
+            ValueError,
+            match=(
+                "This DAG can support at most 3 concurrent executions. "
+                "Please call ray.get\(\) on previous CompiledDAGRefs and ensure "
+                "the results go out of scope before calling dag.execute again."
+            ),
+        ):
+            compiled_dag.execute(1)
+
+    def test_chain(self, ray_start_regular):
+        actors = [Actor.options(num_cpus=0).remote(0) for _ in range(10)]
+        with InputNode() as inp:
+            dag = inp
+            for a in actors:
+                dag = a.inc.bind(dag)
+        compiled_dag = dag.experimental_compile()
+        # driver -(21)-> a0.inc (20) -(19)-> ... a9.inc (2) -(1)-> driver
+        # 10 (actors) + 10 (output channels of actors) + 1 (input channel)
+        assert compiled_dag.max_concurrent_executions == 21
+
+    def test_branch_multi_actors(self, ray_start_regular):
+        a = Actor.remote(0)
+        c = Collector.remote()
+        with InputNode() as i:
+            branch = a.inc.bind(i[0])
+            dag = c.collect_two.bind(branch, i[1])
+        compiled_dag = dag.experimental_compile()
+        # driver -(x)-> a.inc (3) -> c.collect_two (2) -(1)-> driver
+        #    \                           ^
+        #     \ -----------(3)----------/
+        assert compiled_dag.max_concurrent_executions == 3
+        refs = []
+        for i in range(3):
+            ref = compiled_dag.execute(0, 1)
+            refs.append(ref)
+        # No blocking when capacity is not exceeded.
+        result = ray.get(ref)
+        assert result == [0, 1, 0, 1, 0, 1]
+        # Throws an error when capacity is exceeded.
+        refs = []
+        for i in range(3):
+            ref = compiled_dag.execute(0, 1)
+            refs.append(ref)
+        with pytest.raises(
+            ValueError,
+            match=(
+                "This DAG can support at most 3 concurrent executions. "
+                "Please call ray.get\(\) on previous CompiledDAGRefs and ensure "
+                "the results go out of scope before calling dag.execute again."
+            ),
+        ):
+            compiled_dag.execute(1)
+        compiled_dag.teardown()
+
+    def test_branch_multi_output_node(self, ray_start_regular):
+        actors = [Actor.remote(0) for _ in range(3)]
+        with InputNode() as i:
+            out = [a.inc.bind(i) for a in actors]
+            dag = MultiOutputNode(out)
+        compiled_dag = dag.experimental_compile()
+        # driver -(3)-> a0.inc (2) -(1)-> driver
+        #  \------(3)-> a1.inc (2) -(1)---/
+        #   \-----(3)-> a2.inc (2) -(1)--/
+        assert compiled_dag.max_concurrent_executions == 3
+        refs = []
+        for i in range(3):
+            ref = compiled_dag.execute(1)
+            refs.append(ref)
+        # No blocking when capacity is not exceeded.
+        result = ray.get(ref)
+        assert result == [3, 3, 3]
+        # Throws an error when capacity is exceeded.
+        refs = []
+        for i in range(3):
+            ref = compiled_dag.execute(1)
+            refs.append(ref)
+        with pytest.raises(
+            ValueError,
+            match=(
+                "This DAG can support at most 3 concurrent executions. "
+                "Please call ray.get\(\) on previous CompiledDAGRefs and ensure "
+                "the results go out of scope before calling dag.execute again."
+            ),
+        ):
+            compiled_dag.execute(1)
+        compiled_dag.teardown()
+
+
 class TestCompositeChannel:
     def test_composite_channel_one_actor(self, ray_start_regular_shared):
         """
@@ -952,7 +954,7 @@ class TestCompositeChannel:
         compiled_dag = dag.experimental_compile()
         # See doc string of test_dag_capacity for explanation of the ASCII diagram.
         # driver -(3)-> a.inc(x) -(x)-> a.inc(x) -(x)-> a.inc(2) -(1)-> driver
-        assert compiled_dag.capacity == 3
+        assert compiled_dag.max_concurrent_executions == 3
 
         ref = compiled_dag.execute(1)
         assert ray.get(ref) == 4
@@ -988,7 +990,7 @@ class TestCompositeChannel:
         compiled_dag = dag.experimental_compile()
         # See doc string of test_dag_capacity for explanation of the ASCII diagram.
         # driver -(5)-> a.inc(x) -(x)-> b.inc(4) -(3)-> a.inc(2) -(1)-> driver
-        assert compiled_dag.capacity == 5
+        assert compiled_dag.max_concurrent_executions == 5
 
         ref = compiled_dag.execute(1)
         assert ray.get(ref) == 102
@@ -1026,7 +1028,7 @@ class TestCompositeChannel:
         # driver -(3)-> a.inc (x) -(x)-> a.inc(2) -(1)-> driver
         #                   \                            ^
         #                    -------- b.inc (2) --------/
-        assert compiled_dag.capacity == 3
+        assert compiled_dag.max_concurrent_executions == 3
 
         ref = compiled_dag.execute(1)
         assert ray.get(ref) == [2, 101]

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -717,7 +717,7 @@ def test_asyncio_exceptions(ray_start_regular_shared, max_queue_size):
 
 class TestMaxConcurrency:
     """
-    Test computation of max concurrent execution of CompiledDAGs and exceptions 
+    Test computation of max concurrent execution of CompiledDAGs and exceptions
     when it is exceeded.
 
     This test checks a series of linear and branched DAGs. For each DAG, its structure
@@ -952,7 +952,7 @@ class TestCompositeChannel:
             dag = a.inc.bind(dag)
 
         compiled_dag = dag.experimental_compile()
-        # See doc string of test_dag_capacity for explanation of the ASCII diagram.
+        # See doc string of TestMaxConcurrency for explanation of the ASCII diagram.
         # driver -(3)-> a.inc(x) -(x)-> a.inc(x) -(x)-> a.inc(2) -(1)-> driver
         assert compiled_dag.max_concurrent_executions == 3
 
@@ -988,7 +988,7 @@ class TestCompositeChannel:
 
         # a: 0+1 -> b: 100+1 -> a: 1+101
         compiled_dag = dag.experimental_compile()
-        # See doc string of test_dag_capacity for explanation of the ASCII diagram.
+        # See doc string of TestMaxConcurrency for explanation of the ASCII diagram.
         # driver -(5)-> a.inc(x) -(x)-> b.inc(4) -(3)-> a.inc(2) -(1)-> driver
         assert compiled_dag.max_concurrent_executions == 5
 
@@ -1024,7 +1024,7 @@ class TestCompositeChannel:
             dag = MultiOutputNode([a.inc.bind(dag), b.inc.bind(dag)])
 
         compiled_dag = dag.experimental_compile()
-        # See doc string of test_dag_capacity for explanation of the ASCII diagram.
+        # See doc string of TestMaxConcurrency for explanation of the ASCII diagram.
         # driver -(3)-> a.inc (x) -(x)-> a.inc(2) -(1)-> driver
         #                   \                            ^
         #                    -------- b.inc (2) --------/

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -219,6 +219,12 @@ class ChannelInterface:
         """
         raise NotImplementedError
 
+    def capacity(self) -> int:
+        """
+        Return the maximum number of items that can be held in the channel.
+        """
+        raise NotImplementedError
+
 
 # Interfaces for channel I/O.
 @DeveloperAPI

--- a/python/ray/experimental/channel/intra_process_channel.py
+++ b/python/ray/experimental/channel/intra_process_channel.py
@@ -63,3 +63,8 @@ class IntraProcessChannel(ChannelInterface):
     def close(self) -> None:
         ctx = ChannelContext.get_current().serialization_context
         ctx.reset_data(self._channel_id)
+
+    def capacity(self) -> int:
+        # IntraProcessChannel can buffer at most one object in the
+        # serialization context.
+        return 1

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -442,6 +442,10 @@ class Channel(ChannelInterface):
             self.ensure_registered_as_reader()
         self._worker.core_worker.experimental_channel_set_error(self._reader_ref)
 
+    def capacity(self) -> int:
+        # Shared memory channel can buffer at most one object in shared memory.
+        return 1
+
 
 @PublicAPI(stability="alpha")
 class CompositeChannel(ChannelInterface):
@@ -555,3 +559,8 @@ class CompositeChannel(ChannelInterface):
     def close(self) -> None:
         for channel in self._channels:
             channel.close()
+
+    def capacity(self) -> int:
+        # Because the underlying shared memory channel or the intra-process channel
+        # has a capacity of 1
+        return 1

--- a/python/ray/experimental/channel/torch_tensor_nccl_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_nccl_channel.py
@@ -170,6 +170,11 @@ class NestedTorchTensorNcclChannel(ChannelInterface):
         if self._cpu_data_channel is not None:
             self._cpu_data_channel.close()
 
+    def capacity(self) -> int:
+        # NCCL channel does not buffer data so the overall capacity is 0
+        # (even though the CPU channel may buffer data).
+        return 0
+
 
 def _torch_zeros_allocator(shape: Tuple[int], dtype: "torch.dtype"):
     import torch
@@ -405,6 +410,10 @@ class TorchTensorNcclChannel(ChannelInterface):
             self._typ.shape != TorchTensorType.AUTO
             and self._typ.dtype != TorchTensorType.AUTO
         )
+
+    def capacity(self) -> int:
+        # NCCL channel does not buffer data.
+        return 0
 
 
 def _do_init_nccl_group(self, group_id, world_size, comm_id, rank, actor_handles):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Execution of an accelerated DAG may block if it cannot buffer more intermediate results and while its outputs are not consumed. We'd like to error/warn in such cases so that users can take appropriate actions (e.g., consume the execution results).

This PR detects ADAG capacity by using a modified Dijkstra algorithm, and errors/warns users when `execute()` is called based on provided config.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #46089 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
