### PR TITLE
[ci] split window serve jobs into two

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -93,8 +93,15 @@ steps:
         --test-env=RAY_CI_POST_WHEEL_TESTS="1"
         --test-env=USERPROFILE
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+    depends_on: windowsbuild
+
+  - label: ":ray-serve: serve: :windows: enormous tests"
+    tags: serve
+    job_env: WINDOWS
+    instance_type: windows
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
-        --skip-ray-installation
         --build-name windowsbuild
         --operating-system windows
         --only-tags use_all_core_windows
@@ -102,7 +109,6 @@ steps:
         --test-env=CI="1"
         --test-env=RAY_CI_POST_WHEEL_TESTS="1"
         --test-env=USERPROFILE
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
     depends_on: windowsbuild
 
   - label: ":train: ml: :windows: tests"

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -148,7 +148,7 @@ py_test_module_list(
 )
 
 py_test_module_list(
-    size = "large",
+    size = "enormous",
     files = [
         "test_deploy_app.py",
         "test_metrics.py",
@@ -160,7 +160,7 @@ py_test_module_list(
     tags = [
         "exclusive",
         "team:serve",
-         "use_all_core_windows",
+        "use_all_core_windows",
     ],
     deps = [
         ":common",


### PR DESCRIPTION
Split the window serve jobs into two - apparently the build_upload_info on windows will fail if it is called twice (https://buildkite.com/ray-project/postmerge/builds/5411#0190a59d-96ad-49a2-91d5-7572c86e4e3c/7936-7992), and this only happens on the master branch

Test:
- CI 