### PR TITLE
Accelerated DAG: Support channel writes larger than the max gRPC payload size

### DIFF
--- a/python/ray/dag/context.py
+++ b/python/ray/dag/context.py
@@ -20,13 +20,6 @@ DEFAULT_ASYNCIO_MAX_QUEUE_SIZE = int(
 # The maximum memory usage for buffered results is 1 GB.
 DEFAULT_MAX_BUFFERED_RESULTS = int(os.environ.get("RAY_DAG_max_buffered_results", 1000))
 
-# We still need to add support for transferring objects that are larger than the gRPC
-# payload limit, which Ray sets to ~512 MiB (so we set it slightly lower here to be
-# safe).
-# TODO(jhumphri): Add support for transferring objects that are larger than the gRPC
-# payload limit. We can support this by breaking an object into multiple RPCs.
-MAX_GRPC_PAYLOAD = int(1024 * 1024 * 450)  # 450 MiB
-
 
 @DeveloperAPI
 @dataclass
@@ -60,9 +53,6 @@ class DAGContext:
             executions is beyond the DAG capacity, the new execution would
             be blocked in the first place; therefore, this limit is only
             enforced when it is smaller than the DAG capacity.
-        max_grpc_payload: The maximum payload size that fits within a single gRPC.
-            Currently, mutable objects larger than this size cannot can sent via a
-            multi-node channel, though we plan to support this in the future.
     """
 
     execution_timeout: int = DEFAULT_EXECUTION_TIMEOUT_S
@@ -70,7 +60,6 @@ class DAGContext:
     buffer_size_bytes: int = DEFAULT_BUFFER_SIZE_BYTES
     asyncio_max_queue_size: int = DEFAULT_ASYNCIO_MAX_QUEUE_SIZE
     max_buffered_results: int = DEFAULT_MAX_BUFFERED_RESULTS
-    max_grpc_payload: int = MAX_GRPC_PAYLOAD
 
     @staticmethod
     def get_current() -> "DAGContext":

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1261,13 +1261,12 @@ def test_driver_and_actor_as_readers(ray_start_cluster):
         dag.experimental_compile()
 
 
-def test_payload_too_large(ray_start_regular):
+def test_large_payload(ray_start_regular):
     a = Actor.remote(0)
     with InputNode() as i:
         dag = a.echo.bind(i)
 
     compiled_dag = dag.experimental_compile()
-    dag_id = compiled_dag.get_id()
 
     # Ray sets the gRPC payload max size to 512 MiB. We choose a size in this test that
     # is a bit larger.
@@ -1276,7 +1275,6 @@ def test_payload_too_large(ray_start_regular):
 
     for i in range(3):
         ref = compiled_dag.execute(val)
-        assert str(ref) == f"CompiledDAGRef({dag_id}, execution_index={i})"
         result = ray.get(ref)
         assert result == val
 

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1278,7 +1278,7 @@ def test_payload_too_large(ray_start_regular):
         ref = compiled_dag.execute(val)
         assert str(ref) == f"CompiledDAGRef({dag_id}, execution_index={i})"
         result = ray.get(ref)
-        assert (result == val).all()
+        assert result == val
 
     # Note: must teardown before starting a new Ray session, otherwise you'll get
     # a segfault from the dangling monitor thread upon the new Ray init.

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -300,15 +300,6 @@ class Channel(ChannelInterface):
 
         self._num_readers = len(self._readers)
         if self.is_remote():
-            from ray.dag.context import DAGContext
-
-            if typ.buffer_size_bytes > DAGContext.get_current().max_grpc_payload:
-                raise ValueError(
-                    "The reader and writer are on different nodes, so the object "
-                    "written to the channel must have a size less than or equal to "
-                    "the max gRPC payload size "
-                    f"({DAGContext.get_current().max_grpc_payload} bytes)."
-                )
             self._num_readers = 1
 
     def _create_reader_ref(
@@ -417,15 +408,6 @@ class Channel(ChannelInterface):
         # include the size of the metadata, so we must account for the size of the
         # metadata explicitly.
         size = serialized_value.total_bytes + len(serialized_value.metadata)
-
-        from ray.dag.context import DAGContext
-
-        if size > DAGContext.get_current().max_grpc_payload and self.is_remote():
-            raise ValueError(
-                "The reader and writer are on different nodes, so the object written "
-                "to the channel must have a size less than or equal to the max gRPC "
-                f"payload size ({DAGContext.get_current().max_grpc_payload} bytes)."
-            )
         if size > self._typ.buffer_size_bytes:
             # Now make the channel backing store larger.
             self._typ.buffer_size_bytes = size

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -300,6 +300,11 @@ class Channel(ChannelInterface):
 
         self._num_readers = len(self._readers)
         if self.is_remote():
+            # Even though there may be multiple readers on a remote node, we set
+            # `self._num_readers` to 1 here. On this local node, only the IO thread in
+            # the mutable object provider will read the mutable object. The IO thread
+            # will then send a gRPC with the mutable object contents to the remote node
+            # where the readers are.
             self._num_readers = 1
 
     def _create_reader_ref(

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -973,7 +973,9 @@ def test_payload_too_large(ray_start_cluster):
     a = create_actor(actor_node)
     assert driver_node != ray.get(a.get_node_id.remote())
 
-    size = 1024 * 1024 * 512
+    # Ray sets the gRPC payload max size to 512 MiB. We choose a size in this test that
+    # is a bit larger.
+    size = 1024 * 1024 * 600
     ch = ray_channel.Channel(None, [a], size)
 
     val = b"x" * size
@@ -1022,7 +1024,9 @@ def test_payload_resize_too_large(ray_start_cluster):
 
     ch = ray_channel.Channel(None, [a], 1000)
 
-    size = 1024 * 1024 * 512
+    # Ray sets the gRPC payload max size to 512 MiB. We choose a size in this test that
+    # is a bit larger.
+    size = 1024 * 1024 * 600
     val = b"x" * size
     ch.write(val)
     ray.get(a.read.remote(ch, val))

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -938,7 +938,7 @@ def test_put_error(ray_start_cluster):
     sys.platform != "linux" and sys.platform != "darwin",
     reason="Requires Linux or Mac.",
 )
-def test_payload_too_large(ray_start_cluster):
+def test_payload_large(ray_start_cluster):
     cluster = ray_start_cluster
     # This node is for the driver.
     first_node_handle = cluster.add_node(num_cpus=1)
@@ -987,7 +987,7 @@ def test_payload_too_large(ray_start_cluster):
     sys.platform != "linux" and sys.platform != "darwin",
     reason="Requires Linux or Mac.",
 )
-def test_payload_resize_too_large(ray_start_cluster):
+def test_payload_resize_large(ray_start_cluster):
     cluster = ray_start_cluster
     # This node is for the driver.
     first_node_handle = cluster.add_node(num_cpus=1)

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -246,6 +246,24 @@ Status MutableObjectManager::WriteAcquire(const ObjectID &object_id,
   return Status::OK();
 }
 
+Status MutableObjectManager::WriteGetObjectBackingStore(const ObjectID &object_id,
+                                                        int64_t data_size,
+                                                        int64_t metadata_size,
+                                                        std::shared_ptr<Buffer> &data) {
+  RAY_LOG(DEBUG) << "WriteGetObjectBackingStore " << object_id;
+  absl::ReaderMutexLock guard(&destructor_lock_);
+
+  Channel *channel = GetChannel(object_id);
+  if (!channel) {
+    return Status::ChannelError("Channel has not been registered");
+  }
+
+  std::unique_ptr<plasma::MutableObject> &object = channel->mutable_object;
+  int64_t total_size = data_size + metadata_size;
+  data = SharedMemoryBuffer::Slice(object->buffer, 0, total_size);
+  return Status::OK();
+}
+
 Status MutableObjectManager::WriteRelease(const ObjectID &object_id) {
   RAY_LOG(DEBUG) << "WriteRelease " << object_id;
   absl::ReaderMutexLock guard(&destructor_lock_);

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -257,6 +257,7 @@ Status MutableObjectManager::WriteGetObjectBackingStore(const ObjectID &object_i
   if (!channel) {
     return Status::ChannelError("Channel has not been registered");
   }
+  RAY_CHECK(channel->written);
 
   std::unique_ptr<plasma::MutableObject> &object = channel->mutable_object;
   int64_t total_size = data_size + metadata_size;

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -246,10 +246,10 @@ Status MutableObjectManager::WriteAcquire(const ObjectID &object_id,
   return Status::OK();
 }
 
-Status MutableObjectManager::WriteGetObjectBackingStore(const ObjectID &object_id,
-                                                        int64_t data_size,
-                                                        int64_t metadata_size,
-                                                        std::shared_ptr<Buffer> &data) {
+Status MutableObjectManager::GetObjectBackingStore(const ObjectID &object_id,
+                                                   int64_t data_size,
+                                                   int64_t metadata_size,
+                                                   std::shared_ptr<Buffer> &data) {
   RAY_LOG(DEBUG) << "WriteGetObjectBackingStore " << object_id;
   absl::ReaderMutexLock guard(&destructor_lock_);
 

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -115,10 +115,10 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   /// \param[in] metadata_size The size of the metadata in the object.
   /// \param[out] data The mutable object buffer in plasma that can be written to.
   /// \return The return status.
-  Status WriteGetObjectBackingStore(const ObjectID &object_id,
-                                    int64_t data_size,
-                                    int64_t metadata_size,
-                                    std::shared_ptr<Buffer> &data);
+  Status GetObjectBackingStore(const ObjectID &object_id,
+                               int64_t data_size,
+                               int64_t metadata_size,
+                               std::shared_ptr<Buffer> &data);
 
   /// Acquires a write lock on the object that prevents readers from reading
   /// until we are done writing. This is safe for concurrent writers.

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -107,6 +107,14 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   ///         otherwise.
   bool ChannelRegistered(const ObjectID &object_id) { return GetChannel(object_id); }
 
+  /// Gets the backing store for an object. WriteAcquire() must have already been called
+  /// before this method is called, and WriteRelease() must not yet have been called.
+  ///
+  /// \param[in] object_id The ID of the object.
+  /// \param[in] data_size The size of the data in the object.
+  /// \param[in] metadata_size The size of the metadata in the object.
+  /// \param[out] data The mutable object buffer in plasma that can be written to.
+  /// \return The return status.
   Status WriteGetObjectBackingStore(const ObjectID &object_id,
                                     int64_t data_size,
                                     int64_t metadata_size,

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -107,6 +107,11 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   ///         otherwise.
   bool ChannelRegistered(const ObjectID &object_id) { return GetChannel(object_id); }
 
+  Status WriteGetObjectBackingStore(const ObjectID &object_id,
+                                    int64_t data_size,
+                                    int64_t metadata_size,
+                                    std::shared_ptr<Buffer> &data);
+
   /// Acquires a write lock on the object that prevents readers from reading
   /// until we are done writing. This is safe for concurrent writers.
   ///

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -157,6 +157,9 @@ void MutableObjectProvider::HandlePushMutableObject(
   if (total_written == total_size) {
     // The entire object has been written, so call `WriteRelease()`.
     RAY_CHECK_OK(object_manager_->WriteRelease(info.local_object_id));
+    reply->set_done(true);
+  } else {
+    reply->set_done(false);
   }
 }
 

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -115,12 +115,8 @@ void MutableObjectProvider::HandlePushMutableObject(
   uint64_t written_so_far = request.written_so_far();
   uint64_t chunk_size = request.chunk_size();
 
-  RAY_LOG(WARNING) << "Here! written_so_far = " << written_so_far
-                   << ", chunk_size = " << chunk_size;
-
   std::shared_ptr<Buffer> backing_store;
   if (!written_so_far) {
-    RAY_LOG(WARNING) << "written_so_far is 0, so WriteAcquire()";
     // We set `metadata` to nullptr since the metadata is at the end of the object, which
     // we will not have until the last chunk is received (or until the two last chunks are
     // received, if the metadata happens to span both). The metadata will end up being
@@ -146,8 +142,6 @@ void MutableObjectProvider::HandlePushMutableObject(
   size_t total_written = written_so_far + chunk_size;
   RAY_CHECK_LE(total_written, total_size);
   if (total_written == total_size) {
-    RAY_LOG(WARNING) << "written_so_far is equal to total_written (" << total_written
-                     << "), so WriteRelease()";
     // The entire object has been written, so call `WriteRelease()`.
     RAY_CHECK_OK(object_manager_->WriteRelease(info.local_object_id));
   }

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -89,6 +89,9 @@ void MutableObjectProvider::HandleRegisterMutableObject(
     const ObjectID &reader_object_id) {
   absl::MutexLock guard(&remote_writer_object_to_local_reader_lock_);
 
+  uint64_t chunk_idx = request.chunk_idx();
+  uint64_t total_num_chunks = request.total_num_chunks();
+
   LocalReaderInfo info;
   info.num_readers = num_readers;
   info.local_object_id = reader_object_id;
@@ -111,6 +114,9 @@ void MutableObjectProvider::HandlePushMutableObject(
   }
   size_t data_size = request.data_size();
   size_t metadata_size = request.metadata_size();
+
+  uint64_t chunk_idx = request.chunk_idx();
+  uint64_t total_num_chunks = request.total_num_chunks();
 
   // Copy both the data and metadata to a local channel.
   std::shared_ptr<Buffer> data;

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -127,10 +127,12 @@ void MutableObjectProvider::HandlePushMutableObject(
                                                total_metadata_size,
                                                info.num_readers,
                                                object_backing_store));
-    RAY_CHECK(object_backing_store);
+  } else {
+    RAY_CHECK_OK(object_manager_->GetObjectBackingStore(info.local_object_id,
+                                                        total_data_size,
+                                                        total_metadata_size,
+                                                        object_backing_store));
   }
-  RAY_CHECK_OK(object_manager_->GetObjectBackingStore(
-      info.local_object_id, total_data_size, total_metadata_size, object_backing_store));
   RAY_CHECK(object_backing_store);
 
   // The buffer has the data immediately followed by the metadata. `WriteAcquire()`

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -115,8 +115,12 @@ void MutableObjectProvider::HandlePushMutableObject(
   uint64_t written_so_far = request.written_so_far();
   uint64_t chunk_size = request.chunk_size();
 
+  RAY_LOG(WARNING) << "Here! written_so_far = " << written_so_far
+                   << ", chunk_size = " << chunk_size;
+
   std::shared_ptr<Buffer> backing_store;
   if (!written_so_far) {
+    RAY_LOG(WARNING) << "written_so_far is 0, so WriteAcquire()";
     // We set `metadata` to nullptr since the metadata is at the end of the object, which
     // we will not have until the last chunk is received (or until the two last chunks are
     // received, if the metadata happens to span both). The metadata will end up being
@@ -142,6 +146,8 @@ void MutableObjectProvider::HandlePushMutableObject(
   size_t total_written = written_so_far + chunk_size;
   RAY_CHECK_LE(total_written, total_size);
   if (total_written == total_size) {
+    RAY_LOG(WARNING) << "written_so_far is equal to total_written (" << total_written
+                     << "), so WriteRelease()";
     // The entire object has been written, so call `WriteRelease()`.
     RAY_CHECK_OK(object_manager_->WriteRelease(info.local_object_id));
   }

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -193,6 +193,13 @@ class MutableObjectProvider {
   // and then send the changes to remote nodes via the network.
   std::vector<std::unique_ptr<std::thread>> io_threads_;
 
+  // Protects the `written_so_far_` map.
+  absl::Mutex written_so_far_lock_;
+  // For objects larger than the gRPC max payload size *that this node receives from a
+  // writer node*, this map tracks how many bytes have been received so far for a single
+  // object write.
+  std::unordered_map<ObjectID, uint64_t> written_so_far_;
+
   friend class MutableObjectProvider_MutableObjectBufferReadRelease_Test;
 };
 

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -198,7 +198,8 @@ class MutableObjectProvider {
   // For objects larger than the gRPC max payload size *that this node receives from a
   // writer node*, this map tracks how many bytes have been received so far for a single
   // object write.
-  std::unordered_map<ObjectID, uint64_t> written_so_far_;
+  std::unordered_map<ObjectID, uint64_t> written_so_far_
+      ABSL_GUARDED_BY(written_so_far_lock_);
 
   friend class MutableObjectProvider_MutableObjectBufferReadRelease_Test;
 };

--- a/src/ray/core_worker/test/mutable_object_provider_test.cc
+++ b/src/ray/core_worker/test/mutable_object_provider_test.cc
@@ -222,8 +222,8 @@ TEST(MutableObjectProvider, HandlePushMutableObject) {
 
   ray::rpc::PushMutableObjectRequest request;
   request.set_writer_object_id(object_id.Binary());
-  request.set_data_size(0);
-  request.set_metadata_size(0);
+  request.set_total_data_size(0);
+  request.set_total_metadata_size(0);
 
   ray::rpc::PushMutableObjectReply reply;
   provider.HandlePushMutableObject(request, &reply);

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -356,17 +356,19 @@ message RegisterMutableObjectReply {
 }
 
 message PushMutableObjectRequest {
+  // The object ID of the object written to on the writer node.
   bytes writer_object_id = 1;
-  uint64 data_size = 2;
-  uint64 metadata_size = 3;
-  bytes data = 4;
+  // The total size of the data (across all chunks).
+  uint64 total_data_size = 2;
+  // The total size of the metadata (across all chunks).
+  uint64 total_metadata_size = 3;
 
-  // A large object cannot fit within a single gRPC, so we break it down into multiple
-  // chunks.
-  // `chunk_idx` is the index of this chunk with the stream of chunks.
-  uint64 chunk_idx = 5;
-  // The total number of chunks for this object.
-  uint64 total_num_chunks = 6;
+  // The number of bytes written so far.
+  uint64 written_so_far = 4;
+  // The size of this chunk. Note that this size could include both data and metadata.
+  uint64 chunk_size = 5;
+  // The chunk payload. Note that this could include both data and metadata.
+  bytes payload = 6;
 }
 
 message PushMutableObjectReply {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -363,8 +363,8 @@ message PushMutableObjectRequest {
   // The total size of the metadata (across all chunks).
   uint64 total_metadata_size = 3;
 
-  // The number of bytes written so far.
-  uint64 written_so_far = 4;
+  // The offset of the chunk (in bytes) within the object.
+  uint64 offset = 4;
   // The size of this chunk. Note that this size could include both data and metadata.
   uint64 chunk_size = 5;
   // The chunk payload. Note that this could include both data and metadata.

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -360,6 +360,13 @@ message PushMutableObjectRequest {
   uint64 data_size = 2;
   uint64 metadata_size = 3;
   bytes data = 4;
+
+  // A large object cannot fit within a single gRPC, so we break it down into multiple
+  // chunks.
+  // `chunk_idx` is the index of this chunk with the stream of chunks.
+  uint64 chunk_idx = 5;
+  // The total number of chunks for this object.
+  uint64 total_num_chunks = 6;
 }
 
 message PushMutableObjectReply {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -372,7 +372,9 @@ message PushMutableObjectRequest {
 }
 
 message PushMutableObjectReply {
-  // Empty for now.
+  // The receiver sets this to true once it has received all chunks for a mutable object
+  // write, false otherwise (i.e., the receiver still expects to receive more chunks).
+  bool done = 1;
 }
 
 // Service for inter-node-manager communication.

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -444,12 +444,12 @@ void raylet::RayletClient::PushMutableObject(
 
     uint64_t chunk_size = (i < total_num_chunks - 1) ? kMaxGrpcPayloadSize
                                                      : (total_size % kMaxGrpcPayloadSize);
-    uint64_t written_so_far = i * kMaxGrpcPayloadSize;
-    request.set_written_so_far(written_so_far);
+    uint64_t offset = i * kMaxGrpcPayloadSize;
+    request.set_offset(offset);
     request.set_chunk_size(chunk_size);
     // This assumes that the format of the object is a contiguous buffer of (data |
     // metadata).
-    request.set_payload(static_cast<char *>(data) + written_so_far, chunk_size);
+    request.set_payload(static_cast<char *>(data) + offset, chunk_size);
 
     // Only execute the callback once the entire object has been sent.
     bool execute_callback = (i == total_num_chunks - 1);

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -453,7 +453,6 @@ void raylet::RayletClient::PushMutableObject(
 
     // Only execute the callback once the entire object has been sent.
     bool execute_callback = (i == total_num_chunks - 1);
-    absl::Notification wait;
     // TODO: Add failure recovery, retries, and timeout.
     grpc_client_->PushMutableObject(
         request,
@@ -465,9 +464,7 @@ void raylet::RayletClient::PushMutableObject(
           if (execute_callback) {
             callback(status, reply);
           }
-          wait.Notify();
         });
-    wait.WaitForNotification();
   }
 }
 

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -450,12 +450,13 @@ void raylet::RayletClient::PushMutableObject(
 
     // Only execute the callback once the entire object has been sent.
     bool execute_callback = (i == total_num_chunks - 1);
+    // TODO: Add failure recovery, retries, and timeout.
     grpc_client_->PushMutableObject(
         request,
         [callback, execute_callback](const Status &status,
                                      const rpc::PushMutableObjectReply &reply) {
           if (!status.ok()) {
-            RAY_LOG(INFO) << "Error pushing mutable object: " << status;
+            RAY_LOG(ERROR) << "Error pushing mutable object: " << status;
           }
           if (execute_callback) {
             callback(status, reply);

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -424,7 +424,9 @@ void raylet::RayletClient::PushMutableObject(
     uint64_t metadata_size,
     void *data,
     const ray::rpc::ClientCallback<ray::rpc::PushMutableObjectReply> &callback) {
-  static constexpr uint64_t kMaxGrpcPayloadSize = 1024 * 1024 * 450;  // 450 MiB.
+  // Ray sets the gRPC max payload size to ~512 MiB. We set the max chunk size to a
+  // slightly lower value to allow extra padding just in case.
+  static constexpr uint64_t kMaxGrpcPayloadSize = 1024 * 1024 * 500;  // 500 MiB.
   uint64_t total_size = data_size + metadata_size;
   uint64_t total_num_chunks = total_size / kMaxGrpcPayloadSize;
   // If `total_size` is not a multiple of `kMaxGrpcPayloadSize`, then we need to send an

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -456,8 +456,8 @@ void raylet::RayletClient::PushMutableObject(
     // TODO: Add failure recovery, retries, and timeout.
     grpc_client_->PushMutableObject(
         request,
-        [callback, execute_callback, &wait](const Status &status,
-                                            const rpc::PushMutableObjectReply &reply) {
+        [callback, execute_callback](const Status &status,
+                                     const rpc::PushMutableObjectReply &reply) {
           if (!status.ok()) {
             RAY_LOG(ERROR) << "Error pushing mutable object: " << status;
           }

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -432,9 +432,6 @@ void raylet::RayletClient::PushMutableObject(
   if (total_size % kMaxGrpcPayloadSize) {
     total_num_chunks++;
   }
-  RAY_LOG(WARNING) << "total_size: " << total_size
-                   << ", total_num_chunks: " << total_num_chunks
-                   << ", kMaxGrpcPayloadSize: " << kMaxGrpcPayloadSize;
 
   for (uint64_t i = 0; i < total_num_chunks; i++) {
     rpc::PushMutableObjectRequest request;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, objects larger than the max gRPC payload size cannot be written to accelerated DAG channels when the writer and the readers are on different nodes. This PR adds support for writing objects larger than the max gRPC payload size.

An object is broken into chunks, and each chunk is sent from the writer node to the reader node. As each chunk arrives, they are written to the mutable object on the reader node. Once the last chunk arrives and is written to the mutable object, the gRPC handler calls `WriteRelease()` and the readers can then read the complete object.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
