### PR TITLE
fix beyond the basics cards column width

### DIFF
--- a/doc/source/_static/css/index.css
+++ b/doc/source/_static/css/index.css
@@ -101,6 +101,7 @@ html[data-theme='light'] {
   display: flex;
   flex-direction: column;
   gap: 0.5em;
+  flex: 1;
 }
 
 .link-card-icon-label {


### PR DESCRIPTION
## Why are these changes needed?

Fixes widths of the "Beyond the Basics" cards so they all take the same horizontal space by adding `flex: 1` to the cards

## Related issue number

Closes https://github.com/ray-project/ray/issues/45876

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
