### PR TITLE
[core][experimental] Support multiple readers for IntraProcessChannel

### DIFF
--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1140,7 +1140,7 @@ def test_simulate_pipeline_parallelism(ray_start_regular_shared):
 
     Compared to reading data from shared memory channels for each forward pass, using
     `IntraProcessChannel` may be more efficient because it avoids the overhead of
-    context switching and deserialization for each forward pass.
+    deserialization for each forward pass.
     """
 
     @ray.remote

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1204,6 +1204,7 @@ def test_simulate_pipeline_parallelism(ray_start_regular_shared):
         "BWD rank-1, batch-1",
         "BWD rank-1, batch-2",
     ]
+    output_dag.teardown()
 
 
 def test_channel_access_after_close(ray_start_regular_shared):

--- a/python/ray/experimental/channel/intra_process_channel.py
+++ b/python/ray/experimental/channel/intra_process_channel.py
@@ -1,7 +1,6 @@
 import uuid
 from typing import Any, Optional
 
-import ray
 from ray.experimental.channel import ChannelContext
 from ray.experimental.channel.common import ChannelInterface
 from ray.util.annotations import PublicAPI

--- a/python/ray/experimental/channel/intra_process_channel.py
+++ b/python/ray/experimental/channel/intra_process_channel.py
@@ -17,12 +17,13 @@ class IntraProcessChannel(ChannelInterface):
     side effects.
 
     Args:
-        num_readers: The number of readers that will read from this channel.
+        num_readers: The number of readers that will read from this channel. Readers
+            can be the same method of the same actor.
     """
 
     def __init__(
         self,
-        num_readers: int = 0,
+        num_readers,
         _channel_id: Optional[str] = None,
     ):
         # Generate a unique ID for the channel. The writer and reader will use

--- a/python/ray/experimental/channel/intra_process_channel.py
+++ b/python/ray/experimental/channel/intra_process_channel.py
@@ -12,7 +12,9 @@ class IntraProcessChannel(ChannelInterface):
     IntraProcessChannel is a channel for communication between two tasks in the same
     worker process. It writes data directly to the worker's _SerializationContext
     and reads data from the _SerializationContext to avoid the serialization
-    overhead and the need for reading/writing from shared memory.
+    overhead and the need for reading/writing from shared memory. Note that if the
+    readers may mutate the data, users should deep copy the data themselves to avoid
+    side effects.
 
     Args:
         num_readers: The number of readers that will read from this channel.

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -15,21 +15,39 @@ class _SerializationContext:
         # execute one task at a time in `do_exec_tasks`. It will not execute multiple
         # Ray tasks on a single actor simultaneously.
         self.intra_process_channel_buffers: Dict[str, Any] = {}
+        # The number of readers for each channel. When the number of readers
+        # reaches 0, remove the data from the buffer.
+        self.channel_id_to_num_readers: Dict[str, int] = {}
 
     def set_use_external_transport(self, use_external_transport: bool) -> None:
         self.use_external_transport = use_external_transport
 
-    def set_data(self, channel_id: str, value: Any) -> None:
+    def set_data(self, channel_id: str, value: Any, num_readers: int) -> None:
+        assert num_readers > 0, "num_readers must be greater than 0."
         assert (
             channel_id not in self.intra_process_channel_buffers
         ), f"Channel {channel_id} already exists in the buffer."
+        assert (
+            channel_id not in self.channel_id_to_num_readers
+        ), f"Channel {channel_id} already exists in the channel_id_to_num_readers."
+
         self.intra_process_channel_buffers[channel_id] = value
+        self.channel_id_to_num_readers[channel_id] = num_readers
 
     def get_data(self, channel_id: str) -> Any:
         assert (
             channel_id in self.intra_process_channel_buffers
         ), f"Channel {channel_id} does not exist in the buffer."
-        return self.intra_process_channel_buffers.pop(channel_id)
+        assert (
+            channel_id in self.channel_id_to_num_readers
+        ), f"Channel {channel_id} does not exist in the channel_id_to_num_readers."
+
+        self.channel_id_to_num_readers[channel_id] -= 1
+        if self.channel_id_to_num_readers[channel_id] == 0:
+            # All readers have read the data, so we can remove it.
+            self.channel_id_to_num_readers.pop(channel_id)
+            return self.intra_process_channel_buffers.pop(channel_id)
+        return self.intra_process_channel_buffers[channel_id]
 
     def reset_data(self, channel_id: str) -> None:
         self.intra_process_channel_buffers.pop(channel_id, None)

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -51,6 +51,7 @@ class _SerializationContext:
 
     def reset_data(self, channel_id: str) -> None:
         self.intra_process_channel_buffers.pop(channel_id, None)
+        self.channel_id_to_num_readers.pop(channel_id, None)
 
     def reset_tensors(self, tensors: List["torch.Tensor"]) -> List["torch.Tensor"]:
         prev_tensors = self.tensors

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -557,10 +557,7 @@ class CompositeChannel(ChannelInterface):
         # Create a local channel for the writer and the local readers.
         num_local_readers = len(self._readers) - len(remote_readers)
         if num_local_readers > 0:
-            assert (
-                num_local_readers == 1
-            ), "Only support one reader on the same actor for now."
-            local_channel = IntraProcessChannel(self._writer)
+            local_channel = IntraProcessChannel(num_local_readers)
             self._channels.add(local_channel)
             actor_id = self._get_actor_id(self._writer)
             self._channel_dict[actor_id] = local_channel

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -11,6 +11,7 @@ import pytest
 
 import ray
 import ray.cluster_utils
+import ray.exceptions
 import ray.experimental.channel as ray_channel
 from ray.exceptions import RayChannelError, RayChannelTimeoutError
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
@@ -622,7 +623,7 @@ def test_remote_reader_close(ray_start_cluster, remote):
     sys.platform != "linux" and sys.platform != "darwin",
     reason="Requires Linux or Mac.",
 )
-def test_intra_process_channel(ray_start_cluster):
+def test_intra_process_channel_single_reader(ray_start_cluster):
     """
     (1) Test whether an actor can read/write from an IntraProcessChannel.
     (2) Test whether the _SerializationContext cleans up the
@@ -653,7 +654,7 @@ def test_intra_process_channel(ray_start_cluster):
             return len(ctx.intra_process_channel_buffers)
 
     actor = Actor.remote()
-    channel = ray_channel.IntraProcessChannel(actor)
+    channel = ray_channel.IntraProcessChannel(num_readers=1)
     ray.get(actor.pass_channel.remote(channel))
 
     ray.get(actor.write.remote("hello"))
@@ -668,6 +669,72 @@ def test_intra_process_channel(ray_start_cluster):
 
     # The _SerializationContext should clean up the data after a read.
     assert ray.get(actor.get_ctx_buffer_size.remote()) == 0
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux" and sys.platform != "darwin",
+    reason="Requires Linux or Mac.",
+)
+def test_intra_process_channel_multi_readers(ray_start_cluster):
+    """
+    (1) Test whether an actor can read/write from an IntraProcessChannel.
+    (2) Test whether the _SerializationContext cleans up the
+    data after all readers have read it.
+    (3) Test whether the actor can write again after reading num_readers times.
+    (4) Test whether an exception is raised when calling write() before all readers
+    have read the data.
+    """
+    # This node is for both the driver and the Reader actors.
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=1)
+    ray.init(address=cluster.address)
+
+    @ray.remote(num_cpus=1)
+    class Actor:
+        def __init__(self):
+            pass
+
+        def pass_channel(self, channel):
+            self._chan = channel
+
+        def read(self):
+            return self._chan.read()
+
+        def write(self, value):
+            self._chan.write(value)
+
+        def get_ctx_buffer_size(self):
+            ctx = ray_channel.ChannelContext.get_current().serialization_context
+            return len(ctx.intra_process_channel_buffers)
+
+    actor = Actor.remote()
+    channel = ray_channel.IntraProcessChannel(num_readers=2)
+    ray.get(actor.pass_channel.remote(channel))
+
+    ray.get(actor.write.remote("hello"))
+    # first read
+    assert ray.get(actor.read.remote()) == "hello"
+    assert ray.get(actor.get_ctx_buffer_size.remote()) == 1
+    # second read
+    assert ray.get(actor.read.remote()) == "hello"
+    assert ray.get(actor.get_ctx_buffer_size.remote()) == 0
+
+    # Write again after reading num_readers times.
+    ray.get(actor.write.remote("world"))
+    # first read
+    assert ray.get(actor.read.remote()) == "world"
+    assert ray.get(actor.get_ctx_buffer_size.remote()) == 1
+    # second read
+    assert ray.get(actor.read.remote()) == "world"
+    assert ray.get(actor.get_ctx_buffer_size.remote()) == 0
+
+    # Write again
+    ray.get(actor.write.remote("hello world"))
+    # first read
+    assert ray.get(actor.read.remote()) == "hello world"
+    assert ray.get(actor.get_ctx_buffer_size.remote()) == 1
+    with pytest.raises(ray.exceptions.RayTaskError):
+        ray.get(actor.write.remote("world hello"))
 
 
 @pytest.mark.skipif(
@@ -789,13 +856,17 @@ def test_composite_channel_multiple_readers(ray_start_cluster):
     ray.get(actor1.write.remote("world"))
     assert ray.get([actor1.read.remote(), actor2.read.remote()]) == ["world"] * 2
 
-    with pytest.raises(ray.exceptions.RayTaskError):
-        # actor1 writes data to CompositeChannel and two Ray tasks on actor1 read it.
-        # This is not supported and should raise an exception.
-        actor1_output_channel = ray.get(
-            actor1.create_composite_channel.remote(actor1, [actor1, actor1])
-        )
+    actor1_output_channel = ray.get(
+        actor1.create_composite_channel.remote(actor1, [actor1, actor1])
+    )
+    ray.get(actor1.write.remote("hello world"))
+    assert ray.get(actor1.read.remote()) == "hello world"
+    assert ray.get(actor1.read.remote()) == "hello world"
 
+    with pytest.raises(ray.exceptions.RayTaskError):
+        # actor1_output_channel has two readers, so it can only be read twice.
+        # The third read should raise an exception.
+        ray.get(actor1.read.remote())
     """
     TODO (kevin85421): Add tests for the following cases:
     (1) actor1 writes data to CompositeChannel and two Ray tasks on actor2 read it.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR enables `IntraProcessChannel` to be read more than once. Before this PR, the data caches in serialization_context would be removed if read once. This PR also adds a test to simulate the pattern of pipeline parallelism.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
