### PR TITLE
[Docker] Upgrade base deps docker python env to 3.9.7

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -13,7 +13,7 @@ ENV LANG=C.UTF-8
 # TODO(ilr) $HOME seems to point to result in "" instead of "/home/ray"
 ENV PATH "/home/ray/anaconda3/bin:$PATH"
 ARG DEBIAN_FRONTEND=noninteractive
-ARG PYTHON_VERSION=3.8.16
+ARG PYTHON_VERSION=3.9.7
 ARG HOSTTYPE=${HOSTTYPE:-x86_64}
 
 ARG RAY_UID=1000


### PR DESCRIPTION
## Why are these changes needed?

Due to CI remove 3.8 from ray supported python list, need to upgrade base deps docker python version.

## Related issue number

Closes #45622

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., git commit -s) in this PR.
- [x] I've run scripts/format.sh to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in doc/source/tune/api/ under the 
           corresponding .rst file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(