### PR TITLE
Add perf metrics for 2.31.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 422.150144,
+    "_dashboard_memory_usage_mb": 473.06752,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.65,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1225\t9.33GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3575\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4789\t0.93GiB\tpython distributed/test_many_actors.py\n2384\t0.29GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3695\t0.24GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2767\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3858\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4583\t0.07GiB\tray::JobSupervisor\n4040\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3856\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
-    "actors_per_second": 656.4820098150251,
+    "_peak_memory": 3.67,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1223\t9.72GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3595\t1.71GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4678\t0.88GiB\tpython distributed/test_many_actors.py\n2549\t0.44GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3715\t0.35GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3009\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3881\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4469\t0.07GiB\tray::JobSupervisor\n4076\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3879\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "actors_per_second": 603.9096963863203,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 656.4820098150251
+            "perf_metric_value": 603.9096963863203
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 65.662
+            "perf_metric_value": 93.238
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3333.28
+            "perf_metric_value": 3526.237
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3456.493
+            "perf_metric_value": 3733.065
         }
     ],
     "success": "1",
-    "time": 15.232709884643555
+    "time": 16.558767080307007
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 182.657024,
+    "_dashboard_memory_usage_mb": 193.503232,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.64,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3548\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1209\t0.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2279\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3663\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4732\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4938\t0.08GiB\tray::StateAPIGeneratorActor.start\n2760\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4531\t0.07GiB\tray::JobSupervisor\n3825\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4002\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "_peak_memory": 1.66,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3558\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2125\t0.4GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1217\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3675\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4832\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5102\t0.09GiB\tray::StateAPIGeneratorActor.start\n2326\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4635\t0.07GiB\tray::JobSupervisor\n3838\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3836\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 356.96608310545133
+            "perf_metric_value": 346.9124752975113
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.877
+            "perf_metric_value": 3.924
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 48.58
+            "perf_metric_value": 63.659
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 197.137
+            "perf_metric_value": 133.071
         }
     ],
     "success": "1",
-    "tasks_per_second": 356.96608310545133,
-    "time": 302.80138659477234,
+    "tasks_per_second": 346.9124752975113,
+    "time": 302.8825714588165,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 137.633792,
+    "_dashboard_memory_usage_mb": 111.362048,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.25,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1224\t9.73GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3624\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4824\t0.42GiB\tpython distributed/test_many_pgs.py\n2809\t0.38GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3749\t0.15GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2607\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4609\t0.07GiB\tray::JobSupervisor\n3914\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4093\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3912\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 2.21,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1141\t9.78GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3478\t0.98GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4441\t0.41GiB\tpython distributed/test_many_pgs.py\n2345\t0.35GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3593\t0.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2738\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3756\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4239\t0.07GiB\tray::JobSupervisor\n3938\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3754\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23.5616061289441
+            "perf_metric_value": 22.96731187832995
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.492
+            "perf_metric_value": 3.377
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.796
+            "perf_metric_value": 8.221
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 204.615
+            "perf_metric_value": 281.247
         }
     ],
-    "pgs_per_second": 23.5616061289441,
+    "pgs_per_second": 22.96731187832995,
     "success": "1",
-    "time": 42.44192838668823
+    "time": 43.540141105651855
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1164.107776,
+    "_dashboard_memory_usage_mb": 1100.976128,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.08,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3561\t2.86GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4731\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3681\t0.68GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1206\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2174\t0.23GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5002\t0.09GiB\tray::StateAPIGeneratorActor.start\n4947\t0.08GiB\tray::DashboardTester.run\n2551\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3843\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4521\t0.07GiB\tray::JobSupervisor",
+    "_peak_memory": 4.53,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3588\t1.55GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3718\t1.43GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4837\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2121\t0.34GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1228\t0.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n5036\t0.09GiB\tray::DashboardTester.run\n5090\t0.08GiB\tray::StateAPIGeneratorActor.start\n4620\t0.07GiB\tray::JobSupervisor\n2545\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3884\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 587.8163884392604
+            "perf_metric_value": 588.1590100663536
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 42.944
+            "perf_metric_value": 128.651
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3642.242
+            "perf_metric_value": 1221.413
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4549.74
+            "perf_metric_value": 3317.765
         }
     ],
     "success": "1",
-    "tasks_per_second": 587.8163884392604,
-    "time": 317.01211500167847,
+    "tasks_per_second": 588.1590100663536,
+    "time": 317.00220489501953,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.24.0"}
+{"release_version": "2.31.0", "commit": "c74f2e42a6a556b907909bf6bf9f1b49c10537b8", "branch": "master"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8726.401857123754,
-        162.20549696513925
+        8333.524788377435,
+        139.4971970860079
     ],
     "1_1_actor_calls_concurrent": [
-        5525.453533356669,
-        275.6986719349956
+        5128.690143549978,
+        72.51862619127049
     ],
     "1_1_actor_calls_sync": [
-        2022.1643749529967,
-        42.58171596149864
+        2058.3799984150405,
+        11.233477115678642
     ],
     "1_1_async_actor_calls_async": [
-        3295.7761919502855,
-        149.90516121451026
+        3257.4165702788237,
+        126.34490761943368
     ],
     "1_1_async_actor_calls_sync": [
-        1306.2185283312654,
-        22.393311157323094
+        1374.6956063631808,
+        19.92364573442667
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2271.9010969950546,
-        58.46933903250449
+        2389.576009385017,
+        96.41355340514747
     ],
     "1_n_actor_calls_async": [
-        8723.546909820518,
-        133.04998221108622
+        8761.526579680127,
+        246.64842704677028
     ],
     "1_n_async_actor_calls_async": [
-        7526.072989853183,
-        80.26873719023843
+        7552.746593848862,
+        44.30686270497591
     ],
     "client__1_1_actor_calls_async": [
-        956.234692691667,
-        10.622834071499192
+        987.0826476868258,
+        15.867004371591774
     ],
     "client__1_1_actor_calls_concurrent": [
-        964.227785207118,
-        19.39077588012691
+        983.3703155378647,
+        11.430681150062163
     ],
     "client__1_1_actor_calls_sync": [
-        511.54682034013,
-        20.183100809422037
+        534.2825013844715,
+        2.950503846313585
     ],
     "client__get_calls": [
-        1099.299059786817,
-        48.740510949504255
+        1079.3418038309135,
+        33.135415306177244
     ],
     "client__put_calls": [
-        793.6471952322032,
-        19.166421115489065
+        814.6764560093619,
+        12.322138031313903
     ],
     "client__put_gigabytes": [
-        0.13033848458516117,
-        0.0004047979867318293
+        0.13149954065134536,
+        0.001063187907570302
     ],
     "client__tasks_and_get_batch": [
-        0.9191916564759186,
-        0.004240563507874709
+        0.9454156734042978,
+        0.0038137424075750334
     ],
     "client__tasks_and_put_batch": [
-        11163.342583763659,
-        86.36159399829216
+        11759.788796582228,
+        372.25256677234967
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12352.999319488557,
-        302.78838782381274
+        13048.216108376133,
+        230.29813938308763
     ],
     "multi_client_put_gigabytes": [
-        35.52392832333356,
-        2.4551866947000778
+        32.76192945223942,
+        0.8011869785099314
     ],
     "multi_client_tasks_async": [
-        23658.661959832083,
-        3659.740758379274
+        23557.51911206466,
+        1772.622998691743
     ],
     "n_n_actor_calls_async": [
-        26706.0034223919,
-        796.7068479444016
+        27657.83033159681,
+        630.3849349038278
     ],
     "n_n_actor_calls_with_arg_async": [
-        2669.6470548189563,
-        37.75431784396307
+        2713.0325692965866,
+        45.54010191103914
     ],
     "n_n_async_actor_calls_async": [
-        23029.099137990735,
-        353.5298340819868
+        23307.202618153802,
+        661.4791179159593
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10575.12534552304
+            "perf_metric_value": 10593.772848299006
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5342.356803322341
+            "perf_metric_value": 5300.894918847503
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12352.999319488557
+            "perf_metric_value": 13048.216108376133
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.60264129638186
+            "perf_metric_value": 20.28764104367834
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.618329296876913
+            "perf_metric_value": 8.033801054151493
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 35.52392832333356
+            "perf_metric_value": 32.76192945223942
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.459623096174152
+            "perf_metric_value": 13.16167615938565
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.356105950176277
+            "perf_metric_value": 5.378868872174563
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 990.8897375942615
+            "perf_metric_value": 987.4363632697047
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7728.179866020124
+            "perf_metric_value": 7954.923588767402
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23658.661959832083
+            "perf_metric_value": 23557.51911206466
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2022.1643749529967
+            "perf_metric_value": 2058.3799984150405
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8726.401857123754
+            "perf_metric_value": 8333.524788377435
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5525.453533356669
+            "perf_metric_value": 5128.690143549978
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8723.546909820518
+            "perf_metric_value": 8761.526579680127
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26706.0034223919
+            "perf_metric_value": 27657.83033159681
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2669.6470548189563
+            "perf_metric_value": 2713.0325692965866
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1306.2185283312654
+            "perf_metric_value": 1374.6956063631808
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3295.7761919502855
+            "perf_metric_value": 3257.4165702788237
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2271.9010969950546
+            "perf_metric_value": 2389.576009385017
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7526.072989853183
+            "perf_metric_value": 7552.746593848862
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23029.099137990735
+            "perf_metric_value": 23307.202618153802
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 804.4799825746657
+            "perf_metric_value": 840.8257707443967
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1099.299059786817
+            "perf_metric_value": 1079.3418038309135
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 793.6471952322032
+            "perf_metric_value": 814.6764560093619
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13033848458516117
+            "perf_metric_value": 0.13149954065134536
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11163.342583763659
+            "perf_metric_value": 11759.788796582228
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 511.54682034013
+            "perf_metric_value": 534.2825013844715
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 956.234692691667
+            "perf_metric_value": 987.0826476868258
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 964.227785207118
+            "perf_metric_value": 983.3703155378647
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9191916564759186
+            "perf_metric_value": 0.9454156734042978
         }
     ],
     "placement_group_create/removal": [
-        804.4799825746657,
-        13.347218543583795
+        840.8257707443967,
+        5.485007857797762
     ],
     "single_client_get_calls_Plasma_Store": [
-        10575.12534552304,
-        389.0501847163306
+        10593.772848299006,
+        535.7824591422661
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.459623096174152,
-        0.16042112976023476
+        13.16167615938565,
+        0.22204297681947535
     ],
     "single_client_put_calls_Plasma_Store": [
-        5342.356803322341,
-        87.92133379840806
+        5300.894918847503,
+        76.1977969185646
     ],
     "single_client_put_gigabytes": [
-        19.60264129638186,
-        6.0658657511900165
+        20.28764104367834,
+        4.860173002545708
     ],
     "single_client_tasks_and_get_batch": [
-        7.618329296876913,
-        0.22870606905835902
+        8.033801054151493,
+        0.34932465613267877
     ],
     "single_client_tasks_async": [
-        7728.179866020124,
-        391.64056111377556
+        7954.923588767402,
+        493.94900258711215
     ],
     "single_client_tasks_sync": [
-        990.8897375942615,
-        9.752000220743424
+        987.4363632697047,
+        8.44617749321566
     ],
     "single_client_wait_1k_refs": [
-        5.356105950176277,
-        0.05359089594239002
+        5.378868872174563,
+        0.10672725450140629
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 16.769440987999985,
+    "broadcast_time": 19.440196102000016,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.769440987999985
+            "perf_metric_value": 19.440196102000016
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.085048134999994,
-    "get_time": 23.721352370000005,
+    "args_time": 17.234402031000002,
+    "get_time": 22.85316222099999,
     "large_object_size": 107374182400,
-    "large_object_time": 29.037520325999992,
+    "large_object_time": 30.948722583000006,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.085048134999994
+            "perf_metric_value": 17.234402031000002
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.574067407000001
+            "perf_metric_value": 5.560233610000012
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.721352370000005
+            "perf_metric_value": 22.85316222099999
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 192.34304552800003
+            "perf_metric_value": 182.31759296599998
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.037520325999992
+            "perf_metric_value": 30.948722583000006
         }
     ],
-    "queued_time": 192.34304552800003,
-    "returns_time": 5.574067407000001,
+    "queued_time": 182.31759296599998,
+    "returns_time": 5.560233610000012,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0548744773864747,
-    "max_iteration_time": 3.340198516845703,
-    "min_iteration_time": 0.4613649845123291,
+    "avg_iteration_time": 1.0120761251449586,
+    "max_iteration_time": 3.3703677654266357,
+    "min_iteration_time": 0.27796387672424316,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0548744773864747
+            "perf_metric_value": 1.0120761251449586
         }
     ],
     "success": 1,
-    "total_time": 105.48765969276428
+    "total_time": 101.20782685279846
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.161747217178345
+            "perf_metric_value": 10.912366151809692
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.27835304737091
+            "perf_metric_value": 24.80071632862091
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 55.185825729370116
+            "perf_metric_value": 62.212187099456784
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5885274410247803
+            "perf_metric_value": 1.6078929901123047
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3104.279580116272
+            "perf_metric_value": 3011.46821808815
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4851944753960548
+            "perf_metric_value": 0.49633745404952434
         }
     ],
-    "stage_0_time": 10.161747217178345,
-    "stage_1_avg_iteration_time": 25.27835304737091,
-    "stage_1_max_iteration_time": 25.942532539367676,
-    "stage_1_min_iteration_time": 24.44790744781494,
-    "stage_1_time": 252.78363347053528,
-    "stage_2_avg_iteration_time": 55.185825729370116,
-    "stage_2_max_iteration_time": 56.937405824661255,
-    "stage_2_min_iteration_time": 53.556705951690674,
-    "stage_2_time": 275.930006980896,
-    "stage_3_creation_time": 1.5885274410247803,
-    "stage_3_time": 3104.279580116272,
-    "stage_4_spread": 0.4851944753960548,
+    "stage_0_time": 10.912366151809692,
+    "stage_1_avg_iteration_time": 24.80071632862091,
+    "stage_1_max_iteration_time": 26.903640270233154,
+    "stage_1_min_iteration_time": 23.28272032737732,
+    "stage_1_time": 248.00730347633362,
+    "stage_2_avg_iteration_time": 62.212187099456784,
+    "stage_2_max_iteration_time": 63.847378969192505,
+    "stage_2_min_iteration_time": 59.83901596069336,
+    "stage_2_time": 311.0617163181305,
+    "stage_3_creation_time": 1.6078929901123047,
+    "stage_3_time": 3011.46821808815,
+    "stage_4_spread": 0.49633745404952434,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9132710030025517,
-    "avg_pg_remove_time_ms": 0.9020739549548232,
+    "avg_pg_create_time_ms": 0.9355983018021244,
+    "avg_pg_remove_time_ms": 0.8868805465475326,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9132710030025517
+            "perf_metric_value": 0.9355983018021244
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9020739549548232
+            "perf_metric_value": 0.8868805465475326
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 8.01%: actors_per_second (THROUGHPUT) regresses from 656.4820098150251 to 603.9096963863203 in benchmarks/many_actors.json
REGRESSION 7.78%: multi_client_put_gigabytes (THROUGHPUT) regresses from 35.52392832333356 to 32.76192945223942 in microbenchmark.json
REGRESSION 7.18%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5525.453533356669 to 5128.690143549978 in microbenchmark.json
REGRESSION 4.50%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8726.401857123754 to 8333.524788377435 in microbenchmark.json
REGRESSION 2.82%: tasks_per_second (THROUGHPUT) regresses from 356.96608310545133 to 346.9124752975113 in benchmarks/many_nodes.json
REGRESSION 2.52%: pgs_per_second (THROUGHPUT) regresses from 23.5616061289441 to 22.96731187832995 in benchmarks/many_pgs.json
REGRESSION 1.82%: client__get_calls (THROUGHPUT) regresses from 1099.299059786817 to 1079.3418038309135 in microbenchmark.json
REGRESSION 1.16%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 3295.7761919502855 to 3257.4165702788237 in microbenchmark.json
REGRESSION 0.78%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5342.356803322341 to 5300.894918847503 in microbenchmark.json
REGRESSION 0.43%: multi_client_tasks_async (THROUGHPUT) regresses from 23658.661959832083 to 23557.51911206466 in microbenchmark.json
REGRESSION 0.35%: single_client_tasks_sync (THROUGHPUT) regresses from 990.8897375942615 to 987.4363632697047 in microbenchmark.json
REGRESSION 199.58%: dashboard_p50_latency_ms (LATENCY) regresses from 42.944 to 128.651 in benchmarks/many_tasks.json
REGRESSION 42.00%: dashboard_p50_latency_ms (LATENCY) regresses from 65.662 to 93.238 in benchmarks/many_actors.json
REGRESSION 37.45%: dashboard_p99_latency_ms (LATENCY) regresses from 204.615 to 281.247 in benchmarks/many_pgs.json
REGRESSION 31.04%: dashboard_p95_latency_ms (LATENCY) regresses from 48.58 to 63.659 in benchmarks/many_nodes.json
REGRESSION 15.93%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 16.769440987999985 to 19.440196102000016 in scalability/object_store.json
REGRESSION 12.73%: stage_2_avg_iteration_time (LATENCY) regresses from 55.185825729370116 to 62.212187099456784 in stress_tests/stress_test_many_tasks.json
REGRESSION 8.00%: dashboard_p99_latency_ms (LATENCY) regresses from 3456.493 to 3733.065 in benchmarks/many_actors.json
REGRESSION 7.39%: stage_0_time (LATENCY) regresses from 10.161747217178345 to 10.912366151809692 in stress_tests/stress_test_many_tasks.json
REGRESSION 6.58%: 107374182400_large_object_time (LATENCY) regresses from 29.037520325999992 to 30.948722583000006 in scalability/single_node.json
REGRESSION 5.79%: dashboard_p95_latency_ms (LATENCY) regresses from 3333.28 to 3526.237 in benchmarks/many_actors.json
REGRESSION 2.44%: avg_pg_create_time_ms (LATENCY) regresses from 0.9132710030025517 to 0.9355983018021244 in stress_tests/stress_test_placement_group.json
REGRESSION 2.30%: stage_4_spread (LATENCY) regresses from 0.4851944753960548 to 0.49633745404952434 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.22%: stage_3_creation_time (LATENCY) regresses from 1.5885274410247803 to 1.6078929901123047 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.21%: dashboard_p50_latency_ms (LATENCY) regresses from 3.877 to 3.924 in benchmarks/many_nodes.json
REGRESSION 0.87%: 10000_args_time (LATENCY) regresses from 17.085048134999994 to 17.234402031000002 in scalability/single_node.json
```