### PR TITLE
Add perf metrics for 2.33.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 500.076544,
+    "_dashboard_memory_usage_mb": 500.719616,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.72,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1133\t10.03GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3513\t1.74GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4605\t0.91GiB\tpython distributed/test_many_actors.py\n3628\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2320\t0.33GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3104\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4400\t0.07GiB\tray::JobSupervisor\n3791\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3970\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3789\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
-    "actors_per_second": 615.180594485976,
+    "_peak_memory": 3.74,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1219\t8.56GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3654\t1.82GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4487\t0.87GiB\tpython distributed/test_many_actors.py\n2212\t0.39GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3769\t0.34GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3935\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4285\t0.07GiB\tray::JobSupervisor\n2863\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4080\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3933\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "actors_per_second": 554.2728005409015,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 615.180594485976
+            "perf_metric_value": 554.2728005409015
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 74.394
+            "perf_metric_value": 92.76
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3035.866
+            "perf_metric_value": 4891.92
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3441.396
+            "perf_metric_value": 4891.92
         }
     ],
     "success": "1",
-    "time": 16.25538921356201
+    "time": 18.04165744781494
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 189.751296,
+    "_dashboard_memory_usage_mb": 198.520832,
     "_dashboard_test_success": true,
     "_peak_memory": 1.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3500\t0.55GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1141\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2460\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3625\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4864\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5132\t0.09GiB\tray::StateAPIGeneratorActor.start\n2656\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4657\t0.07GiB\tray::JobSupervisor\n3788\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3786\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3600\t0.55GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2958\t0.31GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1243\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3715\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4952\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5163\t0.08GiB\tray::StateAPIGeneratorActor.start\n4746\t0.07GiB\tray::JobSupervisor\n3884\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3008\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3882\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 344.2841239720449
+            "perf_metric_value": 352.05295620792083
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.971
+            "perf_metric_value": 4.162
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 68.223
+            "perf_metric_value": 44.529
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 140.505
+            "perf_metric_value": 122.298
         }
     ],
     "success": "1",
-    "tasks_per_second": 344.2841239720449,
-    "time": 302.9045777320862,
+    "tasks_per_second": 352.05295620792083,
+    "time": 302.8404817581177,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 189.5424,
+    "_dashboard_memory_usage_mb": 162.418688,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.2,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1249\t9.21GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3551\t0.98GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4583\t0.42GiB\tpython distributed/test_many_pgs.py\n2390\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3683\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3849\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2628\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4372\t0.07GiB\tray::JobSupervisor\n4039\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3847\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 2.21,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1292\t10.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3612\t1.01GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4695\t0.4GiB\tpython distributed/test_many_pgs.py\n2601\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3727\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3890\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2968\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4494\t0.07GiB\tray::JobSupervisor\n4042\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3888\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.687659485012095
+            "perf_metric_value": 22.61454883772771
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.39
+            "perf_metric_value": 3.461
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.334
+            "perf_metric_value": 10.003
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 332.736
+            "perf_metric_value": 213.243
         }
     ],
-    "pgs_per_second": 22.687659485012095,
+    "pgs_per_second": 22.61454883772771,
     "success": "1",
-    "time": 44.07682514190674
+    "time": 44.21932125091553
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1232.416768,
+    "_dashboard_memory_usage_mb": 1251.663872,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.37,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3733\t1.96GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3618\t1.68GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4484\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1235\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2417\t0.24GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4683\t0.09GiB\tray::StateAPIGeneratorActor.start\n4621\t0.08GiB\tray::DashboardTester.run\n4285\t0.07GiB\tray::JobSupervisor\n3899\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3025\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/",
+    "_peak_memory": 5.42,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3604\t2.91GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3721\t0.97GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4584\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1262\t0.29GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2330\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4842\t0.09GiB\tray::StateAPIGeneratorActor.start\n4788\t0.08GiB\tray::DashboardTester.run\n4377\t0.07GiB\tray::JobSupervisor\n2641\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3886\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 578.8766226882515
+            "perf_metric_value": 582.2528587251263
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 141.285
+            "perf_metric_value": 274.662
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1649.419
+            "perf_metric_value": 3995.805
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3448.302
+            "perf_metric_value": 5377.161
         }
     ],
     "success": "1",
-    "tasks_per_second": 578.8766226882515,
-    "time": 317.2748382091522,
+    "tasks_per_second": 582.2528587251263,
+    "time": 317.1746687889099,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.32.0"}
+{"release_version": "2.33.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        9241.526232225291,
-        132.04014985321072
+        9089.554836685598,
+        248.04186524328813
     ],
     "1_1_actor_calls_concurrent": [
-        5433.582983286094,
-        203.77840697231508
+        5417.434493378696,
+        124.35218516682983
     ],
     "1_1_actor_calls_sync": [
-        2063.6151992547047,
-        41.087530717556106
+        2130.918760045077,
+        63.88949262425519
     ],
     "1_1_async_actor_calls_async": [
-        4541.586332149929,
-        244.29996229786013
+        4984.024768215769,
+        203.5406701867711
     ],
     "1_1_async_actor_calls_sync": [
-        1499.3849412965205,
-        31.19427048888692
+        1498.0246714553275,
+        34.850293170313556
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2981.1837517965705,
-        129.12171570334309
+        3146.5764172550494,
+        54.100329844822454
     ],
     "1_n_actor_calls_async": [
-        8825.80303025342,
-        137.32428841583177
+        8619.17554203447,
+        183.22254158143645
     ],
     "1_n_async_actor_calls_async": [
-        7872.539571860014,
-        165.88537648403613
+        7688.844331638531,
+        173.03007749476023
     ],
     "client__1_1_actor_calls_async": [
-        1020.0334940870466,
-        10.493190404958229
+        995.0481100035444,
+        8.31562300997794
     ],
     "client__1_1_actor_calls_concurrent": [
-        1023.0375442360598,
-        9.873541601530931
+        998.230670582613,
+        9.82808610026736
     ],
     "client__1_1_actor_calls_sync": [
-        509.9599816194958,
-        26.55553704027681
+        520.1986351829904,
+        10.298920473666511
     ],
     "client__get_calls": [
-        1175.306212007341,
-        6.848643951008982
+        1111.7945170817964,
+        69.14025902831608
     ],
     "client__put_calls": [
-        794.0222907625882,
-        23.489002030449676
+        813.0590293747532,
+        5.480470279957046
     ],
     "client__put_gigabytes": [
-        0.13160907472336658,
-        0.000597729723962875
+        0.1374322283958248,
+        0.001227703724483899
     ],
     "client__tasks_and_get_batch": [
-        0.9724735940970552,
-        0.014680443297132861
+        0.9436564669925184,
+        0.00729535146912279
     ],
     "client__tasks_and_put_batch": [
-        11309.127935041968,
-        230.80678248448353
+        11331.335480466743,
+        75.76791617643977
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12520.58965968965,
-        127.48894702402845
+        12887.278980942054,
+        368.22075531306916
     ],
     "multi_client_put_gigabytes": [
-        37.39369500194131,
-        2.6031810715230144
+        37.486165484657576,
+        1.7916027512903987
     ],
     "multi_client_tasks_async": [
-        23283.706392178385,
-        3093.661219187642
+        22970.98779525776,
+        1910.7851737390622
     ],
     "n_n_actor_calls_async": [
-        27232.414296780542,
-        758.7912476297421
+        26680.036638509766,
+        988.5399124919908
     ],
     "n_n_actor_calls_with_arg_async": [
-        2605.856362562882,
-        17.70949766672506
+        2706.5919733776227,
+        38.25614650279406
     ],
     "n_n_async_actor_calls_async": [
-        23591.92555321498,
-        1068.3154500015673
+        23108.484424180868,
+        479.60987709728556
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10121.103242219997
+            "perf_metric_value": 9953.300735952664
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5227.298677681264
+            "perf_metric_value": 5329.421150658071
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12520.58965968965
+            "perf_metric_value": 12887.278980942054
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.46333348333893
+            "perf_metric_value": 20.286051717751697
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.9070880635954
+            "perf_metric_value": 8.032581753745204
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 37.39369500194131
+            "perf_metric_value": 37.486165484657576
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.756244682120503
+            "perf_metric_value": 13.923467935755424
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.302957674144409
+            "perf_metric_value": 5.5725098263282975
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 981.7983599799647
+            "perf_metric_value": 1005.4990392468012
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7981.871660623128
+            "perf_metric_value": 8191.316149029263
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23283.706392178385
+            "perf_metric_value": 22970.98779525776
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2063.6151992547047
+            "perf_metric_value": 2130.918760045077
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9241.526232225291
+            "perf_metric_value": 9089.554836685598
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5433.582983286094
+            "perf_metric_value": 5417.434493378696
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8825.80303025342
+            "perf_metric_value": 8619.17554203447
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27232.414296780542
+            "perf_metric_value": 26680.036638509766
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2605.856362562882
+            "perf_metric_value": 2706.5919733776227
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1499.3849412965205
+            "perf_metric_value": 1498.0246714553275
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4541.586332149929
+            "perf_metric_value": 4984.024768215769
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2981.1837517965705
+            "perf_metric_value": 3146.5764172550494
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7872.539571860014
+            "perf_metric_value": 7688.844331638531
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23591.92555321498
+            "perf_metric_value": 23108.484424180868
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 784.1202913310515
+            "perf_metric_value": 868.0323927376729
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1175.306212007341
+            "perf_metric_value": 1111.7945170817964
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 794.0222907625882
+            "perf_metric_value": 813.0590293747532
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13160907472336658
+            "perf_metric_value": 0.1374322283958248
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11309.127935041968
+            "perf_metric_value": 11331.335480466743
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 509.9599816194958
+            "perf_metric_value": 520.1986351829904
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1020.0334940870466
+            "perf_metric_value": 995.0481100035444
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1023.0375442360598
+            "perf_metric_value": 998.230670582613
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9724735940970552
+            "perf_metric_value": 0.9436564669925184
         }
     ],
     "placement_group_create/removal": [
-        784.1202913310515,
-        2.674372951834296
+        868.0323927376729,
+        13.255102196866675
     ],
     "single_client_get_calls_Plasma_Store": [
-        10121.103242219997,
-        344.32801069166834
+        9953.300735952664,
+        852.2693665348787
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.756244682120503,
-        0.09167947289933939
+        13.923467935755424,
+        0.21147472135446713
     ],
     "single_client_put_calls_Plasma_Store": [
-        5227.298677681264,
-        73.4380388161718
+        5329.421150658071,
+        59.418471384708326
     ],
     "single_client_put_gigabytes": [
-        19.46333348333893,
-        5.440510765037708
+        20.286051717751697,
+        5.578372207610081
     ],
     "single_client_tasks_and_get_batch": [
-        7.9070880635954,
-        0.3896057750384761
+        8.032581753745204,
+        0.5527545237782773
     ],
     "single_client_tasks_async": [
-        7981.871660623128,
-        279.39202571036645
+        8191.316149029263,
+        481.35667160598746
     ],
     "single_client_tasks_sync": [
-        981.7983599799647,
-        9.168440320587788
+        1005.4990392468012,
+        10.263240079707185
     ],
     "single_client_wait_1k_refs": [
-        5.302957674144409,
-        0.08188715171339318
+        5.5725098263282975,
+        0.12061844035414801
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 19.440196102000016,
+    "broadcast_time": 19.648705655000015,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 19.440196102000016
+            "perf_metric_value": 19.648705655000015
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.415384294000006,
-    "get_time": 23.645023898000005,
+    "args_time": 18.025089421000004,
+    "get_time": 24.442244895,
     "large_object_size": 107374182400,
-    "large_object_time": 30.474318987000004,
+    "large_object_time": 29.384843175999947,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.415384294000006
+            "perf_metric_value": 18.025089421000004
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.771739185999991
+            "perf_metric_value": 5.781148879999989
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.645023898000005
+            "perf_metric_value": 24.442244895
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 187.84350834300002
+            "perf_metric_value": 195.866151365
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.474318987000004
+            "perf_metric_value": 29.384843175999947
         }
     ],
-    "queued_time": 187.84350834300002,
-    "returns_time": 5.771739185999991,
+    "queued_time": 195.866151365,
+    "returns_time": 5.781148879999989,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0517002582550048,
-    "max_iteration_time": 2.9446706771850586,
-    "min_iteration_time": 0.512861967086792,
+    "avg_iteration_time": 1.1202176332473754,
+    "max_iteration_time": 2.7064244747161865,
+    "min_iteration_time": 0.12006998062133789,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0517002582550048
+            "perf_metric_value": 1.1202176332473754
         }
     ],
     "success": 1,
-    "total_time": 105.17023873329163
+    "total_time": 112.02198362350464
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.851820707321167
+            "perf_metric_value": 10.469495058059692
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.859845495224
+            "perf_metric_value": 25.46910936832428
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 65.67325186729431
+            "perf_metric_value": 67.55193538665772
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.573556900024414
+            "perf_metric_value": 2.7512922286987305
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3065.2378103733063
+            "perf_metric_value": 3257.0328571796417
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.48427910077229586
+            "perf_metric_value": 0.48565336003962284
         }
     ],
-    "stage_0_time": 10.851820707321167,
-    "stage_1_avg_iteration_time": 23.859845495224,
-    "stage_1_max_iteration_time": 24.58528447151184,
-    "stage_1_min_iteration_time": 23.121485948562622,
-    "stage_1_time": 238.59854221343994,
-    "stage_2_avg_iteration_time": 65.67325186729431,
-    "stage_2_max_iteration_time": 66.63724613189697,
-    "stage_2_min_iteration_time": 64.36803317070007,
-    "stage_2_time": 328.3679451942444,
-    "stage_3_creation_time": 1.573556900024414,
-    "stage_3_time": 3065.2378103733063,
-    "stage_4_spread": 0.48427910077229586,
+    "stage_0_time": 10.469495058059692,
+    "stage_1_avg_iteration_time": 25.46910936832428,
+    "stage_1_max_iteration_time": 27.362030506134033,
+    "stage_1_min_iteration_time": 24.83807682991028,
+    "stage_1_time": 254.69121026992798,
+    "stage_2_avg_iteration_time": 67.55193538665772,
+    "stage_2_max_iteration_time": 70.03894901275635,
+    "stage_2_min_iteration_time": 62.81902503967285,
+    "stage_2_time": 337.7604937553406,
+    "stage_3_creation_time": 2.7512922286987305,
+    "stage_3_time": 3257.0328571796417,
+    "stage_4_spread": 0.48565336003962284,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9259017792794532,
-    "avg_pg_remove_time_ms": 0.9261005015020346,
+    "avg_pg_create_time_ms": 0.9454739759751765,
+    "avg_pg_remove_time_ms": 0.9134947552545347,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9259017792794532
+            "perf_metric_value": 0.9454739759751765
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9261005015020346
+            "perf_metric_value": 0.9134947552545347
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 9.90%: actors_per_second (THROUGHPUT) regresses from 615.180594485976 to 554.2728005409015 in benchmarks/many_actors.json
REGRESSION 5.40%: client__get_calls (THROUGHPUT) regresses from 1175.306212007341 to 1111.7945170817964 in microbenchmark.json
REGRESSION 2.96%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9724735940970552 to 0.9436564669925184 in microbenchmark.json
REGRESSION 2.45%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1020.0334940870466 to 995.0481100035444 in microbenchmark.json
REGRESSION 2.42%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1023.0375442360598 to 998.230670582613 in microbenchmark.json
REGRESSION 2.34%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8825.80303025342 to 8619.17554203447 in microbenchmark.json
REGRESSION 2.33%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7872.539571860014 to 7688.844331638531 in microbenchmark.json
REGRESSION 2.05%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23591.92555321498 to 23108.484424180868 in microbenchmark.json
REGRESSION 2.03%: n_n_actor_calls_async (THROUGHPUT) regresses from 27232.414296780542 to 26680.036638509766 in microbenchmark.json
REGRESSION 1.66%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10121.103242219997 to 9953.300735952664 in microbenchmark.json
REGRESSION 1.64%: 1_1_actor_calls_async (THROUGHPUT) regresses from 9241.526232225291 to 9089.554836685598 in microbenchmark.json
REGRESSION 1.34%: multi_client_tasks_async (THROUGHPUT) regresses from 23283.706392178385 to 22970.98779525776 in microbenchmark.json
REGRESSION 0.32%: pgs_per_second (THROUGHPUT) regresses from 22.687659485012095 to 22.61454883772771 in benchmarks/many_pgs.json
REGRESSION 0.30%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5433.582983286094 to 5417.434493378696 in microbenchmark.json
REGRESSION 0.09%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1499.3849412965205 to 1498.0246714553275 in microbenchmark.json
REGRESSION 142.26%: dashboard_p95_latency_ms (LATENCY) regresses from 1649.419 to 3995.805 in benchmarks/many_tasks.json
REGRESSION 94.40%: dashboard_p50_latency_ms (LATENCY) regresses from 141.285 to 274.662 in benchmarks/many_tasks.json
REGRESSION 74.85%: stage_3_creation_time (LATENCY) regresses from 1.573556900024414 to 2.7512922286987305 in stress_tests/stress_test_many_tasks.json
REGRESSION 61.14%: dashboard_p95_latency_ms (LATENCY) regresses from 3035.866 to 4891.92 in benchmarks/many_actors.json
REGRESSION 55.94%: dashboard_p99_latency_ms (LATENCY) regresses from 3448.302 to 5377.161 in benchmarks/many_tasks.json
REGRESSION 42.15%: dashboard_p99_latency_ms (LATENCY) regresses from 3441.396 to 4891.92 in benchmarks/many_actors.json
REGRESSION 24.69%: dashboard_p50_latency_ms (LATENCY) regresses from 74.394 to 92.76 in benchmarks/many_actors.json
REGRESSION 6.74%: stage_1_avg_iteration_time (LATENCY) regresses from 23.859845495224 to 25.46910936832428 in stress_tests/stress_test_many_tasks.json
REGRESSION 6.51%: avg_iteration_time (LATENCY) regresses from 1.0517002582550048 to 1.1202176332473754 in stress_tests/stress_test_dead_actors.json
REGRESSION 6.26%: stage_3_time (LATENCY) regresses from 3065.2378103733063 to 3257.0328571796417 in stress_tests/stress_test_many_tasks.json
REGRESSION 4.81%: dashboard_p50_latency_ms (LATENCY) regresses from 3.971 to 4.162 in benchmarks/many_nodes.json
REGRESSION 4.27%: 1000000_queued_time (LATENCY) regresses from 187.84350834300002 to 195.866151365 in scalability/single_node.json
REGRESSION 3.50%: 10000_args_time (LATENCY) regresses from 17.415384294000006 to 18.025089421000004 in scalability/single_node.json
REGRESSION 3.37%: 10000_get_time (LATENCY) regresses from 23.645023898000005 to 24.442244895 in scalability/single_node.json
REGRESSION 2.86%: stage_2_avg_iteration_time (LATENCY) regresses from 65.67325186729431 to 67.55193538665772 in stress_tests/stress_test_many_tasks.json
REGRESSION 2.11%: avg_pg_create_time_ms (LATENCY) regresses from 0.9259017792794532 to 0.9454739759751765 in stress_tests/stress_test_placement_group.json
REGRESSION 2.09%: dashboard_p50_latency_ms (LATENCY) regresses from 3.39 to 3.461 in benchmarks/many_pgs.json
REGRESSION 1.07%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 19.440196102000016 to 19.648705655000015 in scalability/object_store.json
REGRESSION 0.28%: stage_4_spread (LATENCY) regresses from 0.48427910077229586 to 0.48565336003962284 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.16%: 3000_returns_time (LATENCY) regresses from 5.771739185999991 to 5.781148879999989 in scalability/single_node.json
```