### PR TITLE
[deprecated][core] Async Python bindings of C++ GcsClient.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2361,6 +2361,11 @@ flatbuffer_cc_library(
     out_prefix = "ray/raylet/format/",
 )
 
+ray_cc_library(
+    name = "python_callbacks",
+    hdrs = ["src/ray/gcs/gcs_client/python_callbacks.h"],
+)
+
 pyx_library(
     name = "_raylet",
     srcs = glob([
@@ -2389,6 +2394,7 @@ pyx_library(
         linkstatic = 1,
     ),
     deps = [
+        ":python_callbacks",
         "//:core_worker_lib",
         "//:exported_internal",
         "//:gcs_server_lib",

--- a/python/ray/_private/gcs_aio_client.py
+++ b/python/ray/_private/gcs_aio_client.py
@@ -1,7 +1,8 @@
+import os
 import logging
 from typing import Dict, List, Optional
 from concurrent.futures import ThreadPoolExecutor
-from ray._raylet import GcsClient, JobID
+from ray._raylet import GcsClient, NewGcsClient, JobID
 from ray.core.generated import (
     gcs_pb2,
 )
@@ -14,12 +15,61 @@ from ray._private.ray_constants import env_integer
 # If the arg `executor` in GcsAioClient constructor is set, use it.
 # Otherwise if env var `GCS_AIO_CLIENT_DEFAULT_THREAD_COUNT` is set, use it.
 # Otherwise, use 5.
+# This is only used for the OldGcsAioClient.
 GCS_AIO_CLIENT_DEFAULT_THREAD_COUNT = env_integer(
     "GCS_AIO_CLIENT_DEFAULT_THREAD_COUNT", 5
 )
 
-
 logger = logging.getLogger(__name__)
+
+
+class GcsAioClient:
+    """
+    Async GCS client.
+
+    This class is in transition to use the new C++ GcsClient binding. The old
+    PythonGcsClient binding is not deleted until we are confident that the new
+    binding is stable.
+
+    Defaults to the new binding. If you want to use the old binding, please
+    set the environment variable `RAY_USE_OLD_GCS_CLIENT=1`.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        use_old_client = os.getenv("RAY_USE_OLD_GCS_CLIENT") == "1"
+        logger.debug(f"Using {'old' if use_old_client else 'new'} GCS client")
+        if use_old_client:
+            return OldGcsAioClient(*args, **kwargs)
+        else:
+            return NewGcsAioClient(*args, **kwargs)
+
+
+class NewGcsAioClient:
+    def __init__(
+        self,
+        address: str = None,
+        loop=None,
+        executor=None,
+        nums_reconnect_retry: int = 5,
+    ):
+        # See https://github.com/ray-project/ray/blob/d0b46eff9ddcf9ec7256dd3a6dda33e7fb7ced95/python/ray/_raylet.pyx#L2693 # noqa: E501
+        timeout_ms = 1000 * (nums_reconnect_retry + 1)
+        self.inner = NewGcsClient.standalone(
+            str(address), cluster_id=None, timeout_ms=timeout_ms
+        )
+        # Forwarded Methods. Not using __getattr__ because we want one fewer layer of
+        # indirection.
+        self.internal_kv_get = self.inner.async_internal_kv_get
+        self.internal_kv_multi_get = self.inner.async_internal_kv_multi_get
+        self.internal_kv_put = self.inner.async_internal_kv_put
+        self.internal_kv_del = self.inner.async_internal_kv_del
+        self.internal_kv_exists = self.inner.async_internal_kv_exists
+        self.internal_kv_keys = self.inner.async_internal_kv_keys
+        self.check_alive = self.inner.async_check_alive
+        self.get_all_job_info = self.inner.async_get_all_job_info
+        # Forwarded Properties.
+        self.address = self.inner.address
+        self.cluster_id = self.inner.cluster_id
 
 
 class AsyncProxy:
@@ -45,7 +95,7 @@ class AsyncProxy:
             return attr
 
 
-class GcsAioClient:
+class OldGcsAioClient:
     def __init__(
         self,
         loop=None,

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -44,13 +44,16 @@ cdef extern from * namespace "polyfill" nogil:
 
 
 cdef extern from "ray/common/status.h" namespace "ray" nogil:
-    cdef cppclass StatusCode:
+    # TODO(ryw) in Cython 3.x we can directly use `cdef enum class CStatusCode`
+    cdef cppclass CStatusCode "ray::StatusCode":
         pass
+    cdef CStatusCode CStatusCode_OK "ray::StatusCode::OK"
+    c_bool operator==(CStatusCode lhs, CStatusCode rhs)
 
     cdef cppclass CRayStatus "ray::Status":
         CRayStatus()
-        CRayStatus(StatusCode code, const c_string &msg)
-        CRayStatus(StatusCode code, const c_string &msg, int rpc_code)
+        CRayStatus(CStatusCode code, const c_string &msg)
+        CRayStatus(CStatusCode code, const c_string &msg, int rpc_code)
         CRayStatus(const CRayStatus &s)
 
         @staticmethod
@@ -135,7 +138,7 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
 
         c_string ToString()
         c_string CodeAsString()
-        StatusCode code()
+        CStatusCode code()
         c_string message()
         int rpc_code()
 
@@ -143,18 +146,6 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
     cdef CRayStatus RayStatus_OK "Status::OK"()
     cdef CRayStatus RayStatus_Invalid "Status::Invalid"()
     cdef CRayStatus RayStatus_NotImplemented "Status::NotImplemented"()
-
-
-cdef extern from "ray/common/status.h" namespace "ray::StatusCode" nogil:
-    cdef StatusCode StatusCode_OK "OK"
-    cdef StatusCode StatusCode_OutOfMemory "OutOfMemory"
-    cdef StatusCode StatusCode_KeyError "KeyError"
-    cdef StatusCode StatusCode_TypeError "TypeError"
-    cdef StatusCode StatusCode_Invalid "Invalid"
-    cdef StatusCode StatusCode_IOError "IOError"
-    cdef StatusCode StatusCode_UnknownError "UnknownError"
-    cdef StatusCode StatusCode_NotImplemented "NotImplemented"
-    cdef StatusCode StatusCode_RedisError "RedisError"
 
 
 cdef extern from "ray/common/id.h" namespace "ray" nogil:
@@ -376,6 +367,17 @@ cdef extern from "ray/core_worker/common.h" nogil:
         const CNodeID &GetSpilledNodeID() const
         const c_bool GetDidSpill() const
 
+cdef extern from "ray/gcs/gcs_client/python_callbacks.h" namespace "ray" nogil:
+    # Each type needs default constructors asked by cython.
+    cdef cppclass PyDefaultCallback:
+        PyDefaultCallback()
+        PyDefaultCallback(object py_callback)
+    cdef cppclass PyMultiItemCallback[Item]:
+        PyMultiItemCallback()
+        PyMultiItemCallback(object py_callback)
+    cdef cppclass BoolConverter:
+        pass
+
 cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
     cdef cppclass CActorInfoAccessor "ray::gcs::ActorInfoAccessor":
         pass
@@ -385,11 +387,20 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             c_vector[CJobTableData] &result,
             int64_t timeout_ms)
 
+        CRayStatus AsyncGetAll(
+            const PyDefaultCallback &callback,
+            int64_t timeout_ms)
+
     cdef cppclass CNodeInfoAccessor "ray::gcs::NodeInfoAccessor":
         CRayStatus CheckAlive(
             const c_vector[c_string] &raylet_addresses,
             int64_t timeout_ms,
             c_vector[c_bool] &result)
+
+        CRayStatus AsyncCheckAlive(
+            const c_vector[c_string] &raylet_addresses,
+            int64_t timeout_ms,
+            const PyMultiItemCallback[BoolConverter] &callback)
 
         CRayStatus DrainNodes(
             const c_vector[CNodeID] &node_ids,
@@ -444,6 +455,45 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             const c_string &key,
             int64_t timeout_ms,
             c_bool &exists)
+
+        CRayStatus AsyncInternalKVKeys(
+            const c_string &ns,
+            const c_string &prefix,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
+
+        CRayStatus AsyncInternalKVGet(
+            const c_string &ns,
+            const c_string &key,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
+
+        CRayStatus AsyncInternalKVMultiGet(
+            const c_string &ns,
+            const c_vector[c_string] &keys,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
+
+        CRayStatus AsyncInternalKVPut(
+            const c_string &ns,
+            const c_string &key,
+            const c_string &value,
+            c_bool overwrite,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
+
+        CRayStatus AsyncInternalKVExists(
+            const c_string &ns,
+            const c_string &key,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
+
+        CRayStatus AsyncInternalKVDel(
+            const c_string &ns,
+            const c_string &key,
+            c_bool del_by_prefix,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
 
     cdef cppclass CRuntimeEnvAccessor "ray::gcs::RuntimeEnvAccessor":
         CRayStatus PinRuntimeEnvUri(

--- a/src/ray/gcs/gcs_client/python_callbacks.h
+++ b/src/ray/gcs/gcs_client/python_callbacks.h
@@ -1,0 +1,355 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Python.h>
+
+#include <boost/optional/optional.hpp>
+#include <functional>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "ray/common/status.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+
+//// Converters
+// Converts C++ types to PyObject*.
+// None of the converters hold the GIL, but all of them requires the GIL to be held.
+// This means the caller should hold the GIL before calling these functions.
+//
+// A Converter is a functor that takes a C++ type and returns a PyObject*.
+// The conversion may fail, in which case the converter should set an exception and return
+// nullptr.
+//
+// By default you can use `DefaultConverter::convert` to convert any type. If you need
+// special handling you can compose out your own.
+class BytesConverter {
+  // Serializes the message to a string. Returns false if the serialization fails.
+  // template <typename T>
+  // static bool serialize(const T &message, std::string &result);
+
+  // Specialization for types with a SerializeToString method
+  template <typename Message>
+  static bool serialize(const Message &message,
+                        std::string &result,
+                        typename std::enable_if<std::is_member_function_pointer<
+                            decltype(&Message::SerializeToString)>::value>::type * = 0) {
+    return message.SerializeToString(&result);
+  }
+
+  // Specialization for types with a Binary method, i.e. `BaseID`s
+  // Never fails.
+  template <typename ID>
+  static bool serialize(
+      const ID &id,
+      std::string &result,
+      typename std::enable_if<
+          std::is_member_function_pointer<decltype(&ID::Binary)>::value>::type * = 0) {
+    result = id.Binary();
+    return true;
+  }
+
+ public:
+  template <typename T>
+  static PyObject *convert(const T &arg) {
+    std::string serialized_message;
+    if (serialize(arg, serialized_message)) {
+      return PyBytes_FromStringAndSize(serialized_message.data(),
+                                       serialized_message.size());
+    } else {
+      PyErr_SetString(PyExc_ValueError, "Failed to serialize message.");
+      Py_RETURN_NONE;
+    }
+  }
+
+  static PyObject *convert(const std::string &arg) {
+    return PyBytes_FromStringAndSize(arg.data(), arg.size());
+  }
+};
+
+class BoolConverter {
+ public:
+  static PyObject *convert(bool arg) { return PyBool_FromLong(arg); }
+};
+
+class IntConverter {
+ public:
+  static PyObject *convert(int arg) { return PyLong_FromLong(arg); }
+};
+
+template <typename Inner>
+class OptionalConverter {
+ public:
+  template <typename T>
+  static PyObject *convert(const boost::optional<T> &arg) {
+    if (arg) {
+      return Inner::convert(*arg);
+    } else {
+      Py_RETURN_NONE;
+    }
+  }
+};
+
+template <typename Inner>
+class VectorConverter {
+ public:
+  template <typename T>
+  static PyObject *convert(const std::vector<T> &arg) {
+    PyObject *list = PyList_New(arg.size());
+    for (size_t i = 0; i < arg.size(); i++) {
+      PyObject *item = Inner::convert(arg[i]);
+      if (item == nullptr) {
+        // Failed to convert an item. Free the list and all items within.
+        Py_DECREF(list);
+        return nullptr;
+      }
+      PyList_SetItem(list, i, Inner::convert(arg[i]));
+    }
+    return list;
+  }
+};
+
+// Returns a Python tuple of two elements.
+template <typename Left, typename Right>
+class PairConverter {
+ public:
+  template <typename T, typename U>
+  static PyObject *convert(const T &left, const U &right) {
+    PyObject *result = PyTuple_New(2);
+    PyObject *left_obj = Left::convert(left);
+    if (left_obj == nullptr) {
+      Py_DECREF(result);
+      return nullptr;
+    }
+    PyTuple_SetItem(result, 0, left_obj);
+    PyObject *right_obj = Right::convert(right);
+    if (right_obj == nullptr) {
+      Py_DECREF(result);
+      return nullptr;
+    }
+    PyTuple_SetItem(result, 1, right_obj);
+    return result;
+  }
+};
+
+template <typename KeyConverter, typename ValueConverter>
+class MapConverter {
+ public:
+  template <typename MapType>
+  static PyObject *convert(const MapType &arg) {
+    PyObject *dict = PyDict_New();
+    for (const auto &pair : arg) {
+      PyObject *key = KeyConverter::convert(pair.first);
+      if (key == nullptr) {
+        Py_DECREF(dict);
+        return nullptr;
+      }
+      PyObject *value = ValueConverter::convert(pair.second);
+      if (value == nullptr) {
+        Py_DECREF(key);
+        Py_DECREF(dict);
+        return nullptr;
+      }
+      if (PyDict_SetItem(dict, key, value) < 0) {
+        Py_DECREF(key);
+        Py_DECREF(value);
+        Py_DECREF(dict);
+        return nullptr;
+      }
+      Py_XDECREF(key);
+      Py_XDECREF(value);
+    }
+    return dict;
+  }
+};
+
+// Converts ray::Status to Tuple[StatusCode, error_message, rpc_code]
+class StatusConverter {
+ public:
+  static PyObject *convert(const ray::Status &status) {
+    static_assert(std::is_same_v<char, std::underlying_type_t<ray::StatusCode>>,
+                  "StatusCode underlying type should be char.");
+    return PyTuple_Pack(3,
+                        IntConverter::convert(static_cast<int>(status.code())),
+                        BytesConverter::convert(status.message()),
+                        IntConverter::convert(status.rpc_code()));
+  }
+};
+
+// Default converter, converts all types implemented above.
+// Resolution:
+// - single bool, int, status: BoolConverter, IntConverter, StatusConverter
+// - optional<T>:              OptionalConverter<T>
+// - vector<T>:                VectorConverter<T>
+// - single generic argument:  BytesConverter
+// - 2 args (T, U):            PairConverter<T, U>
+// - map<K, V>:                MapConverter<K, V> (we can't do generics over MapType for
+// collision w/ BytesConverter, so we specialize for std::unordered_map and
+// absl::flat_hash_map)
+class DefaultConverter {
+ public:
+  static PyObject *convert(bool arg) { return BoolConverter::convert(arg); }
+  static PyObject *convert(int arg) { return IntConverter::convert(arg); }
+  static PyObject *convert(const Status &arg) { return StatusConverter::convert(arg); }
+
+  template <typename T>
+  static PyObject *convert(const T &arg) {
+    return BytesConverter::convert(arg);
+  }
+  template <typename T>
+  static PyObject *convert(const boost::optional<T> &arg) {
+    return OptionalConverter<DefaultConverter>::convert(arg);
+  }
+  template <typename T>
+  static PyObject *convert(const std::vector<T> &arg) {
+    return VectorConverter<DefaultConverter>::convert(arg);
+  }
+  template <typename T, typename U>
+  static PyObject *convert(const T &left, const U &right) {
+    return PairConverter<DefaultConverter, DefaultConverter>::convert(left, right);
+  }
+  template <typename Key, typename Value>
+  static PyObject *convert(const std::unordered_map<Key, Value> &arg) {
+    return MapConverter<DefaultConverter, DefaultConverter>::convert(arg);
+  }
+  template <typename Key, typename Value>
+  static PyObject *convert(const absl::flat_hash_map<Key, Value> &arg) {
+    return MapConverter<DefaultConverter, DefaultConverter>::convert(arg);
+  }
+};
+
+// Wraps a Python `Callable[[T, Exception], None]` into a C++ `std::function<void(U)>`.
+// This is a base class for all the callbacks, with subclass handling the conversion.
+// The base class handles:
+// - GIL management
+// - PyObject Ref counting
+// - Exception handling.
+//
+// `Converter`: a functor that converts U to owned PyObject*.
+//
+// TODO: For all these we also need to handle exc. We do this by giving the py_callable
+// another arg so it becomes Callable[[T, Exception], None]. The exception is a
+// 3-tuple of (type, value, tb).
+// TODO: Subscribe need iterator/generator.
+template <class Converter>
+class PyCallback {
+ private:
+  class PythonGilHolder {
+   public:
+    PythonGilHolder() : state_(PyGILState_Ensure()) {}
+    ~PythonGilHolder() { PyGILState_Release(state_); }
+
+   private:
+    PyGILState_STATE state_;
+  };
+
+ public:
+  // Ref counted Python object.
+  // This callback class is copyable, and as a std::function it's indeed copied around.
+  // But we don't want to hold the GIL and do ref counting so many times, so we use a
+  // shared_ptr to manage the ref count for us, and only call Py_XINCREF once.
+  //
+  // Note this ref counted is only from C++ side. If this ref count goes to 0, we only
+  // Issue 1 decref, which does not necessarily free the object.
+  std::shared_ptr<PyObject> py_callable;
+
+  // Needed by Cython to place a placeholder object.
+  PyCallback() {}
+
+  PyCallback(PyObject *callable) {
+    if (callable == nullptr) {
+      py_callable = nullptr;
+      return;
+    }
+    PythonGilHolder gil;
+    Py_XINCREF(callable);
+
+    py_callable = std::shared_ptr<PyObject>(callable, [](PyObject *obj) {
+      PythonGilHolder gil;
+      Py_XDECREF(obj);
+    });
+  }
+
+  // Typically Args is just a single argument, but we allow multiple arguments for e.g.
+  // (Status, boost::optional<MessageType>).
+  //
+  // Converts the arguments to a Python Object and may raise exceptions.
+  // Invokes the Python callable with (converted_arg, None), or (None, exception).
+  //
+  // The callback should not return anything and should not raise exceptions. If it
+  // raises, we catch it and log it.
+  template <typename... Args>
+  void operator()(const Args &...args) {
+    if (py_callable == nullptr) {
+      return;
+    }
+
+    // Hold the GIL.
+    PythonGilHolder gil;
+    PyObject *arg_obj = Converter::convert(args...);
+    if (arg_obj == nullptr) {
+      // Failed to convert the arguments. The exception is set by the converter.
+      PyObject *exc_obj = PyErr_Occurred();
+      if (exc_obj == nullptr) {
+        // The converter didn't set an exception?
+        RAY_LOG(WARNING) << "Failed to convert arguments, but no exception set.";
+        PyErr_SetString(PyExc_ValueError, "Failed to convert arguments.");
+        exc_obj = PyErr_Occurred();
+      }
+      PyObject *result =
+          PyObject_CallFunctionObjArgs(py_callable.get(), Py_None, exc_obj, NULL);
+      Py_XDECREF(result);
+    } else {
+      PyObject *result =
+          PyObject_CallFunctionObjArgs(py_callable.get(), arg_obj, Py_None, NULL);
+      Py_XDECREF(arg_obj);
+      Py_XDECREF(result);
+    }
+    if (PyErr_Occurred()) {
+      // Our binding code raised exceptions. Not much we can do here. Print it out.
+      PyObject *ptype, *pvalue, *ptraceback;
+      PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+      PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
+      PyObject *str_exc = PyObject_Str(pvalue);
+      const char *exc_str = PyUnicode_AsUTF8(str_exc);
+
+      RAY_LOG(ERROR) << "Python exception in cpython binding callback: " << exc_str;
+
+      // Clean up
+      Py_XDECREF(ptype);
+      Py_XDECREF(pvalue);
+      Py_XDECREF(ptraceback);
+      Py_XDECREF(str_exc);
+
+      PyErr_Clear();
+    }
+  }
+};
+
+// Concrete callback types.
+// Most types are using the DefaultConverter, but we allow specialization for some types.
+using PyDefaultCallback = PyCallback<DefaultConverter>;
+// Specialization for a pair of (Status, Vector<T>).
+// We need this because `MultiItemCallback` uses (Status, std::vector<T>&&) not const ref.
+// and C++ can't deduce it well (will implicit convert the vector&& to bool)
+template <typename ItemConverter>
+using PyMultiItemCallback =
+    PyCallback<PairConverter<StatusConverter, VectorConverter<ItemConverter>>>;
+
+}  // namespace ray


### PR DESCRIPTION
Superceded by #46788.

Implements async binding of C++ GcsClient in Python as NewGcsAioClient.

Previously we only have *sync* GcsClient bindings, ones that blocks on completion. To facilitate GcsAioClient we use python thread pool executor - one dedicated thread blocked for the sync call, whose underlying API is async. This is a big waste and we can do better.

The trick is to play the callback-to-async games wisely. Invoke a C++ async API with a python callback function; the callback serializes the reply data or exception, then switch to the python asyncio thread and complete a future. The future, in turn, is awaited by a postprocess function that does any python-side treatment (e.g. python protobuf deserialization, or converting to dict), then pass on to user code. The end result is an `async` method just like Python-native ones.

This PR adds the NewGcsAioClient and uses it as implementation of GcsAioClient by default. Can switch back to the OldGcsAioClient by `RAY_USE_OLD_GCS_CLIENT=1`.