### PR TITLE
[RLlib] Make Tune trial ID available in EnvRunners (and callbacks).

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -623,6 +623,7 @@ class Algorithm(Trainable, AlgorithmBase):
             num_env_runners=self.config.num_env_runners,
             local_env_runner=True,
             logdir=self.logdir,
+            tune_trial_id=self.trial_id,
         )
 
         # Compile, validate, and freeze an evaluation config.
@@ -649,6 +650,7 @@ class Algorithm(Trainable, AlgorithmBase):
                 config=self.evaluation_config,
                 num_env_runners=self.config.evaluation_num_env_runners,
                 logdir=self.logdir,
+                tune_trial_id=self.trial_id,
             )
 
         self.evaluation_dataset = None

--- a/rllib/env/env_runner.py
+++ b/rllib/env/env_runner.py
@@ -7,7 +7,7 @@ from ray.rllib.utils.actor_manager import FaultAwareApply
 from ray.rllib.utils.annotations import OldAPIStack
 from ray.rllib.utils.framework import try_import_tf
 from ray.rllib.utils.torch_utils import convert_to_torch_tensor
-from ray.rllib.utils.typing import TensorType
+from ray.rllib.utils.typing import ModuleID, TensorType
 
 if TYPE_CHECKING:
     from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
@@ -80,6 +80,8 @@ class EnvRunner(FaultAwareApply, metaclass=abc.ABCMeta):
     def get_state(
         self,
         components: Optional[Container[str]] = None,
+        *,
+        module_ids: Optional[Container[ModuleID]] = None,
         inference_only: bool = False,
     ) -> Dict[str, Any]:
         """Returns this EnvRunner's (possibly serialized) current state as a dict.
@@ -90,6 +92,9 @@ class EnvRunner(FaultAwareApply, metaclass=abc.ABCMeta):
                 of the state is expensive (e.g. reading/compiling the weights of a large
                 NN) and at the same time, these components are not required by the
                 caller.
+            module_ids: An optional container of ModuleIDs to return. Only applies, if
+                components contains the "rl_module" key. Allows for selecting only
+                specific single-agent RLModules within a MultiAgentRLModule.
             inference_only: Whether to return the inference-only weight set of the
                 underlying RLModule. Note that this setting only has an effect if
                 components is None or the string "rl_module" is in components.

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -80,6 +80,7 @@ class EnvRunnerGroup:
         local_env_runner: bool = True,
         logdir: Optional[str] = None,
         _setup: bool = True,
+        tune_trial_id: Optional[str] = None,
         # Deprecated args.
         num_workers=DEPRECATED_VALUE,
         local_worker=DEPRECATED_VALUE,
@@ -132,6 +133,7 @@ class EnvRunnerGroup:
             "resources": self._remote_config.custom_resources_per_env_runner,
             "max_restarts": config.max_num_env_runner_restarts,
         }
+        self._tune_trial_id = tune_trial_id
 
         # Set the EnvRunner subclass to be used as "workers". Default: RolloutWorker.
         self.env_runner_cls = config.env_runner_cls
@@ -1166,6 +1168,7 @@ class EnvRunnerGroup:
             log_dir=self._logdir,
             spaces=spaces,
             dataset_shards=self._ds_shards,
+            tune_trial_id=self._tune_trial_id,
         )
 
         return worker

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -68,6 +68,7 @@ class MultiAgentEnvRunner(EnvRunner):
 
         # Get the worker index on which this instance is running.
         self.worker_index: int = kwargs.get("worker_index")
+        self.tune_trial_id: str = kwargs.get("tune_trial_id")
 
         # Set up all metrics-related structures and counters.
         self.metrics: Optional[MetricsLogger] = None

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -41,7 +41,7 @@ from ray.rllib.utils.metrics import (
 )
 from ray.rllib.utils.metrics.metrics_logger import MetricsLogger
 from ray.rllib.utils.spaces.space_utils import unbatch
-from ray.rllib.utils.typing import EpisodeID, ModelWeights, ResultDict
+from ray.rllib.utils.typing import EpisodeID, ModelWeights, ModuleID, ResultDict
 from ray.tune.registry import ENV_CREATOR, _global_registry
 from ray.util.annotations import PublicAPI
 
@@ -63,7 +63,8 @@ class SingleAgentEnvRunner(EnvRunner):
         """
         super().__init__(config=config)
 
-        self.worker_index = kwargs.get("worker_index")
+        self.worker_index: int = kwargs.get("worker_index")
+        self.tune_trial_id: str = kwargs.get("tune_trial_id")
 
         # Create a MetricsLogger object for logging custom stats.
         self.metrics = MetricsLogger()
@@ -643,8 +644,8 @@ class SingleAgentEnvRunner(EnvRunner):
         self,
         components: Optional[Container[str]] = None,
         *,
+        module_ids: Optional[Container[ModuleID]] = None,
         inference_only: bool = True,
-        module_ids=None,
     ) -> Dict[str, Any]:
         components = force_list(
             components

--- a/rllib/evaluation/rollout_worker.py
+++ b/rllib/evaluation/rollout_worker.py
@@ -68,7 +68,6 @@ from ray.rllib.policy.torch_policy_v2 import TorchPolicyV2
 from ray.rllib.utils import force_list
 from ray.rllib.utils.annotations import OldAPIStack, override
 from ray.rllib.utils.debug import summarize, update_global_seed_if_necessary
-from ray.rllib.utils.deprecation import DEPRECATED_VALUE, deprecation_warning
 from ray.rllib.utils.error import ERR_MSG_NO_GPUS, HOWTO_CHANGE_CONFIG
 from ray.rllib.utils.filter import Filter, NoFilter, get_filter
 from ray.rllib.utils.framework import try_import_tf, try_import_torch
@@ -233,8 +232,7 @@ class RolloutWorker(ParallelIteratorWorker, EnvRunner):
         spaces: Optional[Dict[PolicyID, Tuple[Space, Space]]] = None,
         default_policy_class: Optional[Type[Policy]] = None,
         dataset_shards: Optional[List[ray.data.Dataset]] = None,
-        # Deprecated: This is all specified in `config` anyways.
-        tf_session_creator=DEPRECATED_VALUE,  # Use config.tf_session_options instead.
+        **kwargs,
     ):
         """Initializes a RolloutWorker instance.
 
@@ -256,15 +254,6 @@ class RolloutWorker(ParallelIteratorWorker, EnvRunner):
                 to (obs_space, action_space)-tuples. This is used in case no
                 Env is created on this RolloutWorker.
         """
-        # Deprecated args.
-        if tf_session_creator != DEPRECATED_VALUE:
-            deprecation_warning(
-                old="RolloutWorker(.., tf_session_creator=.., ..)",
-                new="config.framework(tf_session_args={..}); "
-                "RolloutWorker(config=config, ..)",
-                error=True,
-            )
-
         self._original_kwargs: dict = locals().copy()
         del self._original_kwargs["self"]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Make Tune trial ID available in EnvRunners (and callbacks).
* EnvRunners get a `self.tune_trial_id` property.
* This property is available in all env-runner based callbacks via the `env_runner` arg (access `env_runner.tune_trial_id` inside your callbacks).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
