### PR TITLE
[RLlib] Fix `sample_timeout_s` setting being ignored by PPO/DQN/SAC/... on old API stack.

### DIFF
--- a/rllib/algorithms/bc/bc.py
+++ b/rllib/algorithms/bc/bc.py
@@ -161,11 +161,13 @@ class BC(MARWIL):
                     train_batch = synchronous_parallel_sample(
                         worker_set=self.workers,
                         max_agent_steps=self.config.train_batch_size,
+                        sample_timeout_s=self.config.sample_timeout_s,
                     )
                 else:
                     train_batch = synchronous_parallel_sample(
                         worker_set=self.workers,
                         max_env_steps=self.config.train_batch_size,
+                        sample_timeout_s=self.config.sample_timeout_s,
                     )
 
                 # TODO (sven): Use metrics API as soon as we moved to new API stack

--- a/rllib/algorithms/dqn/dqn.py
+++ b/rllib/algorithms/dqn/dqn.py
@@ -772,8 +772,14 @@ class DQN(Algorithm):
             # Sample (MultiAgentBatch) from workers.
             with self._timers[SAMPLE_TIMER]:
                 new_sample_batch: SampleBatchType = synchronous_parallel_sample(
-                    worker_set=self.workers, concat=True
+                    worker_set=self.workers,
+                    concat=True,
+                    sample_timeout_s=self.config.sample_timeout_s,
                 )
+
+            # Return early if all our workers failed.
+            if not new_sample_batch:
+                return {}
 
             # Update counters
             self._counters[NUM_AGENT_STEPS_SAMPLED] += new_sample_batch.agent_steps()

--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -533,12 +533,17 @@ class PPO(Algorithm):
                 train_batch = synchronous_parallel_sample(
                     worker_set=self.workers,
                     max_agent_steps=self.config.total_train_batch_size,
+                    sample_timeout_s=self.config.sample_timeout_s,
                 )
             else:
                 train_batch = synchronous_parallel_sample(
                     worker_set=self.workers,
                     max_env_steps=self.config.total_train_batch_size,
+                    sample_timeout_s=self.config.sample_timeout_s,
                 )
+            # Return early if all our workers failed.
+            if not train_batch:
+                return {}
             train_batch = train_batch.as_multi_agent()
             self._counters[NUM_AGENT_STEPS_SAMPLED] += train_batch.agent_steps()
             self._counters[NUM_ENV_STEPS_SAMPLED] += train_batch.env_steps()

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -23,7 +23,7 @@ def synchronous_parallel_sample(
     max_agent_steps: Optional[int] = None,
     max_env_steps: Optional[int] = None,
     concat: bool = True,
-    sample_timeout_s: Optional[float] = 60.0,
+    sample_timeout_s: Optional[float] = None,
     random_actions: bool = False,
     _uses_new_env_runners: bool = False,
     _return_metrics: bool = False,
@@ -51,7 +51,7 @@ def synchronous_parallel_sample(
             episodes all episode lists from workers are flattened into a single list.
         sample_timeout_s: The timeout in sec to use on the `foreach_worker` call.
             After this time, the call will return with a result (or not if all workers
-            are stalling).
+            are stalling). If None, will block indefinitely and not timeout.
         _uses_new_env_runners: Whether the new `EnvRunner API` is used. In this case
             episodes instead of `SampleBatch` objects are returned.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix `sample_timeout_s` setting being ignored by PPO/DQN/SAC/... on old API stack. Instead, a default value of 60.0s would always be used.

The bug would be that if e.g. PPO sampling times out (after the hard-coded 60s), an empty training batch would be returned leading to follow-up errors on the old API stack. The new API stack does not have this problem as it properly passes the `sample_timeout_s` setting on to the sampling utility function.

With this fix, users on the old and new API stacks should now be able to fine-tune their timeout setting in such a way that it properly captures worker failures/slowdowns and thus truly makes PPO fault tolerant (without returning empty train batches).

This PR also changes the default value of the `synchronous_parallel_sample` utility function to `sample_timeout_s=None` to mimic to old RLlib behavior (e.g. Ray 2.9).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
