### PR TITLE
[Data] Truncate progress bar description

### DIFF
--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -106,17 +106,25 @@ class ProgressBar:
                 "DEFAULT_ENABLE_PROGRESS_BAR_NAME_TRUNCATION = False`."
             )
         op_names = name.split("->")
-        # Include as many operators as possible without exceeding `MAX_NAME_LENGTH`.
-        # Always include the first and last operator names so
-        # it is easy to identify the DAG.
+        if len(op_names) == 1:
+            return op_names[0]
+
+        # Include as many operators as possible without approximately
+        # exceeding `MAX_NAME_LENGTH`. Always include the first and
+        # last operator names soit is easy to identify the DAG.
         truncated_op_names = [op_names[0]]
-        for i, op_name in enumerate(op_names[1:-1]):
-            if len("->".join(truncated_op_names)) + len(op_name) > self.MAX_NAME_LENGTH:
+        for op_name in op_names[1:-1]:
+            if (
+                len("->".join(truncated_op_names))
+                + len("->")
+                + len(op_name)
+                + len("->")
+                + len(op_names[-1])
+            ) > self.MAX_NAME_LENGTH:
                 truncated_op_names.append("...")
                 break
             truncated_op_names.append(op_name)
-        if len(op_names) > 1:
-            truncated_op_names.append(op_names[-1])
+        truncated_op_names.append(op_names[-1])
         return "->".join(truncated_op_names)
 
     def block_until_complete(self, remaining: List[ObjectRef]) -> None:

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -115,7 +115,8 @@ class ProgressBar:
                 truncated_op_names.append("...")
                 break
             truncated_op_names.append(op_name)
-        truncated_op_names.append(op_names[-1])
+        if len(op_names) > 1:
+            truncated_op_names.append(op_names[-1])
         return "->".join(truncated_op_names)
 
     def block_until_complete(self, remaining: List[ObjectRef]) -> None:

--- a/python/ray/data/_internal/progress_bar.py
+++ b/python/ray/data/_internal/progress_bar.py
@@ -55,10 +55,7 @@ class ProgressBar:
         unit: str,
         position: int = 0,
         enabled: Optional[bool] = None,
-        display_full_name: bool = False,
     ):
-        # If True, disables name trunctating.
-        self._display_full_name = display_full_name
         self._desc = self._truncate_name(name)
         self._progress = 0
         # Prepend a space to the unit for better formatting.
@@ -91,7 +88,8 @@ class ProgressBar:
             self._bar = None
 
     def _truncate_name(self, name: str) -> str:
-        if not self._display_full_name and len(name) > self.MAX_NAME_LENGTH:
+        ctx = ray.data.context.DataContext.get_current()
+        if ctx.enable_progress_bar_name_truncation and len(name) > self.MAX_NAME_LENGTH:
             return name[: self.MAX_NAME_LENGTH - 3] + "..."
         return name
 

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -83,6 +83,9 @@ DEFAULT_USE_RAY_TQDM = bool(int(os.environ.get("RAY_TQDM", "1")))
 DEFAULT_ENABLE_PROGRESS_BARS = not bool(
     env_integer("RAY_DATA_DISABLE_PROGRESS_BARS", 0)
 )
+DEFAULT_ENABLE_PROGRESS_BAR_NAME_TRUNCATION = env_bool(
+    "RAY_DATA_ENABLE_PROGRESS_BAR_NAME_TRUNCATION", True
+)
 
 DEFAULT_ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS = False
 
@@ -209,6 +212,9 @@ class DataContext:
             to use.
         use_ray_tqdm: Whether to enable distributed tqdm.
         enable_progress_bars: Whether to enable progress bars.
+        enable_progress_bar_name_truncation: If True, the name of the progress bar
+            (often the operator name) will be truncated if it exceeds
+            `ProgressBar.MAX_NAME_LENGTH`. Otherwise, the full operator name is shown.
         enable_get_object_locations_for_metrics: Whether to enable
             ``get_object_locations`` for metrics.
         write_file_retry_on_errors: A list of substrings of error messages that should
@@ -271,6 +277,9 @@ class DataContext:
     )
     use_ray_tqdm: bool = DEFAULT_USE_RAY_TQDM
     enable_progress_bars: bool = DEFAULT_ENABLE_PROGRESS_BARS
+    enable_progress_bar_name_truncation: bool = (
+        DEFAULT_ENABLE_PROGRESS_BAR_NAME_TRUNCATION
+    )
     enable_get_object_locations_for_metrics: bool = (
         DEFAULT_ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
For `ProgressBar`s used by Ray Data's executor to display operator completion progress, the description of the bar is currently the full operator name. This can become very long and unwieldy with operators with long names, or datasets with many operators (e.g. consecutive `MapBatches` operators become fused into one giant operator with a really long name).

This PR adds logic to truncate the `ProgressBar`'s description if it exceeds 100 characters. There is also a parameter to disable this truncation, and always show the full progress bar description. 

## Related issue number
For the following script:
```
import ray
import time
import os

paths = ["s3://anonymous@air-example-data/iris.csv"]
ds = ray.data.read_csv(paths, override_num_blocks=20)
num_map_ops = 100

def f_with_really_long_name(batch):
    time.sleep(1)
    return batch

for _ in range(num_map_ops):
    ds = ds.map_batches(f_with_really_long_name)

ds.materialize()
```

We can compare the output before and after:
<details>
<summary>Before</summary>
<br>

```
Running 0: 0 bundle [00:00, ? bundle/s]lly_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatch
- ReadCSV->SplitBlocks(20): 1 active, 0 queued, [cpu: 1.0, objects: 5.6KB]: : 18 bundle [00:01, 16.37 bundle/s]es(f_with_really_long_name
- MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_rRunning: 2/10 CPU, 0/0 GPU, 512.0MB/1.0GB object_store_memory: : 0 bundle [00:01, ? bundle/s]apBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name): 2 active, 17 queued, [cpu: 2.0, objects: 512.0MB]: : 0 bundle [00:01, ? bundle/s]
```
</details>

<details>
<summary>After (note the `...` in the last line)</summary>
<br>

```
✔️  Dataset execution finished in 32.55 seconds: 100%|█████████████████████████████████████████████████████████████████████████| 20/20 [00:32<00:00,  1.63s/ bundle]]
- ReadCSV->SplitBlocks(20): 0 active, 0 queued, [cpu: 0.0, objects: 0.0B]: : 20 bundle [00:32,  1.63s/ bundle]]name): 3 active, 17 queued, [cpu: 3.0, objects: 768.0
- MapBatches(f_with_really_long_name)->MapBatches(f_with_really_long_name)->...->MapBatches(f_with_really_long_name): 0 active, 0 queued, [cpu: 0.0, objects: 840.0B
```
</details>


<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
