### PR TITLE
[autoscaler][aws] Fix replace cloudwatch alarm config

### DIFF
--- a/python/ray/autoscaler/_private/aws/cloudwatch/cloudwatch_helper.py
+++ b/python/ray/autoscaler/_private/aws/cloudwatch/cloudwatch_helper.py
@@ -46,7 +46,7 @@ class CloudwatchHelper:
         ] = {
             CloudwatchConfigType.AGENT.value: self._replace_cwa_config_vars,
             CloudwatchConfigType.DASHBOARD.value: self._replace_dashboard_config_vars,
-            CloudwatchConfigType.ALARM.value: self._load_config_file,
+            CloudwatchConfigType.ALARM.value: self._replace_alarm_config_vars,
         }
         self.CLOUDWATCH_CONFIG_TYPE_TO_UPDATE_FUNC_HEAD_NODE: Dict[str, Callable] = {
             CloudwatchConfigType.AGENT.value: self._restart_cloudwatch_agent,


### PR DESCRIPTION
placeholders like `instance_id` were not replaced

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

CW alarms were not created correctly when new instances were launched.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
