### PR TITLE
[Doc] Add setuptools dependency for building docs

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -45,7 +45,7 @@ steps:
     key: doc_build
     instance_type: medium
     commands:
-      - FAST=True make -C doc/ html
+      - make -C doc/ html
     depends_on: docbuild
     job_env: docbuild
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -1,5 +1,8 @@
 # Production requirements. This is what readthedocs.com picks up
 
+# Required to build the docs on 3.12 due to pkg_resources deprecation
+setuptools>=70.0.0
+
 # Syntax highlighting
 Pygments==2.16.1
 


### PR DESCRIPTION
## Why are these changes needed?

This PR:

- Adds a _temporary_ `setuptools>=70.0.0` dependency for building the docs to make `sphinxcontrib-redoc` usable on Python 3.12. This is not intended to be a long term solution, so #46374 has been made to track the follow-up work.
- Remove unused environment variable in the buildkite job that builds docs
- Bump the os version and python version used to build the docs on RTD

## Related issue number

Closes #46205.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
