### PR TITLE
Add perf metrics for 2.34.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 500.076544,
+    "_dashboard_memory_usage_mb": 459.20256,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.72,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1133\t10.03GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3513\t1.74GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4605\t0.91GiB\tpython distributed/test_many_actors.py\n3628\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2320\t0.33GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3104\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4400\t0.07GiB\tray::JobSupervisor\n3791\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3970\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3789\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
-    "actors_per_second": 615.180594485976,
+    "_peak_memory": 3.76,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3447\t1.74GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5206\t0.93GiB\tpython distributed/test_many_actors.py\n3564\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2845\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1249\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3737\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2771\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3884\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n4986\t0.07GiB\tray::JobSupervisor\n3735\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "actors_per_second": 627.338335492887,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 615.180594485976
+            "perf_metric_value": 627.338335492887
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 74.394
+            "perf_metric_value": 178.601
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3035.866
+            "perf_metric_value": 3542.989
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3441.396
+            "perf_metric_value": 3933.547
         }
     ],
     "success": "1",
-    "time": 16.25538921356201
+    "time": 15.940361738204956
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 189.751296,
+    "_dashboard_memory_usage_mb": 193.712128,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3500\t0.55GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1141\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2460\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3625\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4864\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5132\t0.09GiB\tray::StateAPIGeneratorActor.start\n2656\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4657\t0.07GiB\tray::JobSupervisor\n3788\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3786\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 1.65,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3461\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1255\t0.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2918\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3578\t0.18GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4426\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4642\t0.08GiB\tray::StateAPIGeneratorActor.start\n2822\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4216\t0.07GiB\tray::JobSupervisor\n3750\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3748\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 344.2841239720449
+            "perf_metric_value": 342.8427005545737
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.971
+            "perf_metric_value": 3.87
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 68.223
+            "perf_metric_value": 34.039
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 140.505
+            "perf_metric_value": 119.573
         }
     ],
     "success": "1",
-    "tasks_per_second": 344.2841239720449,
-    "time": 302.9045777320862,
+    "tasks_per_second": 342.8427005545737,
+    "time": 302.91678953170776,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 189.5424,
+    "_dashboard_memory_usage_mb": 120.446976,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.2,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1249\t9.21GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3551\t0.98GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4583\t0.42GiB\tpython distributed/test_many_pgs.py\n2390\t0.25GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3683\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3849\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2628\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4372\t0.07GiB\tray::JobSupervisor\n4039\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3847\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 2.12,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3438\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5718\t0.4GiB\tpython distributed/test_many_pgs.py\n2536\t0.35GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1206\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3560\t0.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2784\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3734\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n5507\t0.07GiB\tray::JobSupervisor\n3877\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3732\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.687659485012095
+            "perf_metric_value": 22.249430148995714
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.39
+            "perf_metric_value": 3.722
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.334
+            "perf_metric_value": 12.055
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 332.736
+            "perf_metric_value": 358.789
         }
     ],
-    "pgs_per_second": 22.687659485012095,
+    "pgs_per_second": 22.249430148995714,
     "success": "1",
-    "time": 44.07682514190674
+    "time": 44.944971323013306
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1232.416768,
+    "_dashboard_memory_usage_mb": 1263.501312,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.37,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3733\t1.96GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3618\t1.68GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4484\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1235\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2417\t0.24GiB\t/usr/bin/vector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4683\t0.09GiB\tray::StateAPIGeneratorActor.start\n4621\t0.08GiB\tray::DashboardTester.run\n4285\t0.07GiB\tray::JobSupervisor\n3899\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3025\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/",
+    "_peak_memory": 5.45,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3382\t3.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3499\t0.83GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4186\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1117\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2858\t0.22GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4397\t0.08GiB\tray::DashboardTester.run\n4472\t0.08GiB\tray::StateAPIGeneratorActor.start\n2725\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3674\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3984\t0.07GiB\tray::JobSupervisor",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 578.8766226882515
+            "perf_metric_value": 557.3705625276606
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 141.285
+            "perf_metric_value": 167.38
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1649.419
+            "perf_metric_value": 3170.14
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3448.302
+            "perf_metric_value": 5042.844
         }
     ],
     "success": "1",
-    "tasks_per_second": 578.8766226882515,
-    "time": 317.2748382091522,
+    "tasks_per_second": 557.3705625276606,
+    "time": 317.94138526916504,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.32.0"}
+{"release_version": "2.34.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        9241.526232225291,
-        132.04014985321072
+        9060.701663275304,
+        118.69740715773278
     ],
     "1_1_actor_calls_concurrent": [
-        5433.582983286094,
-        203.77840697231508
+        5167.9800954515,
+        141.99267026522367
     ],
     "1_1_actor_calls_sync": [
-        2063.6151992547047,
-        41.087530717556106
+        2055.7051275912527,
+        54.594914220148404
     ],
     "1_1_async_actor_calls_async": [
-        4541.586332149929,
-        244.29996229786013
+        4456.606860484332,
+        300.0483750432424
     ],
     "1_1_async_actor_calls_sync": [
-        1499.3849412965205,
-        31.19427048888692
+        1486.2327104183764,
+        35.32117622112775
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2981.1837517965705,
-        129.12171570334309
+        3038.941703794114,
+        225.62938703844412
     ],
     "1_n_actor_calls_async": [
-        8825.80303025342,
-        137.32428841583177
+        8786.234839177117,
+        155.79705585932524
     ],
     "1_n_async_actor_calls_async": [
-        7872.539571860014,
-        165.88537648403613
+        7804.984752431155,
+        207.2088124010455
     ],
     "client__1_1_actor_calls_async": [
-        1020.0334940870466,
-        10.493190404958229
+        963.1902909183787,
+        7.024139165271597
     ],
     "client__1_1_actor_calls_concurrent": [
-        1023.0375442360598,
-        9.873541601530931
+        947.6614978210325,
+        6.215662216629677
     ],
     "client__1_1_actor_calls_sync": [
-        509.9599816194958,
-        26.55553704027681
+        519.725991336052,
+        5.524396654486067
     ],
     "client__get_calls": [
-        1175.306212007341,
-        6.848643951008982
+        1119.7725751916082,
+        22.31873036313672
     ],
     "client__put_calls": [
-        794.0222907625882,
-        23.489002030449676
+        801.476709529905,
+        24.90986781791733
     ],
     "client__put_gigabytes": [
-        0.13160907472336658,
-        0.000597729723962875
+        0.13929452807454937,
+        0.0004893965578803182
     ],
     "client__tasks_and_get_batch": [
-        0.9724735940970552,
-        0.014680443297132861
+        0.911263457119588,
+        0.009582733256630546
     ],
     "client__tasks_and_put_batch": [
-        11309.127935041968,
-        230.80678248448353
+        11004.98249042869,
+        406.99702282940336
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12520.58965968965,
-        127.48894702402845
+        12455.514706383783,
+        82.98752196297701
     ],
     "multi_client_put_gigabytes": [
-        37.39369500194131,
-        2.6031810715230144
+        38.4735559860673,
+        1.895531621126946
     ],
     "multi_client_tasks_async": [
-        23283.706392178385,
-        3093.661219187642
+        23311.858831941317,
+        2350.5613878864333
     ],
     "n_n_actor_calls_async": [
-        27232.414296780542,
-        758.7912476297421
+        26545.931713712664,
+        526.4393166387501
     ],
     "n_n_actor_calls_with_arg_async": [
-        2605.856362562882,
-        17.70949766672506
+        2699.08314274893,
+        34.72492860665786
     ],
     "n_n_async_actor_calls_async": [
-        23591.92555321498,
-        1068.3154500015673
+        22710.046003881216,
+        682.7591872434975
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10121.103242219997
+            "perf_metric_value": 10303.517743023112
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5227.298677681264
+            "perf_metric_value": 5241.163782117501
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12520.58965968965
+            "perf_metric_value": 12455.514706383783
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.46333348333893
+            "perf_metric_value": 20.184014305625574
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.9070880635954
+            "perf_metric_value": 7.900197666889211
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 37.39369500194131
+            "perf_metric_value": 38.4735559860673
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.756244682120503
+            "perf_metric_value": 13.679337230724197
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.302957674144409
+            "perf_metric_value": 5.485273551888224
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 981.7983599799647
+            "perf_metric_value": 986.5998779605792
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7981.871660623128
+            "perf_metric_value": 8011.455682416454
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23283.706392178385
+            "perf_metric_value": 23311.858831941317
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2063.6151992547047
+            "perf_metric_value": 2055.7051275912527
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9241.526232225291
+            "perf_metric_value": 9060.701663275304
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5433.582983286094
+            "perf_metric_value": 5167.9800954515
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8825.80303025342
+            "perf_metric_value": 8786.234839177117
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27232.414296780542
+            "perf_metric_value": 26545.931713712664
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2605.856362562882
+            "perf_metric_value": 2699.08314274893
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1499.3849412965205
+            "perf_metric_value": 1486.2327104183764
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4541.586332149929
+            "perf_metric_value": 4456.606860484332
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2981.1837517965705
+            "perf_metric_value": 3038.941703794114
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7872.539571860014
+            "perf_metric_value": 7804.984752431155
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23591.92555321498
+            "perf_metric_value": 22710.046003881216
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 784.1202913310515
+            "perf_metric_value": 824.4108502776797
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1175.306212007341
+            "perf_metric_value": 1119.7725751916082
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 794.0222907625882
+            "perf_metric_value": 801.476709529905
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13160907472336658
+            "perf_metric_value": 0.13929452807454937
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11309.127935041968
+            "perf_metric_value": 11004.98249042869
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 509.9599816194958
+            "perf_metric_value": 519.725991336052
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1020.0334940870466
+            "perf_metric_value": 963.1902909183787
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1023.0375442360598
+            "perf_metric_value": 947.6614978210325
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9724735940970552
+            "perf_metric_value": 0.911263457119588
         }
     ],
     "placement_group_create/removal": [
-        784.1202913310515,
-        2.674372951834296
+        824.4108502776797,
+        17.72810428024577
     ],
     "single_client_get_calls_Plasma_Store": [
-        10121.103242219997,
-        344.32801069166834
+        10303.517743023112,
+        277.61596662520196
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.756244682120503,
-        0.09167947289933939
+        13.679337230724197,
+        0.3123070691705992
     ],
     "single_client_put_calls_Plasma_Store": [
-        5227.298677681264,
-        73.4380388161718
+        5241.163782117501,
+        47.53421003771766
     ],
     "single_client_put_gigabytes": [
-        19.46333348333893,
-        5.440510765037708
+        20.184014305625574,
+        5.646629723807168
     ],
     "single_client_tasks_and_get_batch": [
-        7.9070880635954,
-        0.3896057750384761
+        7.900197666889211,
+        0.39150208385232466
     ],
     "single_client_tasks_async": [
-        7981.871660623128,
-        279.39202571036645
+        8011.455682416454,
+        468.6887008054221
     ],
     "single_client_tasks_sync": [
-        981.7983599799647,
-        9.168440320587788
+        986.5998779605792,
+        16.522476248712984
     ],
     "single_client_wait_1k_refs": [
-        5.302957674144409,
-        0.08188715171339318
+        5.485273551888224,
+        0.07839577116526375
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 19.440196102000016,
+    "broadcast_time": 18.28579454300001,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 19.440196102000016
+            "perf_metric_value": 18.28579454300001
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.415384294000006,
-    "get_time": 23.645023898000005,
+    "args_time": 18.382605733000005,
+    "get_time": 23.411743029999997,
     "large_object_size": 107374182400,
-    "large_object_time": 30.474318987000004,
+    "large_object_time": 32.98956875599998,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.415384294000006
+            "perf_metric_value": 18.382605733000005
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.771739185999991
+            "perf_metric_value": 5.741477676000002
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.645023898000005
+            "perf_metric_value": 23.411743029999997
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 187.84350834300002
+            "perf_metric_value": 186.319367591
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.474318987000004
+            "perf_metric_value": 32.98956875599998
         }
     ],
-    "queued_time": 187.84350834300002,
-    "returns_time": 5.771739185999991,
+    "queued_time": 186.319367591,
+    "returns_time": 5.741477676000002,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0517002582550048,
-    "max_iteration_time": 2.9446706771850586,
-    "min_iteration_time": 0.512861967086792,
+    "avg_iteration_time": 1.0309033346176149,
+    "max_iteration_time": 3.268310546875,
+    "min_iteration_time": 0.07307100296020508,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0517002582550048
+            "perf_metric_value": 1.0309033346176149
         }
     ],
     "success": 1,
-    "total_time": 105.17023873329163
+    "total_time": 103.0905613899231
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.851820707321167
+            "perf_metric_value": 8.773437261581421
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.859845495224
+            "perf_metric_value": 23.938837790489195
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 65.67325186729431
+            "perf_metric_value": 61.69442081451416
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.573556900024414
+            "perf_metric_value": 2.573246955871582
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3065.2378103733063
+            "perf_metric_value": 3035.906775712967
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.48427910077229586
+            "perf_metric_value": 0.5129273527822178
         }
     ],
-    "stage_0_time": 10.851820707321167,
-    "stage_1_avg_iteration_time": 23.859845495224,
-    "stage_1_max_iteration_time": 24.58528447151184,
-    "stage_1_min_iteration_time": 23.121485948562622,
-    "stage_1_time": 238.59854221343994,
-    "stage_2_avg_iteration_time": 65.67325186729431,
-    "stage_2_max_iteration_time": 66.63724613189697,
-    "stage_2_min_iteration_time": 64.36803317070007,
-    "stage_2_time": 328.3679451942444,
-    "stage_3_creation_time": 1.573556900024414,
-    "stage_3_time": 3065.2378103733063,
-    "stage_4_spread": 0.48427910077229586,
+    "stage_0_time": 8.773437261581421,
+    "stage_1_avg_iteration_time": 23.938837790489195,
+    "stage_1_max_iteration_time": 24.63253116607666,
+    "stage_1_min_iteration_time": 23.625248670578003,
+    "stage_1_time": 239.38846349716187,
+    "stage_2_avg_iteration_time": 61.69442081451416,
+    "stage_2_max_iteration_time": 62.908058643341064,
+    "stage_2_min_iteration_time": 59.646355867385864,
+    "stage_2_time": 308.4730384349823,
+    "stage_3_creation_time": 2.573246955871582,
+    "stage_3_time": 3035.906775712967,
+    "stage_4_spread": 0.5129273527822178,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9259017792794532,
-    "avg_pg_remove_time_ms": 0.9261005015020346,
+    "avg_pg_create_time_ms": 0.9371462897900398,
+    "avg_pg_remove_time_ms": 0.9081441951950084,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9259017792794532
+            "perf_metric_value": 0.9371462897900398
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9261005015020346
+            "perf_metric_value": 0.9081441951950084
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 7.37%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1023.0375442360598 to 947.6614978210325 in microbenchmark.json
REGRESSION 6.29%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9724735940970552 to 0.911263457119588 in microbenchmark.json
REGRESSION 5.57%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1020.0334940870466 to 963.1902909183787 in microbenchmark.json
REGRESSION 4.89%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5433.582983286094 to 5167.9800954515 in microbenchmark.json
REGRESSION 4.73%: client__get_calls (THROUGHPUT) regresses from 1175.306212007341 to 1119.7725751916082 in microbenchmark.json
REGRESSION 3.74%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23591.92555321498 to 22710.046003881216 in microbenchmark.json
REGRESSION 3.72%: tasks_per_second (THROUGHPUT) regresses from 578.8766226882515 to 557.3705625276606 in benchmarks/many_tasks.json
REGRESSION 2.69%: client__tasks_and_put_batch (THROUGHPUT) regresses from 11309.127935041968 to 11004.98249042869 in microbenchmark.json
REGRESSION 2.52%: n_n_actor_calls_async (THROUGHPUT) regresses from 27232.414296780542 to 26545.931713712664 in microbenchmark.json
REGRESSION 1.96%: 1_1_actor_calls_async (THROUGHPUT) regresses from 9241.526232225291 to 9060.701663275304 in microbenchmark.json
REGRESSION 1.93%: pgs_per_second (THROUGHPUT) regresses from 22.687659485012095 to 22.249430148995714 in benchmarks/many_pgs.json
REGRESSION 1.87%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 4541.586332149929 to 4456.606860484332 in microbenchmark.json
REGRESSION 0.88%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1499.3849412965205 to 1486.2327104183764 in microbenchmark.json
REGRESSION 0.86%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7872.539571860014 to 7804.984752431155 in microbenchmark.json
REGRESSION 0.52%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12520.58965968965 to 12455.514706383783 in microbenchmark.json
REGRESSION 0.45%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8825.80303025342 to 8786.234839177117 in microbenchmark.json
REGRESSION 0.42%: tasks_per_second (THROUGHPUT) regresses from 344.2841239720449 to 342.8427005545737 in benchmarks/many_nodes.json
REGRESSION 0.38%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2063.6151992547047 to 2055.7051275912527 in microbenchmark.json
REGRESSION 0.09%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.9070880635954 to 7.900197666889211 in microbenchmark.json
REGRESSION 140.07%: dashboard_p50_latency_ms (LATENCY) regresses from 74.394 to 178.601 in benchmarks/many_actors.json
REGRESSION 92.20%: dashboard_p95_latency_ms (LATENCY) regresses from 1649.419 to 3170.14 in benchmarks/many_tasks.json
REGRESSION 63.53%: stage_3_creation_time (LATENCY) regresses from 1.573556900024414 to 2.573246955871582 in stress_tests/stress_test_many_tasks.json
REGRESSION 46.24%: dashboard_p99_latency_ms (LATENCY) regresses from 3448.302 to 5042.844 in benchmarks/many_tasks.json
REGRESSION 18.47%: dashboard_p50_latency_ms (LATENCY) regresses from 141.285 to 167.38 in benchmarks/many_tasks.json
REGRESSION 16.70%: dashboard_p95_latency_ms (LATENCY) regresses from 3035.866 to 3542.989 in benchmarks/many_actors.json
REGRESSION 16.65%: dashboard_p95_latency_ms (LATENCY) regresses from 10.334 to 12.055 in benchmarks/many_pgs.json
REGRESSION 14.30%: dashboard_p99_latency_ms (LATENCY) regresses from 3441.396 to 3933.547 in benchmarks/many_actors.json
REGRESSION 9.79%: dashboard_p50_latency_ms (LATENCY) regresses from 3.39 to 3.722 in benchmarks/many_pgs.json
REGRESSION 8.25%: 107374182400_large_object_time (LATENCY) regresses from 30.474318987000004 to 32.98956875599998 in scalability/single_node.json
REGRESSION 7.83%: dashboard_p99_latency_ms (LATENCY) regresses from 332.736 to 358.789 in benchmarks/many_pgs.json
REGRESSION 5.92%: stage_4_spread (LATENCY) regresses from 0.48427910077229586 to 0.5129273527822178 in stress_tests/stress_test_many_tasks.json
REGRESSION 5.55%: 10000_args_time (LATENCY) regresses from 17.415384294000006 to 18.382605733000005 in scalability/single_node.json
REGRESSION 1.21%: avg_pg_create_time_ms (LATENCY) regresses from 0.9259017792794532 to 0.9371462897900398 in stress_tests/stress_test_placement_group.json
REGRESSION 0.33%: stage_1_avg_iteration_time (LATENCY) regresses from 23.859845495224 to 23.938837790489195 in stress_tests/stress_test_many_tasks.json
```