### PR TITLE
[ADAG] Fix exception handling in ADAG task execution

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -162,6 +162,9 @@ def _exec_task(self, task: "ExecutableTask", idx: int) -> bool:
     try:
         output_val = method(*resolved_inputs)
         output_writer.write(output_val)
+    except IOError:
+        # Channel closed. Exit the loop.
+        return True
     except Exception as exc:
         # TODO(rui): consider different ways of passing down the exception,
         # e.g., wrapping with RayTaskError.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This fixes the following failures in `test_accelerated_dag` ([link](https://buildkite.com/ray-project/postmerge/builds/5020#01902f4d-0cb3-4ed1-8d89-397e75d0c676
)):

```

[2024-06-19T07:31:14Z] (Actor pid=47092) Traceback (most recent call last):
--
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "/rayci/python/ray/dag/compiled_dag_node.py", line 164, in _exec_task
  | [2024-06-19T07:31:14Z] (Actor pid=47092)     output_writer.write(output_val)
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "/rayci/python/ray/experimental/channel/common.py", line 349, in write
  | [2024-06-19T07:31:14Z] (Actor pid=47092)     self._output_channel.write(val)
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "/rayci/python/ray/experimental/channel/shared_memory_channel.py", line 548, in write
  | [2024-06-19T07:31:14Z] (Actor pid=47092)     channel.write(value)
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "/rayci/python/ray/experimental/channel/shared_memory_channel.py", line 416, in write
  | [2024-06-19T07:31:14Z] (Actor pid=47092)     self._worker.core_worker.experimental_channel_put_serialized(
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "python/ray/_raylet.pyx", line 3651, in ray._raylet.CoreWorker.experimental_channel_put_serialized
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "python/ray/_raylet.pyx", line 581, in ray._raylet.check_status
  | [2024-06-19T07:31:14Z] (Actor pid=47092) OSError: Channel closed.
  | [2024-06-19T07:31:14Z] (Actor pid=47092)
  | [2024-06-19T07:31:14Z] (Actor pid=47092) During handling of the above exception, another exception occurred:
  | [2024-06-19T07:31:14Z] (Actor pid=47092)
  | [2024-06-19T07:31:14Z] (Actor pid=47092) Traceback (most recent call last):
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "/rayci/python/ray/dag/compiled_dag_node.py", line 96, in do_exec_tasks
  | [2024-06-19T07:31:14Z] (Actor pid=47092)     done = _exec_task(self, task, idx)
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "/rayci/python/ray/dag/compiled_dag_node.py", line 168, in _exec_task
  | [2024-06-19T07:31:14Z] (Actor pid=47092)     output_writer.write(RayDAGTaskError(exc))
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "/rayci/python/ray/experimental/channel/common.py", line 349, in write
  | [2024-06-19T07:31:14Z] (Actor pid=47092)     self._output_channel.write(val)
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "/rayci/python/ray/experimental/channel/shared_memory_channel.py", line 548, in write
  | [2024-06-19T07:31:14Z] (Actor pid=47092)     channel.write(value)
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "/rayci/python/ray/experimental/channel/shared_memory_channel.py", line 416, in write
  | [2024-06-19T07:31:14Z] (Actor pid=47092)     self._worker.core_worker.experimental_channel_put_serialized(
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "python/ray/_raylet.pyx", line 3651, in ray._raylet.CoreWorker.experimental_channel_put_serialized
  | [2024-06-19T07:31:14Z] (Actor pid=47092)   File "python/ray/_raylet.pyx", line 581, in ray._raylet.check_status
  | [2024-06-19T07:31:14Z] (Actor pid=47092) OSError: Channel closed.

```

With the fix, we don't write (including exceptions) to the channel if the channel is already closed.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
