### PR TITLE
[Data] Fix `read_tfrecords()` docstring to display `tfx-bsl` tip

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1712,9 +1712,9 @@ def read_tfrecords(
         Using tfx-bsl for reading tfrecord files is prefered, When reading large
         datasets in production use cases. To use this implementation you should
         install tfx-bsl with:
-            1. `pip install tfx_bsl --no-dependencies`
-            2. Pass tfx_read_options to read_tfrecords, for example:
-                `ds = read_tfrecords(path, ..., tfx_read_options=TFXReadOptions())`
+        1. `pip install tfx_bsl --no-dependencies`
+        2. Pass tfx_read_options to read_tfrecords, for example:
+            `ds = read_tfrecords(path, ..., tfx_read_options=TFXReadOptions())`
 
     .. warning::
         This function exclusively supports ``tf.train.Example`` messages. If a file

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1708,7 +1708,7 @@ def read_tfrecords(
     `tf.train.Example <https://www.tensorflow.org/api_docs/python/tf/train/Example>`_
     messages.
 
-    .. info:
+    .. tip::
         Using tfx-bsl for reading tfrecord files is prefered, When reading large
         datasets in production use cases. To use this implementation you should
         install tfx-bsl with:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1709,12 +1709,13 @@ def read_tfrecords(
     messages.
 
     .. tip::
-        Using tfx-bsl for reading tfrecord files is prefered, When reading large
-        datasets in production use cases. To use this implementation you should
-        install tfx-bsl with:
+        Using the ``tfx-bsl`` library is more performant when reading large
+        datasets (for example, in production use cases). To use this
+        implementation, you must first install ``tfx-bsl``:
+
         1. `pip install tfx_bsl --no-dependencies`
         2. Pass tfx_read_options to read_tfrecords, for example:
-            `ds = read_tfrecords(path, ..., tfx_read_options=TFXReadOptions())`
+           `ds = read_tfrecords(path, ..., tfx_read_options=TFXReadOptions())`
 
     .. warning::
         This function exclusively supports ``tf.train.Example`` messages. If a file


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The [documentation](https://docs.ray.io/en/latest/data/api/doc/ray.data.read_tfrecords.html) for `read_tfrecords()` is missing the section about `tfx-bsl` optimization, because the `.. info::` tag is not recognized. Change it to a tip instead.

[Now looks like](https://anyscale-ray--46717.com.readthedocs.build/en/46717/data/api/doc/ray.data.read_tfrecords.html#ray-data-read-tfrecords):
<img width="966" alt="Screenshot at Jul 22 09-23-24" src="https://github.com/user-attachments/assets/7f53473a-a59a-4841-b4da-2f82ba6722da">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
