### PR TITLE
[ADAG] Fix test_dag_errors

### DIFF
--- a/python/ray/dag/BUILD
+++ b/python/ray/dag/BUILD
@@ -122,7 +122,6 @@ py_test_module_list(
     tags = [
         "accelerated_dag",
         "exclusive",
-        "manual",
         "no_windows",
         "team:core",
     ],

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -5,6 +5,7 @@ import logging
 import os
 import pickle
 import random
+import re
 import sys
 import time
 
@@ -421,8 +422,22 @@ def test_dag_errors(ray_start_regular):
     with pytest.raises(
         TypeError,
         match=(
-            "wait\(\) does not support CompiledDAGRef. "
-            "Please call ray.get\(\) on the CompiledDAGRef to get the result."
+            re.escape(
+                "wait() expected a list of ray.ObjectRef or ray.ObjectRefGenerator, "
+                "got <class 'ray.experimental.compiled_dag_ref.CompiledDAGRef'>"
+            )
+        ),
+    ):
+        ray.wait(ref)
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            re.escape(
+                "wait() expected a list of ray.ObjectRef or ray.ObjectRefGenerator, "
+                "got list containing "
+                "<class 'ray.experimental.compiled_dag_ref.CompiledDAGRef'>"
+            )
         ),
     ):
         ray.wait([ref])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We made CompiledDAGRef not a subclass of ObjectRef, and ray.wait() error message changes.

This PR fixes the `ray.wait()` test failure in `test_dag_errors`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/pull/46194

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
