### PR TITLE
[doc][build] build doc with python 3.12

### DIFF
--- a/.buildkite/base.rayci.yml
+++ b/.buildkite/base.rayci.yml
@@ -7,7 +7,7 @@ steps:
     label: "wanda: oss-ci-base_test-py{{matrix}}"
     wanda: ci/docker/base.test.wanda.yaml
     matrix:
-      - "3.10"
+      - "3.9"
       - "3.11"
       - "3.12"
     env:
@@ -21,7 +21,7 @@ steps:
     label: "wanda: oss-ci-base_build-py{{matrix}}"
     wanda: ci/docker/base.build.wanda.yaml
     matrix:
-      - "3.10"
+      - "3.9"
       - "3.11"
       - "3.12"
     env:
@@ -57,14 +57,19 @@ steps:
     label: "wanda: oss-ci-base_gpu-py{{matrix}}"
     wanda: ci/docker/base.gpu.wanda.yaml
     matrix:
-      - "3.10"
       - "3.11"
     env:
       PYTHON: "{{matrix}}"
 
   - name: docbuild
+    label: "wanda: docbuild-py{{matrix}}"
     wanda: ci/docker/doc.build.wanda.yaml
-    depends_on: oss-ci-base_build
+    depends_on: oss-ci-base_build-multipy
+    matrix:
+      - "3.9"
+      - "3.12"
+    env:
+      PYTHON: "{{matrix}}"
 
   - name: docgpubuild
     wanda: ci/docker/docgpu.build.wanda.yaml

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -47,7 +47,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci/doc:cmd_build
     depends_on: docbuild
-    job_env: docbuild
+    job_env: docbuild-py3.12
 
   - label: ":tapioca: build: ray py{{matrix}} docker (x86_64)"
     tags:

--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -27,7 +27,7 @@ steps:
     key: lint-medium
     instance_type: medium
     depends_on: docbuild
-    job_env: docbuild
+    job_env: docbuild-py3.9
     commands:
       - ./ci/lint/lint.sh {{matrix}}
     matrix:
@@ -39,7 +39,7 @@ steps:
     commands:
       - make -C doc/ linkcheck_all
     depends_on: docbuild
-    job_env: docbuild
+    job_env: docbuild-py3.9
     tags:
       - oss
       - skip-on-premerge

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -246,10 +246,10 @@ def ray_deps_setup():
 
     http_archive(
         name = "openssl",
-        strip_prefix = "openssl-1.1.1w",
-        sha256 = "cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8",
+        strip_prefix = "openssl-1.1.1f",
+        sha256 = "186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35",
         urls = [
-            "https://www.openssl.org/source/openssl-1.1.1w.tar.gz",
+            "https://openssl.org/source/old/1.1.1/openssl-1.1.1f.tar.gz",
         ],
         build_file = "@rules_foreign_cc_thirdparty//openssl:BUILD.openssl.bazel",
     )

--- a/ci/docker/doc.build.wanda.yaml
+++ b/ci/docker/doc.build.wanda.yaml
@@ -1,7 +1,9 @@
-name: "docbuild"
-froms: ["cr.ray.io/rayproject/oss-ci-base_build"]
+name: "docbuild-py$PYTHON"
+froms: ["cr.ray.io/rayproject/oss-ci-base_build-py$PYTHON"]
 dockerfile: ci/docker/doc.build.Dockerfile
 srcs:
   - doc/requirements-doc.txt
+build_args:
+  - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_build-py$PYTHON
 tags:
-  - cr.ray.io/rayproject/docbuild
+  - cr.ray.io/rayproject/docbuild-py$PYTHON

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -64,8 +64,8 @@ api_annotations() {
 
 api_policy_check() {
   # install ray and compile doc to generate API files
-  RAY_DISABLE_EXTRA_CPP=1 pip install -e "python[all]"
   make -C doc/ html
+  RAY_DISABLE_EXTRA_CPP=1 pip install -e "python[all]"
   # validate the API files
   bazel run //ci/ray_ci/doc:cmd_check_api_discrepancy -- /ray "$@"
 }


### PR DESCRIPTION
Build doc in CI with python 3.12 to align with what we recommend as the local dev build environment. 

I tested the build 

> s3://ray-ci-results/doc_build/44b1106a3f4470d359009adf2dc3bebc4af79409.tgz

and the pickfile has more files that we want

Test:
- CI