### PR TITLE
[Doc] Add Algolia search to docs

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -7,7 +7,7 @@ setuptools>=70.0.0
 Pygments==2.16.1
 
 # Sphinx
-sphinx==7.1.2
+sphinx==7.3.7
 sphinx-click==5.1.0
 sphinx-copybutton==0.5.2
 sphinxemoji==0.2.0
@@ -19,6 +19,7 @@ sphinx_design==0.5.0
 pydata-sphinx-theme==0.14.1
 autodoc_pydantic==2.2.0
 appnope
+sphinx-docsearch==0.0.7
 
 pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -66,7 +66,13 @@ extensions = [
     "sphinx_remove_toctrees",
     "sphinx_design",
     "sphinx.ext.intersphinx",
+    "sphinx_docsearch",
 ]
+
+# Configuration for algolia
+docsearch_app_id = "LBHF0PABBL"
+docsearch_api_key = "6c42f30d9669d8e42f6fc92f44028596"
+docsearch_index_name = "docs-ray"
 
 remove_from_toctrees = [
     "cluster/running-applications/job-submission/doc/*",


### PR DESCRIPTION
## Why are these changes needed?

This PR updates the documentation search engine to use Algolia, improving search results.

To add support for Algolia, I've

- Added the `sphinx-docsearch==0.0.7` requirement.
- Bumped the current `sphinx` version to `7.3.7`.
- Committed the public Algolia search API key, [in accordance with their documentation](https://www.algolia.com/doc/guides/security/api-keys/#search-only-api-key).

## Related issue number

Closes #43208.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
