### PR TITLE
Remove the eviction Policy from the parameter list, when no spot instance is used when starting a new node via the autoscaler in Azure

### DIFF
--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -292,7 +292,10 @@ class AzureNodeProvider(NodeProvider):
                 },
             }
         }
-        if parameters["properties"]["parameters"].get("priority", {}).get("value") == "spot":
+        if (
+            parameters["properties"]["parameters"].get("priority", {}).get("value")
+            == "spot"
+        ):
             parameters["properties"]["parameters"].pop("evictionPolicy", None)
 
         # TODO: we could get the private/public ips back directly

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -292,6 +292,8 @@ class AzureNodeProvider(NodeProvider):
                 },
             }
         }
+        if parameters["properties"]["parameters"].get("priority", {}).get("value") == "spot":
+            parameters["properties"]["parameters"].pop("evictionPolicy", None)
 
         # TODO: we could get the private/public ips back directly
         create_or_update = get_azure_sdk_function(


### PR DESCRIPTION
## Why are these changes needed?

Fixes an issue related to the latest addition of the options for azure spot instance.

## Related issue number

Closes #46198

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
