### PR TITLE
[core] fix structured logging to use explicit value

### DIFF
--- a/python/ray/_private/ray_logging/filters.py
+++ b/python/ray/_private/ray_logging/filters.py
@@ -10,9 +10,9 @@ class CoreContextFilter(logging.Filter):
             return True
 
         runtime_context = ray.get_runtime_context()
-        setattr(record, LogKey.JOB_ID, runtime_context.get_job_id())
-        setattr(record, LogKey.WORKER_ID, runtime_context.get_worker_id())
-        setattr(record, LogKey.NODE_ID, runtime_context.get_node_id())
+        setattr(record, LogKey.JOB_ID.value, runtime_context.get_job_id())
+        setattr(record, LogKey.WORKER_ID.value, runtime_context.get_worker_id())
+        setattr(record, LogKey.NODE_ID.value, runtime_context.get_node_id())
         if runtime_context.worker.mode == ray.WORKER_MODE:
             actor_id = runtime_context.get_actor_id()
             if actor_id is not None:

--- a/python/ray/_private/ray_logging/formatters.py
+++ b/python/ray/_private/ray_logging/formatters.py
@@ -39,16 +39,16 @@ def generate_record_format_attrs(
     # Otherwise, include only Ray and user-provided context.
     if not exclude_standard_attrs:
         record_format_attrs = {
-            LogKey.ASCTIME: formatter.formatTime(record),
-            LogKey.LEVELNAME: record.levelname,
-            LogKey.MESSAGE: record.getMessage(),
-            LogKey.FILENAME: record.filename,
-            LogKey.LINENO: record.lineno,
+            LogKey.ASCTIME.value: formatter.formatTime(record),
+            LogKey.LEVELNAME.value: record.levelname,
+            LogKey.MESSAGE.value: record.getMessage(),
+            LogKey.FILENAME.value: record.filename,
+            LogKey.LINENO.value: record.lineno,
         }
         if record.exc_info:
             if not record.exc_text:
                 record.exc_text = formatter.formatException(record.exc_info)
-            record_format_attrs[LogKey.EXC_TEXT] = record.exc_text
+            record_format_attrs[LogKey.EXC_TEXT.value] = record.exc_text
 
     for key, value in record.__dict__.items():
         # Both Ray and user-provided context are stored in `record_format`.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

After python 3.12 upgrade, it will take "LogKey.XXX" as key implicitly:

```
This is a Ray task LogKey.JOB_ID=01000000 LogKey.WORKER_ID=49cd430b9e8c7cb52a5543db9f348ff1c52a306edc7dada20c163970 LogKey.NODE_ID=2120f4e042396ddd89331fe1e26b80ba3d4819aafd9f07ad59ed48fb task_id=c8ef45ccd0112571ffffffffffffffffffffffff01000000
```

This will fail `python/ray/tests/test_logging_2.py::TestTextModeE2E`

We should use ".value" as value.

## Related issue number

<!-- For example: "Closes #1234" -->

fix https://github.com/ray-project/ray/issues/46522

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
