### PR TITLE
[doc][build/02] remove local site-package files from global cache

### DIFF
--- a/ci/ray_ci/doc/test_build_cache.py
+++ b/ci/ray_ci/doc/test_build_cache.py
@@ -1,10 +1,16 @@
 import sys
 import os
+import pickle
 import pytest
 import tempfile
 from unittest import mock
 
 from ci.ray_ci.doc.build_cache import BuildCache
+
+
+class FakeCache:
+    def __init__(self, dependencies):
+        self.dependencies = dependencies
 
 
 @mock.patch("subprocess.check_output")
@@ -24,6 +30,29 @@ def test_zip_cache():
             files.add(file_name)
 
         assert BuildCache(temp_dir)._zip_cache(files) == "12345.tgz"
+
+
+def test_massage_cache():
+    cache = FakeCache(
+        {
+            "doc1": ["site-packages/dep1", "dep2"],
+            "doc2": ["dep3", "site-packages/dep4"],
+        }
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        cache_path = os.path.join(temp_dir, "env_cache.pkl")
+        with open(cache_path, "wb") as file:
+            pickle.dump(cache, file)
+
+        build_cache = BuildCache(temp_dir)
+        build_cache._massage_cache("env_cache.pkl")
+
+        with open(cache_path, "rb") as file:
+            cache = pickle.load(file)
+            assert cache.dependencies == {
+                "doc1": ["dep2"],
+                "doc2": ["dep3"],
+            }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The generated doc build files might include local files, such as local python site-packages. Remove these files since they cannot be used as a global cache.

Test:
- CI