### PR TITLE
Add perf metrics for 2.33.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1232.416768,
+    "_dashboard_memory_usage_mb": 1293.504512,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.37,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3733\t1.96GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3618\t1.68GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4484\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1235\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2417\t0.24GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4683\t0.09GiB\tray::StateAPIGeneratorActor.start\n4621\t0.08GiB\tray::DashboardTester.run\n4285\t0.07GiB\tray::JobSupervisor\n3899\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3025\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/",
+    "_peak_memory": 5.63,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3510\t2.06GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3625\t1.98GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4513\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2094\t0.3GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1119\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4726\t0.09GiB\tray::StateAPIGeneratorActor.start\n4670\t0.08GiB\tray::DashboardTester.run\n2434\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4312\t0.07GiB\tray::JobSupervisor\n3795\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 578.8766226882515
+            "perf_metric_value": 570.9662463612389
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 141.285
+            "perf_metric_value": 169.765
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1649.419
+            "perf_metric_value": 2669.048
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3448.302
+            "perf_metric_value": 4126.598
         }
     ],
     "success": "1",
-    "tasks_per_second": 578.8766226882515,
-    "time": 317.2748382091522,
+    "tasks_per_second": 570.9662463612389,
+    "time": 317.5141701698303,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.32.0"}
+{"release_version": "2.33.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        9241.526232225291,
-        132.04014985321072
+        8962.418648814873,
+        88.1705160807435
     ],
     "1_1_actor_calls_concurrent": [
-        5433.582983286094,
-        203.77840697231508
+        5119.423141351966,
+        63.81190044533031
     ],
     "1_1_actor_calls_sync": [
-        2063.6151992547047,
-        41.087530717556106
+        1996.6786836228223,
+        58.23340603523277
     ],
     "1_1_async_actor_calls_async": [
-        4541.586332149929,
-        244.29996229786013
+        4616.745057409327,
+        352.05439823738095
     ],
     "1_1_async_actor_calls_sync": [
-        1499.3849412965205,
-        31.19427048888692
+        1504.356714114197,
+        22.668610740965626
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2981.1837517965705,
-        129.12171570334309
+        3009.8473678904393,
+        142.90726355717445
     ],
     "1_n_actor_calls_async": [
-        8825.80303025342,
-        137.32428841583177
+        8227.763837992337,
+        318.7508261500715
     ],
     "1_n_async_actor_calls_async": [
-        7872.539571860014,
-        165.88537648403613
+        7744.743511533576,
+        131.2505711844922
     ],
     "client__1_1_actor_calls_async": [
-        1020.0334940870466,
-        10.493190404958229
+        958.5370241236403,
+        18.100942921678108
     ],
     "client__1_1_actor_calls_concurrent": [
-        1023.0375442360598,
-        9.873541601530931
+        953.7334027028625,
+        5.645449509967645
     ],
     "client__1_1_actor_calls_sync": [
-        509.9599816194958,
-        26.55553704027681
+        516.9723558134372,
+        4.319396403414238
     ],
     "client__get_calls": [
-        1175.306212007341,
-        6.848643951008982
+        1015.3375725005734,
+        78.03759652882351
     ],
     "client__put_calls": [
-        794.0222907625882,
-        23.489002030449676
+        755.3389003423397,
+        19.307508648490337
     ],
     "client__put_gigabytes": [
-        0.13160907472336658,
-        0.000597729723962875
+        0.13507800928532288,
+        0.000813109370587394
     ],
     "client__tasks_and_get_batch": [
-        0.9724735940970552,
-        0.014680443297132861
+        0.9001965521302608,
+        0.004545115460918647
     ],
     "client__tasks_and_put_batch": [
-        11309.127935041968,
-        230.80678248448353
+        10918.811029137974,
+        221.4720726481438
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12520.58965968965,
-        127.48894702402845
+        12085.950108018375,
+        145.4030099464754
     ],
     "multi_client_put_gigabytes": [
-        37.39369500194131,
-        2.6031810715230144
+        42.36117553493574,
+        3.1258835445086683
     ],
     "multi_client_tasks_async": [
-        23283.706392178385,
-        3093.661219187642
+        22189.698488373317,
+        2180.872550108281
     ],
     "n_n_actor_calls_async": [
-        27232.414296780542,
-        758.7912476297421
+        26201.02353095661,
+        1369.77201218317
     ],
     "n_n_actor_calls_with_arg_async": [
-        2605.856362562882,
-        17.70949766672506
+        2531.2050976452842,
+        27.47481783971637
     ],
     "n_n_async_actor_calls_async": [
-        23591.92555321498,
-        1068.3154500015673
+        23053.74096049589,
+        966.3382700967951
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10121.103242219997
+            "perf_metric_value": 10024.589887659495
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5227.298677681264
+            "perf_metric_value": 5246.209719545058
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12520.58965968965
+            "perf_metric_value": 12085.950108018375
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.46333348333893
+            "perf_metric_value": 19.67721106022737
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.9070880635954
+            "perf_metric_value": 7.699142510511168
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 37.39369500194131
+            "perf_metric_value": 42.36117553493574
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.756244682120503
+            "perf_metric_value": 12.449573496772846
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.302957674144409
+            "perf_metric_value": 5.367313675357354
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 981.7983599799647
+            "perf_metric_value": 957.7571564162879
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7981.871660623128
+            "perf_metric_value": 7767.973857314019
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23283.706392178385
+            "perf_metric_value": 22189.698488373317
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2063.6151992547047
+            "perf_metric_value": 1996.6786836228223
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9241.526232225291
+            "perf_metric_value": 8962.418648814873
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5433.582983286094
+            "perf_metric_value": 5119.423141351966
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8825.80303025342
+            "perf_metric_value": 8227.763837992337
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27232.414296780542
+            "perf_metric_value": 26201.02353095661
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2605.856362562882
+            "perf_metric_value": 2531.2050976452842
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1499.3849412965205
+            "perf_metric_value": 1504.356714114197
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4541.586332149929
+            "perf_metric_value": 4616.745057409327
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2981.1837517965705
+            "perf_metric_value": 3009.8473678904393
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7872.539571860014
+            "perf_metric_value": 7744.743511533576
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23591.92555321498
+            "perf_metric_value": 23053.74096049589
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 784.1202913310515
+            "perf_metric_value": 799.9585821197729
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1175.306212007341
+            "perf_metric_value": 1015.3375725005734
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 794.0222907625882
+            "perf_metric_value": 755.3389003423397
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13160907472336658
+            "perf_metric_value": 0.13507800928532288
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11309.127935041968
+            "perf_metric_value": 10918.811029137974
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 509.9599816194958
+            "perf_metric_value": 516.9723558134372
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1020.0334940870466
+            "perf_metric_value": 958.5370241236403
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1023.0375442360598
+            "perf_metric_value": 953.7334027028625
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9724735940970552
+            "perf_metric_value": 0.9001965521302608
         }
     ],
     "placement_group_create/removal": [
-        784.1202913310515,
-        2.674372951834296
+        799.9585821197729,
+        8.78636247128877
     ],
     "single_client_get_calls_Plasma_Store": [
-        10121.103242219997,
-        344.32801069166834
+        10024.589887659495,
+        292.75095671585177
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.756244682120503,
-        0.09167947289933939
+        12.449573496772846,
+        0.17680156218043316
     ],
     "single_client_put_calls_Plasma_Store": [
-        5227.298677681264,
-        73.4380388161718
+        5246.209719545058,
+        98.04207911208779
     ],
     "single_client_put_gigabytes": [
-        19.46333348333893,
-        5.440510765037708
+        19.67721106022737,
+        5.70923174022301
     ],
     "single_client_tasks_and_get_batch": [
-        7.9070880635954,
-        0.3896057750384761
+        7.699142510511168,
+        0.4141207039320734
     ],
     "single_client_tasks_async": [
-        7981.871660623128,
-        279.39202571036645
+        7767.973857314019,
+        299.68898781815574
     ],
     "single_client_tasks_sync": [
-        981.7983599799647,
-        9.168440320587788
+        957.7571564162879,
+        7.08297467683738
     ],
     "single_client_wait_1k_refs": [
-        5.302957674144409,
-        0.08188715171339318
+        5.367313675357354,
+        0.06892288270519953
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 19.440196102000016,
+    "broadcast_time": 15.570380599999964,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 19.440196102000016
+            "perf_metric_value": 15.570380599999964
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.415384294000006,
-    "get_time": 23.645023898000005,
+    "args_time": 17.273491784,
+    "get_time": 24.687547909000017,
     "large_object_size": 107374182400,
-    "large_object_time": 30.474318987000004,
+    "large_object_time": 30.045898813999997,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.415384294000006
+            "perf_metric_value": 17.273491784
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.771739185999991
+            "perf_metric_value": 5.885276685999997
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.645023898000005
+            "perf_metric_value": 24.687547909000017
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 187.84350834300002
+            "perf_metric_value": 184.42638667399999
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.474318987000004
+            "perf_metric_value": 30.045898813999997
         }
     ],
-    "queued_time": 187.84350834300002,
-    "returns_time": 5.771739185999991,
+    "queued_time": 184.42638667399999,
+    "returns_time": 5.885276685999997,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0517002582550048,
-    "max_iteration_time": 2.9446706771850586,
-    "min_iteration_time": 0.512861967086792,
+    "avg_iteration_time": 1.0422629594802857,
+    "max_iteration_time": 2.5716567039489746,
+    "min_iteration_time": 0.11588501930236816,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0517002582550048
+            "perf_metric_value": 1.0422629594802857
         }
     ],
     "success": 1,
-    "total_time": 105.17023873329163
+    "total_time": 104.22651696205139
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.851820707321167
+            "perf_metric_value": 10.968713283538818
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.859845495224
+            "perf_metric_value": 25.866676759719848
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 65.67325186729431
+            "perf_metric_value": 65.33734908103943
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.573556900024414
+            "perf_metric_value": 1.7089431285858154
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3065.2378103733063
+            "perf_metric_value": 3173.5833747386932
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.48427910077229586
+            "perf_metric_value": 0.48019995519801134
         }
     ],
-    "stage_0_time": 10.851820707321167,
-    "stage_1_avg_iteration_time": 23.859845495224,
-    "stage_1_max_iteration_time": 24.58528447151184,
-    "stage_1_min_iteration_time": 23.121485948562622,
-    "stage_1_time": 238.59854221343994,
-    "stage_2_avg_iteration_time": 65.67325186729431,
-    "stage_2_max_iteration_time": 66.63724613189697,
-    "stage_2_min_iteration_time": 64.36803317070007,
-    "stage_2_time": 328.3679451942444,
-    "stage_3_creation_time": 1.573556900024414,
-    "stage_3_time": 3065.2378103733063,
-    "stage_4_spread": 0.48427910077229586,
+    "stage_0_time": 10.968713283538818,
+    "stage_1_avg_iteration_time": 25.866676759719848,
+    "stage_1_max_iteration_time": 27.254989624023438,
+    "stage_1_min_iteration_time": 24.257266998291016,
+    "stage_1_time": 258.6669008731842,
+    "stage_2_avg_iteration_time": 65.33734908103943,
+    "stage_2_max_iteration_time": 68.07902336120605,
+    "stage_2_min_iteration_time": 60.67615079879761,
+    "stage_2_time": 326.6877791881561,
+    "stage_3_creation_time": 1.7089431285858154,
+    "stage_3_time": 3173.5833747386932,
+    "stage_4_spread": 0.48019995519801134,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9259017792794532,
-    "avg_pg_remove_time_ms": 0.9261005015020346,
+    "avg_pg_create_time_ms": 0.9953421636631397,
+    "avg_pg_remove_time_ms": 0.8993933258272226,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9259017792794532
+            "perf_metric_value": 0.9953421636631397
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9261005015020346
+            "perf_metric_value": 0.8993933258272226
         }
     ],
     "success": 1


### PR DESCRIPTION
```
New release perf metrics missing file benchmarks/many_pgs.json
New release perf metrics missing file benchmarks/many_nodes.json
New release perf metrics missing file benchmarks/many_actors.json
REGRESSION 13.61%: client__get_calls (THROUGHPUT) regresses from 1175.306212007341 to 1015.3375725005734 in microbenchmark.json
REGRESSION 7.43%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9724735940970552 to 0.9001965521302608 in microbenchmark.json
REGRESSION 6.78%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8825.80303025342 to 8227.763837992337 in microbenchmark.json
REGRESSION 6.77%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1023.0375442360598 to 953.7334027028625 in microbenchmark.json
REGRESSION 6.03%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1020.0334940870466 to 958.5370241236403 in microbenchmark.json
REGRESSION 5.78%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5433.582983286094 to 5119.423141351966 in microbenchmark.json
REGRESSION 4.87%: client__put_calls (THROUGHPUT) regresses from 794.0222907625882 to 755.3389003423397 in microbenchmark.json
REGRESSION 4.70%: multi_client_tasks_async (THROUGHPUT) regresses from 23283.706392178385 to 22189.698488373317 in microbenchmark.json
REGRESSION 3.79%: n_n_actor_calls_async (THROUGHPUT) regresses from 27232.414296780542 to 26201.02353095661 in microbenchmark.json
REGRESSION 3.47%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12520.58965968965 to 12085.950108018375 in microbenchmark.json
REGRESSION 3.45%: client__tasks_and_put_batch (THROUGHPUT) regresses from 11309.127935041968 to 10918.811029137974 in microbenchmark.json
REGRESSION 3.24%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2063.6151992547047 to 1996.6786836228223 in microbenchmark.json
REGRESSION 3.02%: 1_1_actor_calls_async (THROUGHPUT) regresses from 9241.526232225291 to 8962.418648814873 in microbenchmark.json
REGRESSION 2.86%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2605.856362562882 to 2531.2050976452842 in microbenchmark.json
REGRESSION 2.68%: single_client_tasks_async (THROUGHPUT) regresses from 7981.871660623128 to 7767.973857314019 in microbenchmark.json
REGRESSION 2.63%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.9070880635954 to 7.699142510511168 in microbenchmark.json
REGRESSION 2.45%: single_client_tasks_sync (THROUGHPUT) regresses from 981.7983599799647 to 957.7571564162879 in microbenchmark.json
REGRESSION 2.40%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.756244682120503 to 12.449573496772846 in microbenchmark.json
REGRESSION 2.28%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23591.92555321498 to 23053.74096049589 in microbenchmark.json
REGRESSION 1.62%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7872.539571860014 to 7744.743511533576 in microbenchmark.json
REGRESSION 1.37%: tasks_per_second (THROUGHPUT) regresses from 578.8766226882515 to 570.9662463612389 in benchmarks/many_tasks.json
REGRESSION 0.95%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10121.103242219997 to 10024.589887659495 in microbenchmark.json
REGRESSION 61.82%: dashboard_p95_latency_ms (LATENCY) regresses from 1649.419 to 2669.048 in benchmarks/many_tasks.json
REGRESSION 20.16%: dashboard_p50_latency_ms (LATENCY) regresses from 141.285 to 169.765 in benchmarks/many_tasks.json
REGRESSION 19.67%: dashboard_p99_latency_ms (LATENCY) regresses from 3448.302 to 4126.598 in benchmarks/many_tasks.json
REGRESSION 8.60%: stage_3_creation_time (LATENCY) regresses from 1.573556900024414 to 1.7089431285858154 in stress_tests/stress_test_many_tasks.json
REGRESSION 8.41%: stage_1_avg_iteration_time (LATENCY) regresses from 23.859845495224 to 25.866676759719848 in stress_tests/stress_test_many_tasks.json
REGRESSION 7.50%: avg_pg_create_time_ms (LATENCY) regresses from 0.9259017792794532 to 0.9953421636631397 in stress_tests/stress_test_placement_group.json
REGRESSION 4.41%: 10000_get_time (LATENCY) regresses from 23.645023898000005 to 24.687547909000017 in scalability/single_node.json
REGRESSION 3.53%: stage_3_time (LATENCY) regresses from 3065.2378103733063 to 3173.5833747386932 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.97%: 3000_returns_time (LATENCY) regresses from 5.771739185999991 to 5.885276685999997 in scalability/single_node.json
REGRESSION 1.08%: stage_0_time (LATENCY) regresses from 10.851820707321167 to 10.968713283538818 in stress_tests/stress_test_many_tasks.json
```