### PR TITLE
[test] runtime env pip version pinned to 24.1.2 for python 3.12 support

### DIFF
--- a/python/ray/tests/test_runtime_env_conda_and_pip_4.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_4.py
@@ -157,7 +157,7 @@ def test_run_in_virtualenv(cloned_virtualenv):
 def test_runtime_env_with_pip_config(start_cluster):
     @ray.remote(
         runtime_env={
-            "pip": {"packages": ["pip-install-test==0.5"], "pip_version": "==20.2.3"}
+            "pip": {"packages": ["pip-install-test==0.5"], "pip_version": "==24.1.2"}
         }
     )
     def f():
@@ -165,7 +165,7 @@ def test_runtime_env_with_pip_config(start_cluster):
 
         return pip.__version__
 
-    assert ray.get(f.remote()) == "20.2.3"
+    assert ray.get(f.remote()) == "24.1.2"
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_env_conda_and_pip_5.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_5.py
@@ -8,10 +8,10 @@ import ray
 def test_runtime_env_with_pip_config(start_cluster):
 
     pip_versions = [
-        ("==20.2.3", lambda pip_version: parse(pip_version) == parse("20.2.3")),
+        ("==24.1.2", lambda pip_version: parse(pip_version) == parse("24.1.2")),
         (
-            "<20.3, >19",
-            lambda pip_version: parse("19") < parse(pip_version) < parse("20.3"),
+            "<24.2, >19",
+            lambda pip_version: parse("19") < parse(pip_version) < parse("24.2"),
         ),
     ]
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The old version (20.2.3) will fail `test_runtime_env_conda_and_pip_4.py::test_runtime_env_with_pip_config` showing error like:

```
No module named 'pip._vendor.six.moves'
```

After upgrade, it will pass.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
