### PR TITLE
[train] fix tensorflow example by using ScalingConfig

### DIFF
--- a/python/ray/train/examples/tf/tensorflow_autoencoder_example.py
+++ b/python/ray/train/examples/tf/tensorflow_autoencoder_example.py
@@ -121,7 +121,7 @@ def train_tensorflow_mnist(
 ) -> Result:
     train_dataset = get_dataset(split_type="train")
     config = {"lr": 1e-3, "batch_size": 64, "epochs": epochs}
-    scaling_config = dict(num_workers=num_workers, use_gpu=use_gpu)
+    scaling_config = ScalingConfig(num_workers=num_workers, use_gpu=use_gpu)
     trainer = TensorflowTrainer(
         train_loop_per_worker=train_func,
         train_loop_config=config,

--- a/python/ray/train/examples/tf/tensorflow_autoencoder_example.py
+++ b/python/ray/train/examples/tf/tensorflow_autoencoder_example.py
@@ -14,7 +14,7 @@ from ray import train
 from ray.air.integrations.keras import ReportCheckpointCallback
 from ray.data.datasource import SimpleTensorFlowDatasource
 from ray.data.extensions import TensorArray
-from ray.train import Result
+from ray.train import Result, ScalingConfig
 from ray.train.tensorflow import TensorflowTrainer, prepare_dataset_shard
 
 

--- a/python/ray/train/examples/tf/tune_tensorflow_autoencoder_example.py
+++ b/python/ray/train/examples/tf/tune_tensorflow_autoencoder_example.py
@@ -6,6 +6,7 @@ from ray.train.examples.tf.tensorflow_mnist_example import train_func
 from ray.train.tensorflow import TensorflowTrainer
 from ray.tune.tune_config import TuneConfig
 from ray.tune.tuner import Tuner
+from ray.train import ScalingConfig
 
 
 def tune_tensorflow_mnist(

--- a/python/ray/train/examples/tf/tune_tensorflow_autoencoder_example.py
+++ b/python/ray/train/examples/tf/tune_tensorflow_autoencoder_example.py
@@ -11,7 +11,7 @@ from ray.tune.tuner import Tuner
 def tune_tensorflow_mnist(
     num_workers: int = 2, num_samples: int = 2, use_gpu: bool = False
 ):
-    scaling_config = dict(num_workers=num_workers, use_gpu=use_gpu)
+    scaling_config = ScalingConfig(num_workers=num_workers, use_gpu=use_gpu)
     trainer = TensorflowTrainer(
         train_loop_per_worker=train_func,
         scaling_config=scaling_config,

--- a/python/ray/train/examples/tf/tune_tensorflow_autoencoder_example.py
+++ b/python/ray/train/examples/tf/tune_tensorflow_autoencoder_example.py
@@ -2,11 +2,11 @@ import argparse
 
 import ray
 from ray import tune
+from ray.train import ScalingConfig
 from ray.train.examples.tf.tensorflow_mnist_example import train_func
 from ray.train.tensorflow import TensorflowTrainer
 from ray.tune.tune_config import TuneConfig
 from ray.tune.tuner import Tuner
-from ray.train import ScalingConfig
 
 
 def tune_tensorflow_mnist(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I was trying to run the basic example [https://github.com/ray-project/ray/blob/master/python/ray/train/examples/tf/tune_tensorflow_autoencoder_example.py](https://github.com/ray-project/ray/issues/url)

Gave me this error:

ValueError: scaling_config should be an instance of ScalingConfig, found <class 'dict'> with value {'num_workers': 2, 'use_gpu': False}.

This chage soloved the issue:

scaling_config = dict(num_workers=num_workers, use_gpu=use_gpu)

to:

from ray.train import ScalingConfig
...
scaling_config = ScalingConfig(num_workers=num_workers, use_gpu=use_gpu)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #46505

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
