### PR TITLE
[release auto] use python3 for interpreter

### DIFF
--- a/.buildkite/release-automation/set-ray-version.sh
+++ b/.buildkite/release-automation/set-ray-version.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if [[ -z "${RAY_VERSION:-}" ]]; then
-    RAY_VERSION="$(python python/ray/_version.py | cut -d' ' -f1)"
+    RAY_VERSION="$(python3 python/ray/_version.py | cut -d' ' -f1)"
     if [[ "${RAY_VERSION}" =~ dev0 ]]; then
         echo "RAY_VERSION is not set, value is ${RAY_VERSION}" >/dev/stderr
         exit 1


### PR DESCRIPTION
python is not installed by default in the forge.