### PR TITLE
[ci] deflake //python/ray/tests:test_implicit_resource

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -209,7 +209,6 @@ py_test_module_list(
     "test_streaming_generator_4.py",
     "test_streaming_generator_backpressure.py",
     "test_streaming_generator_regression.py",
-    "test_implicit_resource.py",
   ],
   size = "medium",
   tags = ["exclusive", "medium_size_python_tests_k_to_z", "team:core"],
@@ -527,6 +526,7 @@ py_test_module_list(
 py_test_module_list(
   files = [
     "test_plasma_unlimited.py",
+    "test_implicit_resource.py",
   ],
   size = "enormous",
   tags = ["exclusive", "large_size_python_tests_shard_1", "team:core"],


### PR DESCRIPTION
This test is flaky on windows and timed out https://buildkite.com/ray-project/postmerge/builds/5383#0190a2fc-5c5f-4f14-a80f-833ab7758a04/6641-7318 - it looks like it has been in this state for a while and we have marked it as non-blocking, but it can still show up as red on postmerge. Increase the test timed out.

Test:
- CI