### PR TITLE
[data] make AvroDatasource an internal API

### DIFF
--- a/python/ray/data/_internal/datasource/avro_datasource.py
+++ b/python/ray/data/_internal/datasource/avro_datasource.py
@@ -5,13 +5,11 @@ from ray.data._internal.util import _check_import
 from ray.data.block import Block
 from ray.data.context import DataContext
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
     import pyarrow
 
 
-@PublicAPI(stability="alpha")
 class AvroDatasource(FileBasedDatasource):
     """A datasource that reads Avro files."""
 

--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -1,4 +1,3 @@
-from ray.data.datasource.avro_datasource import AvroDatasource
 from ray.data.datasource.bigquery_datasink import _BigQueryDatasink
 from ray.data.datasource.bigquery_datasource import BigQueryDatasource
 from ray.data.datasource.binary_datasource import BinaryDatasource
@@ -59,7 +58,6 @@ from ray.data.datasource.webdataset_datasource import WebDatasetDatasource
 # we want to only import the Hugging Face datasets library when we use
 # ray.data.from_huggingface() or HuggingFaceDatasource() directly.
 __all__ = [
-    "AvroDatasource",
     "BaseFileMetadataProvider",
     "BinaryDatasource",
     "_BigQueryDatasink",

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -21,6 +21,7 @@ import numpy as np
 import ray
 from ray._private.auto_init_hook import wrap_auto_init
 from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
+from ray.data._internal.datasource.avro_datasource import AvroDatasource
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.logical.operators.from_operators import (
     FromArrow,
@@ -46,7 +47,6 @@ from ray.data.block import Block, BlockAccessor, BlockExecStats, BlockMetadata
 from ray.data.context import DataContext
 from ray.data.dataset import Dataset, MaterializedDataset
 from ray.data.datasource import (
-    AvroDatasource,
     BaseFileMetadataProvider,
     BigQueryDatasource,
     BinaryDatasource,


### PR DESCRIPTION
Make `AvroDatasource` an internal API, according to https://docs.google.com/spreadsheets/d/1wQALnsUuFN4dMgmGITfiVX41fCc6P6FEjYVO6jDWGtM/edit#gid=1683753102. If this looks good, I'll move the rest of many datasource classes to internal.

Test:
- CI