### PR TITLE
[test] skip dask tests on Python 3.12+

### DIFF
--- a/python/ray/util/dask/tests/test_dask_callback.py
+++ b/python/ray/util/dask/tests/test_dask_callback.py
@@ -1,8 +1,14 @@
+import sys
+
 import dask
 import pytest
 
 import ray
 from ray.util.dask import ray_dask_get, RayDaskCallback
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="Skip dask tests for Python version 3.12+"
+)
 
 
 @pytest.fixture

--- a/python/ray/util/dask/tests/test_dask_optimization.py
+++ b/python/ray/util/dask/tests/test_dask_optimization.py
@@ -1,3 +1,5 @@
+import sys
+
 import dask
 import dask.dataframe as dd
 from dask.dataframe.shuffle import SimpleShuffleLayer
@@ -11,6 +13,10 @@ from ray.util.dask import dataframe_optimize
 from ray.util.dask.optimizations import (
     rewrite_simple_shuffle_layer,
     MultipleReturnSimpleShuffleLayer,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="Skip dask tests for Python version 3.12+"
 )
 
 

--- a/python/ray/util/dask/tests/test_dask_scheduler.py
+++ b/python/ray/util/dask/tests/test_dask_scheduler.py
@@ -14,6 +14,10 @@ from ray.util.client.common import ClientObjectRef
 from ray.util.dask import disable_dask_on_ray, enable_dask_on_ray, ray_dask_get
 from ray.util.dask.callbacks import ProgressBarCallback
 
+pytestmark = pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="Skip dask tests for Python version 3.12+"
+)
+
 
 @pytest.fixture
 def ray_start_1_cpu():

--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -1,7 +1,8 @@
 # Used by CI for datasets and docs.
 # https://github.com/ray-project/ray/pull/29448#discussion_r1006256498
 
-dask[complete]==2022.10.1
+dask[complete]==2022.10.1; python_version < '3.12'
+dask[complete]==2024.6.0; python_version >= '3.12'
 aioboto3==11.2.0
 crc32c==2.3
 flask_cors

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -387,7 +387,8 @@ cython==0.29.37
     # via
     #   -r /ray/ci/../python/requirements/test-requirements.txt
     #   gpy
-dask==2022.10.1
+dask==2022.10.1; python_version < '3.12'
+dask==2024.6.0; python_version >= '3.12'
     # via
     #   -r /ray/ci/../python/requirements/ml/data-requirements.txt
     #   distributed
@@ -425,7 +426,8 @@ dill==0.3.7
     #   pymoo
 distlib==0.3.7
     # via virtualenv
-distributed==2022.10.1
+distributed==2022.10.1; python_version < '3.12'
+distributed==2024.6.0; python_version >= '3.12'
     # via dask
 dm-control==1.0.12
     # via -r /ray/ci/../python/requirements/ml/rllib-test-requirements.txt


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

dask has to be upgraded to `2024.6.0` for successful builds. But on Ray side, we don't have any plan to support dask version later than `2022.10.1`. So we will keep dask as is for `<= Python 3.11`, and skip dask tests on `Python 3.12+`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
