### PR TITLE
[adag] mark test_accelerated_dag test as manual

### DIFF
--- a/python/ray/dag/BUILD
+++ b/python/ray/dag/BUILD
@@ -72,11 +72,19 @@ py_test(
 
 py_test_module_list(
   files = [
-    "tests/experimental/test_accelerated_dag.py",
     "tests/experimental/test_torch_tensor_dag.py",
   ],
   size = "medium",
   tags = ["exclusive", "accelerated_dag", "no_windows", "team:core"],
+  deps = ["//:ray_lib"],
+)
+
+py_test_module_list(
+  files = [
+    "tests/experimental/test_accelerated_dag.py",
+  ],
+  size = "medium",
+  tags = ["exclusive", "accelerated_dag", "no_windows", "team:core", "manual"],
   deps = ["//:ray_lib"],
 )
 


### PR DESCRIPTION
currently failing on master, but not release blocking.
