### PR TITLE
[doc] auto-generation of class apis

### DIFF
--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -16,6 +16,14 @@ TEAM_API_CONFIGS = {
             "ray.data.dataset.MaterializedDataset",
             # special case where we cannot deprecate although we want to
             "ray.data.random_access_dataset.RandomAccessDataset",
+            # TODO(can): apis that are auto-generated so falsely classified as not
+            # documented with the current logic
+            "ray.data.iterator.DataIterator",
+            "ray.data.iterator.DataIterator.iter_batches",
+            "ray.data.iterator.DataIterator.iter_torch_batches",
+            "ray.data.iterator.DataIterator.to_tf",
+            "ray.data.iterator.DataIterator.materialize",
+            "ray.data.iterator.DataIterator.stats",
         },
     },
 }

--- a/doc/source/_templates/autosummary/class_v2.rst
+++ b/doc/source/_templates/autosummary/class_v2.rst
@@ -1,0 +1,26 @@
+{{ name | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+{% block methods %}
+{% if methods %}
+{% set api_groups = methods | get_api_groups(name, module) %}
+{% for api_group in api_groups %}
+
+{% if api_groups | length > 1 %}
+.. rubric:: {{ api_group | capitalize }}
+{% endif %}
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc
+
+   {% for method in methods | select_api_group(name, module, api_group) %}
+      {{ name }}.{{ method }}
+   {% endfor %}
+
+{% endfor %}
+{% endif %}
+{% endblock %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Set, Dict, Any
 from datetime import datetime
 from importlib import import_module
 import os
@@ -6,9 +6,13 @@ import sys
 from jinja2.filters import FILTERS
 import sphinx
 from sphinx.ext import autodoc
+from sphinx.ext.autosummary import generate
+from sphinx.util.inspect import safe_getattr
 from docutils import nodes
 import pathlib
 import logging
+
+DEFAULT_API_GROUP = "others"
 
 logger = logging.getLogger(__name__)
 
@@ -179,13 +183,21 @@ release = find_version("ray", "_version.py")
 
 language = "en"
 
+# autogen files are only used to auto-generate public API documentation.
+# They are not included in the toctree to avoid warnings such as documents not included
+# in any toctree.
+autogen_files = [
+    "data/api/_autogen.rst",
+]
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # Also helps resolve warnings about documents not included in any toctree.
 exclude_patterns = [
     "templates/*",
     "cluster/running-applications/doc/ray.*",
-]
+    "data/api/ray.data.*.rst",
+] + autogen_files
 
 # If "DOC_LIB" is found, only build that top-level navigation item.
 build_one_lib = os.getenv("DOC_LIB")
@@ -385,7 +397,40 @@ def filter_out_undoc_class_members(member_name, class_name, module_name):
         return ""
 
 
+def get_api_groups(method_names, class_name, module_name):
+    api_groups = set()
+    cls = getattr(import_module(module_name), class_name)
+    for method_name in method_names:
+        method = getattr(cls, method_name)
+        api_groups.add(safe_getattr(method, "_annotated_api_group", DEFAULT_API_GROUP))
+
+    return sorted(api_groups)
+
+
+def select_api_group(method_names, class_name, module_name, api_group):
+    cls = getattr(import_module(module_name), class_name)
+    return [
+        method_name
+        for method_name in method_names
+        if _is_public_api(getattr(cls, method_name))
+        and _is_api_group(getattr(cls, method_name), api_group)
+    ]
+
+
+def _is_public_api(obj):
+    api_type = safe_getattr(obj, "_annotated_type", None)
+    if not api_type:
+        return False
+    return api_type.value == "PublicAPI"
+
+
+def _is_api_group(obj, group):
+    return safe_getattr(obj, "_annotated_api_group", DEFAULT_API_GROUP) == group
+
+
 FILTERS["filter_out_undoc_class_members"] = filter_out_undoc_class_members
+FILTERS["get_api_groups"] = get_api_groups
+FILTERS["select_api_group"] = select_api_group
 
 
 def add_custom_assets(
@@ -423,6 +468,16 @@ def add_custom_assets(
         app.add_css_file("css/ray-libraries.css")
     elif pagename == "ray-overview/use-cases":
         app.add_css_file("css/use_cases.css")
+
+
+def _autogen_apis(app: sphinx.application.Sphinx):
+    """
+    Auto-generate public API documentation.
+    """
+    generate.generate_autosummary_docs(
+        [os.path.join(app.srcdir, file) for file in autogen_files],
+        app=app,
+    )
 
 
 def setup(app):
@@ -465,6 +520,9 @@ def setup(app):
     linkcheck_summarizer = LinkcheckSummarizer()
     app.connect("builder-inited", linkcheck_summarizer.add_handler_to_linkcheck)
     app.connect("build-finished", linkcheck_summarizer.summarize)
+
+    # Hook into the auto generation of public apis
+    app.connect("builder-inited", _autogen_apis)
 
 
 redoc = [

--- a/doc/source/data/api/_autogen.rst
+++ b/doc/source/data/api/_autogen.rst
@@ -1,0 +1,18 @@
+:orphan:
+
+.. # This file is only used to auto-generate API docs.
+.. # It should not be included in the toctree.
+.. #
+.. # For any classes that you want to include in the
+.. # API docs, add them to the list of autosummary
+.. # below, then include the generated ray.data.<class>.rst
+.. # file in your top level rst file.
+
+.. currentmodule:: ray.data
+
+.. autosummary::
+    :nosignatures:
+    :template: autosummary/class_v2.rst
+    :toctree:
+
+    DataIterator

--- a/doc/source/data/api/data_iterator.rst
+++ b/doc/source/data/api/data_iterator.rst
@@ -1,18 +1,3 @@
 .. _dataset-iterator-api:
 
-DataIterator API
-================
-
-.. currentmodule:: ray.data
-
-.. autoclass:: DataIterator
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   DataIterator.iter_batches
-   DataIterator.iter_torch_batches
-   DataIterator.to_tf
-   DataIterator.materialize
-   DataIterator.stats
+.. include:: ray.data.DataIterator.rst

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -102,6 +102,7 @@ class DataIterator(abc.ABC):
         """
         raise NotImplementedError
 
+    @PublicAPI(stability="beta")
     def iter_batches(
         self,
         *,
@@ -249,6 +250,7 @@ class DataIterator(abc.ABC):
         return _IterableFromIterator(_wrapped_iterator)
 
     @abc.abstractmethod
+    @PublicAPI(stability="beta")
     def stats(self) -> str:
         """Returns a string containing execution timing information."""
         raise NotImplementedError
@@ -258,6 +260,7 @@ class DataIterator(abc.ABC):
         """Return the schema of the dataset iterated over."""
         raise NotImplementedError
 
+    @PublicAPI(stability="beta")
     def iter_torch_batches(
         self,
         *,
@@ -674,6 +677,7 @@ class DataIterator(abc.ABC):
 
         return TorchIterableDataset(make_generator)
 
+    @PublicAPI(stability="beta")
     def to_tf(
         self,
         feature_columns: Union[str, List[str]],
@@ -855,6 +859,7 @@ class DataIterator(abc.ABC):
         )
         return dataset.with_options(options)
 
+    @PublicAPI(stability="beta")
     def materialize(self) -> "MaterializedDataset":
         """Execute and materialize this data iterator into object store memory.
 


### PR DESCRIPTION
After discuss offline with @bveeramani and @angelinalg, this is another attempt to auto-generate doc apis. Compared to the previous work, this focuses only on a single class and its methods. It also supports the common pattern of logical group of methods within a class, which can be documented in the code itself.

Only the content of the class doc are generated, and users have freedom to include that content in any structure they want. 

The new flow for adding a new class will be:
- Adding the class name into `_autogen.rst`
- Include the class full name, for example, `ray.data.DataIterator` in any top level rst.

I made an demo in this PR using DataIterator class.

Test:
- CI
- https://anyscale-ray--46243.com.readthedocs.build/en/46243/