### PR TITLE
[core] fix core container tests

### DIFF
--- a/ci/docker/ray.cpu.base.wanda.yaml
+++ b/ci/docker/ray.cpu.base.wanda.yaml
@@ -1,8 +1,8 @@
 name: "ray-py$PYTHON_VERSION-cpu-base"
-froms: ["ubuntu:focal"]
+froms: ["ubuntu:22.04"]
 dockerfile: docker/base-deps/Dockerfile
 build_args:
   - PYTHON_VERSION
-  - BASE_IMAGE=ubuntu:focal
+  - BASE_IMAGE=ubuntu:22.04
 tags:
   - cr.ray.io/rayproject/ray-py$PYTHON_VERSION-cpu-base

--- a/ci/docker/runtime_env_container/Dockerfile
+++ b/ci/docker/runtime_env_container/Dockerfile
@@ -4,7 +4,4 @@ FROM $BASE_IMAGE
 COPY python/ray/tests/runtime_env_container/ /home/ray/tests/
 
 # Install podman
-RUN sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
-    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4D64390375060AA4 && \
-    sudo apt-get update && \
-    sudo apt-get install podman -y
+RUN sudo apt-get update && sudo apt-get install podman -y


### PR DESCRIPTION
Fix the installation of podman in core container tests. The container is already using ubuntu 22 so it can install podman from the official repositories

Test:
- CI