### PR TITLE
Fix for accelerated DAG GPU microbenchmarks

### DIFF
--- a/release/microbenchmark/experimental/accelerated_dag_gpu_microbenchmark.py
+++ b/release/microbenchmark/experimental/accelerated_dag_gpu_microbenchmark.py
@@ -113,7 +113,7 @@ def exec_ray_dag(
                 TorchTensorType(
                     "auto" if dynamic_shape else SHAPE,
                     "auto" if dynamic_shape else DTYPE,
-                    transport="nccl" if use_nccl else None,
+                    transport="nccl" if use_nccl else "auto",
                 )
             )
 
@@ -124,9 +124,9 @@ def exec_ray_dag(
 
         def _run():
             i = np.random.randint(100)
-            output_channel = dag.execute(i)
+            ref = dag.execute(i)
             # TODO(swang): Replace with fake ObjectRef.
-            result = output_channel.read()
+            result = ray.get(ref)
             assert result == (i, SHAPE, DTYPE)
 
     else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The GPU microbenchmark code became out-of-sync with the accelerated DAG library. This PR fixes the microbenchmark code.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
