### PR TITLE
[ADAG] Handle one more exceptional case in DAG execution

### DIFF
--- a/python/ray/experimental/compiled_dag_ref.py
+++ b/python/ray/experimental/compiled_dag_ref.py
@@ -14,8 +14,8 @@ def _process_return_vals(return_vals: List[Any], return_single_output: bool):
     a single return value instead of a list.
     """
     # Check for exceptions.
-    if isinstance(return_vals, RayTaskError):
-        raise return_vals.as_instanceof_cause()
+    if isinstance(return_vals, Exception):
+        raise return_vals
 
     for val in return_vals:
         if isinstance(val, RayTaskError):

--- a/python/ray/experimental/compiled_dag_ref.py
+++ b/python/ray/experimental/compiled_dag_ref.py
@@ -14,6 +14,9 @@ def _process_return_vals(return_vals: List[Any], return_single_output: bool):
     a single return value instead of a list.
     """
     # Check for exceptions.
+    if isinstance(return_vals, RayTaskError):
+        raise return_vals.as_instanceof_cause()
+
     for val in return_vals:
         if isinstance(val, RayTaskError):
             raise val.as_instanceof_cause()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We see the following exceptions when testing vllm:
```
ERROR 07-23 14:56:26 async_llm_engine.py:55]     return _process_return_vals(
ERROR 07-23 14:56:26 async_llm_engine.py:55]   File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/experimental/compiled_dag_ref.py", line 17, in _process_return_vals
ERROR 07-23 14:56:26 async_llm_engine.py:55]     for val in return_vals:
ERROR 07-23 14:56:26 async_llm_engine.py:55] TypeError: 'RayChannelError' object is not iterable
```

This PR properly throws that exception instead of failing for TypeError.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
