### PR TITLE
[Core] Fix structured logging to use explicit value (#46523)

### DIFF
--- a/python/ray/_private/ray_logging/filters.py
+++ b/python/ray/_private/ray_logging/filters.py
@@ -10,9 +10,9 @@ class CoreContextFilter(logging.Filter):
             return True
 
         runtime_context = ray.get_runtime_context()
-        setattr(record, LogKey.JOB_ID, runtime_context.get_job_id())
-        setattr(record, LogKey.WORKER_ID, runtime_context.get_worker_id())
-        setattr(record, LogKey.NODE_ID, runtime_context.get_node_id())
+        setattr(record, LogKey.JOB_ID.value, runtime_context.get_job_id())
+        setattr(record, LogKey.WORKER_ID.value, runtime_context.get_worker_id())
+        setattr(record, LogKey.NODE_ID.value, runtime_context.get_node_id())
         if runtime_context.worker.mode == ray.WORKER_MODE:
             actor_id = runtime_context.get_actor_id()
             if actor_id is not None:

--- a/python/ray/_private/ray_logging/formatters.py
+++ b/python/ray/_private/ray_logging/formatters.py
@@ -14,16 +14,16 @@ def generate_record_format_attrs(
     # Otherwise, include only Ray and user-provided context.
     if not exclude_standard_attrs:
         record_format_attrs = {
-            LogKey.ASCTIME: formatter.formatTime(record),
-            LogKey.LEVELNAME: record.levelname,
-            LogKey.MESSAGE: record.getMessage(),
-            LogKey.FILENAME: record.filename,
-            LogKey.LINENO: record.lineno,
+            LogKey.ASCTIME.value: formatter.formatTime(record),
+            LogKey.LEVELNAME.value: record.levelname,
+            LogKey.MESSAGE.value: record.getMessage(),
+            LogKey.FILENAME.value: record.filename,
+            LogKey.LINENO.value: record.lineno,
         }
         if record.exc_info:
             if not record.exc_text:
                 record.exc_text = formatter.formatException(record.exc_info)
-            record_format_attrs[LogKey.EXC_TEXT] = record.exc_text
+            record_format_attrs[LogKey.EXC_TEXT.value] = record.exc_text
 
     for key, value in record.__dict__.items():
         # Both Ray and user-provided context are stored in `record_format`.


### PR DESCRIPTION
After python 3.12 upgrade, it will take "LogKey.XXX" as key implicitly:

```
This is a Ray task LogKey.JOB_ID=01000000 LogKey.WORKER_ID=49cd430b9e8c7cb52a5543db9f348ff1c52a306edc7dada20c163970 LogKey.NODE_ID=2120f4e042396ddd89331fe1e26b80ba3d4819aafd9f07ad59ed48fb task_id=c8ef45ccd0112571ffffffffffffffffffffffff01000000
```

This will fail `python/ray/tests/test_logging_2.py::TestTextModeE2E`

We should use ".value" as value.