### PR TITLE
[ci] deflake serve window tests

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -88,11 +88,21 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
         --build-name windowsbuild
         --operating-system windows
-        --except-tags no_windows
+        --except-tags no_windows,use_all_core_windows
         --test-env=CI="1"
         --test-env=RAY_CI_POST_WHEEL_TESTS="1"
         --test-env=USERPROFILE
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
+        --skip-ray-installation
+        --build-name windowsbuild
+        --operating-system windows
+        --only-tags use_all_core_windows
+        --except-tags no_windows
+        --test-env=CI="1"
+        --test-env=RAY_CI_POST_WHEEL_TESTS="1"
+        --test-env=USERPROFILE
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
     depends_on: windowsbuild
 
   - label: ":train: ml: :windows: tests"

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -28,10 +28,7 @@ py_test_module_list(
         "test_deployment_node.py",
         "test_deployment_scheduler.py",
         "test_deployment_version.py",
-        "test_enable_task_events.py",
         "test_expected_versions.py",
-        "test_kv_store.py",
-        "test_long_poll.py",
         "test_max_queued_requests.py",
         "test_persistence.py",
         "test_proxy.py",
@@ -73,7 +70,6 @@ py_test_module_list(
         "test_proxy_response_generator.py",
         "test_proxy_state.py",
         "test_ray_client.py",
-        "test_regression.py",
         "test_replica_placement_group.py",
         "test_request_timeout.py",
         "test_streaming_response.py",
@@ -135,8 +131,6 @@ py_test_module_list(
         "test_autoscaling_policy.py",
         "test_deploy.py",
         "test_deploy_2.py",
-        "test_deploy_app.py",
-        "test_metrics.py",
         "test_standalone.py",
         "test_standalone_3.py",
         "test_telemetry.py",
@@ -145,6 +139,28 @@ py_test_module_list(
     tags = [
         "exclusive",
         "team:serve",
+    ],
+    deps = [
+        ":common",
+        ":conftest",
+        "//python/ray/serve:serve_lib",
+    ],
+)
+
+py_test_module_list(
+    size = "large",
+    files = [
+        "test_deploy_app.py",
+        "test_metrics.py",
+        "test_enable_task_events.py",
+        "test_kv_store.py",
+        "test_long_poll.py",
+        "test_regression.py",
+    ],
+    tags = [
+        "exclusive",
+        "team:serve",
+         "use_all_core_windows",
     ],
     deps = [
         ":common",


### PR DESCRIPTION
This set of serve tests when running in parallel leads to flakiness and timed out, but run fine when running serially. I move them into running serially.

<img width="1429" alt="Screenshot 2024-07-10 at 7 40 56 PM" src="https://github.com/ray-project/ray/assets/128072568/8caf660b-5eba-4bc3-a72c-663aa7683f58">


Test:
- CI
- https://buildkite.com/ray-project/postmerge/builds/5381