### PR TITLE
[Dashboard] escape newline characters to pervent log message from bre…

### DIFF
--- a/dashboard/client/src/components/LogView/LogVirtualView.tsx
+++ b/dashboard/client/src/components/LogView/LogVirtualView.tsx
@@ -213,6 +213,9 @@ const LogVirtualView: React.FC<LogVirtualViewProps> = ({
       // Keep the `origin` as message and formattedLogLine, if json parsing failed.
     }
 
+    // Replace newline characters with "\n" to prevent the text from breaking into
+    // multiple lines.
+    message = message.replaceAll("\n", "\\n");
     return (
       <Box
         key={`${index}list`}


### PR DESCRIPTION
…aking into multiple lines

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Science we start to parse out json logs in dashboard's log viewer, log message itself could contain newline characters, \n, and rendered into overlapping multi-line on the screen. This PR escapes the new line characters to `\\n` so they will be rendered as raw sting `\n` instead of newlines. 

## Related issue number

Closes https://github.com/ray-project/ray/issues/46371

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

This is the behavior in product's log viewer:
![image (47)](https://github.com/ray-project/ray/assets/7553988/a2fc086b-2db0-432f-9ca9-25d7eb5b0000)

This is on the dashboard after the change: 
<img width="1725" alt="image" src="https://github.com/ray-project/ray/assets/7553988/71766038-17d9-4a0b-8de3-c9c3e50f25bf">

