### PR TITLE
[ci] fix bazel version in window flaky tests

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -134,6 +134,7 @@ steps:
     job_env: WINDOWS
     instance_type: windows
     commands:
+      - bash ci/ray_ci/windows/install_tools.sh
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... serverless
         --skip-ray-installation
         --except-tags no_windows
@@ -152,6 +153,7 @@ steps:
     job_env: WINDOWS
     instance_type: windows
     commands:
+      - bash ci/ray_ci/windows/install_tools.sh
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
         --skip-ray-installation
         --except-tags no_windows


### PR DESCRIPTION
Forgot to fix bazel version in the new window flaky test jobs

Test:
- CI