### PR TITLE
Throw an exception for unsupported cases in accelerated DAGs

### DIFF
--- a/python/ray/dag/BUILD
+++ b/python/ray/dag/BUILD
@@ -115,7 +115,7 @@ py_test_module_list(
 )
 
 py_test_module_list(
-    size = "medium",
+    size = "large",
     files = [
         "tests/experimental/test_accelerated_dag.py",
     ],

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -809,7 +809,8 @@ class CompiledDAG:
                 if read_by_driver:
                     if len(readers) != 1:
                         raise ValueError(
-                            "DAG outputs currently cannot be read by other actor tasks."
+                            "DAG outputs currently can only be read by the driver--not "
+                            "the driver and actors."
                         )
                     # This node is a multi-output node, which means that it will only be
                     # read by the driver, not an actor. Thus, we handle this case by

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -800,8 +800,17 @@ class CompiledDAG:
                 # in the DAG.
                 readers = [self.idx_to_task[idx] for idx in task.downstream_node_idxs]
 
-                if isinstance(readers[0].dag_node, MultiOutputNode):
-                    assert len(readers) == 1
+                dag_nodes = [reader.dag_node for reader in readers]
+                read_by_driver = False
+                for dag_node in dag_nodes:
+                    if isinstance(dag_node, MultiOutputNode):
+                        read_by_driver = True
+                        break
+                if read_by_driver:
+                    if len(readers) != 1:
+                        raise ValueError(
+                            "DAG outputs currently cannot be read by other actor tasks."
+                        )
                     # This node is a multi-output node, which means that it will only be
                     # read by the driver, not an actor. Thus, we handle this case by
                     # setting `reader_handles` to `[self._driver_actor]`.

--- a/python/ray/dag/context.py
+++ b/python/ray/dag/context.py
@@ -18,6 +18,13 @@ DEFAULT_ASYNCIO_MAX_QUEUE_SIZE = int(
 # The maximum memory usage for buffered results is 1 GB.
 DEFAULT_MAX_BUFFERED_RESULTS = int(os.environ.get("RAY_DAG_max_buffered_results", 1000))
 
+# We still need to add support for transferring objects that are larger than the gRPC
+# payload limit, which Ray sets to ~512 MiB (so we set it slightly lower here to be
+# safe).
+# TODO(jhumphri): Add support for transferring objects that are larger than the gRPC
+# payload limit. We can support this by breaking an object into multiple RPCs.
+GRPC_MAX_PAYLOAD = int(1024 * 1024 * 450)  # 450 MiB
+
 
 @DeveloperAPI
 @dataclass

--- a/python/ray/dag/context.py
+++ b/python/ray/dag/context.py
@@ -23,7 +23,7 @@ DEFAULT_MAX_BUFFERED_RESULTS = int(os.environ.get("RAY_DAG_max_buffered_results"
 # safe).
 # TODO(jhumphri): Add support for transferring objects that are larger than the gRPC
 # payload limit. We can support this by breaking an object into multiple RPCs.
-GRPC_MAX_PAYLOAD = int(1024 * 1024 * 450)  # 450 MiB
+MAX_GRPC_PAYLOAD = int(1024 * 1024 * 450)  # 450 MiB
 
 
 @DeveloperAPI
@@ -54,11 +54,15 @@ class DAGContext:
             executions is beyond the DAG capacity, the new execution would
             be blocked in the first place; therefore, this limit is only
             enforced when it is smaller than the DAG capacity.
+        max_grpc_payload: The maximum payload size that fits within a single gRPC.
+            Currently, mutable objects larger than this size cannot can sent via a
+            multi-node channel, though we plan to support this in the future.
     """
 
     buffer_size_bytes: int = DEFAULT_BUFFER_SIZE_BYTES
     asyncio_max_queue_size: int = DEFAULT_ASYNCIO_MAX_QUEUE_SIZE
     max_buffered_results: int = DEFAULT_MAX_BUFFERED_RESULTS
+    max_grpc_payload: int = MAX_GRPC_PAYLOAD
 
     @staticmethod
     def get_current() -> "DAGContext":

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1036,8 +1036,8 @@ def test_driver_and_actor_as_readers(ray_start_cluster):
 
 def test_readers_on_different_nodes(ray_start_cluster):
     cluster = ray_start_cluster
-    # This node is for the driver (including the DriverHelperActor) and one of the
-    # readers.
+    # This node is for the driver (including the CompiledDAG.DAGDriverProxyActor) and
+    # one of the readers.
     first_node_handle = cluster.add_node(num_cpus=2)
     # This node is for the other reader.
     second_node_handle = cluster.add_node(num_cpus=1)
@@ -1082,8 +1082,8 @@ def test_readers_on_different_nodes(ray_start_cluster):
 
 def test_bunch_readers_on_different_nodes(ray_start_cluster):
     cluster = ray_start_cluster
-    # This node is for the driver (including the DriverHelperActor) and two of the
-    # readers.
+    # This node is for the driver (including the CompiledDAG.DAGDriverProxyActor) and
+    # two of the readers.
     first_node_handle = cluster.add_node(num_cpus=3)
     # This node is for the other two readers.
     second_node_handle = cluster.add_node(num_cpus=2)

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1018,6 +1018,7 @@ def test_channel_access_after_close(ray_start_regular_shared):
     with pytest.raises(RayChannelError, match="Channel closed."):
         ray.get(ref)
 
+
 def test_driver_and_actor_as_readers(ray_start_cluster):
     a = Actor.remote(0)
     b = Actor.remote(10)

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1018,7 +1018,7 @@ def test_channel_access_after_close(ray_start_regular_shared):
     with pytest.raises(RayChannelError, match="Channel closed."):
         ray.get(ref)
 
-def test_driver_and_actor_as_readers(ray_start_regular):
+def test_driver_and_actor_as_readers(ray_start_cluster):
     a = Actor.remote(0)
     b = Actor.remote(10)
     with InputNode() as inp:

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -300,8 +300,9 @@ class Channel(ChannelInterface):
 
             if typ.buffer_size_bytes > GRPC_MAX_PAYLOAD:
                 raise ValueError(
-                    "The object written to the channel must have a size less than or "
-                    f"equal to the max gRPC payload size ({GRPC_MAX_PAYLOAD} bytes)."
+                    "The reader and writer are on different nodes, so the object "
+                    "written to the channel must have a size less than or equal to "
+                    f"the max gRPC payload size ({GRPC_MAX_PAYLOAD} bytes)."
                 )
             self._num_readers = 1
 
@@ -408,8 +409,9 @@ class Channel(ChannelInterface):
 
         if size > GRPC_MAX_PAYLOAD and self.is_remote():
             raise ValueError(
-                "The object written to the channel must have a size less than or equal "
-                f"to the max gRPC payload size ({GRPC_MAX_PAYLOAD} bytes)."
+                "The reader and writer are on different nodes, so the object written "
+                "to the channel must have a size less than or equal to the max gRPC "
+                f"payload size ({GRPC_MAX_PAYLOAD} bytes)."
             )
         if size > self._typ.buffer_size_bytes:
             # Now make the channel backing store larger.

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -301,7 +301,7 @@ class Channel(ChannelInterface):
             if typ.buffer_size_bytes > GRPC_MAX_PAYLOAD:
                 raise ValueError(
                     "The object written to the channel must have a size less than or "
-                    f"equal to the max gRPC payload size ({GRPC_MAX_PAYLOAD} bytes)"
+                    f"equal to the max gRPC payload size ({GRPC_MAX_PAYLOAD} bytes)."
                 )
             self._num_readers = 1
 
@@ -409,7 +409,7 @@ class Channel(ChannelInterface):
         if size > GRPC_MAX_PAYLOAD and self.is_remote():
             raise ValueError(
                 "The object written to the channel must have a size less than or equal "
-                f"to the max gRPC payload size ({GRPC_MAX_PAYLOAD} bytes)"
+                f"to the max gRPC payload size ({GRPC_MAX_PAYLOAD} bytes)."
             )
         if size > self._typ.buffer_size_bytes:
             # Now make the channel backing store larger.

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -884,8 +884,9 @@ def test_payload_too_large(ray_start_cluster):
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "The object written to the channel must have a size less than or equal to "
-            "the max gRPC payload size (471859200 bytes)."
+            "The reader and writer are on different nodes, so the object written to "
+            "the channel must have a size less than or equal to the max gRPC payload "
+            "size (471859200 bytes)."
         ),
     ):
         ray_channel.Channel(None, [a], 1024 * 1024 * 512)
@@ -935,8 +936,9 @@ def test_payload_resize_too_large(ray_start_cluster):
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "The object written to the channel must have a size less than or equal to "
-            "the max gRPC payload size (471859200 bytes)."
+            "The reader and writer are on different nodes, so the object written to "
+            "the channel must have a size less than or equal to the max gRPC payload "
+            "size (471859200 bytes)."
         ),
     ):
         chan.write(b"x" * (1024 * 1024 * 512))

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -56,8 +56,8 @@ def test_driver_as_reader(ray_start_cluster, remote):
         # This node is for the writer actor.
         cluster.add_node(num_cpus=1)
     else:
-        # This node is for both the driver (including the DriverHelperActor) and the
-        # writer actor.
+        # This node is for both the driver (including the
+        # CompiledDAG.DAGDriverProxyActor) and the writer actor.
         cluster.add_node(num_cpus=2)
         ray.init(address=cluster.address)
 
@@ -95,8 +95,8 @@ def test_driver_as_reader_with_resize(ray_start_cluster, remote):
         # This node is for the writer actor.
         cluster.add_node(num_cpus=1)
     else:
-        # This node is for both the driver (including the DriverHelperActor) and the
-        # writer actor.
+        # This node is for both the driver (including the
+        # CompiledDAG.DAGDriverProxyActor) and the writer actor.
         cluster.add_node(num_cpus=2)
         ray.init(address=cluster.address)
 
@@ -785,8 +785,8 @@ def test_composite_channel_multiple_readers(ray_start_cluster):
 )
 def test_put_error(ray_start_cluster):
     cluster = ray_start_cluster
-    # This node is for both the driver (including the DriverHelperActor) and the
-    # writer actor.
+    # This node is for both the driver (including the CompiledDAG.DAGDriverProxyActor)
+    # and the writer actor.
     cluster.add_node(num_cpus=2)
     ray.init(address=cluster.address)
 
@@ -944,8 +944,8 @@ def test_payload_resize_too_large(ray_start_cluster):
 )
 def test_readers_on_different_nodes(ray_start_cluster):
     cluster = ray_start_cluster
-    # This node is for the driver (including the DriverHelperActor) and one of the
-    # readers.
+    # This node is for the driver (including the CompiledDAG.DAGDriverProxyActor) and
+    # one of the readers.
     first_node_handle = cluster.add_node(num_cpus=2)
     # This node is for the other reader.
     second_node_handle = cluster.add_node(num_cpus=1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR throws an exception for unsupported cases in DAGs. These cases are listed below. We plan to support these in the future.
1. An object larger than the gRPC payload size is written to a shared memory channel
2. Reader actors are on different nodes
3. This TODO: https://github.com/ray-project/ray/blob/692c0ec37b680f05b9ff14e371bccf6dddd2c8f0/python/ray/dag/compiled_dag_node.py#L722

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #45603

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
