### PR TITLE
fix air_example_vicuna_13b_lightning_deepspeed_finetuning

### DIFF
--- a/release/ray_release/byod/byod_vicuna_test.sh
+++ b/release/ray_release/byod/byod_vicuna_test.sh
@@ -13,4 +13,6 @@ sudo mount /dev/nvme1n1 /mnt/local_storage || true
 EOF
 pip3 uninstall -y pytorch-lightning
 pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
-pip3 install lightning==2.0.3  transformers==4.30.2 accelerate==0.20.3 deepspeed==0.12.3
+pip3 install lightning==2.0.3  transformers==4.30.2 accelerate==0.20.3 \
+  deepspeed==0.12.3 myst-parser==0.15.2 myst-nb==0.13.1 \
+  wandb==0.13.4

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -895,9 +895,6 @@
   cluster:
     byod:
       type: gpu
-      pip:
-        - myst-parser==0.15.2
-        - myst-nb==0.13.1
       post_build_script: byod_vicuna_test.sh
     cluster_compute: vicuna_13b_deepspeed_compute_aws.yaml
 


### PR DESCRIPTION
Fix air_example_vicuna_13b_lightning_deepspeed_finetuning, seem like the usage of runtime_env causes installation of a conflicting wandb version: https://console.anyscale-staging.com/o/anyscale-internal/jobs/prodjob_1sp8d1ta6zkl2eq6dwj895cq9n#

Test:
- release test