### PR TITLE
setup-dev.py: remove outdated dashboard link

### DIFF
--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -121,6 +121,7 @@ if __name__ == "__main__":
     do_link("widgets", force=args.yes, skip_list=args.skip)
     do_link("cluster_utils.py", force=args.yes, skip_list=args.skip)
     do_link("_private", force=args.yes, skip_list=args.skip)
+    do_link("dashboard", force=args.yes, skip_list=args.skip)
 
     if args.extras is not None:
         for package in args.extras:

--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -121,15 +121,6 @@ if __name__ == "__main__":
     do_link("widgets", force=args.yes, skip_list=args.skip)
     do_link("cluster_utils.py", force=args.yes, skip_list=args.skip)
     do_link("_private", force=args.yes, skip_list=args.skip)
-    # Link package's `dashboard` directly to local (repo's) dashboard.
-    # The repo's `dashboard` is a file, soft-linking to which will not work
-    # on Mac.
-    do_link(
-        "dashboard",
-        force=args.yes,
-        skip_list=args.skip,
-        local_path="../../../dashboard",
-    )
 
     if args.extras is not None:
         for package in args.extras:


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If I run `python python/ray/setup-dev.py` to setup dev environment, the `dashboard` module would be incorrectly setup:

For example:
```
>>> import ray.dashboard.modules.dashboard_sdk
...
ModuleNotFoundError: No module named 'ray.dashboard.modules.dashboard_sdk'
```

After this fix, it will work again:

```
>>> import ray.dashboard.modules.dashboard_sdk
>>>
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
