### PR TITLE
[py312] keep dask versions back to 2022.10.1

### DIFF
--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -1,7 +1,7 @@
 # Used by CI for datasets and docs.
 # https://github.com/ray-project/ray/pull/29448#discussion_r1006256498
 
-dask[complete]==2024.6.0
+dask[complete]==2022.10.1
 aioboto3==11.2.0
 crc32c==2.3
 flask_cors

--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -1,7 +1,8 @@
 # Used by CI for datasets and docs.
 # https://github.com/ray-project/ray/pull/29448#discussion_r1006256498
 
-dask[complete]==2022.10.1
+dask[complete]==2022.10.1; python_version <= '3.11'
+dask[complete]==2024.6.0
 aioboto3==11.2.0
 crc32c==2.3
 flask_cors

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -323,7 +323,7 @@ cython==0.29.37
     # via
     #   -r /ray/ci/../python/requirements/test-requirements.txt
     #   gpy
-dask==2024.6.0
+dask==2022.10.1
     # via dask
 databricks-cli==0.18.0
     # via mlflow
@@ -353,7 +353,7 @@ dill==0.3.8
     #   multiprocess
 distlib==0.3.7
     # via virtualenv
-distributed==2024.6.0
+distributed==2022.10.1
     # via dask
 dm-tree==0.1.8
     # via

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -323,7 +323,8 @@ cython==0.29.37
     # via
     #   -r /ray/ci/../python/requirements/test-requirements.txt
     #   gpy
-dask==2022.10.1
+dask==2022.10.1; python_version <= '3.11'
+dask==2024.6.0
     # via dask
 databricks-cli==0.18.0
     # via mlflow
@@ -353,7 +354,8 @@ dill==0.3.8
     #   multiprocess
 distlib==0.3.7
     # via virtualenv
-distributed==2022.10.1
+distributed==2022.10.1; python_version <= '3.11'
+distributed==2024.6.0
     # via dask
 dm-tree==0.1.8
     # via


### PR DESCRIPTION
We are not gonna support any dask versions later than that.


