### PR TITLE
[serve] deflake test_serve_dashboard

### DIFF
--- a/python/ray/dashboard/BUILD
+++ b/python/ray/dashboard/BUILD
@@ -99,7 +99,7 @@ py_test(
 
 py_test(
     name = "test_serve_dashboard",
-    size = "large",
+    size = "enormous",
     srcs = ["modules/serve/tests/test_serve_dashboard.py"],
     tags = ["team:serve"],
     deps = [":conftest"],


### PR DESCRIPTION
linux://python/ray/dashboard:test_serve_dashboard has become timedout and flaky recently (https://github.com/ray-project/ray/issues/46459); not sure if it has anything to do with https://github.com/ray-project/ray/pull/45943. I just increase its timed out in this PR

Test:
- CI
- https://buildkite.com/ray-project/postmerge/builds/5358