### PR TITLE
[Ray Dashboard] make memory profile href link relative path

### DIFF
--- a/python/ray/dashboard/client/src/common/ProfilingLink.tsx
+++ b/python/ray/dashboard/client/src/common/ProfilingLink.tsx
@@ -289,7 +289,7 @@ export const MemoryProfilingButton = ({
   if (!pid || !ip) {
     return <div></div>;
   }
-  const profilerUrl = `/memory_profile?pid=${pid}&ip=${ip}`;
+  const profilerUrl = `memory_profile?pid=${pid}&ip=${ip}`;
 
   return <ProfilerButton profilerUrl={profilerUrl} type={type} />;
 };
@@ -302,7 +302,7 @@ export const TaskMemoryProfilingButton = ({
   if (!taskId) {
     return null;
   }
-  const profilerUrl = `/memory_profile?task_id=${taskId}&attempt_number=${attemptNumber}&node_id=${nodeId}`;
+  const profilerUrl = `memory_profile?task_id=${taskId}&attempt_number=${attemptNumber}&node_id=${nodeId}`;
 
   return <ProfilerButton profilerUrl={profilerUrl} />;
 };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When we host ray dashboard behind a prefix URL Path e.g. `https://<some>.<ray>.<domain_name>/ray_dashboard/` it's important to use relative href link instead of having a forward slash `/` to prevent [reset the URL Path](https://stackoverflow.com/a/10659501) , this change is to ensure consistent behavior with other similar profiling URL such as [cpu profile](https://github.com/ray-project/ray/blob/26b9464582d3b1af63d0c28bc5f64daca3ce2d88/python/ray/dashboard/client/src/common/ProfilingLink.tsx#L124) and [traceback](https://github.com/ray-project/ray/blob/26b9464582d3b1af63d0c28bc5f64daca3ce2d88/python/ray/dashboard/client/src/common/ProfilingLink.tsx#L103)

ideally we want `https://<some>.<ray>.<domain_name>/ray_dashboard/memory_profile...` instead of `https://<some>.<ray>.<domain_name>/memory_profile...`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I use browser's developer tool to inspect the different between `traceback` and `memory_profile` URL, after i manually remove the leading `/` it worked 
<img width="748" alt="image" src="https://github.com/ray-project/ray/assets/56123090/3f055c45-20ae-475e-a75a-fcb68de0bb13">

