### PR TITLE
[doc][api] fix autosummary parsing

### DIFF
--- a/ci/ray_ci/doc/autodoc.py
+++ b/ci/ray_ci/doc/autodoc.py
@@ -97,8 +97,6 @@ class Autodoc:
         with open(rst_file, "r") as f:
             line = f.readline()
             while line:
-                line = line.strip()
-
                 # parse currentmodule block
                 if line.startswith(_SPHINX_CURRENTMODULE_HEADER):
                     module = line[len(_SPHINX_CURRENTMODULE_HEADER) :].strip()

--- a/ci/ray_ci/doc/test_autodoc.py
+++ b/ci/ray_ci/doc/test_autodoc.py
@@ -16,7 +16,7 @@ def test_walk():
             f.write("\tapi_02.rst\n")
         with open(os.path.join(tmp, "api_01.rst"), "w") as f:
             f.write(".. currentmodule:: ci.ray_ci.doc\n")
-            f.write(".. autosummary::\n\n")
+            f.write(".. autosummary::\n")
             f.write("\t~mock.mock_function\n")
             f.write("\tmock.mock_module.mock_w00t\n")
         with open(os.path.join(tmp, "api_02.rst"), "w") as f:


### PR DESCRIPTION
Currently the `autosummary\n` will be strip the newline character, leads to incorrect parsing. The test case only works since it has double new lines. Fix the code + test case.

Test:
- CI