### PR TITLE
[data] Add better support for udf returns from list of datetime objects

### DIFF
--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -39,26 +39,31 @@ def validate_numpy_batch(batch: Union[Dict[str, np.ndarray], Dict[str, list]]) -
             f"a numpy batch to a block, got: {type(batch)} "
             f"({_truncated_repr(batch)})"
         )
- 
+
+
 def _detect_highest_datetime_precision(datetime_list: List[datetime]) -> str:
-    highest_precision = 'D' 
-    
+    highest_precision = "D"
+
     for dt in datetime_list:
         if dt.microsecond != 0 and dt.microsecond % 1000 != 0:
-            highest_precision = 'us'
+            highest_precision = "us"
             break
         elif dt.microsecond != 0 and dt.microsecond % 1000 == 0:
-            highest_precision = 'ms'
+            highest_precision = "ms"
         elif dt.hour != 0 or dt.minute != 0 or dt.second != 0:
             # pyarrow does not support h or m, use s for those cases too
-            highest_precision = 's'
-    
+            highest_precision = "s"
+
     return highest_precision
+
 
 def _convert_datetime_list_to_array(datetime_list: List[datetime]) -> np.ndarray:
     precision = _detect_highest_datetime_precision(datetime_list)
-        
-    return np.array([np.datetime64(dt, precision) for dt in datetime_list], dtype=f"datetime64[{precision}]")
+
+    return np.array(
+        [np.datetime64(dt, precision) for dt in datetime_list],
+        dtype=f"datetime64[{precision}]",
+    )
 
 
 def convert_udf_returns_to_numpy(udf_return_col: Any) -> Any:

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -6,6 +6,7 @@ import ray
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
+from datetime import datetime
 
 
 class UserObj:
@@ -44,6 +45,37 @@ def test_list_of_objects(ray_start_regular_shared):
     data = [1, 2, 3, UserObj()]
     output = do_map_batches(data)
     assert_structure_equals(output, np.array([1, 2, 3, UserObj()]))
+
+DATETIME_DAY_PRECISION = datetime(year=2024, month=1, day=1)
+DATETIME_HOUR_PRECISION = datetime(year=2024, month=1, day=1, hour=1)
+DATETIME_MIN_PRECISION = datetime(year=2024, month=1, day=1, minute=1)
+DATETIME_SEC_PRECISION = datetime(year=2024, month=1, day=1, second=1)
+DATETIME_MILLISEC_PRECISION = datetime(year=2024, month=1, day=1, microsecond=1000)
+DATETIME_MICROSEC_PRECISION = datetime(year=2024, month=1, day=1, microsecond=1)
+
+DATETIME64_DAY_PRECISION = np.datetime64("2024-01-01")
+DATETIME64_HOUR_PRECISION = np.datetime64("2024-01-01T01:00", 's')
+DATETIME64_MIN_PRECISION = np.datetime64("2024-01-01T00:01", 's')
+DATETIME64_SEC_PRECISION = np.datetime64("2024-01-01T00:00:01")
+DATETIME64_MILLISEC_PRECISION = np.datetime64("2024-01-01T00:00:00.001")
+DATETIME64_MICROSEC_PRECISION = np.datetime64("2024-01-01T00:00:00.000001")
+
+@pytest.mark.parametrize(
+    "data,expected_output",
+    [
+        ([DATETIME_DAY_PRECISION], np.array([DATETIME64_DAY_PRECISION])),
+        ([DATETIME_HOUR_PRECISION], np.array([DATETIME64_HOUR_PRECISION])),
+        ([DATETIME_MIN_PRECISION], np.array([DATETIME64_MIN_PRECISION])),
+        ([DATETIME_SEC_PRECISION], np.array([DATETIME64_SEC_PRECISION])),
+        ([DATETIME_MILLISEC_PRECISION], np.array([DATETIME64_MILLISEC_PRECISION])),
+        ([DATETIME_MICROSEC_PRECISION], np.array([DATETIME64_MICROSEC_PRECISION])),
+        ([DATETIME_MICROSEC_PRECISION, DATETIME_MILLISEC_PRECISION], np.array([DATETIME64_MICROSEC_PRECISION, DATETIME_MILLISEC_PRECISION], dtype="datetime64[us]")),
+        ([DATETIME_SEC_PRECISION, DATETIME_MILLISEC_PRECISION], np.array([DATETIME64_SEC_PRECISION, DATETIME_MILLISEC_PRECISION], dtype="datetime64[ms]")),
+    ]
+)
+def test_list_of_datetimes(data, expected_output, ray_start_regular_shared):
+    output = do_map_batches(data)
+    assert_structure_equals(output, expected_output)
 
 
 def test_array_like(ray_start_regular_shared):

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import numpy as np
 import pytest
 import torch
@@ -6,7 +8,6 @@ import ray
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
-from datetime import datetime
 
 
 class UserObj:
@@ -46,6 +47,7 @@ def test_list_of_objects(ray_start_regular_shared):
     output = do_map_batches(data)
     assert_structure_equals(output, np.array([1, 2, 3, UserObj()]))
 
+
 DATETIME_DAY_PRECISION = datetime(year=2024, month=1, day=1)
 DATETIME_HOUR_PRECISION = datetime(year=2024, month=1, day=1, hour=1)
 DATETIME_MIN_PRECISION = datetime(year=2024, month=1, day=1, minute=1)
@@ -54,11 +56,12 @@ DATETIME_MILLISEC_PRECISION = datetime(year=2024, month=1, day=1, microsecond=10
 DATETIME_MICROSEC_PRECISION = datetime(year=2024, month=1, day=1, microsecond=1)
 
 DATETIME64_DAY_PRECISION = np.datetime64("2024-01-01")
-DATETIME64_HOUR_PRECISION = np.datetime64("2024-01-01T01:00", 's')
-DATETIME64_MIN_PRECISION = np.datetime64("2024-01-01T00:01", 's')
+DATETIME64_HOUR_PRECISION = np.datetime64("2024-01-01T01:00", "s")
+DATETIME64_MIN_PRECISION = np.datetime64("2024-01-01T00:01", "s")
 DATETIME64_SEC_PRECISION = np.datetime64("2024-01-01T00:00:01")
 DATETIME64_MILLISEC_PRECISION = np.datetime64("2024-01-01T00:00:00.001")
 DATETIME64_MICROSEC_PRECISION = np.datetime64("2024-01-01T00:00:00.000001")
+
 
 @pytest.mark.parametrize(
     "data,expected_output",
@@ -69,9 +72,21 @@ DATETIME64_MICROSEC_PRECISION = np.datetime64("2024-01-01T00:00:00.000001")
         ([DATETIME_SEC_PRECISION], np.array([DATETIME64_SEC_PRECISION])),
         ([DATETIME_MILLISEC_PRECISION], np.array([DATETIME64_MILLISEC_PRECISION])),
         ([DATETIME_MICROSEC_PRECISION], np.array([DATETIME64_MICROSEC_PRECISION])),
-        ([DATETIME_MICROSEC_PRECISION, DATETIME_MILLISEC_PRECISION], np.array([DATETIME64_MICROSEC_PRECISION, DATETIME_MILLISEC_PRECISION], dtype="datetime64[us]")),
-        ([DATETIME_SEC_PRECISION, DATETIME_MILLISEC_PRECISION], np.array([DATETIME64_SEC_PRECISION, DATETIME_MILLISEC_PRECISION], dtype="datetime64[ms]")),
-    ]
+        (
+            [DATETIME_MICROSEC_PRECISION, DATETIME_MILLISEC_PRECISION],
+            np.array(
+                [DATETIME64_MICROSEC_PRECISION, DATETIME_MILLISEC_PRECISION],
+                dtype="datetime64[us]",
+            ),
+        ),
+        (
+            [DATETIME_SEC_PRECISION, DATETIME_MILLISEC_PRECISION],
+            np.array(
+                [DATETIME64_SEC_PRECISION, DATETIME_MILLISEC_PRECISION],
+                dtype="datetime64[ms]",
+            ),
+        ),
+    ],
 )
 def test_list_of_datetimes(data, expected_output, ray_start_regular_shared):
     output = do_map_batches(data)


### PR DESCRIPTION
## Why are these changes needed?
This PR adds better support for the translation of lists of datetime objects. It ensures that if pyarrow blocks are used then the datetime objects will be loaded as timestamps. 

## Related issue number

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
