### PR TITLE
[Core] Fix ObjectFetchTimedOutError

### DIFF
--- a/python/ray/tests/test_reconstruction_2.py
+++ b/python/ray/tests/test_reconstruction_2.py
@@ -9,6 +9,7 @@ import ray
 import ray._private.ray_constants as ray_constants
 from ray._private.internal_api import memory_summary
 from ray._private.test_utils import Semaphore, SignalActor, wait_for_condition
+import ray.exceptions
 
 # Task status.
 WAITING_FOR_DEPENDENCIES = "PENDING_ARGS_AVAIL"
@@ -496,6 +497,52 @@ def test_reconstruct_freed_object(config, ray_start_cluster, reconstruction_enab
             ray.get(x)
         with pytest.raises(ray.exceptions.ObjectFreedError):
             ray.get(obj)
+
+
+def test_object_reconstruction_pending_creation(config, ray_start_cluster):
+    # Test to make sure that an object being reconstructured
+    # has pending_creation set to true.
+    config["fetch_fail_timeout_milliseconds"] = 5000
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=0, resources={"head": 1}, _system_config=config)
+    ray.init(address=cluster.address)
+
+    @ray.remote(num_cpus=0, resources={"head": 0.1})
+    class Counter:
+        def __init__(self):
+            self.count = 0
+
+        def inc(self):
+            self.count = self.count + 1
+            return self.count
+
+    counter = Counter.remote()
+
+    @ray.remote(num_cpus=1, max_retries=-1)
+    def generator(counter):
+        if ray.get(counter.inc.remote()) == 1:
+            # first attempt
+            yield np.zeros(10**6, dtype=np.uint8)
+            time.sleep(10000000)
+            yield np.zeros(10**6, dtype=np.uint8)
+        else:
+            time.sleep(10000000)
+            yield np.zeros(10**6, dtype=np.uint8)
+            time.sleep(10000000)
+            yield np.zeros(10**6, dtype=np.uint8)
+
+    worker = cluster.add_node(num_cpus=8)
+    gen = generator.remote(counter)
+    obj = next(gen)
+
+    cluster.remove_node(worker, allow_graceful=False)
+    # After removing the node, the generator task will be retried
+    # and the obj will be reconstructured and has pending_creation set to true.
+    cluster.add_node(num_cpus=8)
+
+    # This should raise GetTimeoutError instead of ObjectFetchTimedOutError
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(obj, timeout=10)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_reconstruction_2.py
+++ b/python/ray/tests/test_reconstruction_2.py
@@ -9,6 +9,7 @@ import ray
 import ray._private.ray_constants as ray_constants
 from ray._private.internal_api import memory_summary
 from ray._private.test_utils import Semaphore, SignalActor, wait_for_condition
+import ray.exceptions
 
 # Task status.
 WAITING_FOR_DEPENDENCIES = "PENDING_ARGS_AVAIL"
@@ -496,6 +497,50 @@ def test_reconstruct_freed_object(config, ray_start_cluster, reconstruction_enab
             ray.get(x)
         with pytest.raises(ray.exceptions.ObjectFreedError):
             ray.get(obj)
+
+
+def test_pending_creation(config, ray_start_cluster):
+    config["fetch_fail_timeout_milliseconds"] = 5000
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=0, resources={"head": 1}, _system_config=config)
+    ray.init(address=cluster.address)
+
+    @ray.remote(num_cpus=0, resources={"head": 0.1})
+    class Counter:
+        def __init__(self):
+            self.count = 0
+
+        def inc(self):
+            self.count = self.count + 1
+            return self.count
+
+    counter = Counter.remote()
+
+    @ray.remote(num_cpus=1, max_retries=-1)
+    def generator(counter):
+        if ray.get(counter.inc.remote()) == 1:
+            # first attempt
+            yield np.zeros(10**6, dtype=np.uint8)
+            time.sleep(10000000)
+            yield np.zeros(10**6, dtype=np.uint8)
+        else:
+            time.sleep(10000000)
+            yield np.zeros(10**6, dtype=np.uint8)
+            time.sleep(10000000)
+            yield np.zeros(10**6, dtype=np.uint8)
+
+    worker = cluster.add_node(num_cpus=8)
+    gen = generator.remote(counter)
+    obj = next(gen)
+
+    cluster.remove_node(worker, allow_graceful=False)
+    # After removing the node, the generator task will be retried
+    # and the obj will be reconstructured.
+    cluster.add_node(num_cpus=8)
+
+    # This should raise GetTimeoutError instead of ObjectFetchTimedOutError
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(obj, timeout=10)
 
 
 if __name__ == "__main__":

--- a/src/ray/core_worker/object_recovery_manager.cc
+++ b/src/ray/core_worker/object_recovery_manager.cc
@@ -171,6 +171,7 @@ void ObjectRecoveryManager::ReconstructObject(const ObjectID &object_id) {
   auto resubmitted = task_resubmitter_->ResubmitTask(task_id, &task_deps);
 
   if (resubmitted) {
+    reference_counter_->UpdateObjectPendingCreation(object_id, true);
     // Try to recover the task's dependencies.
     for (const auto &dep : task_deps) {
       auto recovered = RecoverObject(dep);

--- a/src/ray/core_worker/object_recovery_manager.cc
+++ b/src/ray/core_worker/object_recovery_manager.cc
@@ -171,6 +171,7 @@ void ObjectRecoveryManager::ReconstructObject(const ObjectID &object_id) {
   auto resubmitted = task_resubmitter_->ResubmitTask(task_id, &task_deps);
 
   if (resubmitted) {
+    reference_counter_->UpdateObjectsPendingCreation({object_id}, true);
     // Try to recover the task's dependencies.
     for (const auto &dep : task_deps) {
       auto recovered = RecoverObject(dep);

--- a/src/ray/core_worker/object_recovery_manager.cc
+++ b/src/ray/core_worker/object_recovery_manager.cc
@@ -171,7 +171,6 @@ void ObjectRecoveryManager::ReconstructObject(const ObjectID &object_id) {
   auto resubmitted = task_resubmitter_->ResubmitTask(task_id, &task_deps);
 
   if (resubmitted) {
-    reference_counter_->UpdateObjectsPendingCreation({object_id}, true);
     // Try to recover the task's dependencies.
     for (const auto &dep : task_deps) {
       auto recovered = RecoverObject(dep);

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -484,11 +484,8 @@ void ReferenceCounter::UpdateSubmittedTaskReferences(
 }
 
 void ReferenceCounter::UpdateResubmittedTaskReferences(
-    const std::vector<ObjectID> return_ids, const std::vector<ObjectID> &argument_ids) {
+    const std::vector<ObjectID> &argument_ids) {
   absl::MutexLock lock(&mutex_);
-  for (const auto &return_id : return_ids) {
-    UpdateObjectPendingCreationInternal(return_id, true);
-  }
   for (const ObjectID &argument_id : argument_ids) {
     auto it = object_id_refs_.find(argument_id);
     RAY_CHECK(it != object_id_refs_.end());
@@ -1522,9 +1519,10 @@ bool ReferenceCounter::IsObjectReconstructable(const ObjectID &object_id,
   return it->second.is_reconstructable;
 }
 
-void ReferenceCounter::UpdateObjectReady(const ObjectID &object_id) {
+void ReferenceCounter::UpdateObjectPendingCreation(const ObjectID &object_id,
+                                                   bool pending_creation) {
   absl::MutexLock lock(&mutex_);
-  UpdateObjectPendingCreationInternal(object_id, /*pending_creation*/ false);
+  UpdateObjectPendingCreationInternal(object_id, pending_creation);
 }
 
 bool ReferenceCounter::IsObjectPendingCreation(const ObjectID &object_id) const {

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1527,11 +1527,6 @@ void ReferenceCounter::UpdateObjectReady(const ObjectID &object_id) {
   UpdateObjectPendingCreationInternal(object_id, /*pending_creation*/ false);
 }
 
-void ReferenceCounter::UpdateObjectPendingCreation(const ObjectID &object_id) {
-  absl::MutexLock lock(&mutex_);
-  UpdateObjectPendingCreationInternal(object_id, /*pending_creation*/ true);
-}
-
 bool ReferenceCounter::IsObjectPendingCreation(const ObjectID &object_id) const {
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1527,6 +1527,11 @@ void ReferenceCounter::UpdateObjectReady(const ObjectID &object_id) {
   UpdateObjectPendingCreationInternal(object_id, /*pending_creation*/ false);
 }
 
+void ReferenceCounter::UpdateObjectPendingCreation(const ObjectID &object_id) {
+  absl::MutexLock lock(&mutex_);
+  UpdateObjectPendingCreationInternal(object_id, /*pending_creation*/ true);
+}
+
 bool ReferenceCounter::IsObjectPendingCreation(const ObjectID &object_id) const {
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -452,10 +452,14 @@ void ReferenceCounter::RemoveLocalReferenceInternal(const ObjectID &object_id,
 }
 
 void ReferenceCounter::UpdateSubmittedTaskReferences(
+    const std::vector<ObjectID> return_ids,
     const std::vector<ObjectID> &argument_ids_to_add,
     const std::vector<ObjectID> &argument_ids_to_remove,
     std::vector<ObjectID> *deleted) {
   absl::MutexLock lock(&mutex_);
+  for (const auto &return_id : return_ids) {
+    UpdateObjectPendingCreationInternal(return_id, true);
+  }
   for (const ObjectID &argument_id : argument_ids_to_add) {
     RAY_LOG(DEBUG) << "Increment ref count for submitted task argument " << argument_id;
     auto it = object_id_refs_.find(argument_id);
@@ -480,8 +484,11 @@ void ReferenceCounter::UpdateSubmittedTaskReferences(
 }
 
 void ReferenceCounter::UpdateResubmittedTaskReferences(
-    const std::vector<ObjectID> &argument_ids) {
+    const std::vector<ObjectID> return_ids, const std::vector<ObjectID> &argument_ids) {
   absl::MutexLock lock(&mutex_);
+  for (const auto &return_id : return_ids) {
+    UpdateObjectPendingCreationInternal(return_id, true);
+  }
   for (const ObjectID &argument_id : argument_ids) {
     auto it = object_id_refs_.find(argument_id);
     RAY_CHECK(it != object_id_refs_.end());
@@ -494,12 +501,16 @@ void ReferenceCounter::UpdateResubmittedTaskReferences(
 }
 
 void ReferenceCounter::UpdateFinishedTaskReferences(
+    const std::vector<ObjectID> return_ids,
     const std::vector<ObjectID> &argument_ids,
     bool release_lineage,
     const rpc::Address &worker_addr,
     const ReferenceTableProto &borrowed_refs,
     std::vector<ObjectID> *deleted) {
   absl::MutexLock lock(&mutex_);
+  for (const auto &return_id : return_ids) {
+    UpdateObjectPendingCreationInternal(return_id, false);
+  }
   // Must merge the borrower refs before decrementing any ref counts. This is
   // to make sure that for serialized IDs, we increment the borrower count for
   // the inner ID before decrementing the submitted_task_ref_count for the
@@ -1511,12 +1522,9 @@ bool ReferenceCounter::IsObjectReconstructable(const ObjectID &object_id,
   return it->second.is_reconstructable;
 }
 
-void ReferenceCounter::UpdateObjectsPendingCreation(
-    const std::vector<ObjectID> &object_ids, bool pending_creation) {
+void ReferenceCounter::UpdateObjectReady(const ObjectID &object_id) {
   absl::MutexLock lock(&mutex_);
-  for (const auto &object_id : object_ids) {
-    UpdateObjectPendingCreationInternal(object_id, pending_creation);
-  }
+  UpdateObjectPendingCreationInternal(object_id, /*pending_creation*/ false);
 }
 
 bool ReferenceCounter::IsObjectPendingCreation(const ObjectID &object_id) const {

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -131,8 +131,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// have already incremented them when the task was first submitted.
   ///
   /// \param[in] argument_ids The arguments of the task to add references for.
-  void UpdateResubmittedTaskReferences(const std::vector<ObjectID> return_ids,
-                                       const std::vector<ObjectID> &argument_ids)
+  void UpdateResubmittedTaskReferences(const std::vector<ObjectID> &argument_ids)
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Update object references that were given to a submitted task. The task
@@ -559,8 +558,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// \param[in] min_bytes_to_evict The minimum number of bytes to evict.
   int64_t EvictLineage(int64_t min_bytes_to_evict);
 
-  /// Update that the object is ready to be fetched.
-  void UpdateObjectReady(const ObjectID &object_id);
+  /// Update whether the object is pending creation.
+  void UpdateObjectPendingCreation(const ObjectID &object_id, bool pending_creation);
 
   /// Whether the object is pending creation (the task that creates it is
   /// scheduled/executing).

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -562,9 +562,6 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// Update that the object is ready to be fetched.
   void UpdateObjectReady(const ObjectID &object_id);
 
-  /// Update that the object's creator task is scheduled/executing.
-  void UpdateObjectPendingCreation(const ObjectID &object_id);
-
   /// Whether the object is pending creation (the task that creates it is
   /// scheduled/executing).
   bool IsObjectPendingCreation(const ObjectID &object_id) const;

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -562,6 +562,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// Update that the object is ready to be fetched.
   void UpdateObjectReady(const ObjectID &object_id);
 
+  /// Update that the object's creator task is scheduled/executing.
+  void UpdateObjectPendingCreation(const ObjectID &object_id);
+
   /// Whether the object is pending creation (the task that creates it is
   /// scheduled/executing).
   bool IsObjectPendingCreation(const ObjectID &object_id) const;

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -121,7 +121,6 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// \param[out] deleted Any objects that are newly out of scope after this
   /// function call.
   void UpdateSubmittedTaskReferences(
-      const std::vector<ObjectID> return_ids,
       const std::vector<ObjectID> &argument_ids_to_add,
       const std::vector<ObjectID> &argument_ids_to_remove = std::vector<ObjectID>(),
       std::vector<ObjectID> *deleted = nullptr) ABSL_LOCKS_EXCLUDED(mutex_);
@@ -131,15 +130,14 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// have already incremented them when the task was first submitted.
   ///
   /// \param[in] argument_ids The arguments of the task to add references for.
-  void UpdateResubmittedTaskReferences(const std::vector<ObjectID> return_ids,
-                                       const std::vector<ObjectID> &argument_ids)
+  void UpdateResubmittedTaskReferences(const std::vector<ObjectID> &argument_ids)
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Update object references that were given to a submitted task. The task
   /// may still be borrowing any object IDs that were contained in its
   /// arguments. This should be called when the task finishes.
   ///
-  /// \param[in] object_ids The object IDs to remove references for.
+  /// \param[in] argument_ids The object IDs to remove references for.
   /// \param[in] release_lineage Whether to decrement the arguments' lineage
   /// ref count.
   /// \param[in] worker_addr The address of the worker that executed the task.
@@ -149,8 +147,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// arguments. Some references in this table may still be borrowed by the
   /// worker and/or a task that the worker submitted.
   /// \param[out] deleted The object IDs whos reference counts reached zero.
-  void UpdateFinishedTaskReferences(const std::vector<ObjectID> return_ids,
-                                    const std::vector<ObjectID> &argument_ids,
+  void UpdateFinishedTaskReferences(const std::vector<ObjectID> &argument_ids,
                                     bool release_lineage,
                                     const rpc::Address &worker_addr,
                                     const ReferenceTableProto &borrowed_refs,
@@ -559,8 +556,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// \param[in] min_bytes_to_evict The minimum number of bytes to evict.
   int64_t EvictLineage(int64_t min_bytes_to_evict);
 
-  /// Update that the object is ready to be fetched.
-  void UpdateObjectReady(const ObjectID &object_id);
+  /// Update whether the objects are pending creation.
+  void UpdateObjectsPendingCreation(const std::vector<ObjectID> &object_ids,
+                                    bool pending_creation);
 
   /// Whether the object is pending creation (the task that creates it is
   /// scheduled/executing).
@@ -802,7 +800,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// any child object is in scope.
     bool has_nested_refs_to_report = false;
 
-    /// Whether the task that creates this object is scheduled/executing.
+    /// Whether the object has no locations in the cluster and
+    /// the task that creates this object is scheduled/executing.
     bool pending_creation = false;
 
     /// Whether or not this object was spilled.

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -303,7 +303,6 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
 bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *task_deps) {
   TaskSpecification spec;
   bool resubmit = false;
-  std::vector<ObjectID> return_ids;
   {
     absl::MutexLock lock(&mu_);
     auto it = submissible_tasks_.find(task_id);
@@ -330,10 +329,6 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
         RAY_CHECK(it->second.num_retries_left == -1);
       }
       spec = it->second.spec;
-
-      for (const auto &return_id : it->second.reconstructable_return_ids) {
-        return_ids.push_back(return_id);
-      }
     }
   }
 
@@ -349,7 +344,7 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
       }
     }
 
-    reference_counter_->UpdateResubmittedTaskReferences(return_ids, *task_deps);
+    reference_counter_->UpdateResubmittedTaskReferences(*task_deps);
 
     for (const auto &task_dep : *task_deps) {
       bool was_freed = reference_counter_->TryMarkFreedObjectInUseAgain(task_dep);
@@ -366,8 +361,7 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
     }
     if (spec.IsActorTask()) {
       const auto actor_creation_return_id = spec.ActorCreationDummyObjectId();
-      reference_counter_->UpdateResubmittedTaskReferences(return_ids,
-                                                          {actor_creation_return_id});
+      reference_counter_->UpdateResubmittedTaskReferences({actor_creation_return_id});
     }
 
     RAY_LOG(INFO) << "Resubmitting task that produced lost plasma object, attempt #"
@@ -706,7 +700,7 @@ bool TaskManager::HandleReportGeneratorItemReturns(
       num_objects_written += 1;
     }
     // When an object is reported, the object is ready to be fetched.
-    reference_counter_->UpdateObjectReady(object_id);
+    reference_counter_->UpdateObjectPendingCreation(object_id, false);
     HandleTaskReturn(object_id,
                      return_object,
                      NodeID::FromBinary(request.worker_addr().raylet_id()),

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -30,15 +30,6 @@ const int64_t kTaskFailureThrottlingThreshold = 50;
 // Throttle task failure logs to once this interval.
 const int64_t kTaskFailureLoggingFrequencyMillis = 5000;
 
-absl::flat_hash_set<ObjectID> ObjectRefStream::GetItemsConsumed() const {
-  absl::flat_hash_set<ObjectID> result;
-  for (int64_t index = 0; index < next_index_; index++) {
-    const auto &object_id = GetObjectRefAtIndex(index);
-    result.emplace(object_id);
-  }
-  return result;
-}
-
 absl::flat_hash_set<ObjectID> ObjectRefStream::GetItemsUnconsumed() const {
   absl::flat_hash_set<ObjectID> result;
   for (int64_t index = 0; index <= max_index_seen_; index++) {
@@ -1025,16 +1016,6 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
                                  spec.AttemptNumber(),
                                  RayConfig::instance().task_oom_retry_delay_base_ms())
                            : RayConfig::instance().task_retry_delay_ms();
-    if (spec.IsStreamingGenerator()) {
-      absl::MutexLock lock(&object_ref_stream_ops_mu_);
-      const auto generator_id = spec.ReturnId(0);
-      auto stream_it = object_ref_streams_.find(generator_id);
-      if (stream_it != object_ref_streams_.end()) {
-        for (ObjectID obj : stream_it->second.GetItemsConsumed()) {
-          reference_counter_->UpdateObjectPendingCreation(obj);
-        }
-      }
-    }
     retry_task_callback_(spec, /*object_recovery*/ false, update_seqno, delay_ms);
     return true;
   } else {

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -267,7 +267,8 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
     returned_refs.push_back(std::move(ref));
   }
 
-  reference_counter_->UpdateSubmittedTaskReferences(return_ids, task_deps);
+  reference_counter_->UpdateObjectsPendingCreation(return_ids, true);
+  reference_counter_->UpdateSubmittedTaskReferences(task_deps);
 
   // If it is a generator task, create an object ref stream.
   // The language frontend is responsible for calling DeleteObjectRefStream.
@@ -303,7 +304,6 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
 bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *task_deps) {
   TaskSpecification spec;
   bool resubmit = false;
-  std::vector<ObjectID> return_ids;
   {
     absl::MutexLock lock(&mu_);
     auto it = submissible_tasks_.find(task_id);
@@ -330,10 +330,6 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
         RAY_CHECK(it->second.num_retries_left == -1);
       }
       spec = it->second.spec;
-
-      for (const auto &return_id : it->second.reconstructable_return_ids) {
-        return_ids.push_back(return_id);
-      }
     }
   }
 
@@ -349,7 +345,7 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
       }
     }
 
-    reference_counter_->UpdateResubmittedTaskReferences(return_ids, *task_deps);
+    reference_counter_->UpdateResubmittedTaskReferences(*task_deps);
 
     for (const auto &task_dep : *task_deps) {
       bool was_freed = reference_counter_->TryMarkFreedObjectInUseAgain(task_dep);
@@ -366,8 +362,7 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
     }
     if (spec.IsActorTask()) {
       const auto actor_creation_return_id = spec.ActorCreationDummyObjectId();
-      reference_counter_->UpdateResubmittedTaskReferences(return_ids,
-                                                          {actor_creation_return_id});
+      reference_counter_->UpdateResubmittedTaskReferences({actor_creation_return_id});
     }
 
     RAY_LOG(INFO) << "Resubmitting task that produced lost plasma object, attempt #"
@@ -706,7 +701,7 @@ bool TaskManager::HandleReportGeneratorItemReturns(
       num_objects_written += 1;
     }
     // When an object is reported, the object is ready to be fetched.
-    reference_counter_->UpdateObjectReady(object_id);
+    reference_counter_->UpdateObjectsPendingCreation({object_id}, false);
     HandleTaskReturn(object_id,
                      return_object,
                      NodeID::FromBinary(request.worker_addr().raylet_id()),
@@ -1150,7 +1145,6 @@ void TaskManager::OnTaskDependenciesInlined(
     const std::vector<ObjectID> &contained_ids) {
   std::vector<ObjectID> deleted;
   reference_counter_->UpdateSubmittedTaskReferences(
-      /*return_ids=*/{},
       /*argument_ids_to_add=*/contained_ids,
       /*argument_ids_to_remove=*/inlined_dependency_ids,
       &deleted);
@@ -1196,13 +1190,10 @@ void TaskManager::RemoveFinishedTaskReferences(
     }
   }
 
+  reference_counter_->UpdateObjectsPendingCreation(return_ids, false);
   std::vector<ObjectID> deleted;
-  reference_counter_->UpdateFinishedTaskReferences(return_ids,
-                                                   plasma_dependencies,
-                                                   release_lineage,
-                                                   borrower_addr,
-                                                   borrowed_refs,
-                                                   &deleted);
+  reference_counter_->UpdateFinishedTaskReferences(
+      plasma_dependencies, release_lineage, borrower_addr, borrowed_refs, &deleted);
   in_memory_store_->Delete(deleted);
 }
 

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -161,6 +161,8 @@ class ObjectRefStream {
   /// \return A list of object IDs that are not read yet.
   absl::flat_hash_set<ObjectID> GetItemsUnconsumed() const;
 
+  absl::flat_hash_set<ObjectID> GetItemsConsumed() const;
+
   /// Pop all ObjectIDs that are not read yet via
   /// TryReadNextItem.
   ///

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -161,8 +161,6 @@ class ObjectRefStream {
   /// \return A list of object IDs that are not read yet.
   absl::flat_hash_set<ObjectID> GetItemsUnconsumed() const;
 
-  absl::flat_hash_set<ObjectID> GetItemsConsumed() const;
-
   /// Pop all ObjectIDs that are not read yet via
   /// TryReadNextItem.
   ///

--- a/src/ray/core_worker/test/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/test/object_recovery_manager_test.cc
@@ -260,6 +260,7 @@ TEST_F(ObjectRecoveryManagerTest, TestReconstruction) {
   task_resubmitter_->AddTask(object_id.TaskId(), {});
 
   ASSERT_TRUE(manager_.RecoverObject(object_id));
+  ASSERT_TRUE(ref_counter_->IsObjectPendingCreation(object_id));
   ASSERT_TRUE(object_directory_->Flush() == 1);
 
   ASSERT_TRUE(failed_reconstructions_.empty());

--- a/src/ray/core_worker/test/reference_count_test.cc
+++ b/src/ray/core_worker/test/reference_count_test.cc
@@ -2462,7 +2462,8 @@ TEST_F(ReferenceCountLineageEnabledTest, TestUnreconstructableObjectOutOfScope) 
 
   // Unreconstructable objects go out of scope once their lineage ref count
   // reaches 0.
-  rc->UpdateResubmittedTaskReferences({return_id}, {id});
+  rc->UpdateResubmittedTaskReferences({id});
+  rc->UpdateObjectPendingCreation(return_id, true);
   ASSERT_TRUE(rc->IsObjectPendingCreation(return_id));
   rc->UpdateFinishedTaskReferences(
       {return_id}, {id}, true, empty_borrower, empty_refs, &out);
@@ -2634,7 +2635,7 @@ TEST_F(ReferenceCountLineageEnabledTest, TestResubmittedTask) {
   ASSERT_TRUE(rc->HasReference(id));
 
   // Simulate retrying the task.
-  rc->UpdateResubmittedTaskReferences({}, {id});
+  rc->UpdateResubmittedTaskReferences({id});
   rc->UpdateFinishedTaskReferences({}, {id}, true, empty_borrower, empty_refs, &out);
   ASSERT_FALSE(rc->HasReference(id));
   ASSERT_EQ(lineage_deleted.size(), 1);

--- a/src/ray/core_worker/test/reference_count_test.cc
+++ b/src/ray/core_worker/test/reference_count_test.cc
@@ -405,7 +405,7 @@ class MockWorkerClient : public MockCoreWorkerClientInterface {
   ObjectID SubmitTaskWithArg(const ObjectID &arg_id) {
     ObjectID return_id = ObjectID::FromRandom();
     if (!arg_id.IsNil()) {
-      rc_.UpdateSubmittedTaskReferences({return_id}, {arg_id});
+      rc_.UpdateSubmittedTaskReferences({arg_id});
     }
     rc_.AddOwnedObject(return_id, {}, address_, "", 0, false, /*add_local_ref=*/true);
     return_ids_.push_back(return_id);
@@ -442,8 +442,9 @@ class MockWorkerClient : public MockCoreWorkerClientInterface {
     if (!arg_id.IsNil()) {
       arguments.push_back(arg_id);
     }
+    rc_.UpdateObjectsPendingCreation({return_id}, false);
     rc_.UpdateFinishedTaskReferences(
-        {return_id}, arguments, false, borrower_address, borrower_refs, nullptr);
+        arguments, false, borrower_address, borrower_refs, nullptr);
   }
 
   WorkerID GetID() const { return WorkerID::FromBinary(address_.worker_id()); }
@@ -506,22 +507,21 @@ TEST_F(ReferenceCountTest, TestBasic) {
   rc->AddLocalReference(return_id2, "");
   ASSERT_FALSE(rc->IsObjectPendingCreation(return_id1));
   ASSERT_FALSE(rc->IsObjectPendingCreation(return_id2));
-  rc->UpdateSubmittedTaskReferences({return_id1}, {id1});
-  rc->UpdateSubmittedTaskReferences({return_id2}, {id1, id2});
+  rc->UpdateObjectsPendingCreation({return_id1, return_id2}, true);
+  rc->UpdateSubmittedTaskReferences({id1});
+  rc->UpdateSubmittedTaskReferences({id2});
   ASSERT_TRUE(rc->IsObjectPendingCreation(return_id1));
   ASSERT_TRUE(rc->IsObjectPendingCreation(return_id2));
 
   ASSERT_EQ(rc->NumObjectIDsInScope(), 4);
-  rc->UpdateFinishedTaskReferences(
-      {return_id1}, {id1}, false, empty_borrower, empty_refs, &out);
+  rc->UpdateObjectsPendingCreation({return_id1, return_id2}, false);
+  rc->UpdateFinishedTaskReferences({id1}, false, empty_borrower, empty_refs, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 4);
   ASSERT_EQ(out.size(), 0);
-  rc->UpdateFinishedTaskReferences(
-      {return_id2}, {id2}, false, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id2}, false, empty_borrower, empty_refs, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 3);
   ASSERT_EQ(out.size(), 1);
-  rc->UpdateFinishedTaskReferences(
-      {return_id2}, {id1}, false, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id1}, false, empty_borrower, empty_refs, &out);
   ASSERT_EQ(out.size(), 2);
   ASSERT_FALSE(rc->IsObjectPendingCreation(return_id1));
   ASSERT_FALSE(rc->IsObjectPendingCreation(return_id2));
@@ -532,18 +532,16 @@ TEST_F(ReferenceCountTest, TestBasic) {
 
   // Local & submitted task references.
   rc->AddLocalReference(id1, "");
-  rc->UpdateSubmittedTaskReferences({return_id1}, {id1, id2});
+  rc->UpdateSubmittedTaskReferences({id1, id2});
   rc->AddLocalReference(id2, "");
   ASSERT_EQ(rc->NumObjectIDsInScope(), 2);
   rc->RemoveLocalReference(id1, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 2);
   ASSERT_EQ(out.size(), 0);
-  rc->UpdateFinishedTaskReferences(
-      {return_id1}, {id2}, false, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id2}, false, empty_borrower, empty_refs, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 2);
   ASSERT_EQ(out.size(), 0);
-  rc->UpdateFinishedTaskReferences(
-      {return_id1}, {id1}, false, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id1}, false, empty_borrower, empty_refs, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 1);
   ASSERT_EQ(out.size(), 1);
   rc->RemoveLocalReference(id2, &out);
@@ -552,11 +550,11 @@ TEST_F(ReferenceCountTest, TestBasic) {
   out.clear();
 
   // Submitted task with inlined references.
-  rc->UpdateSubmittedTaskReferences({return_id1}, {id1});
-  rc->UpdateSubmittedTaskReferences({return_id1}, {id2}, {id1}, &out);
+  rc->UpdateSubmittedTaskReferences({id1});
+  rc->UpdateSubmittedTaskReferences({id2}, {id1}, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 1);
   ASSERT_EQ(out.size(), 1);
-  rc->UpdateSubmittedTaskReferences({return_id1}, {}, {id2}, &out);
+  rc->UpdateSubmittedTaskReferences({}, {id2}, &out);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 0);
   ASSERT_EQ(out.size(), 2);
   out.clear();
@@ -585,9 +583,9 @@ TEST_F(ReferenceCountTest, TestUnreconstructableObjectOutOfScope) {
   ASSERT_FALSE(rc->SetDeleteCallback(id, callback));
   rc->AddOwnedObject(id, {}, address, "", 0, false, /*add_local_ref=*/false);
   ASSERT_TRUE(rc->SetDeleteCallback(id, callback));
-  rc->UpdateSubmittedTaskReferences({}, {id});
+  rc->UpdateSubmittedTaskReferences({id});
   ASSERT_FALSE(*out_of_scope);
-  rc->UpdateFinishedTaskReferences({}, {id}, false, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id}, false, empty_borrower, empty_refs, &out);
   ASSERT_TRUE(*out_of_scope);
 }
 
@@ -2452,20 +2450,19 @@ TEST_F(ReferenceCountLineageEnabledTest, TestUnreconstructableObjectOutOfScope) 
   ASSERT_FALSE(rc->SetDeleteCallback(id, callback));
   rc->AddOwnedObject(id, {}, address, "", 0, false, /*add_local_ref=*/false);
   ASSERT_TRUE(rc->SetDeleteCallback(id, callback));
-  rc->UpdateSubmittedTaskReferences({return_id}, {id});
+  rc->UpdateObjectsPendingCreation({return_id}, true);
+  rc->UpdateSubmittedTaskReferences({id});
   ASSERT_TRUE(rc->IsObjectPendingCreation(return_id));
   ASSERT_FALSE(*out_of_scope);
-  rc->UpdateFinishedTaskReferences(
-      {return_id}, {id}, false, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id}, false, empty_borrower, empty_refs, &out);
   ASSERT_FALSE(rc->IsObjectPendingCreation(return_id));
   ASSERT_FALSE(*out_of_scope);
 
   // Unreconstructable objects go out of scope once their lineage ref count
   // reaches 0.
-  rc->UpdateResubmittedTaskReferences({return_id}, {id});
+  rc->UpdateResubmittedTaskReferences({id});
   ASSERT_TRUE(rc->IsObjectPendingCreation(return_id));
-  rc->UpdateFinishedTaskReferences(
-      {return_id}, {id}, true, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id}, true, empty_borrower, empty_refs, &out);
   ASSERT_FALSE(rc->IsObjectPendingCreation(return_id));
   ASSERT_TRUE(*out_of_scope);
 }
@@ -2532,11 +2529,11 @@ TEST_F(ReferenceCountLineageEnabledTest, TestPinLineageRecursive) {
     auto id = ids[i];
     // Submit a dependent task on id.
     ASSERT_TRUE(rc->HasReference(id));
-    rc->UpdateSubmittedTaskReferences({}, {id});
+    rc->UpdateSubmittedTaskReferences({id});
     rc->RemoveLocalReference(id, nullptr);
 
     // The task finishes but is retryable.
-    rc->UpdateFinishedTaskReferences({}, {id}, false, empty_borrower, empty_refs, &out);
+    rc->UpdateFinishedTaskReferences({id}, false, empty_borrower, empty_refs, &out);
     // We should fail to set the deletion callback because the object has
     // already gone out of scope.
     ASSERT_FALSE(rc->SetDeleteCallback(
@@ -2577,10 +2574,10 @@ TEST_F(ReferenceCountLineageEnabledTest, TestEvictLineage) {
       });
 
   // ID1 depends on ID0.
-  rc->UpdateSubmittedTaskReferences({ids[1]}, {ids[0]});
+  rc->UpdateSubmittedTaskReferences({ids[0]});
   rc->RemoveLocalReference(ids[0], nullptr);
   rc->UpdateFinishedTaskReferences(
-      {ids[1]}, {ids[0]}, /*release_lineage=*/false, empty_borrower, empty_refs, nullptr);
+      {ids[0]}, /*release_lineage=*/false, empty_borrower, empty_refs, nullptr);
 
   bool lineage_evicted = false;
   for (const auto &id : ids) {
@@ -2620,22 +2617,22 @@ TEST_F(ReferenceCountLineageEnabledTest, TestResubmittedTask) {
   ASSERT_TRUE(rc->HasReference(id));
 
   // Submit 2 dependent tasks.
-  rc->UpdateSubmittedTaskReferences({}, {id});
-  rc->UpdateSubmittedTaskReferences({}, {id});
+  rc->UpdateSubmittedTaskReferences({id});
+  rc->UpdateSubmittedTaskReferences({id});
   rc->RemoveLocalReference(id, nullptr);
   ASSERT_TRUE(rc->HasReference(id));
 
   // Both tasks finish, 1 is retryable.
-  rc->UpdateFinishedTaskReferences({}, {id}, true, empty_borrower, empty_refs, &out);
-  rc->UpdateFinishedTaskReferences({}, {id}, false, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id}, true, empty_borrower, empty_refs, &out);
+  rc->UpdateFinishedTaskReferences({id}, false, empty_borrower, empty_refs, &out);
   // The dependency is no longer in scope, but we still keep a reference to it
   // because it is in the lineage of the retryable task.
   ASSERT_EQ(out.size(), 1);
   ASSERT_TRUE(rc->HasReference(id));
 
   // Simulate retrying the task.
-  rc->UpdateResubmittedTaskReferences({}, {id});
-  rc->UpdateFinishedTaskReferences({}, {id}, true, empty_borrower, empty_refs, &out);
+  rc->UpdateResubmittedTaskReferences({id});
+  rc->UpdateFinishedTaskReferences({id}, true, empty_borrower, empty_refs, &out);
   ASSERT_FALSE(rc->HasReference(id));
   ASSERT_EQ(lineage_deleted.size(), 1);
 }

--- a/src/ray/core_worker/test/task_manager_test.cc
+++ b/src/ray/core_worker/test/task_manager_test.cc
@@ -984,7 +984,6 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   ASSERT_EQ(last_delay_ms_, 0);
   ASSERT_EQ(last_object_recovery_, true);
   resubmitted_task_deps.clear();
-  ASSERT_TRUE(reference_counter_->IsObjectPendingCreation(return_id));
 
   // The return ID goes out of scope.
   reference_counter_->RemoveLocalReference(return_id, nullptr);

--- a/src/ray/protobuf/pubsub.proto
+++ b/src/ray/protobuf/pubsub.proto
@@ -109,9 +109,9 @@ message WorkerObjectLocationsPubMessage {
   // counting protocol that causes the object to be released while there are
   // still references.
   bool ref_removed = 7;
-  // If this is set, the task that creates the object is pending execution. If
-  // there are no locations and this is set, the subscriber should wait for the
-  // new location to appear.
+  // If this is set, the object has no location in the cluster and
+  // the task that (re)creates the object is pending execution.
+  // The subscriber should wait for the new location to appear.
   bool pending_creation = 8;
   // Whether or not this object was spilled.
   bool did_spill = 9;

--- a/src/ray/protobuf/pubsub.proto
+++ b/src/ray/protobuf/pubsub.proto
@@ -109,9 +109,9 @@ message WorkerObjectLocationsPubMessage {
   // counting protocol that causes the object to be released while there are
   // still references.
   bool ref_removed = 7;
-  // If this is set, the object has no location in the cluster and
-  // the task that (re)creates the object is pending execution.
-  // The subscriber should wait for the new location to appear.
+  // If this is set, the task that creates the object is pending execution. If
+  // there are no locations and this is set, the subscriber should wait for the
+  // new location to appear.
   bool pending_creation = 8;
   // Whether or not this object was spilled.
   bool did_spill = 9;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

TL;DR the bug is that for an object that's being reconstructed, we failed to set `pending_creation` to true so pull manager fails with `ObjectFetchTimedOutError`.

There are two places where we mark the object as pending_creation:

1. The creator task is executing for the first time (`ReferenceCounter::UpdateSubmittedTaskReferences`).
2. The creator task is re-executing to recover a lost object (`ReferenceCounter::UpdateResubmittedTaskReferences`).

However, if the creator task is re-executing due to failure (e.g. worker process crash, `TaskManager::RetryTaskIfPossible`), the return object is not marked as pending_creation, which is fine for non-streaming-generator tasks since return objects are atomically available only after the creator task finishes so they should still remain pending_creation during retry. However for streaming generator task, some return objects may be already available and used by downstream tasks when the generator task fails. 

A repro sequence of events:

1. Streaming generator task A (yields 2 objects in total) starts. 
2. Task A yields object a. a.pending_creation is false.
3. Task A fails, a retry A' is submitted.
4. a.pending_creation is still false.
5. Object a is lost.
6. Retrying to reconstruct a and realize there is a submitted A' so task A is not submitted again (`ReferenceCounter::UpdateResubmittedTaskReferences` is not called).
7. a.pending_creation is still false and will remain false (should be true) until submitted A' yields a again.

This PR fixes this issue by marking pending_creation whenever the object is lost and the creator task is running to re-create it instead of inside `ReferenceCounter::UpdateResubmittedTaskReferences` which might not be called.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
