### PR TITLE
[ADAG] Make CompiledDAGRef not inherit from ObjectRef

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -2546,10 +2546,15 @@ def get(object_refs: "ObjectRef[R]", *, timeout: Optional[float] = None) -> R:
     ...
 
 
+@overload
+def get(object_refs: CompiledDAGRef, *, timeout: Optional[float] = None) -> Any:
+    ...
+
+
 @PublicAPI
 @client_mode_hook
 def get(
-    object_refs: Union["ObjectRef[Any]", Sequence["ObjectRef[Any]"]],
+    object_refs: Union["ObjectRef[Any]", Sequence["ObjectRef[Any]"], CompiledDAGRef],
     *,
     timeout: Optional[float] = None,
 ) -> Union[Any, List[Any]]:
@@ -2839,11 +2844,6 @@ def wait(
                 "wait() expected a list of ray.ObjectRef or "
                 "ray.ObjectRefGenerator, "
                 f"got list containing {type(ray_waitable)}"
-            )
-        if isinstance(ray_waitable, CompiledDAGRef):
-            raise TypeError(
-                "wait() does not support CompiledDAGRef. "
-                "Please call ray.get() on the CompiledDAGRef to get the result."
             )
     worker.check_connected()
 

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -488,6 +488,7 @@ def test_exceed_max_buffered_results(ray_start_regular):
     ):
         ray.get(ref)
 
+    del refs
     compiled_dag.teardown()
 
 

--- a/python/ray/experimental/compiled_dag_ref.py
+++ b/python/ray/experimental/compiled_dag_ref.py
@@ -3,14 +3,13 @@ import traceback
 import ray
 
 
-class CompiledDAGRef(ray.ObjectRef):
+class CompiledDAGRef:
     """
     A reference to a compiled DAG execution result.
 
-    This is a subclass of ObjectRef and resembles ObjectRef in the
-    most common way. For example, similar to ObjectRef, ray.get()
-    can be called on it to retrieve result. However, there are several
-    major differences:
+    A CompiledDAGRef resembles an ObjectRef in the most common way.
+    For example, similar to ObjectRef, ray.get() can be called on
+    it to retrieve result. However, there are several major differences:
     1. ray.get() can only be called once on CompiledDAGRef.
     2. ray.wait() is not supported.
     3. CompiledDAGRef cannot be copied, deep copied, or pickled.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We observed performance regression in many_tasks.aws release test. The cause is repeated calls of `isinstance(ray_waitable, CompiledDAGRef)` in `ray.wait()`.

In this PR we make `CompiledDAGRef` not a subclass of `ObjectRef` and remove the type check in `ray.wait()`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
