### PR TITLE
Revert https://github.com/ray-project/ray/pull/46393

### DIFF
--- a/release/ray_release/byod/byod.Dockerfile
+++ b/release/ray_release/byod/byod.Dockerfile
@@ -24,5 +24,3 @@ EOF
 
 COPY "$PIP_REQUIREMENTS" .
 RUN "$HOME"/anaconda3/bin/pip install --no-cache-dir -r "${PIP_REQUIREMENTS}"
-
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so:$LD_PRELOAD


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Did some bisecting and found out this commit was causing Serve's performance test latency to spike. Reverting https://github.com/ray-project/ray/commit/05067f4955e6e79e3cbf05fe6875677de5663924 to go back to previous state.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Tested with this [build](https://buildkite.com/ray-project/release/builds/19127#019099c2-04b9-428a-bbe3-a6c6acfd5117) and seeing the following performance metrics:
```
{
"perf_metric_name": "handle_1mb_p50_latency",
"perf_metric_type": "LATENCY",
"perf_metric_value": 4.620143499948881
},
{
"perf_metric_name": "handle_1mb_p90_latency",
"perf_metric_type": "LATENCY",
"perf_metric_value": 4.826495099950989
},
{
"perf_metric_name": "handle_1mb_p95_latency",
"perf_metric_type": "LATENCY",
"perf_metric_value": 4.9588876999621325
},
{
"perf_metric_name": "handle_1mb_p99_latency",
"perf_metric_type": "LATENCY",
"perf_metric_value": 5.219728340008487
},
{
"perf_metric_name": "handle_10mb_p50_latency",
"perf_metric_type": "LATENCY",
"perf_metric_value": 43.33374250001043
},
{
"perf_metric_name": "handle_10mb_p90_latency",
"perf_metric_type": "LATENCY",
"perf_metric_value": 44.26841059998878
},
{
"perf_metric_name": "handle_10mb_p95_latency",
"perf_metric_type": "LATENCY",
"perf_metric_value": 44.49023079997119
},
{
"perf_metric_name": "handle_10mb_p99_latency",
"perf_metric_type": "LATENCY",
"perf_metric_value": 45.28908214994885
},
```
