### PR TITLE
[data] fix doc build

### DIFF
--- a/doc/source/data/api/dataset.rst
+++ b/doc/source/data/api/dataset.rst
@@ -18,7 +18,7 @@ Developer API
   Dataset.to_pandas_refs
   Dataset.to_numpy_refs
   Dataset.to_arrow_refs
-  Dataset.get_internal_block_refs
+  Dataset.iter_internal_ref_bundles
   block.Block
   block.BlockExecStats
   block.BlockMetadata


### PR DESCRIPTION
The doc build is broken due to a race with https://github.com/ray-project/ray/pull/46455/files. It complains about the missing documentation of https://buildkite.com/ray-project/postmerge/builds/5406#0190a445-c3a1-45d5-9438-d0cc3230acdb/175-253.

Test:
- CI