### PR TITLE
[Test] Make test fixture init_and_serve_lazy do the tear down

### DIFF
--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -43,8 +43,8 @@ class C:
 
 @pytest.mark.xfail(cluster_not_supported, reason="cluster not supported")
 @pytest.fixture
-def init_and_serve_lazy():
-    cluster = ray.cluster_utils.Cluster()
+def init_and_serve_lazy(ray_start_cluster):
+    cluster = ray_start_cluster
     cluster.add_node(num_cpus=1, num_gpus=0)
     cluster.wait_for_nodes(1)
     address = cluster.address
@@ -55,7 +55,6 @@ def init_and_serve_lazy():
     server_handle = ray_client_server.serve("localhost:50051", connect)
     yield server_handle
     ray_client_server.shutdown_with_server(server_handle.grpc_server)
-    time.sleep(2)
 
 
 def test_validate_port():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently `init_and_serve_lazy` doesn't destroy the cluster it starts in the end.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
