### PR TITLE
[Serve] Add status code to retry when request timed out

### DIFF
--- a/doc/source/serve/advanced-guides/performance.md
+++ b/doc/source/serve/advanced-guides/performance.md
@@ -62,7 +62,7 @@ and it can't be updated during runtime. Use [client-side retries](serve-best-pra
 to retry requests that time out due to transient failures.
 
 :::{note}
-Serve returns response with status code 408 when the request timed out. Clients can
+Serve returns response with status code `408` when the request timed out. Clients can
 handle this status code and retry the request.
 :::
 

--- a/doc/source/serve/advanced-guides/performance.md
+++ b/doc/source/serve/advanced-guides/performance.md
@@ -55,7 +55,16 @@ proper backpressure. You can increase the value in the deployment decorator; e.g
 
 By default, Serve lets client HTTP requests run to completion no matter how long they take. However, slow requests could bottleneck the replica processing, blocking other requests that are waiting. Set an end-to-end timeout, so slow requests can be terminated and retried.
 
-You can set an end-to-end timeout for HTTP requests by setting the `request_timeout_s` in the `http_options` field of the Serve config. HTTP Proxies wait for that many seconds before terminating an HTTP request. This config is global to your Ray cluster, and it can't be updated during runtime. Use [client-side retries](serve-best-practices-http-requests) to retry requests that time out due to transient failures.
+You can set an end-to-end timeout for HTTP requests by setting the `request_timeout_s`
+in the `http_options` field of the Serve config. HTTP Proxies wait for that many
+seconds before terminating an HTTP request. This config is global to your Ray cluster,
+and it can't be updated during runtime. Use [client-side retries](serve-best-practices-http-requests)
+to retry requests that time out due to transient failures.
+
+:::{note}
+Serve returns response with status code 408 when the request timed out. Clients can
+handle this status code and retry the request.
+:::
 
 ### Give the Serve Controller more time to process requests
 

--- a/doc/source/serve/advanced-guides/performance.md
+++ b/doc/source/serve/advanced-guides/performance.md
@@ -55,7 +55,7 @@ proper backpressure. You can increase the value in the deployment decorator; e.g
 
 By default, Serve lets client HTTP requests run to completion no matter how long they take. However, slow requests could bottleneck the replica processing, blocking other requests that are waiting. Set an end-to-end timeout, so slow requests can be terminated and retried.
 
-You can set an end-to-end timeout for HTTP requests by setting the `request_timeout_s`
+You can set an end-to-end timeout for HTTP requests by setting the `request_timeout_s` parameter
 in the `http_options` field of the Serve config. HTTP Proxies wait for that many
 seconds before terminating an HTTP request. This config is global to your Ray cluster,
 and it can't be updated during runtime. Use [client-side retries](serve-best-practices-http-requests)

--- a/doc/source/serve/advanced-guides/performance.md
+++ b/doc/source/serve/advanced-guides/performance.md
@@ -62,8 +62,7 @@ and it can't be updated during runtime. Use [client-side retries](serve-best-pra
 to retry requests that time out due to transient failures.
 
 :::{note}
-Serve returns response with status code `408` when the request timed out. Clients can
-handle this status code and retry the request.
+Serve returns a response with status code `408` when a request times out. Clients can retry when they receive this `408` response.
 :::
 
 ### Give the Serve Controller more time to process requests

--- a/doc/source/serve/advanced-guides/performance.md
+++ b/doc/source/serve/advanced-guides/performance.md
@@ -58,7 +58,7 @@ By default, Serve lets client HTTP requests run to completion no matter how long
 You can set an end-to-end timeout for HTTP requests by setting the `request_timeout_s` parameter
 in the `http_options` field of the Serve config. HTTP Proxies wait for that many
 seconds before terminating an HTTP request. This config is global to your Ray cluster,
-and it can't be updated during runtime. Use [client-side retries](serve-best-practices-http-requests)
+and you can't update it during runtime. Use [client-side retries](serve-best-practices-http-requests)
 to retry requests that time out due to transient failures.
 
 :::{note}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It's not immediately apparent what's the status code returned by Serve when the request timed out. Added a note section on the timeout setup so user knows what status code to expect and potentially retry.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
