### PR TITLE
[doc] fix module visited check

### DIFF
--- a/ci/ray_ci/doc/module.py
+++ b/ci/ray_ci/doc/module.py
@@ -29,7 +29,7 @@ class Module:
         Depth-first search through the module and its children to find annotated classes
         and functions.
         """
-        if module in self._visited:
+        if module.__hash__ in self._visited:
             return
         self._visited.add(module.__hash__)
 

--- a/ci/ray_ci/doc/test_module.py
+++ b/ci/ray_ci/doc/test_module.py
@@ -1,5 +1,6 @@
 import sys
 import pytest
+import importlib
 
 from ci.ray_ci.doc.module import Module
 from ci.ray_ci.doc.api import AnnotationType, CodeType
@@ -14,6 +15,8 @@ def test_walk():
     assert apis[1].name == "ci.ray_ci.doc.mock.mock_module.mock_function"
     assert apis[1].annotation_type.value == AnnotationType.DEPRECATED.value
     assert apis[1].code_type.value == CodeType.FUNCTION.value
+    assert module._module.__hash__ in module._visited
+    assert module._module not in module._visited
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/doc/test_module.py
+++ b/ci/ray_ci/doc/test_module.py
@@ -1,6 +1,5 @@
 import sys
 import pytest
-import importlib
 
 from ci.ray_ci.doc.module import Module
 from ci.ray_ci.doc.api import AnnotationType, CodeType


### PR DESCRIPTION
We are using `module.__hash__` as the cache for recursively go through all child modules; but the check is on the `module` object. Surprise that we don't hit infinite loop for data APIs.

Test:
- CI