### PR TITLE
[Core] Replace lambda default arguments

### DIFF
--- a/python/ray/_private/runtime_env/uri_cache.py
+++ b/python/ray/_private/runtime_env/uri_cache.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Set, Callable
+from typing import Set, Callable, Optional
 
 default_logger = logging.getLogger(__name__)
 
@@ -29,14 +29,18 @@ class URICache:
 
     def __init__(
         self,
-        delete_fn: Callable[[str, logging.Logger], int] = lambda uri, logger: 0,
+        delete_fn: Optional[Callable[[str, logging.Logger], int]] = None,
         max_total_size_bytes: int = DEFAULT_MAX_URI_CACHE_SIZE_BYTES,
         debug_mode: bool = False,
     ):
         # Maps URIs to the size in bytes of their corresponding disk contents.
         self._used_uris: Set[str] = set()
         self._unused_uris: Set[str] = set()
-        self._delete_fn = delete_fn
+
+        if delete_fn is None:
+            self._delete_fn = lambda uri, logger: 0
+        else:
+            self._delete_fn = delete_fn
 
         # Total size of both used and unused URIs in the cache.
         self._total_size_bytes = 0

--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -32,9 +32,7 @@ def add_resources(dict1: Dict[str, float], dict2: Dict[str, float]) -> Dict[str,
     return new_dict
 
 
-def freq_of_dicts(
-    dicts: List[Dict], serializer=lambda d: frozenset(d.items()), deserializer=dict
-) -> DictCount:
+def freq_of_dicts(dicts: List[Dict], serializer=None, deserializer=dict) -> DictCount:
     """Count a list of dictionaries (or unhashable types).
 
     This is somewhat annoying because mutable data structures aren't hashable,
@@ -53,6 +51,9 @@ def freq_of_dicts(
             is a tuple containing a unique entry from `dicts` and its
             corresponding frequency count.
     """
+    if serializer is None:
+        serializer = lambda d: frozenset(d.items())  # noqa: E731
+
     freqs = Counter(serializer(d) for d in dicts)
     as_list = []
     for as_set, count in freqs.items():


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes instances where lambda functions are used as default arguments. Since default arguments are evaluated at function definition time, mutable objects can have unintuitive behavior; additionally, they prevent our documentation from rendering correctly. This PR is part of #45129, but has been split up to minimize codeowner impact.

## Related issue number

Partially addresses #45129.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
