### PR TITLE
[Data] Replace lambda mutable default arguments

### DIFF
--- a/python/ray/data/_internal/aggregate.py
+++ b/python/ray/data/_internal/aggregate.py
@@ -1,5 +1,5 @@
 import math
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
 
 from ray.data._internal.null_aggregate import (
     _null_wrap_accumulate_block,
@@ -335,9 +335,13 @@ class Quantile(_AggregateOnKeyBase):
 
         import math
 
-        def percentile(input_values, key=lambda x: x):
+        def percentile(input_values, key: Optional[Callable[[Any], Any]] = None):
             if not input_values:
                 return None
+
+            if key is None:
+                key = lambda x: x  # noqa: E731
+
             input_values = sorted(input_values)
             k = (len(input_values) - 1) * self._q
             f = math.floor(k)

--- a/python/ray/data/_internal/datasource/csv_datasink.py
+++ b/python/ray/data/_internal/datasource/csv_datasink.py
@@ -12,12 +12,15 @@ class CSVDatasink(BlockBasedFileDatasink):
         self,
         path: str,
         *,
-        arrow_csv_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
+        arrow_csv_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         arrow_csv_args: Optional[Dict[str, Any]] = None,
         file_format="csv",
         **file_datasink_kwargs,
     ):
         super().__init__(path, file_format=file_format, **file_datasink_kwargs)
+
+        if arrow_csv_args_fn is None:
+            arrow_csv_args_fn = lambda: {}  # noqa: E731
 
         if arrow_csv_args is None:
             arrow_csv_args = {}

--- a/python/ray/data/_internal/datasource/json_datasink.py
+++ b/python/ray/data/_internal/datasource/json_datasink.py
@@ -12,12 +12,15 @@ class JSONDatasink(BlockBasedFileDatasink):
         self,
         path: str,
         *,
-        pandas_json_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
+        pandas_json_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         pandas_json_args: Optional[Dict[str, Any]] = None,
         file_format: str = "json",
         **file_datasink_kwargs,
     ):
         super().__init__(path, file_format=file_format, **file_datasink_kwargs)
+
+        if pandas_json_args_fn is None:
+            pandas_json_args_fn = lambda: {}  # noqa: E731
 
         if pandas_json_args is None:
             pandas_json_args = {}

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -23,7 +23,7 @@ class ParquetDatasink(_FileDatasink):
         self,
         path: str,
         *,
-        arrow_parquet_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
+        arrow_parquet_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         arrow_parquet_args: Optional[Dict[str, Any]] = None,
         num_rows_per_file: Optional[int] = None,
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
@@ -32,6 +32,9 @@ class ParquetDatasink(_FileDatasink):
         filename_provider: Optional[FilenameProvider] = None,
         dataset_uuid: Optional[str] = None,
     ):
+        if arrow_parquet_args_fn is None:
+            arrow_parquet_args_fn = lambda: {}  # noqa: E731
+
         if arrow_parquet_args is None:
             arrow_parquet_args = {}
 

--- a/python/ray/data/aggregate/_aggregate.py
+++ b/python/ray/data/aggregate/_aggregate.py
@@ -43,7 +43,7 @@ class AggregateFn:
         name: str,
         accumulate_row: Callable[[AggType, T], AggType] = None,
         accumulate_block: Callable[[AggType, Block], AggType] = None,
-        finalize: Callable[[AggType], U] = lambda a: a,
+        finalize: Optional[Callable[[AggType], U]] = None,
     ):
         if (accumulate_row is None and accumulate_block is None) or (
             accumulate_row is not None and accumulate_block is not None
@@ -61,6 +61,9 @@ class AggregateFn:
 
         if not isinstance(name, str):
             raise TypeError("`name` must be provided.")
+
+        if finalize is None:
+            finalize = lambda a: a  # noqa: E731
 
         self.init = init
         self.merge = merge

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2631,7 +2631,7 @@ class Dataset:
         try_create_dir: bool = True,
         arrow_open_stream_args: Optional[Dict[str, Any]] = None,
         filename_provider: Optional[FilenameProvider] = None,
-        arrow_parquet_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
+        arrow_parquet_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         num_rows_per_file: Optional[int] = None,
         ray_remote_args: Dict[str, Any] = None,
         concurrency: Optional[int] = None,
@@ -2703,6 +2703,9 @@ class Dataset:
                         #pyarrow.parquet.write_table>`_, which is used to write out each
                 block to a file.
         """  # noqa: E501
+        if arrow_parquet_args_fn is None:
+            arrow_parquet_args_fn = lambda: {}  # noqa: E731
+
         datasink = ParquetDatasink(
             path,
             arrow_parquet_args_fn=arrow_parquet_args_fn,
@@ -2729,7 +2732,7 @@ class Dataset:
         try_create_dir: bool = True,
         arrow_open_stream_args: Optional[Dict[str, Any]] = None,
         filename_provider: Optional[FilenameProvider] = None,
-        pandas_json_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
+        pandas_json_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         num_rows_per_file: Optional[int] = None,
         ray_remote_args: Dict[str, Any] = None,
         concurrency: Optional[int] = None,
@@ -2811,6 +2814,9 @@ class Dataset:
                 :class:`~ray.data.Dataset` block. These
                 are dict(orient="records", lines=True) by default.
         """
+        if pandas_json_args_fn is None:
+            pandas_json_args_fn = lambda: {}  # noqa: E731
+
         datasink = JSONDatasink(
             path,
             pandas_json_args_fn=pandas_json_args_fn,
@@ -2909,7 +2915,7 @@ class Dataset:
         try_create_dir: bool = True,
         arrow_open_stream_args: Optional[Dict[str, Any]] = None,
         filename_provider: Optional[FilenameProvider] = None,
-        arrow_csv_args_fn: Callable[[], Dict[str, Any]] = lambda: {},
+        arrow_csv_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         num_rows_per_file: Optional[int] = None,
         ray_remote_args: Dict[str, Any] = None,
         concurrency: Optional[int] = None,
@@ -2989,6 +2995,9 @@ class Dataset:
                     #pyarrow.csv.write_csv>`_
                 when writing each block to a file.
         """
+        if arrow_csv_args_fn is None:
+            arrow_csv_args_fn = lambda: {}  # noqa: E731
+
         datasink = CSVDatasink(
             path,
             arrow_csv_args_fn=arrow_csv_args_fn,

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -219,9 +219,19 @@ def assert_base_partitioned_ds():
         num_rows=6,
         schema="{one: int64, two: string}",
         sorted_values=None,
-        ds_take_transform_fn=lambda taken: [[s["one"], s["two"]] for s in taken],
-        sorted_values_transform_fn=lambda sorted_values: sorted_values,
+        ds_take_transform_fn=None,
+        sorted_values_transform_fn=None,
     ):
+        if ds_take_transform_fn is None:
+            ds_take_transform_fn = lambda taken: [  # noqa: E731
+                [s["one"], s["two"]] for s in taken
+            ]
+
+        if sorted_values_transform_fn is None:
+            sorted_values_transform_fn = (  # noqa: E731
+                lambda sorted_values: sorted_values
+            )
+
         if sorted_values is None:
             sorted_values = [[1, "a"], [1, "b"], [1, "c"], [3, "e"], [3, "f"], [3, "g"]]
         # Test metadata ops.


### PR DESCRIPTION
## Why are these changes needed?

Across the code base there are a number of instances where lambda functions were being used as default arguments. Our documentation build system doesn't handle these correctly, resulting in rendering issues with docs. Additionally, functions are mutable, [which means that these can have really weird/unintended behavior that is hard to debug](https://docs.astral.sh/ruff/rules/mutable-argument-default/).

This PR changes all the instances I could find where we were using a lambda function as a default argument and swaps it out according to the usual `if arg is None: arg = <lambda function>` pattern.

@angelinalg Can you confirm this fixes the documentation side of things for the functions that are part of the public API?

## Related issue number

Partially addresses #45129.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
