### PR TITLE
[Data] Ensure `InputDataBuffer` doesn't free block references

### DIFF
--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -41,6 +41,7 @@ class InputDataBuffer(PhysicalOperator):
             self._input_data_factory = input_data_factory
             self._is_input_initialized = False
         self._num_output_blocks = num_output_blocks
+        self._input_data_index = 0
         super().__init__("Input", [], target_max_block_size=None)
 
     def start(self, options: ExecutionOptions) -> None:
@@ -57,10 +58,14 @@ class InputDataBuffer(PhysicalOperator):
         super().start(options)
 
     def has_next(self) -> bool:
-        return len(self._input_data) > 0
+        return self._input_data_index < len(self._input_data)
 
     def _get_next_inner(self) -> RefBundle:
-        return self._input_data.pop(0)
+        # We can't pop the input data. If we do, Ray might garbage collect the block
+        # references, and Ray won't be able to reconstruct downstream objects.
+        bundle = self._input_data[self._input_data_index]
+        self._input_data_index += 1
+        return bundle
 
     def _set_num_output_blocks(self, num_output_blocks):
         self._num_output_blocks = num_output_blocks

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -942,6 +942,7 @@ def test_all_to_all_estimated_output_blocks():
 
 
 def test_input_data_buffer_does_not_free_inputs():
+    # Tests https://github.com/ray-project/ray/issues/46282
     block = pd.DataFrame({"id": [0]})
     block_ref = ray.put(block)
     metadata = BlockAccessor.for_block(block).get_metadata()
@@ -952,6 +953,8 @@ def test_input_data_buffer_does_not_free_inputs():
     op.get_next()
     gc.collect()
 
+    # `InputDataBuffer` should still hold a reference to the input block even after
+    # `get_next` is called.
     assert len(gc.get_referrers(block_ref)) > 0
 
 

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -1,4 +1,5 @@
 import collections
+import gc
 import random
 import time
 from typing import Any, Iterable, List
@@ -37,7 +38,7 @@ from ray.data._internal.execution.operators.task_pool_map_operator import (
 )
 from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.util import make_ref_bundles
-from ray.data.block import Block
+from ray.data.block import Block, BlockAccessor
 from ray.data.context import DataContext
 from ray.data.tests.util import run_one_op_task, run_op_tasks_sync
 from ray.tests.conftest import *  # noqa
@@ -938,6 +939,20 @@ def test_all_to_all_estimated_output_blocks():
     # estimated output blocks for op2 should fallback to op1
     assert op2._estimated_output_blocks is None
     assert op2.num_outputs_total() == estimated_output_blocks
+
+
+def test_input_data_buffer_does_not_free_inputs():
+    block = pd.DataFrame({"id": [0]})
+    block_ref = ray.put(block)
+    metadata = BlockAccessor.for_block(block).get_metadata()
+    op = InputDataBuffer(
+        input_data=[RefBundle([(block_ref, metadata)], owns_blocks=False)]
+    )
+
+    op.get_next()
+    gc.collect()
+
+    assert len(gc.get_referrers(block_ref)) > 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

See https://github.com/ray-project/ray/issues/46282.

## Related issue number

<!-- For example: "Closes #1234" -->

Fixes https://github.com/ray-project/ray/issues/46282

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
