### PR TITLE
[api] add oss tag to api lint check

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -21,6 +21,8 @@ steps:
       - documentation_style
 
   - label: ":lint-roller: lint: {{matrix}}"
+    tags:
+      - oss
     key: lint-medium
     instance_type: medium
     depends_on:


### PR DESCRIPTION
Add oss tag to api lint check; add both for that api annotation and api policy (they only matter for oss documentation, for now)

Tests:
- CI