### PR TITLE
[Data] Rename `_estimated_output_blocks` to `_estimated_num_output_bundles`

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -184,7 +184,7 @@ class PhysicalOperator(Operator):
         self._started = False
         self._in_task_submission_backpressure = False
         self._metrics = OpRuntimeMetrics(self)
-        self._estimated_output_blocks = None
+        self._estimated_num_output_bundles = None
         self._execution_completed = False
 
     def __reduce__(self):
@@ -269,8 +269,8 @@ class PhysicalOperator(Operator):
         The value returned may be an estimate based off the consumption so far.
         This is useful for reporting progress.
         """
-        if self._estimated_output_blocks is not None:
-            return self._estimated_output_blocks
+        if self._estimated_num_output_bundles is not None:
+            return self._estimated_num_output_bundles
         if len(self.input_dependencies) == 1:
             return self.input_dependencies[0].num_outputs_total()
         raise AttributeError

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -91,7 +91,7 @@ class LimitOperator(OneToOneOperator):
             )
             # _consumed_rows / _limit is roughly equal to
             # _cur_output_bundles / total output blocks
-            self._estimated_output_blocks = round(
+            self._estimated_num_output_bundles = round(
                 estimated_total_output_rows
                 / self._consumed_rows
                 * self._cur_output_bundles
@@ -113,8 +113,8 @@ class LimitOperator(OneToOneOperator):
         # bundles we will have. We estimate based off the consumption so far.
         if self._execution_completed:
             return self._cur_output_bundles
-        elif self._estimated_output_blocks is not None:
-            return self._estimated_output_blocks
+        elif self._estimated_num_output_bundles is not None:
+            return self._estimated_num_output_bundles
         else:
             return self.input_dependencies[0].num_outputs_total()
 

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -322,7 +322,7 @@ class MapOperator(OneToOneOperator, ABC):
                 / self._metrics.num_inputs_received
                 * self._next_data_task_idx
             )
-            self._estimated_output_blocks = round(
+            self._estimated_num_output_bundles = round(
                 estimated_num_tasks
                 * self._metrics.num_outputs_of_finished_tasks
                 / self._metrics.num_tasks_finished

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -884,7 +884,7 @@ def test_operator_metrics():
         assert metrics.obj_store_mem_freed == metrics.bytes_task_inputs_processed, i
 
 
-def test_map_estimated_output_blocks():
+def test_map_estimated_num_output_bundles():
     # Test map operator estimation
     input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
 
@@ -906,12 +906,12 @@ def test_map_estimated_output_blocks():
         if op.metrics.num_inputs_received % min_rows_per_bundle == 0:
             # enough inputs for a task bundle
             run_op_tasks_sync(op)
-            assert op._estimated_output_blocks == 50
+            assert op._estimated_num_output_bundles == 50
 
     op.all_inputs_done()
 
     # 100 inputs -> 100 / 10 = 10 tasks -> 10 * 5 = 50 output blocks
-    assert op._estimated_output_blocks == 50
+    assert op._estimated_num_output_bundles == 50
 
 
 def test_map_estimated_blocks_split():
@@ -936,14 +936,14 @@ def test_map_estimated_blocks_split():
         if op.metrics.num_inputs_received % min_rows_per_bundle == 0:
             # enough inputs for a task bundle
             run_op_tasks_sync(op)
-            assert op._estimated_output_blocks == 100
+            assert op._estimated_num_output_bundles == 100
 
     op.all_inputs_done()
     # Each output block is split in 2, so the number of blocks double.
-    assert op._estimated_output_blocks == 100
+    assert op._estimated_num_output_bundles == 100
 
 
-def test_limit_estimated_output_blocks():
+def test_limit_estimated_num_output_bundles():
     # Test limit operator estimation
     input_op = InputDataBuffer(make_ref_bundles([[i, i] for i in range(100)]))
     op = LimitOperator(100, input_op)
@@ -951,12 +951,12 @@ def test_limit_estimated_output_blocks():
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
         run_op_tasks_sync(op)
-        assert op._estimated_output_blocks == 50
+        assert op._estimated_num_output_bundles == 50
 
     op.all_inputs_done()
 
     # 2 rows per bundle, 100 / 2 = 50 blocks output
-    assert op._estimated_output_blocks == 50
+    assert op._estimated_num_output_bundles == 50
 
     # Test limit operator estimation where: limit > # of rows
     input_op = InputDataBuffer(make_ref_bundles([[i, i] for i in range(100)]))
@@ -965,15 +965,15 @@ def test_limit_estimated_output_blocks():
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
         run_op_tasks_sync(op)
-        assert op._estimated_output_blocks == 100
+        assert op._estimated_num_output_bundles == 100
 
     op.all_inputs_done()
 
     # all blocks are outputted
-    assert op._estimated_output_blocks == 100
+    assert op._estimated_num_output_bundles == 100
 
 
-def test_all_to_all_estimated_output_blocks():
+def test_all_to_all_estimated_num_output_bundles():
     # Test all to all operator
     input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
 
@@ -1002,7 +1002,7 @@ def test_all_to_all_estimated_output_blocks():
     run_op_tasks_sync(op2)
 
     # estimated output blocks for op2 should fallback to op1
-    assert op2._estimated_output_blocks is None
+    assert op2._estimated_num_output_bundles is None
     assert op2.num_outputs_total() == estimated_output_blocks
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The name is misleading. The value represents bundles, not blocks.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
