### PR TITLE
[core] Add string rep to the new status ChannelTimeoutError

### DIFF
--- a/src/ray/common/status.cc
+++ b/src/ray/common/status.cc
@@ -66,6 +66,7 @@ namespace ray {
 #define STATUS_CODE_AUTH_ERROR "AuthError"
 #define STATUS_CODE_INVALID_ARGUMENT "InvalidArgument"
 #define STATUS_CODE_CHANNEL_ERROR "ChannelError"
+#define STATUS_CODE_CHANNEL_TIMEOUT_ERROR "ChannelTimeoutError"
 
 // not a real status (catch all for codes not known)
 #define STATUS_CODE_UNKNOWN "Unknown"
@@ -105,6 +106,7 @@ const absl::flat_hash_map<StatusCode, std::string> kCodeToStr = {
     {StatusCode::AuthError, STATUS_CODE_AUTH_ERROR},
     {StatusCode::InvalidArgument, STATUS_CODE_INVALID_ARGUMENT},
     {StatusCode::ChannelError, STATUS_CODE_CHANNEL_ERROR},
+    {StatusCode::ChannelTimeoutError, STATUS_CODE_CHANNEL_TIMEOUT_ERROR},
 };
 
 const absl::flat_hash_map<std::string, StatusCode> kStrToCode = []() {
@@ -148,7 +150,7 @@ std::string Status::CodeAsString() const {
 
 StatusCode Status::StringToCode(const std::string &str) {
   // Note: unknown string is mapped to IOError, while unknown code is mapped to "Unknown"
-  // which is not an error. This means for code -> string -> code is not identity.
+  // which is not an error. This means code -> string -> code is not identity.
   auto it = kStrToCode.find(str);
   if (it == kStrToCode.end()) {
     return StatusCode::IOError;

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -118,6 +118,7 @@ enum class StatusCode : char {
   ChannelError = 35,
   // Indicates that a read or write on a channel (a mutable plasma object) timed out.
   ChannelTimeoutError = 36,
+  // If you add to this list, please also update kCodeToStr in status.cc.
 };
 
 #if defined(__clang__)


### PR DESCRIPTION
#46259 added this new status type but it's not added to the kCodeToStr map, making it possible be converted to IOError sometimes. Adds the string rep.