### PR TITLE
[Data] Remove read task warning if size bytes not set in metadata

### DIFF
--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Iterable, List
 
 import ray
@@ -25,22 +26,30 @@ READ_FILE_RETRY_ON_ERRORS = ["AWS Error NETWORK_CONNECTION", "AWS Error ACCESS_D
 READ_FILE_MAX_ATTEMPTS = 10
 READ_FILE_RETRY_MAX_BACKOFF_SECONDS = 32
 
+logger = logging.getLogger(__name__)
 
-# Defensively compute the size of the block as the max size reported by the
-# datasource and the actual read task size. This is to guard against issues
-# with bad metadata reporting.
+
 def cleaned_metadata(read_task: ReadTask):
     block_meta = read_task.get_metadata()
     task_size = len(cloudpickle.dumps(read_task))
-    if block_meta.size_bytes is not None and task_size > block_meta.size_bytes:
-        if task_size > TASK_SIZE_WARN_THRESHOLD_BYTES:
-            print(
-                f"WARNING: the read task size ({task_size} bytes) is larger "
-                "than the reported output size of the task "
-                f"({block_meta.size_bytes} bytes). This may be a size "
-                "reporting bug in the datasource being read from."
-            )
+    if (
+        block_meta.size_bytes is not None
+        and task_size > block_meta.size_bytes
+        and task_size > TASK_SIZE_WARN_THRESHOLD_BYTES
+    ):
+        logger.warning(
+            f"The read task size ({task_size} bytes) is larger "
+            "than the reported output size of the task "
+            f"({block_meta.size_bytes} bytes). This may be a size "
+            "reporting bug in the datasource being read from."
+        )
+
+    # Defensively compute the size of the block as the max size reported by the
+    # datasource and the actual read task size. This is to guard against issues
+    # with bad metadata reporting.
+    if block_meta.size_bytes is None or task_size > block_meta.size_bytes:
         block_meta.size_bytes = task_size
+
     return block_meta
 
 

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -32,7 +32,7 @@ READ_FILE_RETRY_MAX_BACKOFF_SECONDS = 32
 def cleaned_metadata(read_task: ReadTask):
     block_meta = read_task.get_metadata()
     task_size = len(cloudpickle.dumps(read_task))
-    if block_meta.size_bytes is None or task_size > block_meta.size_bytes:
+    if block_meta.size_bytes is not None and task_size > block_meta.size_bytes:
         if task_size > TASK_SIZE_WARN_THRESHOLD_BYTES:
             print(
                 f"WARNING: the read task size ({task_size} bytes) is larger "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`Datasource.get_read_tasks()` returns a list of `ReadTask`, where each `ReadTask` encapsulates a data reading function and it's associated output metadata. If a serialized `ReadTask` is more than 100KB and `size_bytes` isn't set in the output metadata (which is often the case), then Ray Data emits a warning per read task:

```
WARNING: the read task size (288451 bytes) is larger than the reported output size of the task (None bytes). This may be a size reporting bug in the datasource being read from.
```

This warning isn't helpful and usually doesn't indicate an actual issue, so I'm removing it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
