### PR TITLE
[core][experimental] Check whether the channel is closed for the shared memory write operation

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1417,6 +1417,11 @@ Status CoreWorker::ExperimentalChannelWriteAcquire(
     int64_t num_readers,
     int64_t timeout_ms,
     std::shared_ptr<Buffer> *data) {
+  Status status = experimental_mutable_object_provider_->GetChannelStatus(
+      object_id, /*is_reader*/ false);
+  if (!status.ok()) {
+    return status;
+  }
   return experimental_mutable_object_provider_->WriteAcquire(object_id,
                                                              data_size,
                                                              metadata->Data(),
@@ -1560,7 +1565,8 @@ Status CoreWorker::Get(const std::vector<ObjectID> &ids,
   // Check whether these are experimental.Channel objects.
   bool is_experimental_channel = false;
   for (const ObjectID &id : ids) {
-    Status status = experimental_mutable_object_provider_->GetChannelStatus(id);
+    Status status =
+        experimental_mutable_object_provider_->GetChannelStatus(id, /*is_reader*/ true);
     if (status.ok()) {
       is_experimental_channel = true;
       // We continue rather than break because we want to check that *all* of the

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -454,15 +454,6 @@ MutableObjectManager::ToTimeoutPoint(int64_t timeout_ms) {
   return timeout_point;
 }
 
-Status MutableObjectManager::IsChannelClosed(const ObjectID &object_id) {
-  Channel *channel = GetChannel(object_id);
-  if (!channel) {
-    return Status::NotFound(
-        absl::StrFormat("Could not find channel for object ID %s.", object_id.Hex()));
-  }
-  return channel->mutable_object->header->CheckHasError();
-}
-
 Status MutableObjectManager::GetChannelStatus(const ObjectID &object_id, bool is_reader) {
   Channel *channel = GetChannel(object_id);
   if (!channel) {
@@ -553,7 +544,7 @@ MutableObjectManager::ToTimeoutPoint(int64_t timeout_ms) {
   return nullptr;
 }
 
-Status MutableObjectManager::IsChannelClosed(const ObjectID &object_id) {
+Status MutableObjectManager::GetChannelStatus(const ObjectID &object_id, bool is_reader) {
   return Status::NotImplemented("Not supported on Windows.");
 }
 

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -463,6 +463,19 @@ Status MutableObjectManager::IsChannelClosed(const ObjectID &object_id) {
   return channel->mutable_object->header->CheckHasError();
 }
 
+Status MutableObjectManager::GetChannelStatus(const ObjectID &object_id, bool is_reader) {
+  Channel *channel = GetChannel(object_id);
+  if (!channel) {
+    return Status::NotFound(
+        absl::StrFormat("Could not find channel for object ID %s.", object_id.Hex()));
+  }
+  if ((is_reader && channel->reader_registered) ||
+      (!is_reader && channel->writer_registered)) {
+    return Status::OK();
+  }
+  return channel->mutable_object->header->CheckHasError();
+}
+
 #else  // defined(__APPLE__) || defined(__linux__)
 
 MutableObjectManager::~MutableObjectManager() {}

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -107,32 +107,6 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   ///         otherwise.
   bool ChannelRegistered(const ObjectID &object_id) { return GetChannel(object_id); }
 
-  /// Checks if a reader channel is registered for an object.
-  ///
-  /// \param[in] object_id The ID of the object.
-  /// \return The return status. True if the channel is registered as a reader for
-  ///         object_id, false otherwise.
-  bool ReaderChannelRegistered(const ObjectID &object_id) {
-    Channel *c = GetChannel(object_id);
-    if (!c) {
-      return false;
-    }
-    return c->reader_registered;
-  }
-
-  /// Checks if a writer channel is registered for an object.
-  ///
-  /// \param[in] object_id The ID of the object.
-  /// \return The return status. True if the channel is registered as a writer for
-  ///         object_id, false otherwise.
-  bool WriterChannelRegistered(const ObjectID &object_id) {
-    Channel *c = GetChannel(object_id);
-    if (!c) {
-      return false;
-    }
-    return c->writer_registered;
-  }
-
   /// Acquires a write lock on the object that prevents readers from reading
   /// until we are done writing. This is safe for concurrent writers.
   ///
@@ -213,6 +187,19 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   /// \param[in] object_id The ID of the object.
   /// \return The channel or nullptr.
   Channel *GetChannel(const ObjectID &object_id);
+
+  /// Returns the current status of the channel for the object. Possible statuses are:
+  /// 1. Status::OK()
+  //     - The channel is registered and open.
+  /// 2. Status::ChannelError()
+  ///    - The channel was registered and previously open, but is now closed.
+  /// 3. Status::NotFound()
+  ///    - No channel exists for this object.
+  ///
+  /// \param[in] object_id The ID of the object.
+  /// \param[in] is_reader Whether the channel is a reader channel.
+  /// \return Current status of the channel.
+  Status GetChannelStatus(const ObjectID &object_id, bool is_reader);
 
  private:
   /// Converts a timeout in milliseconds to a timeout point.

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -174,13 +174,6 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   /// an error on acquire.
   Status SetErrorAll();
 
-  /// Checks if the channel is closed.
-  ///
-  /// \param[in] object_id The ID of the object.
-  /// \return Status indicating whether the object (if a channel for it exists) has its
-  ///         error bit set (i.e., the channel is closed).
-  Status IsChannelClosed(const ObjectID &object_id);
-
   /// Returns the channel for object_id. If no channel exists for object_id, returns
   /// nullptr.
   ///

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -131,14 +131,6 @@ void MutableObjectProvider::HandlePushMutableObject(
   RAY_CHECK_OK(object_manager_->WriteRelease(info.local_object_id));
 }
 
-bool MutableObjectProvider::ReaderChannelRegistered(const ObjectID &object_id) {
-  return object_manager_->ReaderChannelRegistered(object_id);
-}
-
-bool MutableObjectProvider::WriterChannelRegistered(const ObjectID &object_id) {
-  return object_manager_->WriterChannelRegistered(object_id);
-}
-
 Status MutableObjectProvider::WriteAcquire(const ObjectID &object_id,
                                            int64_t data_size,
                                            const uint8_t *metadata,
@@ -168,11 +160,9 @@ Status MutableObjectProvider::SetError(const ObjectID &object_id) {
   return object_manager_->SetError(object_id);
 }
 
-Status MutableObjectProvider::GetChannelStatus(const ObjectID &object_id) {
-  if (ReaderChannelRegistered(object_id)) {
-    return Status::OK();
-  }
-  return object_manager_->IsChannelClosed(object_id);
+Status MutableObjectProvider::GetChannelStatus(const ObjectID &object_id,
+                                               bool is_reader) {
+  return object_manager_->GetChannelStatus(object_id, is_reader);
 }
 
 void MutableObjectProvider::PollWriterClosure(

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -65,20 +65,6 @@ class MutableObjectProvider {
   void HandlePushMutableObject(const rpc::PushMutableObjectRequest &request,
                                rpc::PushMutableObjectReply *reply);
 
-  /// Checks if a reader channel is registered for an object.
-  ///
-  /// \param[in] object_id The ID of the object.
-  /// The return status. True if the channel is registered as a reader for object_id,
-  /// false otherwise.
-  bool ReaderChannelRegistered(const ObjectID &object_id);
-
-  /// Checks if a writer channel is registered for an object.
-  ///
-  /// \param[in] object_id The ID of the object.
-  /// The return status. True if the channel is registered as a writer for object_id,
-  /// false otherwise.
-  bool WriterChannelRegistered(const ObjectID &object_id);
-
   /// Acquires a write lock on the object that prevents readers from reading
   /// until we are done writing. This is safe for concurrent writers.
   ///
@@ -151,8 +137,9 @@ class MutableObjectProvider {
   ///    - No channel exists for this object.
   ///
   /// \param[in] object_id The ID of the object.
+  /// \param[in] is_reader Whether the channel is a reader channel.
   /// \return Current status of the channel.
-  Status GetChannelStatus(const ObjectID &object_id);
+  Status GetChannelStatus(const ObjectID &object_id, bool is_reader);
 
  private:
   struct LocalReaderInfo {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* In #46320, a check is added in `CoreWorker::Get` to avoid a mutable object being considered a normal immutable object after the channel is closed and the reader is unregistered.

* For the channel's `write` operation, the function `CoreWorker::ExperimentalChannelWriteAcquire` will only be called by a mutable object, and thus it doesn't have the issue of considering a mutable object as an immutable object.

* If we write to a channel after it is closed, an exception will be thrown as expected. However, the exception is thrown by `MutableObjectManager::WriteAcquire`, which is asymmetric with the codepath of the `read` operation. For the `read` operation, the exception is thrown by `CoreWorker::Get` instead of `MutableObjectManager`. Hence, this PR adds a check in `CoreWorker::ExperimentalChannelWriteAcquire`.
  https://github.com/ray-project/ray/blob/6a7521cde6cc1b11fdf07a3d5c7b792d6c4ae9a5/src/ray/core_worker/experimental_mutable_object_manager.cc#L234

* Remove `IsChannelClosed` / `ReaderChannelRegistered` / `WriterChannelRegistered` because they are unused after this PR.
## Related issue number

https://github.com/ray-project/ray/pull/46320#issuecomment-2197438895

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
