### PR TITLE
[Tune] Replace lambda default arguments

### DIFF
--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -1372,9 +1372,10 @@ class PopulationBasedTestingSuite(unittest.TestCase):
                 seen.add(fn()["v"])
             self.assertEqual(seen, values)
 
-        def explore_fn(
-            config, mutations, resample_probability, custom_explore_fn=lambda x: x
-        ):
+        def explore_fn(config, mutations, resample_probability, custom_explore_fn=None):
+            if custom_explore_fn is None:
+                custom_explore_fn = lambda x: x  # noqa: E731
+
             new_config, _ = _explore(
                 config,
                 mutations,


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes instances where lambda functions are used as default arguments. Since default arguments are evaluated at function definition time, mutable objects can have unintuitive behavior; additionally, they prevent our documentation from rendering correctly. This PR is part of #45129, but has been split up to minimize codeowner impact.

## Related issue number

Partially addresses #45129.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
