### PR TITLE
Add perf metrics for 2.32.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 473.06752,
+    "_dashboard_memory_usage_mb": 500.076544,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1223\t9.72GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3595\t1.71GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4678\t0.88GiB\tpython distributed/test_many_actors.py\n2549\t0.44GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3715\t0.35GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3009\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3881\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4469\t0.07GiB\tray::JobSupervisor\n4076\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3879\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
-    "actors_per_second": 603.9096963863203,
+    "_peak_memory": 3.72,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1133\t10.03GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3513\t1.74GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4605\t0.91GiB\tpython distributed/test_many_actors.py\n3628\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2320\t0.33GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3104\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4400\t0.07GiB\tray::JobSupervisor\n3791\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3970\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3789\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "actors_per_second": 615.180594485976,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 603.9096963863203
+            "perf_metric_value": 615.180594485976
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 93.238
+            "perf_metric_value": 74.394
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3526.237
+            "perf_metric_value": 3035.866
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3733.065
+            "perf_metric_value": 3441.396
         }
     ],
     "success": "1",
-    "time": 16.558767080307007
+    "time": 16.25538921356201
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 193.503232,
+    "_dashboard_memory_usage_mb": 189.751296,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.66,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3558\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2125\t0.4GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1217\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3675\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4832\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5102\t0.09GiB\tray::StateAPIGeneratorActor.start\n2326\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4635\t0.07GiB\tray::JobSupervisor\n3838\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3836\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 1.67,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3500\t0.55GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1141\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2460\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3625\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4864\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5132\t0.09GiB\tray::StateAPIGeneratorActor.start\n2656\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4657\t0.07GiB\tray::JobSupervisor\n3788\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3786\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 346.9124752975113
+            "perf_metric_value": 344.2841239720449
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.924
+            "perf_metric_value": 3.971
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 63.659
+            "perf_metric_value": 68.223
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 133.071
+            "perf_metric_value": 140.505
         }
     ],
     "success": "1",
-    "tasks_per_second": 346.9124752975113,
-    "time": 302.8825714588165,
+    "tasks_per_second": 344.2841239720449,
+    "time": 302.9045777320862,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 111.362048,
+    "_dashboard_memory_usage_mb": 189.5424,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.21,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1141\t9.78GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3478\t0.98GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4441\t0.41GiB\tpython distributed/test_many_pgs.py\n2345\t0.35GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3593\t0.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2738\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3756\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4239\t0.07GiB\tray::JobSupervisor\n3938\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3754\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 2.2,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1249\t9.21GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3551\t0.98GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4583\t0.42GiB\tpython distributed/test_many_pgs.py\n2390\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3683\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3849\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2628\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4372\t0.07GiB\tray::JobSupervisor\n4039\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3847\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.96731187832995
+            "perf_metric_value": 22.687659485012095
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.377
+            "perf_metric_value": 3.39
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.221
+            "perf_metric_value": 10.334
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 281.247
+            "perf_metric_value": 332.736
         }
     ],
-    "pgs_per_second": 22.96731187832995,
+    "pgs_per_second": 22.687659485012095,
     "success": "1",
-    "time": 43.540141105651855
+    "time": 44.07682514190674
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1100.976128,
+    "_dashboard_memory_usage_mb": 1232.416768,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.53,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3588\t1.55GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3718\t1.43GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4837\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2121\t0.34GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1228\t0.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n5036\t0.09GiB\tray::DashboardTester.run\n5090\t0.08GiB\tray::StateAPIGeneratorActor.start\n4620\t0.07GiB\tray::JobSupervisor\n2545\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3884\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
+    "_peak_memory": 5.37,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3733\t1.96GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3618\t1.68GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4484\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1235\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2417\t0.24GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4683\t0.09GiB\tray::StateAPIGeneratorActor.start\n4621\t0.08GiB\tray::DashboardTester.run\n4285\t0.07GiB\tray::JobSupervisor\n3899\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3025\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 588.1590100663536
+            "perf_metric_value": 578.8766226882515
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 128.651
+            "perf_metric_value": 141.285
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1221.413
+            "perf_metric_value": 1649.419
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3317.765
+            "perf_metric_value": 3448.302
         }
     ],
     "success": "1",
-    "tasks_per_second": 588.1590100663536,
-    "time": 317.00220489501953,
+    "tasks_per_second": 578.8766226882515,
+    "time": 317.2748382091522,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.31.0", "commit": "c74f2e42a6a556b907909bf6bf9f1b49c10537b8", "branch": "master"}
+{"release_version": "2.32.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8333.524788377435,
-        139.4971970860079
+        9241.526232225291,
+        132.04014985321072
     ],
     "1_1_actor_calls_concurrent": [
-        5128.690143549978,
-        72.51862619127049
+        5433.582983286094,
+        203.77840697231508
     ],
     "1_1_actor_calls_sync": [
-        2058.3799984150405,
-        11.233477115678642
+        2063.6151992547047,
+        41.087530717556106
     ],
     "1_1_async_actor_calls_async": [
-        3257.4165702788237,
-        126.34490761943368
+        4541.586332149929,
+        244.29996229786013
     ],
     "1_1_async_actor_calls_sync": [
-        1374.6956063631808,
-        19.92364573442667
+        1499.3849412965205,
+        31.19427048888692
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2389.576009385017,
-        96.41355340514747
+        2981.1837517965705,
+        129.12171570334309
     ],
     "1_n_actor_calls_async": [
-        8761.526579680127,
-        246.64842704677028
+        8825.80303025342,
+        137.32428841583177
     ],
     "1_n_async_actor_calls_async": [
-        7552.746593848862,
-        44.30686270497591
+        7872.539571860014,
+        165.88537648403613
     ],
     "client__1_1_actor_calls_async": [
-        987.0826476868258,
-        15.867004371591774
+        1020.0334940870466,
+        10.493190404958229
     ],
     "client__1_1_actor_calls_concurrent": [
-        983.3703155378647,
-        11.430681150062163
+        1023.0375442360598,
+        9.873541601530931
     ],
     "client__1_1_actor_calls_sync": [
-        534.2825013844715,
-        2.950503846313585
+        509.9599816194958,
+        26.55553704027681
     ],
     "client__get_calls": [
-        1079.3418038309135,
-        33.135415306177244
+        1175.306212007341,
+        6.848643951008982
     ],
     "client__put_calls": [
-        814.6764560093619,
-        12.322138031313903
+        794.0222907625882,
+        23.489002030449676
     ],
     "client__put_gigabytes": [
-        0.13149954065134536,
-        0.001063187907570302
+        0.13160907472336658,
+        0.000597729723962875
     ],
     "client__tasks_and_get_batch": [
-        0.9454156734042978,
-        0.0038137424075750334
+        0.9724735940970552,
+        0.014680443297132861
     ],
     "client__tasks_and_put_batch": [
-        11759.788796582228,
-        372.25256677234967
+        11309.127935041968,
+        230.80678248448353
     ],
     "multi_client_put_calls_Plasma_Store": [
-        13048.216108376133,
-        230.29813938308763
+        12520.58965968965,
+        127.48894702402845
     ],
     "multi_client_put_gigabytes": [
-        32.76192945223942,
-        0.8011869785099314
+        37.39369500194131,
+        2.6031810715230144
     ],
     "multi_client_tasks_async": [
-        23557.51911206466,
-        1772.622998691743
+        23283.706392178385,
+        3093.661219187642
     ],
     "n_n_actor_calls_async": [
-        27657.83033159681,
-        630.3849349038278
+        27232.414296780542,
+        758.7912476297421
     ],
     "n_n_actor_calls_with_arg_async": [
-        2713.0325692965866,
-        45.54010191103914
+        2605.856362562882,
+        17.70949766672506
     ],
     "n_n_async_actor_calls_async": [
-        23307.202618153802,
-        661.4791179159593
+        23591.92555321498,
+        1068.3154500015673
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10593.772848299006
+            "perf_metric_value": 10121.103242219997
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5300.894918847503
+            "perf_metric_value": 5227.298677681264
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13048.216108376133
+            "perf_metric_value": 12520.58965968965
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.28764104367834
+            "perf_metric_value": 19.46333348333893
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8.033801054151493
+            "perf_metric_value": 7.9070880635954
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 32.76192945223942
+            "perf_metric_value": 37.39369500194131
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.16167615938565
+            "perf_metric_value": 12.756244682120503
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.378868872174563
+            "perf_metric_value": 5.302957674144409
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 987.4363632697047
+            "perf_metric_value": 981.7983599799647
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7954.923588767402
+            "perf_metric_value": 7981.871660623128
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23557.51911206466
+            "perf_metric_value": 23283.706392178385
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2058.3799984150405
+            "perf_metric_value": 2063.6151992547047
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8333.524788377435
+            "perf_metric_value": 9241.526232225291
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5128.690143549978
+            "perf_metric_value": 5433.582983286094
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8761.526579680127
+            "perf_metric_value": 8825.80303025342
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27657.83033159681
+            "perf_metric_value": 27232.414296780542
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2713.0325692965866
+            "perf_metric_value": 2605.856362562882
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1374.6956063631808
+            "perf_metric_value": 1499.3849412965205
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3257.4165702788237
+            "perf_metric_value": 4541.586332149929
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2389.576009385017
+            "perf_metric_value": 2981.1837517965705
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7552.746593848862
+            "perf_metric_value": 7872.539571860014
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23307.202618153802
+            "perf_metric_value": 23591.92555321498
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 840.8257707443967
+            "perf_metric_value": 784.1202913310515
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1079.3418038309135
+            "perf_metric_value": 1175.306212007341
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 814.6764560093619
+            "perf_metric_value": 794.0222907625882
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13149954065134536
+            "perf_metric_value": 0.13160907472336658
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11759.788796582228
+            "perf_metric_value": 11309.127935041968
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 534.2825013844715
+            "perf_metric_value": 509.9599816194958
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 987.0826476868258
+            "perf_metric_value": 1020.0334940870466
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 983.3703155378647
+            "perf_metric_value": 1023.0375442360598
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9454156734042978
+            "perf_metric_value": 0.9724735940970552
         }
     ],
     "placement_group_create/removal": [
-        840.8257707443967,
-        5.485007857797762
+        784.1202913310515,
+        2.674372951834296
     ],
     "single_client_get_calls_Plasma_Store": [
-        10593.772848299006,
-        535.7824591422661
+        10121.103242219997,
+        344.32801069166834
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.16167615938565,
-        0.22204297681947535
+        12.756244682120503,
+        0.09167947289933939
     ],
     "single_client_put_calls_Plasma_Store": [
-        5300.894918847503,
-        76.1977969185646
+        5227.298677681264,
+        73.4380388161718
     ],
     "single_client_put_gigabytes": [
-        20.28764104367834,
-        4.860173002545708
+        19.46333348333893,
+        5.440510765037708
     ],
     "single_client_tasks_and_get_batch": [
-        8.033801054151493,
-        0.34932465613267877
+        7.9070880635954,
+        0.3896057750384761
     ],
     "single_client_tasks_async": [
-        7954.923588767402,
-        493.94900258711215
+        7981.871660623128,
+        279.39202571036645
     ],
     "single_client_tasks_sync": [
-        987.4363632697047,
-        8.44617749321566
+        981.7983599799647,
+        9.168440320587788
     ],
     "single_client_wait_1k_refs": [
-        5.378868872174563,
-        0.10672725450140629
+        5.302957674144409,
+        0.08188715171339318
     ]
 }

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.234402031000002,
-    "get_time": 22.85316222099999,
+    "args_time": 17.415384294000006,
+    "get_time": 23.645023898000005,
     "large_object_size": 107374182400,
-    "large_object_time": 30.948722583000006,
+    "large_object_time": 30.474318987000004,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.234402031000002
+            "perf_metric_value": 17.415384294000006
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.560233610000012
+            "perf_metric_value": 5.771739185999991
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 22.85316222099999
+            "perf_metric_value": 23.645023898000005
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 182.31759296599998
+            "perf_metric_value": 187.84350834300002
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.948722583000006
+            "perf_metric_value": 30.474318987000004
         }
     ],
-    "queued_time": 182.31759296599998,
-    "returns_time": 5.560233610000012,
+    "queued_time": 187.84350834300002,
+    "returns_time": 5.771739185999991,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0120761251449586,
-    "max_iteration_time": 3.3703677654266357,
-    "min_iteration_time": 0.27796387672424316,
+    "avg_iteration_time": 1.0517002582550048,
+    "max_iteration_time": 2.9446706771850586,
+    "min_iteration_time": 0.512861967086792,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0120761251449586
+            "perf_metric_value": 1.0517002582550048
         }
     ],
     "success": 1,
-    "total_time": 101.20782685279846
+    "total_time": 105.17023873329163
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.912366151809692
+            "perf_metric_value": 10.851820707321167
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 24.80071632862091
+            "perf_metric_value": 23.859845495224
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 62.212187099456784
+            "perf_metric_value": 65.67325186729431
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.6078929901123047
+            "perf_metric_value": 1.573556900024414
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3011.46821808815
+            "perf_metric_value": 3065.2378103733063
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.49633745404952434
+            "perf_metric_value": 0.48427910077229586
         }
     ],
-    "stage_0_time": 10.912366151809692,
-    "stage_1_avg_iteration_time": 24.80071632862091,
-    "stage_1_max_iteration_time": 26.903640270233154,
-    "stage_1_min_iteration_time": 23.28272032737732,
-    "stage_1_time": 248.00730347633362,
-    "stage_2_avg_iteration_time": 62.212187099456784,
-    "stage_2_max_iteration_time": 63.847378969192505,
-    "stage_2_min_iteration_time": 59.83901596069336,
-    "stage_2_time": 311.0617163181305,
-    "stage_3_creation_time": 1.6078929901123047,
-    "stage_3_time": 3011.46821808815,
-    "stage_4_spread": 0.49633745404952434,
+    "stage_0_time": 10.851820707321167,
+    "stage_1_avg_iteration_time": 23.859845495224,
+    "stage_1_max_iteration_time": 24.58528447151184,
+    "stage_1_min_iteration_time": 23.121485948562622,
+    "stage_1_time": 238.59854221343994,
+    "stage_2_avg_iteration_time": 65.67325186729431,
+    "stage_2_max_iteration_time": 66.63724613189697,
+    "stage_2_min_iteration_time": 64.36803317070007,
+    "stage_2_time": 328.3679451942444,
+    "stage_3_creation_time": 1.573556900024414,
+    "stage_3_time": 3065.2378103733063,
+    "stage_4_spread": 0.48427910077229586,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9355983018021244,
-    "avg_pg_remove_time_ms": 0.8868805465475326,
+    "avg_pg_create_time_ms": 0.9259017792794532,
+    "avg_pg_remove_time_ms": 0.9261005015020346,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9355983018021244
+            "perf_metric_value": 0.9259017792794532
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.8868805465475326
+            "perf_metric_value": 0.9261005015020346
         }
     ],
     "success": 1


### PR DESCRIPTION
```
New release perf metrics missing file scalability/object_store.json
REGRESSION 6.74%: placement_group_create/removal (THROUGHPUT) regresses from 840.8257707443967 to 784.1202913310515 in microbenchmark.json
REGRESSION 4.55%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 534.2825013844715 to 509.9599816194958 in microbenchmark.json
REGRESSION 4.46%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10593.772848299006 to 10121.103242219997 in microbenchmark.json
REGRESSION 4.06%: single_client_put_gigabytes (THROUGHPUT) regresses from 20.28764104367834 to 19.46333348333893 in microbenchmark.json
REGRESSION 4.04%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 13048.216108376133 to 12520.58965968965 in microbenchmark.json
REGRESSION 3.95%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2713.0325692965866 to 2605.856362562882 in microbenchmark.json
REGRESSION 3.83%: client__tasks_and_put_batch (THROUGHPUT) regresses from 11759.788796582228 to 11309.127935041968 in microbenchmark.json
REGRESSION 3.08%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.16167615938565 to 12.756244682120503 in microbenchmark.json
REGRESSION 2.54%: client__put_calls (THROUGHPUT) regresses from 814.6764560093619 to 794.0222907625882 in microbenchmark.json
REGRESSION 1.58%: tasks_per_second (THROUGHPUT) regresses from 588.1590100663536 to 578.8766226882515 in benchmarks/many_tasks.json
REGRESSION 1.58%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 8.033801054151493 to 7.9070880635954 in microbenchmark.json
REGRESSION 1.54%: n_n_actor_calls_async (THROUGHPUT) regresses from 27657.83033159681 to 27232.414296780542 in microbenchmark.json
REGRESSION 1.41%: single_client_wait_1k_refs (THROUGHPUT) regresses from 5.378868872174563 to 5.302957674144409 in microbenchmark.json
REGRESSION 1.39%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5300.894918847503 to 5227.298677681264 in microbenchmark.json
REGRESSION 1.22%: pgs_per_second (THROUGHPUT) regresses from 22.96731187832995 to 22.687659485012095 in benchmarks/many_pgs.json
REGRESSION 1.16%: multi_client_tasks_async (THROUGHPUT) regresses from 23557.51911206466 to 23283.706392178385 in microbenchmark.json
REGRESSION 0.76%: tasks_per_second (THROUGHPUT) regresses from 346.9124752975113 to 344.2841239720449 in benchmarks/many_nodes.json
REGRESSION 0.57%: single_client_tasks_sync (THROUGHPUT) regresses from 987.4363632697047 to 981.7983599799647 in microbenchmark.json
REGRESSION 35.04%: dashboard_p95_latency_ms (LATENCY) regresses from 1221.413 to 1649.419 in benchmarks/many_tasks.json
REGRESSION 25.70%: dashboard_p95_latency_ms (LATENCY) regresses from 8.221 to 10.334 in benchmarks/many_pgs.json
REGRESSION 18.31%: dashboard_p99_latency_ms (LATENCY) regresses from 281.247 to 332.736 in benchmarks/many_pgs.json
REGRESSION 9.82%: dashboard_p50_latency_ms (LATENCY) regresses from 128.651 to 141.285 in benchmarks/many_tasks.json
REGRESSION 7.17%: dashboard_p95_latency_ms (LATENCY) regresses from 63.659 to 68.223 in benchmarks/many_nodes.json
REGRESSION 5.59%: dashboard_p99_latency_ms (LATENCY) regresses from 133.071 to 140.505 in benchmarks/many_nodes.json
REGRESSION 5.56%: stage_2_avg_iteration_time (LATENCY) regresses from 62.212187099456784 to 65.67325186729431 in stress_tests/stress_test_many_tasks.json
REGRESSION 4.42%: avg_pg_remove_time_ms (LATENCY) regresses from 0.8868805465475326 to 0.9261005015020346 in stress_tests/stress_test_placement_group.json
REGRESSION 3.93%: dashboard_p99_latency_ms (LATENCY) regresses from 3317.765 to 3448.302 in benchmarks/many_tasks.json
REGRESSION 3.92%: avg_iteration_time (LATENCY) regresses from 1.0120761251449586 to 1.0517002582550048 in stress_tests/stress_test_dead_actors.json
REGRESSION 3.80%: 3000_returns_time (LATENCY) regresses from 5.560233610000012 to 5.771739185999991 in scalability/single_node.json
REGRESSION 3.46%: 10000_get_time (LATENCY) regresses from 22.85316222099999 to 23.645023898000005 in scalability/single_node.json
REGRESSION 3.03%: 1000000_queued_time (LATENCY) regresses from 182.31759296599998 to 187.84350834300002 in scalability/single_node.json
REGRESSION 1.79%: stage_3_time (LATENCY) regresses from 3011.46821808815 to 3065.2378103733063 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.20%: dashboard_p50_latency_ms (LATENCY) regresses from 3.924 to 3.971 in benchmarks/many_nodes.json
REGRESSION 1.05%: 10000_args_time (LATENCY) regresses from 17.234402031000002 to 17.415384294000006 in scalability/single_node.json
REGRESSION 0.38%: dashboard_p50_latency_ms (LATENCY) regresses from 3.377 to 3.39 in benchmarks/many_pgs.json
```