### PR TITLE
[core] Async APIs for the New GcsClient.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2361,6 +2361,11 @@ flatbuffer_cc_library(
     out_prefix = "ray/raylet/format/",
 )
 
+ray_cc_library(
+    name = "python_callbacks",
+    hdrs = ["src/ray/gcs/gcs_client/python_callbacks.h"],
+)
+
 pyx_library(
     name = "_raylet",
     srcs = glob([
@@ -2389,6 +2394,7 @@ pyx_library(
         linkstatic = 1,
     ),
     deps = [
+        ":python_callbacks",
         "//:core_worker_lib",
         "//:exported_internal",
         "//:gcs_server_lib",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,14 +7,14 @@
 # If you would like to help with the move in your PR, please use `git mv` so that the history of the file is retained.
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_python//python:defs.bzl", "py_library", "py_runtime", "py_runtime_pair")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@com_github_google_flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_github_grpc_grpc//bazel:cython_library.bzl", "pyx_library")
-load("@com_github_google_flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
-load("//bazel:ray.bzl", "COPTS", "PYX_COPTS", "PYX_SRCS", "copy_to_workspace", "ray_cc_binary", "ray_cc_library", "ray_cc_test")
 load("@python3_9//:defs.bzl", python39 = "interpreter")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_python//python:defs.bzl", "py_library", "py_runtime", "py_runtime_pair")
+load("//bazel:ray.bzl", "COPTS", "PYX_COPTS", "PYX_SRCS", "copy_to_workspace", "ray_cc_binary", "ray_cc_library", "ray_cc_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -2363,7 +2363,10 @@ flatbuffer_cc_library(
 
 ray_cc_library(
     name = "python_callbacks",
-    hdrs = ["src/ray/gcs/gcs_client/python_callbacks.h"],
+    hdrs = [
+        "src/ray/gcs/callback.h",
+        "src/ray/gcs/gcs_client/python_callbacks.h",
+    ],
 )
 
 pyx_library(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,14 +7,14 @@
 # If you would like to help with the move in your PR, please use `git mv` so that the history of the file is retained.
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("@com_github_google_flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
-load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
-load("@com_github_grpc_grpc//bazel:cython_library.bzl", "pyx_library")
-load("@python3_9//:defs.bzl", python39 = "interpreter")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:defs.bzl", "py_library", "py_runtime", "py_runtime_pair")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@com_github_grpc_grpc//bazel:cython_library.bzl", "pyx_library")
+load("@com_github_google_flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
 load("//bazel:ray.bzl", "COPTS", "PYX_COPTS", "PYX_SRCS", "copy_to_workspace", "ray_cc_binary", "ray_cc_library", "ray_cc_test")
+load("@python3_9//:defs.bzl", python39 = "interpreter")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -2364,7 +2364,6 @@ flatbuffer_cc_library(
 ray_cc_library(
     name = "python_callbacks",
     hdrs = [
-        "src/ray/gcs/callback.h",
         "src/ray/gcs/gcs_client/python_callbacks.h",
     ],
 )

--- a/python/ray/_private/gcs_aio_client.py
+++ b/python/ray/_private/gcs_aio_client.py
@@ -1,7 +1,8 @@
+import os
 import logging
 from typing import Dict, List, Optional
 from concurrent.futures import ThreadPoolExecutor
-from ray._raylet import GcsClient, JobID
+from ray._raylet import GcsClient, NewGcsClient, JobID
 from ray.core.generated import (
     gcs_pb2,
 )
@@ -14,12 +15,61 @@ from ray._private.ray_constants import env_integer
 # If the arg `executor` in GcsAioClient constructor is set, use it.
 # Otherwise if env var `GCS_AIO_CLIENT_DEFAULT_THREAD_COUNT` is set, use it.
 # Otherwise, use 5.
+# This is only used for the OldGcsAioClient.
 GCS_AIO_CLIENT_DEFAULT_THREAD_COUNT = env_integer(
     "GCS_AIO_CLIENT_DEFAULT_THREAD_COUNT", 5
 )
 
-
 logger = logging.getLogger(__name__)
+
+
+class GcsAioClient:
+    """
+    Async GCS client.
+
+    This class is in transition to use the new C++ GcsClient binding. The old
+    PythonGcsClient binding is not deleted until we are confident that the new
+    binding is stable.
+
+    Defaults to the new binding. If you want to use the old binding, please
+    set the environment variable `RAY_USE_OLD_GCS_CLIENT=1`.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        use_old_client = os.getenv("RAY_USE_OLD_GCS_CLIENT") == "1"
+        logger.debug(f"Using {'old' if use_old_client else 'new'} GCS client")
+        if use_old_client:
+            return OldGcsAioClient(*args, **kwargs)
+        else:
+            return NewGcsAioClient(*args, **kwargs)
+
+
+class NewGcsAioClient:
+    def __init__(
+        self,
+        address: str = None,
+        loop=None,
+        executor=None,
+        nums_reconnect_retry: int = 5,
+    ):
+        # See https://github.com/ray-project/ray/blob/d0b46eff9ddcf9ec7256dd3a6dda33e7fb7ced95/python/ray/_raylet.pyx#L2693 # noqa: E501
+        timeout_ms = 1000 * (nums_reconnect_retry + 1)
+        self.inner = NewGcsClient.standalone(
+            str(address), cluster_id=None, timeout_ms=timeout_ms
+        )
+        # Forwarded Methods. Not using __getattr__ because we want one fewer layer of
+        # indirection.
+        self.internal_kv_get = self.inner.async_internal_kv_get
+        self.internal_kv_multi_get = self.inner.async_internal_kv_multi_get
+        self.internal_kv_put = self.inner.async_internal_kv_put
+        self.internal_kv_del = self.inner.async_internal_kv_del
+        self.internal_kv_exists = self.inner.async_internal_kv_exists
+        self.internal_kv_keys = self.inner.async_internal_kv_keys
+        self.check_alive = self.inner.async_check_alive
+        self.get_all_job_info = self.inner.async_get_all_job_info
+        # Forwarded Properties.
+        self.address = self.inner.address
+        self.cluster_id = self.inner.cluster_id
 
 
 class AsyncProxy:
@@ -45,7 +95,7 @@ class AsyncProxy:
             return attr
 
 
-class GcsAioClient:
+class OldGcsAioClient:
     def __init__(
         self,
         loop=None,

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -44,13 +44,16 @@ cdef extern from * namespace "polyfill" nogil:
 
 
 cdef extern from "ray/common/status.h" namespace "ray" nogil:
-    cdef cppclass StatusCode:
+    # TODO(ryw) in Cython 3.x we can directly use `cdef enum class CStatusCode`
+    cdef cppclass CStatusCode "ray::StatusCode":
         pass
+    cdef CStatusCode CStatusCode_OK "ray::StatusCode::OK"
+    c_bool operator==(CStatusCode lhs, CStatusCode rhs)
 
     cdef cppclass CRayStatus "ray::Status":
         CRayStatus()
-        CRayStatus(StatusCode code, const c_string &msg)
-        CRayStatus(StatusCode code, const c_string &msg, int rpc_code)
+        CRayStatus(CStatusCode code, const c_string &msg)
+        CRayStatus(CStatusCode code, const c_string &msg, int rpc_code)
         CRayStatus(const CRayStatus &s)
 
         @staticmethod
@@ -135,7 +138,7 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
 
         c_string ToString()
         c_string CodeAsString()
-        StatusCode code()
+        CStatusCode code()
         c_string message()
         int rpc_code()
 
@@ -143,18 +146,6 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
     cdef CRayStatus RayStatus_OK "Status::OK"()
     cdef CRayStatus RayStatus_Invalid "Status::Invalid"()
     cdef CRayStatus RayStatus_NotImplemented "Status::NotImplemented"()
-
-
-cdef extern from "ray/common/status.h" namespace "ray::StatusCode" nogil:
-    cdef StatusCode StatusCode_OK "OK"
-    cdef StatusCode StatusCode_OutOfMemory "OutOfMemory"
-    cdef StatusCode StatusCode_KeyError "KeyError"
-    cdef StatusCode StatusCode_TypeError "TypeError"
-    cdef StatusCode StatusCode_Invalid "Invalid"
-    cdef StatusCode StatusCode_IOError "IOError"
-    cdef StatusCode StatusCode_UnknownError "UnknownError"
-    cdef StatusCode StatusCode_NotImplemented "NotImplemented"
-    cdef StatusCode StatusCode_RedisError "RedisError"
 
 
 cdef extern from "ray/common/id.h" namespace "ray" nogil:
@@ -376,6 +367,17 @@ cdef extern from "ray/core_worker/common.h" nogil:
         const CNodeID &GetSpilledNodeID() const
         const c_bool GetDidSpill() const
 
+cdef extern from "ray/gcs/gcs_client/python_callbacks.h" namespace "ray" nogil:
+    # Each type needs default constructors asked by cython.
+    cdef cppclass PyDefaultCallback:
+        PyDefaultCallback()
+        PyDefaultCallback(object py_callback)
+    cdef cppclass PyMultiItemCallback[Item]:
+        PyMultiItemCallback()
+        PyMultiItemCallback(object py_callback)
+    cdef cppclass BoolConverter:
+        pass
+
 cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
     cdef cppclass CActorInfoAccessor "ray::gcs::ActorInfoAccessor":
         pass
@@ -385,11 +387,20 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             c_vector[CJobTableData] &result,
             int64_t timeout_ms)
 
+        CRayStatus AsyncGetAll(
+            const PyDefaultCallback &callback,
+            int64_t timeout_ms)
+
     cdef cppclass CNodeInfoAccessor "ray::gcs::NodeInfoAccessor":
         CRayStatus CheckAlive(
             const c_vector[c_string] &raylet_addresses,
             int64_t timeout_ms,
             c_vector[c_bool] &result)
+
+        CRayStatus AsyncCheckAlive(
+            const c_vector[c_string] &raylet_addresses,
+            int64_t timeout_ms,
+            const PyMultiItemCallback[BoolConverter] &callback)
 
         CRayStatus DrainNodes(
             const c_vector[CNodeID] &node_ids,
@@ -444,6 +455,45 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             const c_string &key,
             int64_t timeout_ms,
             c_bool &exists)
+
+        CRayStatus AsyncInternalKVKeys(
+            const c_string &ns,
+            const c_string &prefix,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
+
+        CRayStatus AsyncInternalKVGet(
+            const c_string &ns,
+            const c_string &key,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
+
+        CRayStatus AsyncInternalKVMultiGet(
+            const c_string &ns,
+            const c_vector[c_string] &keys,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
+
+        CRayStatus AsyncInternalKVPut(
+            const c_string &ns,
+            const c_string &key,
+            const c_string &value,
+            c_bool overwrite,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
+
+        CRayStatus AsyncInternalKVExists(
+            const c_string &ns,
+            const c_string &key,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
+
+        CRayStatus AsyncInternalKVDel(
+            const c_string &ns,
+            const c_string &key,
+            c_bool del_by_prefix,
+            int64_t timeout_ms,
+            const PyDefaultCallback &callback)
 
     cdef cppclass CRuntimeEnvAccessor "ray::gcs::RuntimeEnvAccessor":
         CRayStatus PinRuntimeEnvUri(

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -6,7 +6,6 @@ from libc.stdint cimport uint8_t, int32_t, uint64_t, int64_t, uint32_t
 from libcpp.unordered_map cimport unordered_map
 from libcpp.vector cimport vector as c_vector
 from libcpp.pair cimport pair as c_pair
-from libcpp.functional cimport function
 from ray.includes.optional cimport (
     optional,
 )

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -369,10 +369,14 @@ cdef extern from "ray/core_worker/common.h" nogil:
 
 cdef extern from "ray/gcs/gcs_client/python_callbacks.h" namespace "ray::gcs":
     cdef cppclass MultiItemPyCallback[T]:
-        MultiItemPyCallback(object (*)(CRayStatus, c_vector[T] &&) , void (object, void*), void*) nogil
+        MultiItemPyCallback(
+            object (*)(CRayStatus, c_vector[T] &&),
+            void (object, void*), void*) nogil
 
     cdef cppclass OptionalItemPyCallback[T]:
-        OptionalItemPyCallback(object (*)(CRayStatus, const optional[T]&) , void (object, void*), void*) nogil
+        OptionalItemPyCallback(
+            object (*)(CRayStatus, const optional[T]&),
+            void (object, void*), void*) nogil
 
 cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
     cdef cppclass CActorInfoAccessor "ray::gcs::ActorInfoAccessor":

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -368,41 +368,11 @@ cdef extern from "ray/core_worker/common.h" nogil:
         const c_bool GetDidSpill() const
 
 cdef extern from "ray/gcs/gcs_client/python_callbacks.h" namespace "ray::gcs":
-    # Facility for async bindings. C++ APIs need a callback (`std::function<void(T)>`),
-    # and in the callback we want to do type conversion and complete the Python future.
-    # However, Cython can't wrap a Python callable to a stateful C++ std::function.
+    cdef cppclass MultiItemPyCallback[T]:
+        MultiItemPyCallback(object (*)(CRayStatus, c_vector[T] &&) , void (object, void*), void*) nogil
 
-    # Fortunately, Cython can convert *pure* Cython functions to C++ function pointers.
-    # Hence we make this C++ Functor `CpsHandler` to wrap Python calls to C++ callbacks.
-
-    # Different APIs have different type signatures, but the code of completing the future
-    # is the same. So we ask 2 Cython function pointers: `Handler` and `Continuation`.
-    # `Handler` is unique for each API, converting C++ types to Python types. `Continuation`
-    # is shared by all APIs, completing the Python future.
-
-    # One issue is the `Continuation` have to be stateless, so we need to keep the Future
-    # in the functor. But we don't want to expose the Future to C++ too much, so we keep
-    # it as a void*. For that, we Py_INCREF the Future in the functor and Py_DECREF it
-    # after the completion.
-
-    # On C++ async API calling:
-    # 1. Create a Future.
-    # 2. Creates a `CpsHandler` functor with `Handler` and `Continuation` and the Future.
-    # 3. Invokes the async API with the functor.
-
-    # On C++ async API completion:
-    # 1. The CpsHandler functor is called. It acquires GIL and:
-    # 2. The functor calls the Cython function `Handler` with C++ types. It returns
-    #     # `Tuple[result, exception]`.
-    # 3. The functor calls the Cython function `Continuation` with the tuple and the
-    #     # Future (as void*). It completes the Python future with the result or with the
-    #     # exception.
-
-    cdef cppclass MultiItemCpsHandler[T]:
-        MultiItemCpsHandler(object (*)(CRayStatus, c_vector[T] &&) , void (object, void*), void*) nogil
-
-    cdef cppclass OptionalItemCpsHandler[T]:
-        OptionalItemCpsHandler(object (*)(CRayStatus, const optional[T]&) , void (object, void*), void*) nogil
+    cdef cppclass OptionalItemPyCallback[T]:
+        OptionalItemPyCallback(object (*)(CRayStatus, const optional[T]&) , void (object, void*), void*) nogil
 
 cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
     cdef cppclass CActorInfoAccessor "ray::gcs::ActorInfoAccessor":
@@ -414,7 +384,7 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             int64_t timeout_ms)
 
         CRayStatus AsyncGetAll(
-            const MultiItemCpsHandler[CJobTableData] &callback,
+            const MultiItemPyCallback[CJobTableData] &callback,
             int64_t timeout_ms)
 
     cdef cppclass CNodeInfoAccessor "ray::gcs::NodeInfoAccessor":
@@ -426,7 +396,7 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
         CRayStatus AsyncCheckAlive(
             const c_vector[c_string] &raylet_addresses,
             int64_t timeout_ms,
-            const MultiItemCpsHandler[c_bool] &callback)
+            const MultiItemPyCallback[c_bool] &callback)
 
         CRayStatus DrainNodes(
             const c_vector[CNodeID] &node_ids,
@@ -486,19 +456,19 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             const c_string &ns,
             const c_string &prefix,
             int64_t timeout_ms,
-            const OptionalItemCpsHandler[c_vector[c_string]] &callback)
+            const OptionalItemPyCallback[c_vector[c_string]] &callback)
 
         CRayStatus AsyncInternalKVGet(
             const c_string &ns,
             const c_string &key,
             int64_t timeout_ms,
-            const OptionalItemCpsHandler[c_string] &callback)
+            const OptionalItemPyCallback[c_string] &callback)
 
         CRayStatus AsyncInternalKVMultiGet(
             const c_string &ns,
             const c_vector[c_string] &keys,
             int64_t timeout_ms,
-            const OptionalItemCpsHandler[unordered_map[c_string, c_string]] &callback)
+            const OptionalItemPyCallback[unordered_map[c_string, c_string]] &callback)
 
         CRayStatus AsyncInternalKVPut(
             const c_string &ns,
@@ -506,20 +476,20 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             const c_string &value,
             c_bool overwrite,
             int64_t timeout_ms,
-            const OptionalItemCpsHandler[int] &callback)
+            const OptionalItemPyCallback[int] &callback)
 
         CRayStatus AsyncInternalKVExists(
             const c_string &ns,
             const c_string &key,
             int64_t timeout_ms,
-            const OptionalItemCpsHandler[c_bool] &callback)
+            const OptionalItemPyCallback[c_bool] &callback)
 
         CRayStatus AsyncInternalKVDel(
             const c_string &ns,
             const c_string &key,
             c_bool del_by_prefix,
             int64_t timeout_ms,
-            const OptionalItemCpsHandler[int] &callback)
+            const OptionalItemPyCallback[int] &callback)
 
     cdef cppclass CRuntimeEnvAccessor "ray::gcs::RuntimeEnvAccessor":
         CRayStatus PinRuntimeEnvUri(

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -91,8 +91,10 @@ cdef class NewGcsClient:
             optional[c_string] opt_value = c_string()
             CRayStatus status
         with nogil:
-            status = self.inner.get().InternalKV().Get(ns, key, timeout_ms, opt_value.value())
-        return raise_or_return(convert_optional_str_none_for_not_found(status, opt_value))
+            status = self.inner.get().InternalKV().Get(
+                ns, key, timeout_ms, opt_value.value())
+        return raise_or_return(
+            convert_optional_str_none_for_not_found(status, opt_value))
 
     def internal_kv_multi_get(
         self, keys: List[bytes], namespace=None, timeout=None
@@ -101,10 +103,12 @@ cdef class NewGcsClient:
             c_string ns = namespace or b""
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
             c_vector[c_string] c_keys = [key for key in keys]
-            optional[unordered_map[c_string, c_string]] opt_values = unordered_map[c_string, c_string]()
+            optional[unordered_map[c_string, c_string]] opt_values = \
+                unordered_map[c_string, c_string]()
             CRayStatus status
         with nogil:
-            status = self.inner.get().InternalKV().MultiGet(ns, c_keys, timeout_ms, opt_values.value())
+            status = self.inner.get().InternalKV().MultiGet(
+                ns, c_keys, timeout_ms, opt_values.value())
         return raise_or_return(convert_optional_multi_get(status, opt_values))
 
     def internal_kv_put(self, c_string key, c_string value, c_bool overwrite=False,
@@ -118,7 +122,8 @@ cdef class NewGcsClient:
             optional[c_bool] opt_added = 0
             CRayStatus status
         with nogil:
-            status = self.inner.get().InternalKV().Put(ns, key, value, overwrite, timeout_ms, opt_added.value())
+            status = self.inner.get().InternalKV().Put(
+                ns, key, value, overwrite, timeout_ms, opt_added.value())
         added = raise_or_return(convert_optional_bool(status, opt_added))
         return 1 if added else 0
 
@@ -133,7 +138,8 @@ cdef class NewGcsClient:
             optional[int] opt_num_deleted = 0
             CRayStatus status
         with nogil:
-            status = self.inner.get().InternalKV().Del(ns, key, del_by_prefix, timeout_ms, opt_num_deleted.value())
+            status = self.inner.get().InternalKV().Del(
+                ns, key, del_by_prefix, timeout_ms, opt_num_deleted.value())
         return raise_or_return(convert_optional_int(status, opt_num_deleted))
 
     def internal_kv_keys(
@@ -145,7 +151,8 @@ cdef class NewGcsClient:
             optional[c_vector[c_string]] opt_keys = c_vector[c_string]()
             CRayStatus status
         with nogil:
-            status = self.inner.get().InternalKV().Keys(ns, prefix, timeout_ms, opt_keys.value())
+            status = self.inner.get().InternalKV().Keys(
+                ns, prefix, timeout_ms, opt_keys.value())
         return raise_or_return(convert_optional_vector_str(status, opt_keys))
 
     def internal_kv_exists(self, c_string key, namespace=None, timeout=None) -> bool:
@@ -155,7 +162,8 @@ cdef class NewGcsClient:
             optional[c_bool] opt_exists = 0
             CRayStatus status
         with nogil:
-            status = self.inner.get().InternalKV().Exists(ns, key, timeout_ms, opt_exists.value())
+            status = self.inner.get().InternalKV().Exists(
+                ns, key, timeout_ms, opt_exists.value())
         return raise_or_return(convert_optional_bool(status, opt_exists))
 
     #############################################################
@@ -283,7 +291,8 @@ cdef class NewGcsClient:
             c_vector[c_bool] results
             CRayStatus status
         with nogil:
-            status = self.inner.get().Nodes().CheckAlive(c_node_ips, timeout_ms, results)
+            status = self.inner.get().Nodes().CheckAlive(
+                c_node_ips, timeout_ms, results)
         return raise_or_return(convert_multi_bool(status, move(results)))
 
     def async_check_alive(
@@ -316,7 +325,8 @@ cdef class NewGcsClient:
         for node_id in node_ids:
             c_node_ids.push_back(CNodeID.FromBinary(node_id))
         with nogil:
-            status = self.inner.get().Nodes().DrainNodes(c_node_ids, timeout_ms, results)
+            status = self.inner.get().Nodes().DrainNodes(
+                c_node_ids, timeout_ms, results)
         return raise_or_return(convert_multi_str(status, move(results)))
 
     def get_all_node_info(

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -291,7 +291,6 @@ cdef class NewGcsClient:
                         fut_ptr)))
         return asyncio.wrap_future(fut)
 
-
     #############################################################
     # NodeInfo methods
     #############################################################
@@ -413,8 +412,12 @@ cdef class NewGcsClient:
 
         with nogil:
             check_status_timeout_as_rpc_error(
-                self.inner.get().Jobs().AsyncGetAll(MultiItemPyCallback[CJobTableData](postprocess_async_get_all_job_info, assign_and_decrement,
-                        fut_ptr), timeout_ms))
+                self.inner.get().Jobs().AsyncGetAll(
+                    MultiItemPyCallback[CJobTableData](
+                        postprocess_async_get_all_job_info,
+                        assign_and_decrement,
+                        fut_ptr),
+                    timeout_ms))
         return asyncio.wrap_future(fut)
 
     #############################################################
@@ -538,7 +541,8 @@ cdef void assign_and_decrement(result, void* fut_ptr):
         cpython.Py_DECREF(fut)
 
 # Returns a Python object, or raises an exception.
-cdef postprocess_async_get_all_job_info(CRayStatus status, c_vector[CJobTableData]&& c_data):
+cdef postprocess_async_get_all_job_info(
+        CRayStatus status, c_vector[CJobTableData]&& c_data):
     # -> Dict[JobID, gcs_pb2.JobTableData]
     cdef c_string b
     try:
@@ -553,7 +557,8 @@ cdef postprocess_async_get_all_job_info(CRayStatus status, c_vector[CJobTableDat
     except Exception as e:
         return None, e
 
-cdef postprocess_optional_str_none_for_not_found(CRayStatus status, const optional[c_string]& c_str):
+cdef postprocess_optional_str_none_for_not_found(
+        CRayStatus status, const optional[c_string]& c_str):
     # -> Optional[bytes]
     try:
         if status.IsNotFound():
@@ -563,7 +568,8 @@ cdef postprocess_optional_str_none_for_not_found(CRayStatus status, const option
     except Exception as e:
         return None, e
 
-cdef postprocess_optional_multi_get(CRayStatus status, const optional[unordered_map[c_string, c_string]]& c_map):
+cdef postprocess_optional_multi_get(
+        CRayStatus status, const optional[unordered_map[c_string, c_string]]& c_map):
     # -> Dict[str, str]
     cdef unordered_map[c_string, c_string].const_iterator it
     try:
@@ -587,7 +593,8 @@ cdef postprocess_optional_int(CRayStatus status, const optional[int]& c_int):
     except Exception as e:
         return None, e
 
-cdef postprocess_optional_vector_str(CRayStatus status, const optional[c_vector[c_string]]& c_vec):
+cdef postprocess_optional_vector_str(
+        CRayStatus status, const optional[c_vector[c_string]]& c_vec):
     # -> Dict[str, str]
     try:
         check_status_timeout_as_rpc_error(status)

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -14,32 +14,9 @@ Binding of C++ ray::gcs::GcsClient.
 #
 # We need to best-effort import everything we need.
 #
-# Implementation Notes:
-#
-# Async API
-#
-# One challenge is that the C++ async API is callback-based, and the callbacks are
-# invoked in the C++ threads. In `make_future_and_callback` we create a future and a
-# callback, and the callback will fulfill the future in the event loop thread. The
-# future is returned to Python to await, and the callback is passed to the C++ async
-# API. Once C++ async API invokes the callback, the future is fulfilled in the Python
-# event loop thread.
-#
-# Marshalling
-#
-# The C++ API returns ints, strings, `ray::Status` and C++ protobuf types. We need to
-# convert them to Python types. In `python_callbacks.h` we define a series of converters
-# with Cpython APIs:
-#
-# - bools, ints and strings are converted using `PyBool_FromLong` and alike.
-# - `ray::Status` is marshalled to a 3-tuple and unmarshall it back to `CRayStatus` via
-#     `to_c_ray_status`.
-# - C++ protobuf types are serialized them to bytes, passed to Python and deserialized
-# in the Python `postprocess` functions. Later if we need performance for specific
-# methods we can add a custom Converter in `python_callbacks.h`.
-
+# For how async API are implemented, see src/ray/gcs/gcs_client/python_callbacks.h
 from asyncio import Future
-from typing import List, Dict, Any, Tuple, Optional, Callable
+from typing import List
 from libcpp.utility cimport move
 import concurrent.futures
 from ray.includes.common cimport (

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -529,7 +529,7 @@ cdef raise_or_return(tup):
 
 cdef convert_get_all_node_info(
         CRayStatus status, c_vector[CGcsNodeInfo]&& c_data):
-    # -> Dict[JobID, gcs_pb2.JobTableData]
+    # -> Dict[NodeID, gcs_pb2.GcsNodeInfo]
     cdef c_string b
     try:
         check_status_timeout_as_rpc_error(status)
@@ -538,7 +538,7 @@ cdef convert_get_all_node_info(
             b = c_proto.SerializeAsString()
             proto = gcs_pb2.GcsNodeInfo()
             proto.ParseFromString(b)
-            node_table_data[proto.node_id] = proto
+            node_table_data[NodeID.from_binary(proto.node_id)] = proto
         return node_table_data, None
     except Exception as e:
         return None, e
@@ -554,7 +554,7 @@ cdef convert_get_all_job_info(
             b = c_proto.SerializeAsString()
             proto = gcs_pb2.JobTableData()
             proto.ParseFromString(b)
-            job_table_data[proto.job_id] = proto
+            job_table_data[JobID.from_binary(proto.job_id)] = proto
         return job_table_data, None
     except Exception as e:
         return None, e

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -853,6 +853,7 @@ class InternalKVAccessor {
   /// \param added It's an output parameter. It'll be set to be true if
   ///     any row is added.
   /// \return Status
+  /// TODO(ryw): change the out parameter type to `int` just like AsyncInternalKVPut.
   virtual Status Put(const std::string &ns,
                      const std::string &key,
                      const std::string &value,

--- a/src/ray/gcs/gcs_client/python_callbacks.h
+++ b/src/ray/gcs/gcs_client/python_callbacks.h
@@ -1,0 +1,355 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Python.h>
+
+#include <boost/optional/optional.hpp>
+#include <functional>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "ray/common/status.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+
+//// Converters
+// Converts C++ types to PyObject*.
+// None of the converters hold the GIL, but all of them requires the GIL to be held.
+// This means the caller should hold the GIL before calling these functions.
+//
+// A Converter is a functor that takes a C++ type and returns a PyObject*.
+// The conversion may fail, in which case the converter should set an exception and return
+// nullptr.
+//
+// By default you can use `DefaultConverter::convert` to convert any type. If you need
+// special handling you can compose out your own.
+class BytesConverter {
+  // Serializes the message to a string. Returns false if the serialization fails.
+  // template <typename T>
+  // static bool serialize(const T &message, std::string &result);
+
+  // Specialization for types with a SerializeToString method
+  template <typename Message>
+  static bool serialize(const Message &message,
+                        std::string &result,
+                        typename std::enable_if<std::is_member_function_pointer<
+                            decltype(&Message::SerializeToString)>::value>::type * = 0) {
+    return message.SerializeToString(&result);
+  }
+
+  // Specialization for types with a Binary method, i.e. `BaseID`s
+  // Never fails.
+  template <typename ID>
+  static bool serialize(
+      const ID &id,
+      std::string &result,
+      typename std::enable_if<
+          std::is_member_function_pointer<decltype(&ID::Binary)>::value>::type * = 0) {
+    result = id.Binary();
+    return true;
+  }
+
+ public:
+  template <typename T>
+  static PyObject *convert(const T &arg) {
+    std::string serialized_message;
+    if (serialize(arg, serialized_message)) {
+      return PyBytes_FromStringAndSize(serialized_message.data(),
+                                       serialized_message.size());
+    } else {
+      PyErr_SetString(PyExc_ValueError, "Failed to serialize message.");
+      Py_RETURN_NONE;
+    }
+  }
+
+  static PyObject *convert(const std::string &arg) {
+    return PyBytes_FromStringAndSize(arg.data(), arg.size());
+  }
+};
+
+class BoolConverter {
+ public:
+  static PyObject *convert(bool arg) { return PyBool_FromLong(arg); }
+};
+
+class IntConverter {
+ public:
+  static PyObject *convert(int arg) { return PyLong_FromLong(arg); }
+};
+
+template <typename Inner>
+class OptionalConverter {
+ public:
+  template <typename T>
+  static PyObject *convert(const boost::optional<T> &arg) {
+    if (arg) {
+      return Inner::convert(*arg);
+    } else {
+      Py_RETURN_NONE;
+    }
+  }
+};
+
+template <typename Inner>
+class VectorConverter {
+ public:
+  template <typename T>
+  static PyObject *convert(const std::vector<T> &arg) {
+    PyObject *list = PyList_New(arg.size());
+    for (size_t i = 0; i < arg.size(); i++) {
+      PyObject *item = Inner::convert(arg[i]);
+      if (item == nullptr) {
+        // Failed to convert an item. Free the list and all items within.
+        Py_DECREF(list);
+        return nullptr;
+      }
+      PyList_SetItem(list, i, Inner::convert(arg[i]));
+    }
+    return list;
+  }
+};
+
+// Returns a Python tuple of two elements.
+template <typename Left, typename Right>
+class PairConverter {
+ public:
+  template <typename T, typename U>
+  static PyObject *convert(const T &left, const U &right) {
+    PyObject *result = PyTuple_New(2);
+    PyObject *left_obj = Left::convert(left);
+    if (left_obj == nullptr) {
+      Py_DECREF(result);
+      return nullptr;
+    }
+    PyTuple_SetItem(result, 0, left_obj);
+    PyObject *right_obj = Right::convert(right);
+    if (right_obj == nullptr) {
+      Py_DECREF(result);
+      return nullptr;
+    }
+    PyTuple_SetItem(result, 1, right_obj);
+    return result;
+  }
+};
+
+template <typename KeyConverter, typename ValueConverter>
+class MapConverter {
+ public:
+  template <typename MapType>
+  static PyObject *convert(const MapType &arg) {
+    PyObject *dict = PyDict_New();
+    for (const auto &pair : arg) {
+      PyObject *key = KeyConverter::convert(pair.first);
+      if (key == nullptr) {
+        Py_DECREF(dict);
+        return nullptr;
+      }
+      PyObject *value = ValueConverter::convert(pair.second);
+      if (value == nullptr) {
+        Py_DECREF(key);
+        Py_DECREF(dict);
+        return nullptr;
+      }
+      if (PyDict_SetItem(dict, key, value) < 0) {
+        Py_DECREF(key);
+        Py_DECREF(value);
+        Py_DECREF(dict);
+        return nullptr;
+      }
+      Py_XDECREF(key);
+      Py_XDECREF(value);
+    }
+    return dict;
+  }
+};
+
+// Converts ray::Status to Tuple[StatusCode, error_message, rpc_code]
+class StatusConverter {
+ public:
+  static PyObject *convert(const ray::Status &status) {
+    static_assert(std::is_same_v<char, std::underlying_type_t<ray::StatusCode>>,
+                  "StatusCode underlying type should be char.");
+    return PyTuple_Pack(3,
+                        IntConverter::convert(static_cast<int>(status.code())),
+                        BytesConverter::convert(status.message()),
+                        IntConverter::convert(status.rpc_code()));
+  }
+};
+
+// Default converter, converts all types implemented above.
+// Resolution:
+// - single bool, int, status: BoolConverter, IntConverter, StatusConverter
+// - optional<T>:              OptionalConverter<T>
+// - vector<T>:                VectorConverter<T>
+// - single generic argument:  BytesConverter
+// - 2 args (T, U):            PairConverter<T, U>
+// - map<K, V>:                MapConverter<K, V> (we can't do generics over MapType for
+// collision w/ BytesConverter, so we specialize for std::unordered_map and
+// absl::flat_hash_map)
+class DefaultConverter {
+ public:
+  static PyObject *convert(bool arg) { return BoolConverter::convert(arg); }
+  static PyObject *convert(int arg) { return IntConverter::convert(arg); }
+  static PyObject *convert(const Status &arg) { return StatusConverter::convert(arg); }
+
+  template <typename T>
+  static PyObject *convert(const T &arg) {
+    return BytesConverter::convert(arg);
+  }
+  template <typename T>
+  static PyObject *convert(const boost::optional<T> &arg) {
+    return OptionalConverter<DefaultConverter>::convert(arg);
+  }
+  template <typename T>
+  static PyObject *convert(const std::vector<T> &arg) {
+    return VectorConverter<DefaultConverter>::convert(arg);
+  }
+  template <typename T, typename U>
+  static PyObject *convert(const T &left, const U &right) {
+    return PairConverter<DefaultConverter, DefaultConverter>::convert(left, right);
+  }
+  template <typename Key, typename Value>
+  static PyObject *convert(const std::unordered_map<Key, Value> &arg) {
+    return MapConverter<DefaultConverter, DefaultConverter>::convert(arg);
+  }
+  template <typename Key, typename Value>
+  static PyObject *convert(const absl::flat_hash_map<Key, Value> &arg) {
+    return MapConverter<DefaultConverter, DefaultConverter>::convert(arg);
+  }
+};
+
+// Wraps a Python `Callable[[T, Exception], None]` into a C++ `std::function<void(U)>`.
+// This is a base class for all the callbacks, with subclass handling the conversion.
+// The base class handles:
+// - GIL management
+// - PyObject Ref counting
+// - Exception handling.
+//
+// `Converter`: a functor that converts U to owned PyObject*.
+//
+// TODO: For all these we also need to handle exc. We do this by giving the py_callable
+// another arg so it becomes Callable[[T, Exception], None]. The exception is a
+// 3-tuple of (type, value, tb).
+// TODO: Subscribe need iterator/generator.
+template <class Converter>
+class PyCallback {
+ private:
+  class PythonGilHolder {
+   public:
+    PythonGilHolder() : state_(PyGILState_Ensure()) {}
+    ~PythonGilHolder() { PyGILState_Release(state_); }
+
+   private:
+    PyGILState_STATE state_;
+  };
+
+ public:
+  // Ref counted Python object.
+  // This callback class is copyable, and as a std::function it's indeed copied around.
+  // But we don't want to hold the GIL and do ref counting so many times, so we use a
+  // shared_ptr to manage the ref count for us, and only call Py_XINCREF once.
+  //
+  // Note this ref counted is only from C++ side. If this ref count goes to 0, we only
+  // Issue 1 decref, which does not necessarily free the object.
+  std::shared_ptr<PyObject> py_callable;
+
+  // Needed by Cython to place a placeholder object.
+  PyCallback() {}
+
+  PyCallback(PyObject *callable) {
+    if (callable == nullptr) {
+      py_callable = nullptr;
+      return;
+    }
+    PythonGilHolder gil;
+    Py_XINCREF(callable);
+
+    py_callable = std::shared_ptr<PyObject>(callable, [](PyObject *obj) {
+      PythonGilHolder gil;
+      Py_XDECREF(obj);
+    });
+  }
+
+  // Typically Args is just a single argument, but we allow multiple arguments for e.g.
+  // (Status, boost::optional<MessageType>).
+  //
+  // Converts the arguments to a Python Object and may raise exceptions.
+  // Invokes the Python callable with (converted_arg, None), or (None, exception).
+  //
+  // The callback should not return anything and should not raise exceptions. If it
+  // raises, we catch it and log it.
+  template <typename... Args>
+  void operator()(const Args &...args) {
+    if (py_callable == nullptr) {
+      return;
+    }
+
+    // Hold the GIL.
+    PythonGilHolder gil;
+    PyObject *arg_obj = Converter::convert(args...);
+    if (arg_obj == nullptr) {
+      // Failed to convert the arguments. The exception is set by the converter.
+      PyObject *exc_obj = PyErr_Occurred();
+      if (exc_obj == nullptr) {
+        // The converter didn't set an exception?
+        RAY_LOG(WARNING) << "Failed to convert arguments, but no exception set.";
+        PyErr_SetString(PyExc_ValueError, "Failed to convert arguments.");
+        exc_obj = PyErr_Occurred();
+      }
+      PyObject *result =
+          PyObject_CallFunctionObjArgs(py_callable.get(), Py_None, exc_obj, NULL);
+      Py_XDECREF(result);
+    } else {
+      PyObject *result =
+          PyObject_CallFunctionObjArgs(py_callable.get(), arg_obj, Py_None, NULL);
+      Py_XDECREF(arg_obj);
+      Py_XDECREF(result);
+    }
+    if (PyErr_Occurred()) {
+      // Our binding code raised exceptions. Not much we can do here. Print it out.
+      PyObject *ptype, *pvalue, *ptraceback;
+      PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+      PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
+      PyObject *str_exc = PyObject_Str(pvalue);
+      const char *exc_str = PyUnicode_AsUTF8(str_exc);
+
+      RAY_LOG(ERROR) << "Python exception in cpython binding callback: " << exc_str;
+
+      // Clean up
+      Py_XDECREF(ptype);
+      Py_XDECREF(pvalue);
+      Py_XDECREF(ptraceback);
+      Py_XDECREF(str_exc);
+
+      PyErr_Clear();
+    }
+  }
+};
+
+// Concrete callback types.
+// Most types are using the DefaultConverter, but we allow specialization for some types.
+using PyDefaultCallback = PyCallback<DefaultConverter>;
+// Specialization for a pair of (Status, Vector<T>).
+// We need this because `MultiItemCallback` uses (Status, std::vector<T>&&) not const ref.
+// and C++ can't deduce it well (will implicit convert the vector&& to bool)
+template <typename ItemConverter>
+using PyMultiItemCallback =
+    PyCallback<PairConverter<StatusConverter, VectorConverter<ItemConverter>>>;
+
+}  // namespace ray

--- a/src/ray/gcs/gcs_client/python_callbacks.h
+++ b/src/ray/gcs/gcs_client/python_callbacks.h
@@ -16,340 +16,83 @@
 
 #include <Python.h>
 
-#include <boost/optional/optional.hpp>
-#include <functional>
 #include <string>
-#include <type_traits>
 #include <vector>
 
-#include "absl/container/flat_hash_map.h"
-#include "ray/common/status.h"
 #include "ray/util/logging.h"
 
 namespace ray {
+namespace gcs {
 
-//// Converters
-// Converts C++ types to PyObject*.
-// None of the converters hold the GIL, but all of them requires the GIL to be held.
-// This means the caller should hold the GIL before calling these functions.
-//
-// A Converter is a functor that takes a C++ type and returns a PyObject*.
-// The conversion may fail, in which case the converter should set an exception and return
-// nullptr.
-//
-// By default you can use `DefaultConverter::convert` to convert any type. If you need
-// special handling you can compose out your own.
-class BytesConverter {
-  // Serializes the message to a string. Returns false if the serialization fails.
-  // template <typename T>
-  // static bool serialize(const T &message, std::string &result);
-
-  // Specialization for types with a SerializeToString method
-  template <typename Message>
-  static bool serialize(const Message &message,
-                        std::string &result,
-                        typename std::enable_if<std::is_member_function_pointer<
-                            decltype(&Message::SerializeToString)>::value>::type * = 0) {
-    return message.SerializeToString(&result);
-  }
-
-  // Specialization for types with a Binary method, i.e. `BaseID`s
-  // Never fails.
-  template <typename ID>
-  static bool serialize(
-      const ID &id,
-      std::string &result,
-      typename std::enable_if<
-          std::is_member_function_pointer<decltype(&ID::Binary)>::value>::type * = 0) {
-    result = id.Binary();
-    return true;
-  }
-
+class PythonGilHolder {
  public:
-  template <typename T>
-  static PyObject *convert(const T &arg) {
-    std::string serialized_message;
-    if (serialize(arg, serialized_message)) {
-      return PyBytes_FromStringAndSize(serialized_message.data(),
-                                       serialized_message.size());
-    } else {
-      PyErr_SetString(PyExc_ValueError, "Failed to serialize message.");
-      Py_RETURN_NONE;
-    }
-  }
+  PythonGilHolder() : state_(PyGILState_Ensure()) {}
+  ~PythonGilHolder() { PyGILState_Release(state_); }
 
-  static PyObject *convert(const std::string &arg) {
-    return PyBytes_FromStringAndSize(arg.data(), arg.size());
-  }
-};
-
-class BoolConverter {
- public:
-  static PyObject *convert(bool arg) { return PyBool_FromLong(arg); }
-};
-
-class IntConverter {
- public:
-  static PyObject *convert(int arg) { return PyLong_FromLong(arg); }
-};
-
-template <typename Inner>
-class OptionalConverter {
- public:
-  template <typename T>
-  static PyObject *convert(const boost::optional<T> &arg) {
-    if (arg) {
-      return Inner::convert(*arg);
-    } else {
-      Py_RETURN_NONE;
-    }
-  }
-};
-
-template <typename Inner>
-class VectorConverter {
- public:
-  template <typename T>
-  static PyObject *convert(const std::vector<T> &arg) {
-    PyObject *list = PyList_New(arg.size());
-    for (size_t i = 0; i < arg.size(); i++) {
-      PyObject *item = Inner::convert(arg[i]);
-      if (item == nullptr) {
-        // Failed to convert an item. Free the list and all items within.
-        Py_DECREF(list);
-        return nullptr;
-      }
-      PyList_SetItem(list, i, Inner::convert(arg[i]));
-    }
-    return list;
-  }
-};
-
-// Returns a Python tuple of two elements.
-template <typename Left, typename Right>
-class PairConverter {
- public:
-  template <typename T, typename U>
-  static PyObject *convert(const T &left, const U &right) {
-    PyObject *result = PyTuple_New(2);
-    PyObject *left_obj = Left::convert(left);
-    if (left_obj == nullptr) {
-      Py_DECREF(result);
-      return nullptr;
-    }
-    PyTuple_SetItem(result, 0, left_obj);
-    PyObject *right_obj = Right::convert(right);
-    if (right_obj == nullptr) {
-      Py_DECREF(result);
-      return nullptr;
-    }
-    PyTuple_SetItem(result, 1, right_obj);
-    return result;
-  }
-};
-
-template <typename KeyConverter, typename ValueConverter>
-class MapConverter {
- public:
-  template <typename MapType>
-  static PyObject *convert(const MapType &arg) {
-    PyObject *dict = PyDict_New();
-    for (const auto &pair : arg) {
-      PyObject *key = KeyConverter::convert(pair.first);
-      if (key == nullptr) {
-        Py_DECREF(dict);
-        return nullptr;
-      }
-      PyObject *value = ValueConverter::convert(pair.second);
-      if (value == nullptr) {
-        Py_DECREF(key);
-        Py_DECREF(dict);
-        return nullptr;
-      }
-      if (PyDict_SetItem(dict, key, value) < 0) {
-        Py_DECREF(key);
-        Py_DECREF(value);
-        Py_DECREF(dict);
-        return nullptr;
-      }
-      Py_XDECREF(key);
-      Py_XDECREF(value);
-    }
-    return dict;
-  }
-};
-
-// Converts ray::Status to Tuple[StatusCode, error_message, rpc_code]
-class StatusConverter {
- public:
-  static PyObject *convert(const ray::Status &status) {
-    static_assert(std::is_same_v<char, std::underlying_type_t<ray::StatusCode>>,
-                  "StatusCode underlying type should be char.");
-    return PyTuple_Pack(3,
-                        IntConverter::convert(static_cast<int>(status.code())),
-                        BytesConverter::convert(status.message()),
-                        IntConverter::convert(status.rpc_code()));
-  }
-};
-
-// Default converter, converts all types implemented above.
-// Resolution:
-// - single bool, int, status: BoolConverter, IntConverter, StatusConverter
-// - optional<T>:              OptionalConverter<T>
-// - vector<T>:                VectorConverter<T>
-// - single generic argument:  BytesConverter
-// - 2 args (T, U):            PairConverter<T, U>
-// - map<K, V>:                MapConverter<K, V> (we can't do generics over MapType for
-// collision w/ BytesConverter, so we specialize for std::unordered_map and
-// absl::flat_hash_map)
-class DefaultConverter {
- public:
-  static PyObject *convert(bool arg) { return BoolConverter::convert(arg); }
-  static PyObject *convert(int arg) { return IntConverter::convert(arg); }
-  static PyObject *convert(const Status &arg) { return StatusConverter::convert(arg); }
-
-  template <typename T>
-  static PyObject *convert(const T &arg) {
-    return BytesConverter::convert(arg);
-  }
-  template <typename T>
-  static PyObject *convert(const boost::optional<T> &arg) {
-    return OptionalConverter<DefaultConverter>::convert(arg);
-  }
-  template <typename T>
-  static PyObject *convert(const std::vector<T> &arg) {
-    return VectorConverter<DefaultConverter>::convert(arg);
-  }
-  template <typename T, typename U>
-  static PyObject *convert(const T &left, const U &right) {
-    return PairConverter<DefaultConverter, DefaultConverter>::convert(left, right);
-  }
-  template <typename Key, typename Value>
-  static PyObject *convert(const std::unordered_map<Key, Value> &arg) {
-    return MapConverter<DefaultConverter, DefaultConverter>::convert(arg);
-  }
-  template <typename Key, typename Value>
-  static PyObject *convert(const absl::flat_hash_map<Key, Value> &arg) {
-    return MapConverter<DefaultConverter, DefaultConverter>::convert(arg);
-  }
-};
-
-// Wraps a Python `Callable[[T, Exception], None]` into a C++ `std::function<void(U)>`.
-// This is a base class for all the callbacks, with subclass handling the conversion.
-// The base class handles:
-// - GIL management
-// - PyObject Ref counting
-// - Exception handling.
-//
-// `Converter`: a functor that converts U to owned PyObject*.
-//
-// TODO: For all these we also need to handle exc. We do this by giving the py_callable
-// another arg so it becomes Callable[[T, Exception], None]. The exception is a
-// 3-tuple of (type, value, tb).
-// TODO: Subscribe need iterator/generator.
-template <class Converter>
-class PyCallback {
  private:
-  class PythonGilHolder {
-   public:
-    PythonGilHolder() : state_(PyGILState_Ensure()) {}
-    ~PythonGilHolder() { PyGILState_Release(state_); }
-
-   private:
-    PyGILState_STATE state_;
-  };
-
- public:
-  // Ref counted Python object.
-  // This callback class is copyable, and as a std::function it's indeed copied around.
-  // But we don't want to hold the GIL and do ref counting so many times, so we use a
-  // shared_ptr to manage the ref count for us, and only call Py_XINCREF once.
-  //
-  // Note this ref counted is only from C++ side. If this ref count goes to 0, we only
-  // Issue 1 decref, which does not necessarily free the object.
-  std::shared_ptr<PyObject> py_callable;
-
-  // Needed by Cython to place a placeholder object.
-  PyCallback() {}
-
-  PyCallback(PyObject *callable) {
-    if (callable == nullptr) {
-      py_callable = nullptr;
-      return;
-    }
-    PythonGilHolder gil;
-    Py_XINCREF(callable);
-
-    py_callable = std::shared_ptr<PyObject>(callable, [](PyObject *obj) {
-      PythonGilHolder gil;
-      Py_XDECREF(obj);
-    });
-  }
-
-  // Typically Args is just a single argument, but we allow multiple arguments for e.g.
-  // (Status, boost::optional<MessageType>).
-  //
-  // Converts the arguments to a Python Object and may raise exceptions.
-  // Invokes the Python callable with (converted_arg, None), or (None, exception).
-  //
-  // The callback should not return anything and should not raise exceptions. If it
-  // raises, we catch it and log it.
-  template <typename... Args>
-  void operator()(const Args &...args) {
-    if (py_callable == nullptr) {
-      return;
-    }
-
-    // Hold the GIL.
-    PythonGilHolder gil;
-    PyObject *arg_obj = Converter::convert(args...);
-    if (arg_obj == nullptr) {
-      // Failed to convert the arguments. The exception is set by the converter.
-      PyObject *exc_obj = PyErr_Occurred();
-      if (exc_obj == nullptr) {
-        // The converter didn't set an exception?
-        RAY_LOG(WARNING) << "Failed to convert arguments, but no exception set.";
-        PyErr_SetString(PyExc_ValueError, "Failed to convert arguments.");
-        exc_obj = PyErr_Occurred();
-      }
-      PyObject *result =
-          PyObject_CallFunctionObjArgs(py_callable.get(), Py_None, exc_obj, NULL);
-      Py_XDECREF(result);
-    } else {
-      PyObject *result =
-          PyObject_CallFunctionObjArgs(py_callable.get(), arg_obj, Py_None, NULL);
-      Py_XDECREF(arg_obj);
-      Py_XDECREF(result);
-    }
-    if (PyErr_Occurred()) {
-      // Our binding code raised exceptions. Not much we can do here. Print it out.
-      PyObject *ptype, *pvalue, *ptraceback;
-      PyErr_Fetch(&ptype, &pvalue, &ptraceback);
-      PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
-      PyObject *str_exc = PyObject_Str(pvalue);
-      const char *exc_str = PyUnicode_AsUTF8(str_exc);
-
-      RAY_LOG(ERROR) << "Python exception in cpython binding callback: " << exc_str;
-
-      // Clean up
-      Py_XDECREF(ptype);
-      Py_XDECREF(pvalue);
-      Py_XDECREF(ptraceback);
-      Py_XDECREF(str_exc);
-
-      PyErr_Clear();
-    }
-  }
+  PyGILState_STATE state_;
 };
 
-// Concrete callback types.
-// Most types are using the DefaultConverter, but we allow specialization for some types.
-using PyDefaultCallback = PyCallback<DefaultConverter>;
-// Specialization for a pair of (Status, Vector<T>).
-// We need this because `MultiItemCallback` uses (Status, std::vector<T>&&) not const ref.
-// and C++ can't deduce it well (will implicit convert the vector&& to bool)
-template <typename ItemConverter>
-using PyMultiItemCallback =
-    PyCallback<PairConverter<StatusConverter, VectorConverter<ItemConverter>>>;
+// Facility for async bindings. C++ APIs need a callback (`std::function<void(T)>`),
+// and in the callback we want to do type conversion and complete the Python future.
+// However, Cython can't wrap a Python callable to a stateful C++ std::function.
+//
+// Fortunately, Cython can convert *pure* Cython functions to C++ function pointers.
+// Hence we make this C++ Functor `CpsHandler` to wrap Python calls to C++ callbacks.
+//
+// Different APIs have different type signatures, but the code of completing the future
+// is the same. So we ask 2 Cython function pointers: `Handler` and `Continuation`.
+// `Handler` is unique for each API, converting C++ types to Python types. `Continuation`
+// is shared by all APIs, completing the Python future.
+//
+// One issue is the `Continuation` have to be stateless, so we need to keep the Future
+// in the functor. But we don't want to expose the Future to C++ too much, so we keep
+// it as a void*. For that, we Py_INCREF the Future in the functor and Py_DECREF it
+// after the completion.
+//
+// On C++ async API calling:
+// 1. Create a Future.
+// 2. Creates a `CpsHandler` functor with `Handler` and `Continuation` and the Future.
+// 3. Invokes the async API with the functor.
+//
+// On C++ async API completion:
+// 1. The CpsHandler functor is called. It acquires GIL and:
+// 2. The functor calls the Cython function `Handler` with C++ types. It returns
+//  `Tuple[result, exception]`.
+// 3. The functor calls the Cython function `Continuation` with the tuple and the
+//  Future (as void*). It completes the Python future with the result or with the
+//  exception.
+template <typename... Args>
+class CpsHandler {
+ public:
+  // The Handler is a Cython function that takes Args... and returns a PyObject*.
+  // It must not raise exceptions.
+  // The return PyObject* is passed to the Continuation.
+  using Handler = PyObject *(*)(Args...);
+  // It must not raise exceptions.
+  using Continuation = void (*)(PyObject *, void *);
+
+  CpsHandler(Handler handler, Continuation continuation, void *context)
+      : handler(handler), continuation(continuation), context(context) {}
+
+  void operator()(Args &&...args) {
+    PythonGilHolder gil;
+    PyObject *result = handler(std::forward<Args>(args)...);
+    continuation(result, context);
+  }
+
+ private:
+  Handler handler = nullptr;
+  Continuation continuation = nullptr;
+  void *context = nullptr;
+};
+
+template <typename T>
+using MultiItemCpsHandler = CpsHandler<Status, std::vector<T> &&>;
+
+template <typename Data>
+using OptionalItemCpsHandler = CpsHandler<Status, const std::optional<Data> &>;
+
+}  // namespace gcs
 
 }  // namespace ray


### PR DESCRIPTION
Implements async binding of C++ GcsClient in Python as NewGcsAioClient.

Previously we only have sync GcsClient bindings, ones that blocks on completion. To facilitate GcsAioClient we use python thread pool executor - one dedicated thread blocked for the sync call, whose underlying API is async. This is a big waste and we can do better.

The trick is to play the callback-to-async games wisely. Invoke a C++ async API with a python callback function; the callback serializes the reply data or exception, then switch to the python asyncio thread and complete a future. The future, in turn, is awaited by a converter function that does any python-side treatment (e.g. python protobuf deserialization, or converting to dict), then pass on to user code. The end result is an async method just like Python-native ones.

This PR adds the NewGcsAioClient and uses it as implementation of GcsAioClient by default. Can switch back to the OldGcsAioClient by RAY_USE_OLD_GCS_CLIENT=1.