### PR TITLE
[doc][api] fix check for auto-generated api docs

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -26,11 +26,10 @@ steps:
       - lint
     key: lint-medium
     instance_type: medium
-    depends_on:
-      - oss-ci-base_build
+    depends_on: docbuild
+    job_env: docbuild
     commands:
       - ./ci/lint/lint.sh {{matrix}}
-    job_env: oss-ci-base_build
     matrix:
       - api_annotations
       - api_policy_check data

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -63,7 +63,10 @@ api_annotations() {
 }
 
 api_policy_check() {
+  # install ray and compile doc to generate API files
   RAY_DISABLE_EXTRA_CPP=1 pip install -e "python[all]"
+  make -C doc/ html
+  # validate the API files
   bazel run //ci/ray_ci/doc:cmd_check_api_discrepancy -- /ray "$@"
 }
 

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -16,14 +16,6 @@ TEAM_API_CONFIGS = {
             "ray.data.dataset.MaterializedDataset",
             # special case where we cannot deprecate although we want to
             "ray.data.random_access_dataset.RandomAccessDataset",
-            # TODO(can): apis that are auto-generated so falsely classified as not
-            # documented with the current logic
-            "ray.data.iterator.DataIterator",
-            "ray.data.iterator.DataIterator.iter_batches",
-            "ray.data.iterator.DataIterator.iter_torch_batches",
-            "ray.data.iterator.DataIterator.to_tf",
-            "ray.data.iterator.DataIterator.materialize",
-            "ray.data.iterator.DataIterator.stats",
         },
     },
 }


### PR DESCRIPTION
Fix api policy check for auto-generated API docs. For the check to work properly, we first need to compile ray docs to generate all API docs.

Test:
- CI