### PR TITLE
[core] catch exception in async_callback

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -5167,7 +5167,7 @@ cdef void async_callback(shared_ptr[CRayObject] obj,
     except Exception as e:
         # Only log the error here because this calllback is called from Cpp
         # and Cython will ignore the exception anyway
-        logger.error(f"Caught Exception: {e}")
+        logger.exception(f"failed to run async callback (user func)")
     finally:
         # NOTE: we manually increment the Python reference count of the callback when
         # registering it in the core worker, so we must decrement here to avoid a leak.

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -5164,6 +5164,10 @@ cdef void async_callback(shared_ptr[CRayObject] obj,
 
         user_callback = <object>user_callback_ptr
         user_callback(result)
+    except Exception as e:
+        # Only log the error here because this calllback is called from Cpp
+        # and Cython will ignore the exception anyway
+        logger.error(f"Caught Exception: {e}")
     finally:
         # NOTE: we manually increment the Python reference count of the callback when
         # registering it in the core worker, so we must decrement here to avoid a leak.

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -5164,7 +5164,7 @@ cdef void async_callback(shared_ptr[CRayObject] obj,
 
         user_callback = <object>user_callback_ptr
         user_callback(result)
-    except Exception as e:
+    except Exception:
         # Only log the error here because this calllback is called from Cpp
         # and Cython will ignore the exception anyway
         logger.exception(f"failed to run async callback (user func)")


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

async_callback doesn't catch the exception currently. cython will ignore the exception if any thrown.
This will break the test `test_on_completed_callback_refcount` on Python 3.12 because the traceback refcount is not decremented correctly. Since it is ignoring the exception before, simply logging it will fix the issue and still provide better user experience.


## Related issue number

<!-- For example: "Closes #1234" -->

fix https://github.com/ray-project/ray/issues/46452

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
