### PR TITLE
[core][adag] Fix for asyncio outputs

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1431,7 +1431,9 @@ class CompiledDAG:
             fut = asyncio.Future()
             await self._fut_queue.put(fut)
 
-        return CompiledDAGFuture(self, self._execution_index, fut)
+        fut = CompiledDAGFuture(self, self._execution_index, fut)
+        self._execution_index += 1
+        return fut
 
     def teardown(self):
         """Teardown and cancel all actor tasks for this DAG. After this

--- a/python/ray/experimental/compiled_dag_ref.py
+++ b/python/ray/experimental/compiled_dag_ref.py
@@ -92,7 +92,7 @@ class CompiledDAGRef:
 
 
 @PublicAPI(stability="alpha")
-class CompiledDAGFuture(CompiledDAGRef):
+class CompiledDAGFuture:
     """
     A reference to a compiled DAG execution result, when executed with asyncio.
     This differs from CompiledDAGRef in that `await` must be called on the


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When asyncio interface is used, we do not need to call `get` on the underlying objects because this is already done by a background thread. Therefore, when a CompiledDAGFuture goes out of scope, we should just let the underlying future go out of scope instead of trying to call `get` like we do for CompiledDAGRefs.

When testing locally, I found that without these changes, the program would produce errors when a CompiledDAGFuture went out of scope because it tried to call CompiledDAGRef.__del__. I'm not sure why these don't appear when running the existing tests though.

Closes #46766.
