### PR TITLE
[ADAG] Fix missing states in channel pickling

### DIFF
--- a/python/ray/dag/BUILD
+++ b/python/ray/dag/BUILD
@@ -103,6 +103,7 @@ py_test_module_list(
     size = "medium",
     files = [
         "tests/experimental/test_detect_deadlock_dag.py",
+        "tests/experimental/test_multi_node_dag.py",
         "tests/experimental/test_torch_tensor_dag.py",
     ],
     tags = [

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -18,7 +18,6 @@ import ray._private
 import ray.cluster_utils
 from ray.dag import InputNode, MultiOutputNode
 from ray.tests.conftest import *  # noqa
-from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from ray._private.utils import (
     get_or_create_event_loop,
 )
@@ -1131,106 +1130,6 @@ def test_driver_and_actor_as_readers(ray_start_cluster):
         ValueError,
         match="DAG outputs currently can only be read by the driver--not the driver "
         "and actors.",
-    ):
-        dag.experimental_compile()
-
-
-def test_readers_on_different_nodes(ray_start_cluster):
-    cluster = ray_start_cluster
-    # This node is for the driver (including the CompiledDAG.DAGDriverProxyActor) and
-    # one of the readers.
-    first_node_handle = cluster.add_node(num_cpus=2)
-    # This node is for the other reader.
-    second_node_handle = cluster.add_node(num_cpus=1)
-    ray.init(address=cluster.address)
-    cluster.wait_for_nodes()
-
-    nodes = [first_node_handle.node_id, second_node_handle.node_id]
-    # We want to check that the readers are on different nodes. Thus, we convert `nodes`
-    # to a set and then back to a list to remove duplicates. Then we check that the
-    # length of `nodes` is 2.
-    nodes = list(set(nodes))
-    assert len(nodes) == 2
-
-    def create_actor(node):
-        return Actor.options(
-            scheduling_strategy=NodeAffinitySchedulingStrategy(node, soft=False)
-        ).remote(0)
-
-    a = create_actor(nodes[0])
-    b = create_actor(nodes[1])
-    actors = [a, b]
-
-    def _get_node_id(self) -> "ray.NodeID":
-        return ray.get_runtime_context().get_node_id()
-
-    nodes_check = ray.get([act.__ray_call__.remote(_get_node_id) for act in actors])
-    a_node = nodes_check[0]
-    b_node = nodes_check[1]
-    assert a_node != b_node
-
-    with InputNode() as inp:
-        x = a.inc.bind(inp)
-        y = b.inc.bind(inp)
-        dag = MultiOutputNode([x, y])
-
-    with pytest.raises(
-        ValueError,
-        match="All reader actors must be on the same node.*",
-    ):
-        dag.experimental_compile()
-
-
-def test_bunch_readers_on_different_nodes(ray_start_cluster):
-    cluster = ray_start_cluster
-    # This node is for the driver (including the CompiledDAG.DAGDriverProxyActor) and
-    # two of the readers.
-    first_node_handle = cluster.add_node(num_cpus=3)
-    # This node is for the other two readers.
-    second_node_handle = cluster.add_node(num_cpus=2)
-    ray.init(address=cluster.address)
-    cluster.wait_for_nodes()
-
-    nodes = [first_node_handle.node_id, second_node_handle.node_id]
-    # We want to check that the readers are on different nodes. Thus, we convert `nodes`
-    # to a set and then back to a list to remove duplicates. Then we check that the
-    # length of `nodes` is 2.
-    nodes = list(set(nodes))
-    assert len(nodes) == 2
-
-    def create_actor(node):
-        return Actor.options(
-            scheduling_strategy=NodeAffinitySchedulingStrategy(node, soft=False)
-        ).remote(0)
-
-    a = create_actor(nodes[0])
-    b = create_actor(nodes[0])
-    c = create_actor(nodes[1])
-    d = create_actor(nodes[1])
-    actors = [a, b, c, d]
-
-    def _get_node_id(self) -> "ray.NodeID":
-        return ray.get_runtime_context().get_node_id()
-
-    nodes_check = ray.get([act.__ray_call__.remote(_get_node_id) for act in actors])
-    a_node = nodes_check[0]
-    b_node = nodes_check[1]
-    c_node = nodes_check[2]
-    d_node = nodes_check[3]
-    assert a_node == b_node
-    assert b_node != c_node
-    assert c_node == d_node
-
-    with InputNode() as inp:
-        w = a.inc.bind(inp)
-        x = b.inc.bind(inp)
-        y = c.inc.bind(inp)
-        z = d.inc.bind(inp)
-        dag = MultiOutputNode([w, x, y, z])
-
-    with pytest.raises(
-        ValueError,
-        match="All reader actors must be on the same node.*",
     ):
         dag.experimental_compile()
 

--- a/python/ray/dag/tests/experimental/test_multi_node_dag.py
+++ b/python/ray/dag/tests/experimental/test_multi_node_dag.py
@@ -1,0 +1,213 @@
+import random
+import ray
+import os
+import sys
+import time
+import pytest
+from ray.dag import InputNode, MultiOutputNode
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+from ray.tests.conftest import *  # noqa
+
+if sys.platform != "linux" and sys.platform != "darwin":
+    pytest.skip("Skipping, requires Linux or Mac.", allow_module_level=True)
+
+
+@ray.remote
+class Actor:
+    def __init__(self, init_value, fail_after=None, sys_exit=False):
+        self.i = init_value
+        self.fail_after = fail_after
+        self.sys_exit = sys_exit
+
+        self.count = 0
+
+    def _fail_if_needed(self):
+        if self.fail_after and self.count > self.fail_after:
+            # Randomize the failures to better cover multi actor scenarios.
+            if random.random() > 0.5:
+                if self.sys_exit:
+                    os._exit(1)
+                else:
+                    raise RuntimeError("injected fault")
+
+    def inc(self, x):
+        self.i += x
+        self.count += 1
+        self._fail_if_needed()
+        return self.i
+
+    def double_and_inc(self, x):
+        self.i *= 2
+        self.i += x
+        return self.i
+
+    def echo(self, x):
+        self.count += 1
+        self._fail_if_needed()
+        return x
+
+    def append_to(self, lst):
+        lst.append(self.i)
+        return lst
+
+    def inc_two(self, x, y):
+        self.i += x
+        self.i += y
+        return self.i
+
+    def sleep(self, x):
+        time.sleep(x)
+        return x
+
+    @ray.method(num_returns=2)
+    def return_two(self, x):
+        return x, x + 1
+
+
+def test_readers_on_different_nodes(ray_start_cluster):
+    cluster = ray_start_cluster
+    # This node is for the driver (including the CompiledDAG.DAGDriverProxyActor) and
+    # one of the readers.
+    first_node_handle = cluster.add_node(num_cpus=2)
+    # This node is for the other reader.
+    second_node_handle = cluster.add_node(num_cpus=1)
+    ray.init(address=cluster.address)
+    cluster.wait_for_nodes()
+
+    nodes = [first_node_handle.node_id, second_node_handle.node_id]
+    # We want to check that the readers are on different nodes. Thus, we convert `nodes`
+    # to a set and then back to a list to remove duplicates. Then we check that the
+    # length of `nodes` is 2.
+    nodes = list(set(nodes))
+    assert len(nodes) == 2
+
+    def create_actor(node):
+        return Actor.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(node, soft=False)
+        ).remote(0)
+
+    a = create_actor(nodes[0])
+    b = create_actor(nodes[1])
+    actors = [a, b]
+
+    def _get_node_id(self) -> "ray.NodeID":
+        return ray.get_runtime_context().get_node_id()
+
+    nodes_check = ray.get([act.__ray_call__.remote(_get_node_id) for act in actors])
+    a_node = nodes_check[0]
+    b_node = nodes_check[1]
+    assert a_node != b_node
+
+    with InputNode() as inp:
+        x = a.inc.bind(inp)
+        y = b.inc.bind(inp)
+        dag = MultiOutputNode([x, y])
+
+    with pytest.raises(
+        ValueError,
+        match="All reader actors must be on the same node.*",
+    ):
+        dag.experimental_compile()
+
+
+def test_bunch_readers_on_different_nodes(ray_start_cluster):
+    cluster = ray_start_cluster
+    # This node is for the driver (including the CompiledDAG.DAGDriverProxyActor) and
+    # two of the readers.
+    first_node_handle = cluster.add_node(num_cpus=3)
+    # This node is for the other two readers.
+    second_node_handle = cluster.add_node(num_cpus=2)
+    ray.init(address=cluster.address)
+    cluster.wait_for_nodes()
+
+    nodes = [first_node_handle.node_id, second_node_handle.node_id]
+    # We want to check that the readers are on different nodes. Thus, we convert `nodes`
+    # to a set and then back to a list to remove duplicates. Then we check that the
+    # length of `nodes` is 2.
+    nodes = list(set(nodes))
+    assert len(nodes) == 2
+
+    def create_actor(node):
+        return Actor.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(node, soft=False)
+        ).remote(0)
+
+    a = create_actor(nodes[0])
+    b = create_actor(nodes[0])
+    c = create_actor(nodes[1])
+    d = create_actor(nodes[1])
+    actors = [a, b, c, d]
+
+    def _get_node_id(self) -> "ray.NodeID":
+        return ray.get_runtime_context().get_node_id()
+
+    nodes_check = ray.get([act.__ray_call__.remote(_get_node_id) for act in actors])
+    a_node = nodes_check[0]
+    b_node = nodes_check[1]
+    c_node = nodes_check[2]
+    d_node = nodes_check[3]
+    assert a_node == b_node
+    assert b_node != c_node
+    assert c_node == d_node
+
+    with InputNode() as inp:
+        w = a.inc.bind(inp)
+        x = b.inc.bind(inp)
+        y = c.inc.bind(inp)
+        z = d.inc.bind(inp)
+        dag = MultiOutputNode([w, x, y, z])
+
+    with pytest.raises(
+        ValueError,
+        match="All reader actors must be on the same node.*",
+    ):
+        dag.experimental_compile()
+
+
+def test_pp(ray_start_cluster):
+    cluster = ray_start_cluster
+    # This node is for the driver.
+    cluster.add_node(num_cpus=0)
+    ray.init(address=cluster.address)
+    TP = 2
+    # This node is for the PP stage 1.
+    cluster.add_node(resources={"pp1": TP})
+    # This node is for the PP stage 2.
+    cluster.add_node(resources={"pp2": TP})
+
+    @ray.remote
+    class Worker:
+        def __init__(self):
+            pass
+
+        def execute_model(self, val):
+            return val
+
+    pp1_workers = [
+        Worker.options(num_cpus=0, resources={"pp1": 1}).remote() for _ in range(TP)
+    ]
+    pp2_workers = [
+        Worker.options(num_cpus=0, resources={"pp2": 1}).remote() for _ in range(TP)
+    ]
+
+    with InputNode() as inp:
+        outputs = [inp for _ in range(TP)]
+        outputs = [pp1_workers[i].execute_model.bind(outputs[i]) for i in range(TP)]
+        outputs = [pp2_workers[i].execute_model.bind(outputs[i]) for i in range(TP)]
+        dag = MultiOutputNode(outputs)
+
+    compiled_dag = dag.experimental_compile()
+    ref = compiled_dag.execute(1)
+    assert ray.get(ref) == [1] * TP
+
+    # So that raylets' error messages are printed to the driver
+    time.sleep(2)
+
+    compiled_dag.teardown()
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -183,6 +183,8 @@ class Channel(ChannelInterface):
         _reader_node_id: Optional["ray.NodeID"] = None,
         _writer_ref: Optional["ray.ObjectRef"] = None,
         _reader_ref: Optional["ray.ObjectRef"] = None,
+        _writer_registered: bool = False,
+        _reader_registered: bool = False,
     ):
         """
         Create a channel that can be read and written by co-located Ray processes.
@@ -227,8 +229,8 @@ class Channel(ChannelInterface):
         self._worker = ray._private.worker.global_worker
         self._worker.check_connected()
 
-        self._writer_registered = False
-        self._reader_registered = False
+        self._writer_registered = _writer_registered
+        self._reader_registered = _reader_registered
 
         if _writer_ref is None:
             # We are the writer. Check that the passed handle matches the
@@ -375,6 +377,8 @@ class Channel(ChannelInterface):
         reader_node_id,
         writer_ref: "ray.ObjectRef",
         reader_ref: "ray.ObjectRef",
+        writer_registered: bool,
+        reader_registered: bool,
     ) -> "Channel":
         chan = Channel(
             writer,
@@ -384,6 +388,8 @@ class Channel(ChannelInterface):
             _reader_node_id=reader_node_id,
             _writer_ref=writer_ref,
             _reader_ref=reader_ref,
+            _writer_registered=writer_registered,
+            _reader_registered=reader_registered,
         )
         return chan
 
@@ -397,6 +403,8 @@ class Channel(ChannelInterface):
             self._reader_node_id,
             self._writer_ref,
             self._reader_ref,
+            self._writer_registered,
+            self._reader_registered,
         )
 
     def __str__(self) -> str:
@@ -535,11 +543,13 @@ class CompositeChannel(ChannelInterface):
         readers: List[ray.actor.ActorHandle],
         _channel_dict: Optional[Dict[ray.ActorID, ChannelInterface]] = None,
         _channels: Optional[Set[ChannelInterface]] = None,
+        _writer_registered: bool = False,
+        _reader_registered: bool = False,
     ):
         self._writer = writer
         self._readers = readers
-        self._writer_registered = False
-        self._reader_registered = False
+        self._writer_registered = _writer_registered
+        self._reader_registered = _reader_registered
         # A dictionary that maps the actor ID to the channel object.
         self._channel_dict = _channel_dict or {}
         # The set of channels is a deduplicated version of the _channel_dict values.
@@ -609,10 +619,15 @@ class CompositeChannel(ChannelInterface):
             self._readers,
             self._channel_dict,
             self._channels,
+            self._writer_registered,
+            self._reader_registered,
         )
 
     def __str__(self) -> str:
-        return f"CompositeChannel(_channels={self._channels})"
+        return (
+            "CompositeChannel(_channels="
+            f"{[str(channel) for channel in self._channels]})"
+        )
 
     def write(self, value: Any, timeout: Optional[float] = None) -> None:
         self.ensure_registered_as_writer()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When an ADAG channel is pickled, it currently does not include `_writer_registered` flag. However, when the channel is deserialized and passed to another node, the channel may be double registered, causing runtime failures. 

Using the repro script of https://github.com/ray-project/ray/issues/46411 as an example:
* The first registration (`ensure_registered_as_writer()`) happens when the driver calls `do_allocate_channel()` on the actor, `_writer_registered` is set to `True`
* However, when the driver ray.get() on the channel, its `_writer_registered` is False as the field is not pickled
* The second registration happens when driver calls `do_exec_tasks()` (-> `_prep_task()` -> `output_writer.start()` -> `_output_channel.ensure_registered_as_writer()`) on the actor, the task's output channel is passed in from driver (with _writer_registered` == `False`).
* Since `ensure_registered_as_writer()` (if the reader is a remote node) eventually calls `ExperimentalRegisterMutableObjectReaderRemote()` (->`HandleRegisterMutableObject()`) on the remote node, where it inserts an entry to a hash map keyed with `writer_object_id`. If there is already an entry with the same key, the check fails as shown in the following snippet:
```
  bool success =
      remote_writer_object_to_local_reader_.insert({writer_object_id, info}).second;
  RAY_CHECK(success);
  ```

This PR fixes the issue by including these states in pickling. A new test `test_pp` is added to verify the fix.

This PR also introduces `test_multi_node_dag` and moves several tests from `test_accelerated_dag` since it got large. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #46411

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
