### PR TITLE
[api] support comment lines in autosummary block

### DIFF
--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -58,6 +58,9 @@ class API:
             if line.strip().startswith(":"):
                 # option lines
                 continue
+            if line.strip().startswith(".."):
+                # comment lines
+                continue
             if not line.strip():
                 # empty lines
                 continue

--- a/ci/ray_ci/doc/test_api.py
+++ b/ci/ray_ci/doc/test_api.py
@@ -20,6 +20,7 @@ def test_from_autosummary():
                     "\t:toc\n"
                     "\n"
                     "\tfun_01\n"
+                    "\t.. this is a comment\n"
                     "\tfun_02\n"
                     "something else"
                 ),


### PR DESCRIPTION
The doc autosummary block can have comments (in addition to the list of apis, e.g. https://github.com/ray-project/ray/blob/master/doc/source/ray-core/api/utility.rst?plain=1#L14). 

Teach the parser to understand the comment lines.

Test:
- CI