### PR TITLE
[Train] Replace lambda default arguments

### DIFF
--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -233,12 +233,15 @@ def _upload_to_uri_with_exclude_fsspec(
 def _list_at_fs_path(
     fs: pyarrow.fs.FileSystem,
     fs_path: str,
-    file_filter: Callable[[pyarrow.fs.FileInfo], bool] = lambda x: True,
+    file_filter: Optional[Callable[[pyarrow.fs.FileInfo], bool]] = None,
 ) -> List[str]:
     """Returns the list of filenames at (fs, fs_path), similar to os.listdir.
 
     If the path doesn't exist, returns an empty list.
     """
+    if file_filter is None:
+        file_filter = lambda x: True  # noqa: E731
+
     selector = pyarrow.fs.FileSelector(fs_path, allow_not_found=True, recursive=False)
     return [
         os.path.relpath(file_info.path.lstrip("/"), start=fs_path.lstrip("/"))

--- a/python/ray/train/tests/dummy_preprocessor.py
+++ b/python/ray/train/tests/dummy_preprocessor.py
@@ -6,9 +6,13 @@ from ray.data.preprocessor import Preprocessor
 class DummyPreprocessor(Preprocessor):
     _is_fittable = False
 
-    def __init__(self, transform=lambda b: b):
+    def __init__(self, transform=None):
         self.id = uuid.uuid4()
-        self.transform = transform
+
+        if transform is None:
+            self.transform = lambda b: b
+        else:
+            self.transform = transform
 
     def transform_batch(self, batch):
         self._batch_transformed = True


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes instances where lambda functions are used as default arguments. Since default arguments are evaluated at function definition time, mutable objects can have unintuitive behavior; additionally, they prevent our documentation from rendering correctly. This PR is part of #45129, but has been split up to minimize codeowner impact.

## Related issue number

Partially addresses #45129.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
