### PR TITLE
[Data] Make `GroupedData.map_groups()` allow partial callables

### DIFF
--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -251,7 +251,7 @@ class GroupedData:
 
         # Change the name of the wrapped function so that users see the name of their
         # function rather than `wrapped_fn` in the progress bar.
-        wrapped_fn.__name__ = getattr(fn, '__name__', 'wrapped_fn')
+        wrapped_fn.__name__ = getattr(fn, "__name__", "wrapped_fn")
 
         # Note we set batch_size=None here, so it will use the entire block as a batch,
         # which ensures that each group will be contained within a batch in entirety.

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -251,7 +251,7 @@ class GroupedData:
 
         # Change the name of the wrapped function so that users see the name of their
         # function rather than `wrapped_fn` in the progress bar.
-        wrapped_fn.__name__ = fn.__name__
+        wrapped_fn.__name__ = getattr(fn, '__name__', 'wrapped_fn')
 
         # Note we set batch_size=None here, so it will use the entire block as a batch,
         # which ensures that each group will be contained within a batch in entirety.

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -251,7 +251,7 @@ class GroupedData:
 
         # Change the name of the wrapped function so that users see the name of their
         # function rather than `wrapped_fn` in the progress bar.
-        wrapped_fn.__name__ = getattr(fn, "__name__", "wrapped_fn")
+        wrapped_fn.__name__ = getattr(fn, "__name__", getattr(fn, "__class__").__name__)
 
         # Note we set batch_size=None here, so it will use the entire block as a batch,
         # which ensures that each group will be contained within a batch in entirety.


### PR DESCRIPTION
## Why are these changes needed?
Partially parameterized callables (such as `functools.partial`) raise an `AttributeError` when used in `GroupedData.map_groups()` due to the lack of `__name__` attribute.

## Related issue number
Closes #46185 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
