### PR TITLE
[data] un-whitelist a bunch of fixed api documentations

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -23,6 +23,7 @@ steps:
   - label: ":lint-roller: lint: {{matrix}}"
     tags:
       - oss
+      - any_change
     key: lint-medium
     instance_type: medium
     depends_on:

--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -23,7 +23,7 @@ steps:
   - label: ":lint-roller: lint: {{matrix}}"
     tags:
       - oss
-      - any_change
+      - lint
     key: lint-medium
     instance_type: medium
     depends_on:

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -86,6 +86,8 @@ if __name__ == "__main__":
     RAY_CI_RELEASE_TESTS_AFFECTED = 0
     RAY_CI_COMPILED_PYTHON_AFFECTED = 0
     RAY_CI_ACCELERATED_DAG_AFFECTED = 0
+    # Whether to run jobs that are affected by any changes
+    RAY_CI_ANY_CHANGE_AFFECTED = 1
 
     if is_pull_request():
         commit_range = get_commit_range()
@@ -425,6 +427,7 @@ if __name__ == "__main__":
             "RAY_CI_ACCELERATED_DAG_AFFECTED={}".format(
                 RAY_CI_ACCELERATED_DAG_AFFECTED
             ),
+            "RAY_CI_ANY_CHANGE_AFFECTED={}".format(RAY_CI_ANY_CHANGE_AFFECTED),
         ]
     )
 

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     RAY_CI_COMPILED_PYTHON_AFFECTED = 0
     RAY_CI_ACCELERATED_DAG_AFFECTED = 0
     # Whether to run jobs that are affected by any changes
-    RAY_CI_ANY_CHANGE_AFFECTED = 1
+    RAY_CI_LINT_AFFECTED = 1
 
     if is_pull_request():
         commit_range = get_commit_range()
@@ -427,7 +427,7 @@ if __name__ == "__main__":
             "RAY_CI_ACCELERATED_DAG_AFFECTED={}".format(
                 RAY_CI_ACCELERATED_DAG_AFFECTED
             ),
-            "RAY_CI_ANY_CHANGE_AFFECTED={}".format(RAY_CI_ANY_CHANGE_AFFECTED),
+            "RAY_CI_LINT_AFFECTED={}".format(RAY_CI_LINT_AFFECTED),
         ]
     )
 

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -16,21 +16,6 @@ TEAM_API_CONFIGS = {
             "ray.data.dataset.MaterializedDataset",
             # special case where we cannot deprecate although we want to
             "ray.data.random_access_dataset.RandomAccessDataset",
-            # TODO(can): fix these
-            "ray.data.datasource.bigquery_datasource.BigQueryDatasource",
-            "ray.data.datasource.binary_datasource.BinaryDatasource",
-            "ray.data.datasource.csv_datasource.CSVDatasource",
-            "ray.data.datasource.json_datasource.JSONDatasource",
-            "ray.data.datasource.mongo_datasource.MongoDatasource",
-            "ray.data.datasource.numpy_datasource.NumpyDatasource",
-            "ray.data.datasource.parquet_bulk_datasource.ParquetBulkDatasource",
-            "ray.data.datasource.parquet_datasource.ParquetDatasource",
-            "ray.data.datasource.range_datasource.RangeDatasource",
-            "ray.data.datasource.sql_datasource.SQLDatasource",
-            "ray.data.datasource.text_datasource.TextDatasource",
-            "ray.data.datasource.webdataset_datasource.WebDatasetDatasource",
-            "ray.data.datasource.tfrecords_datasource.TFRecordDatasource",
-            "ray.data.datasource.tfrecords_datasource.TFXReadOptions",
         },
     },
 }


### PR DESCRIPTION
- Un-whitelist a bunch of api policy check; these methods are all fixed now
- A previous PR added the `oss` tag to the lint check, caused it to skip in microcheck/premerge because the determine_test_to_run doesn't not produce this `oss` tag. Add a `any_change` tag to go with `oss` tag, for jobs that we want to run everywhere.

Test:
- CI