### PR TITLE
[Core] Add ray-start option 'session-name'

### DIFF
--- a/dashboard/head.py
+++ b/dashboard/head.py
@@ -102,7 +102,7 @@ class DashboardHead:
             gcs_address: The GCS address in the {address}:{port} format.
             log_dir: The log directory. E.g., /tmp/session_latest/logs.
             temp_dir: The temp directory. E.g., /tmp.
-            session_dir: The session directory. E.g., tmp/session_latest.
+            session_dir: The session directory. E.g., /tmp/session_latest.
             minimal: Whether or not it will load the minimal modules.
             serve_frontend: If configured, frontend HTML is
                 served from the dashboard.

--- a/doc/source/ray-core/configure.rst
+++ b/doc/source/ray-core/configure.rst
@@ -95,11 +95,14 @@ If using the command line, connect to the Ray cluster as follow:
 Logging and Debugging
 ---------------------
 
-Each Ray session will have a unique name. By default, the name is
+Each Ray session will have a unique name. By default, the name is given automatically like 
 ``session_{timestamp}_{pid}``. The format of ``timestamp`` is
 ``%Y-%m-%d_%H-%M-%S_%f`` (See `Python time format <strftime.org>`__ for details);
 the pid belongs to the startup process (the process calling ``ray.init()`` or
 the Ray process executed by a shell in ``ray start``).
+
+Change the *session name* by passing ``--session-name={unique session name}`` to ``ray start``.
+If the given session name is not unique, the old data with the same session name may be overwritten.
 
 For each session, Ray will place all its temporary files under the
 *session directory*. A *session directory* is a subdirectory of the

--- a/doc/source/ray-core/configure.rst
+++ b/doc/source/ray-core/configure.rst
@@ -112,7 +112,7 @@ You can sort by their names to find the latest session.
 
 Change the *root temporary directory* by passing ``--temp-dir={your temp path}`` to ``ray start``.
 
-(There is not currently a stable way to change the root temporary directory when calling ``ray.init()``, but if you need to, you can provide the ``_temp_dir`` argument to ``ray.init()``.)
+(There is not currently a stable way to change the root temporary directory when calling ``ray.init()``, but if you need to, you can provide the ``_temp_dir`` argument to ``ray.init()``. The session name is also changable when calling ``ray.init()`` by providing ``_session_name`` argument.)
 
 Look :ref:`Logging Directory Structure <logging-directory-structure>` for more details.
 

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -459,6 +459,9 @@ class Node:
 
         try_to_create_directory(self._temp_dir)
 
+        if self._ray_params.session_name is not None:
+            self._session_name = self._ray_params.session_name
+
         if self.head:
             self._session_dir = os.path.join(self._temp_dir, self._session_name)
         else:

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1425,6 +1425,7 @@ def init(
         "_redis_password", ray_constants.REDIS_DEFAULT_PASSWORD
     )
     _temp_dir: Optional[str] = kwargs.pop("_temp_dir", None)
+    _session_name: Optional[str] = kwargs.pop("_session_name", None)
     _metrics_export_port: Optional[int] = kwargs.pop("_metrics_export_port", None)
     _system_config: Optional[Dict[str, str]] = kwargs.pop("_system_config", None)
     _tracing_startup_hook: Optional[Callable] = kwargs.pop(
@@ -1658,6 +1659,7 @@ def init(
             redis_max_memory=_redis_max_memory,
             plasma_store_socket_name=None,
             temp_dir=_temp_dir,
+            session_name=_session_name,
             storage=storage,
             _system_config=_system_config,
             enable_object_reconstruction=_enable_object_reconstruction,
@@ -1727,6 +1729,7 @@ def init(
             redis_password=_redis_password,
             object_ref_seed=None,
             temp_dir=_temp_dir,
+            session_name=_session_name,
             _system_config=_system_config,
             enable_object_reconstruction=_enable_object_reconstruction,
             metrics_export_port=_metrics_export_port,

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1373,6 +1373,8 @@ def init(
         _temp_dir: If provided, specifies the root temporary
             directory for the Ray process. Must be an absolute path. Defaults to an
             OS-specific conventional location, e.g., "/tmp/ray".
+        _session_name: The session name of the Ray process, only works when --head is 
+            specified. If it is not unique, the old data will be overwritten.
         _metrics_export_port: Port number Ray exposes system metrics
             through a Prometheus endpoint. It is currently under active
             development, and the API is subject to change.

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -505,6 +505,12 @@ Windows powershell users need additional escaping:
     "works when --head is specified",
 )
 @click.option(
+    "--session-name",
+    default=None,
+    help="The session name of the Ray process, only works when --head "
+    "is specified. If it is not unique, the old data will be overwritten.",
+)
+@click.option(
     "--storage",
     default=None,
     help="the persistent storage URI for the cluster. Experimental.",
@@ -603,6 +609,7 @@ def start(
     plasma_store_socket_name,
     raylet_socket_name,
     temp_dir,
+    session_name,
     storage,
     system_config,
     enable_object_reconstruction,
@@ -653,6 +660,13 @@ def start(
             "All the worker nodes will use the same temp_dir as a head node. "
         )
         temp_dir = None
+    if session_name and not head:
+        cli_logger.warning(
+            f"`--session-name={session_name}` option will be ignored. "
+            "`--head` is a required flag to use `--session-name`. "
+            "All the worker nodes will use the same session_name as a head node. "
+        )
+        session_name = None
 
     redirect_output = None if not no_redirect_output else True
 
@@ -687,6 +701,7 @@ def start(
         plasma_store_socket_name=plasma_store_socket_name,
         raylet_socket_name=raylet_socket_name,
         temp_dir=temp_dir,
+        session_name=session_name,
         storage=storage,
         include_dashboard=include_dashboard,
         dashboard_host=dashboard_host,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

> Currently, the session name for a ray cluster is set to session_{timestamp}_{pid} ([documentation](https://docs.ray.io/en/latest/ray-core/configure.html#logging-and-debugging)), which is hard to retrieve/predict. We want to provide users the Grafana metrics for their KubeRay ray cluster, but we don't know what the SessionName label filter should be set to. If we can customize the session name as a command-line argument to ray start, we can generate a unique name and pass it to the Kuberay as RayStartParams. Then, we can easily filter the prometheus metrics with this name.

## Related issue number

#46281

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(