### PR TITLE
[release auto] block pre-release jobs when  RAY_VERSION is specified

### DIFF
--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -2,6 +2,11 @@ group: Pre-release checks
 depends_on:
   - forge
 steps:
+  - block: "Run pre-release checks"
+    if: build.env("RAY_VERSION") != null
+    key: block-pre-release-checks
+    depends_on: []
+
   - label: "Check release blockers"
     key: check-release-blockers
     instance_type: small_branch


### PR DESCRIPTION
when `RAY_VERSION` is set, it is often for wheel download, verification and uploading, so the pre-release tests do not need to run.

running them might actually rebuild the artifacts and lead to issues for the release process.

