### PR TITLE
[doc][api] recursively get all rsts from the head file

### DIFF
--- a/ci/ray_ci/doc/test_autodoc.py
+++ b/ci/ray_ci/doc/test_autodoc.py
@@ -15,18 +15,27 @@ def test_walk():
             f.write("\tapi_01.rst\n")
             f.write("\tapi_02.rst\n")
         with open(os.path.join(tmp, "api_01.rst"), "w") as f:
+            f.write(".. include:: api_03.rst\n")
             f.write(".. currentmodule:: ci.ray_ci.doc\n")
             f.write(".. autosummary::\n")
-            f.write("\t~mock.mock_function\n")
             f.write("\tmock.mock_module.mock_w00t\n")
         with open(os.path.join(tmp, "api_02.rst"), "w") as f:
             f.write(".. currentmodule:: ci.ray_ci.doc.mock\n")
             f.write(".. autoclass:: MockClass\n")
+        with open(os.path.join(tmp, "api_03.rst"), "w") as f:
+            f.write(".. currentmodule:: ci.ray_ci.doc\n")
+            f.write(".. autosummary::\n")
+            f.write("\t~mock.mock_function\n")
 
         autodoc = Autodoc(os.path.join(tmp, "head.rst"))
-        apis = autodoc.get_apis()
+        apis = sorted(autodoc.get_apis(), key=lambda x: x.name)
         assert str(apis) == str(
             [
+                API(
+                    name="ci.ray_ci.doc.mock.MockClass",
+                    annotation_type=AnnotationType.PUBLIC_API,
+                    code_type=CodeType.CLASS,
+                ),
                 API(
                     name="ci.ray_ci.doc.mock.mock_function",
                     annotation_type=AnnotationType.PUBLIC_API,
@@ -37,24 +46,19 @@ def test_walk():
                     annotation_type=AnnotationType.PUBLIC_API,
                     code_type=CodeType.FUNCTION,
                 ),
-                API(
-                    name="ci.ray_ci.doc.mock.MockClass",
-                    annotation_type=AnnotationType.PUBLIC_API,
-                    code_type=CodeType.CLASS,
-                ),
             ]
         )
         assert (
             apis[0].get_canonical_name()
-            == f"{mock_function.__module__}.{mock_function.__qualname__}"
+            == f"{MockClass.__module__}.{MockClass.__qualname__}"
         )
         assert (
             apis[1].get_canonical_name()
-            == f"{mock_w00t.__module__}.{mock_w00t.__qualname__}"
+            == f"{mock_function.__module__}.{mock_function.__qualname__}"
         )
         assert (
             apis[2].get_canonical_name()
-            == f"{MockClass.__module__}.{MockClass.__qualname__}"
+            == f"{mock_w00t.__module__}.{mock_w00t.__qualname__}"
         )
 
 

--- a/ci/ray_ci/doc/test_autodoc.py
+++ b/ci/ray_ci/doc/test_autodoc.py
@@ -62,5 +62,21 @@ def test_walk():
         )
 
 
+def test_get_autodoc_rsts_in_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        with open(os.path.join(tmp, "head.rst"), "w") as f:
+            f.write(".. include:: api_00.rst\n")
+            f.write(".. toctree::\n\n")
+            f.write("\tapi_01.rst\n")
+            f.write("\tapi_02.rst\n")
+
+        autodoc = Autodoc("head.rst")
+        sorted(autodoc._get_autodoc_rsts_in_file(os.path.join(tmp, "head.rst"))) == {
+            os.path.join(tmp, "api_00.rst"),
+            os.path.join(tmp, "api_01.rst"),
+            os.path.join(tmp, "api_02.rst"),
+        }
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-vv", __file__]))


### PR DESCRIPTION
Currently `api_policy_check` only obtain APIs in the head rst file, and rsts included in the head file. However, we now have rsts including other rsts, etc.

This PR updates the logic to recursively obtain all rsts from the head file.

Test:
- CI