### PR TITLE
[ci] remove nvidia-disable-check

### DIFF
--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -63,8 +63,6 @@ class LinuxContainer(Container):
         gpu_ids: Optional[List[int]] = None,
     ) -> List[str]:
         extra_args = [
-            "--env",
-            "NVIDIA_DISABLE_REQUIRE=1",
             "--add-host",
             "rayci.localhost:host-gateway",
         ]


### PR DESCRIPTION
CUDA checks the compatibility between the host driver and the docker image CUDA version. Previously we have this check since the driver is older than the CUDA version and cuda will be unhappy about it. Remove this check now that we have upgraded the cuda version in the host.

Test:
- CI