### PR TITLE
[ci] split window flaky tests into smaller jobs

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -110,8 +110,8 @@ steps:
         --test-env=USERPROFILE
     depends_on: windowsbuild
 
-  - label: "flaky :windows: tests"
-    key: windows_flaky_tests
+  - label: "flaky :windows: core tests"
+    key: windows_core_flaky_tests
     tags: skip-on-premerge
     job_env: WINDOWS
     instance_type: windows
@@ -125,6 +125,15 @@ steps:
         --test-env=CI="1"
         --test-env=RAY_CI_POST_WHEEL_TESTS="1"
         --test-env=USERPROFILE
+    depends_on: windowsbuild
+    soft_fail: true
+
+  - label: "flaky :windows: serverless tests"
+    key: windows_serverless_flaky_tests
+    tags: skip-on-premerge
+    job_env: WINDOWS
+    instance_type: windows
+    commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless
         --skip-ray-installation
         --except-tags no_windows
@@ -134,6 +143,15 @@ steps:
         --test-env=CI="1"
         --test-env=RAY_CI_POST_WHEEL_TESTS="1"
         --test-env=USERPROFILE
+    depends_on: windowsbuild
+    soft_fail: true
+
+  - label: "flaky :windows: serve tests"
+    key: windows_serve_flaky_tests
+    tags: skip-on-premerge
+    job_env: WINDOWS
+    instance_type: windows
+    commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
         --skip-ray-installation
         --except-tags no_windows


### PR DESCRIPTION
Split window flaky test jobs into core, serve and serverless. Couple of reasons;
- the  script `ci/build/upload_build_info.sh` fails on windows when being called repeatedly https://buildkite.com/ray-project/postmerge/builds/5319#0190996e-9a8d-4385-bb22-0d51ff2cd9cd/7990-7991
- it can take hours and the whole things keep retrying

Test:
- CI
- postmerge: https://buildkite.com/ray-project/postmerge/builds/5349