### PR TITLE
[RLlib] Replace lambda default argument

### DIFF
--- a/rllib/env/wrappers/group_agents_wrapper.py
+++ b/rllib/env/wrappers/group_agents_wrapper.py
@@ -131,7 +131,10 @@ class GroupAgentsWrapper(MultiAgentEnv):
                 out[agent_id] = value
         return out
 
-    def _group_items(self, items, agg_fn=lambda gvals: list(gvals.values())):
+    def _group_items(self, items, agg_fn=None):
+        if agg_fn is None:
+            agg_fn = lambda gvals: list(gvals.values())  # noqa: E731
+
         grouped_items = {}
         for agent_id, item in items.items():
             if agent_id in self.agent_id_to_group:


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes instances where lambda functions are used as default arguments. Since default arguments are evaluated at function definition time, mutable objects can have unintuitive behavior; additionally, they prevent our documentation from rendering correctly. This PR is part of #45129, but has been split up to minimize codeowner impact.

## Related issue number

Partially addresses #45129.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
