### PR TITLE
Fix events row being too large

### DIFF
--- a/python/ray/dashboard/client/src/components/EventTable.tsx
+++ b/python/ray/dashboard/client/src/components/EventTable.tsx
@@ -20,7 +20,6 @@ import { sliceToPage } from "../common/util";
 import { getEvents, getGlobalEvents } from "../service/event";
 import { Event } from "../type/event";
 import { useFilter } from "../util/hook";
-import LogVirtualView from "./LogView/LogVirtualView";
 import { StatusChip } from "./StatusChip";
 
 type EventTableProps = {

--- a/python/ray/dashboard/client/src/components/EventTable.tsx
+++ b/python/ray/dashboard/client/src/components/EventTable.tsx
@@ -327,7 +327,7 @@ const EventTable = (props: EventTableProps) => {
                         </Grid>
                       )}
                     </Grid>
-                    <LogVirtualView content={message} language="prolog" />
+                    <pre style={{ whiteSpace: "pre-wrap" }}>{message}</pre>
                   </Box>
                 );
               },


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Visual bug caused events to have a bunch of white space. 600px height.

Before:
![image](https://github.com/user-attachments/assets/d63dafeb-6981-4446-88c9-5b53ccb70ea3)


After:
![Screenshot 2024-07-18 at 3 28 35 PM](https://github.com/user-attachments/assets/be6a3ace-cf06-4fd3-8dd4-0a2428f67049)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Caused by #46391
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
