### PR TITLE
[doc][build/01] wrapper command for doc build

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -45,7 +45,7 @@ steps:
     key: doc_build
     instance_type: medium
     commands:
-      - make -C doc/ html
+      - bazel run //ci/ray_ci/doc:cmd_build
     depends_on: docbuild
     job_env: docbuild
 

--- a/ci/ray_ci/doc/BUILD.bazel
+++ b/ci/ray_ci/doc/BUILD.bazel
@@ -7,6 +7,13 @@ py_binary(
     deps = [":doc"],
 )
 
+py_binary(
+    name = "cmd_build",
+    srcs = ["cmd_build.py"],
+    deps = [":doc"],
+    exec_compatible_with = ["//:hermetic_python"],
+)
+
 py_library(
     name = "doc",
     srcs = glob(
@@ -17,6 +24,9 @@ py_library(
         ],
     ),
     visibility = ["//ci/ray_ci/doc:__subpackages__"],
+    deps = [
+        "//ci/ray_ci:ray_ci_lib",
+    ],
 )
 
 py_test(

--- a/ci/ray_ci/doc/cmd_build.py
+++ b/ci/ray_ci/doc/cmd_build.py
@@ -1,0 +1,49 @@
+import subprocess
+
+import click
+
+from ci.ray_ci.utils import logger
+
+
+@click.command()
+@click.option(
+    "--ray-checkout-dir",
+    default="/ray",
+)
+def main(ray_checkout_dir: str) -> None:
+    """
+    This script builds ray doc and upload build artifacts to S3.
+    """
+    logger.info("Building ray doc.")
+    _build(ray_checkout_dir)
+
+    logger.info("Uploading build artifacts to S3.")
+    _upload_build_artifacts()
+
+    return
+
+
+def _build(ray_checkout_dir):
+    subprocess.run(
+        [
+            "make",
+            "-C",
+            "doc/",
+            "html",
+        ],
+        cwd=ray_checkout_dir,
+        check=True,
+    )
+
+
+def _upload_build_artifacts():
+    """
+    Upload the build artifacts to S3.
+
+    TODO(can): to be implemented
+    """
+    pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a wrapper command to implement global caching for doc build. This PR just build doc as it is for now.

Test:
- CI
- Run locally: `bazel run //ci/ray_ci/doc:cmd_build -- --ray-checkout-dir /home/ubuntu/ray`