### PR TITLE
[ci] readd back data.datasource.AvroDatasource

### DIFF
--- a/python/ray/data/datasource/__init__.py
+++ b/python/ray/data/datasource/__init__.py
@@ -1,3 +1,4 @@
+from ray.data._internal.datasource.avro_datasource import AvroDatasource
 from ray.data.datasource.bigquery_datasink import _BigQueryDatasink
 from ray.data.datasource.bigquery_datasource import BigQueryDatasource
 from ray.data.datasource.binary_datasource import BinaryDatasource
@@ -58,6 +59,7 @@ from ray.data.datasource.webdataset_datasource import WebDatasetDatasource
 # we want to only import the Hugging Face datasets library when we use
 # ray.data.from_huggingface() or HuggingFaceDatasource() directly.
 __all__ = [
+    "AvroDatasource",
     "BaseFileMetadataProvider",
     "BinaryDatasource",
     "_BigQueryDatasink",


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/46159/files removed `data.datasource.AvroDatasource` ass a module, because I thought we shouldn't expose this as something for users to use, but not entirely sure.

Test:
- CI