### PR TITLE
[core] Replace GCS stubs in dashboard to use NewGcsAioClient.

### DIFF
--- a/python/ray/_private/gcs_aio_client.py
+++ b/python/ray/_private/gcs_aio_client.py
@@ -67,11 +67,13 @@ class NewGcsAioClient:
         self.internal_kv_keys = self.inner.async_internal_kv_keys
         self.check_alive = self.inner.async_check_alive
         self.get_all_job_info = self.inner.async_get_all_job_info
-        # Note: this only exists in the new client.
-        self.get_all_actor_info = self.inner.async_get_all_actor_info
         # Forwarded Properties.
         self.address = self.inner.address
         self.cluster_id = self.inner.cluster_id
+        # Note: these only exists in the new client.
+        self.get_all_actor_info = self.inner.async_get_all_actor_info
+        self.get_all_node_info = self.inner.async_get_all_node_info
+        self.kill_actor = self.inner.async_kill_actor
 
 
 class AsyncProxy:

--- a/python/ray/_private/gcs_aio_client.py
+++ b/python/ray/_private/gcs_aio_client.py
@@ -67,6 +67,8 @@ class NewGcsAioClient:
         self.internal_kv_keys = self.inner.async_internal_kv_keys
         self.check_alive = self.inner.async_check_alive
         self.get_all_job_info = self.inner.async_get_all_job_info
+        # Note: this only exists in the new client.
+        self.get_all_actor_info = self.inner.async_get_all_actor_info
         # Forwarded Properties.
         self.address = self.inner.address
         self.cluster_id = self.inner.cluster_id

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -286,6 +286,7 @@ class DashboardHead:
             self.gcs_aio_client = GcsAioClient(
                 address=gcs_address, nums_reconnect_retry=0
             )
+            # TODO(ryw): once we removed the old gcs client, also remove this.
             gcs_channel = GcsChannel(gcs_address=gcs_address, aio=True)
             gcs_channel.connect()
             self.aiogrpc_gcs_channel = gcs_channel.channel()

--- a/python/ray/dashboard/modules/actor/actor_head.py
+++ b/python/ray/dashboard/modules/actor/actor_head.py
@@ -3,13 +3,15 @@ import logging
 import os
 import time
 from collections import deque
+from typing import Dict
 
 import aiohttp.web
 
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
+from ray import ActorID
 from ray._private.gcs_pubsub import GcsAioActorSubscriber
-from ray.core.generated import gcs_service_pb2, gcs_service_pb2_grpc
+from ray.core.generated import gcs_pb2, gcs_service_pb2, gcs_service_pb2_grpc
 from ray.dashboard.datacenter import DataOrganizer, DataSource
 from ray.dashboard.modules.actor import actor_consts
 
@@ -77,11 +79,52 @@ def actor_table_data_to_dict(message):
     return light_message
 
 
+class GetAllActorInfo:
+    """
+    Gets all actor info from GCS via gRPC ActorInfoGcsService.GetAllActorInfo.
+    It makes the call via GcsAioClient or a direct gRPC stub, depends on the env var
+    RAY_USE_OLD_GCS_CLIENT.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        use_old_client = os.getenv("RAY_USE_OLD_GCS_CLIENT") == "1"
+        if use_old_client:
+            return GetAllActorInfoFromGrpc(*args, **kwargs)
+        else:
+            return GetAllActorInfoFromNewGcsClient(*args, **kwargs)
+
+
+class GetAllActorInfoFromNewGcsClient:
+    def __init__(self, dashboard_head):
+        self.gcs_aio_client = dashboard_head.gcs_aio_client
+
+    async def __call__(self) -> Dict[ActorID, gcs_pb2.ActorTableData]:
+        return await self.gcs_aio_client.get_all_actor_info()
+
+
+class GetAllActorInfoFromGrpc:
+    def __init__(self, dashboard_head):
+        gcs_channel = dashboard_head.aiogrpc_gcs_channel
+        self._gcs_actor_info_stub = gcs_service_pb2_grpc.ActorInfoGcsServiceStub(
+            gcs_channel
+        )
+
+    async def __call__(self) -> Dict[ActorID, gcs_pb2.ActorTableData]:
+        request = gcs_service_pb2.GetAllActorInfoRequest()
+        reply = await self._gcs_actor_info_stub.GetAllActorInfo(request, timeout=5)
+        if reply.status.code != 0:
+            raise Exception(f"Failed to GetAllActorInfo: {reply.status.message}")
+        actors = {}
+        for message in reply.actor_table_data:
+            actors[ActorID.FromBinary(message.actorId)] = message
+        return actors
+
+
 class ActorHead(dashboard_utils.DashboardHeadModule):
     def __init__(self, dashboard_head):
         super().__init__(dashboard_head)
-        # ActorInfoGcsService
-        self._gcs_actor_info_stub = None
+
+        self.get_all_actor_info = GetAllActorInfo(dashboard_head)
         # A queue of dead actors in order of when they died
         self.dead_actors_queue = deque()
 
@@ -95,33 +138,24 @@ class ActorHead(dashboard_utils.DashboardHeadModule):
         while True:
             try:
                 logger.info("Getting all actor info from GCS.")
-                request = gcs_service_pb2.GetAllActorInfoRequest()
-                reply = await self._gcs_actor_info_stub.GetAllActorInfo(
-                    request, timeout=5
-                )
-                if reply.status.code == 0:
-                    actors = {}
-                    for message in reply.actor_table_data:
-                        actor_table_data = actor_table_data_to_dict(message)
-                        actors[actor_table_data["actorId"]] = actor_table_data
-                    # Update actors.
-                    DataSource.actors.reset(actors)
-                    # Update node actors and job actors.
-                    node_actors = {}
-                    for actor_id, actor_table_data in actors.items():
-                        node_id = actor_table_data["address"]["rayletId"]
-                        # Update only when node_id is not Nil.
-                        if node_id != actor_consts.NIL_NODE_ID:
-                            node_actors.setdefault(node_id, {})[
-                                actor_id
-                            ] = actor_table_data
-                    DataSource.node_actors.reset(node_actors)
-                    logger.info("Received %d actor info from GCS.", len(actors))
-                    break
-                else:
-                    raise Exception(
-                        f"Failed to GetAllActorInfo: {reply.status.message}"
-                    )
+
+                actors = await self.get_all_actor_info()
+                actor_dicts: Dict[str, dict] = {
+                    actor_id.hex(): actor_table_data_to_dict(actor_table_data)
+                    for actor_id, actor_table_data in actors.items()
+                }
+                # Update actors.
+                DataSource.actors.reset(actor_dicts)
+                # Update node actors and job actors.
+                node_actors = {}
+                for actor_id, actor_table_data in actor_dicts.items():
+                    node_id = actor_table_data["address"]["rayletId"]
+                    # Update only when node_id is not Nil.
+                    if node_id != actor_consts.NIL_NODE_ID:
+                        node_actors.setdefault(node_id, {})[actor_id] = actor_table_data
+                DataSource.node_actors.reset(node_actors)
+                logger.info("Received %d actor info from GCS.", len(actors))
+                break  # breaks the while True.
             except Exception:
                 logger.exception("Error Getting all actor info from GCS.")
                 await asyncio.sleep(
@@ -258,10 +292,6 @@ class ActorHead(dashboard_utils.DashboardHeadModule):
         )
 
     async def run(self, server):
-        gcs_channel = self._dashboard_head.aiogrpc_gcs_channel
-        self._gcs_actor_info_stub = gcs_service_pb2_grpc.ActorInfoGcsServiceStub(
-            gcs_channel
-        )
         await asyncio.gather(self._update_actors(), self._cleanup_actors())
 
     @staticmethod

--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -1,8 +1,10 @@
 import asyncio
 import json
 import logging
+import os
 import time
 from itertools import chain
+from typing import Dict
 
 import aiohttp.web
 import grpc
@@ -11,6 +13,7 @@ import ray._private.utils
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
+from ray import NodeID
 from ray._private import ray_constants
 from ray._private.ray_constants import DEBUG_AUTOSCALING_ERROR, DEBUG_AUTOSCALING_STATUS
 from ray.autoscaler._private.util import (
@@ -19,6 +22,7 @@ from ray.autoscaler._private.util import (
     parse_usage,
 )
 from ray.core.generated import (
+    gcs_pb2,
     gcs_service_pb2,
     gcs_service_pb2_grpc,
     node_manager_pb2,
@@ -85,14 +89,52 @@ def node_stats_to_dict(message):
         message.core_workers_stats.extend(core_workers_stats)
 
 
+class GetAllNodeInfo:
+    """
+    Gets all node info from GCS via gRPC NodeInfoGcsService.GetAllNodeInfo.
+    It makes the call via GcsAioClient or a direct gRPC stub, depending on the env var
+    RAY_USE_OLD_GCS_CLIENT.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        use_old_client = os.getenv("RAY_USE_OLD_GCS_CLIENT") == "1"
+        if use_old_client:
+            return GetAllNodeInfoFromGrpc(*args, **kwargs)
+        else:
+            return GetAllNodeInfoFromNewGcsClient(*args, **kwargs)
+
+
+class GetAllNodeInfoFromNewGcsClient:
+    def __init__(self, dashboard_head):
+        self.gcs_aio_client = dashboard_head.gcs_aio_client
+
+    async def __call__(self, timeout) -> Dict[NodeID, gcs_pb2.GcsNodeInfo]:
+        return await self.gcs_aio_client.get_all_node_info(timeout=timeout)
+
+
+class GetAllNodeInfoFromGrpc:
+    def __init__(self, dashboard_head):
+        gcs_channel = dashboard_head.aiogrpc_gcs_channel
+        self._gcs_node_info_stub = gcs_service_pb2_grpc.NodeInfoGcsServiceStub(
+            gcs_channel
+        )
+
+    async def __call__(self, timeout) -> Dict[NodeID, gcs_pb2.GcsNodeInfo]:
+        request = gcs_service_pb2.GetAllNodeInfoRequest()
+        reply = await self._gcs_node_info_stub.GetAllNodeInfo(request, timeout=timeout)
+        if reply.status.code != 0:
+            raise Exception(f"Failed to GetAllNodeInfo: {reply.status.message}")
+        nodes = {}
+        for message in reply.node_info_list:
+            nodes[NodeID.FromBinary(message.nodeId)] = message
+        return nodes
+
+
 class NodeHead(dashboard_utils.DashboardHeadModule):
     def __init__(self, dashboard_head):
         super().__init__(dashboard_head)
         self._stubs = {}
-        # NodeInfoGcsService
-        self._gcs_node_info_stub = None
-        # NodeResourceInfoGcsService
-        self._gcs_node_resource_info_sub = None
+        self.get_all_node_info = None
         self._collect_memory_info = False
         DataSource.nodes.signal.append(self._update_stubs)
         # Total number of node updates happened.
@@ -137,18 +179,15 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
         Returns:
             A dict of information about the nodes in the cluster.
         """
-        request = gcs_service_pb2.GetAllNodeInfoRequest()
-        reply = await self._gcs_node_info_stub.GetAllNodeInfo(
-            request, timeout=node_consts.GCS_RPC_TIMEOUT_SECONDS
-        )
-        if reply.status.code == 0:
-            result = {}
-            for node_info in reply.node_info_list:
-                node_info_dict = gcs_node_info_to_dict(node_info)
-                result[node_info_dict["nodeId"]] = node_info_dict
-            return result
-        else:
-            logger.error("Failed to GetAllNodeInfo: %s", reply.status.message)
+        try:
+            nodes = await self.get_all_node_info(timeout=5)
+            return {
+                node_id.hex(): gcs_node_info_to_dict(node_info)
+                for node_id, node_info in nodes.items()
+            }
+        except Exception:
+            logger.exception("Failed to GetAllNodeInfo.")
+            raise
 
     async def _update_nodes(self):
         # TODO(fyrestone): Refactor code for updating actor / node / job.
@@ -394,14 +433,7 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
                 DataSource.node_stats[node_id] = reply_dict
 
     async def run(self, server):
-        gcs_channel = self._dashboard_head.aiogrpc_gcs_channel
-        self._gcs_node_info_stub = gcs_service_pb2_grpc.NodeInfoGcsServiceStub(
-            gcs_channel
-        )
-        self._gcs_node_resource_info_stub = (
-            gcs_service_pb2_grpc.NodeResourceInfoGcsServiceStub(gcs_channel)
-        )
-
+        self.get_all_node_info = GetAllNodeInfo(self._dashboard_head)
         await asyncio.gather(
             self._update_nodes(),
             self._update_node_stats(),

--- a/python/ray/dashboard/modules/snapshot/snapshot_head.py
+++ b/python/ray/dashboard/modules/snapshot/snapshot_head.py
@@ -10,6 +10,7 @@ import aiohttp.web
 
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
+from ray import ActorID
 from ray._private.gcs_aio_client import GcsAioClient
 from ray._private.pydantic_compat import BaseModel, Extra, Field, validator
 from ray._private.storage import _load_class
@@ -73,11 +74,62 @@ class RayActivityResponse(BaseModel, extra=Extra.allow):
         return v
 
 
+class KillActor:
+    """
+    Kill an actor via GCS using gRPC ActorInfoGcsService.KillActorViaGcs.
+    It makes the call via GcsAioClient or a direct gRPC stub, depending on the env var
+    RAY_USE_OLD_GCS_CLIENT.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        use_old_client = os.getenv("RAY_USE_OLD_GCS_CLIENT") == "1"
+        if use_old_client:
+            return KillActorViaGcsFromGrpc(*args, **kwargs)
+        else:
+            return KillActorViaGcsFromNewGcsClient(*args, **kwargs)
+
+
+class KillActorViaGcsFromNewGcsClient:
+    def __init__(self, dashboard_head):
+        self.gcs_aio_client = dashboard_head.gcs_aio_client
+
+    async def async_kill_actor(
+        self,
+        actor_id: ActorID,
+        force_kill: bool,
+        no_restart: bool,
+        timeout: Optional[float] = None,
+    ):
+        return await self.gcs_client.async_kill_actor_via_gcs(
+            actor_id.hex(), force_kill, no_restart, timeout
+        )
+
+
+class KillActorViaGcsFromGrpc:
+    def __init__(self, dashboard_head):
+        gcs_channel = dashboard_head.aiogrpc_gcs_channel
+        self._gcs_actor_info_stub = gcs_service_pb2_grpc.ActorInfoGcsServiceStub(
+            gcs_channel
+        )
+
+    async def async_kill_actor(
+        self,
+        actor_id: ActorID,
+        force_kill: bool,
+        no_restart: bool,
+        timeout: Optional[float] = None,
+    ):
+        request = gcs_service_pb2.KillActorViaGcsRequest()
+        request.actor_id = bytes.fromhex(actor_id.hex())
+        request.force_kill = force_kill
+        request.no_restart = no_restart
+        await self._gcs_actor_info_stub.KillActorViaGcs(request, timeout=timeout)
+
+
 class APIHead(dashboard_utils.DashboardHeadModule):
     def __init__(self, dashboard_head):
         super().__init__(dashboard_head)
-        self._gcs_actor_info_stub = None
-        self._dashboard_head = dashboard_head
+        self._kill_actor = None
         self._gcs_aio_client: GcsAioClient = dashboard_head.gcs_aio_client
         self._job_info_client = None
         # For offloading CPU intensive work.
@@ -95,12 +147,11 @@ class APIHead(dashboard_utils.DashboardHeadModule):
                 success=False, message="actor_id is required."
             )
 
-        request = gcs_service_pb2.KillActorViaGcsRequest()
-        request.actor_id = bytes.fromhex(actor_id)
-        request.force_kill = force_kill
-        request.no_restart = no_restart
-        await self._gcs_actor_info_stub.KillActorViaGcs(
-            request, timeout=SNAPSHOT_API_TIMEOUT_SECONDS
+        await self._kill_actor.async_kill_actor(
+            ActorID.from_hex(actor_id),
+            force_kill,
+            no_restart,
+            timeout=SNAPSHOT_API_TIMEOUT_SECONDS,
         )
 
         message = (
@@ -231,9 +282,7 @@ class APIHead(dashboard_utils.DashboardHeadModule):
             )
 
     async def run(self, server):
-        self._gcs_actor_info_stub = gcs_service_pb2_grpc.ActorInfoGcsServiceStub(
-            self._dashboard_head.aiogrpc_gcs_channel
-        )
+        self._kill_actor = KillActor(self._dashboard_head)
         # Lazily constructed because dashboard_head's gcs_aio_client
         # is lazily constructed
         if not self._job_info_client:

--- a/python/ray/dashboard/modules/snapshot/snapshot_head.py
+++ b/python/ray/dashboard/modules/snapshot/snapshot_head.py
@@ -100,8 +100,8 @@ class KillActorViaGcsFromNewGcsClient:
         no_restart: bool,
         timeout: Optional[float] = None,
     ):
-        return await self.gcs_client.async_kill_actor_via_gcs(
-            actor_id.hex(), force_kill, no_restart, timeout
+        return await self.gcs_aio_client.kill_actor(
+            actor_id, force_kill, no_restart, timeout
         )
 
 

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -378,13 +378,25 @@ cdef extern from "ray/gcs/gcs_client/python_callbacks.h" namespace "ray::gcs":
             object (*)(CRayStatus, const optional[T]&),
             void (object, void*), void*) nogil
 
+    cdef cppclass StatusPyCallback:
+        StatusPyCallback(
+            object (*)(CRayStatus),
+            void (object, void*), void*) nogil
+
 cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
     cdef cppclass CActorInfoAccessor "ray::gcs::ActorInfoAccessor":
         CRayStatus AsyncGetAllByFilter(
             const optional[CActorID] &actor_id,
             const optional[CJobID] &job_id,
             const optional[c_string] &actor_state_name,
-            const MultiItemCallback[CActorTableData] &callback)
+            const MultiItemPyCallback[CActorTableData] &callback,
+            int64_t timeout_ms)
+
+        CRayStatus AsyncKillActor(const CActorID &actor_id,
+                                  c_bool force_kill,
+                                  c_bool no_restart,
+                                  const StatusPyCallback &callback,
+                                  int64_t timeout_ms)
 
     cdef cppclass CJobInfoAccessor "ray::gcs::JobInfoAccessor":
         CRayStatus GetAll(
@@ -414,6 +426,10 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
         CRayStatus GetAllNoCache(
             int64_t timeout_ms,
             c_vector[CGcsNodeInfo] &result)
+
+        CRayStatus AsyncGetAll(
+            const MultiItemPyCallback[CGcsNodeInfo] &callback,
+            int64_t timeout_ms)
 
     cdef cppclass CNodeResourceInfoAccessor "ray::gcs::NodeResourceInfoAccessor":
         CRayStatus GetAllResourceUsage(

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -380,7 +380,11 @@ cdef extern from "ray/gcs/gcs_client/python_callbacks.h" namespace "ray::gcs":
 
 cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
     cdef cppclass CActorInfoAccessor "ray::gcs::ActorInfoAccessor":
-        pass
+        CRayStatus AsyncGetAllByFilter(
+            const optional[CActorID] &actor_id,
+            const optional[CJobID] &job_id,
+            const optional[c_string] &actor_state_name,
+            const MultiItemCallback[CActorTableData] &callback)
 
     cdef cppclass CJobInfoAccessor "ray::gcs::JobInfoAccessor":
         CRayStatus GetAll(

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -27,8 +27,9 @@ from ray.includes.common cimport (
     CStatusCode_OK,
     MultiItemPyCallback,
     OptionalItemPyCallback,
+    StatusPyCallback,
 )
-from ray.includes.optional cimport optional
+from ray.includes.optional cimport optional, make_optional
 from ray.core.generated import gcs_pb2
 from cython.operator import dereference, postincrement
 cimport cpython
@@ -339,6 +340,24 @@ cdef class NewGcsClient:
             status = self.inner.get().Nodes().GetAllNoCache(timeout_ms, reply)
         return raise_or_return(convert_get_all_node_info(status, move(reply)))
 
+    def async_get_all_node_info(
+        self, timeout: Optional[float] = None
+    ) -> Future[Dict[NodeID, gcs_pb2.GcsNodeInfo]]:
+        cdef:
+            int64_t timeout_ms = round(1000 * timeout) if timeout else -1
+            fut = incremented_fut()
+            void* fut_ptr = <void*>fut
+
+        with nogil:
+            check_status_timeout_as_rpc_error(
+                self.inner.get().Nodes().AsyncGetAll(
+                    MultiItemPyCallback[CGcsNodeInfo](
+                        convert_get_all_node_info,
+                        assign_and_decrement_fut,
+                        fut_ptr),
+                    timeout_ms))
+        return asyncio.wrap_future(fut)
+
     #############################################################
     # NodeResources methods
     #############################################################
@@ -372,21 +391,52 @@ cdef class NewGcsClient:
     ) -> Future[Dict[ActorID, gcs_pb2.ActorTableData]]:
         cdef:
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
-            optional[CActorID] c_actor_id = None if actor_id is None else actor_id.native()
-            optional[CJobID] c_job_id = None if job_id is None else job_id.native()
-            optional[c_string] c_actor_state_name = None if actor_state_name is None else actor_state_name.encode()
+            optional[CActorID] c_actor_id
+            optional[CJobID] c_job_id
+            optional[c_string] c_actor_state_name
             fut = incremented_fut()
             void* fut_ptr = <void*>fut
+        if actor_id is not None:
+            c_actor_id = (<ActorID>actor_id).native()
+        if job_id is not None:
+            c_job_id = (<JobID>job_id).native()
+        if actor_state_name is not None:
+            c_actor_state_name = <c_string>actor_state_name.encode()
 
         with nogil:
             check_status_timeout_as_rpc_error(
-                self.inner.get().Jobs().AsyncGetAllByFilter(
+                self.inner.get().Actors().AsyncGetAllByFilter(
                     c_actor_id, c_job_id, c_actor_state_name,
                     MultiItemPyCallback[CActorTableData](
                         convert_get_all_actor_info,
                         assign_and_decrement_fut,
                         fut_ptr),
                     timeout_ms))
+        return asyncio.wrap_future(fut)
+
+    def async_kill_actor(
+        self, actor_id: ActorID, c_bool force_kill, c_bool no_restart, timeout: Optional[float] = None
+    ) -> ConcurrentFuture[None]:
+        """
+        On success: returns None.
+        On failure: raises an exception.
+        """
+        cdef:
+            int64_t timeout_ms = round(1000 * timeout) if timeout else -1
+            fut = incremented_fut()
+            void* fut_ptr = <void*>fut
+            CActorID c_actor_id = actor_id.native()
+
+        with nogil:
+            check_status_timeout_as_rpc_error(
+                self.inner.get().Actors().AsyncKillActor(
+                    c_actor_id,
+                    force_kill,
+                    no_restart,
+                    StatusPyCallback(convert_status, assign_and_decrement_fut, fut_ptr),
+                    timeout_ms
+                )
+            )
         return asyncio.wrap_future(fut)
     #############################################################
     # Job methods
@@ -599,12 +649,18 @@ cdef convert_get_all_actor_info(
             b = c_proto.SerializeAsString()
             proto = gcs_pb2.ActorTableData()
             proto.ParseFromString(b)
-            job_table_data[ActorID.from_binary(proto.actor_id)] = proto
+            actor_table_data[ActorID.from_binary(proto.actor_id)] = proto
         return actor_table_data, None
     except Exception as e:
         return None, e
 
-
+cdef convert_status(CRayStatus status):
+    # -> None
+    try:
+        check_status_timeout_as_rpc_error(status)
+        return None, None
+    except Exception as e:
+        return None, e
 cdef convert_optional_str_none_for_not_found(
         CRayStatus status, const optional[c_string]& c_str):
     # If status is NotFound, return None.

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -384,9 +384,9 @@ cdef class NewGcsClient:
 
     def async_get_all_actor_info(
         self,
-        actor_id: Optional[ActorID]=None,
-        job_id: Optional[JobID]=None,
-        actor_state_name: Optional[str]=None,
+        actor_id: Optional[ActorID] = None,
+        job_id: Optional[JobID] = None,
+        actor_state_name: Optional[str] = None,
         timeout: Optional[float] = None
     ) -> Future[Dict[ActorID, gcs_pb2.ActorTableData]]:
         cdef:
@@ -415,7 +415,8 @@ cdef class NewGcsClient:
         return asyncio.wrap_future(fut)
 
     def async_kill_actor(
-        self, actor_id: ActorID, c_bool force_kill, c_bool no_restart, timeout: Optional[float] = None
+        self, actor_id: ActorID, c_bool force_kill, c_bool no_restart,
+        timeout: Optional[float] = None
     ) -> ConcurrentFuture[None]:
         """
         On success: returns None.
@@ -441,6 +442,7 @@ cdef class NewGcsClient:
     #############################################################
     # Job methods
     #############################################################
+
     def get_all_job_info(
         self, timeout: Optional[float] = None
     ) -> Dict[JobID, gcs_pb2.JobTableData]:

--- a/python/ray/includes/unique_ids.pxd
+++ b/python/ray/includes/unique_ids.pxd
@@ -54,6 +54,9 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         CActorID FromBinary(const c_string &binary)
 
         @staticmethod
+        CActorID FromHex(const c_string &hex_str)
+
+        @staticmethod
         const CActorID Nil()
 
         @staticmethod

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -293,6 +293,11 @@ cdef class ActorID(BaseID):
                                parent_task_counter).Binary())
 
     @classmethod
+    def from_hex(cls, hex_id):
+        binary_id = CActorID.FromHex(<c_string>hex_id).Binary()
+        return cls(binary_id)
+
+    @classmethod
     def nil(cls):
         return cls(CActorID.Nil().Binary())
 

--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -30,7 +30,8 @@ class MockActorInfoAccessor : public ActorInfoAccessor {
               (const std::optional<ActorID> &actor_id,
                const std::optional<JobID> &job_id,
                const std::optional<std::string> &actor_state_name,
-               const MultiItemCallback<rpc::ActorTableData> &callback),
+               const MultiItemCallback<rpc::ActorTableData> &callback,
+               int64_t timeout_ms),
               (override));
   MOCK_METHOD(Status,
               AsyncGetByName,
@@ -61,7 +62,8 @@ class MockActorInfoAccessor : public ActorInfoAccessor {
               (const ActorID &actor_id,
                bool force_kill,
                bool no_restart,
-               const StatusCallback &callback),
+               const StatusCallback &callback,
+               int64_t timeout_ms),
               (override));
   MOCK_METHOD(Status,
               AsyncCreateActor,

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -60,12 +60,14 @@ class ActorInfoAccessor {
   /// \param  job_id To filter actors by job_id.
   /// \param  actor_state_name To filter actors based on actor state.
   /// \param callback Callback that will be called after lookup finishes.
+  /// \param timeout_ms -1 means infinite.
   /// \return Status
   virtual Status AsyncGetAllByFilter(
       const std::optional<ActorID> &actor_id,
       const std::optional<JobID> &job_id,
       const std::optional<std::string> &actor_state_name,
-      const MultiItemCallback<rpc::ActorTableData> &callback);
+      const MultiItemCallback<rpc::ActorTableData> &callback,
+      int64_t timeout_ms = -1);
 
   /// Get actor specification for a named actor from the GCS asynchronously.
   ///
@@ -143,11 +145,13 @@ class ActorInfoAccessor {
   /// \param force_kill Whether to force kill an actor by killing the worker.
   /// \param no_restart If set to true, the killed actor will not be restarted anymore.
   /// \param callback Callback that will be called after the actor is destroyed.
+  /// \param timeout_ms RPC timeout in milliseconds. -1 means infinite.
   /// \return Status
   virtual Status AsyncKillActor(const ActorID &actor_id,
                                 bool force_kill,
                                 bool no_restart,
-                                const StatusCallback &callback);
+                                const StatusCallback &callback,
+                                int64_t timeout_ms = -1);
 
   /// Asynchronously request GCS to create the actor.
   ///

--- a/src/ray/gcs/gcs_client/python_callbacks.h
+++ b/src/ray/gcs/gcs_client/python_callbacks.h
@@ -104,6 +104,8 @@ using MultiItemPyCallback = PyCallback<Status, std::vector<T> &&>;
 template <typename Data>
 using OptionalItemPyCallback = PyCallback<Status, const std::optional<Data> &>;
 
+using StatusPyCallback = PyCallback<Status>;
+
 }  // namespace gcs
 
 }  // namespace ray


### PR DESCRIPTION
This is part of the effort to remove all direct grpc calls to GCS server. Now, `actor_head.py`, `node_head.py` and `snapshot_head.py` makes direct call for service `ActorInfoGcsService.GetAllActorInfo` and alike. This PR makes the binding in NewGcsClient and feature flag it under `RAY_USE_OLD_GCS_CLIENT`.

How it works: the grpc calling code is extracted to a separate class. The class keeps a GcsAioClient or a stub, depends on that env var.

This PR applies to all where `_dashboard_head.aiogrpc_gcs_channel` is used, except for `StateDataSourceClient` which itself deserves a dedicated PR.

With this PR and a future one replacing usage in `StateDataSourceClient`, once we remove the old gcs client, we can delete `aiogrpc_gcs_channel` in DashboardHead once and for all.

Changes:
- `actor_head.py`: `GetAllActorInfo`
- `node_head.py`: `GetAllNodeInfo`
- `snapshot_head.py`: `KillActorViaGcs`

For each method, adds `timeout_ms` in `accessor.h|cc`, adds pxd binding and pxi implementation.