### PR TITLE
[Core] Rename state_ts to state_ts_ns to indicate that the unit is nanosecond

### DIFF
--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -250,7 +250,7 @@ def generate_task_event(
     )
     state_updates = TaskStateUpdate(
         node_id=node_id,
-        state_ts={state: 1},
+        state_ts_ns={state: 1},
     )
     return TaskEvents(
         task_id=id,
@@ -1007,7 +1007,7 @@ async def test_api_manager_list_tasks_events(state_api_manager):
     second = int(1e9)
     state_updates = TaskStateUpdate(
         node_id=node_id.binary(),
-        state_ts={
+        state_ts_ns={
             TaskStatus.PENDING_ARGS_AVAIL: current,
             TaskStatus.SUBMITTED_TO_WORKER: current + second,
             TaskStatus.RUNNING: current + (2 * second),
@@ -1058,7 +1058,7 @@ async def test_api_manager_list_tasks_events(state_api_manager):
     """
     state_updates = TaskStateUpdate(
         node_id=node_id.binary(),
-        state_ts={
+        state_ts_ns={
             TaskStatus.PENDING_ARGS_AVAIL: current,
             TaskStatus.SUBMITTED_TO_WORKER: current + second,
             TaskStatus.RUNNING: current + (2 * second),
@@ -1081,7 +1081,7 @@ async def test_api_manager_list_tasks_events(state_api_manager):
     Test None of start & end time is updated.
     """
     state_updates = TaskStateUpdate(
-        state_ts={
+        state_ts_ns={
             TaskStatus.PENDING_ARGS_AVAIL: current,
             TaskStatus.SUBMITTED_TO_WORKER: current + second,
         },

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1583,15 +1583,15 @@ def protobuf_to_task_state_dict(message: TaskEvents) -> dict:
     task_state["end_time_ms"] = None
     events = []
 
-    if "state_ts" in state_updates:
-        state_ts = state_updates["state_ts"]
+    if "state_ts_ns" in state_updates:
+        state_ts_ns = state_updates["state_ts_ns"]
         for state_name, state in TaskStatus.items():
-            # state_ts is Map[str, str] after protobuf MessageToDict
+            # state_ts_ns is Map[str, str] after protobuf MessageToDict
             key = str(state)
-            if key in state_ts:
+            if key in state_ts_ns:
                 # timestamp is recorded as nanosecond from the backend.
                 # We need to convert it to the second.
-                ts_ms = int(state_ts[key]) // 1e6
+                ts_ms = int(state_ts_ns[key]) // 1e6
                 events.append(
                     {
                         "state": state_name,

--- a/src/ray/gcs/gcs_server/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_task_manager.cc
@@ -113,7 +113,7 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTaskAttemptFailedIfNeeded(
   // We could mark the task as failed even if might not have state updates yet (i.e. only
   // profiling events are reported).
   auto state_updates = task_events.mutable_state_updates();
-  (*state_updates->mutable_state_ts())[ray::rpc::TaskStatus::FAILED] = failed_ts;
+  (*state_updates->mutable_state_ts_ns())[ray::rpc::TaskStatus::FAILED] = failed_ts;
   state_updates->mutable_error_info()->CopyFrom(error_info);
 }
 
@@ -433,7 +433,7 @@ void GcsTaskManager::HandleGetTaskEvents(rpc::GetTaskEventsRequest request,
       ray::rpc::TaskStatus state = ray::rpc::TaskStatus::NIL;
       if (task_event.has_state_updates()) {
         for (int i = task_status_descriptor->value_count() - 1; i >= 0; --i) {
-          if (task_event.state_updates().state_ts().contains(
+          if (task_event.state_updates().state_ts_ns().contains(
                   task_status_descriptor->value(i)->number())) {
             state = static_cast<ray::rpc::TaskStatus>(
                 task_status_descriptor->value(i)->number());

--- a/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
@@ -687,7 +687,8 @@ TEST_F(GcsTaskManagerTest, TestMarkTaskAttemptFailedIfNeeded) {
   {
     auto reply = SyncGetTaskEvents({tasks_finished});
     auto task_event = *(reply.events_by_task().begin());
-    EXPECT_FALSE(task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
+    EXPECT_FALSE(
+      task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
     EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FINISHED), 2);
   }
 }
@@ -757,7 +758,8 @@ TEST_F(GcsTaskManagerTest, TestJobFinishesFailAllRunningTasks) {
     auto reply = SyncGetTaskEvents(tasks);
     EXPECT_EQ(reply.events_by_task_size(), 10);
     for (const auto &task_event : reply.events_by_task()) {
-      EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FINISHED), 2);
+      EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FINISHED),
+                2);
       EXPECT_FALSE(
           task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
     }

--- a/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
@@ -673,22 +673,22 @@ TEST_F(GcsTaskManagerTest, TestMarkTaskAttemptFailedIfNeeded) {
   {
     auto reply = SyncGetTaskEvents({tasks_running});
     auto task_event = *(reply.events_by_task().begin());
-    EXPECT_EQ(task_event.state_updates().state_ts().at(rpc::TaskStatus::FAILED), 4);
+    EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED), 4);
   }
 
   // Check task attempt failed event is not overriding failed tasks.
   {
     auto reply = SyncGetTaskEvents({tasks_failed});
     auto task_event = *(reply.events_by_task().begin());
-    EXPECT_EQ(task_event.state_updates().state_ts().at(rpc::TaskStatus::FAILED), 3);
+    EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED), 3);
   }
 
   // Check task attempt failed event is not overriding finished tasks.
   {
     auto reply = SyncGetTaskEvents({tasks_finished});
     auto task_event = *(reply.events_by_task().begin());
-    EXPECT_FALSE(task_event.state_updates().state_ts().contains(rpc::TaskStatus::FAILED));
-    EXPECT_EQ(task_event.state_updates().state_ts().at(rpc::TaskStatus::FINISHED), 2);
+    EXPECT_FALSE(task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
+    EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FINISHED), 2);
   }
 }
 
@@ -740,7 +740,7 @@ TEST_F(GcsTaskManagerTest, TestJobFinishesFailAllRunningTasks) {
     auto reply = SyncGetTaskEvents(tasks);
     EXPECT_EQ(reply.events_by_task_size(), 10);
     for (const auto &task_event : reply.events_by_task()) {
-      EXPECT_EQ(task_event.state_updates().state_ts().at(rpc::TaskStatus::FAILED),
+      EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED),
                 /* 5 ms to ns */ 5 * 1000 * 1000);
       EXPECT_TRUE(task_event.state_updates().has_error_info());
       EXPECT_TRUE(task_event.state_updates().error_info().error_type() ==
@@ -757,9 +757,9 @@ TEST_F(GcsTaskManagerTest, TestJobFinishesFailAllRunningTasks) {
     auto reply = SyncGetTaskEvents(tasks);
     EXPECT_EQ(reply.events_by_task_size(), 10);
     for (const auto &task_event : reply.events_by_task()) {
-      EXPECT_EQ(task_event.state_updates().state_ts().at(rpc::TaskStatus::FINISHED), 2);
+      EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FINISHED), 2);
       EXPECT_FALSE(
-          task_event.state_updates().state_ts().contains(rpc::TaskStatus::FAILED));
+          task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
     }
   }
 
@@ -769,7 +769,7 @@ TEST_F(GcsTaskManagerTest, TestJobFinishesFailAllRunningTasks) {
     auto reply = SyncGetTaskEvents(tasks);
     EXPECT_EQ(reply.events_by_task_size(), 10);
     for (const auto &task_event : reply.events_by_task()) {
-      EXPECT_EQ(task_event.state_updates().state_ts().at(rpc::TaskStatus::FAILED), 3);
+      EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED), 3);
     }
   }
 
@@ -781,9 +781,9 @@ TEST_F(GcsTaskManagerTest, TestJobFinishesFailAllRunningTasks) {
     EXPECT_EQ(reply.events_by_task_size(), 5);
     for (const auto &task_event : reply.events_by_task()) {
       EXPECT_FALSE(
-          task_event.state_updates().state_ts().contains(rpc::TaskStatus::FAILED));
+          task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
       EXPECT_FALSE(
-          task_event.state_updates().state_ts().contains(rpc::TaskStatus::FINISHED));
+          task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FINISHED));
     }
   }
 }

--- a/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
@@ -688,7 +688,7 @@ TEST_F(GcsTaskManagerTest, TestMarkTaskAttemptFailedIfNeeded) {
     auto reply = SyncGetTaskEvents({tasks_finished});
     auto task_event = *(reply.events_by_task().begin());
     EXPECT_FALSE(
-      task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
+        task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
     EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FINISHED), 2);
   }
 }

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -277,8 +277,8 @@ inline bool IsTaskTerminated(const rpc::TaskEvents &task_event) {
   }
 
   const auto &state_updates = task_event.state_updates();
-  return state_updates.state_ts().contains(rpc::TaskStatus::FINISHED) ||
-         state_updates.state_ts().contains(rpc::TaskStatus::FAILED);
+  return state_updates.state_ts_ns().contains(rpc::TaskStatus::FINISHED) ||
+         state_updates.state_ts_ns().contains(rpc::TaskStatus::FAILED);
 }
 
 inline size_t NumProfileEvents(const rpc::TaskEvents &task_event) {
@@ -309,7 +309,7 @@ inline bool IsTaskFinished(const rpc::TaskEvents &task_event) {
   }
 
   const auto &state_updates = task_event.state_updates();
-  return state_updates.state_ts().contains(rpc::TaskStatus::FINISHED);
+  return state_updates.state_ts_ns().contains(rpc::TaskStatus::FINISHED);
 }
 
 /// Fill the rpc::TaskStateUpdate with the timestamps according to the status change.
@@ -324,7 +324,7 @@ inline void FillTaskStatusUpdateTime(const ray::rpc::TaskStatus &task_status,
     // Not status change.
     return;
   }
-  (*state_updates->mutable_state_ts())[task_status] = timestamp;
+  (*state_updates->mutable_state_ts_ns())[task_status] = timestamp;
 }
 
 inline std::string FormatPlacementGroupLabelName(const std::string &pg_id) {

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -230,7 +230,7 @@ message TaskStateUpdate {
   optional bool is_debugger_paused = 13;
   // Key is the integer value of TaskStatus enum (protobuf doesn't support Enum as key).
   // Value is the timestamp when status changes to the target status indicated by the key.
-  map<int32, int64> state_ts = 14;
+  map<int32, int64> state_ts_ns = 14;
 }
 
 // Represents events and state changes from a single task run.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Make it clear that state_ts is nanosecond
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
