### PR TITLE
Fix for incorrect channel read behavior after accelerated DAG teardown

### DIFF
--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1011,11 +1011,11 @@ def test_channel_access_after_close(ray_start_regular_shared):
         dag = a.foo.bind(inp)
 
     dag = dag.experimental_compile()
-    x = dag.execute(1)
+    ref = dag.execute(1)
     dag.teardown()
 
     with pytest.raises(RayChannelError, match="Channel closed."):
-        ray.get(x)
+        ray.get(ref)
 
 
 if __name__ == "__main__":

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -998,7 +998,7 @@ class TestCompositeChannel:
         compiled_dag.teardown()
 
 
-def test_channel_access_after_close(ray_start_regular):
+def test_channel_access_after_close(ray_start_regular_shared):
     # Tests that an access to a channel after accelerated DAG teardown raises a
     # RayChannelError exception as the channel is closed (see issue #46284).
     @ray.remote

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -998,6 +998,26 @@ class TestCompositeChannel:
         compiled_dag.teardown()
 
 
+def test_channel_access_after_close(ray_start_regular):
+    # Tests that an access to a channel after accelerated DAG teardown raises a
+    # RayChannelError exception as the channel is closed (see issue #46284).
+    @ray.remote
+    class Actor:
+        def foo(self, arg):
+            return arg
+
+    a = Actor.remote()
+    with InputNode() as inp:
+        dag = a.foo.bind(inp)
+
+    dag = dag.experimental_compile()
+    x = dag.execute(1)
+    dag.teardown()
+
+    with pytest.raises(RayChannelError, match="Channel closed."):
+        ray.get(x)
+
+
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1564,12 +1564,10 @@ Status CoreWorker::Get(const std::vector<ObjectID> &ids,
       // The channel is not registered but the error bit is set (likely because the
       // channel was previously open and then was closed), so we should return an error.
       return error_set;
-    } else {
-      if (is_experimental_channel) {
+    } else if (is_experimental_channel) {
         return Status::NotImplemented(
             "ray.get can only be called on all normal objects, or all "
             "experimental.Channel objects");
-      }
     }
   }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1554,16 +1554,16 @@ Status CoreWorker::Get(const std::vector<ObjectID> &ids,
   // Check whether these are experimental.Channel objects.
   bool is_experimental_channel = false;
   for (const ObjectID &id : ids) {
-    Status ret = experimental_mutable_object_provider_->IsExperimentalChannel(id);
-    if (ret.ok()) {
+    Status status = experimental_mutable_object_provider_->GetChannelStatus(id);
+    if (status.ok()) {
       is_experimental_channel = true;
       // We continue rather than break because we want to check that *all* of the
       // objects are either experimental or not experimental. We cannot have a mix of
       // the two.
       continue;
-    } else if (ret.IsChannelError()) {
+    } else if (status.IsChannelError()) {
       // The channel has been closed.
-      return ret;
+      return status;
     } else if (is_experimental_channel) {
       return Status::NotImplemented(
           "ray.get can only be called on all normal objects, or all "

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1565,9 +1565,9 @@ Status CoreWorker::Get(const std::vector<ObjectID> &ids,
       // channel was previously open and then was closed), so we should return an error.
       return error_set;
     } else if (is_experimental_channel) {
-        return Status::NotImplemented(
-            "ray.get can only be called on all normal objects, or all "
-            "experimental.Channel objects");
+      return Status::NotImplemented(
+          "ray.get can only be called on all normal objects, or all "
+          "experimental.Channel objects");
     }
   }
 

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -431,8 +431,8 @@ Status MutableObjectManager::SetErrorAll() {
 Status MutableObjectManager::IsErrorSet(const ObjectID &object_id) {
   Channel *channel = GetChannel(object_id);
   if (!channel) {
-    return Status::NotFound(absl::StrFormat("Could not find channel for object ID %s.",
-                                            object_id.Hex()));
+    return Status::NotFound(
+        absl::StrFormat("Could not find channel for object ID %s.", object_id.Hex()));
   }
   return channel->mutable_object->header->CheckHasError();
 }

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -437,7 +437,6 @@ Status MutableObjectManager::IsErrorSet(const ObjectID &object_id) {
   return channel->mutable_object->header->CheckHasError();
 }
 
-
 #else  // defined(__APPLE__) || defined(__linux__)
 
 MutableObjectManager::~MutableObjectManager() {}

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -428,6 +428,16 @@ Status MutableObjectManager::SetErrorAll() {
   return ret;
 }
 
+Status MutableObjectManager::IsErrorSet(const ObjectID &object_id) {
+  Channel *channel = GetChannel(object_id);
+  if (!channel) {
+    return Status::NotFound(absl::StrFormat("Could not find channel for object ID %s.",
+                                            object_id.Hex()));
+  }
+  return channel->mutable_object->header->CheckHasError();
+}
+
+
 #else  // defined(__APPLE__) || defined(__linux__)
 
 MutableObjectManager::~MutableObjectManager() {}
@@ -495,6 +505,10 @@ Status MutableObjectManager::SetErrorInternal(const ObjectID &object_id) {
 }
 
 Status MutableObjectManager::SetErrorAll() {
+  return Status::NotImplemented("Not supported on Windows.");
+}
+
+Status MutableObjectManager::IsErrorSet(const ObjectID &object_id) {
   return Status::NotImplemented("Not supported on Windows.");
 }
 

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -428,7 +428,7 @@ Status MutableObjectManager::SetErrorAll() {
   return ret;
 }
 
-Status MutableObjectManager::IsErrorSet(const ObjectID &object_id) {
+Status MutableObjectManager::IsChannelClosed(const ObjectID &object_id) {
   Channel *channel = GetChannel(object_id);
   if (!channel) {
     return Status::NotFound(
@@ -507,7 +507,7 @@ Status MutableObjectManager::SetErrorAll() {
   return Status::NotImplemented("Not supported on Windows.");
 }
 
-Status MutableObjectManager::IsErrorSet(const ObjectID &object_id) {
+Status MutableObjectManager::IsChannelClosed(const ObjectID &object_id) {
   return Status::NotImplemented("Not supported on Windows.");
 }
 

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -196,11 +196,14 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   ///         error bit set (i.e., the channel is closed).
   Status IsChannelClosed(const ObjectID &object_id);
 
- private:
-  // Returns the channel for object_id. If no channel exists for object_id, returns
-  // nullptr.
+  /// Returns the channel for object_id. If no channel exists for object_id, returns
+  /// nullptr.
+  ///
+  /// \param[in] object_id The ID of the object.
+  /// \return The channel or nullptr.
   Channel *GetChannel(const ObjectID &object_id);
 
+ private:
   // Returns the plasma object header for the object.
   PlasmaObjectHeader *GetHeader(const ObjectID &object_id);
 

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -189,12 +189,12 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   /// an error on acquire.
   Status SetErrorAll();
 
-  /// Checks if the error bit is set for the channel.
+  /// Checks if the channel is closed.
   ///
   /// \param[in] object_id The ID of the object.
   /// \return Status indicating whether the object (if a channel for it exists) has its
-  ///         error bit set.
-  Status IsErrorSet(const ObjectID &object_id);
+  ///         error bit set (i.e., the channel is closed).
+  Status IsChannelClosed(const ObjectID &object_id);
 
  private:
   // Returns the channel for object_id. If no channel exists for object_id, returns

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -103,14 +103,15 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   /// Checks if a channel is registered for an object.
   ///
   /// \param[in] object_id The ID of the object.
-  /// The return status. True if the channel is registered for object_id, false otherwise.
+  /// \return The return status. True if the channel is registered for object_id, false
+  ///         otherwise.
   bool ChannelRegistered(const ObjectID &object_id) { return GetChannel(object_id); }
 
   /// Checks if a reader channel is registered for an object.
   ///
   /// \param[in] object_id The ID of the object.
-  /// The return status. True if the channel is registered as a reader for object_id,
-  /// false otherwise.
+  /// \return The return status. True if the channel is registered as a reader for
+  ///         object_id, false otherwise.
   bool ReaderChannelRegistered(const ObjectID &object_id) {
     Channel *c = GetChannel(object_id);
     if (!c) {
@@ -122,8 +123,8 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   /// Checks if a writer channel is registered for an object.
   ///
   /// \param[in] object_id The ID of the object.
-  /// The return status. True if the channel is registered as a writer for object_id,
-  /// false otherwise.
+  /// \return The return status. True if the channel is registered as a writer for
+  ///         object_id, false otherwise.
   bool WriterChannelRegistered(const ObjectID &object_id) {
     Channel *c = GetChannel(object_id);
     if (!c) {
@@ -188,9 +189,17 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   /// an error on acquire.
   Status SetErrorAll();
 
-  Channel *GetChannel(const ObjectID &object_id);
+  /// Checks if the error bit is set for the channel.
+  ///
+  /// \param[in] object_id The ID of the object.
+  /// \return Status indicating whether the object (if a channel for it exists) has its
+  ///         error bit set.
+  Status IsErrorSet(const ObjectID &object_id);
 
  private:
+  // Returns the channel for object_id. If not channel exists for object_id, returns nullptr.
+  Channel *GetChannel(const ObjectID &object_id);
+
   // Returns the plasma object header for the object.
   PlasmaObjectHeader *GetHeader(const ObjectID &object_id);
 

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -197,7 +197,8 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   Status IsErrorSet(const ObjectID &object_id);
 
  private:
-  // Returns the channel for object_id. If not channel exists for object_id, returns nullptr.
+  // Returns the channel for object_id. If no channel exists for object_id, returns
+  // nullptr.
   Channel *GetChannel(const ObjectID &object_id);
 
   // Returns the plasma object header for the object.

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -166,8 +166,23 @@ Status MutableObjectProvider::SetError(const ObjectID &object_id) {
   return object_manager_->SetError(object_id);
 }
 
-Status MutableObjectProvider::IsErrorSet(const ObjectID &object_id) {
-  return object_manager_->IsErrorSet(object_id);
+Status MutableObjectProvider::IsChannelClosed(const ObjectID &object_id) {
+  return object_manager_->IsChannelClosed(object_id);
+}
+
+Status MutableObjectProvider::IsExperimentalChannel(const ObjectID &object_id) {
+  if (ReaderChannelRegistered(object_id)) {
+    return Status::OK();
+  }
+
+  Status closed = IsChannelClosed(object_id);
+  if (closed.IsChannelError()) {
+    // The channel is not registered but the error bit is set (likely because the
+    // channel was previously open and then was closed), so we should return an error.
+    return closed;
+  }
+  return Status::ObjectNotFound(
+      "This object is not registered as an experimental channel.");
 }
 
 void MutableObjectProvider::PollWriterClosure(

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -166,6 +166,10 @@ Status MutableObjectProvider::SetError(const ObjectID &object_id) {
   return object_manager_->SetError(object_id);
 }
 
+Status MutableObjectProvider::IsErrorSet(const ObjectID &object_id) {
+  return object_manager_->IsErrorSet(object_id);
+}
+
 void MutableObjectProvider::PollWriterClosure(
     instrumented_io_context &io_context,
     const ObjectID &object_id,

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -166,23 +166,11 @@ Status MutableObjectProvider::SetError(const ObjectID &object_id) {
   return object_manager_->SetError(object_id);
 }
 
-Status MutableObjectProvider::IsChannelClosed(const ObjectID &object_id) {
-  return object_manager_->IsChannelClosed(object_id);
-}
-
-Status MutableObjectProvider::IsExperimentalChannel(const ObjectID &object_id) {
+Status MutableObjectProvider::GetChannelStatus(const ObjectID &object_id) {
   if (ReaderChannelRegistered(object_id)) {
     return Status::OK();
   }
-
-  Status closed = IsChannelClosed(object_id);
-  if (closed.IsChannelError()) {
-    // The channel is not registered but the error bit is set (likely because the
-    // channel was previously open and then was closed), so we should return an error.
-    return closed;
-  }
-  return Status::ObjectNotFound(
-      "This object is not registered as an experimental channel.");
+  return object_manager_->IsChannelClosed(object_id);
 }
 
 void MutableObjectProvider::PollWriterClosure(

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -135,7 +135,7 @@ class MutableObjectProvider {
   /// 1. Status::OK()
   //     - The channel is registered and open.
   /// 2. Status::ChannelError()
-  ///    - The channel was is registered and was previously open, is now closed.
+  ///    - The channel was registered and previously open, but is now closed.
   /// 3. Status::NotFound()
   ///    - No channel exists for this object.
   ///

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -131,12 +131,21 @@ class MutableObjectProvider {
   /// \param[in] object_id The ID of the object.
   Status SetError(const ObjectID &object_id);
 
-  /// Checks if the error bit is set for the channel.
+  /// Checks if the channel is closed.
   ///
   /// \param[in] object_id The ID of the object.
   /// \return Status indicating whether the object (if a channel for it exists) has its
-  ///         error bit set.
-  Status IsErrorSet(const ObjectID &object_id);
+  ///         error bit set (i.e., the channel is closed).
+  Status IsChannelClosed(const ObjectID &object_id);
+
+  /// Checks if the object is a ref for an experimental channel.
+  ///
+  /// param[in] object_id The ID of the object.
+  /// \return Status indicating whether the object is a ref for an experimental channel
+  ///         (Status::OK()), a ref for a closed experimental channel
+  ///         (Status::ChannelError()), or not a ref for an experimental channel
+  ///         (Status::ObjectNotFound()).
+  Status IsExperimentalChannel(const ObjectID &object_id);
 
  private:
   struct LocalReaderInfo {

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -131,6 +131,13 @@ class MutableObjectProvider {
   /// \param[in] object_id The ID of the object.
   Status SetError(const ObjectID &object_id);
 
+  /// Checks if the error bit is set for the channel.
+  ///
+  /// \param[in] object_id The ID of the object.
+  /// \return Status indicating whether the object (if a channel for it exists) has its
+  ///         error bit set.
+  Status IsErrorSet(const ObjectID &object_id);
+
  private:
   struct LocalReaderInfo {
     int64_t num_readers;

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -131,21 +131,17 @@ class MutableObjectProvider {
   /// \param[in] object_id The ID of the object.
   Status SetError(const ObjectID &object_id);
 
-  /// Checks if the channel is closed.
+  /// Returns the current status of the channel for the object. Possible statuses are:
+  /// 1. Status::OK()
+  //     - The channel is registered and open.
+  /// 2. Status::ChannelError()
+  ///    - The channel was is registered and was previously open, is now closed.
+  /// 3. Status::NotFound()
+  ///    - No channel exists for this object.
   ///
   /// \param[in] object_id The ID of the object.
-  /// \return Status indicating whether the object (if a channel for it exists) has its
-  ///         error bit set (i.e., the channel is closed).
-  Status IsChannelClosed(const ObjectID &object_id);
-
-  /// Checks if the object is a ref for an experimental channel.
-  ///
-  /// param[in] object_id The ID of the object.
-  /// \return Status indicating whether the object is a ref for an experimental channel
-  ///         (Status::OK()), a ref for a closed experimental channel
-  ///         (Status::ChannelError()), or not a ref for an experimental channel
-  ///         (Status::ObjectNotFound()).
-  Status IsExperimentalChannel(const ObjectID &object_id);
+  /// \return Current status of the channel.
+  Status GetChannelStatus(const ObjectID &object_id);
 
  private:
   struct LocalReaderInfo {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Prior to this PR (described in #46284), calling `ray.get()` on a `CompiledDAGRef` (i.e., a channel) after DAG teardown would return a large series of zeroes. This issue could be reproduced with this script:
```
import ray
from ray.dag import InputNode

@ray.remote
class Actor:
    def foo(self, arg):
        return arg
        
a = Actor.remote()
with InputNode() as inp:
    dag = a.foo.bind(inp)
    
dag = dag.experimental_compile()
x = dag.execute(1)
dag.teardown()
# `ray.get(x)` returns a large series of zeroes.
print(ray.get(x))
```

This issue happened because the channel was unregistered with the mutable object manager on DAG teardown, and thus on a subsequent access to the channel, the core worker thought the channel reference was for a normal immutable Ray object rather than for a channel mutable object. Thus, the core worker was returning the raw underlying memory for the mutable object, and the memory buffers were sized equal to the total size of the underlying memory, not the amount of data in the mutable object.

This PR fixes this issue by properly checking that a channel is either currently registered or previously registered, rather than just checking only that the channel is currently registered.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #46284

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
