### PR TITLE
[RLlib] Add error message if `Checkpointable.from_checkpoint()` is called on wrong class.

### DIFF
--- a/rllib/utils/checkpoints.py
+++ b/rllib/utils/checkpoints.py
@@ -410,8 +410,22 @@ class Checkpointable(abc.ABC):
         # Get the class constructor to call.
         with open(path / cls.CLASS_AND_CTOR_ARGS_FILE_NAME, "rb") as f:
             ctor_info = pickle.load(f)
+        ctor = ctor_info["class"]
+
+        # Check, whether the constructor actually goes together with `cls`.
+        if not issubclass(ctor, cls):
+            raise ValueError(
+                f"The class ({ctor}) stored in checkpoint ({path}) does not seem to be "
+                f"a subclass of `cls` ({cls})!"
+            )
+        elif not issubclass(ctor, Checkpointable):
+            raise ValueError(
+                f"The class ({ctor}) stored in checkpoint ({path}) does not seem to be "
+                "an implementer of the `Checkpointable` API!"
+            )
+
         # Construct an initial object.
-        obj = ctor_info["class"](
+        obj = ctor(
             *ctor_info["ctor_args_and_kwargs"][0],
             **ctor_info["ctor_args_and_kwargs"][1],
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Add error message if `Checkpointable.from_checkpoint()` is called on wrong class.

Things like:
```
module = RLModule.from_checkpoint([some Algorithm checkpoint])

# Now `module` would be an Algorithm. Hardly what the user had intended here.
```
should trigger such an error for better transparency.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
