### PR TITLE
[py12] data tests

### DIFF
--- a/.buildkite/base.rayci.yml
+++ b/.buildkite/base.rayci.yml
@@ -45,7 +45,7 @@ steps:
     label: "wanda: oss-ci-base_ml-py{{matrix}}"
     wanda: ci/docker/base.ml.wanda.yaml
     matrix:
-      - "3.10"
+      - "3.12"
     env:
       PYTHON: "{{matrix}}"
     depends_on: oss-ci-base_test-multipy

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -13,7 +13,7 @@ steps:
   - name: databuild-multipy
     label: "wanda: databuild-py{{matrix}}"
     wanda: ci/docker/data.build.wanda.yaml
-    matrix: ["3.10"]
+    matrix: ["3.12"]
     env:
       PYTHON: "{{matrix}}"
     depends_on: oss-ci-base_ml-multipy
@@ -55,6 +55,24 @@ steps:
         --build-name data16build
         --except-tags data_integration,doctest
     depends_on: data16build
+
+  - label: ":database: data: arrow 16 {{matrix.python}} tests ({{matrix.worker_id}})"
+    key: data16_python_tests
+    if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
+    tags: 
+      - python
+      - data
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
+        --workers 2 --worker-id {{matrix.worker_id}} --parallelism-per-worker 3
+        --python-version {{matrix.python}}
+        --except-tags data_integration,doctest
+    depends_on: databuild-multipy
+    matrix:
+      setup:
+        python: ["3.12"]
+        worker_id: ["0", "1"]
 
   - label: ":database: data: arrow nightly tests"
     if: pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -17,16 +17,6 @@ steps:
       IMAGE_TO: mlbuild
       RAYCI_IS_GPU_BUILD: "false"
 
-  - name: mlbuild-multipy
-    wanda: ci/docker/ml.build.wanda.yaml
-    depends_on: oss-ci-base_ml-multipy
-    env:
-      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_ml-py{{matrix}}
-      IMAGE_TO: mlbuild-py{{matrix}}
-      RAYCI_IS_GPU_BUILD: "false"
-    matrix:
-      - "3.10"
-
   - name: mllightning2gpubuild
     wanda: ci/docker/mllightning2gpu.build.wanda.yaml
     depends_on: oss-ci-base_gpu
@@ -38,16 +28,6 @@ steps:
       IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_gpu
       IMAGE_TO: mlgpubuild
       RAYCI_IS_GPU_BUILD: "true"
-
-  - name: mlgpubuild-multipy
-    wanda: ci/docker/ml.build.wanda.yaml
-    depends_on: oss-ci-base_gpu-multipy
-    env:
-      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_gpu-py{{matrix}}
-      IMAGE_TO: mlgpubuild-py{{matrix}}
-      RAYCI_IS_GPU_BUILD: "true"
-    matrix:
-      - "3.10"
 
   # tests
   - label: ":train: ml: train tests"

--- a/ci/docker/data.build.wanda.yaml
+++ b/ci/docker/data.build.wanda.yaml
@@ -11,5 +11,6 @@ srcs:
   - python/requirements/ml/data-test-requirements.txt
 build_args:
   - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml-py$PYTHON
+  - ARROW_VERSION=16.*
 tags:
   - cr.ray.io/rayproject/databuild-py$PYTHON

--- a/python/ray/air/util/data_batch_conversion.py
+++ b/python/ray/air/util/data_batch_conversion.py
@@ -319,7 +319,7 @@ def _cast_ndarray_columns_to_tensor_extension(df: "pd.DataFrame") -> "pd.DataFra
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", category=FutureWarning)
                     warnings.simplefilter("ignore", category=SettingWithCopyWarning)
-                    df.loc[:, col_name] = TensorArray(col)
+                    df[col_name] = TensorArray(col)
             except Exception as e:
                 raise ValueError(
                     f"Tried to cast column {col_name} to the TensorArray tensor "
@@ -354,5 +354,5 @@ def _cast_tensor_columns_to_ndarrays(df: "pd.DataFrame") -> "pd.DataFrame":
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=FutureWarning)
                 warnings.simplefilter("ignore", category=SettingWithCopyWarning)
-                df.loc[:, col_name] = pd.Series(list(col.to_numpy()))
+                df[col_name] = list(col.to_numpy())
     return df

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -1266,6 +1266,9 @@ def test_union(ray_start_regular_shared):
     assert ds2.count() == 210
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="No tensorflow for Python 3.12+"
+)
 def test_iter_tf_batches(ray_start_regular_shared):
     df1 = pd.DataFrame(
         {"one": [1, 2, 3], "two": [1.0, 2.0, 3.0], "label": [1.0, 2.0, 3.0]}
@@ -1288,6 +1291,9 @@ def test_iter_tf_batches(ray_start_regular_shared):
         np.testing.assert_array_equal(np.sort(df.values), np.sort(combined_iterations))
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="No tensorflow for Python 3.12+"
+)
 def test_iter_tf_batches_tensor_ds(ray_start_regular_shared):
     arr1 = np.arange(12).reshape((3, 2, 2))
     arr2 = np.arange(12, 24).reshape((3, 2, 2))
@@ -1545,6 +1551,9 @@ def test_pandas_block_select():
 # tests should only be carefully reordered to retain this invariant!
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="TODO(scottjlee): Not working yet for py312"
+)
 def test_unsupported_pyarrow_versions_check(shutdown_only, unsupported_pyarrow_version):
     ray.shutdown()
 
@@ -1560,6 +1569,9 @@ def test_unsupported_pyarrow_versions_check(shutdown_only, unsupported_pyarrow_v
         ray.get(should_error.remote())
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="TODO(scottjlee): Not working yet for py312"
+)
 def test_unsupported_pyarrow_versions_check_disabled(
     shutdown_only,
     unsupported_pyarrow_version,
@@ -1609,6 +1621,9 @@ def test_read_write_local_node_ray_client(ray_start_cluster_enabled):
         ds.write_parquet("local://" + data_path).materialize()
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="No tensorflow for Python 3.12+"
+)
 def test_read_warning_large_parallelism(ray_start_regular, propagate_logs, caplog):
     with caplog.at_level(logging.WARNING, logger="ray.data.read_api"):
         ray.data.range(5000, override_num_blocks=5000).materialize()

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 from dataclasses import astuple, dataclass
 
@@ -398,6 +399,10 @@ def test_write_large_data_csv(shutdown_only, tmp_path):
     )
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Skip due to incompatibility tensorflow with Python 3.12+",
+)
 def test_write_large_data_tfrecords(shutdown_only, tmp_path):
     _test_write_large_data(
         tmp_path,

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -1355,6 +1355,10 @@ def test_from_huggingface_e2e(ray_start_regular_shared):
     _check_usage_record(["FromArrow"])
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Skip due to incompatibility tensorflow with Python 3.12+",
+)
 def test_from_tf_e2e(ray_start_regular_shared):
     import tensorflow as tf
     import tensorflow_datasets as tfds

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import Any, Iterable, List
 
 import pandas as pd
@@ -178,6 +179,10 @@ def test_write_datasink(ray_start_regular_shared):
     assert ray.get(output.data_sink.get_rows_written.remote()) == 10
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Skip due to incompatibility tensorflow with Python 3.12+",
+)
 def test_from_tf(ray_start_regular_shared):
     import tensorflow as tf
     import tensorflow_datasets as tfds

--- a/python/ray/data/tests/test_iterator.py
+++ b/python/ray/data/tests/test_iterator.py
@@ -1,13 +1,17 @@
+import sys
 import threading
 from typing import Dict
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-import tensorflow as tf
 import torch
 
 import ray
+
+if sys.version_info <= (3, 12):
+    # Skip this test for Python 3.12+ due to to incompatibility tensorflow
+    import tensorflow as tf
 
 
 def build_model():
@@ -219,5 +223,9 @@ def test_iterator_to_materialized_dataset(ray_start_regular_shared):
 
 if __name__ == "__main__":
     import sys
+
+    if sys.version_info >= (3, 12):
+        # Skip this test for Python 3.12+ due to to incompatibility tensorflow
+        sys.exit(0)
 
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_mars.py
+++ b/python/ray/data/tests/test_mars.py
@@ -1,10 +1,15 @@
-import mars
-import mars.dataframe as md
+import sys
+
 import pyarrow as pa
 import pytest
 
 import ray
 from ray.data.tests.test_execution_optimizer import _check_usage_record  # noqa
+
+if sys.version_info <= (3, 12):
+    # Skip this test for Python 3.12+ due to to incompatibility mars
+    import mars
+    import mars.dataframe as md
 
 
 @pytest.fixture(scope="module")
@@ -15,6 +20,9 @@ def ray_start_regular(request):  # pragma: no cover
         ray.shutdown()
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="No pymars support for Python 3.12+"
+)
 def test_mars(ray_start_regular):
     import pandas as pd
 
@@ -48,6 +56,9 @@ def test_mars(ray_start_regular):
     cluster.stop()
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="No pymars support for Python 3.12+"
+)
 def test_from_mars_e2e(ray_start_regular):
     import pandas as pd
 

--- a/python/ray/data/tests/test_object_gc.py
+++ b/python/ray/data/tests/test_object_gc.py
@@ -1,3 +1,4 @@
+import sys
 import threading
 
 import pytest
@@ -97,6 +98,9 @@ def test_torch_iteration(shutdown_only):
     check_iter_torch_batches_no_spill(ctx, ds)
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="No tensorflow for Python 3.12+"
+)
 def test_tf_iteration(shutdown_only):
     # The object store is about 800MB.
     ctx = ray.init(num_cpus=1, object_store_memory=800e6)

--- a/python/ray/data/tests/test_tensor.py
+++ b/python/ray/data/tests/test_tensor.py
@@ -564,7 +564,7 @@ def test_tensors_in_tables_pandas_roundtrip(
     ds_df = ds.to_pandas()
     expected_df = df + 1
     if enable_automatic_tensor_extension_cast:
-        expected_df.loc[:, "two"] = list(expected_df["two"].to_numpy())
+        expected_df["two"] = list(expected_df["two"].to_numpy())
     pd.testing.assert_frame_equal(ds_df, expected_df)
 
 
@@ -585,7 +585,7 @@ def test_tensors_in_tables_pandas_roundtrip_variable_shaped(
     ds_df = ds.to_pandas()
     expected_df = df + 1
     if enable_automatic_tensor_extension_cast:
-        expected_df.loc[:, "two"] = _create_possibly_ragged_ndarray(
+        expected_df["two"] = _create_possibly_ragged_ndarray(
             expected_df["two"].to_numpy()
         )
     pd.testing.assert_frame_equal(ds_df, expected_df)
@@ -873,8 +873,8 @@ def test_tensors_in_tables_iter_batches(
     )
     df = pd.concat([df1, df2], ignore_index=True)
     if enable_automatic_tensor_extension_cast:
-        df.loc[:, "one"] = list(df["one"].to_numpy())
-        df.loc[:, "two"] = list(df["two"].to_numpy())
+        df["one"] = list(df["one"].to_numpy())
+        df["two"] = list(df["two"].to_numpy())
     ds = ray.data.from_pandas([df1, df2])
     batches = list(ds.iter_batches(batch_size=2, batch_format="pandas"))
     assert len(batches) == 3

--- a/python/ray/data/tests/test_tf.py
+++ b/python/ray/data/tests/test_tf.py
@@ -1,13 +1,19 @@
+import sys
+
 import numpy as np
 import pandas as pd
 import pytest
-import tensorflow as tf
 
 import ray
 from ray import train
 from ray.data.preprocessors import Concatenator
 from ray.train import ScalingConfig
-from ray.train.tensorflow import TensorflowTrainer
+
+if sys.version_info <= (3, 12):
+    # Skip this test for Python 3.12+ due to to incompatibility tensorflow
+    import tensorflow as tf
+
+    from ray.train.tensorflow import TensorflowTrainer
 
 
 class TestToTF:
@@ -95,13 +101,16 @@ class TestToTF:
 
     @pytest.mark.parametrize(
         "data, expected_dtype",
+        # Skip this test for Python 3.12+ due to to incompatibility tensorflow
         [
             (0, tf.int64),
             (0.0, tf.double),
             (False, tf.bool),
             ("eggs", tf.string),
             (np.zeros([2, 2], dtype=np.float32), tf.float32),
-        ],
+        ]
+        if sys.version_info <= (3, 12)
+        else [],
     )
     def test_element_spec_dtype(self, data, expected_dtype):
         ds = ray.data.from_items([{"spam": data, "ham": data}])
@@ -194,5 +203,9 @@ class TestToTF:
 
 if __name__ == "__main__":
     import sys
+
+    if sys.version_info >= (3, 12):
+        # Skip this test for Python 3.12+ due to to incompatibility tensorflow
+        sys.exit(0)
 
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_tfrecords.py
+++ b/python/ray/data/tests/test_tfrecords.py
@@ -1,10 +1,10 @@
 import json
 import os
+import sys
 from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
-import tensorflow as tf
 from pandas.api.types import is_float_dtype, is_int64_dtype, is_object_dtype
 
 import ray
@@ -13,6 +13,10 @@ from ray.tests.conftest import *  # noqa: F401,F403
 
 if TYPE_CHECKING:
     from tensorflow_metadata.proto.v0 import schema_pb2
+
+if sys.version_info <= (3, 12):
+    # Skip this test for Python 3.12+ due to to incompatibility tensorflow
+    import tensorflow as tf
 
 
 def tf_records_partial():
@@ -763,5 +767,9 @@ def read_tfrecords_with_tfx_read_override(paths, tfx_read=False, **read_opts):
 
 if __name__ == "__main__":
     import sys
+
+    if sys.version_info >= (3, 12):
+        # Skip this test for Python 3.12+ due to to incompatibility tensorflow
+        sys.exit(0)
 
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -2,11 +2,15 @@
 # https://github.com/ray-project/ray/pull/29448#discussion_r1006256498
 
 dask[complete]==2022.10.1; python_version < '3.12'
+distributed==2022.10.1; python_version < '3.12'
 dask[complete]==2024.6.0; python_version >= '3.12'
+distributed==2024.6.0; python_version >= '3.12'
 aioboto3==11.2.0
 crc32c==2.3
 flask_cors
-modin==0.22.2
-pandas==1.5.3
+modin==0.22.2; python_version < '3.12'
+pandas==1.5.3; python_version < '3.12'
+modin==0.31.0; python_version >= '3.12'
+pandas==2.2.2; python_version >= '3.12'
 responses==0.13.4
-pymars>=0.8.3
+pymars>=0.8.3; python_version < "3.12"

--- a/python/requirements/ml/data-test-requirements.txt
+++ b/python/requirements/ml/data-test-requirements.txt
@@ -1,7 +1,7 @@
 # Used by CI for datasets tests.
 # https://github.com/ray-project/ray/pull/29448#discussion_r1006256498
 
-python-snappy; python_version <= '3.10'
+python-snappy
 tensorflow-datasets==4.9.3
 datasets
 pytest-repeat

--- a/python/requirements/ml/rllib-test-requirements.txt
+++ b/python/requirements/ml/rllib-test-requirements.txt
@@ -3,12 +3,12 @@
 # Environment adapters.
 # ---------------------
 # Atari
-gymnasium==0.28.1
-imageio==2.31.1
-ale_py==0.8.1
+gymnasium==0.28.1; python_version < "3.12"
+imageio==2.31.1; python_version < "3.12"
+ale_py==0.8.1; python_version < "3.12"
 # For testing MuJoCo envs with gymnasium.
-mujoco==2.3.6
-dm_control==1.0.12
+mujoco==2.3.6; python_version < "3.12"
+dm_control==1.0.12; python_version < "3.12"
 
 # For tests on PettingZoo's multi-agent envs.
 pettingzoo==1.23.1
@@ -16,8 +16,8 @@ pettingzoo==1.23.1
 # TODO: remove if a future pettingzoo and/or ray version fixes this dependancy issue.
 chess==1.7.0
 pymunk==6.2.1
-supersuit==3.8.0
-tinyscaler==1.2.6
+supersuit==3.8.0; python_version < "3.12"
+tinyscaler==1.2.6; python_version < "3.12"
 shimmy
 
 # Kaggle envs.
@@ -31,9 +31,9 @@ mlagents_envs==0.28.0
 minigrid
 # For tests on RecSim and Kaggle envs.
 # Explicitly depends on `tensorflow` and doesn't accept `tensorflow-macos`
-recsim==0.2.4; (sys_platform != 'darwin' or platform_machine != 'arm64')
+recsim==0.2.4; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version < "3.12"
 # recsim depends on dopamine-rl, but dopamine-rl pins gym <= 0.25.2, which break some envs
-dopamine-rl==4.0.5; (sys_platform != 'darwin' or platform_machine != 'arm64')
+dopamine-rl==4.0.5; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version < "3.12"
 tensorflow_estimator
 # DeepMind's OpenSpiel
 open-spiel==1.4

--- a/python/requirements/ml/train-test-requirements.txt
+++ b/python/requirements/ml/train-test-requirements.txt
@@ -1,3 +1,3 @@
 evaluate==0.4.0
-mosaicml
+mosaicml; python_version < "3.12"
 sentencepiece==0.1.96

--- a/python/requirements/ml/tune-requirements.txt
+++ b/python/requirements/ml/tune-requirements.txt
@@ -11,4 +11,4 @@ hyperopt==0.2.7
 nevergrad==0.4.3.post7
 optuna==3.2.0
 
-tune-sklearn==0.4.6
+tune-sklearn==0.4.6; python_version < "3.12"

--- a/python/requirements/ml/tune-test-requirements.txt
+++ b/python/requirements/ml/tune-test-requirements.txt
@@ -1,6 +1,6 @@
 -r dl-cpu-requirements.txt
 
-aim==3.17.5
+aim==3.17.5; python_version < "3.12"
 
 gpy==1.13.1
 

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -30,7 +30,7 @@ adagio==0.2.4
     #   qpd
 adal==1.2.7
     # via msrestazure
-aim==3.17.5
+aim==3.17.5 ; python_version < "3.12"
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/tune-test-requirements.txt
 aim-ui==3.17.5
     # via aim
@@ -55,6 +55,7 @@ aiohttp==3.9.5
     #   aiobotocore
     #   aiohttp-cors
     #   datasets
+    #   delta-sharing
     #   fsspec
     #   google-auth
     #   s3fs
@@ -74,7 +75,7 @@ aiosqlite==0.19.0
     # via ypy-websocket
 alabaster==0.7.13
     # via sphinx
-ale-py==0.8.1
+ale-py==0.8.1 ; python_version < "3.12"
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements/ml/rllib-test-requirements.txt
     #   gym
@@ -348,6 +349,8 @@ contextlib2==21.6.0
     #   pytest-shutil
 contourpy==1.1.1
     # via matplotlib
+cramjam==2.8.3
+    # via python-snappy
 crc32c==2.3
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/data-requirements.txt
 crcmod==1.7
@@ -405,6 +408,8 @@ defusedxml==0.7.1
     #   nbconvert
     #   pymars
     #   semgrep
+delta-sharing==1.0.5
+    # via -r /home/ubuntu/ray/ci/../python/requirements/ml/data-test-requirements.txt
 dill==0.3.7
     # via
     #   datasets
@@ -412,11 +417,13 @@ dill==0.3.7
     #   multiprocess
 distlib==0.3.7
     # via virtualenv
-distributed==2022.10.1
-    # via dask
+distributed==2022.10.1 ; python_version < "3.12"
+    # via
+    #   -r /home/ubuntu/ray/ci/../python/requirements/ml/data-requirements.txt
+    #   dask
 distro==1.9.0
     # via azure-cli-core
-dm-control==1.0.12
+dm-control==1.0.12 ; python_version < "3.12"
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/rllib-test-requirements.txt
 dm-env==1.6
     # via dm-control
@@ -444,7 +451,7 @@ docutils==0.19
     #   -r /home/ubuntu/ray/ci/../python/requirements/lint-requirements.txt
     #   myst-parser
     #   sphinx
-dopamine-rl==4.0.5 ; sys_platform != "darwin" or platform_machine != "arm64"
+dopamine-rl==4.0.5 ; (sys_platform != "darwin" or platform_machine != "arm64") and python_version < "3.12"
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements/ml/rllib-test-requirements.txt
     #   recsim
@@ -560,6 +567,7 @@ fsspec==2023.5.0
     #   -r /home/ubuntu/ray/ci/../python/requirements.txt
     #   dask
     #   datasets
+    #   delta-sharing
     #   etils
     #   evaluate
     #   gradio-client
@@ -698,7 +706,7 @@ gym==0.26.2
     #   recsim
 gym-notices==0.0.8
     # via gym
-gymnasium==0.28.1
+gymnasium==0.28.1 ; python_version < "3.12"
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements.txt
     #   -r /home/ubuntu/ray/ci/../python/requirements/ml/rllib-test-requirements.txt
@@ -768,7 +776,7 @@ idna==3.7
     #   snowflake-connector-python
     #   trustme
     #   yarl
-imageio==2.31.1
+imageio==2.31.1 ; python_version < "3.12"
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements/ml/rllib-test-requirements.txt
     #   moviepy
@@ -1058,13 +1066,14 @@ ml-dtypes==0.3.2
     #   jax
     #   jaxlib
     #   tensorflow
+    #   tensorstore
 mlagents-envs==0.28.0
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/rllib-test-requirements.txt
 mlflow==2.9.2
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/core-requirements.txt
 mock==5.1.0
     # via pytest-shutil
-modin==0.22.2
+modin==0.22.2 ; python_version < "3.12"
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/data-requirements.txt
 monai==1.3.2
     # via mosaicml
@@ -1074,7 +1083,7 @@ monotonic==1.6
     #   segment-analytics-python
 more-itertools==10.1.0
     # via configspace
-mosaicml==0.2.4
+mosaicml==0.2.4 ; python_version < "3.12"
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/train-test-requirements.txt
 moto==4.2.12
     # via -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
@@ -1084,7 +1093,6 @@ mpmath==1.3.0
     # via sympy
 msal==1.28.1
     # via
-    #   -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
     #   azure-cli-core
     #   azure-identity
     #   msal-extensions
@@ -1109,7 +1117,7 @@ msrestazure==0.6.4
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
     #   azure-cli-core
-mujoco==2.3.6
+mujoco==2.3.6 ; python_version < "3.12"
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements/ml/rllib-test-requirements.txt
     #   dm-control
@@ -1420,7 +1428,7 @@ packaging==23.0
     #   torchmetrics
     #   transformers
     #   utilsforecast
-pandas==1.5.3
+pandas==1.5.3 ; python_version < "3.12"
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements.txt
     #   -r /home/ubuntu/ray/ci/../python/requirements/ml/data-requirements.txt
@@ -1429,6 +1437,7 @@ pandas==1.5.3
     #   cmdstanpy
     #   dask
     #   datasets
+    #   delta-sharing
     #   dopamine-rl
     #   evaluate
     #   gradio
@@ -1590,6 +1599,7 @@ pyarrow==14.0.2
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements.txt
     #   datasets
+    #   delta-sharing
     #   feather-format
     #   mlflow
     #   pylance
@@ -1650,7 +1660,7 @@ pyjwt==2.8.0
     #   snowflake-connector-python
 pylance==0.10.18
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/data-test-requirements.txt
-pymars==0.10.0
+pymars==0.10.0 ; python_version < "3.12"
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/data-requirements.txt
 pymongo==4.3.2
     # via -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
@@ -1704,6 +1714,7 @@ pytest==7.4.4
     #   pytest-fixture-config
     #   pytest-forked
     #   pytest-lazy-fixture
+    #   pytest-mock
     #   pytest-remotedata
     #   pytest-repeat
     #   pytest-rerunfailures
@@ -1724,6 +1735,8 @@ pytest-httpserver==1.0.6
     # via -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
 pytest-lazy-fixture==0.6.3
     # via -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
+pytest-mock==3.14.0
+    # via -r /home/ubuntu/ray/ci/../python/requirements/ml/data-test-requirements.txt
 pytest-remotedata==0.3.2
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/tune-test-requirements.txt
 pytest-repeat==0.9.3
@@ -1763,6 +1776,8 @@ python-lsp-jsonrpc==1.0.0
     # via semgrep
 python-multipart==0.0.6
     # via gradio
+python-snappy==0.7.2
+    # via -r /home/ubuntu/ray/ci/../python/requirements/ml/data-test-requirements.txt
 pytorch-lightning==1.8.6
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/tune-test-requirements.txt
 pytorch-ranger==0.1.1
@@ -1776,9 +1791,9 @@ pytz==2022.7.1
     #   snowflake-connector-python
 pyu2f==0.1.5
     # via google-reauth
-pyvmomi==8.0.2.0.1
+pyvmomi==8.0.3.0.1
     # via vsphere-automation-sdk
-pywavelets==1.5.0
+pywavelets==1.6.0
     # via scikit-image
 pyyaml==6.0.1
     # via
@@ -1834,11 +1849,11 @@ querystring-parser==1.2.4
     #   tune-sklearn
 raydp==1.7.0b20231020.dev0
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/data-test-requirements.txt
-recsim==0.2.4 ; sys_platform != "darwin" or platform_machine != "arm64"
+recsim==0.2.4 ; (sys_platform != "darwin" or platform_machine != "arm64") and python_version < "3.12"
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/rllib-test-requirements.txt
 redis==4.4.2
     # via -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
-regex==2023.10.3
+regex==2024.5.15
     # via
     #   cfn-lint
     #   transformers
@@ -1854,6 +1869,7 @@ requests==2.31.0
     #   comet-ml
     #   databricks-cli
     #   datasets
+    #   delta-sharing
     #   dm-control
     #   docker
     #   evaluate
@@ -1888,7 +1904,7 @@ requests==2.31.0
     #   transformers
     #   vapi-runtime
     #   wandb
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via
     #   google-auth-oauthlib
     #   kubernetes
@@ -1900,7 +1916,7 @@ responses==0.13.4
     #   -r /home/ubuntu/ray/ci/../python/requirements/ml/data-requirements.txt
     #   evaluate
     #   moto
-restrictedpython==7.0
+restrictedpython==7.1
     # via aim
 retry-decorator==1.1.1
     # via
@@ -1922,6 +1938,7 @@ rich==12.6.0
     #   flax
     #   memray
     #   semgrep
+    #   typer
 rsa==4.7.2
     # via
     #   gcs-oauth2-boto-plugin
@@ -1938,7 +1955,7 @@ s3fs==2023.5.0
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/core-requirements.txt
 s3transfer==0.6.2
     # via boto3
-safetensors==0.4.1
+safetensors==0.4.3
     # via
     #   accelerate
     #   timm
@@ -1999,14 +2016,14 @@ semantic-version==2.10.0
     #   gradio
 semgrep==1.32.0
     # via -r /home/ubuntu/ray/ci/../python/requirements/lint-requirements.txt
-send2trash==1.8.2
+send2trash==1.8.3
     # via
     #   jupyter-server
     #   nbclassic
     #   notebook
 sentencepiece==0.1.96
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/train-test-requirements.txt
-sentry-sdk==1.37.1
+sentry-sdk==2.10.0
     # via
     #   comet-ml
     #   wandb
@@ -2018,6 +2035,8 @@ setproctitle==1.3.3
     # via wandb
 shellcheck-py==0.7.1.1
     # via -r /home/ubuntu/ray/ci/../python/requirements/lint-requirements.txt
+shellingham==1.5.4
+    # via typer
 shimmy==1.3.0
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/rllib-test-requirements.txt
 shortuuid==1.0.1
@@ -2072,7 +2091,7 @@ smart-open==6.2.0
     #   -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
 smmap==5.0.1
     # via gitdb
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
     #   httpcore
@@ -2094,17 +2113,17 @@ sphinx==6.2.1
     #   -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
     #   myst-nb
     #   myst-parser
-sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-applehelp==1.0.8
     # via sphinx
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==1.0.6
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.0.6
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-qthelp==1.0.8
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 sqlalchemy==1.4.17
     # via
@@ -2115,9 +2134,9 @@ sqlalchemy==1.4.17
     #   mlflow
     #   optuna
     #   pymars
-sqlglot==20.4.0
+sqlglot==25.6.1
     # via fugue
-sqlparse==0.4.4
+sqlparse==0.5.1
     # via mlflow
 sshpubkeys==3.3.1
     # via moto
@@ -2135,9 +2154,9 @@ statsmodels==0.14.0
     # via
     #   hpbandster
     #   statsforecast
-supersuit==3.8.0
+supersuit==3.8.0 ; python_version < "3.12"
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/rllib-test-requirements.txt
-sympy==1.12
+sympy==1.13.1
     # via
     #   cfn-lint
     #   onnxruntime
@@ -2151,7 +2170,7 @@ tblib==3.0.0
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements/docker/ray-docker-requirements.txt
     #   distributed
-tenacity==8.2.3
+tenacity==8.5.0
     # via plotly
 tensorboard==2.15.2
     # via
@@ -2184,23 +2203,23 @@ tensorflow-io-gcs-filesystem==0.31.0 ; python_version < "3.12"
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements/ml/dl-cpu-requirements.txt
     #   tensorflow
-tensorflow-metadata==1.13.0
+tensorflow-metadata==1.14.0
     # via tensorflow-datasets
 tensorflow-probability==0.23.0 ; python_version < "3.12"
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements/ml/dl-cpu-requirements.txt
     #   dopamine-rl
-tensorstore==0.1.45
+tensorstore==0.1.63
     # via
     #   flax
     #   orbax-checkpoint
-termcolor==2.3.0
+termcolor==2.4.0
     # via
     #   pytest-shutil
     #   pytest-sugar
     #   tensorflow
     #   tensorflow-datasets
-terminado==0.18.0
+terminado==0.18.1
     # via
     #   jupyter-server
     #   nbclassic
@@ -2215,13 +2234,13 @@ threadpoolctl==3.1.0
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
     #   scikit-learn
-tifffile==2023.7.10
+tifffile==2024.7.21
     # via scikit-image
 timm==0.9.2
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/tune-test-requirements.txt
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via nbconvert
-tinyscaler==1.2.6
+tinyscaler==1.2.6 ; python_version < "3.12"
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements/ml/rllib-test-requirements.txt
     #   supersuit
@@ -2233,11 +2252,11 @@ toml==0.10.2
     #   tensorflow-datasets
 tomli==2.0.1
     # via semgrep
-tomlkit==0.12.3
+tomlkit==0.13.0
     # via
     #   snowflake-connector-python
     #   yq
-toolz==0.12.0
+toolz==0.12.1
     # via
     #   altair
     #   chex
@@ -2323,7 +2342,7 @@ tqdm==4.64.1
     #   torch-geometric
     #   torchtext
     #   transformers
-traitlets==5.14.0
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel
@@ -2343,7 +2362,7 @@ transformers==4.36.2
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements/ml/core-requirements.txt
     #   mosaicml
-triad==0.9.3
+triad==0.9.8
     # via
     #   adagio
     #   fugue
@@ -2354,9 +2373,9 @@ trustme==0.9.0
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/tune-requirements.txt
 typeguard==2.13.3
     # via ax-platform
-typer==0.9.0
+typer==0.12.3
     # via -r /home/ubuntu/ray/ci/../python/requirements.txt
-types-python-dateutil==2.8.19.14
+types-python-dateutil==2.9.0.20240316
     # via arrow
 types-pyyaml==6.0.12.2
     # via -r /home/ubuntu/ray/ci/../python/requirements/lint-requirements.txt
@@ -2389,13 +2408,13 @@ typing-extensions==4.8.0
     #   tensorflow
     #   torch
     #   typer
-ujson==5.8.0
+ujson==5.10.0
     # via python-lsp-jsonrpc
 uri-template==1.3.0
     # via jsonschema
 uritemplate==4.1.1
     # via google-api-python-client
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   botocore
     #   databricks-cli
@@ -2407,7 +2426,7 @@ urllib3==1.26.18
     #   responses
     #   semgrep
     #   sentry-sdk
-utilsforecast==0.0.23
+utilsforecast==0.2.0
     # via statsforecast
 uvicorn==0.22.0
     # via
@@ -2451,11 +2470,11 @@ watchfiles==0.19.0
     # via
     #   -r /home/ubuntu/ray/ci/../python/requirements.txt
     #   -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
-wcmatch==8.5
+wcmatch==8.5.2
     # via semgrep
-wcwidth==0.2.12
+wcwidth==0.2.13
     # via prompt-toolkit
-webcolors==1.13
+webcolors==24.6.0
     # via jsonschema
 webdataset==0.2.86
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/data-test-requirements.txt
@@ -2463,7 +2482,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.6.4
+websocket-client==1.8.0
     # via
     #   comet-ml
     #   docker
@@ -2481,7 +2500,7 @@ werkzeug==2.3.8
     #   moto
     #   pytest-httpserver
     #   tensorboard
-wheel==0.42.0
+wheel==0.43.0
     # via
     #   astunparse
     #   lightgbm
@@ -2494,7 +2513,7 @@ wrapt==1.14.1
     #   comet-ml
     #   tensorflow
     #   tensorflow-datasets
-wurlitzer==3.0.3
+wurlitzer==3.1.1
     # via comet-ml
 xgboost==1.7.6
     # via -r /home/ubuntu/ray/ci/../python/requirements/ml/core-requirements.txt
@@ -2515,8 +2534,10 @@ y-py==0.6.2
     #   ypy-websocket
 yahp==0.1.1
     # via mosaicml
-yarl==1.9.3
-    # via aiohttp
+yarl==1.9.4
+    # via
+    #   aiohttp
+    #   delta-sharing
 ypy-websocket==0.8.4
     # via jupyter-server-ydoc
 yq==3.2.2
@@ -2525,7 +2546,7 @@ yq==3.2.2
     #   -r /home/ubuntu/ray/ci/../python/requirements/test-requirements.txt
 zict==3.0.0
     # via distributed
-zipp==3.17.0
+zipp==3.19.2
     # via
     #   etils
     #   importlib-metadata


### PR DESCRIPTION
Add py312 version of data tests to the master branch. Incorporated changes from @scottjlee  and @omatthew98. Note that I didn't upgrade `tensorflow-datasets`, but I skipped all tensorflow related tests for python 3.12 version anyway.

Test:
- CI