### PR TITLE
[ci] fix windows wheel build

### DIFF
--- a/python/build-wheel-windows.sh
+++ b/python/build-wheel-windows.sh
@@ -66,7 +66,7 @@ install_ray() {
 
 
     pushd python/ray/dashboard/client
-      choco install nodejs -y
+      choco install nodejs --version=22.4.1 -y
       refreshenv
       # https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported
       export NODE_OPTIONS=--openssl-legacy-provider


### PR DESCRIPTION
Pin nodejs version for windows build, to the closest version that we have successfully build windows wheels. The latest version 22.5.0 is broken https://buildkite.com/ray-project/postmerge/builds/5493#0190c313-b748-4ec5-8058-dcc46dd61bff/320-403

Linux pins nodejs version, and mac seems fine even without pinning.

Test:
- CI