### PR TITLE
fixed a typo in ValueError message for contains_tensor

### DIFF
--- a/python/ray/train/_internal/session.py
+++ b/python/ray/train/_internal/session.py
@@ -406,7 +406,7 @@ class _TrainSession:
 
             if contains_tensor(metrics):
                 raise ValueError(
-                    "Passing objects containg Torch tensors as metrics "
+                    "Passing objects containing Torch tensors as metrics "
                     "is not supported as it will throw an exception on "
                     "deserialization. You can either convert the tensors "
                     "to Python objects or report a `train.Checkpoint` "


### PR DESCRIPTION
## Why are these changes needed?

I've been seeing this typo when I was using Ray at work from a long time and wanted to fix it

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy (I just fixed a typo in the error message so it's not needed) 
   - [] Unit tests
   - [] Release tests
   - [X] This PR is not tested :(
