### PR TITLE
[test] fix test_pip_with_env_vars for python 3.12 support

### DIFF
--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -1072,7 +1072,11 @@ setup(
         with open(python_filename, "w+") as f:
             f.writelines(python_code)
 
-        gz_filename = os.path.join(tmp_path, "dist", "{name}-{ver}.tar.gz".format(name=package_name, ver=package_version))
+        gz_filename = os.path.join(
+            tmp_path,
+            "dist",
+            "{name}-{ver}.tar.gz".format(name=package_name, ver=package_version),
+        )
         subprocess.check_call(["python", "setup.py", "sdist"])
 
         with pytest.raises(ray.exceptions.RuntimeEnvSetupError):

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -1021,13 +1021,22 @@ def test_runtime_env_override(call_ray_start):
     reason="This test is only run on linux CI machines.",
 )
 def test_pip_with_env_vars(start_cluster, tmp_path):
-
+    """
+    The file structure:
+        $tmp_path/
+        │
+        ├── setup.py
+        ├── dist/ # the tar.gz file will be generated here
+        └── test_package/
+            └── test.py
+    """
     with chdir(tmp_path):
         TEST_ENV_NAME = "TEST_ENV_VARS"
         TEST_ENV_VALUE = "TEST"
         package_name = "test_package"
-        package_dir = os.path.join(tmp_path, package_name)
-        try_to_create_directory(package_dir)
+        package_version = "0.0.1"
+        package_dir = tmp_path
+        try_to_create_directory(os.path.join(package_dir, package_name))
 
         setup_filename = os.path.join(package_dir, "setup.py")
         setup_code = """import os
@@ -1038,28 +1047,33 @@ class InstallTestPackage(install):
     # this function will be called when pip install this package
     def run(self):
         assert os.environ.get('{TEST_ENV_NAME}') == '{TEST_ENV_VALUE}'
+        super().run()
 
 setup(
-    name='test_package',
-    version='0.0.1',
+    name='{package_name}',
+    version='{package_version}',
     packages=find_packages(),
     cmdclass=dict(install=InstallTestPackage),
     license="MIT",
     zip_safe=False,
 )
 """.format(
-            TEST_ENV_NAME=TEST_ENV_NAME, TEST_ENV_VALUE=TEST_ENV_VALUE
+            TEST_ENV_NAME=TEST_ENV_NAME,
+            TEST_ENV_VALUE=TEST_ENV_VALUE,
+            package_name=package_name,
+            package_version=package_version,
         )
-        with open(setup_filename, "wt") as f:
+
+        with open(setup_filename, "w+") as f:
             f.writelines(setup_code)
 
-        python_filename = os.path.join(package_dir, "test.py")
+        python_filename = os.path.join(package_dir, package_name, "test.py")
         python_code = "import os; print(os.environ)"
-        with open(python_filename, "wt") as f:
+        with open(python_filename, "w+") as f:
             f.writelines(python_code)
 
-        gz_filename = os.path.join(tmp_path, package_name + ".tar.gz")
-        subprocess.check_call(["tar", "-zcvf", gz_filename, package_name])
+        gz_filename = os.path.join(tmp_path, "dist", "{name}-{ver}.tar.gz".format(name=package_name, ver=package_version))
+        subprocess.check_call(["python", "setup.py", "sdist"])
 
         with pytest.raises(ray.exceptions.RuntimeEnvSetupError):
 


### PR DESCRIPTION
Current `test_pip_with_env_vars` has three issues:

- It doesn't call `super().run()` in the install function
- It hacks by tarballing the dir directly instead of using `python setup.py sdist`
- Its file structure format doesn't comply with setup.py standards:

Its current structure looks like:

```
$package_name/
│
├── setup.py
└── test.py
```

Nonetheless, the standard structure should be like:

```
$tmp_path/
│
├── setup.py
└── $package_name/
    └── test.py
```

After upgrading to python 3.12 the above assumptions and hacks do not apply and break the test. This change will fix them.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
