### PR TITLE
[core][experimental] Support actor as the InputNode and MultiOutputNode of an ADAG 

### DIFF
--- a/python/ray/_private/ray_experimental_perf.py
+++ b/python/ray/_private/ray_experimental_perf.py
@@ -12,6 +12,7 @@ from ray.dag import InputNode, MultiOutputNode
 from ray._private.utils import (
     get_or_create_event_loop,
 )
+from ray._private.test_utils import get_actor_node_id
 
 logger = logging.getLogger(__name__)
 
@@ -42,14 +43,6 @@ def create_driver_actor():
             ray.get_runtime_context().get_node_id(), soft=False
         )
     ).remote()
-
-
-def get_actor_node_id(actor_handle: "ray.actor.ActorHandle") -> str:
-    return ray.get(
-        actor_handle.__ray_call__.remote(
-            lambda self: ray.get_runtime_context().get_node_id()
-        )
-    )
 
 
 def main(results=None):

--- a/python/ray/_private/ray_experimental_perf.py
+++ b/python/ray/_private/ray_experimental_perf.py
@@ -96,20 +96,20 @@ def main(results=None):
     n_cpu = multiprocessing.cpu_count() // 2
     print(f"Testing multiple readers/channels, n={n_cpu}")
 
-    reader_to_node = []
+    reader_to_node_id = []
     for _ in range(n_cpu):
         reader = ChannelReader.remote()
         reader_node = get_actor_node_id(reader)
-        reader_to_node.append((reader, reader_node))
-    chans = [ray_channel.Channel(None, reader_to_node, 1000)]
-    ray.get([reader.ready.remote() for reader, _ in reader_to_node])
-    for reader, _ in reader_to_node:
+        reader_to_node_id.append((reader, reader_node))
+    chans = [ray_channel.Channel(None, reader_to_node_id, 1000)]
+    ray.get([reader.ready.remote() for reader, _ in reader_to_node_id])
+    for reader, _ in reader_to_node_id:
         reader.read.remote(chans)
     results += timeit(
         "[unstable] local put:n remote get, single channel calls",
         lambda: put_channel_small(chans),
     )
-    for reader, _ in reader_to_node:
+    for reader, _ in reader_to_node_id:
         ray.kill(reader)
 
     reader = ChannelReader.remote()
@@ -125,21 +125,23 @@ def main(results=None):
     )
     ray.kill(reader)
 
-    reader_to_node = []
+    reader_to_node_id = []
     for _ in range(n_cpu):
         reader = ChannelReader.remote()
         reader_node = get_actor_node_id(reader)
-        reader_to_node.append((reader, reader_node))
-    chans = [ray_channel.Channel(None, [reader_to_node[i]], 1000) for i in range(n_cpu)]
-    ray.get([reader.ready.remote() for reader, _ in reader_to_node])
-    for chan, reader_node_tuple in zip(chans, reader_to_node):
+        reader_to_node_id.append((reader, reader_node))
+    chans = [
+        ray_channel.Channel(None, [reader_to_node_id[i]], 1000) for i in range(n_cpu)
+    ]
+    ray.get([reader.ready.remote() for reader, _ in reader_to_node_id])
+    for chan, reader_node_tuple in zip(chans, reader_to_node_id):
         reader = reader_node_tuple[0]
         reader.read.remote([chan])
     results += timeit(
         "[unstable] local put:n remote get, n channels calls",
         lambda: put_channel_small(chans),
     )
-    for reader, _ in reader_to_node:
+    for reader, _ in reader_to_node_id:
         ray.kill(reader)
 
     # Tests for compiled DAGs.

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1709,6 +1709,14 @@ def get_and_run_resource_killer(
     return resource_killer
 
 
+def get_actor_node_id(actor_handle: "ray.actor.ActorHandle") -> str:
+    return ray.get(
+        actor_handle.__ray_call__.remote(
+            lambda self: ray.get_runtime_context().get_node_id()
+        )
+    )
+
+
 @contextmanager
 def chdir(d: str):
     old_dir = os.getcwd()

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -59,7 +59,8 @@ def do_allocate_channel(
     """Generic actor method to allocate an output channel.
 
     Args:
-        readers: The actor handles of the readers.
+        reader_to_node: A list of tuples, where each tuple contains a reader
+            actor handle and the node ID where the handle is located.
         typ: The output type hint for the channel.
 
     Returns:
@@ -788,6 +789,14 @@ class CompiledDAG:
         self._input_kwargs = tuple(input_kwargs)
 
     def _get_node_id(self, actor_handle: "ray.actor.ActorHandle") -> str:
+        """
+        Get the node ID of an actor handle and cache it.
+
+        Args:
+            actor_handle: The actor handle.
+        Returns:
+            The node ID of the actor handle.
+        """
         if actor_handle in self.actor_to_node_id:
             return self.actor_to_node_id[actor_handle]
         node_id = None

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -522,6 +522,7 @@ class CompiledDAG:
         self.actor_to_executable_tasks: Dict[
             "ray.actor.ActorHandle", List["ExecutableTask"]
         ] = {}
+        # Mapping from the actor handle to the node ID that the actor is on.
         self.actor_to_node_id: Dict["ray.actor.ActorHandle", str] = {}
 
         # Type hints specified by the user for DAG (intermediate) outputs.

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1340,7 +1340,7 @@ class TestActorInputOutput:
 
         def generate_torch_tensor(self, size) -> torch.Tensor:
             return torch.zeros(size)
-        
+
         def add_value_to_tensor(self, value: int, tensor: torch.Tensor) -> torch.Tensor:
             """
             Add `value` to all elements of the tensor.
@@ -1482,6 +1482,7 @@ class TestActorInputOutput:
         tensor. Then, the refiner model takes the image tensor and the prompt to refine
         the image. This test doesn't use the actual model but simulates the data flow.
         """
+
         @ray.remote
         class Replica:
             def __init__(self):

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1258,8 +1258,9 @@ def test_driver_and_actor_as_readers(ray_start_cluster):
 
     with pytest.raises(
         ValueError,
-        match="DAG outputs currently can only be read by the driver--not the driver "
-        "and actors.",
+        match="DAG outputs currently can only be read by the driver or "
+        "the same actor that is also the InputNode, not by both "
+        "the driver and actors.",
     ):
         dag.experimental_compile()
 

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -14,7 +14,6 @@ import torch
 import pytest
 
 from ray.exceptions import RayChannelError, RayChannelTimeoutError
-import ray.remote_function
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 import ray
 import ray._private

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -84,8 +84,8 @@ class ChannelOutputType:
 
         Args:
             writer: The actor that may write to the channel. None signifies the driver.
-            readers: The actors that may read from the channel. None signifies
-                the driver.
+            reader_to_node: A list of tuples, where each tuple contains a reader
+                actor handle and the node ID where the handle is located.
         Returns:
             A ChannelInterface that can be used to pass data
                 of this type.

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -4,7 +4,7 @@ import copy
 import threading
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import ray
 from ray.experimental.channel.nccl_group import _NcclGroup
@@ -76,7 +76,7 @@ class ChannelOutputType:
     def create_channel(
         self,
         writer: Optional["ray.actor.ActorHandle"],
-        readers: List[Optional["ray.actor.ActorHandle"]],
+        reader_to_node: List[Tuple["ray.actor.ActorHandle", str]],
     ) -> "ChannelInterface":
         """
         Instantiate a ChannelInterface class that can be used

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -76,7 +76,7 @@ class ChannelOutputType:
     def create_channel(
         self,
         writer: Optional["ray.actor.ActorHandle"],
-        reader_to_node: List[Tuple["ray.actor.ActorHandle", str]],
+        reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]],
     ) -> "ChannelInterface":
         """
         Instantiate a ChannelInterface class that can be used
@@ -84,7 +84,7 @@ class ChannelOutputType:
 
         Args:
             writer: The actor that may write to the channel. None signifies the driver.
-            reader_to_node: A list of tuples, where each tuple contains a reader
+            reader_to_node_id: A list of tuples, where each tuple contains a reader
                 actor handle and the node ID where the handle is located.
         Returns:
             A ChannelInterface that can be used to pass data

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -76,7 +76,7 @@ class ChannelOutputType:
     def create_channel(
         self,
         writer: Optional["ray.actor.ActorHandle"],
-        reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]],
+        reader_and_node_list: List[Tuple["ray.actor.ActorHandle", str]],
     ) -> "ChannelInterface":
         """
         Instantiate a ChannelInterface class that can be used
@@ -84,8 +84,8 @@ class ChannelOutputType:
 
         Args:
             writer: The actor that may write to the channel. None signifies the driver.
-            reader_to_node_id: A list of tuples, where each tuple contains a reader
-                actor handle and the node ID where the handle is located.
+            reader_and_node_list: A list of tuples, where each tuple contains a reader
+                actor handle and the node ID where the actor is located.
         Returns:
             A ChannelInterface that can be used to pass data
                 of this type.

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -107,8 +107,8 @@ class SharedMemoryType(ChannelOutputType):
 
         Args:
             writer: The actor that may write to the channel. None signifies the driver.
-            readers: The actors that may read from the channel. None signifies
-                the driver.
+            reader_to_node: A list of tuples, where each tuple contains a reader
+                actor handle and the node ID where the handle is located.
         Returns:
             A ChannelInterface that can be used to pass data
                 of this type.
@@ -171,7 +171,8 @@ class Channel(ChannelInterface):
 
         Args:
             writer: The actor that may write to the channel. None signifies the driver.
-            readers: The actors that may read from the channel. No reader may be None.
+            reader_to_node: A list of tuples, where each tuple contains a reader
+                actor handle and the node ID where the handle is located.
             typ: Type information about the values passed through the channel.
                 Either an integer representing the max buffer size in bytes
                 allowed, or a SharedMemoryType.
@@ -487,8 +488,8 @@ class CompositeChannel(ChannelInterface):
 
     Args:
         writer: The actor that may write to the channel. None signifies the driver.
-        readers: The actors that may read from the channel. None signifies
-            the driver.
+        reader_to_node: A list of tuples, where each tuple contains a reader
+            actor handle and the node ID where the handle is located.
     """
 
     def __init__(

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -99,7 +99,7 @@ class SharedMemoryType(ChannelOutputType):
     def create_channel(
         self,
         writer: Optional["ray.actor.ActorHandle"],
-        reader_to_node: List[Tuple["ray.actor.ActorHandle", str]],
+        reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]],
     ) -> "Channel":
         """
         Instantiate a ChannelInterface class that can be used
@@ -107,7 +107,7 @@ class SharedMemoryType(ChannelOutputType):
 
         Args:
             writer: The actor that may write to the channel. None signifies the driver.
-            reader_to_node: A list of tuples, where each tuple contains a reader
+            reader_to_node_id: A list of tuples, where each tuple contains a reader
                 actor handle and the node ID where the handle is located.
         Returns:
             A ChannelInterface that can be used to pass data
@@ -128,12 +128,12 @@ class SharedMemoryType(ChannelOutputType):
                 )
                 return NestedTorchTensorNcclChannel(
                     writer,
-                    reader_to_node,
+                    reader_to_node_id,
                     gpu_data_typ=self._contains_type,
                     cpu_data_typ=cpu_data_typ,
                 )
 
-        return CompositeChannel(writer, reader_to_node)
+        return CompositeChannel(writer, reader_to_node_id)
 
     def set_nccl_group_id(self, group_id: str) -> None:
         assert self.requires_nccl()
@@ -153,7 +153,7 @@ class Channel(ChannelInterface):
     def __init__(
         self,
         writer: Optional[ray.actor.ActorHandle],
-        reader_to_node: List[Tuple["ray.actor.ActorHandle", str]],
+        reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]],
         typ: Optional[Union[int, SharedMemoryType]] = None,
         _writer_node_id: Optional["ray.NodeID"] = None,
         _reader_node_id: Optional["ray.NodeID"] = None,
@@ -171,7 +171,7 @@ class Channel(ChannelInterface):
 
         Args:
             writer: The actor that may write to the channel. None signifies the driver.
-            reader_to_node: A list of tuples, where each tuple contains a reader
+            reader_to_node_id: A list of tuples, where each tuple contains a reader
                 actor handle and the node ID where the handle is located.
             typ: Type information about the values passed through the channel.
                 Either an integer representing the max buffer size in bytes
@@ -179,8 +179,8 @@ class Channel(ChannelInterface):
         Returns:
             Channel: A wrapper around ray.ObjectRef.
         """
-        assert len(reader_to_node) > 0
-        for reader, _ in reader_to_node:
+        assert len(reader_to_node_id) > 0
+        for reader, _ in reader_to_node_id:
             assert isinstance(reader, ray.actor.ActorHandle)
 
         if typ is None:
@@ -195,7 +195,7 @@ class Channel(ChannelInterface):
             )
 
         self._writer = writer
-        self._reader_to_node = reader_to_node
+        self._reader_to_node_id = reader_to_node_id
         self._typ = typ
 
         self._worker = ray._private.worker.global_worker
@@ -229,7 +229,7 @@ class Channel(ChannelInterface):
             # different nodes.
             prev_reader_node = None
             prev_reader = None
-            for reader, node in reader_to_node:
+            for reader, node in reader_to_node_id:
                 if prev_reader_node is None:
                     prev_reader_node = node
                 elif prev_reader_node != node:
@@ -246,7 +246,7 @@ class Channel(ChannelInterface):
             self._writer_ref = _create_channel_ref(self, typ.buffer_size_bytes)
             self._reader_node_id = prev_reader_node
 
-            self._create_reader_ref(reader_to_node, typ.buffer_size_bytes)
+            self._create_reader_ref(reader_to_node_id, typ.buffer_size_bytes)
 
             assert self._reader_ref is not None
         else:
@@ -263,7 +263,7 @@ class Channel(ChannelInterface):
             self._reader_node_id = _reader_node_id
             self._reader_ref = _reader_ref
 
-        self._num_readers = len(self._reader_to_node)
+        self._num_readers = len(self._reader_to_node_id)
         if self.is_remote():
             # Even though there may be multiple readers on a remote node, we set
             # `self._num_readers` to 1 here. On this local node, only the IO thread in
@@ -274,12 +274,12 @@ class Channel(ChannelInterface):
 
     def _create_reader_ref(
         self,
-        reader_to_node: List[Tuple["ray.actor.ActorHandle", str]],
+        reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]],
         buffer_size_bytes: int,
     ):
         # TODO(jhumphri): Free the current reader ref once the reference to it is
         # destroyed below.
-        reader = reader_to_node[0][0]
+        reader = reader_to_node_id[0][0]
         if self.is_remote():
             fn = reader.__ray_call__
             self._reader_ref = ray.get(
@@ -318,8 +318,8 @@ class Channel(ChannelInterface):
             self._reader_ref,
             self._writer_node_id,
             self._reader_node_id,
-            self._reader_to_node[0][0]._actor_id,
-            len(self._reader_to_node),
+            self._reader_to_node_id[0][0]._actor_id,
+            len(self._reader_to_node_id),
         )
         self._writer_registered = True
 
@@ -335,7 +335,7 @@ class Channel(ChannelInterface):
     @staticmethod
     def _deserialize_reader_channel(
         writer: ray.actor.ActorHandle,
-        reader_to_node: List[Tuple["ray.actor.ActorHandle", str]],
+        reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]],
         typ: int,
         writer_node_id,
         reader_node_id,
@@ -346,7 +346,7 @@ class Channel(ChannelInterface):
     ) -> "Channel":
         chan = Channel(
             writer,
-            reader_to_node,
+            reader_to_node_id,
             typ,
             _writer_node_id=writer_node_id,
             _reader_node_id=reader_node_id,
@@ -361,7 +361,7 @@ class Channel(ChannelInterface):
         assert self._reader_ref is not None
         return self._deserialize_reader_channel, (
             self._writer,
-            self._reader_to_node,
+            self._reader_to_node_id,
             self._typ,
             self._writer_node_id,
             self._reader_node_id,
@@ -389,7 +389,9 @@ class Channel(ChannelInterface):
             prev_writer_ref = self._writer_ref
             self._writer_ref = _create_channel_ref(self, self._typ.buffer_size_bytes)
 
-            self._create_reader_ref(self._reader_to_node, self._typ.buffer_size_bytes)
+            self._create_reader_ref(
+                self._reader_to_node_id, self._typ.buffer_size_bytes
+            )
 
             # Write a special message to the channel so that the readers know to
             # stop using the current reader_ref.
@@ -488,21 +490,21 @@ class CompositeChannel(ChannelInterface):
 
     Args:
         writer: The actor that may write to the channel. None signifies the driver.
-        reader_to_node: A list of tuples, where each tuple contains a reader
+        reader_to_node_id: A list of tuples, where each tuple contains a reader
             actor handle and the node ID where the handle is located.
     """
 
     def __init__(
         self,
         writer: Optional[ray.actor.ActorHandle],
-        reader_to_node: List[Tuple["ray.actor.ActorHandle", str]],
+        reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]],
         _channel_dict: Optional[Dict[ray.ActorID, ChannelInterface]] = None,
         _channels: Optional[Set[ChannelInterface]] = None,
         _writer_registered: bool = False,
         _reader_registered: bool = False,
     ):
         self._writer = writer
-        self._reader_to_node = reader_to_node
+        self._reader_to_node_id = reader_to_node_id
         self._writer_registered = _writer_registered
         self._reader_registered = _reader_registered
         # A dictionary that maps the actor ID to the channel object.
@@ -514,13 +516,13 @@ class CompositeChannel(ChannelInterface):
             # We don't need to create channels again.
             return
 
-        remote_reader_to_node: List[Tuple["ray.actor.ActorHandle", str]] = []
-        for reader, node in self._reader_to_node:
+        remote_reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]] = []
+        for reader, node in self._reader_to_node_id:
             if self._writer != reader:
-                remote_reader_to_node.append((reader, node))
+                remote_reader_to_node_id.append((reader, node))
         # There are some local readers which are the same worker process as the writer.
         # Create a local channel for the writer and the local readers.
-        num_local_readers = len(self._reader_to_node) - len(remote_reader_to_node)
+        num_local_readers = len(self._reader_to_node_id) - len(remote_reader_to_node_id)
         if num_local_readers > 0:
             local_channel = IntraProcessChannel(num_local_readers)
             self._channels.add(local_channel)
@@ -528,10 +530,10 @@ class CompositeChannel(ChannelInterface):
             self._channel_dict[actor_id] = local_channel
         # There are some remote readers which are not the same Ray actor as the writer.
         # Create a shared memory channel for the writer and the remote readers.
-        if len(remote_reader_to_node) != 0:
-            remote_channel = Channel(self._writer, remote_reader_to_node)
+        if len(remote_reader_to_node_id) != 0:
+            remote_channel = Channel(self._writer, remote_reader_to_node_id)
             self._channels.add(remote_channel)
-            for reader, _ in remote_reader_to_node:
+            for reader, _ in remote_reader_to_node_id:
                 actor_id = self._get_actor_id(reader)
                 self._channel_dict[actor_id] = remote_channel
 
@@ -547,8 +549,8 @@ class CompositeChannel(ChannelInterface):
         if actor_id is None:
             # The reader is the driver process.
             # Use the actor ID of the DAGDriverProxyActor.
-            assert len(self._reader_to_node) == 1
-            driver_actor = self._reader_to_node[0][0]
+            assert len(self._reader_to_node_id) == 1
+            driver_actor = self._reader_to_node_id[0][0]
             actor_id = self._get_actor_id(driver_actor)
         return actor_id
 
@@ -569,7 +571,7 @@ class CompositeChannel(ChannelInterface):
     def __reduce__(self):
         return CompositeChannel, (
             self._writer,
-            self._reader_to_node,
+            self._reader_to_node_id,
             self._channel_dict,
             self._channels,
             self._writer_registered,

--- a/python/ray/experimental/channel/torch_tensor_nccl_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_nccl_channel.py
@@ -35,7 +35,7 @@ class NestedTorchTensorNcclChannel(ChannelInterface):
     def __init__(
         self,
         writer: ray.actor.ActorHandle,
-        reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]],
+        reader_and_node_list: List[Tuple["ray.actor.ActorHandle", str]],
         gpu_data_typ: "TorchTensorType",
         cpu_data_typ: Optional["SharedMemoryType"] = None,
         _gpu_data_channel: Optional["TorchTensorNcclChannel"] = None,
@@ -53,20 +53,20 @@ class NestedTorchTensorNcclChannel(ChannelInterface):
 
         Args:
             writer: The actor that may write to the channel. None signifies the driver.
-            reader_to_node_id: A list of tuples, where each tuple contains a reader
-                actor handle and the node ID where the handle is located.
+            reader_and_node_list: A list of tuples, where each tuple contains a reader
+                actor handle and the node ID where the actor is located.
             gpu_data_typ: Type information about the GPU tensors
             cpu_data_typ: Type information about the CPU data
         """
         self._writer = writer
-        self._reader_to_node_id = reader_to_node_id
+        self._reader_and_node_list = reader_and_node_list
 
         if _gpu_data_channel is not None or _cpu_data_channel is not None:
             # This path is used when the NestedTorchTensorNcclChannel is being
             # deserialized.
             assert (
                 writer is None
-                and reader_to_node_id is None
+                and reader_and_node_list is None
                 and gpu_data_typ is None
                 and cpu_data_typ is None
             )
@@ -77,12 +77,12 @@ class NestedTorchTensorNcclChannel(ChannelInterface):
             # This path is used when the NestedTorchTensorNcclChannel is first
             # being created, by the writer of the channel.
             self._gpu_data_channel: TorchTensorNcclChannel = (
-                gpu_data_typ.create_channel(writer, reader_to_node_id)
+                gpu_data_typ.create_channel(writer, reader_and_node_list)
             )
             self._cpu_data_channel: Optional["Channel"] = None
             if cpu_data_typ is not None:
                 self._cpu_data_channel = cpu_data_typ.create_channel(
-                    writer, reader_to_node_id
+                    writer, reader_and_node_list
                 )
 
         # Used for serialization.
@@ -101,7 +101,7 @@ class NestedTorchTensorNcclChannel(ChannelInterface):
     ):
         return cls(
             writer=None,
-            reader_to_node_id=None,
+            reader_and_node_list=None,
             gpu_data_typ=None,
             cpu_data_typ=None,
             _gpu_data_channel=gpu_data_channel,
@@ -192,7 +192,7 @@ class TorchTensorNcclChannel(ChannelInterface):
     def __init__(
         self,
         writer: ray.actor.ActorHandle,
-        reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]],
+        reader_and_node_list: List[Tuple["ray.actor.ActorHandle", str]],
         typ: "TorchTensorType",
         _meta_channel: Optional["Channel"] = None,
         _torch_tensor_allocator: Optional[TorchTensorAllocator] = None,
@@ -202,8 +202,8 @@ class TorchTensorNcclChannel(ChannelInterface):
 
         Args:
             writer: The actor that may write to the channel. None signifies the driver.
-            reader_to_node_id: A list of tuples, where each tuple contains a reader
-                actor handle and the node ID where the handle is located.
+            reader_and_node_list: A list of tuples, where each tuple contains a reader
+                actor handle and the node ID where the actor is located.
             typ: Type information about the values passed through the channel.
             _meta_channel: A channel used to send metadata for the tensors,
                 i.e. shape and dtype. If not provided, and if the typ does not
@@ -221,7 +221,7 @@ class TorchTensorNcclChannel(ChannelInterface):
 
         self._writer = writer
         self._writer_rank: Optional[int] = None
-        self._reader_to_node_id = reader_to_node_id
+        self._reader_and_node_list = reader_and_node_list
         self._reader_ranks: Optional[List[int]] = None
         self._writer_registered: bool = False
         self._reader_registered: bool = False
@@ -243,7 +243,8 @@ class TorchTensorNcclChannel(ChannelInterface):
 
         self._writer_rank = self._nccl_group.get_rank(self._writer)
         self._reader_ranks = [
-            self._nccl_group.get_rank(reader) for reader, _ in self._reader_to_node_id
+            self._nccl_group.get_rank(reader)
+            for reader, _ in self._reader_and_node_list
         ]
 
         if (
@@ -273,7 +274,7 @@ class TorchTensorNcclChannel(ChannelInterface):
             )
             self._meta_channel = metadata_type.create_channel(
                 self._writer,
-                self._reader_to_node_id,
+                self._reader_and_node_list,
             )
 
         if self._meta_channel is None:
@@ -298,7 +299,7 @@ class TorchTensorNcclChannel(ChannelInterface):
             self.__class__,
             (
                 self._writer,
-                self._reader_to_node_id,
+                self._reader_and_node_list,
                 self._typ,
                 self._meta_channel,
                 self._torch_tensor_allocator,

--- a/python/ray/experimental/channel/torch_tensor_nccl_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_nccl_channel.py
@@ -50,6 +50,13 @@ class NestedTorchTensorNcclChannel(ChannelInterface):
         writes the worker-local
         ray.experimental.channel.serialization_context._SerializationContext
         when serializing data.
+
+        Args:
+            writer: The actor that may write to the channel. None signifies the driver.
+            reader_to_node: A list of tuples, where each tuple contains a reader
+                actor handle and the node ID where the handle is located.
+            gpu_data_typ: Type information about the GPU tensors
+            cpu_data_typ: Type information about the CPU data
         """
         self._writer = writer
         self._reader_to_node = reader_to_node
@@ -195,8 +202,8 @@ class TorchTensorNcclChannel(ChannelInterface):
 
         Args:
             writer: The actor that may write to the channel. None signifies the driver.
-            readers: The actors that may read from the channel. None signifies
-                the driver.
+            reader_to_node: A list of tuples, where each tuple contains a reader
+                actor handle and the node ID where the handle is located.
             typ: Type information about the values passed through the channel.
             _meta_channel: A channel used to send metadata for the tensors,
                 i.e. shape and dtype. If not provided, and if the typ does not

--- a/python/ray/experimental/channel/torch_tensor_nccl_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_nccl_channel.py
@@ -2,7 +2,7 @@ import io
 import logging
 import uuid
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
 
 import ray
 import ray.util.serialization

--- a/python/ray/experimental/channel/torch_tensor_type.py
+++ b/python/ray/experimental/channel/torch_tensor_type.py
@@ -116,7 +116,7 @@ class TorchTensorType(ChannelOutputType):
     def create_channel(
         self,
         writer: Optional["ray.actor.ActorHandle"],
-        reader_to_node: List[Tuple["ray.actor.ActorHandle", str]],
+        reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]],
         _torch_tensor_allocator: Optional["TorchTensorAllocator"] = None,
     ) -> type:
         if self.requires_nccl():
@@ -126,7 +126,7 @@ class TorchTensorType(ChannelOutputType):
 
             return TorchTensorNcclChannel(
                 writer,
-                reader_to_node,
+                reader_to_node_id,
                 self,
                 _torch_tensor_allocator=_torch_tensor_allocator,
             )
@@ -165,7 +165,7 @@ class TorchTensorType(ChannelOutputType):
         buffer_size_bytes = int(num_elements * element_size_bytes)
         buffer_size_bytes += TENSOR_METADATA_SIZE_BYTES
 
-        return Channel(writer, reader_to_node, buffer_size_bytes)
+        return Channel(writer, reader_to_node_id, buffer_size_bytes)
 
     def requires_nccl(self) -> bool:
         return self.transport == self.NCCL

--- a/python/ray/experimental/channel/torch_tensor_type.py
+++ b/python/ray/experimental/channel/torch_tensor_type.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import ray
 from ray.experimental.channel import ChannelContext, ChannelOutputType

--- a/python/ray/experimental/channel/torch_tensor_type.py
+++ b/python/ray/experimental/channel/torch_tensor_type.py
@@ -116,7 +116,7 @@ class TorchTensorType(ChannelOutputType):
     def create_channel(
         self,
         writer: Optional["ray.actor.ActorHandle"],
-        reader_to_node_id: List[Tuple["ray.actor.ActorHandle", str]],
+        reader_and_node_list: List[Tuple["ray.actor.ActorHandle", str]],
         _torch_tensor_allocator: Optional["TorchTensorAllocator"] = None,
     ) -> type:
         if self.requires_nccl():
@@ -126,7 +126,7 @@ class TorchTensorType(ChannelOutputType):
 
             return TorchTensorNcclChannel(
                 writer,
-                reader_to_node_id,
+                reader_and_node_list,
                 self,
                 _torch_tensor_allocator=_torch_tensor_allocator,
             )
@@ -165,7 +165,7 @@ class TorchTensorType(ChannelOutputType):
         buffer_size_bytes = int(num_elements * element_size_bytes)
         buffer_size_bytes += TENSOR_METADATA_SIZE_BYTES
 
-        return Channel(writer, reader_to_node_id, buffer_size_bytes)
+        return Channel(writer, reader_and_node_list, buffer_size_bytes)
 
     def requires_nccl(self) -> bool:
         return self.transport == self.NCCL

--- a/python/ray/experimental/compiled_dag_ref.py
+++ b/python/ray/experimental/compiled_dag_ref.py
@@ -44,7 +44,6 @@ class CompiledDAGRef:
         dag: "ray.experimental.CompiledDAG",
         execution_index: int,
     ):
-        print("CompiledDAGRef", "__init__")
         """
         Args:
             dag: The compiled DAG that generated this CompiledDAGRef.
@@ -79,7 +78,6 @@ class CompiledDAGRef:
             self.get()
 
     def get(self, timeout: Optional[float] = None):
-        print("CompiledDAGRef", "get()")
         if self._ray_get_called:
             raise ValueError(
                 "ray.get() can only be called once "

--- a/python/ray/experimental/compiled_dag_ref.py
+++ b/python/ray/experimental/compiled_dag_ref.py
@@ -44,6 +44,7 @@ class CompiledDAGRef:
         dag: "ray.experimental.CompiledDAG",
         execution_index: int,
     ):
+        print("CompiledDAGRef", "__init__")
         """
         Args:
             dag: The compiled DAG that generated this CompiledDAGRef.
@@ -78,6 +79,7 @@ class CompiledDAGRef:
             self.get()
 
     def get(self, timeout: Optional[float] = None):
+        print("CompiledDAGRef", "get()")
         if self._ray_get_called:
             raise ValueError(
                 "ray.get() can only be called once "

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -19,6 +19,14 @@ from ray.dag.compiled_dag_node import CompiledDAG
 logger = logging.getLogger(__name__)
 
 
+def get_actor_node_id(actor_handle: "ray.actor.ActorHandle") -> str:
+    return ray.get(
+        actor_handle.__ray_call__.remote(
+            lambda self: ray.get_runtime_context().get_node_id()
+        )
+    )
+
+
 def create_driver_actor():
     return CompiledDAG.DAGDriverProxyActor.options(
         scheduling_strategy=NodeAffinitySchedulingStrategy(
@@ -32,7 +40,14 @@ def create_driver_actor():
     reason="Requires Linux or Mac.",
 )
 def test_put_local_get(ray_start_regular):
-    chan = ray_channel.Channel(None, [create_driver_actor()], 1000)
+    driver_actor = create_driver_actor()
+    chan = ray_channel.Channel(
+        None,
+        [
+            (driver_actor, get_actor_node_id(driver_actor)),
+        ],
+        1000,
+    )
 
     num_writes = 1000
     for i in range(num_writes):
@@ -46,7 +61,14 @@ def test_put_local_get(ray_start_regular):
     reason="Requires Linux or Mac.",
 )
 def test_read_timeout(ray_start_regular):
-    chan = ray_channel.Channel(None, [create_driver_actor()], 1000)
+    driver_actor = create_driver_actor()
+    chan = ray_channel.Channel(
+        None,
+        [
+            (driver_actor, get_actor_node_id(driver_actor)),
+        ],
+        1000,
+    )
 
     with pytest.raises(RayChannelTimeoutError):
         chan.read(timeout=1)
@@ -57,7 +79,14 @@ def test_read_timeout(ray_start_regular):
     reason="Requires Linux or Mac.",
 )
 def test_write_timeout(ray_start_regular):
-    chan = ray_channel.Channel(None, [create_driver_actor()], 1000)
+    driver_actor = create_driver_actor()
+    chan = ray_channel.Channel(
+        None,
+        [
+            (driver_actor, get_actor_node_id(driver_actor)),
+        ],
+        1000,
+    )
 
     val = 1
     bytes = val.to_bytes(8, "little")
@@ -91,7 +120,7 @@ def test_driver_as_reader(ray_start_cluster, remote):
         def setup(self, driver_actor):
             self._channel = ray_channel.Channel(
                 ray.get_runtime_context().current_actor,
-                [driver_actor],
+                [(driver_actor, get_actor_node_id(driver_actor))],
                 1000,
             )
 
@@ -130,7 +159,7 @@ def test_driver_as_reader_with_resize(ray_start_cluster, remote):
         def setup(self, driver_actor):
             self._channel = ray_channel.Channel(
                 ray.get_runtime_context().current_actor,
-                [driver_actor],
+                [(driver_actor, get_actor_node_id(driver_actor))],
                 1000,
             )
 
@@ -169,8 +198,8 @@ def test_set_error_before_read(ray_start_regular):
         def __init__(self):
             self.arr = None
 
-        def create_channel(self, writer, readers):
-            self._channel = ray_channel.Channel(writer, readers, 1000)
+        def create_channel(self, writer, reader_to_node):
+            self._channel = ray_channel.Channel(writer, reader_to_node, 1000)
             return self._channel
 
         def pass_channel(self, channel):
@@ -197,8 +226,9 @@ def test_set_error_before_read(ray_start_regular):
     for _ in range(10):
         a = Actor.remote()
         b = Actor.remote()
+        node_b = get_actor_node_id(b)
 
-        chan = ray.get(a.create_channel.remote(a, [b]))
+        chan = ray.get(a.create_channel.remote(a, [(b, node_b)]))
         ray.get(b.pass_channel.remote(chan))
 
         # Use numpy to enable zero-copy deserialization.
@@ -245,7 +275,12 @@ def test_errors(ray_start_regular):
 
     a = Actor.remote()
     # Multiple consecutive reads from the same process are fine.
-    chan = ray.get(a.make_chan.remote([create_driver_actor()], do_write=True))
+    driver_actor = create_driver_actor()
+    chan = ray.get(
+        a.make_chan.remote(
+            [(driver_actor, get_actor_node_id(driver_actor))], do_write=True
+        )
+    )
     assert chan.read() == b"hello"
 
     @ray.remote
@@ -259,7 +294,9 @@ def test_errors(ray_start_regular):
     readers = [Reader.remote(), Reader.remote()]
     # Check that an exception is thrown when there are more readers than specificed in
     # the channel constructor.
-    chan = ray.get(a.make_chan.remote([readers[0]], do_write=True))
+    chan = ray.get(
+        a.make_chan.remote([(readers[0], get_actor_node_id(readers[0]))], do_write=True)
+    )
     # At least 1 reader.
     with pytest.raises(ray.exceptions.RayTaskError) as exc_info:
         ray.get([reader.read.remote(chan) for reader in readers])
@@ -271,7 +308,10 @@ def test_errors(ray_start_regular):
     reason="Requires Linux or Mac.",
 )
 def test_put_different_meta(ray_start_regular):
-    chan = ray_channel.Channel(None, [create_driver_actor()], 1000)
+    driver_actor = create_driver_actor()
+    chan = ray_channel.Channel(
+        None, [(driver_actor, get_actor_node_id(driver_actor))], 1000
+    )
 
     def _test(val):
         chan.write(val)
@@ -309,8 +349,9 @@ def test_multiple_channels_different_nodes(ray_start_cluster):
                 assert read_val == val
 
     a = Actor.remote()
-    chan_a = ray_channel.Channel(None, [a], 1000)
-    chan_b = ray_channel.Channel(None, [a], 1000)
+    node_a = get_actor_node_id(a)
+    chan_a = ray_channel.Channel(None, [(a, node_a)], 1000)
+    chan_b = ray_channel.Channel(None, [(a, node_a)], 1000)
     channels = [chan_a, chan_b]
 
     val = np.random.rand(5)
@@ -330,7 +371,10 @@ def test_resize_channel_on_same_node(ray_start_regular):
     Tests that the channel backing store is automatically increased when a large object
     is written to it. The writer and reader are on the same node.
     """
-    chan = ray_channel.Channel(None, [create_driver_actor()], 1000)
+    driver_actor = create_driver_actor()
+    chan = ray_channel.Channel(
+        None, [(driver_actor, get_actor_node_id(driver_actor))], 1000
+    )
 
     def _test(val):
         chan.write(val)
@@ -377,7 +421,8 @@ def test_resize_channel_on_same_node_with_actor(ray_start_regular):
         ray.get(actor.read.remote(channel, val))
 
     a = Actor.remote()
-    chan = ray_channel.Channel(None, [a], 1000)
+    node_a = get_actor_node_id(a)
+    chan = ray_channel.Channel(None, [(a, node_a)], 1000)
 
     # `np.random.rand(100)` requires more than 1000 bytes of storage. The channel is
     # allocated above with a backing store size of 1000 bytes.
@@ -421,7 +466,8 @@ def test_resize_channel_on_different_nodes(ray_start_cluster):
         ray.get(actor.read.remote(channel, val))
 
     a = Actor.remote()
-    chan = ray_channel.Channel(None, [a], 1000)
+    node_a = get_actor_node_id(a)
+    chan = ray_channel.Channel(None, [(a, node_a)], 1000)
 
     # `np.random.rand(100)` requires more than 1000 bytes of storage. The channel is
     # allocated above with a backing store size of 1000 bytes.
@@ -464,12 +510,16 @@ def test_put_remote_get(ray_start_regular, num_readers):
                 assert chan.read() == val
 
     num_writes = 1000
-    readers = [Reader.remote() for _ in range(num_readers)]
+    reader_to_node = []
+    for _ in range(num_readers):
+        handle = Reader.remote()
+        node = get_actor_node_id(handle)
+        reader_to_node.append((handle, node))
 
-    chan = ray_channel.Channel(None, readers, 1000)
+    chan = ray_channel.Channel(None, reader_to_node, 1000)
     chan.ensure_registered_as_writer()
 
-    done = [reader.read.remote(chan, num_writes) for reader in readers]
+    done = [reader.read.remote(chan, num_writes) for reader, _ in reader_to_node]
     for i in range(num_writes):
         val = i.to_bytes(8, "little")
         chan.write(val)
@@ -532,14 +582,19 @@ def test_remote_reader(ray_start_cluster, remote):
             for i in range(num_reads):
                 self._reader_chan.read()
 
-    readers = [Reader.remote() for _ in range(num_readers)]
-    channel = ray_channel.Channel(None, readers, 1000)
+    reader_to_node = []
+    for _ in range(num_readers):
+        handle = Reader.remote()
+        node = get_actor_node_id(handle)
+        reader_to_node.append((handle, node))
+
+    channel = ray_channel.Channel(None, reader_to_node, 1000)
 
     # All readers have received the channel.
-    ray.get([reader.pass_channel.remote(channel) for reader in readers])
+    ray.get([reader.pass_channel.remote(channel) for reader, _ in reader_to_node])
 
     for _ in range(num_iterations):
-        work = [reader.read.remote(num_writes) for reader in readers]
+        work = [reader.read.remote(num_writes) for reader, _ in reader_to_node]
         start = time.perf_counter()
         for i in range(num_writes):
             channel.write(b"x")
@@ -598,20 +653,24 @@ def test_remote_reader_close(ray_start_cluster, remote):
         def close(self):
             self._reader_chan.close()
 
-    readers = [Reader.remote() for _ in range(num_readers)]
-    channel = ray_channel.Channel(None, readers, 1000)
+    reader_to_node = []
+    for _ in range(num_readers):
+        handle = Reader.remote()
+        node = get_actor_node_id(handle)
+        reader_to_node.append((handle, node))
+    channel = ray_channel.Channel(None, reader_to_node, 1000)
 
     # All readers have received the channel.
-    ray.get([reader.pass_channel.remote(channel) for reader in readers])
+    ray.get([reader.pass_channel.remote(channel) for reader, _ in reader_to_node])
 
     reads = [
         reader.read.options(concurrency_group="_ray_system").remote()
-        for reader in readers
+        for reader, _ in reader_to_node
     ]
     with pytest.raises(ray.exceptions.GetTimeoutError):
         ray.get(reads, timeout=1.0)
 
-    ray.get([reader.close.remote() for reader in readers])
+    ray.get([reader.close.remote() for reader, _ in reader_to_node])
     ray.get(reads)
 
 
@@ -757,8 +816,8 @@ def test_composite_channel_single_reader(ray_start_cluster):
         def pass_channel(self, channel):
             self._chan = channel
 
-        def create_composite_channel(self, writer, readers):
-            self._chan = ray_channel.CompositeChannel(writer, readers)
+        def create_composite_channel(self, writer, reader_to_node):
+            self._chan = ray_channel.CompositeChannel(writer, reader_to_node)
             return self._chan
 
         def read(self):
@@ -769,29 +828,34 @@ def test_composite_channel_single_reader(ray_start_cluster):
 
     actor1 = Actor.remote()
     actor2 = Actor.remote()
+    node1 = get_actor_node_id(actor1)
+    node2 = get_actor_node_id(actor2)
 
     # Create a channel to communicate between driver process and actor1.
-    driver_to_actor1_channel = ray_channel.CompositeChannel(None, [actor1])
+    driver_to_actor1_channel = ray_channel.CompositeChannel(None, [(actor1, node1)])
     ray.get(actor1.pass_channel.remote(driver_to_actor1_channel))
     driver_to_actor1_channel.write("hello")
     assert ray.get(actor1.read.remote()) == "hello"
 
     # Create a channel to communicate between two tasks in actor1.
-    ray.get(actor1.create_composite_channel.remote(actor1, [actor1]))
+    ray.get(actor1.create_composite_channel.remote(actor1, [(actor1, node1)]))
     ray.get(actor1.write.remote("world"))
     assert ray.get(actor1.read.remote()) == "world"
 
     # Create a channel to communicate between actor1 and actor2.
     actor1_to_actor2_channel = ray.get(
-        actor1.create_composite_channel.remote(actor1, [actor2])
+        actor1.create_composite_channel.remote(actor1, [(actor2, node2)])
     )
     ray.get(actor2.pass_channel.remote(actor1_to_actor2_channel))
     ray.get(actor1.write.remote("hello world"))
     assert ray.get(actor2.read.remote()) == "hello world"
 
     # Create a channel to communicate between actor2 and driver process.
+    driver_actor = create_driver_actor()
     actor2_to_driver_channel = ray.get(
-        actor2.create_composite_channel.remote(actor2, [create_driver_actor()])
+        actor2.create_composite_channel.remote(
+            actor2, [(driver_actor, get_actor_node_id(driver_actor))]
+        )
     )
     ray.get(actor2.write.remote("world hello"))
     assert actor2_to_driver_channel.read() == "world hello"
@@ -824,8 +888,8 @@ def test_composite_channel_multiple_readers(ray_start_cluster):
         def pass_channel(self, channel):
             self._chan = channel
 
-        def create_composite_channel(self, writer, readers):
-            self._chan = ray_channel.CompositeChannel(writer, readers)
+        def create_composite_channel(self, writer, reader_to_node):
+            self._chan = ray_channel.CompositeChannel(writer, reader_to_node)
             return self._chan
 
         def read(self):
@@ -836,9 +900,13 @@ def test_composite_channel_multiple_readers(ray_start_cluster):
 
     actor1 = Actor.remote()
     actor2 = Actor.remote()
+    node1 = get_actor_node_id(actor1)
+    node2 = get_actor_node_id(actor2)
 
     # The driver writes data to CompositeChannel and actor1 and actor2 read it.
-    driver_output_channel = ray_channel.CompositeChannel(None, [actor1, actor2])
+    driver_output_channel = ray_channel.CompositeChannel(
+        None, [(actor1, node1), (actor2, node2)]
+    )
     ray.get(actor1.pass_channel.remote(driver_output_channel))
     ray.get(actor2.pass_channel.remote(driver_output_channel))
     driver_output_channel.write("hello")
@@ -846,14 +914,18 @@ def test_composite_channel_multiple_readers(ray_start_cluster):
 
     # actor1 writes data to CompositeChannel and actor1 and actor2 read it.
     actor1_output_channel = ray.get(
-        actor1.create_composite_channel.remote(actor1, [actor1, actor2])
+        actor1.create_composite_channel.remote(
+            actor1, [(actor1, node1), (actor2, node2)]
+        )
     )
     ray.get(actor2.pass_channel.remote(actor1_output_channel))
     ray.get(actor1.write.remote("world"))
     assert ray.get([actor1.read.remote(), actor2.read.remote()]) == ["world"] * 2
 
     actor1_output_channel = ray.get(
-        actor1.create_composite_channel.remote(actor1, [actor1, actor1])
+        actor1.create_composite_channel.remote(
+            actor1, [(actor1, node1), (actor1, node1)]
+        )
     )
     ray.get(actor1.write.remote("hello world"))
     assert ray.get(actor1.read.remote()) == "hello world"
@@ -896,10 +968,10 @@ def test_put_error(ray_start_cluster):
 
     @ray.remote(num_cpus=1)
     class Actor:
-        def setup(self, driver_actor):
+        def setup(self, reader_to_node):
             self._channel = ray_channel.Channel(
                 ray.get_runtime_context().current_actor,
-                [driver_actor],
+                reader_to_node,
                 1000,
             )
 
@@ -916,7 +988,8 @@ def test_put_error(ray_start_cluster):
                 self._channel.write(b"x")
 
     a = Actor.remote()
-    ray.get(a.setup.remote(create_driver_actor()))
+    driver_actor = create_driver_actor()
+    ray.get(a.setup.remote([(driver_actor, get_actor_node_id(driver_actor))]))
     chan = ray.get(a.get_channel.remote())
 
     # Putting a bytes object multiple times is okay.
@@ -971,12 +1044,13 @@ def test_payload_large(ray_start_cluster):
     actor_node = nodes[0] if nodes[0] != driver_node else nodes[1]
     assert driver_node != actor_node
     a = create_actor(actor_node)
+    node_a = ray.get(a.get_node_id.remote())
     assert driver_node != ray.get(a.get_node_id.remote())
 
     # Ray sets the gRPC payload max size to 512 MiB. We choose a size in this test that
     # is a bit larger.
     size = 1024 * 1024 * 600
-    ch = ray_channel.Channel(None, [a], size)
+    ch = ray_channel.Channel(None, [(a, node_a)], size)
 
     val = b"x" * size
     ch.write(val)
@@ -1022,7 +1096,7 @@ def test_payload_resize_large(ray_start_cluster):
     a = create_actor(actor_node)
     assert driver_node != ray.get(a.get_node_id.remote())
 
-    ch = ray_channel.Channel(None, [a], 1000)
+    ch = ray_channel.Channel(None, [(a, actor_node)], 1000)
 
     # Ray sets the gRPC payload max size to 512 MiB. We choose a size in this test that
     # is a bit larger.
@@ -1072,10 +1146,15 @@ def test_readers_on_different_nodes(ray_start_cluster):
     b_node = nodes_check[1]
     assert a_node != b_node
 
+    driver_actor = create_driver_actor()
+    driver_node = get_actor_node_id(driver_actor)
+
     with pytest.raises(
         ValueError, match="All reader actors must be on the same node.*"
     ):
-        ray_channel.Channel(None, [create_driver_actor(), a, b], 1000)
+        ray_channel.Channel(
+            None, [(driver_actor, driver_node), (a, a_node), (b, b_node)], 1000
+        )
 
 
 @pytest.mark.skipif(
@@ -1124,10 +1203,23 @@ def test_bunch_readers_on_different_nodes(ray_start_cluster):
     assert b_node != c_node
     assert c_node == d_node
 
+    driver_actor = create_driver_actor()
+    driver_node = get_actor_node_id(driver_actor)
+
     with pytest.raises(
         ValueError, match="All reader actors must be on the same node.*"
     ):
-        ray_channel.Channel(None, [create_driver_actor(), a, b, c, d], 1000)
+        ray_channel.Channel(
+            None,
+            [
+                (driver_actor, driver_node),
+                (a, a_node),
+                (b, b_node),
+                (c, c_node),
+                (d, d_node),
+            ],
+            1000,
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -191,8 +191,8 @@ def test_set_error_before_read(ray_start_regular):
         def __init__(self):
             self.arr = None
 
-        def create_channel(self, writer, reader_to_node):
-            self._channel = ray_channel.Channel(writer, reader_to_node, 1000)
+        def create_channel(self, writer, reader_to_node_id):
+            self._channel = ray_channel.Channel(writer, reader_to_node_id, 1000)
             return self._channel
 
         def pass_channel(self, channel):
@@ -503,16 +503,16 @@ def test_put_remote_get(ray_start_regular, num_readers):
                 assert chan.read() == val
 
     num_writes = 1000
-    reader_to_node = []
+    reader_to_node_id = []
     for _ in range(num_readers):
         handle = Reader.remote()
         node = get_actor_node_id(handle)
-        reader_to_node.append((handle, node))
+        reader_to_node_id.append((handle, node))
 
-    chan = ray_channel.Channel(None, reader_to_node, 1000)
+    chan = ray_channel.Channel(None, reader_to_node_id, 1000)
     chan.ensure_registered_as_writer()
 
-    done = [reader.read.remote(chan, num_writes) for reader, _ in reader_to_node]
+    done = [reader.read.remote(chan, num_writes) for reader, _ in reader_to_node_id]
     for i in range(num_writes):
         val = i.to_bytes(8, "little")
         chan.write(val)
@@ -575,19 +575,19 @@ def test_remote_reader(ray_start_cluster, remote):
             for i in range(num_reads):
                 self._reader_chan.read()
 
-    reader_to_node = []
+    reader_to_node_id = []
     for _ in range(num_readers):
         handle = Reader.remote()
         node = get_actor_node_id(handle)
-        reader_to_node.append((handle, node))
+        reader_to_node_id.append((handle, node))
 
-    channel = ray_channel.Channel(None, reader_to_node, 1000)
+    channel = ray_channel.Channel(None, reader_to_node_id, 1000)
 
     # All readers have received the channel.
-    ray.get([reader.pass_channel.remote(channel) for reader, _ in reader_to_node])
+    ray.get([reader.pass_channel.remote(channel) for reader, _ in reader_to_node_id])
 
     for _ in range(num_iterations):
-        work = [reader.read.remote(num_writes) for reader, _ in reader_to_node]
+        work = [reader.read.remote(num_writes) for reader, _ in reader_to_node_id]
         start = time.perf_counter()
         for i in range(num_writes):
             channel.write(b"x")
@@ -646,24 +646,24 @@ def test_remote_reader_close(ray_start_cluster, remote):
         def close(self):
             self._reader_chan.close()
 
-    reader_to_node = []
+    reader_to_node_id = []
     for _ in range(num_readers):
         handle = Reader.remote()
         node = get_actor_node_id(handle)
-        reader_to_node.append((handle, node))
-    channel = ray_channel.Channel(None, reader_to_node, 1000)
+        reader_to_node_id.append((handle, node))
+    channel = ray_channel.Channel(None, reader_to_node_id, 1000)
 
     # All readers have received the channel.
-    ray.get([reader.pass_channel.remote(channel) for reader, _ in reader_to_node])
+    ray.get([reader.pass_channel.remote(channel) for reader, _ in reader_to_node_id])
 
     reads = [
         reader.read.options(concurrency_group="_ray_system").remote()
-        for reader, _ in reader_to_node
+        for reader, _ in reader_to_node_id
     ]
     with pytest.raises(ray.exceptions.GetTimeoutError):
         ray.get(reads, timeout=1.0)
 
-    ray.get([reader.close.remote() for reader, _ in reader_to_node])
+    ray.get([reader.close.remote() for reader, _ in reader_to_node_id])
     ray.get(reads)
 
 
@@ -809,8 +809,8 @@ def test_composite_channel_single_reader(ray_start_cluster):
         def pass_channel(self, channel):
             self._chan = channel
 
-        def create_composite_channel(self, writer, reader_to_node):
-            self._chan = ray_channel.CompositeChannel(writer, reader_to_node)
+        def create_composite_channel(self, writer, reader_to_node_id):
+            self._chan = ray_channel.CompositeChannel(writer, reader_to_node_id)
             return self._chan
 
         def read(self):
@@ -881,8 +881,8 @@ def test_composite_channel_multiple_readers(ray_start_cluster):
         def pass_channel(self, channel):
             self._chan = channel
 
-        def create_composite_channel(self, writer, reader_to_node):
-            self._chan = ray_channel.CompositeChannel(writer, reader_to_node)
+        def create_composite_channel(self, writer, reader_to_node_id):
+            self._chan = ray_channel.CompositeChannel(writer, reader_to_node_id)
             return self._chan
 
         def read(self):
@@ -961,10 +961,10 @@ def test_put_error(ray_start_cluster):
 
     @ray.remote(num_cpus=1)
     class Actor:
-        def setup(self, reader_to_node):
+        def setup(self, reader_to_node_id):
             self._channel = ray_channel.Channel(
                 ray.get_runtime_context().current_actor,
-                reader_to_node,
+                reader_to_node_id,
                 1000,
             )
 

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -15,16 +15,9 @@ import ray.experimental.channel as ray_channel
 from ray.exceptions import RayChannelError, RayChannelTimeoutError
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 from ray.dag.compiled_dag_node import CompiledDAG
+from ray._private.test_utils import get_actor_node_id
 
 logger = logging.getLogger(__name__)
-
-
-def get_actor_node_id(actor_handle: "ray.actor.ActorHandle") -> str:
-    return ray.get(
-        actor_handle.__ray_call__.remote(
-            lambda self: ray.get_runtime_context().get_node_id()
-        )
-    )
 
 
 def create_driver_actor():

--- a/python/ray/tests/test_nccl_channel.py
+++ b/python/ray/tests/test_nccl_channel.py
@@ -17,16 +17,9 @@ from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.experimental.channel.torch_tensor_nccl_channel import (
     _init_nccl_group,
 )
+from ray._private.test_utils import get_actor_node_id
 
 logger = logging.getLogger(__name__)
-
-
-def get_actor_node_id(actor_handle: "ray.actor.ActorHandle") -> str:
-    return ray.get(
-        actor_handle.__ray_call__.remote(
-            lambda self: ray.get_runtime_context().get_node_id()
-        )
-    )
 
 
 @ray.remote(num_cpus=0, num_gpus=1)

--- a/python/ray/tests/test_nccl_channel.py
+++ b/python/ray/tests/test_nccl_channel.py
@@ -37,12 +37,12 @@ class Worker:
     def create_nccl_channel(
         self,
         typ: TorchTensorType,
-        reader_to_node_id: List[Tuple[ray.actor.ActorHandle, str]],
+        reader_and_node_list: List[Tuple[ray.actor.ActorHandle, str]],
     ):
         typ.register_custom_serializer()
         self.chan = typ.create_channel(
             ray.get_runtime_context().current_actor,
-            reader_to_node_id,
+            reader_and_node_list,
             _torch_tensor_allocator=lambda shape, dtype: torch.zeros(
                 shape, dtype=dtype
             ),

--- a/python/ray/tests/test_nccl_channel.py
+++ b/python/ray/tests/test_nccl_channel.py
@@ -37,12 +37,12 @@ class Worker:
     def create_nccl_channel(
         self,
         typ: TorchTensorType,
-        reader_to_node: List[Tuple[ray.actor.ActorHandle, str]],
+        reader_to_node_id: List[Tuple[ray.actor.ActorHandle, str]],
     ):
         typ.register_custom_serializer()
         self.chan = typ.create_channel(
             ray.get_runtime_context().current_actor,
-            reader_to_node,
+            reader_to_node_id,
             _torch_tensor_allocator=lambda shape, dtype: torch.zeros(
                 shape, dtype=dtype
             ),

--- a/python/ray/tests/test_nccl_channel.py
+++ b/python/ray/tests/test_nccl_channel.py
@@ -21,6 +21,14 @@ from ray.experimental.channel.torch_tensor_nccl_channel import (
 logger = logging.getLogger(__name__)
 
 
+def get_actor_node_id(actor_handle: "ray.actor.ActorHandle") -> str:
+    return ray.get(
+        actor_handle.__ray_call__.remote(
+            lambda self: ray.get_runtime_context().get_node_id()
+        )
+    )
+
+
 @ray.remote(num_cpus=0, num_gpus=1)
 class Worker:
     def __init__(self):
@@ -34,12 +42,14 @@ class Worker:
         self.chan = chan
 
     def create_nccl_channel(
-        self, typ: TorchTensorType, readers: List[ray.actor.ActorHandle]
+        self,
+        typ: TorchTensorType,
+        reader_to_node: List[Tuple[ray.actor.ActorHandle, str]],
     ):
         typ.register_custom_serializer()
         self.chan = typ.create_channel(
             ray.get_runtime_context().current_actor,
-            readers,
+            reader_to_node,
             _torch_tensor_allocator=lambda shape, dtype: torch.zeros(
                 shape, dtype=dtype
             ),
@@ -78,6 +88,7 @@ def test_p2p(ray_start_cluster):
 
     sender = Worker.remote()
     receiver = Worker.remote()
+    receiver_node = get_actor_node_id(receiver)
 
     ray.get(
         [
@@ -92,7 +103,7 @@ def test_p2p(ray_start_cluster):
         transport="nccl",
     )
     chan_typ.set_nccl_group_id(nccl_id)
-    chan_ref = sender.create_nccl_channel.remote(chan_typ, [receiver])
+    chan_ref = sender.create_nccl_channel.remote(chan_typ, [(receiver, receiver_node)])
     receiver_ready = receiver.set_nccl_channel.remote(chan_typ, chan_ref)
     ray.get([chan_ref, receiver_ready])
 
@@ -128,8 +139,13 @@ def test_multiple_receivers(ray_start_cluster):
     ]  # noqa
 
     sender = Worker.remote()
-    receivers = [Worker.remote() for _ in range(3)]
-    workers = [sender] + receivers
+    receiver_to_node = []
+    for _ in range(3):
+        handle = Worker.remote()
+        node = get_actor_node_id(handle)
+        receiver_to_node.append((handle, node))
+
+    workers = [sender] + [receiver for receiver, _ in receiver_to_node]
 
     ray.get([worker.start_mock.remote() for worker in workers])
 
@@ -139,9 +155,10 @@ def test_multiple_receivers(ray_start_cluster):
         transport="nccl",
     )
     chan_typ.set_nccl_group_id(nccl_id)
-    chan_ref = sender.create_nccl_channel.remote(chan_typ, receivers)
+    chan_ref = sender.create_nccl_channel.remote(chan_typ, receiver_to_node)
     receiver_ready = [
-        receiver.set_nccl_channel.remote(chan_typ, chan_ref) for receiver in receivers
+        receiver.set_nccl_channel.remote(chan_typ, chan_ref)
+        for receiver, _ in receiver_to_node
     ]
     ray.get(receiver_ready)
 
@@ -151,7 +168,7 @@ def test_multiple_receivers(ray_start_cluster):
     all_refs = []
     for i in range(2):
         sender.produce.remote(i, shape, dtype)
-        all_refs.append([receiver.receive.remote() for receiver in receivers])
+        all_refs.append([receiver.receive.remote() for receiver, _ in receiver_to_node])
     # Check that all receivers received the correct value.
     for i, refs in enumerate(all_refs):
         for val in ray.get(refs):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, ADAG only supports the driver process as the input and output of a DAG. However, if we want to use ADAG as an inference backend and deploy it with Ray Serve, the Ray Serve replica, which is an actor, should be the input and output of the ADAG. This PR supports an actor to be the input and output of an ADAG. That is,

* Driver -> Actor1 -> Driver (supported)
* Actor1 -> Actor2 -> Actor1 (supported by this PR)
* Actor1 -> Actor2 -> Actor3 (not supported)
* Driver -> Actor1 -> Actor2 (not supported)

## Implementation

### Before this PR

The important implementation logic is in `compiled_dag_node.py`.

Without this PR, ADAG always creates a `_driver_actor` on the same node as the driver process. The driver process then reads the output from the shared memory on that node. That is, if we define an ADAG as follows:

```
Driver -> Actor1 -> Driver
```

it actually works as follows under the hood:

```
Driver -> Actor1 -> DAGDriverProxyActor -> Driver
```

### Change 1

This PR checks whether the process compiling the DAG is an actor process or a driver process. If it is a driver process, create a `DAGDriverProxyActor` (`_driver_actor`). If it is an actor process, allocates the actor's actor handle to `self._actor_handle`. When a DAG node is read by a `MultiOutputNode`, we will use `_driver_actor` or `_actor_handle` depending on whether the process is a driver or an actor. 

### Change 2

Without this PR, when we allocate a channel between the an actor and its downstream nodes, we use:

```python
task.output_channel = ray.get(
    fn.remote(
        do_allocate_channel,
        reader_to_node,
        typ=type_hint,
    )
)
```

and then the actor will execute the function `do_allocate_channel`, which will also launch a Ray task in its downstream DAG nodes. The function `_get_reader_node_id` will determine which Ray nodes the downstream DAG nodes are running on.

It will result in a deadlock if the output is an actor. When we try to allocate the channel `Actor 2 -> Actor 1`, we call `ray.get(... do_allocate_channel)` in Actor 1's process. However, Actor 2 also launches a Ray task in Actor 1 to get Actor 1's node ID. Consequently, Actor 1 and Actor 2 end up waiting for each other, causing a deadlock.

```
Actor 1 -> Actor 2 -> Actor 1
```

It doesn't cause a deadlock if the input/output is the driver process. This is because the driver process calls `ray.get(...do_allocate_channel)`, and Actor 1's process launches a Ray task in `DAGDriverProxyActor` to get the node ID.

```
Driver -> Actor 1 -> DAGDriverProxyActor -> Driver
```

* Solution: I get the node ID for each downstream reader handle in the input/output actor and pass the information to the actor.

### Note

I left comments "Change 1" and "Change 2" in this PR. You can focus on reviewing these two parts.

### Possible next steps

* Revisit deadlock detection
* Support Input actor with NCCL channel

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
