### PR TITLE
Add perf metrics for 2.31.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 518.90176,
+    "_dashboard_memory_usage_mb": 473.06752,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.68,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3503\t1.78GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5372\t0.96GiB\tpython distributed/test_many_actors.py\n2288\t0.33GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1139\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3618\t0.24GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3785\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2805\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5165\t0.07GiB\tray::JobSupervisor\n3975\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3783\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
-    "actors_per_second": 617.6896831488957,
+    "_peak_memory": 3.67,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1223\t9.72GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3595\t1.71GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4678\t0.88GiB\tpython distributed/test_many_actors.py\n2549\t0.44GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3715\t0.35GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3009\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3881\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4469\t0.07GiB\tray::JobSupervisor\n4076\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3879\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "actors_per_second": 603.9096963863203,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 617.6896831488957
+            "perf_metric_value": 603.9096963863203
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 47.275
+            "perf_metric_value": 93.238
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2423.563
+            "perf_metric_value": 3526.237
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4809.161
+            "perf_metric_value": 3733.065
         }
     ],
     "success": "1",
-    "time": 16.189358949661255
+    "time": 16.558767080307007
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 186.085376,
+    "_dashboard_memory_usage_mb": 193.503232,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.65,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3458\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1181\t0.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2465\t0.24GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3573\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4837\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5106\t0.08GiB\tray::StateAPIGeneratorActor.start\n4635\t0.07GiB\tray::JobSupervisor\n3736\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2666\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3734\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 1.66,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3558\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2125\t0.4GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1217\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3675\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4832\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5102\t0.09GiB\tray::StateAPIGeneratorActor.start\n2326\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4635\t0.07GiB\tray::JobSupervisor\n3838\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3836\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 344.6572790384348
+            "perf_metric_value": 346.9124752975113
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.756
+            "perf_metric_value": 3.924
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 37.938
+            "perf_metric_value": 63.659
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 195.419
+            "perf_metric_value": 133.071
         }
     ],
     "success": "1",
-    "tasks_per_second": 344.6572790384348,
-    "time": 302.90143299102783,
+    "tasks_per_second": 346.9124752975113,
+    "time": 302.8825714588165,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 146.956288,
+    "_dashboard_memory_usage_mb": 111.362048,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.18,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1202\t9.89GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3564\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4710\t0.41GiB\tpython distributed/test_many_pgs.py\n2110\t0.38GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3679\t0.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2313\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4496\t0.07GiB\tray::JobSupervisor\n3846\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4036\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3844\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 2.21,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1141\t9.78GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3478\t0.98GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4441\t0.41GiB\tpython distributed/test_many_pgs.py\n2345\t0.35GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3593\t0.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2738\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3756\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4239\t0.07GiB\tray::JobSupervisor\n3938\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3754\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23.122692911575257
+            "perf_metric_value": 22.96731187832995
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.234
+            "perf_metric_value": 3.377
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.006
+            "perf_metric_value": 8.221
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 490.457
+            "perf_metric_value": 281.247
         }
     ],
-    "pgs_per_second": 23.122692911575257,
+    "pgs_per_second": 22.96731187832995,
     "success": "1",
-    "time": 43.24755787849426
+    "time": 43.540141105651855
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1169.338368,
+    "_dashboard_memory_usage_mb": 1100.976128,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.78,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3605\t2.08GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3720\t1.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4785\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1221\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2764\t0.24GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5053\t0.08GiB\tray::StateAPIGeneratorActor.start\n4998\t0.08GiB\tray::DashboardTester.run\n2987\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4583\t0.07GiB\tray::JobSupervisor\n3888\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
+    "_peak_memory": 4.53,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3588\t1.55GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3718\t1.43GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4837\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2121\t0.34GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1228\t0.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n5036\t0.09GiB\tray::DashboardTester.run\n5090\t0.08GiB\tray::StateAPIGeneratorActor.start\n4620\t0.07GiB\tray::JobSupervisor\n2545\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3884\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 589.9220404343542
+            "perf_metric_value": 588.1590100663536
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 38.598
+            "perf_metric_value": 128.651
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3102.89
+            "perf_metric_value": 1221.413
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4330.086
+            "perf_metric_value": 3317.765
         }
     ],
     "success": "1",
-    "tasks_per_second": 589.9220404343542,
-    "time": 316.95139241218567,
+    "tasks_per_second": 588.1590100663536,
+    "time": 317.00220489501953,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.30.0"}
+{"release_version": "2.31.0", "commit": "c74f2e42a6a556b907909bf6bf9f1b49c10537b8", "branch": "master"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8933.20887285504,
-        177.9934113962222
+        8333.524788377435,
+        139.4971970860079
     ],
     "1_1_actor_calls_concurrent": [
-        5433.519532534513,
-        164.1306697381876
+        5128.690143549978,
+        72.51862619127049
     ],
     "1_1_actor_calls_sync": [
-        2065.600257768727,
-        62.805248400133635
+        2058.3799984150405,
+        11.233477115678642
     ],
     "1_1_async_actor_calls_async": [
-        3288.4752616288997,
-        106.50912257511672
+        3257.4165702788237,
+        126.34490761943368
     ],
     "1_1_async_actor_calls_sync": [
-        1298.3259900715077,
-        30.9960059878394
+        1374.6956063631808,
+        19.92364573442667
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2282.9083135396877,
-        33.569211303281655
+        2389.576009385017,
+        96.41355340514747
     ],
     "1_n_actor_calls_async": [
-        7999.09786468534,
-        240.5274055318131
+        8761.526579680127,
+        246.64842704677028
     ],
     "1_n_async_actor_calls_async": [
-        7148.833981156601,
-        140.55726545377746
+        7552.746593848862,
+        44.30686270497591
     ],
     "client__1_1_actor_calls_async": [
-        1004.5373307362321,
-        7.2386406094867235
+        987.0826476868258,
+        15.867004371591774
     ],
     "client__1_1_actor_calls_concurrent": [
-        993.150411111262,
-        6.495370194557394
+        983.3703155378647,
+        11.430681150062163
     ],
     "client__1_1_actor_calls_sync": [
-        525.5676701595513,
-        7.259223093436164
+        534.2825013844715,
+        2.950503846313585
     ],
     "client__get_calls": [
-        1027.2844127511862,
-        43.787332210624506
+        1079.3418038309135,
+        33.135415306177244
     ],
     "client__put_calls": [
-        782.6829866165862,
-        12.444956861586565
+        814.6764560093619,
+        12.322138031313903
     ],
     "client__put_gigabytes": [
-        0.12974867196873113,
-        0.0008153816205802196
+        0.13149954065134536,
+        0.001063187907570302
     ],
     "client__tasks_and_get_batch": [
-        0.8448091448208279,
-        0.03277995280220994
+        0.9454156734042978,
+        0.0038137424075750334
     ],
     "client__tasks_and_put_batch": [
-        10913.81106126635,
-        163.45505630570557
+        11759.788796582228,
+        372.25256677234967
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12847.965582428995,
-        227.371465552808
+        13048.216108376133,
+        230.29813938308763
     ],
     "multi_client_put_gigabytes": [
-        32.74094571462406,
-        1.8518261729618408
+        32.76192945223942,
+        0.8011869785099314
     ],
     "multi_client_tasks_async": [
-        21834.59499226869,
-        1466.306541428481
+        23557.51911206466,
+        1772.622998691743
     ],
     "n_n_actor_calls_async": [
-        27240.503592641795,
-        285.1485495890741
+        27657.83033159681,
+        630.3849349038278
     ],
     "n_n_actor_calls_with_arg_async": [
-        2573.976684531894,
-        82.19775263467561
+        2713.0325692965866,
+        45.54010191103914
     ],
     "n_n_async_actor_calls_async": [
-        22180.601943156536,
-        662.4659543753717
+        23307.202618153802,
+        661.4791179159593
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10612.85977893251
+            "perf_metric_value": 10593.772848299006
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5156.839238498811
+            "perf_metric_value": 5300.894918847503
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12847.965582428995
+            "perf_metric_value": 13048.216108376133
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.128661449193785
+            "perf_metric_value": 20.28764104367834
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.735617799600968
+            "perf_metric_value": 8.033801054151493
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 32.74094571462406
+            "perf_metric_value": 32.76192945223942
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.781987811502956
+            "perf_metric_value": 13.16167615938565
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.386309531741722
+            "perf_metric_value": 5.378868872174563
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1001.380589618519
+            "perf_metric_value": 987.4363632697047
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7857.638521551526
+            "perf_metric_value": 7954.923588767402
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21834.59499226869
+            "perf_metric_value": 23557.51911206466
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2065.600257768727
+            "perf_metric_value": 2058.3799984150405
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8933.20887285504
+            "perf_metric_value": 8333.524788377435
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5433.519532534513
+            "perf_metric_value": 5128.690143549978
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7999.09786468534
+            "perf_metric_value": 8761.526579680127
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27240.503592641795
+            "perf_metric_value": 27657.83033159681
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2573.976684531894
+            "perf_metric_value": 2713.0325692965866
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1298.3259900715077
+            "perf_metric_value": 1374.6956063631808
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3288.4752616288997
+            "perf_metric_value": 3257.4165702788237
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2282.9083135396877
+            "perf_metric_value": 2389.576009385017
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7148.833981156601
+            "perf_metric_value": 7552.746593848862
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22180.601943156536
+            "perf_metric_value": 23307.202618153802
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 798.5897498740229
+            "perf_metric_value": 840.8257707443967
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1027.2844127511862
+            "perf_metric_value": 1079.3418038309135
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 782.6829866165862
+            "perf_metric_value": 814.6764560093619
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.12974867196873113
+            "perf_metric_value": 0.13149954065134536
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10913.81106126635
+            "perf_metric_value": 11759.788796582228
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 525.5676701595513
+            "perf_metric_value": 534.2825013844715
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1004.5373307362321
+            "perf_metric_value": 987.0826476868258
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 993.150411111262
+            "perf_metric_value": 983.3703155378647
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.8448091448208279
+            "perf_metric_value": 0.9454156734042978
         }
     ],
     "placement_group_create/removal": [
-        798.5897498740229,
-        13.543156241895135
+        840.8257707443967,
+        5.485007857797762
     ],
     "single_client_get_calls_Plasma_Store": [
-        10612.85977893251,
-        270.52509099812664
+        10593.772848299006,
+        535.7824591422661
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.781987811502956,
-        0.14597397314905913
+        13.16167615938565,
+        0.22204297681947535
     ],
     "single_client_put_calls_Plasma_Store": [
-        5156.839238498811,
-        51.564900584700915
+        5300.894918847503,
+        76.1977969185646
     ],
     "single_client_put_gigabytes": [
-        19.128661449193785,
-        5.44250703557405
+        20.28764104367834,
+        4.860173002545708
     ],
     "single_client_tasks_and_get_batch": [
-        7.735617799600968,
-        0.6212378115067596
+        8.033801054151493,
+        0.34932465613267877
     ],
     "single_client_tasks_async": [
-        7857.638521551526,
-        362.4721080511504
+        7954.923588767402,
+        493.94900258711215
     ],
     "single_client_tasks_sync": [
-        1001.380589618519,
-        29.289784910461382
+        987.4363632697047,
+        8.44617749321566
     ],
     "single_client_wait_1k_refs": [
-        5.386309531741722,
-        0.14180324417145865
+        5.378868872174563,
+        0.10672725450140629
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 17.659990787000027,
+    "broadcast_time": 19.440196102000016,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.659990787000027
+            "perf_metric_value": 19.440196102000016
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.397838494999988,
-    "get_time": 22.694496589999986,
+    "args_time": 17.234402031000002,
+    "get_time": 22.85316222099999,
     "large_object_size": 107374182400,
-    "large_object_time": 29.366374017999988,
+    "large_object_time": 30.948722583000006,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.397838494999988
+            "perf_metric_value": 17.234402031000002
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.513575275999997
+            "perf_metric_value": 5.560233610000012
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 22.694496589999986
+            "perf_metric_value": 22.85316222099999
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 183.01543519700002
+            "perf_metric_value": 182.31759296599998
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.366374017999988
+            "perf_metric_value": 30.948722583000006
         }
     ],
-    "queued_time": 183.01543519700002,
-    "returns_time": 5.513575275999997,
+    "queued_time": 182.31759296599998,
+    "returns_time": 5.560233610000012,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0871897959709167,
-    "max_iteration_time": 2.8652021884918213,
-    "min_iteration_time": 0.13084864616394043,
+    "avg_iteration_time": 1.0120761251449586,
+    "max_iteration_time": 3.3703677654266357,
+    "min_iteration_time": 0.27796387672424316,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0871897959709167
+            "perf_metric_value": 1.0120761251449586
         }
     ],
     "success": 1,
-    "total_time": 108.71918201446533
+    "total_time": 101.20782685279846
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.09369158744812
+            "perf_metric_value": 10.912366151809692
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 24.93844430446625
+            "perf_metric_value": 24.80071632862091
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 59.59709148406982
+            "perf_metric_value": 62.212187099456784
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.687410831451416
+            "perf_metric_value": 1.6078929901123047
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3216.0363504886627
+            "perf_metric_value": 3011.46821808815
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.4720456406930635
+            "perf_metric_value": 0.49633745404952434
         }
     ],
-    "stage_0_time": 10.09369158744812,
-    "stage_1_avg_iteration_time": 24.93844430446625,
-    "stage_1_max_iteration_time": 26.48196816444397,
-    "stage_1_min_iteration_time": 23.490055084228516,
-    "stage_1_time": 249.38453197479248,
-    "stage_2_avg_iteration_time": 59.59709148406982,
-    "stage_2_max_iteration_time": 61.32059621810913,
-    "stage_2_min_iteration_time": 57.57088589668274,
-    "stage_2_time": 297.9873077869415,
-    "stage_3_creation_time": 1.687410831451416,
-    "stage_3_time": 3216.0363504886627,
-    "stage_4_spread": 0.4720456406930635,
+    "stage_0_time": 10.912366151809692,
+    "stage_1_avg_iteration_time": 24.80071632862091,
+    "stage_1_max_iteration_time": 26.903640270233154,
+    "stage_1_min_iteration_time": 23.28272032737732,
+    "stage_1_time": 248.00730347633362,
+    "stage_2_avg_iteration_time": 62.212187099456784,
+    "stage_2_max_iteration_time": 63.847378969192505,
+    "stage_2_min_iteration_time": 59.83901596069336,
+    "stage_2_time": 311.0617163181305,
+    "stage_3_creation_time": 1.6078929901123047,
+    "stage_3_time": 3011.46821808815,
+    "stage_4_spread": 0.49633745404952434,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9000045735734334,
-    "avg_pg_remove_time_ms": 0.8979432732736121,
+    "avg_pg_create_time_ms": 0.9355983018021244,
+    "avg_pg_remove_time_ms": 0.8868805465475326,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9000045735734334
+            "perf_metric_value": 0.9355983018021244
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.8979432732736121
+            "perf_metric_value": 0.8868805465475326
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 6.71%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8933.20887285504 to 8333.524788377435 in microbenchmark.json
REGRESSION 5.61%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5433.519532534513 to 5128.690143549978 in microbenchmark.json
REGRESSION 2.23%: actors_per_second (THROUGHPUT) regresses from 617.6896831488957 to 603.9096963863203 in benchmarks/many_actors.json
REGRESSION 1.74%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1004.5373307362321 to 987.0826476868258 in microbenchmark.json
REGRESSION 1.39%: single_client_tasks_sync (THROUGHPUT) regresses from 1001.380589618519 to 987.4363632697047 in microbenchmark.json
REGRESSION 0.98%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 993.150411111262 to 983.3703155378647 in microbenchmark.json
REGRESSION 0.94%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 3288.4752616288997 to 3257.4165702788237 in microbenchmark.json
REGRESSION 0.67%: pgs_per_second (THROUGHPUT) regresses from 23.122692911575257 to 22.96731187832995 in benchmarks/many_pgs.json
REGRESSION 0.35%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2065.600257768727 to 2058.3799984150405 in microbenchmark.json
REGRESSION 0.30%: tasks_per_second (THROUGHPUT) regresses from 589.9220404343542 to 588.1590100663536 in benchmarks/many_tasks.json
REGRESSION 0.18%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10612.85977893251 to 10593.772848299006 in microbenchmark.json
REGRESSION 0.14%: single_client_wait_1k_refs (THROUGHPUT) regresses from 5.386309531741722 to 5.378868872174563 in microbenchmark.json
REGRESSION 233.31%: dashboard_p50_latency_ms (LATENCY) regresses from 38.598 to 128.651 in benchmarks/many_tasks.json
REGRESSION 97.22%: dashboard_p50_latency_ms (LATENCY) regresses from 47.275 to 93.238 in benchmarks/many_actors.json
REGRESSION 67.80%: dashboard_p95_latency_ms (LATENCY) regresses from 37.938 to 63.659 in benchmarks/many_nodes.json
REGRESSION 45.50%: dashboard_p95_latency_ms (LATENCY) regresses from 2423.563 to 3526.237 in benchmarks/many_actors.json
REGRESSION 10.08%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 17.659990787000027 to 19.440196102000016 in scalability/object_store.json
REGRESSION 8.11%: stage_0_time (LATENCY) regresses from 10.09369158744812 to 10.912366151809692 in stress_tests/stress_test_many_tasks.json
REGRESSION 5.39%: 107374182400_large_object_time (LATENCY) regresses from 29.366374017999988 to 30.948722583000006 in scalability/single_node.json
REGRESSION 5.15%: stage_4_spread (LATENCY) regresses from 0.4720456406930635 to 0.49633745404952434 in stress_tests/stress_test_many_tasks.json
REGRESSION 4.47%: dashboard_p50_latency_ms (LATENCY) regresses from 3.756 to 3.924 in benchmarks/many_nodes.json
REGRESSION 4.42%: dashboard_p50_latency_ms (LATENCY) regresses from 3.234 to 3.377 in benchmarks/many_pgs.json
REGRESSION 4.39%: stage_2_avg_iteration_time (LATENCY) regresses from 59.59709148406982 to 62.212187099456784 in stress_tests/stress_test_many_tasks.json
REGRESSION 3.95%: avg_pg_create_time_ms (LATENCY) regresses from 0.9000045735734334 to 0.9355983018021244 in stress_tests/stress_test_placement_group.json
REGRESSION 0.85%: 3000_returns_time (LATENCY) regresses from 5.513575275999997 to 5.560233610000012 in scalability/single_node.json
REGRESSION 0.70%: 10000_get_time (LATENCY) regresses from 22.694496589999986 to 22.85316222099999 in scalability/single_node.json
```