### PR TITLE
[RLlib] Add correct terminated and truncated batch sizes on zero-length episodes

### DIFF
--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -99,7 +99,8 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     data,
                     Columns.TERMINATEDS,
                     items_to_add=(
-                        [False] * (len(sa_episode) - 1) + [sa_episode.is_terminated]
+                        [False] * (len(sa_episode) - 1)
+                        + [sa_episode.is_terminated] if len(sa_episode) > 0 else []
                     ),
                     num_items=len(sa_episode),
                     single_agent_episode=sa_episode,
@@ -114,7 +115,8 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     data,
                     Columns.TRUNCATEDS,
                     items_to_add=(
-                        [False] * (len(sa_episode) - 1) + [sa_episode.is_truncated]
+                        [False] * (len(sa_episode) - 1)
+                        + [sa_episode.is_truncated] if len(sa_episode) > 0 else []
                     ),
                     num_items=len(sa_episode),
                     single_agent_episode=sa_episode,

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -99,8 +99,9 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     data,
                     Columns.TERMINATEDS,
                     items_to_add=(
-                        [False] * (len(sa_episode) - 1)
-                        + [sa_episode.is_terminated] if len(sa_episode) > 0 else []
+                        [False] * (len(sa_episode) - 1) + [sa_episode.is_terminated]
+                        if len(sa_episode) > 0
+                        else []
                     ),
                     num_items=len(sa_episode),
                     single_agent_episode=sa_episode,
@@ -115,8 +116,9 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     data,
                     Columns.TRUNCATEDS,
                     items_to_add=(
-                        [False] * (len(sa_episode) - 1)
-                        + [sa_episode.is_truncated] if len(sa_episode) > 0 else []
+                        [False] * (len(sa_episode) - 1) + [sa_episode.is_truncated]
+                        if len(sa_episode) > 0
+                        else []
                     ),
                     num_items=len(sa_episode),
                     single_agent_episode=sa_episode,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In `AddColumnsFromEpisodesToTrainBatch`, it is assumed that each `sa_episode` has length ≥ 1. When a zero-length episode is passed to the connector, the data added to the terminateds and truncateds columns are incorrectly sized; they should just be an empty list. This case generally doesn't come up, but when adding custom connectors that modify episode lengths (e.g. for semi-MDP type problems), zero-length episodes can be produced.

## Related issue number

Didn't open issue, but I can if necessary.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
