### PR TITLE
Add perf metrics for 2.31.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 422.150144,
+    "_dashboard_memory_usage_mb": 446.410752,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.65,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1225\t9.33GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3575\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4789\t0.93GiB\tpython distributed/test_many_actors.py\n2384\t0.29GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3695\t0.24GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2767\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3858\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4583\t0.07GiB\tray::JobSupervisor\n4040\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3856\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
-    "actors_per_second": 656.4820098150251,
+    "_peak_memory": 3.68,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1288\t9.49GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3621\t1.8GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4667\t0.94GiB\tpython distributed/test_many_actors.py\n2717\t0.3GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3736\t0.23GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3902\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3044\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4455\t0.07GiB\tray::JobSupervisor\n4087\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3900\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "actors_per_second": 623.0134530256355,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 656.4820098150251
+            "perf_metric_value": 623.0134530256355
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 65.662
+            "perf_metric_value": 35.52
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3333.28
+            "perf_metric_value": 3427.947
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3456.493
+            "perf_metric_value": 3624.765
         }
     ],
     "success": "1",
-    "time": 15.232709884643555
+    "time": 16.05101776123047
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 182.657024,
+    "_dashboard_memory_usage_mb": 184.602624,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.64,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3548\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1209\t0.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2279\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3663\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4732\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4938\t0.08GiB\tray::StateAPIGeneratorActor.start\n2760\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4531\t0.07GiB\tray::JobSupervisor\n3825\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4002\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "_peak_memory": 1.68,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3564\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1235\t0.29GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2269\t0.24GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3679\t0.16GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n5519\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3845\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n5730\t0.09GiB\tray::StateAPIGeneratorActor.start\n5301\t0.08GiB\tray::JobSupervisor\n2555\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3847\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 356.96608310545133
+            "perf_metric_value": 357.3016159272391
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.877
+            "perf_metric_value": 3.836
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 48.58
+            "perf_metric_value": 55.072
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 197.137
+            "perf_metric_value": 119.658
         }
     ],
     "success": "1",
-    "tasks_per_second": 356.96608310545133,
-    "time": 302.80138659477234,
+    "tasks_per_second": 357.3016159272391,
+    "time": 302.79875588417053,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 137.633792,
+    "_dashboard_memory_usage_mb": 121.245696,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.25,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1224\t9.73GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3624\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4824\t0.42GiB\tpython distributed/test_many_pgs.py\n2809\t0.38GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3749\t0.15GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2607\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4609\t0.07GiB\tray::JobSupervisor\n3914\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4093\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3912\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 2.15,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3579\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5015\t0.42GiB\tpython distributed/test_many_pgs.py\n2272\t0.36GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1244\t0.26GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3694\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2265\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4805\t0.07GiB\tray::JobSupervisor\n3888\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4066\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3886\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23.5616061289441
+            "perf_metric_value": 22.520698345340477
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.492
+            "perf_metric_value": 3.141
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.796
+            "perf_metric_value": 9.315
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 204.615
+            "perf_metric_value": 130.576
         }
     ],
-    "pgs_per_second": 23.5616061289441,
+    "pgs_per_second": 22.520698345340477,
     "success": "1",
-    "time": 42.44192838668823
+    "time": 44.4035964012146
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1164.107776,
+    "_dashboard_memory_usage_mb": 1065.43104,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.08,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3561\t2.86GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4731\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3681\t0.68GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1206\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2174\t0.23GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5002\t0.09GiB\tray::StateAPIGeneratorActor.start\n4947\t0.08GiB\tray::DashboardTester.run\n2551\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3843\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4521\t0.07GiB\tray::JobSupervisor",
+    "_peak_memory": 4.17,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3575\t1.6GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3691\t0.95GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4505\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1238\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2744\t0.21GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4646\t0.1GiB\tray::DashboardTester.run\n4716\t0.08GiB\tray::StateAPIGeneratorActor.start\n4307\t0.07GiB\tray::JobSupervisor\n3857\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2731\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 587.8163884392604
+            "perf_metric_value": 500.703996812153
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 42.944
+            "perf_metric_value": 117.021
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3642.242
+            "perf_metric_value": 1289.164
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4549.74
+            "perf_metric_value": 3412.04
         }
     ],
     "success": "1",
-    "tasks_per_second": 587.8163884392604,
-    "time": 317.01211500167847,
+    "tasks_per_second": 500.703996812153,
+    "time": 319.97187972068787,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.24.0"}
+{"release_version": "2.31.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8726.401857123754,
-        162.20549696513925
+        8572.12744768857,
+        386.23244359238294
     ],
     "1_1_actor_calls_concurrent": [
-        5525.453533356669,
-        275.6986719349956
+        5134.279265032814,
+        40.01055226079356
     ],
     "1_1_actor_calls_sync": [
-        2022.1643749529967,
-        42.58171596149864
+        2060.7838505549453,
+        47.39479964777027
     ],
     "1_1_async_actor_calls_async": [
-        3295.7761919502855,
-        149.90516121451026
+        3139.206535851344,
+        76.36027306919485
     ],
     "1_1_async_actor_calls_sync": [
-        1306.2185283312654,
-        22.393311157323094
+        1332.185403602693,
+        3.9077896884722167
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2271.9010969950546,
-        58.46933903250449
+        2432.662342652071,
+        108.26228244055812
     ],
     "1_n_actor_calls_async": [
-        8723.546909820518,
-        133.04998221108622
+        8522.93184364997,
+        277.00556930914536
     ],
     "1_n_async_actor_calls_async": [
-        7526.072989853183,
-        80.26873719023843
+        7229.294929621508,
+        201.4709985659134
     ],
     "client__1_1_actor_calls_async": [
-        956.234692691667,
-        10.622834071499192
+        982.5121885726228,
+        4.98941418684848
     ],
     "client__1_1_actor_calls_concurrent": [
-        964.227785207118,
-        19.39077588012691
+        982.2862959658165,
+        9.018643886652605
     ],
     "client__1_1_actor_calls_sync": [
-        511.54682034013,
-        20.183100809422037
+        515.4196479730319,
+        9.593330000464709
     ],
     "client__get_calls": [
-        1099.299059786817,
-        48.740510949504255
+        1139.3173302405887,
+        8.412512172554328
     ],
     "client__put_calls": [
-        793.6471952322032,
-        19.166421115489065
+        795.0055911445766,
+        13.152348540284482
     ],
     "client__put_gigabytes": [
-        0.13033848458516117,
-        0.0004047979867318293
+        0.1317282857439297,
+        0.0013477041318984584
     ],
     "client__tasks_and_get_batch": [
-        0.9191916564759186,
-        0.004240563507874709
+        0.9263554796372511,
+        0.011911933568880756
     ],
     "client__tasks_and_put_batch": [
-        11163.342583763659,
-        86.36159399829216
+        10912.895280999188,
+        145.6580241518087
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12352.999319488557,
-        302.78838782381274
+        11672.210955124367,
+        86.99397019067479
     ],
     "multi_client_put_gigabytes": [
-        35.52392832333356,
-        2.4551866947000778
+        38.79658735552449,
+        2.42462493932864
     ],
     "multi_client_tasks_async": [
-        23658.661959832083,
-        3659.740758379274
+        24167.796791424014,
+        2612.563370743722
     ],
     "n_n_actor_calls_async": [
-        26706.0034223919,
-        796.7068479444016
+        26970.858668191202,
+        816.4282879641627
     ],
     "n_n_actor_calls_with_arg_async": [
-        2669.6470548189563,
-        37.75431784396307
+        2626.1981592696256,
+        17.55255750677977
     ],
     "n_n_async_actor_calls_async": [
-        23029.099137990735,
-        353.5298340819868
+        22563.93233232106,
+        658.051386451489
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10575.12534552304
+            "perf_metric_value": 10132.225250427977
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5342.356803322341
+            "perf_metric_value": 5091.871292628941
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12352.999319488557
+            "perf_metric_value": 11672.210955124367
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.60264129638186
+            "perf_metric_value": 20.37544620498999
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.618329296876913
+            "perf_metric_value": 7.58621082531657
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 35.52392832333356
+            "perf_metric_value": 38.79658735552449
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.459623096174152
+            "perf_metric_value": 12.911747420977138
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.356105950176277
+            "perf_metric_value": 4.7092411494959325
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 990.8897375942615
+            "perf_metric_value": 968.114499542658
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7728.179866020124
+            "perf_metric_value": 8018.593621447933
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23658.661959832083
+            "perf_metric_value": 24167.796791424014
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2022.1643749529967
+            "perf_metric_value": 2060.7838505549453
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8726.401857123754
+            "perf_metric_value": 8572.12744768857
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5525.453533356669
+            "perf_metric_value": 5134.279265032814
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8723.546909820518
+            "perf_metric_value": 8522.93184364997
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26706.0034223919
+            "perf_metric_value": 26970.858668191202
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2669.6470548189563
+            "perf_metric_value": 2626.1981592696256
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1306.2185283312654
+            "perf_metric_value": 1332.185403602693
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3295.7761919502855
+            "perf_metric_value": 3139.206535851344
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2271.9010969950546
+            "perf_metric_value": 2432.662342652071
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7526.072989853183
+            "perf_metric_value": 7229.294929621508
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23029.099137990735
+            "perf_metric_value": 22563.93233232106
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 804.4799825746657
+            "perf_metric_value": 798.986053163609
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1099.299059786817
+            "perf_metric_value": 1139.3173302405887
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 793.6471952322032
+            "perf_metric_value": 795.0055911445766
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13033848458516117
+            "perf_metric_value": 0.1317282857439297
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11163.342583763659
+            "perf_metric_value": 10912.895280999188
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 511.54682034013
+            "perf_metric_value": 515.4196479730319
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 956.234692691667
+            "perf_metric_value": 982.5121885726228
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 964.227785207118
+            "perf_metric_value": 982.2862959658165
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9191916564759186
+            "perf_metric_value": 0.9263554796372511
         }
     ],
     "placement_group_create/removal": [
-        804.4799825746657,
-        13.347218543583795
+        798.986053163609,
+        5.319453045027013
     ],
     "single_client_get_calls_Plasma_Store": [
-        10575.12534552304,
-        389.0501847163306
+        10132.225250427977,
+        226.57918551053498
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.459623096174152,
-        0.16042112976023476
+        12.911747420977138,
+        0.5731176244476562
     ],
     "single_client_put_calls_Plasma_Store": [
-        5342.356803322341,
-        87.92133379840806
+        5091.871292628941,
+        73.44416394954632
     ],
     "single_client_put_gigabytes": [
-        19.60264129638186,
-        6.0658657511900165
+        20.37544620498999,
+        5.3279756701692635
     ],
     "single_client_tasks_and_get_batch": [
-        7.618329296876913,
-        0.22870606905835902
+        7.58621082531657,
+        0.48281236853328957
     ],
     "single_client_tasks_async": [
-        7728.179866020124,
-        391.64056111377556
+        8018.593621447933,
+        503.42172436942576
     ],
     "single_client_tasks_sync": [
-        990.8897375942615,
-        9.752000220743424
+        968.114499542658,
+        5.907445913459797
     ],
     "single_client_wait_1k_refs": [
-        5.356105950176277,
-        0.05359089594239002
+        4.7092411494959325,
+        0.07056186614822872
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 16.769440987999985,
+    "broadcast_time": 17.728533834000018,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.769440987999985
+            "perf_metric_value": 17.728533834000018
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.085048134999994,
-    "get_time": 23.721352370000005,
+    "args_time": 17.619760428999996,
+    "get_time": 23.901794419999987,
     "large_object_size": 107374182400,
-    "large_object_time": 29.037520325999992,
+    "large_object_time": 31.056718417000013,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.085048134999994
+            "perf_metric_value": 17.619760428999996
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.574067407000001
+            "perf_metric_value": 5.761114001999999
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.721352370000005
+            "perf_metric_value": 23.901794419999987
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 192.34304552800003
+            "perf_metric_value": 188.89327473799997
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.037520325999992
+            "perf_metric_value": 31.056718417000013
         }
     ],
-    "queued_time": 192.34304552800003,
-    "returns_time": 5.574067407000001,
+    "queued_time": 188.89327473799997,
+    "returns_time": 5.761114001999999,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0548744773864747,
-    "max_iteration_time": 3.340198516845703,
-    "min_iteration_time": 0.4613649845123291,
+    "avg_iteration_time": 1.059164800643921,
+    "max_iteration_time": 2.521545171737671,
+    "min_iteration_time": 0.4514594078063965,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0548744773864747
+            "perf_metric_value": 1.059164800643921
         }
     ],
     "success": 1,
-    "total_time": 105.48765969276428
+    "total_time": 105.91673135757446
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.161747217178345
+            "perf_metric_value": 10.921976089477539
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.27835304737091
+            "perf_metric_value": 25.70832121372223
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 55.185825729370116
+            "perf_metric_value": 63.453201389312746
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5885274410247803
+            "perf_metric_value": 1.527787446975708
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3104.279580116272
+            "perf_metric_value": 3098.66676568985
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4851944753960548
+            "perf_metric_value": 0.48545599632674713
         }
     ],
-    "stage_0_time": 10.161747217178345,
-    "stage_1_avg_iteration_time": 25.27835304737091,
-    "stage_1_max_iteration_time": 25.942532539367676,
-    "stage_1_min_iteration_time": 24.44790744781494,
-    "stage_1_time": 252.78363347053528,
-    "stage_2_avg_iteration_time": 55.185825729370116,
-    "stage_2_max_iteration_time": 56.937405824661255,
-    "stage_2_min_iteration_time": 53.556705951690674,
-    "stage_2_time": 275.930006980896,
-    "stage_3_creation_time": 1.5885274410247803,
-    "stage_3_time": 3104.279580116272,
-    "stage_4_spread": 0.4851944753960548,
+    "stage_0_time": 10.921976089477539,
+    "stage_1_avg_iteration_time": 25.70832121372223,
+    "stage_1_max_iteration_time": 27.08970618247986,
+    "stage_1_min_iteration_time": 24.886737823486328,
+    "stage_1_time": 257.0833179950714,
+    "stage_2_avg_iteration_time": 63.453201389312746,
+    "stage_2_max_iteration_time": 64.36236715316772,
+    "stage_2_min_iteration_time": 61.48890399932861,
+    "stage_2_time": 317.2673234939575,
+    "stage_3_creation_time": 1.527787446975708,
+    "stage_3_time": 3098.66676568985,
+    "stage_4_spread": 0.48545599632674713,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9132710030025517,
-    "avg_pg_remove_time_ms": 0.9020739549548232,
+    "avg_pg_create_time_ms": 0.9360118873874913,
+    "avg_pg_remove_time_ms": 0.9300413663664598,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9132710030025517
+            "perf_metric_value": 0.9360118873874913
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9020739549548232
+            "perf_metric_value": 0.9300413663664598
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 14.82%: tasks_per_second (THROUGHPUT) regresses from 587.8163884392604 to 500.703996812153 in benchmarks/many_tasks.json
REGRESSION 12.08%: single_client_wait_1k_refs (THROUGHPUT) regresses from 5.356105950176277 to 4.7092411494959325 in microbenchmark.json
REGRESSION 7.08%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5525.453533356669 to 5134.279265032814 in microbenchmark.json
REGRESSION 5.51%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12352.999319488557 to 11672.210955124367 in microbenchmark.json
REGRESSION 5.10%: actors_per_second (THROUGHPUT) regresses from 656.4820098150251 to 623.0134530256355 in benchmarks/many_actors.json
REGRESSION 4.75%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 3295.7761919502855 to 3139.206535851344 in microbenchmark.json
REGRESSION 4.69%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5342.356803322341 to 5091.871292628941 in microbenchmark.json
REGRESSION 4.42%: pgs_per_second (THROUGHPUT) regresses from 23.5616061289441 to 22.520698345340477 in benchmarks/many_pgs.json
REGRESSION 4.19%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10575.12534552304 to 10132.225250427977 in microbenchmark.json
REGRESSION 3.94%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7526.072989853183 to 7229.294929621508 in microbenchmark.json
REGRESSION 2.30%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8723.546909820518 to 8522.93184364997 in microbenchmark.json
REGRESSION 2.30%: single_client_tasks_sync (THROUGHPUT) regresses from 990.8897375942615 to 968.114499542658 in microbenchmark.json
REGRESSION 2.24%: client__tasks_and_put_batch (THROUGHPUT) regresses from 11163.342583763659 to 10912.895280999188 in microbenchmark.json
REGRESSION 2.02%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23029.099137990735 to 22563.93233232106 in microbenchmark.json
REGRESSION 1.77%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8726.401857123754 to 8572.12744768857 in microbenchmark.json
REGRESSION 1.63%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2669.6470548189563 to 2626.1981592696256 in microbenchmark.json
REGRESSION 0.68%: placement_group_create/removal (THROUGHPUT) regresses from 804.4799825746657 to 798.986053163609 in microbenchmark.json
REGRESSION 0.42%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.618329296876913 to 7.58621082531657 in microbenchmark.json
REGRESSION 172.50%: dashboard_p50_latency_ms (LATENCY) regresses from 42.944 to 117.021 in benchmarks/many_tasks.json
REGRESSION 14.98%: stage_2_avg_iteration_time (LATENCY) regresses from 55.185825729370116 to 63.453201389312746 in stress_tests/stress_test_many_tasks.json
REGRESSION 13.36%: dashboard_p95_latency_ms (LATENCY) regresses from 48.58 to 55.072 in benchmarks/many_nodes.json
REGRESSION 7.48%: stage_0_time (LATENCY) regresses from 10.161747217178345 to 10.921976089477539 in stress_tests/stress_test_many_tasks.json
REGRESSION 6.95%: 107374182400_large_object_time (LATENCY) regresses from 29.037520325999992 to 31.056718417000013 in scalability/single_node.json
REGRESSION 5.72%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 16.769440987999985 to 17.728533834000018 in scalability/object_store.json
REGRESSION 4.87%: dashboard_p99_latency_ms (LATENCY) regresses from 3456.493 to 3624.765 in benchmarks/many_actors.json
REGRESSION 3.36%: 3000_returns_time (LATENCY) regresses from 5.574067407000001 to 5.761114001999999 in scalability/single_node.json
REGRESSION 3.13%: 10000_args_time (LATENCY) regresses from 17.085048134999994 to 17.619760428999996 in scalability/single_node.json
REGRESSION 3.10%: avg_pg_remove_time_ms (LATENCY) regresses from 0.9020739549548232 to 0.9300413663664598 in stress_tests/stress_test_placement_group.json
REGRESSION 2.84%: dashboard_p95_latency_ms (LATENCY) regresses from 3333.28 to 3427.947 in benchmarks/many_actors.json
REGRESSION 2.49%: avg_pg_create_time_ms (LATENCY) regresses from 0.9132710030025517 to 0.9360118873874913 in stress_tests/stress_test_placement_group.json
REGRESSION 1.70%: stage_1_avg_iteration_time (LATENCY) regresses from 25.27835304737091 to 25.70832121372223 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.76%: 10000_get_time (LATENCY) regresses from 23.721352370000005 to 23.901794419999987 in scalability/single_node.json
REGRESSION 0.41%: avg_iteration_time (LATENCY) regresses from 1.0548744773864747 to 1.059164800643921 in stress_tests/stress_test_dead_actors.json
REGRESSION 0.05%: stage_4_spread (LATENCY) regresses from 0.4851944753960548 to 0.48545599632674713 in stress_tests/stress_test_many_tasks.json
```