### PR TITLE
[doc][api] api policy lint check for data team

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -30,7 +30,7 @@ steps:
     job_env: oss-ci-base_build
     matrix:
       - api_annotations
-      - api_discrepancy
+      - api_policy_check data
 
   - label: ":lint-roller: lint: linkcheck"
     instance_type: medium

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -62,10 +62,9 @@ api_annotations() {
   ./ci/lint/check_api_annotations.py
 }
 
-api_discrepancy() {
+api_policy_check() {
   RAY_DISABLE_EXTRA_CPP=1 pip install -e "python[all]"
-  # TODO(can): run this check with other ray packages
-  bazel run //ci/ray_ci/doc:cmd_check_api_discrepancy -- ray.data
+  bazel run //ci/ray_ci/doc:cmd_check_api_discrepancy -- /ray "$@"
 }
 
 documentation_style() {

--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -1,5 +1,6 @@
 import re
 import importlib
+import inspect
 
 from enum import Enum
 from dataclasses import dataclass
@@ -117,7 +118,9 @@ class API:
                 return self.name
             attribute = getattr(attribute, token)
 
-        return f"{attribute.__module__}.{attribute.__qualname__}"
+        if inspect.isclass(attribute) or inspect.isfunction(attribute):
+            return f"{attribute.__module__}.{attribute.__qualname__}"
+        return self.name
 
     def _is_private_name(self) -> bool:
         """
@@ -125,7 +128,7 @@ class API:
         underscores.
         """
         name_has_underscore = self.name.split(".")[-1].startswith("_")
-        is_internal = ".internal." in self.name
+        is_internal = "._internal." in self.name
 
         return name_has_underscore or is_internal
 

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -1,87 +1,87 @@
 import click
-from typing import List, Dict, Set
+from typing import Dict, Set
 
 from ci.ray_ci.doc.module import Module
 from ci.ray_ci.doc.autodoc import Autodoc
-from ci.ray_ci.doc.api import AnnotationType, API
+from ci.ray_ci.doc.api import API
 
 TEAM_API_CONFIGS = {
     "data": {
-        "head_modules": ["ray.data", "ray.data.grouped_data"],
+        "head_modules": {"ray.data", "ray.data.grouped_data"},
         "head_doc_file": "doc/source/data/api/api.rst",
+        # List of APIs that are not following our API policy, and we will be fixing, or
+        # we cannot deprecate them although we want to
+        "white_list_apis": {
+            # not sure what to do
+            "ray.data.dataset.MaterializedDataset",
+            # special case where we cannot deprecate although we want to
+            "ray.data.random_access_dataset.RandomAccessDataset",
+            # TODO(can): fix these
+            "ray.data.datasource.bigquery_datasource.BigQueryDatasource",
+            "ray.data.datasource.binary_datasource.BinaryDatasource",
+            "ray.data.datasource.csv_datasource.CSVDatasource",
+            "ray.data.datasource.json_datasource.JSONDatasource",
+            "ray.data.datasource.mongo_datasource.MongoDatasource",
+            "ray.data.datasource.numpy_datasource.NumpyDatasource",
+            "ray.data.datasource.parquet_bulk_datasource.ParquetBulkDatasource",
+            "ray.data.datasource.parquet_datasource.ParquetDatasource",
+            "ray.data.datasource.range_datasource.RangeDatasource",
+            "ray.data.datasource.sql_datasource.SQLDatasource",
+            "ray.data.datasource.text_datasource.TextDatasource",
+            "ray.data.datasource.webdataset_datasource.WebDatasetDatasource",
+            "ray.data.datasource.tfrecords_datasource.TFRecordDatasource",
+            "ray.data.datasource.tfrecords_datasource.TFXReadOptions",
+        },
     },
 }
 
-@click.option(
-    "--python-version",
-    type=click.Choice(list(PYTHON_VERSIONS.keys())),
-    help=("Python version to build the wheel with"),
-)
 
 @click.command()
-@click.argument("team", required=True, type=click.Choice(list(TEAM_API_CONFIGS.keys())))
 @click.argument("ray_checkout_dir", required=True, type=str)
-def main(team: str, ray_checkout_dir: str) -> None:
+@click.argument("team", required=True, type=click.Choice(list(TEAM_API_CONFIGS.keys())))
+def main(ray_checkout_dir: str, team: str) -> None:
     """
     This script checks for annotated classes and functions in a module, and finds
     discrepancies between the annotations and the documentation.
     """
+
+    # Load all APIs from the codebase
     api_in_codes = {}
     for module in TEAM_API_CONFIGS[team]["head_modules"]:
         module = Module(module)
-        api_in_codes.update({api.name: api for api in module.get_apis()})
+        api_in_codes.update(
+            {api.get_canonical_name(): api for api in module.get_apis()}
+        )
 
+    # Load all APIs from the documentation
     autodoc = Autodoc(f"{ray_checkout_dir}/{TEAM_API_CONFIGS[team]['head_doc_file']}")
-    api_in_docs = {api.name for api in autodoc.get_apis()}
+    api_in_docs = {api.get_canonical_name() for api in autodoc.get_apis()}
 
-    # All public APIs should be documented
-    print("Validating public APIs...")
-    _validate_public_apis(api_in_codes, api_in_docs)
+    # Load the white list APIs
+    white_list_apis = TEAM_API_CONFIGS[team]["white_list_apis"]
 
-    # All deprecated APIs should be documented
-    print("Validating deprecated APIs...")
-    _validate_deprecated_apis(api_in_codes, api_in_docs)
+    # Policy 01: all public APIs should be documented
+    print("Validating that public APIs should be documented...")
+    _validate_documented_public_apis(api_in_codes, api_in_docs, white_list_apis)
 
     return
 
-def _validate_consistent_apis(
-    api_in_codes: Dict[str, API], api_in_docs: Set[str]
+
+def _validate_documented_public_apis(
+    api_in_codes: Dict[str, API], api_in_docs: Set[str], white_list_apis: Set[str]
 ) -> None:
     """
     Validate APIs that are public and documented.
     """
-    for api in api_in_codes.values():
-        if (
-            api.annotation_type == AnnotationType.PUBLIC_API
-            or api.annotation_type == AnnotationType.DEPRECATED
-        ) and api.name in api_in_docs:
-            print(f"\t{api.name}")
+    for name, api in api_in_codes.items():
+        if not api.is_public():
+            continue
 
+        if name in white_list_apis:
+            continue
 
-def _validate_public_apis(api_in_codes: Dict[str, API], api_in_docs: Set[str]) -> None:
-    """
-    Validate that all public APIs in the code are documented.
-    """
-    for api in api_in_codes.values():
-        if (
-            api.annotation_type == AnnotationType.PUBLIC_API
-            and api.name not in api_in_docs
-        ):
-            print(f"\t{api.name}")
-
-
-def _validate_deprecated_apis(
-    api_in_codes: Dict[str, API], api_in_docs: Set[str]
-) -> None:
-    """
-    Validate that all deprecated APIs in the code are documented.
-    """
-    for api in api_in_codes.values():
-        if (
-            api.annotation_type == AnnotationType.DEPRECATED
-            and api.name not in api_in_docs
-        ):
-            print(f"\t{api.name}")
+        assert name in api_in_docs, f"\tAPI {api.name} is public but not documented."
+        print(f"\tAPI {api.name} is public and documented.")
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -1,22 +1,87 @@
 import click
+from typing import List, Dict, Set
 
 from ci.ray_ci.doc.module import Module
+from ci.ray_ci.doc.autodoc import Autodoc
+from ci.ray_ci.doc.api import AnnotationType, API
 
+TEAM_API_CONFIGS = {
+    "data": {
+        "head_modules": ["ray.data", "ray.data.grouped_data"],
+        "head_doc_file": "doc/source/data/api/api.rst",
+    },
+}
+
+@click.option(
+    "--python-version",
+    type=click.Choice(list(PYTHON_VERSIONS.keys())),
+    help=("Python version to build the wheel with"),
+)
 
 @click.command()
-@click.argument("module", required=True, type=str)
-def main(module: str) -> None:
+@click.argument("team", required=True, type=click.Choice(list(TEAM_API_CONFIGS.keys())))
+@click.argument("ray_checkout_dir", required=True, type=str)
+def main(team: str, ray_checkout_dir: str) -> None:
     """
     This script checks for annotated classes and functions in a module, and finds
     discrepancies between the annotations and the documentation.
     """
-    module = Module(module)
-    for api in module.get_apis():
-        print(
-            f"API: {api.name}, "
-            f"Annotation Type: {api.annotation_type}, "
-            f"Code Type: {api.code_type}"
-        )
+    api_in_codes = {}
+    for module in TEAM_API_CONFIGS[team]["head_modules"]:
+        module = Module(module)
+        api_in_codes.update({api.name: api for api in module.get_apis()})
+
+    autodoc = Autodoc(f"{ray_checkout_dir}/{TEAM_API_CONFIGS[team]['head_doc_file']}")
+    api_in_docs = {api.name for api in autodoc.get_apis()}
+
+    # All public APIs should be documented
+    print("Validating public APIs...")
+    _validate_public_apis(api_in_codes, api_in_docs)
+
+    # All deprecated APIs should be documented
+    print("Validating deprecated APIs...")
+    _validate_deprecated_apis(api_in_codes, api_in_docs)
+
+    return
+
+def _validate_consistent_apis(
+    api_in_codes: Dict[str, API], api_in_docs: Set[str]
+) -> None:
+    """
+    Validate APIs that are public and documented.
+    """
+    for api in api_in_codes.values():
+        if (
+            api.annotation_type == AnnotationType.PUBLIC_API
+            or api.annotation_type == AnnotationType.DEPRECATED
+        ) and api.name in api_in_docs:
+            print(f"\t{api.name}")
+
+
+def _validate_public_apis(api_in_codes: Dict[str, API], api_in_docs: Set[str]) -> None:
+    """
+    Validate that all public APIs in the code are documented.
+    """
+    for api in api_in_codes.values():
+        if (
+            api.annotation_type == AnnotationType.PUBLIC_API
+            and api.name not in api_in_docs
+        ):
+            print(f"\t{api.name}")
+
+
+def _validate_deprecated_apis(
+    api_in_codes: Dict[str, API], api_in_docs: Set[str]
+) -> None:
+    """
+    Validate that all deprecated APIs in the code are documented.
+    """
+    for api in api_in_codes.values():
+        if (
+            api.annotation_type == AnnotationType.DEPRECATED
+            and api.name not in api_in_docs
+        ):
+            print(f"\t{api.name}")
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/doc/test_api.py
+++ b/ci/ray_ci/doc/test_api.py
@@ -120,7 +120,7 @@ def test_is_private_name():
             "output": True,
         },
         {
-            "input": "a.b.internal.public_function",
+            "input": "a.b._internal.public_function",
             "output": True,
         },
         {
@@ -146,7 +146,7 @@ def test_is_public():
         code_type=CodeType.FUNCTION,
     ).is_public()
     assert not API(
-        name="a.b.internal.public_function",
+        name="a.b._internal.public_function",
         annotation_type=AnnotationType.PUBLIC_API,
         code_type=CodeType.FUNCTION,
     ).is_public()


### PR DESCRIPTION
Add a lint to check for the first api policy: every public API needs to be documented. This PR adds the check for `data` team.

There are a list of APIs that are not following the rules yes, I'll remove them from the `whitelist` as we are fixing them.

Test:
- CI