### PR TITLE
[Core] Task status should start with PENDING_ARGS_AVAIL when retry

### DIFF
--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1395,9 +1395,10 @@ void TaskManager::MarkDependenciesResolved(const TaskID &task_id) {
   if (it == submissible_tasks_.end()) {
     return;
   }
-  if (it->second.GetStatus() == rpc::TaskStatus::PENDING_ARGS_AVAIL) {
-    SetTaskStatus(it->second, rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
-  }
+
+  RAY_CHECK(it->second.GetStatus() == rpc::TaskStatus::PENDING_ARGS_AVAIL)
+      << ", task ID = " << it->first << ", status = " << it->second.GetStatus();
+  SetTaskStatus(it->second, rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
 }
 
 void TaskManager::MarkTaskWaitingForExecution(const TaskID &task_id,
@@ -1458,12 +1459,12 @@ void TaskManager::MarkTaskRetryOnFailed(TaskEntry &task_entry,
   task_entry.MarkRetryOnFailed();
 
   // Mark the new status and also include task spec info for the new attempt.
-  task_entry.SetStatus(rpc::TaskStatus::PENDING_NODE_ASSIGNMENT);
+  task_entry.SetStatus(rpc::TaskStatus::PENDING_ARGS_AVAIL);
   RAY_UNUSED(RecordTaskStatusEventIfNeeded(task_entry.spec.TaskId(),
                                            task_entry.spec.JobId(),
                                            task_entry.spec.AttemptNumber() + 1,
                                            task_entry.spec,
-                                           rpc::TaskStatus::PENDING_NODE_ASSIGNMENT,
+                                           rpc::TaskStatus::PENDING_ARGS_AVAIL,
                                            /* include_task_info */ true));
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
A new task attempt should always starts with `PENDING_ARGS_AVAIL`. We did it for `MarkTaskRetryOnResubmit` but not for `MarkTaskRetryOnFailed`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
