### PR TITLE
[core][experimental] Add an actionable log when detecting a deadlock caused by using NCCL between DAG nodes on the same actor

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1129,7 +1129,7 @@ class CompiledDAG:
                         logger.error(
                             "Detect a deadlock caused by using NCCL channels to "
                             "transfer data between tasks on the same actor. Please "
-                            "remove `TorchTensorType(transport=\"nccl\")` between "
+                            'remove `TorchTensorType(transport="nccl")` between '
                             "DAG nodes on the same actor."
                         )
                         return True

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1144,9 +1144,10 @@ class CompiledDAG:
                         ].dag_node.get_method_name()
                         logger.error(
                             "Detected a deadlock caused by using NCCL channels to "
-                            f"transfer data between tasks {method} and "
-                            f"{downstream_method} on the same actor {actor_handle}. "
-                            'Please remove `TorchTensorType(transport="nccl")` between '
+                            f"transfer data between the task `{method}` and "
+                            f"its downstream method `{downstream_method}` on the same "
+                            f"actor {actor_handle}. Please remove "
+                            '`TorchTensorType(transport="nccl")` between '
                             "DAG nodes on the same actor."
                         )
                         return True

--- a/python/ray/dag/tests/experimental/test_detect_deadlock_dag.py
+++ b/python/ray/dag/tests/experimental/test_detect_deadlock_dag.py
@@ -105,8 +105,9 @@ def test_invalid_graph_1_actor_log(ray_start_regular):
 
     error_msg = (
         "Detected a deadlock caused by using NCCL channels to transfer "
-        f"data between tasks no_op and no_op on the same actor {str(a)}. "
-        'Please remove `TorchTensorType(transport="nccl")` between DAG '
+        f"data between the task `no_op` and its downstream method `no_op` on "
+        f"the same actor {str(a)}. Please remove "
+        '`TorchTensorType(transport="nccl")` between DAG '
         "nodes on the same actor."
     )
     error_msg_exist = False

--- a/python/ray/dag/tests/experimental/test_detect_deadlock_dag.py
+++ b/python/ray/dag/tests/experimental/test_detect_deadlock_dag.py
@@ -71,6 +71,52 @@ def test_invalid_graph_1_actor(ray_start_regular, tensor_transport):
             dag.experimental_compile()
 
 
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
+def test_invalid_graph_1_actor_log(ray_start_regular):
+    """
+    This test is similar to test_invalid_graph_1_actor, but it checks if the error
+    message is correctly logged.
+    """
+    import logging
+
+    class LogCaptureHandler(logging.Handler):
+        def __init__(self):
+            super().__init__()
+            self.records = []
+
+        def emit(self, record):
+            self.records.append(record)
+
+    logger = logging.getLogger("ray.dag.compiled_dag_node")
+    handler = LogCaptureHandler()
+    logger.addHandler(handler)
+
+    a = MockedWorker.remote()
+
+    ray.get(a.start_mock.remote())
+
+    with InputNode() as inp:
+        dag = a.no_op.bind(inp)
+        dag.with_type_hint(TorchTensorType(transport=TorchTensorType.NCCL))
+        dag = a.no_op.bind(dag)
+
+    with pytest.raises(ValueError, match=INVALID_GRAPH):
+        dag.experimental_compile()
+
+    error_msg = (
+        "Detected a deadlock caused by using NCCL channels to transfer "
+        f"data between tasks no_op and no_op on the same actor {str(a)}. "
+        'Please remove `TorchTensorType(transport="nccl")` between DAG '
+        "nodes on the same actor."
+    )
+    error_msg_exist = False
+    for record in handler.records:
+        if error_msg in record.getMessage():
+            error_msg_exist = True
+    assert error_msg_exist, "Error message not found in log."
+    logger.removeHandler(handler)
+
+
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
 @pytest.mark.parametrize(
     "tensor_transport", [TorchTensorType.AUTO, TorchTensorType.NCCL]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

NCCL is a blocking operation, which means the writer and the reader need to write and read at the same time. However, an actor can only execute one Ray task at a time. Hence, it is impossible for both the reader and writer to operate simultaneously, so the NCCL operation will block forever. If both the reader and the writer are on the same actor, IntraProcessChannel should be used. However, if users specify TorchTensorType, NCCL channel will be created instead.

This PR adds an actionable log when detecting a deadlock caused by using NCCL between DAG nodes on the same actor.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
